### PR TITLE
Upgrade nodejs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ install_nodejs: &install_nodejs
   - run:
       name: Install node.js
       command: |
-        curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+        curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
         sudo apt install -y nodejs
 
 lint: &lint


### PR DESCRIPTION
Solve error from last release:
```
error @babel/core@7.4.5: The engine "node" is incompatible with this module. Expected version ">=6.9.0". Got "6.1.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```