### PR TITLE
Fix #1165 - foreachParN should not use more than 'n' fibers

### DIFF
--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -611,11 +611,11 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   def testForeachParN_Interruption = {
     import zio.duration._
     val actions = List(
-      clock.sleep(100.millis) *> ZIO.fail("A"),
+      clock.sleep(1000.millis) *> ZIO.fail("A"),
       ZIO.succeed(1),
       ZIO.fail("C")
     )
-    val io = ZIO.foreachParN(4)(actions)(a => a).timeout(50.millis)
+    val io = ZIO.foreachParN(4)(actions)(a => a).timeout(500.millis)
     unsafeRun(io.either) must_=== Left("C")
   }
 }

--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -585,7 +585,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def testForeachParN_Threads = {
     val n   = 10L
-    val seq = 0 to 1000000
+    val seq = 0 to 100000
     val res = unsafeRun(IO.foreachParN(n)(seq)(UIO.succeed))
     res must be_===(seq)
   }

--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -63,6 +63,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
    Check `collectM` returns failure ignoring value $testCollectM
    Check `reject` returns failure ignoring value $testReject
    Check `rejectM` returns failure ignoring value $testRejectM
+   Check `foreachParN` works on large lists $testForeachParN
     """
 
   def functionIOGen: Gen[String => Task[Int]] =
@@ -513,5 +514,12 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     ).left.map(_.failureOrCause) must_=== Left(Left("Partial failed!"))
 
     goodCase and partialBadCase and badCase
+  }
+
+  def testForeachParN = {
+    val n   = 10L
+    val seq = 0 to 1000000
+    val res = unsafeRun(IO.foreachParN(n)(seq)(UIO.succeed))
+    res must be_===(seq)
   }
 }

--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -609,15 +609,12 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def testForeachParN_Interruption = {
-    val io = for {
-      latch <- Promise.make[Nothing, Unit]
-      actions = List(
-        latch.await *> ZIO.fail("A"),
-        ZIO.succeed(1),
-        ZIO.fail("C").ensuring(latch.succeed(()))
-      )
-      res <- ZIO.foreachParN(4)(actions)(a => a)
-    } yield res
+    val actions = List(
+      ZIO.never,
+      ZIO.succeed(1),
+      ZIO.fail("C")
+    )
+    val io = ZIO.foreachParN(4)(actions)(a => a)
     unsafeRun(io.either) must_=== Left("C")
   }
 }

--- a/core/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/zio/IOSpec.scala
@@ -611,11 +611,11 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   def testForeachParN_Interruption = {
     import zio.duration._
     val actions = List(
-      clock.sleep(10.millis) *> ZIO.fail("A"),
+      clock.sleep(100.millis) *> ZIO.fail("A"),
       ZIO.succeed(1),
       ZIO.fail("C")
     )
-    val io = ZIO.foreachParN(4)(actions)(a => a).timeout(5.millis)
+    val io = ZIO.foreachParN(4)(actions)(a => a).timeout(50.millis)
     unsafeRun(io.either) must_=== Left("C")
   }
 }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -72,13 +72,13 @@ object Schedule {
     ZSchedule.doWhile(f)
 
   /**
-   * See [[ZSchedule.doUntil]]
+   * See [[ZSchedule.doUntil[A](f:A=>Boolean)*]]
    */
   final def doUntil[A](f: A => Boolean): Schedule[A, A] =
     ZSchedule.doUntil(f)
 
   /**
-   * See [[ZSchedule.doUntil]]
+   * See [[ZSchedule.doUntil[A,B](pf:PartialFunction[A,B])*]]
    */
   final def doUntil[A, B](pf: PartialFunction[A, B]): Schedule[A, Option[B]] =
     ZSchedule.doUntil(pf)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1763,9 +1763,6 @@ private[zio] trait ZIOFunctions extends Serializable {
   final def foreachParN[R, E, A, B](
     n: Long
   )(as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
-  final def foreachParN[R >: LowerR, E <: UpperE, A, B](
-    n: Long
-  )(as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
     for {
       q     <- Queue.bounded[(Promise[E, B], A)](n.toInt)
       pairs <- ZIO.foreach(as)(a => Promise.make[E, B].map(p => (p, a)))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1769,10 +1769,13 @@ private[zio] trait ZIOFunctions extends Serializable {
       _     <- ZIO.foreach(pairs)(pair => q.offer(pair)).fork
       _ <- ZIO.collectAll(
             List.fill(n.toInt)(
-              q.take.flatMap { case (p, a) => fn(a).onError(_ => q.shutdown).flatMap(p.succeed) }.forever.fork
+              q.take.flatMap {
+                case (p, a) =>
+                  fn(a).foldCauseM(e => p.halt(e) *> q.shutdown, b => p.succeed(b)).onError(_ => q.shutdown)
+              }.forever.fork
             )
           )
-      res <- ZIO.collectAll(pairs.map(_._1.await)).ensuring(q.shutdown)
+      res <- ZIO.foreach(pairs)(_._1.await).ensuring(q.shutdown)
     } yield res
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1769,10 +1769,7 @@ private[zio] trait ZIOFunctions extends Serializable {
       _     <- ZIO.foreach(pairs)(pair => q.offer(pair)).fork
       _ <- ZIO.collectAll(
             List.fill(n.toInt)(
-              q.take.flatMap {
-                case (p, a) =>
-                  fn(a).foldCauseM(e => p.halt(e) *> q.shutdown, b => p.succeed(b)).onError(_ => q.shutdown)
-              }.forever.fork
+              q.take.flatMap { case (p, a) => fn(a).foldCauseM(e => p.halt(e) *> q.shutdown, b => p.succeed(b)) }.forever.fork
             )
           )
       res <- ZIO.foreach(pairs)(_._1.await).ensuring(q.shutdown)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1763,7 +1763,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   final def foreachParN[R, E, A, B](
     n: Long
   )(as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
-    for {
+    (for {
       q     <- Queue.bounded[(Promise[E, B], A)](n.toInt)
       pairs <- ZIO.foreach(as)(a => Promise.make[E, B].map(p => (p, a)))
       _     <- ZIO.foreach(pairs)(pair => q.offer(pair)).fork
@@ -1771,7 +1771,7 @@ private[zio] trait ZIOFunctions extends Serializable {
             case (p, a) => fn(a).foldCauseM(c => ZIO.foreach(pairs)(_._1.halt(c)), b => p.succeed(b))
           }.forever.fork))
       res <- ZIO.foreach(pairs)(_._1.await).ensuring(q.shutdown)
-    } yield res
+    } yield res).refailWithTrace
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs


### PR DESCRIPTION
Following the suggestion in #1165 uses a queue to ensure that `foreachParN` only uses `n` fibers and thus can successfully traverse very large lists. I also added a test for this.

I noticed that the performance is still slow compared to `scala.concurrent.Future` and `monix.eval.Task` but I believe that some of these issues are being addressed in #1182 so think it makes sense to resolve that before optimizing this.