### PR TITLE
Implement 460

### DIFF
--- a/benchmarks/src/main/scala/zio/IOPromiseBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOPromiseBenchmark.scala
@@ -1,0 +1,39 @@
+package zio
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class IOPromiseBenchmark {
+
+  var length: Int = 500
+
+  @Benchmark
+  def listOfPromises(): Int = {
+    val task: UIO[Int] = for {
+      promises <- UIO.foreach(1 to length)(_ => Promise.make[Nothing, Int])
+      _        <- UIO.foreach_(promises)(_.succeed(1))
+      sum      <- UIO.foldLeft(promises)(0)((s, p) => p.await.map(_ + s))
+    } yield sum
+
+    IOBenchmarks.unsafeRun(task)
+  }
+
+  @Benchmark
+  def twoPromises(): Int = {
+    def task: UIO[Int] =
+      for {
+        one <- Promise.make[Nothing, Int]
+        two <- Promise.make[Nothing, Int]
+        _   <- one.succeed(1)
+        _   <- two.succeed(2)
+        o   <- one.await
+        t   <- two.await
+      } yield o + t
+
+    IOBenchmarks.unsafeRun(task)
+  }
+}


### PR DESCRIPTION
With this PR Promise extends directly AtomicReference as proposed in #460. I skipped the alternative of using AtomicReferenceFieldUpdater, as I assume would not work with ScalaJS and I see no significant benefits.

I added two very simple benchmark cases to see the performance implications. The numbers below indicate that the new version is maybe a bit faster when wrapping is required, but the improvement is still in the error range. 

It would be nice to run then benchmark on a more suitable computer. A laptop with an open IDE and thermal throttling is maybe not most reliable way to measure performance.

I think a memory usage analyses isn't necessary, as it should be strictly lower than before.

Benchmark results:

| Benchmark                                  | Mode  | Cnt |       Score |        Error | Units |
|--------------------------------------------|-------|-----|------------:|-------------:|-------|
| Promise extends AnyVal (0dfdc99646701611908c56785941532a21450be8)           |       |     |             |              |       |
| IOPromiseBenchmark.listOfPromises          | thrpt | 25  |   2.703,992 |     ± 87,956 | ops/s |
| IOPromiseBenchmark.twoPromises             | thrpt | 25  | 681.622,489 | ± 25.155,348 | ops/s |
| Promise extends AtomicReference (4a6276bde1ca909796ba326a8f782e1996a2595a) |       |     |             |              |       |
| IOPromiseBenchmark.listOfPromises          | thrpt | 25  |   2.782,024 |     ± 32,184 | ops/s |
| IOPromiseBenchmark.twoPromises             | thrpt | 25  | 678.854,900 | ± 14.989,510 | ops/s |
