### PR TITLE
Return null guard for tracingStatus removed in #1047

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -380,9 +380,11 @@ private[zio] final class FiberContext[E, A](
                 case ZIO.Tags.TracingStatus =>
                   val zio = curZio.asInstanceOf[ZIO.TracingStatus[Any, E, Any]]
 
-                  tracingStatus.push(zio.flag.toBoolean)
-                  // do not add TracingRegionExit to the stack trace
-                  stack.push(TracingRegionExit)
+                  if (tracingStatus ne null) {
+                    tracingStatus.push(zio.flag.toBoolean)
+                    // do not add TracingRegionExit to the stack trace
+                    stack.push(TracingRegionExit)
+                  }
 
                   curZio = zio.zio
 


### PR DESCRIPTION
`tracingStatus` can be `null` if tracing is disabled globally.

```scala
private[this] val tracingStatus =
  if (traceExec || traceStack) StackBool()
  else null
```