### PR TITLE
Remove workarounds for Dotty ambiguous implicit errors

### DIFF
--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -3,7 +3,6 @@ package zio
 import org.scalacheck._
 import org.specs2.ScalaCheck
 import org.specs2.execute.Result
-import org.specs2.matcher.describe.Diffable
 
 import scala.collection.mutable
 import scala.util.Try
@@ -96,8 +95,6 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     res must be_===(List(1, 2, 3))
   }
 
-  implicit val d
-    : Diffable[Either[String, Nothing]] = Diffable.eitherDiffable[String, Nothing] //    TODO: Dotty has ambiguous implicits
   def t5 = forAll { (i: Int) =>
     val res = unsafeRun(IO.fail[Int](i).bimap(_.toString, identity).either)
     res must_=== Left(i.toString)
@@ -127,14 +124,13 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     res must be_===(List("1", "2", "3"))
   }
 
-  def t10: Prop = forAll { (l: List[Int]) =>
+  def t10 = forAll { (l: List[Int]) =>
     unsafeRun(IO.foldLeft(l)(0)((acc, el) => IO.succeed(acc + el))) must_=== unsafeRun(IO.succeed(l.sum))
   }
 
-  val ig = Gen.chooseNum(Int.MinValue, Int.MaxValue)
-  val g  = Gen.nonEmptyListOf(ig) //    TODO: Dotty has ambiguous implicits
-  def t11: Prop = forAll(g) { (l: List[Int]) =>
-    (unsafeRunSync(IO.foldLeft(l)(0)((_, _) => IO.fail("fail"))) must_=== unsafeRunSync(IO.fail("fail")))
+  def t11 = forAll { (l: List[Int]) =>
+    l.size > 0 ==>
+      (unsafeRunSync(IO.foldLeft(l)(0)((_, _) => IO.fail("fail"))) must_=== unsafeRunSync(IO.fail("fail")))
   }
 
   def testDone = {

--- a/core/jvm/src/test/scala/zio/IOSyntaxSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSyntaxSpec.scala
@@ -2,7 +2,6 @@ package zio
 
 import org.scalacheck._
 import org.specs2.ScalaCheck
-import org.specs2.matcher.describe.Diffable
 import zio.syntax._
 
 class IOCreationEagerSyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
@@ -26,8 +25,6 @@ class IOCreationEagerSyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       b <- IO.succeed(str)
     } yield a must ===(b))
   }
-  implicit val d
-    : Diffable[Either[String, Nothing]] = Diffable.eitherDiffable[String, Nothing] //    TODO: Dotty has ambiguous implicits
 
   def t2 = forAll(Gen.alphaStr) { str =>
     unsafeRun(for {

--- a/core/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/zio/RTSSpec.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.github.ghik.silencer.silent
 import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.describe.Diffable
 import zio.Cause.{ die, fail, Fail, Then }
 import zio.duration._
 import zio.clock.Clock
@@ -237,9 +236,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   }
 
   def testFlipValue = {
-    implicit val d
-      : Diffable[Right[Nothing, Int]] = Diffable.eitherRightDiffable[Int] //    TODO: Dotty has ambiguous implicits
-    val io                            = IO.succeed(100).flip
+    val io = IO.succeed(100).flip
     unsafeRun(io.either) must_=== Left(100)
   }
 
@@ -1172,17 +1169,11 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   def testRaceChoosesWinner =
     unsafeRun(IO.fail(42).race(IO.succeed(24)).either) must_=== Right(24)
 
-  def testRaceChoosesWinnerInTerminate = {
-    implicit val d
-      : Diffable[Right[Nothing, Int]] = Diffable.eitherRightDiffable[Int] //    TODO: Dotty has ambiguous implicits
+  def testRaceChoosesWinnerInTerminate =
     unsafeRun(IO.die(new Throwable {}).race(IO.succeed(24)).either) must_=== Right(24)
-  }
 
-  def testRaceChoosesFailure = {
-    implicit val d
-      : Diffable[Left[Int, Nothing]] = Diffable.eitherLeftDiffable[Int] //    TODO: Dotty has ambiguous implicits
+  def testRaceChoosesFailure =
     unsafeRun(IO.fail(42).race(IO.fail(42)).either) must_=== Left(42)
-  }
 
   def testRaceOfValueNever =
     unsafeRun(IO.succeedLazy(42).race(IO.never)) must_=== 42
@@ -1193,11 +1184,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   def testRaceAllOfValues =
     unsafeRun(IO.raceAll(IO.fail(42), List(IO.succeed(24))).either) must_=== Right(24)
 
-  def testRaceAllOfFailures = {
-    implicit val d
-      : Diffable[Left[Int, Nothing]] = Diffable.eitherLeftDiffable[Int] //    TODO: Dotty has ambiguous implicits
+  def testRaceAllOfFailures =
     unsafeRun(ZIO.raceAll(IO.fail(24).delay(10.millis), List(IO.fail(24))).either) must_=== Left(24)
-  }
 
   def testRaceAllOfFailuresOneSuccess =
     unsafeRun(ZIO.raceAll(IO.fail(42), List(IO.succeed(24).delay(1.millis))).either) must_=== Right(

--- a/core/jvm/src/test/scala/zio/ZManagedSpec.scala
+++ b/core/jvm/src/test/scala/zio/ZManagedSpec.scala
@@ -6,7 +6,6 @@ import org.scalacheck.{ Gen, _ }
 
 import org.specs2.ScalaCheck
 import org.specs2.matcher.MatchResult
-import org.specs2.matcher.describe.Diffable
 import zio.Cause.Interrupt
 import zio.Exit.Failure
 import zio.duration._
@@ -161,8 +160,6 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       interruption       <- managedFiber.interrupt.timeout(5.seconds).either
     } yield interruption
 
-    implicit val d: Diffable[Right[Nothing, Option[Exit[Nothing, Unit]]]] =
-      Diffable.eitherRightDiffable[Option[Exit[Nothing, Unit]]] //    TODO: Dotty has ambiguous implicits
     unsafeRun(program) must be_===(Right(expected))
   }
 

--- a/core/shared/src/test/scala/zio/FunctionIOSpec.scala
+++ b/core/shared/src/test/scala/zio/FunctionIOSpec.scala
@@ -1,6 +1,5 @@
 package zio
 
-import org.specs2.matcher.describe.Diffable
 import zio.FunctionIO._
 
 class FunctionIOSpec extends BaseCrossPlatformSpec {
@@ -181,8 +180,6 @@ class FunctionIOSpec extends BaseCrossPlatformSpec {
       } yield v must_=== "hola"
     )
 
-  implicit val d
-    : Diffable[Either[String, Nothing]] = Diffable.eitherDiffable[String, Nothing] //    TODO: Dotty has ambiguous implicits
   def e18a =
     unsafeRun(
       for {


### PR DESCRIPTION
specs was upgrded to 4.6.0 in #1114, this release contains
https://github.com/etorreborre/specs2/pull/751 which fixes the
underlying issue that lead to ambiguous implicit errors when using
Dotty, so all the workarounds can now be removed.