### PR TITLE
Fix documentation build

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -72,13 +72,13 @@ object Schedule {
     ZSchedule.doWhile(f)
 
   /**
-   * See [[ZSchedule.doUntil]]
+   * See [[[ZSchedule.doUntil[A](f:* ZSchedule.doUntil]]]
    */
   final def doUntil[A](f: A => Boolean): Schedule[A, A] =
     ZSchedule.doUntil(f)
 
   /**
-   * See [[ZSchedule.doUntil]]
+   * See [[ZSchedule.doUntil[A,B](pf:* ZSchedule.doUntil]]]
    */
   final def doUntil[A, B](pf: PartialFunction[A, B]): Schedule[A, Option[B]] =
     ZSchedule.doUntil(pf)


### PR DESCRIPTION
Fix error on Circle:
https://circleci.com/gh/zio/zio/6083
```
[error] /home/circleci/project/core/shared/src/main/scala/zio/Schedule.scala:80:3: The link target "ZSchedule.doUntil" is ambiguous. Several members fit the target:
[error] [A, B](pf: PartialFunction[A,B]): zio.Schedule[A,Option[B]] in object ZSchedule [chosen]
[error] [A](f: A => Boolean): zio.Schedule[A,A] in object ZSchedule
[error] 
[error] 
[error] Quick crash course on using Scaladoc links
[error] ==========================================
[error] Disambiguating terms and types: Prefix terms with '$' and types with '!' in case both names are in use:
[error]  - [[scala.collection.immutable.List!.apply class List's apply method]] and
[error]  - [[scala.collection.immutable.List$.apply object List's apply method]]
[error] Disambiguating overloaded members: If a term is overloaded, you can indicate the first part of its signature followed by *:
[error]  - [[[scala.collection.immutable.List$.fill[A](Int)(⇒A):List[A]* Fill with a single parameter]]]
[error]  - [[[scala.collection.immutable.List$.fill[A](Int,Int)(⇒A):List[List[A]]* Fill with a two parameters]]]
[error] Notes:
[error]  - you can use any number of matching square brackets to avoid interference with the signature
[error]  - you can use \\. to escape dots in prefixes (don't forget to use * at the end to match the signature!)
[error]  - you can use \\# to escape hashes, otherwise they will be considered as delimiters, like dots.
[error]   /**
[error]   ^
[error] /home/circleci/project/core/shared/src/main/scala/zio/Schedule.scala:74:3: The link target "ZSchedule.doUntil" is ambiguous. Several members fit the target:
[error] [A, B](pf: PartialFunction[A,B]): zio.Schedule[A,Option[B]] in object ZSchedule [chosen]
[error] [A](f: A => Boolean): zio.Schedule[A,A] in object ZSchedule
[error] 
[error]   /**
[error]   ^
[error] two errors found
```