### PR TITLE
Fix #1113 - Move Exit.Cause to top Level

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -20,7 +20,7 @@ import java.util.{ HashMap, Map => JMap }
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
-import zio.Exit.Cause
+import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -18,7 +18,7 @@ package zio.internal
 
 import java.util.concurrent.{ Executor => _, _ }
 import java.util.{ Collections, WeakHashMap, Map => JMap }
-import zio.Exit.Cause
+import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig

--- a/core/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -45,8 +45,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   "single effectTotal for-comprehension" >> singleEffectTotalForComp
   "single suspendWith for-comprehension" >> singleSuspendWithForComp
 
-  private def show(trace: ZTrace): Unit        = if (debug) println(trace.prettyPrint)
-  private def show(cause: Exit.Cause[_]): Unit = if (debug) println(cause.prettyPrint)
+  private def show(trace: ZTrace): Unit   = if (debug) println(trace.prettyPrint)
+  private def show(cause: Cause[_]): Unit = if (debug) println(cause.prettyPrint)
 
   private def mentionsMethod(method: String, trace: ZTraceElement): Boolean =
     trace match {
@@ -79,7 +79,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def mentionedMethod(method: String): Matcher[List[ZTraceElement]] = mentionMethod(method)
 
   private implicit final class CauseMust[R >: Environment](io: ZIO[R, _, _]) {
-    def causeMust(check: Exit.Cause[_] => Result): Result =
+    def causeMust(check: Cause[_] => Result): Result =
       unsafeRunSync(io).fold[Result](
         cause => {
           show(cause)

--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -4,11 +4,10 @@ import org.scalacheck._
 import org.specs2.ScalaCheck
 import org.specs2.execute.Result
 import org.specs2.matcher.describe.Diffable
-import zio.Exit.Cause
 
 import scala.collection.mutable
 import scala.util.Try
-import zio.Exit.Cause.{ die, fail, interrupt, Both }
+import zio.Cause.{ die, fail, interrupt, Both }
 
 class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime with GenIO with ScalaCheck {
   import Prop.forAll
@@ -191,8 +190,8 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     )
 
   def testUnsandbox = {
-    val failure: IO[Exit.Cause[Exception], String] = IO.fail(fail(new Exception("fail")))
-    val success: IO[Exit.Cause[Any], Int]          = IO.succeed(100)
+    val failure: IO[Cause[Exception], String] = IO.fail(fail(new Exception("fail")))
+    val success: IO[Cause[Any], Int]          = IO.succeed(100)
     unsafeRun(for {
       message <- failure.unsandbox.foldM(e => IO.succeed(e.getMessage), _ => IO.succeed("unexpected"))
       result  <- success.unsandbox

--- a/core/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/zio/RTSSpec.scala
@@ -6,8 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.github.ghik.silencer.silent
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.describe.Diffable
-import zio.Exit.Cause
-import zio.Exit.Cause.{ die, fail, Fail, Then }
+import zio.Cause.{ die, fail, Fail, Then }
 import zio.duration._
 import zio.clock.Clock
 

--- a/core/jvm/src/test/scala/zio/ZManagedSpec.scala
+++ b/core/jvm/src/test/scala/zio/ZManagedSpec.scala
@@ -7,8 +7,8 @@ import org.scalacheck.{ Gen, _ }
 import org.specs2.ScalaCheck
 import org.specs2.matcher.MatchResult
 import org.specs2.matcher.describe.Diffable
-import zio.Exit.Cause.Interrupt
-import zio.Exit.{ Cause, Failure }
+import zio.Cause.Interrupt
+import zio.Exit.Failure
 import zio.duration._
 
 import scala.collection.mutable

--- a/core/jvm/src/test/scala/zio/stm/STMSpec.scala
+++ b/core/jvm/src/test/scala/zio/stm/STMSpec.scala
@@ -2,7 +2,7 @@ package zio.stm
 
 import java.util.concurrent.CountDownLatch
 
-import zio.Exit.Cause
+import zio.Cause
 import zio._
 
 final class STMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+sealed trait Cause[+E] extends Product with Serializable { self =>
+  import Cause._
+
+  final def &&[E1 >: E](that: Cause[E1]): Cause[E1] = Both(self, that)
+
+  final def ++[E1 >: E](that: Cause[E1]): Cause[E1] = Then(self, that)
+
+  final def defects: List[Throwable] =
+    self
+      .fold(List.empty[Throwable]) {
+        case (z, Die(v)) => v :: z
+      }
+      .reverse
+
+  final def died: Boolean =
+    self match {
+      case Die(_)            => true
+      case Then(left, right) => left.died || right.died
+      case Both(left, right) => left.died || right.died
+      case Traced(cause, _)  => cause.died
+      case _                 => false
+    }
+
+  final def failed: Boolean =
+    self match {
+      case Fail(_)           => true
+      case Then(left, right) => left.failed || right.failed
+      case Both(left, right) => left.failed || right.failed
+      case Traced(cause, _)  => cause.failed
+      case _                 => false
+    }
+
+  /**
+   * Retrieve the first checked error on the `Left` if available,
+   * if there are no checked errors return the rest of the `Cause`
+   * that is known to contain only `Die` or `Interrupt` causes.
+   * */
+  final def failureOrCause: Either[E, Cause[Nothing]] = self.failures.headOption match {
+    case Some(error) => Left(error)
+    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  }
+
+  final def failures[E1 >: E]: List[E1] =
+    self
+      .fold(List.empty[E1]) {
+        case (z, Fail(v)) => v :: z
+      }
+      .reverse
+
+  final def fold[Z](z: Z)(f: PartialFunction[(Z, Cause[E]), Z]): Z =
+    (f.lift(z -> self).getOrElse(z), self) match {
+      case (z, Then(left, right)) => right.fold(left.fold(z)(f))(f)
+      case (z, Both(left, right)) => right.fold(left.fold(z)(f))(f)
+      case (z, Traced(cause, _))  => cause.fold(z)(f)
+
+      case (z, _) => z
+    }
+
+  final def interrupted: Boolean =
+    self match {
+      case Interrupt         => true
+      case Then(left, right) => left.interrupted || right.interrupted
+      case Both(left, right) => left.interrupted || right.interrupted
+      case Traced(cause, _)  => cause.interrupted
+      case _                 => false
+    }
+
+  final def map[E1](f: E => E1): Cause[E1] = self match {
+    case Fail(value) => Fail(f(value))
+    case c @ Die(_)  => c
+    case Interrupt   => Interrupt
+
+    case Then(left, right)    => Then(left.map(f), right.map(f))
+    case Both(left, right)    => Both(left.map(f), right.map(f))
+    case Traced(cause, trace) => Traced(cause.map(f), trace)
+  }
+
+  final def prettyPrint: String = {
+    sealed trait Segment
+    sealed trait Step extends Segment
+
+    final case class Sequential(all: List[Step])     extends Segment
+    final case class Parallel(all: List[Sequential]) extends Step
+    final case class Failure(lines: List[String])    extends Step
+
+    def prefixBlock[A](values: List[String], p1: String, p2: String): List[String] =
+      values match {
+        case Nil => Nil
+        case head :: tail =>
+          (p1 + head) :: tail.map(p2 + _)
+      }
+
+    def parallelSegments(cause: Cause[Any]): List[Sequential] =
+      cause match {
+        case Cause.Both(left, right) => parallelSegments(left) ++ parallelSegments(right)
+        case _                       => List(causeToSequential(cause))
+      }
+
+    def linearSegments(cause: Cause[Any]): List[Step] =
+      cause match {
+        case Cause.Then(first, second) => linearSegments(first) ++ linearSegments(second)
+        case _                         => causeToSequential(cause).all
+      }
+
+    // Java 11 defines String#lines returning a Stream<String>, so the implicit conversion has to
+    // be requested explicitly
+    def lines(str: String): List[String] = augmentString(str).lines.toList
+
+    def renderThrowable(e: Throwable): List[String] = {
+      import java.io.{ PrintWriter, StringWriter }
+
+      val sw = new StringWriter()
+      val pw = new PrintWriter(sw)
+
+      e.printStackTrace(pw)
+      lines(sw.toString)
+    }
+
+    def renderTrace(maybeTrace: Option[ZTrace]): List[String] =
+      maybeTrace.fold("No ZIO Trace available." :: Nil) { trace =>
+        "" :: lines(trace.prettyPrint)
+      }
+
+    def renderFail(error: List[String], maybeTrace: Option[ZTrace]): Sequential =
+      Sequential(
+        List(Failure("A checked error was not handled." :: error ++ renderTrace(maybeTrace)))
+      )
+
+    def renderFailThrowable(t: Throwable, maybeTrace: Option[ZTrace]): Sequential =
+      renderFail(renderThrowable(t), maybeTrace)
+
+    def renderDie(t: Throwable, maybeTrace: Option[ZTrace]): Sequential =
+      Sequential(
+        List(Failure("An unchecked error was produced." :: renderThrowable(t) ++ renderTrace(maybeTrace)))
+      )
+
+    def renderInterrupt(maybeTrace: Option[ZTrace]): Sequential =
+      Sequential(
+        List(Failure("An unchecked error was produced." :: renderTrace(maybeTrace)))
+      )
+
+    def causeToSequential(cause: Cause[Any]): Sequential =
+      cause match {
+        case Cause.Fail(t: Throwable) =>
+          renderFailThrowable(t, None)
+        case Cause.Fail(error) =>
+          renderFail(lines(error.toString), None)
+        case Cause.Die(t) =>
+          renderDie(t, None)
+        case Cause.Interrupt =>
+          renderInterrupt(None)
+
+        case t: Cause.Then[Any] => Sequential(linearSegments(t))
+        case b: Cause.Both[Any] => Sequential(List(Parallel(parallelSegments(b))))
+        case Traced(c, trace) =>
+          c match {
+            case Cause.Fail(t: Throwable) =>
+              renderFailThrowable(t, Some(trace))
+            case Cause.Fail(error) =>
+              renderFail(lines(error.toString), Some(trace))
+            case Cause.Die(t) =>
+              renderDie(t, Some(trace))
+            case Cause.Interrupt =>
+              renderInterrupt(Some(trace))
+            case _ =>
+              Sequential(
+                Failure("An error was rethrown with a new trace." :: renderTrace(Some(trace))) :: causeToSequential(c).all
+              )
+          }
+
+      }
+
+    def format(segment: Segment): List[String] =
+      segment match {
+        case Failure(lines) =>
+          prefixBlock(lines, "─", " ")
+        case Parallel(all) =>
+          List(("══╦" * (all.size - 1)) + "══╗") ++
+            all.foldRight[List[String]](Nil) {
+              case (current, acc) =>
+                prefixBlock(acc, "  ║", "  ║") ++
+                  prefixBlock(format(current), "  ", "  ")
+            }
+        case Sequential(all) =>
+          all.flatMap { segment =>
+            List("║") ++
+              prefixBlock(format(segment), "╠", "║")
+          } ++ List("▼")
+      }
+
+    val sequence = causeToSequential(this)
+
+    ("Fiber failed." :: {
+      sequence match {
+        // use simple report for single failures
+        case Sequential(List(Failure(cause))) => cause
+
+        case _ => format(sequence).updated(0, "╥")
+      }
+    }).mkString("\n")
+  }
+
+  /**
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
+   * "most important" `Throwable`.
+   */
+  final def squash(implicit ev: E <:< Throwable): Throwable =
+    squashWith(ev)
+
+  /**
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
+   * "most important" `Throwable`.
+   */
+  final def squashWith(f: E => Throwable): Throwable =
+    failures.headOption.map(f) orElse
+      (if (interrupted) Some(new InterruptedException) else None) orElse
+      defects.headOption getOrElse (new InterruptedException)
+
+  /**
+   * Remove all `Fail` and `Interrupt` nodes from this `Cause`,
+   * return only `Die` cause/finalizer defects.
+   */
+  final def stripFailures: Option[Cause[Nothing]] =
+    self match {
+      case Interrupt => None
+      case Fail(_)   => None
+
+      case d @ Die(_) => Some(d)
+
+      case Both(l, r) =>
+        (l.stripFailures, r.stripFailures) match {
+          case (Some(l), Some(r)) => Some(Both(l, r))
+          case (Some(l), None)    => Some(l)
+          case (None, Some(r))    => Some(r)
+          case (None, None)       => None
+        }
+
+      case Then(l, r) =>
+        (l.stripFailures, r.stripFailures) match {
+          case (Some(l), Some(r)) => Some(Then(l, r))
+          case (Some(l), None)    => Some(l)
+          case (None, Some(r))    => Some(r)
+          case (None, None)       => None
+        }
+
+      case Traced(c, trace) => c.stripFailures.map(Traced(_, trace))
+    }
+
+  final def succeeded: Boolean = !failed
+
+  final def traces: List[ZTrace] =
+    self
+      .fold(List.empty[ZTrace]) {
+        case (z, Traced(_, trace)) => trace :: z
+      }
+      .reverse
+
+}
+
+object Cause extends Serializable {
+
+  final def die(defect: Throwable): Cause[Nothing]               = Die(defect)
+  final def fail[E](error: E): Cause[E]                          = Fail(error)
+  final val interrupt: Cause[Nothing]                            = Interrupt
+  final def traced[E](cause: Cause[E], trace: ZTrace): Traced[E] = Traced(cause, trace)
+
+  final case class Fail[E](value: E) extends Cause[E] {
+    override final def equals(that: Any): Boolean = that match {
+      case fail: Fail[_]     => value == fail.value
+      case traced: Traced[_] => this == traced.cause
+      case _                 => false
+    }
+  }
+
+  final case class Die(value: Throwable) extends Cause[Nothing] {
+    override final def equals(that: Any): Boolean = that match {
+      case die: Die          => value == die.value
+      case traced: Traced[_] => this == traced.cause
+      case _                 => false
+    }
+  }
+
+  case object Interrupt extends Cause[Nothing] {
+    override final def equals(that: Any): Boolean =
+      (this eq that.asInstanceOf[AnyRef]) || (that match {
+        case traced: Traced[_] => this == traced.cause
+        case _                 => false
+      })
+  }
+
+  // Traced is excluded completely from equals & hashCode
+  final case class Traced[E](cause: Cause[E], trace: ZTrace) extends Cause[E] {
+    override final def hashCode: Int = cause.hashCode()
+    override final def equals(obj: Any): Boolean = obj match {
+      case traced: Traced[_] => cause == traced.cause
+      case _                 => cause == obj
+    }
+  }
+
+  final case class Then[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
+    override final def equals(that: Any): Boolean = that match {
+      case traced: Traced[_] => that.equals(traced.cause)
+      case other: Cause[_]   => eq(other) || sym(assoc)(other, self) || sym(dist)(self, other)
+      case _                 => false
+    }
+    override final def hashCode: Int = flatten(self).hashCode
+
+    private def eq(that: Cause[_]): Boolean = (self, that) match {
+      case (tl: Then[_], tr: Then[_]) => tl.left == tr.left && tl.right == tr.right
+      case _                          => false
+    }
+
+    private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+      case (Then(Then(al, bl), cl), Then(ar, Then(br, cr))) => al == ar && bl == br && cl == cr
+      case _                                                => false
+    }
+
+    private def dist(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+      case (Then(al, Both(bl, cl)), Both(Then(ar1, br), Then(ar2, cr)))
+          if ar1 == ar2 && al == ar1 && bl == br && cl == cr =>
+        true
+      case (Then(Both(al, bl), cl), Both(Then(ar, cr1), Then(br, cr2)))
+          if cr1 == cr2 && al == ar && bl == br && cl == cr1 =>
+        true
+      case _ => false
+    }
+  }
+
+  final case class Both[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
+    override final def equals(that: Any): Boolean = that match {
+      case traced: Traced[_] => that.equals(traced.cause)
+      case other: Cause[_]   => eq(other) || sym(assoc)(self, other) || comm(other)
+      case _                 => false
+    }
+    override final def hashCode: Int = flatten(self).hashCode
+
+    private def eq(that: Cause[_]) = (self, that) match {
+      case (bl: Both[_], br: Both[_]) => bl.left == br.left && bl.right == br.right
+      case _                          => false
+    }
+    private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+      case (Both(Both(al, bl), cl), Both(ar, Both(br, cr))) => al == ar && bl == br && cl == cr
+      case _                                                => false
+    }
+    private def comm(that: Cause[_]): Boolean = (self, that) match {
+      case (Both(al, bl), Both(ar, br)) => al == br && bl == ar
+      case _                            => false
+    }
+  }
+
+  private[Cause] def sym(f: (Cause[_], Cause[_]) => Boolean): (Cause[_], Cause[_]) => Boolean =
+    (l, r) => f(l, r) || f(r, l)
+
+  private[Cause] def flatten(c: Cause[_]): Set[Cause[_]] = c match {
+    case Then(left, right) => flatten(left) ++ flatten(right)
+    case Both(left, right) => flatten(left) ++ flatten(right)
+    case Traced(cause, _)  => flatten(cause)
+    case o                 => Set(o)
+  }
+}

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -21,7 +21,7 @@ package zio
  * result is either succeeded with a value `A`, or failed with a `Cause[E]`.
  */
 sealed trait Exit[+E, +A] extends Product with Serializable { self =>
-  import Exit._
+  import Exit.{ Cause => _, _ }
 
   /**
    * Parallelly zips the this result with the specified result discarding the first element of the tuple or else returns the failed `Cause[E1]`
@@ -193,10 +193,10 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
 
 object Exit extends Serializable {
 
-  final case class Success[A](value: A)        extends Exit[Nothing, A]
-  final case class Failure[E](cause: Cause[E]) extends Exit[E, Nothing]
+  final case class Success[A](value: A)            extends Exit[Nothing, A]
+  final case class Failure[E](cause: zio.Cause[E]) extends Exit[E, Nothing]
 
-  final val interrupt: Exit[Nothing, Nothing] = halt(Cause.interrupt)
+  final val interrupt: Exit[Nothing, Nothing] = halt(zio.Cause.interrupt)
 
   final def collectAll[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     exits.headOption.map { head =>
@@ -214,9 +214,9 @@ object Exit extends Serializable {
         .map(_.reverse)
     }
 
-  final def die(t: Throwable): Exit[Nothing, Nothing] = halt(Cause.die(t))
+  final def die(t: Throwable): Exit[Nothing, Nothing] = halt(zio.Cause.die(t))
 
-  final def fail[E](error: E): Exit[E, Nothing] = halt(Cause.fail(error))
+  final def fail[E](error: E): Exit[E, Nothing] = halt(zio.Cause.fail(error))
 
   final def flatten[E, A](exit: Exit[E, Exit[E, A]]): Exit[E, A] =
     exit.flatMap(identity)
@@ -233,370 +233,16 @@ object Exit extends Serializable {
       case scala.util.Failure(t) => fail(t)
     }
 
-  final def halt[E](cause: Cause[E]): Exit[E, Nothing] = Failure(cause)
+  final def halt[E](cause: zio.Cause[E]): Exit[E, Nothing] = Failure(cause)
 
   final def succeed[A](a: A): Exit[Nothing, A] = Success(a)
 
   final def unit: Exit[Nothing, Unit] = succeed(())
 
-  sealed trait Cause[+E] extends Product with Serializable { self =>
-    import Cause._
+  @deprecated("use zio.Cause", "1.0.0")
+  type Cause[+E] = zio.Cause[E]
 
-    final def &&[E1 >: E](that: Cause[E1]): Cause[E1] = Both(self, that)
+  @deprecated("use zio.Cause", "1.0.0")
+  val Cause = zio.Cause
 
-    final def ++[E1 >: E](that: Cause[E1]): Cause[E1] = Then(self, that)
-
-    final def defects: List[Throwable] =
-      self
-        .fold(List.empty[Throwable]) {
-          case (z, Die(v)) => v :: z
-        }
-        .reverse
-
-    final def died: Boolean =
-      self match {
-        case Die(_)            => true
-        case Then(left, right) => left.died || right.died
-        case Both(left, right) => left.died || right.died
-        case Traced(cause, _)  => cause.died
-        case _                 => false
-      }
-
-    final def failed: Boolean =
-      self match {
-        case Fail(_)           => true
-        case Then(left, right) => left.failed || right.failed
-        case Both(left, right) => left.failed || right.failed
-        case Traced(cause, _)  => cause.failed
-        case _                 => false
-      }
-
-    /**
-     * Retrieve the first checked error on the `Left` if available,
-     * if there are no checked errors return the rest of the `Cause`
-     * that is known to contain only `Die` or `Interrupt` causes.
-     * */
-    final def failureOrCause: Either[E, Cause[Nothing]] = self.failures.headOption match {
-      case Some(error) => Left(error)
-      case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-    }
-
-    final def failures[E1 >: E]: List[E1] =
-      self
-        .fold(List.empty[E1]) {
-          case (z, Fail(v)) => v :: z
-        }
-        .reverse
-
-    final def fold[Z](z: Z)(f: PartialFunction[(Z, Cause[E]), Z]): Z =
-      (f.lift(z -> self).getOrElse(z), self) match {
-        case (z, Then(left, right)) => right.fold(left.fold(z)(f))(f)
-        case (z, Both(left, right)) => right.fold(left.fold(z)(f))(f)
-        case (z, Traced(cause, _))  => cause.fold(z)(f)
-
-        case (z, _) => z
-      }
-
-    final def interrupted: Boolean =
-      self match {
-        case Interrupt         => true
-        case Then(left, right) => left.interrupted || right.interrupted
-        case Both(left, right) => left.interrupted || right.interrupted
-        case Traced(cause, _)  => cause.interrupted
-        case _                 => false
-      }
-
-    final def map[E1](f: E => E1): Cause[E1] = self match {
-      case Fail(value) => Fail(f(value))
-      case c @ Die(_)  => c
-      case Interrupt   => Interrupt
-
-      case Then(left, right)    => Then(left.map(f), right.map(f))
-      case Both(left, right)    => Both(left.map(f), right.map(f))
-      case Traced(cause, trace) => Traced(cause.map(f), trace)
-    }
-
-    final def prettyPrint: String = {
-      sealed trait Segment
-      sealed trait Step extends Segment
-
-      final case class Sequential(all: List[Step])     extends Segment
-      final case class Parallel(all: List[Sequential]) extends Step
-      final case class Failure(lines: List[String])    extends Step
-
-      def prefixBlock[A](values: List[String], p1: String, p2: String): List[String] =
-        values match {
-          case Nil => Nil
-          case head :: tail =>
-            (p1 + head) :: tail.map(p2 + _)
-        }
-
-      def parallelSegments(cause: Cause[Any]): List[Sequential] =
-        cause match {
-          case Cause.Both(left, right) => parallelSegments(left) ++ parallelSegments(right)
-          case _                       => List(causeToSequential(cause))
-        }
-
-      def linearSegments(cause: Cause[Any]): List[Step] =
-        cause match {
-          case Cause.Then(first, second) => linearSegments(first) ++ linearSegments(second)
-          case _                         => causeToSequential(cause).all
-        }
-
-      // Java 11 defines String#lines returning a Stream<String>, so the implicit conversion has to
-      // be requested explicitly
-      def lines(str: String): List[String] = augmentString(str).lines.toList
-
-      def renderThrowable(e: Throwable): List[String] = {
-        import java.io.{ PrintWriter, StringWriter }
-
-        val sw = new StringWriter()
-        val pw = new PrintWriter(sw)
-
-        e.printStackTrace(pw)
-        lines(sw.toString)
-      }
-
-      def renderTrace(maybeTrace: Option[ZTrace]): List[String] =
-        maybeTrace.fold("No ZIO Trace available." :: Nil) { trace =>
-          "" :: lines(trace.prettyPrint)
-        }
-
-      def renderFail(error: List[String], maybeTrace: Option[ZTrace]): Sequential =
-        Sequential(
-          List(Failure("A checked error was not handled." :: error ++ renderTrace(maybeTrace)))
-        )
-
-      def renderFailThrowable(t: Throwable, maybeTrace: Option[ZTrace]): Sequential =
-        renderFail(renderThrowable(t), maybeTrace)
-
-      def renderDie(t: Throwable, maybeTrace: Option[ZTrace]): Sequential =
-        Sequential(
-          List(Failure("An unchecked error was produced." :: renderThrowable(t) ++ renderTrace(maybeTrace)))
-        )
-
-      def renderInterrupt(maybeTrace: Option[ZTrace]): Sequential =
-        Sequential(
-          List(Failure("An unchecked error was produced." :: renderTrace(maybeTrace)))
-        )
-
-      def causeToSequential(cause: Cause[Any]): Sequential =
-        cause match {
-          case Cause.Fail(t: Throwable) =>
-            renderFailThrowable(t, None)
-          case Cause.Fail(error) =>
-            renderFail(lines(error.toString), None)
-          case Cause.Die(t) =>
-            renderDie(t, None)
-          case Cause.Interrupt =>
-            renderInterrupt(None)
-
-          case t: Cause.Then[Any] => Sequential(linearSegments(t))
-          case b: Cause.Both[Any] => Sequential(List(Parallel(parallelSegments(b))))
-          case Traced(c, trace) =>
-            c match {
-              case Cause.Fail(t: Throwable) =>
-                renderFailThrowable(t, Some(trace))
-              case Cause.Fail(error) =>
-                renderFail(lines(error.toString), Some(trace))
-              case Cause.Die(t) =>
-                renderDie(t, Some(trace))
-              case Cause.Interrupt =>
-                renderInterrupt(Some(trace))
-              case _ =>
-                Sequential(
-                  Failure("An error was rethrown with a new trace." :: renderTrace(Some(trace))) :: causeToSequential(c).all
-                )
-            }
-
-        }
-
-      def format(segment: Segment): List[String] =
-        segment match {
-          case Failure(lines) =>
-            prefixBlock(lines, "─", " ")
-          case Parallel(all) =>
-            List(("══╦" * (all.size - 1)) + "══╗") ++
-              all.foldRight[List[String]](Nil) {
-                case (current, acc) =>
-                  prefixBlock(acc, "  ║", "  ║") ++
-                    prefixBlock(format(current), "  ", "  ")
-              }
-          case Sequential(all) =>
-            all.flatMap { segment =>
-              List("║") ++
-                prefixBlock(format(segment), "╠", "║")
-            } ++ List("▼")
-        }
-
-      val sequence = causeToSequential(this)
-
-      ("Fiber failed." :: {
-        sequence match {
-          // use simple report for single failures
-          case Sequential(List(Failure(cause))) => cause
-
-          case _ => format(sequence).updated(0, "╥")
-        }
-      }).mkString("\n")
-    }
-
-    /**
-     * Squashes a `Cause` down to a single `Throwable`, chosen to be the
-     * "most important" `Throwable`.
-     */
-    final def squash(implicit ev: E <:< Throwable): Throwable =
-      squashWith(ev)
-
-    /**
-     * Squashes a `Cause` down to a single `Throwable`, chosen to be the
-     * "most important" `Throwable`.
-     */
-    final def squashWith(f: E => Throwable): Throwable =
-      failures.headOption.map(f) orElse
-        (if (interrupted) Some(new InterruptedException) else None) orElse
-        defects.headOption getOrElse (new InterruptedException)
-
-    /**
-     * Remove all `Fail` and `Interrupt` nodes from this `Cause`,
-     * return only `Die` cause/finalizer defects.
-     */
-    final def stripFailures: Option[Cause[Nothing]] =
-      self match {
-        case Interrupt => None
-        case Fail(_)   => None
-
-        case d @ Die(_) => Some(d)
-
-        case Both(l, r) =>
-          (l.stripFailures, r.stripFailures) match {
-            case (Some(l), Some(r)) => Some(Both(l, r))
-            case (Some(l), None)    => Some(l)
-            case (None, Some(r))    => Some(r)
-            case (None, None)       => None
-          }
-
-        case Then(l, r) =>
-          (l.stripFailures, r.stripFailures) match {
-            case (Some(l), Some(r)) => Some(Then(l, r))
-            case (Some(l), None)    => Some(l)
-            case (None, Some(r))    => Some(r)
-            case (None, None)       => None
-          }
-
-        case Traced(c, trace) => c.stripFailures.map(Traced(_, trace))
-      }
-
-    final def succeeded: Boolean = !failed
-
-    final def traces: List[ZTrace] =
-      self
-        .fold(List.empty[ZTrace]) {
-          case (z, Traced(_, trace)) => trace :: z
-        }
-        .reverse
-
-  }
-
-  object Cause extends Serializable {
-
-    final def die(defect: Throwable): Cause[Nothing]               = Die(defect)
-    final def fail[E](error: E): Cause[E]                          = Fail(error)
-    final val interrupt: Cause[Nothing]                            = Interrupt
-    final def traced[E](cause: Cause[E], trace: ZTrace): Traced[E] = Traced(cause, trace)
-
-    final case class Fail[E](value: E) extends Cause[E] {
-      override final def equals(that: Any): Boolean = that match {
-        case fail: Fail[_]     => value == fail.value
-        case traced: Traced[_] => this == traced.cause
-        case _                 => false
-      }
-    }
-
-    final case class Die(value: Throwable) extends Cause[Nothing] {
-      override final def equals(that: Any): Boolean = that match {
-        case die: Die          => value == die.value
-        case traced: Traced[_] => this == traced.cause
-        case _                 => false
-      }
-    }
-
-    case object Interrupt extends Cause[Nothing] {
-      override final def equals(that: Any): Boolean =
-        (this eq that.asInstanceOf[AnyRef]) || (that match {
-          case traced: Traced[_] => this == traced.cause
-          case _                 => false
-        })
-    }
-
-    // Traced is excluded completely from equals & hashCode
-    final case class Traced[E](cause: Cause[E], trace: ZTrace) extends Cause[E] {
-      override final def hashCode: Int = cause.hashCode()
-      override final def equals(obj: Any): Boolean = obj match {
-        case traced: Traced[_] => cause == traced.cause
-        case _                 => cause == obj
-      }
-    }
-
-    final case class Then[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      override final def equals(that: Any): Boolean = that match {
-        case traced: Traced[_] => that.equals(traced.cause)
-        case other: Cause[_]   => eq(other) || sym(assoc)(other, self) || sym(dist)(self, other)
-        case _                 => false
-      }
-      override final def hashCode: Int = flatten(self).hashCode
-
-      private def eq(that: Cause[_]): Boolean = (self, that) match {
-        case (tl: Then[_], tr: Then[_]) => tl.left == tr.left && tl.right == tr.right
-        case _                          => false
-      }
-
-      private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
-        case (Then(Then(al, bl), cl), Then(ar, Then(br, cr))) => al == ar && bl == br && cl == cr
-        case _                                                => false
-      }
-
-      private def dist(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
-        case (Then(al, Both(bl, cl)), Both(Then(ar1, br), Then(ar2, cr)))
-            if ar1 == ar2 && al == ar1 && bl == br && cl == cr =>
-          true
-        case (Then(Both(al, bl), cl), Both(Then(ar, cr1), Then(br, cr2)))
-            if cr1 == cr2 && al == ar && bl == br && cl == cr1 =>
-          true
-        case _ => false
-      }
-    }
-
-    final case class Both[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      override final def equals(that: Any): Boolean = that match {
-        case traced: Traced[_] => that.equals(traced.cause)
-        case other: Cause[_]   => eq(other) || sym(assoc)(self, other) || comm(other)
-        case _                 => false
-      }
-      override final def hashCode: Int = flatten(self).hashCode
-
-      private def eq(that: Cause[_]) = (self, that) match {
-        case (bl: Both[_], br: Both[_]) => bl.left == br.left && bl.right == br.right
-        case _                          => false
-      }
-      private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
-        case (Both(Both(al, bl), cl), Both(ar, Both(br, cr))) => al == ar && bl == br && cl == cr
-        case _                                                => false
-      }
-      private def comm(that: Cause[_]): Boolean = (self, that) match {
-        case (Both(al, bl), Both(ar, br)) => al == br && bl == ar
-        case _                            => false
-      }
-    }
-
-    private[Cause] def sym(f: (Cause[_], Cause[_]) => Boolean): (Cause[_], Cause[_]) => Boolean =
-      (l, r) => f(l, r) || f(r, l)
-
-    private[Cause] def flatten(c: Cause[_]): Set[Cause[_]] = c match {
-      case Then(left, right) => flatten(left) ++ flatten(right)
-      case Both(left, right) => flatten(left) ++ flatten(right)
-      case Traced(cause, _)  => flatten(cause)
-      case o                 => Set(o)
-    }
-  }
 }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -197,8 +197,8 @@ trait Fiber[+E, +A] { self =>
     UIO.effectTotal {
       val p: concurrent.Promise[A] = scala.concurrent.Promise[A]()
 
-      def failure(cause: Exit.Cause[E]): UIO[p.type] = UIO(p.failure(cause.squashWith(f)))
-      def success(value: A): UIO[p.type]             = UIO(p.success(value))
+      def failure(cause: Cause[E]): UIO[p.type] = UIO(p.failure(cause.squashWith(f)))
+      def success(value: A): UIO[p.type]        = UIO(p.success(value))
 
       UIO.effectTotal(p.future) <* self.await
         .flatMap[Any, Nothing, p.type](_.foldM[Any, Nothing, p.type](failure, success))

--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -16,8 +16,6 @@
 
 package zio
 
-import zio.Exit.Cause
-
 /**
  * Represents a failure in a fiber. This could be caused by some non-
  * recoverable error, such as a defect or system error, by some typed error,

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -18,7 +18,6 @@ package zio
 
 import java.util.concurrent.atomic.AtomicReference
 import Promise.internal._
-import zio.Exit.Cause
 
 /**
  * A promise represents an asynchronous variable that can be set exactly once,

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -16,8 +16,6 @@
 
 package zio
 
-import zio.Exit.Cause
-
 /**
  * A mutable atomic reference for the `IO` monad. This is the `IO` equivalent of
  * a volatile `var`, augmented with atomic effectful operations, which make it

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.Exit.Cause
 import zio.internal.Tracing
 import zio.internal.tracing.TracingConfig
 import zio.internal.{ Executor, FiberContext, Platform, PlatformConstants }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.Exit.Cause
 import zio.clock.Clock
 import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
@@ -2248,15 +2247,14 @@ object ZIO extends ZIO_R_Any {
     def apply(a: A): ZIO[R, E, A] = new ZIO.Succeed(a)
   }
 
-  final class MapErrorFn[R, E, E2, A](override val underlying: E => E2)
-      extends ZIOFn1[Exit.Cause[E], ZIO[R, E2, Nothing]] {
-    def apply(a: Exit.Cause[E]): ZIO[R, E2, Nothing] =
+  final class MapErrorFn[R, E, E2, A](override val underlying: E => E2) extends ZIOFn1[Cause[E], ZIO[R, E2, Nothing]] {
+    def apply(a: Cause[E]): ZIO[R, E2, Nothing] =
       ZIO.halt(a.map(underlying))
   }
 
-  final class MapErrorCauseFn[R, E, E2, A](override val underlying: Exit.Cause[E] => Exit.Cause[E2])
-      extends ZIOFn1[Exit.Cause[E], ZIO[R, E2, Nothing]] {
-    def apply(a: Exit.Cause[E]): ZIO[R, E2, Nothing] =
+  final class MapErrorCauseFn[R, E, E2, A](override val underlying: Cause[E] => Cause[E2])
+      extends ZIOFn1[Cause[E], ZIO[R, E2, Nothing]] {
+    def apply(a: Cause[E]): ZIO[R, E2, Nothing] =
       ZIO.halt(underlying(a))
   }
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -17,7 +17,6 @@
 package zio
 
 import scala.reflect.ClassTag
-import zio.Exit.Cause
 import zio.clock.Clock
 import zio.duration.Duration
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import scala.collection.JavaConverters._
 
 import zio.internal.FiberContext.{ FiberRefLocals, SuperviseStatus }
-import zio.Exit.Cause
+import zio.Cause
 import zio._
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.tracing.ZIOFn

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -18,7 +18,7 @@ package zio.internal
 
 import java.util.{ Map => JMap }
 
-import zio.Exit.Cause
+import zio.Cause
 import zio.internal.tracing.TracingConfig
 
 /**

--- a/core/shared/src/test/scala/zio/ArbitraryCause.scala
+++ b/core/shared/src/test/scala/zio/ArbitraryCause.scala
@@ -1,7 +1,6 @@
 package zio
 
 import org.scalacheck.{ Arbitrary, Gen }
-import Exit.Cause
 
 object ArbitraryCause {
   implicit def arbCause[T](implicit arbT: Arbitrary[T]): Arbitrary[Cause[T]] =

--- a/core/shared/src/test/scala/zio/BaseCrossPlatformSpec.scala
+++ b/core/shared/src/test/scala/zio/BaseCrossPlatformSpec.scala
@@ -7,7 +7,6 @@ import org.specs2.execute.AsResult
 import org.specs2.matcher.MatchResult
 import org.specs2.matcher.describe.Diffable
 import org.specs2.specification.core.{ AsExecution, Execution }
-import zio.Exit.Cause
 import zio.internal.PlatformLive
 import zio.clock.Clock
 import zio.console.Console

--- a/core/shared/src/test/scala/zio/ExitSpec.scala
+++ b/core/shared/src/test/scala/zio/ExitSpec.scala
@@ -1,7 +1,6 @@
 package zio
 
 import org.specs2.{ ScalaCheck, Specification }
-import zio.Exit.Cause
 
 class ExitSpec extends Specification with ScalaCheck {
   import Cause._

--- a/core/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core/shared/src/test/scala/zio/QueueSpec.scala
@@ -1,6 +1,5 @@
 package zio
 
-import zio.Exit.Cause
 import zio.QueueSpec.waitForSize
 import zio.clock.Clock
 import zio.duration._

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -16,7 +16,8 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   import ArbitraryChunk._
   import ArbitraryStream._
-  import Exit._
+  import Exit.{ Cause => _, _ }
+  import zio.Cause
 
   //in scala 2.11 the proof for Any in not found by the compiler
   import Stream.ConformsAnyProof

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -17,7 +17,7 @@
 package zio.stream
 
 import zio.IO
-import zio.Exit.Cause
+import zio.Cause
 
 /**
  * A `Take[E, A]` represents a single `take` from a queue modeling a stream of

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -18,7 +18,7 @@ package zio.stream
 
 import zio._
 import zio.clock.Clock
-import zio.Exit.Cause
+import zio.Cause
 import scala.annotation.implicitNotFound
 
 /**
@@ -238,7 +238,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
           for {
             out             <- Queue.bounded[Take[E1, B]](outputBuffer).toManaged(_.shutdown)
             permits         <- Semaphore.make(n).toManaged_
-            innerFailure    <- Promise.make[Exit.Cause[E1], Nothing].toManaged_
+            innerFailure    <- Promise.make[Cause[E1], Nothing].toManaged_
             interruptInners <- Promise.make[Nothing, Unit].toManaged_
 
             // - The driver stream forks an inner fiber for each stream created


### PR DESCRIPTION
I would love some help with the check 'ci/circleci: test_211_jdk8_jvm'. not really sure why it failed.

