### PR TITLE
Align parameter names of fold and foldM on ZIO

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -404,8 +404,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  final def fold[B](err: E => B, succ: A => B): ZIO[R, Nothing, B] =
-    foldM(new ZIO.MapFn(err), new ZIO.MapFn(succ))
+  final def fold[B](failure: E => B, success: A => B): ZIO[R, Nothing, B] =
+    foldM(new ZIO.MapFn(failure), new ZIO.MapFn(success))
 
   /**
    * Returns an effect whose failure and success have been lifted into an


### PR DESCRIPTION
Hi! While alternating between 'fold' and 'foldM' I found it a bit inconvenient that they use different parameter names. I found no place — may the CI prove me wrong — where the names are actually used. For consuming projects the old names are still available as deprecated.

Maybe this is a useful contribution.