### PR TITLE
Fix unbounded memory usage in flatMapPar and defect handling

### DIFF
--- a/core/jvm/src/test/scala/zio/ZManagedSpec.scala
+++ b/core/jvm/src/test/scala/zio/ZManagedSpec.scala
@@ -132,18 +132,14 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
     effects must be_===(List(1, 2, 3, 3, 2, 1))
   }
 
-  private def parallelAcquireAndRelease = {
-    val cleanups = new mutable.ListBuffer[String]
-
-    def managed(v: String): ZManaged[Any, Nothing, String] =
-      ZManaged.make(IO.succeed(v))(_ => IO.effectTotal { cleanups += v; () })
-
-    val program = managed("A").zipWithPar(managed("B"))(_ + _).use[Any, Nothing, String](IO.succeed)
-
-    val result = unsafeRun(program)
-
-    result must haveSize(2)
-    result.size === cleanups.size
+  private def parallelAcquireAndRelease = unsafeRun {
+    for {
+      log      <- Ref.make[List[String]](Nil)
+      a        = ZManaged.make(UIO.succeed("A"))(_ => log.update("A" :: _))
+      b        = ZManaged.make(UIO.succeed("B"))(_ => log.update("B" :: _))
+      result   <- a.zipWithPar(b)(_ + _).use(ZIO.succeed)
+      cleanups <- log.get
+    } yield (result must haveSize(2)) and (cleanups must haveSize(2))
   }
 
   private def uninterruptible =

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -26,6 +26,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     bracket                              $bracket
     bracket short circuits               $bracketShortCircuits
     no acquisition when short circuiting $bracketNoAcquisition
+    releases when there are defects      $bracketWithDefects
 
   Stream.buffer
     buffer the Stream                      $bufferStream
@@ -68,11 +69,14 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     associativity             $flatMapAssociativity
 
   Stream.flatMapPar/flattenPar/mergeAll
-    consistent with flatMap     $flatMapParConsistency
-    short circuiting            $flatMapParShortCircuiting
-    interruption propagation    $flatMapParInterruptionPropagation
-    errors interrupt all fibers $flatMapParErrorsInterruptAllFibers
-    finalizer ordering          $flatMapParFinalizerOrdering
+    consistent with flatMap            $flatMapParConsistency
+    short circuiting                   $flatMapParShortCircuiting
+    interruption propagation           $flatMapParInterruptionPropagation
+    inner errors interrupt all fibers  $flatMapParInnerErrorsInterruptAllFibers
+    outer errors interrupt all fibers  $flatMapParOuterErrorsInterruptAllFibers
+    inner defects interrupt all fibers $flatMapParInnerDefectsInterruptAllFibers
+    outer defects interrupt all fibers $flatMapParOuterDefectsInterruptAllFibers
+    finalizer ordering                 $flatMapParFinalizerOrdering
 
   Stream.foreach/foreachWhile
     foreach                     $foreach
@@ -172,6 +176,18 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         result         <- acquired.get
       } yield result must_=== false
     )
+
+  private def bracketWithDefects = unsafeRun {
+    for {
+      ref <- Ref.make(false)
+      _ <- Stream
+            .bracket(ZIO.unit)(_ => ref.set(true))
+            .flatMap(_ => Stream.fromEffect(ZIO.dieMessage("boom")))
+            .run(Sink.drain)
+            .run
+      released <- ref.get
+    } yield released must_=== true
+  }
 
   private def bufferStream = prop { list: List[Int] =>
     unsafeRunSync(
@@ -406,7 +422,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     } yield cancelled must_=== true
   }
 
