### PR TITLE
Speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,6 @@ testJVM: &testJVM
     - run:
         name: Run tests
         command: ./sbt ++${SCALA_VERSION}! testJVM
-    - run:
-        name: Package artifacts
-        command: ./sbt ++${SCALA_VERSION}! package packageSrc publishLocal
     - <<: *save_cache
 
 testJS: &testJS


### PR DESCRIPTION
Remove the `sbt package packageSrc publishLocal` step that consumes 3-4 minutes at every test step for JVM. It will be done in the release step only.