### PR TITLE
Fixed raceAttempt: losing fiber will now get interrupted on success too

### DIFF
--- a/core/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/zio/RTSSpec.scala
@@ -108,7 +108,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     raceAll of values                       $testRaceAllOfValues
     raceAll of failures                     $testRaceAllOfFailures
     raceAll of failures & one success       $testRaceAllOfFailuresOneSuccess
-    raceAttempt interrupts loser            $testRaceAttemptInterruptsLoser
+    raceAttempt interrupts loser on success $testRaceAttemptInterruptsLoserOnSuccess
+    raceAttempt interrupts loser on failure $testRaceAttemptInterruptsLoserOnFailure
     par regression                          $testPar
     par of now values                       $testRepeatedPar
     mergeAll                                $testMergeAll
@@ -1208,7 +1209,18 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     unsafeRun(countdown(50)) must_=== 150
   }
 
-  def testRaceAttemptInterruptsLoser =
+  def testRaceAttemptInterruptsLoserOnSuccess =
+    unsafeRun(for {
+      s      <- Promise.make[Nothing, Unit]
+      effect <- Promise.make[Nothing, Int]
+      winner = s.await *> IO.fromEither(Right(()))
+      loser  = IO.bracket(s.succeed(()))(_ => effect.succeed(42))(_ => IO.never)
+      race   = winner raceAttempt loser
+      _      <- race.either
+      b      <- effect.await
+    } yield b) must_=== 42
+
+  def testRaceAttemptInterruptsLoserOnFailure =
     unsafeRun(for {
       s      <- Promise.make[Nothing, Unit]
       effect <- Promise.make[Nothing, Int]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -250,8 +250,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def raceAttempt[R1 <: R, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[R1, E1, A1] =
     raceWith(that)(
-      { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), f.interrupt *> ZIO.succeed(_)) },
-      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), f.interrupt *> ZIO.succeed(_)) }
+      { case (l, f) => f.interrupt *>  l.fold(ZIO.halt, ZIO.succeed) },
+      { case (r, f) => f.interrupt *> r.fold(ZIO.halt, ZIO.succeed) }
     ).refailWithTrace
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -250,7 +250,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def raceAttempt[R1 <: R, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[R1, E1, A1] =
     raceWith(that)(
-      { case (l, f) => f.interrupt *>  l.fold(ZIO.halt, ZIO.succeed) },
+      { case (l, f) => f.interrupt *> l.fold(ZIO.halt, ZIO.succeed) },
       { case (r, f) => f.interrupt *> r.fold(ZIO.halt, ZIO.succeed) }
     ).refailWithTrace
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -250,8 +250,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def raceAttempt[R1 <: R, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[R1, E1, A1] =
     raceWith(that)(
-      { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), ZIO.succeed) },
-      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), ZIO.succeed) }
+      { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), f.interrupt *> ZIO.succeed(_)) },
+      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), f.interrupt *> ZIO.succeed(_)) }
     ).refailWithTrace
 
   /**


### PR DESCRIPTION
As in description - behaviour of `raceAttempt` is inconsistent with all other `race*` variants - it doesn't interrupt losing fiber if winning fiber finishes successfully. This PR fixes this.