### PR TITLE
Fixed #1017 - ZStream.fromInputStream last chunk is too big

### DIFF
--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -23,7 +23,7 @@ trait ZStreamPlatformSpecific {
           val bytesRead = is.read(buf)
 
           if (bytesRead < 0) None
-          else if (0 < bytesRead && bytesRead < buf.length) Some((Chunk.fromArray(buf).take(buf.length), ()))
+          else if (0 < bytesRead && bytesRead < buf.length) Some((Chunk.fromArray(buf).take(bytesRead), ()))
           else Some((Chunk.fromArray(buf), ()))
         } refineOrDie {
           case e: IOException => e

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -489,11 +489,10 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def fromInputStream = unsafeRun {
     import java.io.ByteArrayInputStream
-
-    val data = List.fill(4096)("0123456789").mkString.getBytes
-    val is   = new ByteArrayInputStream(data)
-
-    ZStream.fromInputStream(is).run(Sink.collectAll[Chunk[Byte]]) map { chunks =>
+    val chunkSize = ZStreamChunk.DefaultChunkSize
+    val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
+    val is        = new ByteArrayInputStream(data)
+    ZStream.fromInputStream(is, chunkSize).run(Sink.collectAll[Chunk[Byte]]) map { chunks =>
       chunks.flatMap(_.toArray[Byte]).toArray must_=== data
     }
   }


### PR DESCRIPTION
A property-based test case would be better but this is hopefully still an improvement.