### PR TITLE
Disable Tracing for zio.interop.Future shim API

### DIFF
--- a/interop-future/jvm/src/main/scala/zio/interop/Future.scala
+++ b/interop-future/jvm/src/main/scala/zio/interop/Future.scala
@@ -1,7 +1,7 @@
 package zio
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 import scala.reflect.ClassTag
 import zio.internal.PlatformLive
 import zio.internal.tracing.TracingConfig

--- a/interop-future/jvm/src/main/scala/zio/interop/Future.scala
+++ b/interop-future/jvm/src/main/scala/zio/interop/Future.scala
@@ -1,10 +1,10 @@
 package zio
 
 import scala.concurrent.ExecutionContext
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import scala.reflect.ClassTag
-
 import zio.internal.PlatformLive
+import zio.internal.tracing.TracingConfig
 
 package object interop {
 
@@ -17,7 +17,7 @@ package object interop {
   private val Global = ExecutionContext.Implicits.global
 
   private final def unsafeRun[E, A](ec: ExecutionContext, io: IO[E, A]): A =
-    Runtime[Any]((), PlatformLive.fromExecutionContext(ec)).unsafeRun(io)
+    Runtime[Any]((), PlatformLive.fromExecutionContext(ec).withTracingConfig(TracingConfig.disabled)).unsafeRun(io)
 
   private final def toTry[A](e: Either[Throwable, A]): Try[A] =
     e.fold(Failure(_), Success(_))


### PR DESCRIPTION
`zio.interop.Future` just got even slower accidentaly... Tracing is not useful for that shim API since all IO's there are one call deep, so I think it's best to disable it.