### PR TITLE
Provide Resource[F, A] conversions to Managed for any F with a ConcurrentEffect instance

### DIFF
--- a/interop-cats/jvm/src/main/scala/zio/interop/catszmanagedjvm.scala
+++ b/interop-cats/jvm/src/main/scala/zio/interop/catszmanagedjvm.scala
@@ -25,9 +25,7 @@ import cats.{ effect, Bifunctor, Monad, MonadError, Monoid, Semigroup, Semigroup
 trait CatsZManagedSyntax {
   import scala.language.implicitConversions
 
-  implicit final def catsIOResourceSyntax[F[_]: ConcurrentEffect, A](
-    resource: Resource[F, A]
-  ): CatsIOResourceSyntax[F, A] =
+  implicit final def catsIOResourceSyntax[F[_], A](resource: Resource[F, A]): CatsIOResourceSyntax[F, A] =
     new CatsIOResourceSyntax(resource)
 
   implicit final def zManagedSyntax[R, E, A](managed: ZManaged[R, E, A]): ZManagedSyntax[R, E, A] =

--- a/interop-cats/jvm/src/main/scala/zio/interop/catszmanagedjvm.scala
+++ b/interop-cats/jvm/src/main/scala/zio/interop/catszmanagedjvm.scala
@@ -17,14 +17,17 @@
 package zio
 package interop
 
+import cats.arrow.FunctionK
 import cats.effect.Resource.{ Allocate, Bind, Suspend }
-import cats.effect.{ ExitCase, LiftIO, Resource, Sync, IO => CIO }
+import cats.effect.{ ConcurrentEffect, ExitCase, LiftIO, Resource, Sync, IO => CIO }
 import cats.{ effect, Bifunctor, Monad, MonadError, Monoid, Semigroup, SemigroupK }
 
 trait CatsZManagedSyntax {
   import scala.language.implicitConversions
 
-  implicit final def catsIOResourceSyntax[A](resource: Resource[CIO, A]): CatsIOResourceSyntax[A] =
+  implicit final def catsIOResourceSyntax[F[_]: ConcurrentEffect, A](
+    resource: Resource[F, A]
+  ): CatsIOResourceSyntax[F, A] =
     new CatsIOResourceSyntax(resource)
 
   implicit final def zManagedSyntax[R, E, A](managed: ZManaged[R, E, A]): ZManagedSyntax[R, E, A] =
@@ -32,15 +35,13 @@ trait CatsZManagedSyntax {
 
 }
 
-final class CatsIOResourceSyntax[A](private val resource: Resource[CIO, A]) extends AnyVal {
+final class CatsIOResourceSyntax[F[_], A](private val resource: Resource[F, A]) extends AnyVal {
 
   /**
    * Convert a cats Resource into a ZManaged.
    * Beware that unhandled error during release of the resource will result in the fiber dying.
    */
-  def toManaged[R](
-    implicit l: LiftIO[ZIO[R, Throwable, ?]]
-  ): ZManaged[R, Throwable, A] = {
+  def toManaged[R](implicit l: LiftIO[ZIO[R, Throwable, ?]], ev: ConcurrentEffect[F]): ZManaged[R, Throwable, A] = {
     def convert[A1](resource: Resource[CIO, A1]): ZManaged[R, Throwable, A1] =
       resource match {
         case Allocate(res) =>
@@ -63,7 +64,8 @@ final class CatsIOResourceSyntax[A](private val resource: Resource[CIO, A]) exte
         case Suspend(res) =>
           ZManaged.unwrap(l.liftIO(res).map(convert))
       }
-    convert(resource)
+
+    convert(resource.mapK(FunctionK.lift(ev.toIO)))
   }
 }
 

--- a/interop-cats/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
+++ b/interop-cats/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
@@ -1,11 +1,11 @@
 package zio.interop
 
-import cats.effect.{ Resource, IO => CIO }
+import cats.effect.Resource
 import org.specs2.Specification
 import org.specs2.specification.AroundTimeout
-import zio.{ DefaultRuntime, ZIO, ZManaged }
+import zio.{ DefaultRuntime, Task, ZIO, ZManaged }
 import zio.interop.catz._
-import cats.implicits._
+
 import scala.collection.mutable
 
 class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with DefaultRuntime {
@@ -28,8 +28,8 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toManagedFinalizersWhenInterrupted = {
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay { effects += x; () })(_ => CIO.delay { effects += x; () })
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect { effects += x; () })(_ => ZIO.effect { effects += x; () })
 
     val testCase = ZIO.runtime[Any].flatMap { implicit r =>
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
@@ -42,8 +42,8 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toManagedFinalizersWhenFailed = {
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay { effects += x; () })(_ => CIO.delay { effects += x; () })
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect { effects += x; () })(_ => ZIO.effect { effects += x; () })
 
     val testCase = ZIO.runtime[Any].flatMap { implicit r =>
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
@@ -56,8 +56,8 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toManagedFinalizersWhenDied = {
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay { effects += x; () })(_ => CIO.delay { effects += x; () })
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect { effects += x; () })(_ => ZIO.effect { effects += x; () })
 
     val testCase = ZIO.runtime[Any].flatMap { implicit r =>
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
@@ -70,9 +70,9 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toManagedFinalizersExceptionAcquisition = {
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay(effects += x) *> CIO.delay(throw new RuntimeException()).void)(
-        _ => CIO.delay { effects += x; () }
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect(effects += x) *> ZIO.effect(throw new RuntimeException()).unit)(
+        _ => ZIO.effect { effects += x; () }
       )
 
     val testCase = ZIO.runtime[Any].flatMap { implicit r =>
@@ -86,8 +86,8 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toManagedFinalizers = {
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay { effects += x; () })(_ => CIO.delay { effects += x; () })
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect { effects += x; () })(_ => ZIO.effect { effects += x; () })
 
     val testCase = ZIO.runtime[Any].flatMap { implicit r =>
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
@@ -101,8 +101,8 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
   def toManagedComposition = {
 
     val effects = new mutable.ListBuffer[Int]
-    def res(x: Int): Resource[CIO, Unit] =
-      Resource.make(CIO.delay { effects += x; () })(_ => CIO.delay { effects += x; () })
+    def res(x: Int): Resource[Task, Unit] =
+      Resource.make(ZIO.effect { effects += x; () })(_ => ZIO.effect { effects += x; () })
 
     def man(x: Int): ZManaged[Any, Throwable, Unit] =
       ZManaged.make(ZIO.effectTotal(effects += x).unit)(_ => ZIO.effectTotal(effects += x))


### PR DESCRIPTION
Fixes #1028 

I tried following @jdegoes [advice](https://github.com/zio/zio/issues/1028#issuecomment-504668846), but as a FP newbie I don't know if what I did is the most idiomatic way to solve this, so feel free to point me to another direction if this is not the correct one.

Basically to be able to mapK over the resource I needed a natural transformation F ~> IO, which I built lifting into FunctionK the toIO function from ConcurrentEffect.

I also modified the tests to use ZIO's Task (for which a Runtime was already in place) instead of Cats IO, because otherwise I would have need to introduce a ContextShift in order to get the ConcurrentEffect instance for Cats IO. 
As a side-effect ( :D ) we also obtained an example of a working conversion between a Resource[Task, A] and a Managed, which was the whole point of the issue I guess (i.e. being able to convert Resources coming from doobie / http4s)

As I said, any feedback is appreciated. Thank you