### PR TITLE
Add ZStream#throttle (#1027)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(core % "test->test;compile->compile")
 
-lazy val streamsJVM = streams.jvm
+lazy val streamsJVM = streams.jvm.dependsOn(testkitJVM % "test->compile")
 lazy val streamsJS  = streams.js
 
 lazy val testkit = crossProject(JVMPlatform)

--- a/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -219,7 +219,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       for {
         clock <- Ref.make(TestClock.Zero).map(ref => new Clock { val clock = TestClock(ref) })
         test <- ZSink
-                 .throttleEnforceM[Any, Nothing, Int](1, 10.milliseconds)(_ => UIO.succeed(1))
+                 .throttleEnforce[Int](1, 10.milliseconds)(_ => 1)
                  .use(sinkTest)
                  .provide(clock)
       } yield test

--- a/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -24,7 +24,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     Sink.foldM short circuits   $foldMShortCircuits
     Sink.collectAllWhile        $collectAllWhile
     ZSink.fromOutputStream      $sinkFromOutputStream
-    ZSink.throttle              $throttle
+    ZSink.throttleEnforce       $throttleEnforce
 
   Usecases
     Number array parsing with Sink.foldM  $jsonNumArrayParsingSinkFoldM
@@ -198,7 +198,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     }
   }
 
-  private def throttle = {
+  private def throttleEnforce = {
 
     def sinkTest(sink: ZSink[Clock, Nothing, Nothing, Int, Option[Int]]) =
       for {
@@ -218,7 +218,10 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun {
       for {
         clock <- Ref.make(TestClock.Zero).map(ref => new Clock { val clock = TestClock(ref) })
-        test  <- ZSink.throttle[Any, Nothing, Int](1, 10.milliseconds)(_ => UIO.succeed(1)).use(sinkTest).provide(clock)
+        test <- ZSink
+                 .throttleEnforceM[Any, Nothing, Int](1, 10.milliseconds)(_ => UIO.succeed(1))
+                 .use(sinkTest)
+                 .provide(clock)
       } yield test
     }
   }

--- a/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -4,6 +4,9 @@ import org.scalacheck.Arbitrary
 import org.specs2.ScalaCheck
 import scala.{ Stream => _ }
 import zio._
+import zio.clock.Clock
+import zio.duration._
+import zio.testkit.TestClock
 
 class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     extends TestRuntime
@@ -21,6 +24,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     Sink.foldM short circuits   $foldMShortCircuits
     Sink.collectAllWhile        $collectAllWhile
     ZSink.fromOutputStream      $sinkFromOutputStream
+    ZSink.throttle              $throttle
 
   Usecases
     Number array parsing with Sink.foldM  $jsonNumArrayParsingSinkFoldM
@@ -191,6 +195,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     stream.run(ZSink.fromOutputStream(output)) map { bytesWritten =>
       (bytesWritten must_=== 10) and (new String(output.toByteArray, "UTF-8") must_=== data)
+    }
+  }
+
+  private def throttle = {
+
+    def sinkTest(sink: ZSink[Clock, Nothing, Nothing, Int, Option[Int]]) =
+      for {
+        init1 <- sink.initial
+        step1 <- sink.step(Step.state(init1), 1)
+        res1  <- sink.extract(Step.state(step1))
+        init2 <- sink.initial
+        _     <- clock.sleep(7.milliseconds)
+        step2 <- sink.step(Step.state(init2), 2)
+        res2  <- sink.extract(Step.state(step2))
+        init3 <- sink.initial
+        _     <- clock.sleep(7.milliseconds)
+        step3 <- sink.step(Step.state(init3), 3)
+        res3  <- sink.extract(Step.state(step3))
+      } yield (res1 must_=== Some(1)) and (res2 must_=== None) and (res3 must_=== Some(3))
+
+    unsafeRun {
+      for {
+        clock <- Ref.make(TestClock.Zero).map(ref => new Clock { val clock = TestClock(ref) })
+        test  <- ZSink.throttle[Any, Nothing, Int](1, 10.milliseconds)(_ => UIO.succeed(1)).use(sinkTest).provide(clock)
+      } yield test
     }
   }
 }

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -880,13 +880,13 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def throttleEnforceFreeElements = unsafeRun {
     Stream(1, 2, 3, 4)
-      .throttleEnforceM(0, 1.second)(_ => UIO.succeed(0))
+      .throttleEnforce(0, 1.second)(_ => 0)
       .runCollect must_=== List(1, 2, 3, 4)
   }
 
   private def throttleEnforceNoBandwidth = unsafeRun {
     Stream(1, 2, 3, 4)
-      .throttleEnforceM(0, 1.second)(_ => UIO.succeed(1))
+      .throttleEnforce(0, 1.second)(_ => 1)
       .runCollect must_=== List()
   }
 
@@ -896,7 +896,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun {
       Stream(1, 2, 3, 4, 5)
         .mapM(delay)
-        .throttleEnforceM(2, 1.second)(_ => UIO.succeed(1))
+        .throttleEnforce(2, 1.second)(_ => 1)
         .take(2)
         .runCollect must_=== List(1, 2)
     }

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -130,7 +130,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   Stream.throttle
     free elements           $throttleFreeElements
     no bandwidth            $throttleNoBandwidth
