### PR TITLE
Upgrade to latest specs2 and scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC8"
+version = "2.0.0"
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -60,9 +60,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.specs2" %%% "specs2-core"          % "4.5.1" % Test,
-      "org.specs2" %%% "specs2-scalacheck"    % "4.5.1" % Test,
-      "org.specs2" %%% "specs2-matcher-extra" % "4.5.1" % Test
+      "org.specs2" %%% "specs2-core"          % "4.6.0" % Test,
+      "org.specs2" %%% "specs2-scalacheck"    % "4.6.0" % Test,
+      "org.specs2" %%% "specs2-matcher-extra" % "4.6.0" % Test
     ),
     publishArtifact in (Test, packageBin) := true
   )
@@ -102,9 +102,9 @@ lazy val stacktracer = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.specs2" %%% "specs2-core"          % "4.5.1" % Test,
-      "org.specs2" %%% "specs2-scalacheck"    % "4.5.1" % Test,
-      "org.specs2" %%% "specs2-matcher-extra" % "4.5.1" % Test
+      "org.specs2" %%% "specs2-core"          % "4.6.0" % Test,
+      "org.specs2" %%% "specs2-scalacheck"    % "4.6.0" % Test,
+      "org.specs2" %%% "specs2-matcher-extra" % "4.6.0" % Test
     )
   )
 


### PR DESCRIPTION
- upgrade to latests version of specs2 that has better dotty & scala 2.13 support to help with #1104 
- Upgrade to latest scalafmt 

