### PR TITLE
Fix confusion between fatal() and withNonFatal()

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -122,9 +122,9 @@ trait Runtime[+R] {
   final def withExecutor(e: Executor): Runtime[R] = mapPlatform(_.withExecutor(e))
 
   /**
-   * Constructs a new `Runtime` with the specified non-fatal predicate.
+   * Constructs a new `Runtime` with the specified fatal predicate.
    */
-  final def withNonFatal(f: Throwable => Boolean): Runtime[R] = mapPlatform(_.withNonFatal(f))
+  final def withFatal(f: Throwable => Boolean): Runtime[R] = mapPlatform(_.withFatal(f))
 
   /**
    * Constructs a new `Runtime` with the fatal error reporter.

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -59,7 +59,7 @@ trait Platform { self =>
    */
   def fatal(t: Throwable): Boolean
 
-  def withNonFatal(f: Throwable => Boolean): Platform =
+  def withFatal(f: Throwable => Boolean): Platform =
     new Platform.Proxy(self) {
       override def fatal(t: Throwable): Boolean = f(t)
     }


### PR DESCRIPTION
The intuition is that withNonFatal means that the given function is
used in fatal.
Unfortunately, the predicate essentially did the opposite.
This can be seen here:
https://github.com/zio/zio/blob/fb9a9e2d0905c050c43bd12b95b214830b6c726d/core/shared/src/main/scala/zio/internal/Platform.scala#L60-L65

It would appear this is a suppliment to the refactoring in #738