### PR TITLE
Adding cond and filterOrElse

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1190,6 +1190,40 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     filterOrElse_[R, E1, A](p)(ZIO.fail(e))
 
   /**
+   * Fail with `e` if the supplied `PartialFunction` does not match, otherwise
+   * succeed with the returned value.
+   */
+  final def collect[E1 >: E, B](e: E1)(pf: PartialFunction[A, B]): ZIO[R, E1, B] =
+    collectM(e)(pf.andThen(ZIO.succeed))
+
+  /**
+   * Fail with `e` if the supplied `PartialFunction` does not match, otherwise
+   * continue with the returned value.
+   */
+  final def collectM[R1 <: R, E1 >: E, B](e: E1)(pf: PartialFunction[A, ZIO[R1, E1, B]]): ZIO[R1, E1, B] =
+    self.flatMap { v =>
+      pf.applyOrElse[A, ZIO[R1, E1, B]](v, _ => ZIO.fail(e))
+    }
+
+  /**
+   * Fail with the returned value if the `PartialFunction` matches, otherwise
+   * continue with our held value.
+   */
+  final def reject[R1 <: R, E1 >: E](pf: PartialFunction[A, E1]): ZIO[R1, E1, A] =
+    rejectM(pf.andThen(ZIO.fail))
+
+  /**
+   * Continue with the returned computation if the `PartialFunction` matches,
+   * translating the successful match into a failure, otherwise continue with
+   * our held value.
+   */
+  final def rejectM[R1 <: R, E1 >: E](pf: PartialFunction[A, ZIO[R1, E1, E1]]): ZIO[R1, E1, A] =
+    self.flatMap { v =>
+      pf.andThen[ZIO[R1, E1, A]](_.flatMap(ZIO.fail))
+        .applyOrElse[A, ZIO[R1, E1, A]](v, ZIO.succeed)
+    }
+
+  /**
    * An integer that identifies the term in the `ZIO` sum type to which this
    * instance belongs (e.g. `IO.Tags.Succeed`).
    */


### PR DESCRIPTION
I'd like to be able to conveniently convert an `A` into an `E`, providing either a static `E` or converting the `A` into an `E`.

- *Note:* `cond` could alternately be called `filter`/`filterOr`. I have not used ZIO enough to have a conception of the idiomatic naming scheme.

Inspiration:
#### `cond(A => Boolean, A => E1)`
- Cats: [`Validated.cond`](https://github.com/typelevel/cats/blob/76dbddf985d5b8ab556db0f13c01bc3062b7a60a/core/src/main/scala/cats/data/Validated.scala#L614)

#### `filterOrElse(A => Boolean, => E1)`
- Scala stdlib: [`Either.filterOrElse`](https://www.scala-lang.org/api/2.12.3/scala/util/Either.html#filterOrElse[A1%3E:A](p:B=%3EBoolean,zero:=%3EA1):scala.util.Either[A1,B])
- Scalaz: [`\/.filter`](https://github.com/scalaz/scalaz/blob/9ef08f7d2edc1286da2bdd4b1a55d201d80de4ca/core/src/main/scala/scalaz/Either.scala#L152)