### PR TITLE
Fixing some scalaz urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Powered by highly-scalable, non-blocking fibers that never waste or leak resourc
 
 To learn more about ZIO, see the following references:
 
- - [Microsite](https://scalaz.github.io/scalaz-zio/)
+ - [Homepage](https://zio.dev/)
  - [Contributor's Guide](CONTRIBUTING.md)
  - [License](LICENSE)
- - [Issues](https://github.com/scalaz/scalaz-zio/issues)
- - [Pull Requests](https://github.com/scalaz/scalaz-zio/pulls)
+ - [Issues](https://github.com/zio/zio/issues)
+ - [Pull Requests](https://github.com/zio/zio/pulls)
 
 ---
 
-# [Learn More on the ZIO Microsite](https://scalaz.github.io/scalaz-zio/)
+# [Learn More on the ZIO Homepage](https://zio.dev/)
 
 ---
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ name := "scalaz-zio"
 inThisBuild(
   List(
     organization := "org.scalaz",
-    homepage := Some(url("https://scalaz.github.io/scalaz-zio/")),
+    homepage := Some(url("https://zio.dev/")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(


### PR DESCRIPTION
Fixes dead link. It also gets rid of "microsite". I think what we link to is "homepage". microsite or docusaurus is just implementation detail ;-)