### PR TITLE
Fix assertion for concurrent incrementation with Ref data structure

### DIFF
--- a/core/jvm/src/test/scala/zio/stm/STMSpec.scala
+++ b/core/jvm/src/test/scala/zio/stm/STMSpec.scala
@@ -221,7 +221,7 @@ final class STMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
         fiber <- ZIO.forkAll(List.fill(10)(incrementRefN(99, ref)))
         _     <- fiber.join
         v     <- ref.get
-      } yield v must_!== 10000
+      } yield v must_!== 1000
     )
 
   def e18 =


### PR DESCRIPTION
STMSpec contains a wrong assertion regarding with concurrent incrementation with Ref data structure.

This test case exists for showing that using Ref to increment a variable concurrently from many fibers should cause data confliction, which in turn using STM would prevent.

But the expected value in this test case has 10000, which would not be produced in any way, because 10 fibers incrementing 1 value 100 times would be at most 1000.

I changed the expected value to 1000 instead.