-    no refill               $throttleNoRefill
     throttle short circuits $throttleShortCircuits
 
   Stream.toQueue            $toQueue
@@ -852,20 +851,14 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def throttleFreeElements = unsafeRun {
     Stream(1, 2, 3, 4)
-      .throttle(0, 0, 0, 1.second)(_ => UIO.succeed(0))
+      .throttle(0, 1.second)(_ => UIO.succeed(0))
       .runCollect must_=== List(1, 2, 3, 4)
   }
 
   private def throttleNoBandwidth = unsafeRun {
     Stream(1, 2, 3, 4)
-      .throttle(0, 0, 0, 1.second)(_ => UIO.succeed(1))
+      .throttle(0, 1.second)(_ => UIO.succeed(1))
       .runCollect must_=== List()
-  }
-
-  private def throttleNoRefill = unsafeRun {
-    Stream(1, 2, 3, 4)
-      .throttle(3, 3, 0, 1.second)(_ => UIO.succeed(1))
-      .runCollect must_=== List(1, 2, 3)
   }
 
   private def throttleShortCircuits = {
@@ -874,7 +867,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun {
       Stream(1, 2, 3, 4, 5)
         .mapM(delay)
-        .throttle(5, 3, 1, 1.second)(_ => UIO.succeed(1))
+        .throttle(2, 1.second)(_ => UIO.succeed(1))
         .take(2)
         .runCollect must_=== List(1, 2)
     }

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -130,8 +130,8 @@ object Sink {
   /**
    * see [[ZSink.throttle]]
    */
-  final def throttle[E, A](units: Long, duration: Duration)(
+  final def throttleEnforceM[E, A](units: Long, duration: Duration)(
     costFn: A => IO[E, Long]
   ): ZManaged[Clock, E, ZSink[Clock, E, Nothing, A, Option[A]]] =
-    ZSink.throttle[Any, E, A](units, duration)(costFn)
+    ZSink.throttleEnforceM[Any, E, A](units, duration)(costFn)
 }

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -16,8 +16,10 @@
 
 package zio.stream
 
+import zio._
+import zio.clock.Clock
+import zio.duration.Duration
 import zio.stream.ZSink.Step
-import zio.IO
 
 object Sink {
 
@@ -125,4 +127,16 @@ object Sink {
   final def succeedLazy[B](b: => B): Sink[Nothing, Nothing, Any, B] =
     ZSink.succeedLazy(b)
 
+  /**
+   * see [[ZSink.throttle]]
+   */
+  final def throttle[E, A](
+    bucketCapacity: Long,
+    initialTokens: Long,
+    refill: Long,
+    refillInterval: Duration
+  )(
+    costFn: A => IO[E, Long]
+  ): ZManaged[Any with Clock, E, Sink[E, Nothing, A, Option[A]]] =
+    ZSink.throttle(bucketCapacity, initialTokens, refill, refillInterval)(costFn)
 }

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -128,7 +128,15 @@ object Sink {
     ZSink.succeedLazy(b)
 
   /**
-   * see [[ZSink.throttle]]
+   * see [[ZSink.throttleEnforce]]
+   */
+  final def throttleEnforce[A](units: Long, duration: Duration)(
+    costFn: A => Long
+  ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, Option[A]]] =
+    ZSink.throttleEnforce(units, duration)(costFn)
+
+  /**
+   * see [[ZSink.throttleEnforceM]]
    */
   final def throttleEnforceM[E, A](units: Long, duration: Duration)(
     costFn: A => IO[E, Long]

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -130,13 +130,8 @@ object Sink {
   /**
    * see [[ZSink.throttle]]
    */
-  final def throttle[E, A](
-    bucketCapacity: Long,
-    initialTokens: Long,
-    refill: Long,
-    refillInterval: Duration
-  )(
+  final def throttle[E, A](units: Long, duration: Duration)(
     costFn: A => IO[E, Long]
-  ): ZManaged[Any with Clock, E, Sink[E, Nothing, A, Option[A]]] =
-    ZSink.throttle(bucketCapacity, initialTokens, refill, refillInterval)(costFn)
+  ): ZManaged[Clock, E, ZSink[Clock, E, Nothing, A, Option[A]]] =
+    ZSink.throttle[Any, E, A](units, duration)(costFn)
 }

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1076,6 +1076,17 @@ object ZSink extends ZSinkPlatformSpecific {
   /**
    * Creates a sink which throttles input elements of type A according to the given bandwidth parameters
    * using the token bucket algorithm. Elements that do not meet the bandwidth constraints are dropped.
+   * The weight of each element is determined by the `costFn` function. Elements are mapped to
+   * `Option[A]`, and `None` denotes that a given element has been dropped.
+   */
+  final def throttleEnforce[A](units: Long, duration: Duration)(
+    costFn: A => Long
+  ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, Option[A]]] =
+    throttleEnforceM[Any, Nothing, A](units, duration)(a => UIO.succeed(costFn(a)))
+
+  /**
+   * Creates a sink which throttles input elements of type A according to the given bandwidth parameters
+   * using the token bucket algorithm. Elements that do not meet the bandwidth constraints are dropped.
    * The weight of each element is determined by the `costFn` effectful function. Elements are mapped to
    * `Option[A]`, and `None` denotes that a given element has been dropped.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1111,10 +1111,10 @@ object ZSink extends ZSinkPlatformSpecific {
     refillInterval: Duration
   )(
     costFn: A => ZIO[R, E, Long]
-  ): ZManaged[R with Clock, E, ZSink[R, E, A, A, Option[A]]] = {
+  ): ZManaged[R with Clock, E, ZSink[R, E, Nothing, A, Option[A]]] = {
     import ZSink.internal._
 
-    def bucketSink(bucket: Ref[Long]) = new ZSink[R, E, A, A, Option[A]] {
+    def bucketSink(bucket: Ref[Long]) = new ZSink[R, E, Nothing, A, Option[A]] {
       type State = (Ref[Long], Option[A])
       val initial = UIO.succeed(Step.more((bucket, None)))
       def step(state: State, a: A) =

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1075,11 +1075,11 @@ object ZSink extends ZSinkPlatformSpecific {
 
   /**
    * Creates a sink which throttles input elements of type A according to the given bandwidth parameters
-   * using the token bucket algorithm. The weight of each element is determined by the `costFn` effectful
-   * function. Stream elements are mapped to `Option[A]`, and `None` denotes that a given element has
-   * been throttled.
+   * using the token bucket algorithm. Elements that do not meet the bandwidth constraints are dropped.
+   * The weight of each element is determined by the `costFn` effectful function. Elements are mapped to
+   * `Option[A]`, and `None` denotes that a given element has been dropped.
    */
-  final def throttle[R, E, A](units: Long, duration: Duration)(
+  final def throttleEnforceM[R, E, A](units: Long, duration: Duration)(
     costFn: A => ZIO[R, E, Long]
   ): ZManaged[R with Clock, E, ZSink[R with Clock, E, Nothing, A, Option[A]]] = {
     import ZSink.internal._

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -784,13 +784,14 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
 
   /**
    * Throttles elements of type A according to the given bandwidth parameters using the token bucket
-   * algorithm. The weight of each element is determined by the `costFn` effectful function.
+   * algorithm. Elements that do not meet the bandwidth constraints are dropped. The weight of each
+   * element is determined by the `costFn` effectful function.
    */
-  final def throttle[R1 <: R, E1 >: E](units: Long, duration: Duration)(
+  final def throttleEnforceM[R1 <: R, E1 >: E](units: Long, duration: Duration)(
     costFn: A => ZIO[R1, E1, Long]
   ): ZStream[R1 with Clock, E1, A] =
     self
-      .transduceManaged(ZSink.throttle(units, duration)(costFn))
+      .transduceManaged(ZSink.throttleEnforceM(units, duration)(costFn))
       .collect { case Some(a) => a }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -785,6 +785,16 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   /**
    * Throttles elements of type A according to the given bandwidth parameters using the token bucket
    * algorithm. Elements that do not meet the bandwidth constraints are dropped. The weight of each
+   * element is determined by the `costFn` function.
+   */
+  final def throttleEnforce(units: Long, duration: Duration)(
+    costFn: A => Long
+  ): ZStream[R with Clock, E, A] =
+    throttleEnforceM(units, duration)(a => UIO.succeed(costFn(a)))
+
+  /**
+   * Throttles elements of type A according to the given bandwidth parameters using the token bucket
+   * algorithm. Elements that do not meet the bandwidth constraints are dropped. The weight of each
    * element is determined by the `costFn` effectful function.
    */
   final def throttleEnforceM[R1 <: R, E1 >: E](units: Long, duration: Duration)(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -774,16 +774,11 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Throttles elements of type A according to the given bandwidth parameters using the token bucket
    * algorithm. The weight of each element is determined by the `costFn` effectful function.
    */
-  final def throttle[R1 <: R, E1 >: E](
-    bucketCapacity: Long,
-    initialTokens: Long,
-    refill: Long,
-    refillInterval: Duration
-  )(
+  final def throttle[R1 <: R, E1 >: E](units: Long, duration: Duration)(
     costFn: A => ZIO[R1, E1, Long]
   ): ZStream[R1 with Clock, E1, A] =
     self
-      .transduceManaged(ZSink.throttle(bucketCapacity, initialTokens, refill, refillInterval)(costFn))
+      .transduceManaged(ZSink.throttle(units, duration)(costFn))
       .collect { case Some(a) => a }
 
   /**


### PR DESCRIPTION
Token bucket throttling implementation.

I would have liked to use ZSchedule to control the bucket refilling, but I can't seem to figure out how to create a schedule which adds an initial delay to the refilling effect, otherwise, the bucket is initialized with the configurable initial capacity and immediately refilled without any delay. Any help is appreciated.

This is my first open-source contribution. Looking forward to the comments.