### PR TITLE
Hold onto slippery fibers

### DIFF
--- a/core/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/zio/RTSSpec.scala
@@ -1078,7 +1078,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   }
 
   def testSupervising = {
-    def forkAwaitStart(ref: Ref[List[Fiber[_, _]]]) = 
+    def forkAwaitStart(ref: Ref[List[Fiber[_, _]]]) =
       withLatch(release => (release *> UIO.never).fork.tap(fiber => ref.update(fiber :: _)))
 
     unsafeRun(


### PR DESCRIPTION
Designed to partially address #1023 

The main problem is not addressed, but cases where fibers are being garbage collected before they can be inspected should be addressed.