### PR TITLE
Fix #1077: Make it easier to compile suprojects with Dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,17 +72,6 @@ lazy val coreJVM = core.jvm
   .configure(_.enablePlugins(JCStressPlugin))
   .settings(dottySettings)
   .settings(replSettings)
-  .settings(
-    libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
-    sources in (Compile, doc) := {
-      val old = (Compile / doc / sources).value
-      if (isDotty.value) {
-        Nil
-      } else {
-        old
-      }
-    }
-  )
 
 lazy val coreJS = core.js
   .settings(
@@ -123,17 +112,6 @@ lazy val stacktracerJS = stacktracer.js
 lazy val stacktracerJVM = stacktracer.jvm
   .settings(dottySettings)
   .settings(replSettings)
-  .settings(
-    libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
-    sources in (Compile, doc) := {
-      val old = (Compile / doc / sources).value
-      if (isDotty.value) {
-        Nil
-      } else {
-        old
-      }
-    }
-  )
 
 lazy val benchmarks = project.module
   .dependsOn(coreJVM, streamsJVM)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -50,7 +50,16 @@ object BuildHelper {
   )
 
   val dottySettings = Seq(
-    crossScalaVersions += "0.16.0-RC3"
+    crossScalaVersions += "0.16.0-RC3",
+    libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
+    sources in (Compile, doc) := {
+      val old = (Compile / doc / sources).value
+      if (isDotty.value) {
+        Nil
+      } else {
+        old
+      }
+    }
   )
 
   val replSettings = Seq(
@@ -120,10 +129,13 @@ object BuildHelper {
     crossScalaVersions := Seq("2.12.8", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
-    libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(
-      compilerPlugin("org.typelevel"   %% "kind-projector"  % "0.10.3"),
-      compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.1")
-    ),
+    libraryDependencies ++= compileOnlyDeps ++ testDeps,
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq()
+      else
+        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.1"))
+    },
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings := true,


### PR DESCRIPTION
- Make sure that adding `.settings(dottySettings)` to a subproject build
  is enough to get correct Dotty support.
- Only enable silencer plugin when compiling with Scala 2
- Remove unused kind-projector plugin

This commit does not actually Dotty on more subprojects because
of compilation errors that will need to be investigated separately.