### PR TITLE
Add variance annotations to ease inference with Dotty

### DIFF
--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -51,12 +51,8 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
    *
    * Ported from @mpilquist work in Cats Effect (https://github.com/typelevel/cats-effect/pull/403)
    */
-  final def acquireN(n: Long): UIO[Unit] = {
-    // TODO: Dotty doesn't infer this properly
-    val i0: ZIO.BracketExitRelease[Any, Nothing, Nothing, Acquisition, Unit] = IO.bracketExit(prepare(n))(cleanup)
-    val i1: UIO[Unit]                                                        = i0(_.awaitAcquire)
-    assertNonNegative(n) *> i1
-  }
+  final def acquireN(n: Long): UIO[Unit] =
+    assertNonNegative(n) *> IO.bracketExit(prepare(n))(cleanup)(_.awaitAcquire)
 
   /**
    * The number of permits currently available.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2135,31 +2135,31 @@ object ZIO extends ZIO_R_Any {
         )
   }
 
-  final class BracketAcquire_[R, E](private val acquire: ZIO[R, E, _]) extends AnyVal {
+  final class BracketAcquire_[-R, +E](private val acquire: ZIO[R, E, _]) extends AnyVal {
     def apply[R1 <: R](release: ZIO[R1, Nothing, _]): BracketRelease_[R1, E] =
       new BracketRelease_(acquire, release)
   }
-  final class BracketRelease_[R, E](acquire: ZIO[R, E, _], release: ZIO[R, Nothing, _]) {
+  final class BracketRelease_[-R, +E](acquire: ZIO[R, E, _], release: ZIO[R, Nothing, _]) {
     def apply[R1 <: R, E1 >: E, B](use: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
       ZIO.bracket(acquire, (_: Any) => release, (_: Any) => use)
   }
 
-  final class BracketAcquire[R, E, A](private val acquire: ZIO[R, E, A]) extends AnyVal {
+  final class BracketAcquire[-R, +E, +A](private val acquire: ZIO[R, E, A]) extends AnyVal {
     def apply[R1 <: R](release: A => ZIO[R1, Nothing, _]): BracketRelease[R1, E, A] =
       new BracketRelease[R1, E, A](acquire, release)
   }
-  class BracketRelease[R, E, A](acquire: ZIO[R, E, A], release: A => ZIO[R, Nothing, _]) {
+  class BracketRelease[-R, +E, +A](acquire: ZIO[R, E, A], release: A => ZIO[R, Nothing, _]) {
     def apply[R1 <: R, E1 >: E, B](use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
       ZIO.bracket(acquire, release, use)
   }
 
-  final class BracketExitAcquire[R, E, A](private val acquire: ZIO[R, E, A]) extends AnyVal {
+  final class BracketExitAcquire[-R, +E, +A](private val acquire: ZIO[R, E, A]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, B](
       release: (A, Exit[E1, B]) => ZIO[R1, Nothing, _]
     ): BracketExitRelease[R1, E, E1, A, B] =
       new BracketExitRelease(acquire, release)
   }
-  class BracketExitRelease[R, E, E1 >: E, A, B](
+  class BracketExitRelease[-R, +E, E1, +A, B](
     acquire: ZIO[R, E, A],
     release: (A, Exit[E1, B]) => ZIO[R, Nothing, _]
   ) {


### PR DESCRIPTION
When doing type inference, the compiler maintains a set of constraints
that look like:

    ?T >: L <: H

Where `?T` is a type variable that will eventually need to be
instantiated and `L` and `H` are the lower-bound and upper-bound
constraints collected by the typechecker.

Eventually, type inference must make a decision and instantiate `?T` to
either `L` or `H`. In Dotty, this decision is delayed as long as
possible (unlike in Scala 2 where this is done after every parameter
list), but there are still situations where this must be done early, for
example if `?T` appears in the type of a lambda parameter. This decision
is made using several heuristics, but the compiler especially pays
attention to the variance of the positions in which `?T` appear, e.g. if
we're returning an expression of type `List[?T]` then the compiler will
favor instantiating `?T` to its lower-bound constraint `L`, because this
imposes the least amount of restriction on what we can do with the
result since `List[L]` is a subtype of every other valid solution.

Armed with this knowledge, we can start sprinkling variance annotations around
the various `Bracket*` classes used in ZIO, which is enough to get the body of
`Semaphore#acquireN` to infer correctly (there doesn't seem to be any deep reason
for it inferring correctly under Scala 2 without the variance
annotations, it's just that Scala 2 uses a different set of heuristics
for deciding whether to prefer instantiating to the lower or upper bound
when the type variable only appears in invariant positions).

Ironically, it seems that all these `Bracket*` classes only exist in the
first place to work around type inference issues in Scala 2 which do not
exist in Dotty, e.g. in Semaphore#acquireN we could use the uncurried
version:

    IO.bracketExit(prepare(n), cleanup, _.awaitAcquire)

And this typechecks fine in Dotty, but not in Scala 2.

(There's no good written documentation on how type inference works in
Dotty yet, but I have an old talk which goes into a lot of details if
you're interested and are prepared to handle my French accent:
https://www.youtube.com/watch?v=YIQjfCKDR5A)