-  private def flatMapParErrorsInterruptAllFibers = unsafeRun {
+  private def flatMapParInnerErrorsInterruptAllFibers = unsafeRun {
     for {
       substreamCancelled <- Ref.make[Boolean](false)
       latch              <- Promise.make[Nothing, Unit]
@@ -431,6 +447,52 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
             .runDrain
       results <- execution.get
     } yield results must_=== List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire")
+  }
+
+  private def flatMapParOuterErrorsInterruptAllFibers = unsafeRun {
+    for {
+      substreamCancelled <- Ref.make[Boolean](false)
+      latch              <- Promise.make[Nothing, Unit]
+      result <- (Stream(()) ++ Stream.fromEffect(latch.await *> ZIO.fail("Ouch")))
+                 .flatMapPar(2) { _ =>
+                   Stream.fromEffect((latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true)))
+                 }
+                 .run(Sink.drain)
+                 .either
+      cancelled <- substreamCancelled.get
+    } yield (cancelled must_=== true) and (result must beLeft("Ouch"))
+  }
+
+  private def flatMapParInnerDefectsInterruptAllFibers = unsafeRun {
+    val ex = new RuntimeException("Ouch")
+
+    for {
+      substreamCancelled <- Ref.make[Boolean](false)
+      latch              <- Promise.make[Nothing, Unit]
+      result <- Stream(
+                 Stream.fromEffect((latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))),
+                 Stream.fromEffect(latch.await *> ZIO.die(ex))
+               ).flatMapPar(2)(identity)
+                 .run(Sink.drain)
+                 .run
+      cancelled <- substreamCancelled.get
+    } yield (cancelled must_=== true) and (result must_=== Exit.die(ex))
+  }
+
+  private def flatMapParOuterDefectsInterruptAllFibers = unsafeRun {
+    val ex = new RuntimeException()
+
+    for {
+      substreamCancelled <- Ref.make[Boolean](false)
+      latch              <- Promise.make[Nothing, Unit]
+      result <- (Stream(()) ++ Stream.fromEffect(latch.await *> ZIO.die(ex)))
+                 .flatMapPar(2) { _ =>
+                   Stream.fromEffect((latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true)))
+                 }
+                 .run(Sink.drain)
+                 .run
+      cancelled <- substreamCancelled.get
+    } yield (cancelled must_=== true) and (result must_=== Exit.die(ex))
   }
 
   private def foreach = {

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -17,11 +17,12 @@
 package zio.stream
 
 import zio.IO
+import zio.Exit.Cause
 
 /**
  * A `Take[E, A]` represents a single `take` from a queue modeling a stream of
- * values. A `Take` may be a failure value `E`, an element value `A`, or end-of-
- * stream marker.
+ * values. A `Take` may be a failure cause `Cause[E]`, an element value `A`
+ * or an end-of-stream marker.
  */
 sealed trait Take[+E, +A] extends Product with Serializable { self =>
   final def flatMap[E1 >: E, B](f: A => Take[E1, B]): Take[E1, B] = self match {
@@ -46,6 +47,7 @@ sealed trait Take[+E, +A] extends Product with Serializable { self =>
 
   final def zipWith[E1 >: E, B, C](that: Take[E1, B])(f: (A, B) => C): Take[E1, C] = (self, that) match {
     case (Take.Value(a), Take.Value(b)) => Take.Value(f(a, b))
+    case (Take.Fail(a), Take.Fail(b))   => Take.Fail(a && b)
     case (Take.End, _)                  => Take.End
     case (t @ Take.Fail(_), _)          => t
     case (_, Take.End)                  => Take.End
@@ -54,14 +56,14 @@ sealed trait Take[+E, +A] extends Product with Serializable { self =>
 }
 
 object Take {
-  final case class Fail[E](value: E)  extends Take[E, Nothing]
-  final case class Value[A](value: A) extends Take[Nothing, A]
-  case object End                     extends Take[Nothing, Nothing]
+  final case class Fail[E](value: Cause[E]) extends Take[E, Nothing]
+  final case class Value[A](value: A)       extends Take[Nothing, A]
+  case object End                           extends Take[Nothing, Nothing]
 
   final def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
     io.flatMap {
       case Take.End      => IO.succeed(None)
       case Take.Value(a) => IO.succeed(Some(a))
-      case Take.Fail(e)  => IO.fail(e)
+      case Take.Fail(e)  => IO.halt(e)
     }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -18,6 +18,7 @@ package zio.stream
 
 import zio._
 import zio.clock.Clock
+import zio.Exit.Cause
 import scala.annotation.implicitNotFound
 
 /**
@@ -235,14 +236,15 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
       override def fold[R2 <: R1, E2 >: E1, B1 >: B, S]: Fold[R2, E2, B1, S] =
         ZManaged.succeedLazy { (s, cont, g) =>
           for {
-            out          <- Queue.bounded[Take[E1, B]](outputBuffer).toManaged(_.shutdown)
-            permits      <- Semaphore.make(n).toManaged_
-            innerFailure <- Promise.make[E1, Nothing].toManaged_
-            innerFibers  <- Ref.make[List[Fiber[E1, Unit]]](Nil).toManaged_
+            out             <- Queue.bounded[Take[E1, B]](outputBuffer).toManaged(_.shutdown)
+            permits         <- Semaphore.make(n).toManaged_
+            innerFailure    <- Promise.make[Exit.Cause[E1], Nothing].toManaged_
+            interruptInners <- Promise.make[Nothing, Unit].toManaged_
             // - The driver stream forks an inner fiber for each stream created
             //   by f, with an upper bound of n concurrent fibers, enforced by the semaphore.
-            //   - On completion, the driver stream joins all pending inner fibers:
-            //     - If one of them failed, all other fibers are interrupted
+            //   - On completion, the driver stream tries to acquire all permits to verify
+            //     that all inner fibers have finished.
+            //     - If one of them failed (signalled by a promise), all other fibers are interrupted
             //     - If they all succeeded, Take.End is enqueued
             //   - On error, the driver stream interrupts all inner fibers and emits a
             //     Take.Fail value
@@ -253,36 +255,36 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
             //     with a promise. The driver will pick that up and interrupt all other fibers.
             //   - On interruption, an inner fiber does nothing
             //   - On completion, an inner fiber does nothing
-            _ <- self
-                  .fold[R2, E1, A, List[Fiber[E1, Unit]]]
-                  .flatMap { fold =>
-                    fold(
-                      Nil,
-                      _ => true,
-                      (fibers, a) =>
-                        permits.withPermit {
-                          f(a)
-                            .foreach(b => out.offer(Take.Value(b)).unit)
-                            .catchAll(e => out.offer(Take.Fail(e)) *> innerFailure.fail(e) *> ZIO.fail(e))
-                            .fork
-                            .map(_ :: fibers)
-                        }
-                    )
-                  }
-                  .mapM(fibers => innerFibers.set(fibers).const(fibers))
-                  .foldCauseM(
-                    _.failureOrCause.fold(
-                      // The driver stream failed.
-                      e => out.offer(Take.Fail(e)).unit.toManaged_,
-                      // The driver stream had a defect.
-                      c => (out.shutdown *> ZIO.halt(c)).toManaged_
-                    ),
-                    innerFibers =>
+            _ <- self.foreachManaged { a =>
+                  for {
+                    latch <- Promise.make[Nothing, Unit]
+                    innerStream = Stream
+                      .bracket(permits.acquire *> latch.succeed(()))(_ => permits.release)
+                      .flatMap(_ => f(a))
+                      .foreach(b => out.offer(Take.Value(b)).unit)
+                      .foldCauseM(
+                        cause => out.offer(Take.Fail(cause)) *> innerFailure.fail(cause),
+                        _ => ZIO.unit
+                      )
+                    _ <- (innerStream race interruptInners.await).fork
+                    // Make sure that the current inner stream has actually succeeded in acquiring
+                    // a permit before continuing. Otherwise, two bad things happen:
+                    // - we might needlessly fork inner streams without available permits
+                    // - worse, we could reach the end of the stream and acquire the permits ourselves
+                    //   before the inners had a chance to start
+                    _ <- latch.await
+                  } yield ()
+                }.foldCauseM(
+                    cause =>
+                      (interruptInners.succeed(()) *> permits.acquireN(n) *> out
+                        .offer(Take.Fail(cause))).unit.toManaged_,
+                    _ =>
                       innerFailure.await
-                        .raceWith(Fiber.joinAll(innerFibers))(
-                          // One of the inner fibers failed. It already enqueued its failure,
-                          // so we don't need to do anything except interrupt all the other fibers.
-                          leftDone = (_, _) => Fiber.interruptAll(innerFibers),
+                        .raceWith(permits.acquireN(n))(
+                          // One of the inner fibers failed. It already enqueued its failure, so we
+                          // just need to interrupt the inner fibers and acquire all permits to await
+                          // their termination
+                          leftDone = (_, permitAcquisition) => interruptInners.succeed(()) *> permitAcquisition.join,
                           // All fibers completed successfully, so we just need to signal that
                           // we're done.
                           rightDone = (_, failureAwait) => out.offer(Take.End) *> failureAwait.interrupt
@@ -290,7 +292,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                         .toManaged_
                   )
                   .fork
-            _ <- ZManaged.finalizer(innerFibers.get.flatMap(Fiber.interruptAll))
+            _ <- ZManaged.finalizer(interruptInners.succeed(()))
             s <- ZStream.fromQueue(out).unTake.fold[R2, E2, B1, S].flatMap(fold => fold(s, cont, g))
           } yield s
         }
@@ -446,11 +448,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                     _ <- f(a).to(p).fork
                   } yield ()
                 }.foldCauseM(
-                    c =>
-                      (c.failureOrCause.fold(
-                        e => out.offer(Take.Fail(e)).unit,
-                        _ => out.shutdown.unit
-                      ) *> ZIO.halt(c)).toManaged_,
+                    c => (out.offer(Take.Fail(c)) *> ZIO.halt(c)).toManaged_,
                     _ => out.offer(Take.End).unit.toManaged_
                   )
                   .fork
@@ -505,8 +503,8 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
             if (!cont(s)) ZIO.succeed(s)
             else
               queue.take.flatMap {
-                case Left(Take.Fail(e))  => IO.fail(e)
-                case Right(Take.Fail(e)) => IO.fail(e)
+                case Left(Take.Fail(e))  => IO.halt(e)
+                case Right(Take.Fail(e)) => IO.halt(e)
                 case Left(Take.End) =>
                   if (rightDone) IO.succeed(s)
                   else loop(true, rightDone, s, queue)
@@ -529,7 +527,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
             queue <- ZManaged.make(Queue.bounded[Elem](capacity))(_.shutdown)
             _ <- self.fold[R2, E2, A, Unit].flatMap { fold =>
                   fold((), _ => true, (_, a) => queue.offer(Left(Take.Value(a))).unit)
-                    .foldM(
+                    .foldCauseM(
                       e => ZManaged.fromEffect(queue.offer(Left(Take.Fail(e)))),
                       _ => ZManaged.fromEffect(queue.offer(Left(Take.End)))
                     )
@@ -539,7 +537,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
 
             _ <- that.fold[R2, E2, B, Unit].flatMap { fold =>
                   fold((), _ => true, (_, a) => queue.offer(Right(Take.Value(a))).unit)
-                    .foldM(
+                    .foldCauseM(
                       e => ZManaged.fromEffect(queue.offer(Right(Take.Fail(e)))),
                       _ => ZManaged.fromEffect(queue.offer(Right(Take.End)))
                     )
@@ -775,7 +773,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
       queue <- ZManaged.make(Queue.bounded[Take[E1, A1]](capacity))(_.shutdown)
       _ <- self.fold[R, E, A, Unit].flatMap { fold =>
             fold((), _ => true, (_, a) => queue.offer(Take.Value(a)).unit)
-              .foldM(
+              .foldCauseM(
                 e => queue.offer(Take.Fail(e)).toManaged_,
                 _ => queue.offer(Take.End).toManaged_
               )
@@ -944,16 +942,22 @@ trait Stream_Functions {
     managed(ZManaged.make(acquire)(release))
 
   /**
+   * The stream that always dies with `ex`.
+   */
+  final def die(ex: Throwable): ZStream[Any, Nothing, Nothing] =
+    halt(Cause.die(ex))
+
+  /**
+   * The stream that always dies with an exception described by `msg`.
+   */
+  final def dieMessage(msg: String): ZStream[Any, Nothing, Nothing] =
+    halt(Cause.die(new RuntimeException(msg)))
+
+  /**
    * The stream that always fails with `error`
    */
   final def fail[E](error: E): ZStream[Any, E, Nothing] =
-    new ZStream[Any, E, Nothing] {
-      def fold[R1, E1 >: E, A1, S]: Fold[R1, E1, A1, S] =
-        ZManaged.succeedLazy { (s, cont, _) =>
-          if (cont(s)) ZManaged.fail(error)
-          else ZManaged.succeed(s)
-        }
-    }
+    halt(Cause.fail(error))
 
   /**
    * Creates a stream that emits no elements, never fails and executes
@@ -1028,6 +1032,11 @@ trait Stream_Functions {
           ZIO.succeed
         )
     }
+
+  /**
+   * The stream that always halts with `cause`.
+   */
+  final def halt[E](cause: Cause[E]): ZStream[Any, E, Nothing] = fromEffect(ZIO.halt(cause))
 
   /**
    * Creates a single-valued stream from a managed resource


### PR DESCRIPTION
Also changes `Take.Fail` to use a full `Cause` so that defects can be signalled across queues as well.

Resolves #1008.