### PR TITLE
clarify that callback must be called at most once for async effects

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1513,6 +1513,8 @@ private[zio] trait ZIOFunctions extends Serializable {
    * Imports an asynchronous effect into a pure `ZIO` value. See `effectAsyncMaybe` for
    * the more expressive variant of this function that can return a value
    * synchronously.
+   *
+   * The callback function `ZIO[R, E, A] => Unit` must be called at most once.
    */
   final def effectAsync[R >: LowerR, E <: UpperE, A](register: (ZIO[R, E, A] => Unit) => Unit): ZIO[R, E, A] =
     effectAsyncMaybe((callback: ZIO[R, E, A] => Unit) => {
@@ -1524,6 +1526,10 @@ private[zio] trait ZIOFunctions extends Serializable {
   /**
    * Imports an asynchronous effect into a pure `ZIO` value, possibly returning
    * the value synchronously.
+   *
+   * If the register function returns a value synchronously then the callback function
+   * `ZIO[R, E, A] => Unit` must not be called. Otherwise the callback function must
+   * be called at most once.
    */
   final def effectAsyncMaybe[R >: LowerR, E <: UpperE, A](
     register: (ZIO[R, E, A] => Unit) => Option[ZIO[R, E, A]]
@@ -1557,6 +1563,10 @@ private[zio] trait ZIOFunctions extends Serializable {
    * until the effect is actually executed. The effect also has the option of
    * returning a canceler, which will be used by the runtime to cancel the
    * asynchronous effect if the fiber executing the effect is interrupted.
+   *
+   * If the register function returns a value synchronously then the callback
+   * function `ZIO[R, E, A] => Unit` must not be called. Otherwise the callback
+   * function must be called at most once.
    */
   final def effectAsyncInterrupt[R >: LowerR, E <: UpperE, A](
     register: (ZIO[R, E, A] => Unit) => Either[Canceler, ZIO[R, E, A]]


### PR DESCRIPTION
Studying the source code I have the impression that the callback function that is provided by the register function for asynchronous effects must be called at most once. I added that information to scala doc.