### PR TITLE
Publish tests JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.specs2" %%% "specs2-core"          % "4.5.1" % Test,
       "org.specs2" %%% "specs2-scalacheck"    % "4.5.1" % Test,
       "org.specs2" %%% "specs2-matcher-extra" % "4.5.1" % Test
-    )
+    ),
+    publishArtifact in (Test, packageBin) := true
   )
   .enablePlugins(BuildInfoPlugin)
 


### PR DESCRIPTION
`TestRuntime` is inherited by multiple tests throughout the codebase.
While it would be better to move it to `testkit`, such change would
create cyclic dependency between the modules. Instead, core's tests are
published as separate JAR reachable via classifier "tests".