### PR TITLE
Fix not existing referenced method in collectAllParN documentation

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1887,7 +1887,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * Evaluate each effect in the structure in parallel, and collect
    * the results. For a sequential version, see `collectAll`.
    *
-   * Unlike `foreachAllPar`, this method will use at most `n` fibers.
+   * Unlike `collectAllPar`, this method will use at most up to `n` fibers.
    */
   final def collectAllParN[R >: LowerR, E <: UpperE, A](n: Long)(as: Iterable[ZIO[R, E, A]]): ZIO[R, E, List[A]] =
     foreachParN[R, E, ZIO[R, E, A], A](n)(as)(ZIO.identityFn)


### PR DESCRIPTION
The `collectAllParN` documentation is referencing a method that does not exist (i.e. `foreachAllPar`).
This simply change the referenced method to the right one `(collectAllPar`). 

"up to" has been added to align with documentation of
`foreachParN_` https://github.com/zio/zio/blob/51ae75d1f1462193b1719067ce00e3ddd867644f/core/shared/src/main/scala/zio/ZIO.scala#L1769 and `foreachParN`  https://github.com/zio/zio/blob/51ae75d1f1462193b1719067ce00e3ddd867644f/core/shared/src/main/scala/zio/ZIO.scala#L1838.