### PR TITLE
Fix #1003 Attach unsafeRun location to the stack trace

### DIFF
--- a/core/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -100,7 +100,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
       (trace.executionTrace must have size 1) and
         (trace.executionTrace must mentionMethod("basicTest")) and
-        (trace.stackTrace must have size 1) and
+        (trace.stackTrace must have size 2) and
         (trace.stackTrace must mentionMethod("basicTest"))
     }
   }
@@ -117,7 +117,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun(io) must { trace: ZTrace =>
       show(trace)
 
-      (trace.stackTrace must have size 1) and
+      (trace.stackTrace must have size 2) and
         (trace.stackTrace must mentionMethod("foreachTrace")) and
         (trace.executionTrace must mentionMethod("foreachTrace")) and
         (trace.executionTrace must mentionMethod("foreach_")) and
@@ -151,7 +151,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         (trace1.stackTrace must mentionMethod("foreachFail")) and
         (trace1.executionTrace must mentionMethod("foreach_")) and
         (trace1.executionTrace must mentionMethod("foreachFail")) and
-        (trace2.stackTrace must have size 1) and
+        (trace2.stackTrace must have size 2) and
         (trace2.stackTrace must mentionMethod("foreachFail")) and
         (trace2.executionTrace must mentionMethod("foreach_")) and
         (trace2.executionTrace must mentionMethod("foreachFail"))
@@ -166,7 +166,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     } yield ()
 
     io causeMust {
-      _.traces.head.stackTrace must have size 1 and contain {
+      _.traces.head.stackTrace must have size 2 and contain {
         (_: ZTraceElement) match {
           case s: SourceLocation => s.method contains "foreachParFail"
           case _                 => false
@@ -189,7 +189,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun(io) must { trace: ZTrace =>
       show(trace)
 
-      (trace.stackTrace must beEmpty) and
+      (trace.stackTrace must have size 1) and
         (trace.executionTrace must forall[ZTraceElement](mentionMethod("leftAssociativeFold")))
     }
   }
@@ -206,11 +206,11 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       // but we haven't yet passed a single flatMap while going through
       // left binds, so our exec trace is empty.
       (trace1.executionTrace must beEmpty) and
-        (trace1.stackTrace must have size 4) and
+        (trace1.stackTrace must have size 5) and
         (trace1.stackTrace must mentionMethod("method2")) and
         (trace1.stackTrace must mentionMethod("method1")) and
         (trace1.stackTrace must mentionMethod("io")) and
-        (trace2.stackTrace must have size 1) and
+        (trace2.stackTrace must have size 2) and
         (trace2.stackTrace must mentionMethod("tuple")) and
         (trace2.executionTrace must mentionMethod("method2")) and
         (trace2.executionTrace must mentionMethod("method1")) and
@@ -287,7 +287,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     import fiberAncestryUploadExampleFixture._
 
     uploadUsers(List(new User)) causeMust { cause =>
-      (cause.traces.head.stackTrace must have size 1) and
+      (cause.traces.head.stackTrace must have size 2) and
         (cause.traces.head.stackTrace.head must mentionMethod("uploadUsers")) and
         (cause.traces(1).stackTrace must beEmpty) and
         (cause.traces(1).executionTrace must have size 1) and
@@ -323,7 +323,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       val trace = cause.traces.head
 
       // the bottom items on exec trace and stack trace refer to this line
-      (trace.stackTrace.last must mentionMethod("blockingTrace")) and
+      (trace.stackTrace must mentionMethod("blockingTrace")) and
         (trace.executionTrace.last must mentionMethod("blockingTrace"))
     }
 
@@ -345,7 +345,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       (cause.traces must have size 1) and
         (cause.traces.head.executionTrace must mentionMethod("traceThis")) and
         (cause.traces.head.executionTrace must not have mentionedMethod("tracingRegions")) and
-        (cause.traces.head.stackTrace must beEmpty)
+        (cause.traces.head.stackTrace must have size 1)
     }
   }
 
@@ -402,7 +402,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     selectHumans causeMust { cause =>
       (cause.traces must have size 1) and
-        (cause.traces.head.stackTrace must have size 1) and
+        (cause.traces.head.stackTrace must have size 2) and
         (cause.traces.head.stackTrace.head must mentionMethod("selectHumans"))
     }
   }
@@ -421,8 +421,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     selectHumans causeMust { cause =>
       (cause.traces must have size 1) and
-        (cause.traces.head.stackTrace must have size 1) and
-        (cause.traces.head.stackTrace.last must mentionMethod("selectHumans"))
+        (cause.traces.head.stackTrace must have size 2) and
+        (cause.traces.head.stackTrace must mentionMethod("selectHumans"))
     }
   }
 
@@ -440,8 +440,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     selectHumans causeMust { cause =>
       (cause.traces must have size 1) and
-        (cause.traces.head.stackTrace must have size 1) and
-        (cause.traces.head.stackTrace.last must mentionMethod("selectHumans"))
+        (cause.traces.head.stackTrace must have size 2) and
+        (cause.traces.head.stackTrace must mentionMethod("selectHumans"))
     }
   }
 
@@ -469,7 +469,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       (cause.traces must have size 1) and
         (cause.traces.head.executionTrace must have size 1) and
         (cause.traces.head.executionTrace must mentionMethod("fail")) and
