### PR TITLE
Fix release errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ microsite: &microsite
   steps:
       - add_ssh_keys:
           fingerprints:
-            - "11:2c:fa:98:69:d8:a1:d5:76:2e:38:d0:91:39:85:ce"
+            - "b3:9b:af:d5:de:74:32:e7:7a:21:77:77:66:fe:2f:42"
       - checkout
       - <<: *load_cache
       - <<: *install_nodejs

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -17,7 +17,9 @@ object Scalaz {
     "-encoding",
     "UTF-8",
     "-feature",
-    "-unchecked"
+    "-unchecked",
+    "-Xmax-classfile-name",
+    "242"
   )
 
   private val std2xOptions = Seq(


### PR DESCRIPTION
Fixes the issue with zio_2.11 not being released (trying this workaround: https://discuss.circleci.com/t/scala-sbt-assembly-does-not-work/10499/9 because we get the same error: `File name too long
[error] This can happen on some encrypted or legacy file systems.  Please see SI-3623 for more details.`)

Closes #1011 as well (updated fingerprint to one without a passphrase)
