### PR TITLE
Feature/#1098

### DIFF
--- a/core/shared/src/main/scala/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/zio/FiberLocal.scala
@@ -22,6 +22,7 @@ import FiberLocal.internal._
  * A container for fiber-local storage. It is the pure equivalent to Java's `ThreadLocal`
  * on a fiber architecture.
  */
+@deprecated("use FiberRef", "1.0.0")
 final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Serializable {
 
   /**
@@ -60,6 +61,7 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
     set(value).bracket_[Any, Nothing].apply[Any](empty)(use) //    TODO: Dotty doesn't infer this properly
 }
 
+@deprecated("use FiberRef", "1.0.0")
 object FiberLocal {
 
   /**

--- a/core/shared/src/test/scala/zio/FiberLocalSpec.scala
+++ b/core/shared/src/test/scala/zio/FiberLocalSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+@deprecated("use FiberRef", "1.0.0")
 class FiberLocalSpec extends BaseCrossPlatformSpec {
 
   def is =


### PR DESCRIPTION
Resolves #1098 

Deprecated FiberLocal class in version 1.0.0 and FiberLocalSpec test in version 1.0.0 