-        (cause.traces.head.stackTrace must have size 3) and
+        (cause.traces.head.stackTrace must have size 4) and
         (cause.traces.head.stackTrace.head must mentionMethod("badMethod")) and
         (cause.traces.head.stackTrace(1) must mentionMethod("apply")) and // PartialFunction.apply
         (cause.traces.head.stackTrace(2) must mentionMethod("catchSomeWithOptimizedEffect"))
@@ -496,7 +496,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         (cause.traces.head.executionTrace must have size 2) and
         (cause.traces.head.executionTrace.head must mentionMethod("refailAndLoseTrace")) and
         (cause.traces.head.executionTrace.last must mentionMethod("fail")) and
-        (cause.traces.head.stackTrace must have size 1) and
+        (cause.traces.head.stackTrace must have size 2) and
         (cause.traces.head.stackTrace.head must mentionMethod("catchAllWithOptimizedEffect"))
     }
   }
@@ -523,7 +523,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       (cause.traces must have size 1) and
         (cause.traces.head.executionTrace must have size 1) and
         (cause.traces.head.executionTrace.head must mentionMethod("fail")) and
-        (cause.traces.head.stackTrace must have size 3) and
+        (cause.traces.head.stackTrace must have size 4) and
         (cause.traces.head.stackTrace.head must mentionMethod("succ")) and
         (cause.traces.head.stackTrace(1) must mentionMethod("mapError")) and
         (cause.traces.head.stackTrace(2) must mentionMethod("mapErrorPreservesTrace"))
@@ -548,7 +548,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun(io) must { trace: ZTrace =>
       show(trace)
 
-      (trace.stackTrace must have size 1) and
+      (trace.stackTrace must have size 2) and
         (trace.stackTrace must mentionMethod("foldMWithOptimizedEffect")) and
         (trace.executionTrace must have size 2) and
         (trace.executionTrace.head must mentionMethod("mkTrace")) and

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -17,7 +17,7 @@
 package zio
 
 import zio.internal.Tracing
-import zio.internal.tracing.TracingConfig
+import zio.internal.tracing.{ TracingConfig, ZIOFn }
 import zio.internal.{ Executor, FiberContext, Platform, PlatformConstants }
 
 /**
@@ -53,7 +53,7 @@ trait Runtime[+R] {
    *
    * This method is effectful and should only be done at the edges of your program.
    */
-  final def unsafeRun[E, A](zio: ZIO[R, E, A]): A =
+  final def unsafeRun[E, A](zio: => ZIO[R, E, A]): A =
     unsafeRunSync(zio).getOrElse(c => throw FiberFailure(c))
 
   /**
@@ -62,7 +62,7 @@ trait Runtime[+R] {
    *
    * This method is effectful and should only be invoked at the edges of your program.
    */
-  final def unsafeRunSync[E, A](zio: ZIO[R, E, A]): Exit[E, A] = {
+  final def unsafeRunSync[E, A](zio: => ZIO[R, E, A]): Exit[E, A] = {
     val result = internal.OneShot.make[Exit[E, A]]
 
     unsafeRunAsync(zio)((x: Exit[E, A]) => result.set(x))
@@ -76,7 +76,7 @@ trait Runtime[+R] {
    *
    * This method is effectful and should only be invoked at the edges of your program.
    */
-  final def unsafeRunAsync[E, A](zio: ZIO[R, E, A])(k: Exit[E, A] => Unit): Unit = {
+  final def unsafeRunAsync[E, A](zio: => ZIO[R, E, A])(k: Exit[E, A] => Unit): Unit = {
     val InitialInterruptStatus = InterruptStatus.Interruptible
 
     val context = new FiberContext[E, A](
@@ -90,7 +90,7 @@ trait Runtime[+R] {
       Platform.newWeakHashMap()
     )
 
-    context.evaluateNow(zio.asInstanceOf[IO[E, A]])
+    context.evaluateNow(ZIOFn.recordStackTrace(() => zio)(zio.asInstanceOf[IO[E, A]]))
     context.runAsync(k)
   }
 

--- a/core/shared/src/main/scala/zio/internal/tracing/ZIOFn.scala
+++ b/core/shared/src/main/scala/zio/internal/tracing/ZIOFn.scala
@@ -16,7 +16,7 @@
 
 package zio.internal.tracing
 
-import zio.{ UIO, ZIO }
+import zio.ZIO
 
 /**
  * Marks a ZIO utility function that wraps a user-supplied lambda.
@@ -46,7 +46,17 @@ private[zio] object ZIOFn {
     final def apply(a: A): B     = real(a)
   }
 
+  /**
+   * Adds the specified lambda to the execution trace before `zio` is evaluated
+   */
   @noinline
   final def recordTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
-    UIO.unit.flatMap(ZIOFn(lambda)(_ => zio))
+    ZIO.unit.flatMap(ZIOFn(lambda)(_ => zio))
+
+  /**
+   * Adds the specified lambda to the stack trace during the evaluation of `zio`
+   * */
+  @noinline
+  final def recordStackTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    zio.map(ZIOFn(lambda)(ZIO.identityFn))
 }


### PR DESCRIPTION
[Fiber trace should tell where unsafeRun was called](https://github.com/zio/zio/issues/1003)