### PR TITLE
Coerce mdoc into thinking we are using Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,8 @@ jobs:
             git config --global user.name "${GH_NAME}"
             echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
             export GITHUB_DEPLOY_KEY=`echo ${GH_TOKEN} | base64`
+            export TRAVIS_BUILD_NUMBER="${CIRCLE_BUILD_NUM}"
+            export TRAVIS_COMMIT="${CIRCLE_SHA1}"
             sbt docs/docusaurusPublishGhpages
       - save_cache:
           key: sbt-cache
@@ -266,4 +268,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-


### PR DESCRIPTION
See https://github.com/scalameta/mdoc/pull/172

mdoc currently only looks for the Travis CI environment variables. So we set those :)