### PR TITLE
Preserve errors in bracketExit when release dies

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1675,8 +1675,10 @@ private[zio] trait ZIOFunctions extends Serializable {
       restore =>
         acquire.flatMap(ZIOFn(traceAs = use) { a =>
           restore(use(a)).run.flatMap(ZIOFn(traceAs = release) { e =>
-            release(a, e) *>
-              ZIO.done(e)
+            release(a, e).foldCauseM(
+              cause2 => ZIO.halt(e.fold(_ ++ cause2, _ => cause2)),
+              _ => ZIO.done(e)
+            )
           })
         })
     )


### PR DESCRIPTION
Similar to how `ensuring` works, we accumulate both errors in
case `use` failed and `release` died.

Ref #777