### PR TITLE
Add Random.shuffle method

### DIFF
--- a/core/shared/src/main/scala-2.11/random.scala
+++ b/core/shared/src/main/scala-2.11/random.scala
@@ -31,4 +31,5 @@ package object random {
   val nextLong: ZIO[Random, Nothing, Long]                      = ZIO.accessM(_.random.nextLong)
   val nextPrintableChar: ZIO[Random, Nothing, Char]             = ZIO.accessM(_.random.nextPrintableChar)
   def nextString(length: Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.random.nextString(length))
+  def shuffle[A](list: List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.random.shuffle(list))
 }

--- a/core/shared/src/main/scala-2.12+/random.scala
+++ b/core/shared/src/main/scala-2.12+/random.scala
@@ -30,4 +30,5 @@ package object random extends Random.Service[Random] {
   val nextLong: ZIO[Random, Nothing, Long]                      = ZIO.accessM(_.random.nextLong)
   val nextPrintableChar: ZIO[Random, Nothing, Char]             = ZIO.accessM(_.random.nextPrintableChar)
   def nextString(length: Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.random.nextString(length))
+  def shuffle[A](list: List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.random.shuffle(list))
 }

--- a/core/shared/src/test/scala/zio/RetrySpec.scala
+++ b/core/shared/src/test/scala/zio/RetrySpec.scala
@@ -263,6 +263,8 @@ class RetrySpec extends BaseCrossPlatformSpec {
         UIO.succeed('A')
       def nextString(length: Int): UIO[String] =
         UIO.succeed("")
+      def shuffle[A](list: List[A]): UIO[List[A]] =
+        UIO.succeed(list.reverse)
     }
   }
 }

--- a/testkit/jvm/src/main/scala/zio/testkit/TestRandom.scala
+++ b/testkit/jvm/src/main/scala/zio/testkit/TestRandom.scala
@@ -42,6 +42,8 @@ final case class TestRandom(ref: Ref[TestRandom.Data]) extends Random.Service[An
 
   def nextString(length: Int): UIO[String] = nextRandom(shiftStrings(length))
 
+  def shuffle[A](list: List[A]): UIO[List[A]] = Random.shuffleWith(nextInt, list)
+
   private def nextRandom[T](shift: Data => (T, Data)) =
     for {
       data            <- ref.get


### PR DESCRIPTION
The `zio.random.Random` is missing `shuffle` method, probably due to implicit argument in `scala.util.Random.shuffle` interface (AFAIK ZIO is implicit-free by design).

Neverthless having a shuffle method for some basic types like: `Array` or `List` would be really nice.