### PR TITLE
Alias `foreach` to `traverse` and `collectAll` to `sequence` (#1121)

### DIFF
--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -206,6 +206,12 @@ object Exit extends Serializable {
         .map(_.reverse)
     }
 
+  /**
+   *  Alias for [[Exit.collectAll]]
+   */
+  final def sequence[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+    collectAll[E, A](exits)
+
   final def collectAllPar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     exits.headOption.map { head =>
       exits
@@ -213,6 +219,12 @@ object Exit extends Serializable {
         .foldLeft(head.map(List(_)))((acc, el) => acc.zipWith(el)((acc, el) => el :: acc, _ && _))
         .map(_.reverse)
     }
+
+  /**
+   *  Alias for [[Exit.collectAllPar]]
+   */
+  final def sequencePar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+    collectAllPar[E, A](exits)
 
   final def die(t: Throwable): Exit[Nothing, Nothing] = halt(zio.Cause.die(t))
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1739,6 +1739,12 @@ private[zio] trait ZIOFunctions extends Serializable {
     }
 
   /**
+   * Alias for [[ZIO.foreach]]
+   */
+  final def traverse[R >: LowerR, E <: UpperE, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
+    foreach[R, E, A, B](in)(f)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
    * and returns the results in a new `List[B]`.
    *
@@ -1749,6 +1755,12 @@ private[zio] trait ZIOFunctions extends Serializable {
         fn(a).zipWithPar(io)((b, bs) => b :: bs)
       }
       .refailWithTrace
+
+  /**
+   * Alias for [[ZIO.foreachPar]]
+   */
+  final def traversePar[R >: LowerR, E <: UpperE, A, B](as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
+    foreachPar[R, E, A, B](as)(fn)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
@@ -1767,6 +1779,14 @@ private[zio] trait ZIOFunctions extends Serializable {
     } yield bs).refailWithTrace
 
   /**
+   * Alias for [[ZIO.foreachParN]]
+   */
+  final def traverseParN[R >: LowerR, E <: UpperE, A, B](
+    n: Long
+  )(as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
+    foreachParN[R, E, A, B](n)(as)(fn)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
    * produced effects sequentially.
    *
@@ -1780,6 +1800,12 @@ private[zio] trait ZIOFunctions extends Serializable {
         else ZIO.unit
       loop
     }
+
+  /**
+   * Alias for [[ZIO.foreach_]]
+   */
+  final def traverse_[R >: LowerR, E <: UpperE, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+    foreach_[R, E, A](as)(f)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
@@ -1800,6 +1826,12 @@ private[zio] trait ZIOFunctions extends Serializable {
       .refailWithTrace
 
   /**
+   * Alias for [[ZIO.foreachPar_]]
+   */
+  final def traversePar_[R >: LowerR, E <: UpperE, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+    foreachPar_[R, E, A](as)(f)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
    * produced effects in parallel, discarding the results.
    *
@@ -1818,11 +1850,25 @@ private[zio] trait ZIOFunctions extends Serializable {
       .refailWithTrace
 
   /**
+   * Alias for [[ZIO.foreachParN_]]
+   */
+  final def traverseParN_[R >: LowerR, E <: UpperE, A](
+    n: Long
+  )(as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+    foreachParN_[R, E, A](n)(as)(f)
+
+  /**
    * Evaluate each effect in the structure from left to right, and collect
    * the results. For a parallel version, see `collectAllPar`.
    */
   final def collectAll[R >: LowerR, E <: UpperE, A](in: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
     foreach[R, E, ZIO[R, E, A], A](in)(ZIO.identityFn)
+
+  /**
+   *  Alias for [[ZIO.collectAll]]
+]] */
+  final def sequence[R >: LowerR, E <: UpperE, A](in: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
+    collectAll[R, E, A](in)
 
   /**
    * Evaluate each effect in the structure in parallel, and collect
@@ -1832,6 +1878,12 @@ private[zio] trait ZIOFunctions extends Serializable {
     foreachPar[R, E, ZIO[R, E, A], A](as)(ZIO.identityFn)
 
   /**
+   *  Alias for [[ZIO.collectAllPar]]
+   */
+  final def sequencePar[R >: LowerR, E <: UpperE, A](as: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
+    collectAllPar[R, E, A](as)
+
+  /**
    * Evaluate each effect in the structure in parallel, and collect
    * the results. For a sequential version, see `collectAll`.
    *
@@ -1839,6 +1891,12 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def collectAllParN[R >: LowerR, E <: UpperE, A](n: Long)(as: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
     foreachParN[R, E, ZIO[R, E, A], A](n)(as)(ZIO.identityFn)
+
+  /**
+   *  Alias for [[ZIO.collectAllParN]]
+   */
+  final def sequenceParN[R >: LowerR, E <: UpperE, A](n: Long)(as: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
+    collectAllParN[R, E, A](n)(as)
 
   /**
    * Races an `IO[E, A]` against zero or more other effects. Yields either the

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -700,11 +700,23 @@ object ZManaged {
     foreach(ms)(scala.Predef.identity)
 
   /**
+   *  Alias for [[ZManaged.collectAll]]
+   */
+  final def sequence[R, E, A1, A2](ms: Iterable[ZManaged[R, E, A2]]): ZManaged[R, E, List[A2]] =
+    collectAll[R, E, A1, A2](ms)
+
+  /**
    * Evaluate each effect in the structure in parallel, and collect
    * the results. For a sequential version, see `collectAll`.
    */
   final def collectAllPar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     foreachPar(as)(scala.Predef.identity)
+
+  /**
+   *  Alias for [[ZManaged.collectAllPar]]
+   */
+  final def sequencePar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+    collectAllPar[R, E, A](as)
 
   /**
    * Evaluate each effect in the structure in parallel, and collect
@@ -714,6 +726,12 @@ object ZManaged {
    */
   final def collectAllParN[R, E, A](n: Long)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     foreachParN(n)(as)(scala.Predef.identity)
+
+  /**
+   *  Alias for [[ZManaged.collectAllParN]]
+   */
+  final def sequenceParN[R, E, A](n: Long)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+    collectAllParN[R, E, A](n)(as)
 
   /**
    * Returns an effect that dies with the specified `Throwable`.
@@ -776,6 +794,12 @@ object ZManaged {
     }
 
   /**
+   * Alias for [[ZManaged.foreach]]
+   */
+  final def traverse[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
+    foreach[R, E, A1, A2](as)(f)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
    * and returns the results in a new `List[B]`.
    *
@@ -790,6 +814,16 @@ object ZManaged {
       case (a, man) =>
         f(a).zipWithPar(man)(_ :: _)
     }
+
+  /**
+   * Alias for [[ZManaged.foreachPar]]
+   */
+  final def traversePar[R, E, A1, A2](
+    as: Iterable[A1]
+  )(
+    f: A1 => ZManaged[R, E, A2]
+  ): ZManaged[R, E, List[A2]] =
+    foreachPar[R, E, A1, A2](as)(f)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
@@ -808,6 +842,18 @@ object ZManaged {
     mergeAllParN[R, E, A2, Vector[A2]](n)(as.map(f))(Vector())((acc, a2) => acc :+ a2).map(_.toList)
 
   /**
+   * Alias for [[ZManaged.foreachParN]]
+   */
+  final def traverseParN[R, E, A1, A2](
+    n: Long
+  )(
+    as: Iterable[A1]
+  )(
+    f: A1 => ZManaged[R, E, A2]
+  ): ZManaged[R, E, List[A2]] =
+    foreachParN[R, E, A1, A2](n)(as)(f)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
    * produced effects sequentially.
    *
@@ -823,6 +869,12 @@ object ZManaged {
     }
 
   /**
+   * Alias for [[ZManaged.foreach_]]
+   */
+  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+    foreach_[R, E, A](as)(f)
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
    * produced effects in parallel, discarding the results.
    *
@@ -835,6 +887,12 @@ object ZManaged {
         else ZManaged.unit
       loop
     }
+
+  /**
+   * Alias for [[ZManaged.foreachPar_]]
+   */
+  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+    foreachPar_[R, E, A](as)(f)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs
@@ -852,6 +910,18 @@ object ZManaged {
     mergeAllParN[R, E, Any, Unit](n)(as.map(f))(()) { (_, _) =>
       ()
     }
+
+  /**
+   * Alias for [[ZManaged.foreachParN_]]
+   */
+  final def traverseParN_[R, E, A](
+    n: Long
+  )(
+    as: Iterable[A]
+  )(
+    f: A => ZManaged[R, E, Any]
+  ): ZManaged[R, E, Unit] =
+    foreachParN_[R, E, A](n)(as)(f)
 
   /**
    * Creates a [[ZManaged]] from an `AutoCloseable` resource. The resource's `close`


### PR DESCRIPTION
Resolves #1121 