### PR TITLE
make ParIO an instance of CommutativeApplicative

### DIFF
--- a/interop-cats/jvm/src/main/scala/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/zio/interop/catsjvm.scala
@@ -292,7 +292,7 @@ private class CatsParallel[R, E](final override val monad: Monad[ZIO[R, E, ?]])
     }
 }
 
-private class CatsParApplicative[R, E] extends Applicative[ParIO[R, E, ?]] {
+private class CatsParApplicative[R, E] extends CommutativeApplicative[ParIO[R, E, ?]] {
 
   final override def pure[A](x: A): ParIO[R, E, A] =
     Par(ZIO.succeed(x))

--- a/interop-cats/jvm/src/main/scala/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/zio/interop/catsjvm.scala
@@ -89,6 +89,9 @@ sealed trait CatsInstances1 extends CatsInstances2 {
 
   implicit def parallelInstance[R, E](implicit M: Monad[ZIO[R, E, ?]]): Parallel[ZIO[R, E, ?], ParIO[R, E, ?]] =
     new CatsParallel[R, E](M)
+
+  implicit def commutativeApplicativeInstance[R, E]: CommutativeApplicative[ParIO[R, E, ?]] =
+    new CatsParApplicative[R, E]
 }
 
 sealed trait CatsInstances2 {


### PR DESCRIPTION
cats-effect has already done this for their IO type, so I guess it makes sense for ZIO too.
https://github.com/typelevel/cats-effect/commit/8db94741a5bbb83e1b04aaaaf70c161135be058b

This is needed to e. g. use unorderedTraverse with ParIO. 