### PR TITLE
Handle spurious wakeup in JVM OneShot

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm/src/main/scala/zio/internal/OneShot.scala
@@ -22,6 +22,8 @@ package zio.internal
  */
 private[zio] class OneShot[A] private (@volatile var value: A) {
 
+  import OneShot._
+
   /**
    * Sets the variable to the value. The behavior of this function
    * is undefined if the variable has already been set.
@@ -50,11 +52,11 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
    * @throws Error if the timeout is reached without the value being set.
    */
   final def get(timeout: Long): A = {
-    var remainingNano = math.min(timeout, Long.MaxValue/1000000L)*1000000L
+    var remainingNano = math.min(timeout, Long.MaxValue / nanosPerMilli) * nanosPerMilli
     while (value == null && remainingNano > 0L) {
-      val waitMilli = remainingNano / 1000000L
-      val waitNano = (remainingNano % 1000000L).toInt
-      val start = System.nanoTime()
+      val waitMilli = remainingNano / nanosPerMilli
+      val waitNano  = (remainingNano % nanosPerMilli).toInt
+      val start     = System.nanoTime()
       this.synchronized {
         if (value == null) this.wait(waitMilli, waitNano)
       }
@@ -83,6 +85,8 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
 }
 
 object OneShot {
+
+  private val nanosPerMilli = 1000000L
 
   /**
    * Makes a new (unset) variable.

--- a/core/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/zio/RTSSpec.scala
@@ -1350,7 +1350,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     for {
       done  <- Ref.make(false)
       start <- IO.succeed(internal.OneShot.make[Unit])
-      fiber <- blocking.effectBlocking { start.set(()); Thread.sleep(Long.MaxValue) }.ensuring(done.set(true)).fork
+      fiber <- blocking.effectBlocking { start.set(()); Thread.sleep(60L * 60L * 1000L) }.ensuring(done.set(true)).fork
       _     <- IO.succeed(start.get())
       res   <- fiber.interrupt
       value <- done.get

--- a/core/jvm/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core/jvm/src/test/scala/zio/internal/OneShotSpec.scala
@@ -34,7 +34,9 @@ class OneShotSpec extends Specification {
 
   def getWithNoValue = {
     val oneShot = OneShot.make[Object]
+    val start = System.nanoTime()
     oneShot.get(10000L) must throwA[Error]
+    (System.nanoTime() - start) must be < 10200L * 1000000L
   }
 
   def setTwice = {

--- a/core/jvm/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core/jvm/src/test/scala/zio/internal/OneShotSpec.scala
@@ -34,7 +34,7 @@ class OneShotSpec extends Specification {
 
   def getWithNoValue = {
     val oneShot = OneShot.make[Object]
-    val start = System.nanoTime()
+    val start   = System.nanoTime()
     oneShot.get(10000L) must throwA[Error]
     (System.nanoTime() - start) must be < 10200L * 1000000L
   }


### PR DESCRIPTION
The spec for `Object#wait` allows early return without `notify` being called, a so-called _spurious wakeup_. To handle for this, `wait` should be called in a loop.

It so happens that when running on Hotspot, such spurious wakeups do not occur when running the test suite. If running on [OpenJ9](https://www.eclipse.org/openj9/) instead of Hotspot, then spurious wakeups do occur, leading to many failed tests.

Limiting `wait` to reliably block for at most X ms requires some tedious book keeping. I've split out the common case of "block forever" in its own method, as this doesn't require the book keeping overhead.

While I'm here: bizarrely, the OpenJ9 implementation of `Thread.sleep` does not sleep at all if the argument is the kind of ridiculously large value that would only ever appear in test code.
