### PR TITLE
Add ZStream#transduceManaged.

### DIFF
--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -875,30 +875,27 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def transduceManaged = {
-    def makeSink(res: Ref[Int]) =
-      (_: Unit) =>
-        new ZSink[Any, Throwable, Int, Int, List[Int]] {
-          override type State = List[Int]
+    final class TestSink(ref: Ref[Int]) extends ZSink[Any, Throwable, Int, Int, List[Int]] {
+      override type State = List[Int]
 
-          override def extract(state: List[Int]): ZIO[Any, Throwable, List[Int]] = ZIO.succeed(state)
+      override def extract(state: List[Int]): ZIO[Any, Throwable, List[Int]] = ZIO.succeed(state)
 
-          override def initial: ZIO[Any, Throwable, ZSink.Step[List[Int], Nothing]] = ZIO.succeed(ZSink.Step.more(Nil))
+      override def initial: ZIO[Any, Throwable, ZSink.Step[List[Int], Nothing]] = ZIO.succeed(ZSink.Step.more(Nil))
 
-          override def step(state: List[Int], a: Int): ZIO[Any, Throwable, ZSink.Step[List[Int], Int]] =
-            for {
-              i <- res.get
-              _ <- if (i != 500) IO.fail(new IllegalStateException(i.toString)) else IO.unit
-            } yield ZSink.Step.done(List(a, a), Chunk.empty)
-        }
+      override def step(state: List[Int], a: Int): ZIO[Any, Throwable, ZSink.Step[List[Int], Int]] =
+        for {
+          i <- ref.get
+          _ <- if (i != 1000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
+        } yield ZSink.Step.done(List(a, a), Chunk.empty)
+    }
 
     val stream = ZStream(1, 2, 3, 4)
     val test = for {
       resource <- Ref.make(0)
-      result <- stream
-                 .transduceManaged(ZManaged.make(resource.set(500))(_ => resource.set(1000)))(makeSink(resource))
-                 .runCollect
-      i <- resource.get
-      _ <- if (i != 1000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
+      sink     = ZManaged.make(resource.set(1000).const(new TestSink(resource)))(_ => resource.set(2000))
+      result   <- stream.transduceManaged(sink).runCollect
+      i        <- resource.get
+      _        <- if (i != 2000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
     } yield result
     unsafeRunSync(test) must_=== Success(List(List(1, 1), List(2, 2), List(3, 3), List(4, 4)))
   }

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -133,6 +133,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     with remainder                       $transduceWithRemainder
     with a sink that always signals more $transduceSinkMore
     managed                              $transduceManaged
+    propagate managed error              $transduceManagedError
 
   Stream.unfold             $unfold
   Stream.unfoldM            $unfoldM
@@ -898,6 +899,12 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       _        <- if (i != 2000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
     } yield result
     unsafeRunSync(test) must_=== Success(List(List(1, 1), List(2, 2), List(3, 3), List(4, 4)))
+  }
+
+  private def transduceManagedError = unsafeRun {
+    val fail = "I'm such a failure!"
+    val sink = ZManaged.fail(fail)
+    ZStream(1, 2, 3).transduceManaged(sink).runCollect.either.map(_ must beLeft(fail))
   }
 
   private def unfold = {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -792,53 +792,70 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
     } yield queue
 
   /**
-   * Applies a transducer to the stream, which converts one or more elements
-   * of type `A` into elements of type `C`.
+   * Applies a transducer to the stream, converting elements of type `A` into elements of type `C`, with a
+   * managed resource of type `D` available.
+   *
+   * @param sinkProducer Called to provide the sink to perform the transduction given a resource created via `managed`.
    */
-  final def transduce[R1 <: R, E1 >: E, A1 >: A, C](sink: ZSink[R1, E1, A1, A1, C]): ZStream[R1, E1, C] =
+  final def transduceManaged[R1 <: R, E1 >: E, A1 >: A, C, D](
+    managed: ZManaged[R1, E1, D]
+  )(sinkProducer: D => ZSink[R1, E1, A1, A1, C]): ZStream[R1, E1, C] =
     new ZStream[R1, E1, C] {
-      override def fold[R2 <: R1, E2 >: E1, C1 >: C, S2]: Fold[R2, E2, C1, S2] =
-        ZManaged.succeedLazy { (s2, cont, f) =>
-          def feed(s1: sink.State, s2: S2, a: Chunk[A1]): ZIO[R2, E2, (sink.State, S2, Boolean)] =
-            sink.stepChunk(s1, a).flatMap { step =>
-              if (ZSink.Step.cont(step)) {
-                IO.succeed((ZSink.Step.state(step), s2, true))
-              } else {
-                sink.extract(ZSink.Step.state(step)).flatMap { c =>
-                  f(s2, c).flatMap { s2 =>
-                    val remaining = ZSink.Step.leftover(step)
-                    sink.initial.flatMap { initStep =>
-                      if (cont(s2) && !remaining.isEmpty) {
-                        feed(ZSink.Step.state(initStep), s2, remaining)
-                      } else {
-                        IO.succeed((ZSink.Step.state(initStep), s2, false))
+      override def fold[R2 <: R1, E2 >: E1, C1 >: C, S]: Fold[R2, E2, C1, S] =
+        managed.either.flatMap {
+          case Left(e1) =>
+            ZManaged.succeed((_, _, _) => ZManaged.fail(e1))
+          case Right(resource) =>
+            ZManaged.succeed { (s: S, cont: S => Boolean, f: (S, C1) => ZIO[R2, E2, S]) =>
+              val sink = sinkProducer(resource)
+
+              def feed(s1: sink.State, s2: S, a: Chunk[A1]): ZIO[R2, E2, (sink.State, S, Boolean)] =
+                sink.stepChunk(s1, a).flatMap { step =>
+                  if (ZSink.Step.cont(step)) {
+                    IO.succeed((ZSink.Step.state(step), s2, true))
+                  } else {
+                    sink.extract(ZSink.Step.state(step)).flatMap { c =>
+                      f(s2, c).flatMap { s2 =>
+                        val remaining = ZSink.Step.leftover(step)
+                        sink.initial.flatMap { initStep =>
+                          if (cont(s2) && !remaining.isEmpty) {
+                            feed(ZSink.Step.state(initStep), s2, remaining)
+                          } else {
+                            IO.succeed((ZSink.Step.state(initStep), s2, false))
+                          }
+                        }
                       }
+                    }
+                  }
+                }
+
+              sink.initial.toManaged_.flatMap { initStep =>
+                val s1 = (ZSink.Step.state(initStep), s, false)
+
+                self.fold[R2, E2, A, (sink.State, S, Boolean)].flatMap { f0 =>
+                  f0(s1, stepState => cont(stepState._2), { (s, a) =>
+                    val (s1, s2, _) = s
+                    feed(s1, s2, Chunk(a))
+                  }).mapM { feedResult =>
+                    val (s1, s2, extractNeeded) = feedResult
+                    if (extractNeeded) {
+                      sink.extract(s1).flatMap(f(s2, _))
+                    } else {
+                      IO.succeed(s2)
                     }
                   }
                 }
               }
             }
-
-          sink.initial.toManaged_.flatMap { initStep =>
-            val s1 = (ZSink.Step.state(initStep), s2, false)
-
-            self.fold[R2, E2, A, (sink.State, S2, Boolean)].flatMap { f0 =>
-              f0(s1, stepState => cont(stepState._2), { (s, a) =>
-                val (s1, s2, _) = s
-                feed(s1, s2, Chunk(a))
-              }).mapM { feedResult =>
-                val (s1, s2, extractNeeded) = feedResult
-                if (extractNeeded) {
-                  sink.extract(s1).flatMap(f(s2, _))
-                } else {
-                  IO.succeed(s2)
-                }
-              }
-            }
-          }
-
         }
     }
+
+  /**
+   * Applies a transducer to the stream, which converts one or more elements
+   * of type `A` into elements of type `C`.
+   */
+  final def transduce[R1 <: R, E1 >: E, A1 >: A, C](sink: ZSink[R1, E1, A1, A1, C]): ZStream[R1, E1, C] =
+    transduceManaged[R1, E1, A1, C, Unit](ZManaged.unit)(Function.const(sink))
 
   /**
    * Zips this stream together with the specified stream.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -794,21 +794,17 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   /**
    * Applies a transducer to the stream, converting elements of type `A` into elements of type `C`, with a
    * managed resource of type `D` available.
-   *
-   * @param sinkProducer Called to provide the sink to perform the transduction given a resource created via `managed`.
    */
-  final def transduceManaged[R1 <: R, E1 >: E, A1 >: A, C, D](
-    managed: ZManaged[R1, E1, D]
-  )(sinkProducer: D => ZSink[R1, E1, A1, A1, C]): ZStream[R1, E1, C] =
+  final def transduceManaged[R1 <: R, E1 >: E, A1 >: A, C](
+    managedSink: ZManaged[R1, E1, ZSink[R1, E1, A1, A1, C]]
+  ): ZStream[R1, E1, C] =
     new ZStream[R1, E1, C] {
       override def fold[R2 <: R1, E2 >: E1, C1 >: C, S]: Fold[R2, E2, C1, S] =
-        managed.either.flatMap {
+        managedSink.either.flatMap {
           case Left(e1) =>
             ZManaged.succeed((_, _, _) => ZManaged.fail(e1))
-          case Right(resource) =>
+          case Right(sink) =>
             ZManaged.succeed { (s: S, cont: S => Boolean, f: (S, C1) => ZIO[R2, E2, S]) =>
-              val sink = sinkProducer(resource)
-
               def feed(s1: sink.State, s2: S, a: Chunk[A1]): ZIO[R2, E2, (sink.State, S, Boolean)] =
                 sink.stepChunk(s1, a).flatMap { step =>
                   if (ZSink.Step.cont(step)) {
@@ -855,7 +851,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * of type `A` into elements of type `C`.
    */
   final def transduce[R1 <: R, E1 >: E, A1 >: A, C](sink: ZSink[R1, E1, A1, A1, C]): ZStream[R1, E1, C] =
-    transduceManaged[R1, E1, A1, C, Unit](ZManaged.unit)(Function.const(sink))
+    transduceManaged[R1, E1, A1, C](ZManaged.succeed(sink))
 
   /**
    * Zips this stream together with the specified stream.


### PR DESCRIPTION
This allows running a stream transduction with a managed resource available for the lifetime of the stream.

The motivation for this is decoding/decoding character data to/from streams of `Chunk[Byte]`. The general case of character decoding cannot be implemented efficiently with the existing `transduce` method, as there's a need for state to be carried over between input elements, which `ZSink` by itself cannot do. Right now to do character decoding properly, one must implement `fold` directly.

There's a few ways `transduce` could be changed to support what character decoding requires, but I thought a `ZManaged` variant was the most straight-forward. Here's roughly what the `ZManaged` value would look like for UTF-8 decoding on the JVM:

```scala
val managedDecoder = ZManaged.succeedLazy {
  val byteBuffer = ByteBuffer.allocate(bufSize)
  val charBuffer = CharBuffer.allocate(bufSize)
  (StandardCharsets.UTF_8.newDecoder(), byteBuffer, charBuffer)
}
```
