### PR TITLE
Add ZManaged.makeExit that allows to handle `Exit` by the finalizer.

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZManagedSpec.scala
@@ -156,7 +156,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
 
   // unlike make, reserve allows interruption
   private def interruptible =
-    doInterrupt(io => ZManaged.reserve(Reservation(io, IO.unit)), Some(Failure(Interrupt)))
+    doInterrupt(io => ZManaged.reserve(Reservation(io, _ => IO.unit)), Some(Failure(Interrupt)))
 
   private def doInterrupt(
     managed: IO[Nothing, Unit] => ZManaged[Any, Nothing, Unit],
@@ -341,7 +341,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
 
     val managed = ZManaged.reserve(Reservation(ZIO.effectTotal(retries += 1) *> {
       if (retries == 3) ZIO.unit else ZIO.fail(())
-    }, ZIO.unit))
+    }, _ => ZIO.unit))
 
     unsafeRun(managed.retry(Schedule.recurs(3)).use(_ => ZIO.unit))
     retries must be_===(3)
@@ -357,7 +357,10 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
         if (retries1 < 3) ZIO.fail(())
         else
           ZIO.succeed {
-            Reservation(ZIO.effectTotal(retries2 += 1) *> { if (retries2 == 3) ZIO.unit else ZIO.fail(()) }, ZIO.unit)
+            Reservation(
+              ZIO.effectTotal(retries2 += 1) *> { if (retries2 == 3) ZIO.unit else ZIO.fail(()) },
+              _ => ZIO.unit
+            )
           }
       }
 
@@ -372,7 +375,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       for {
         latch  <- Promise.make[Nothing, Unit]
         first  = ZManaged.fromEffect(latch.succeed(()) *> ZIO.sleep(Duration.Infinity))
-        second = ZManaged.reserve(Reservation(latch.await *> ZIO.fail(()), ZIO.unit))
+        second = ZManaged.reserve(Reservation(latch.await *> ZIO.fail(()), _ => ZIO.unit))
         _      <- first.zipPar(second).use_(ZIO.unit)
       } yield ()
     } must be_===(Exit.Failure(Cause.Both(Cause.Fail(()), Cause.Interrupt)))
@@ -390,7 +393,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
   private def zipParFailAcquisitionRelease = {
     var releases = 0
     val first    = ZManaged.unit
-    val second   = ZManaged.reserve(Reservation(ZIO.fail(()), ZIO.effectTotal(releases += 1)))
+    val second   = ZManaged.reserve(Reservation(ZIO.fail(()), _ => ZIO.effectTotal(releases += 1)))
 
     unsafeRunSync(first.zipPar(second).use(_ => ZIO.unit))
     releases must be_===(1)
@@ -401,7 +404,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       for {
         reserveLatch <- Promise.make[Nothing, Unit]
         releases     <- Ref.make[Int](0)
-        first        = ZManaged.reserve(Reservation(reserveLatch.succeed(()), releases.update(_ + 1)))
+        first        = ZManaged.reserve(Reservation(reserveLatch.succeed(()), _ => releases.update(_ + 1)))
         second       = ZManaged.fromEffect(reserveLatch.await *> ZIO.fail(()))
         _            <- first.zipPar(second).use_(ZIO.unit).orElse(ZIO.unit)
         count        <- releases.get
@@ -445,7 +448,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
     unsafeRun {
       for {
         latch   <- Promise.make[Nothing, Unit]
-        managed = ZManaged.reserve(Reservation(latch.await, ZIO.unit))
+        managed = ZManaged.reserve(Reservation(latch.await, _ => ZIO.unit))
         res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(res must_=== (None)))
         _       <- latch.succeed(())
       } yield res
@@ -456,7 +459,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       for {
         reserveLatch <- Promise.make[Nothing, Unit]
         releaseLatch <- Promise.make[Nothing, Unit]
-        managed      = ZManaged.reserve(Reservation(reserveLatch.await, releaseLatch.succeed(())))
+        managed      = ZManaged.reserve(Reservation(reserveLatch.await, _ => releaseLatch.succeed(())))
         res          <- managed.timeout(Duration.Zero).use(ZIO.succeed)
         _            <- reserveLatch.succeed(())
         _            <- releaseLatch.await
@@ -468,7 +471,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       for {
         acquireLatch <- Promise.make[Nothing, Unit]
         releaseLatch <- Promise.make[Nothing, Unit]
-        managed      = ZManaged(acquireLatch.await *> ZIO.succeed(Reservation(ZIO.unit, releaseLatch.succeed(()))))
+        managed      = ZManaged(acquireLatch.await *> ZIO.succeed(Reservation(ZIO.unit, _ => releaseLatch.succeed(()))))
         res          <- managed.timeout(Duration.Zero).use(ZIO.succeed)
         _            <- acquireLatch.succeed(())
         _            <- releaseLatch.await
@@ -477,7 +480,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
 
   private def timed = {
     val managed = ZManaged(
-      clock.sleep(20.milliseconds) *> ZIO.succeed(Reservation(clock.sleep(20.milliseconds), ZIO.unit))
+      clock.sleep(20.milliseconds) *> ZIO.succeed(Reservation(clock.sleep(20.milliseconds), _ => ZIO.unit))
     )
     unsafeRun {
       managed.timed.use { case (duration, _) => ZIO.succeed(duration must be_>=(40.milliseconds)) }
@@ -601,7 +604,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       finalized <- Ref.make(false)
       latch     <- Promise.make[Nothing, Unit]
       _ <- ZManaged
-            .reserve(Reservation(latch.succeed(()) *> ZIO.never, finalized.set(true)))
+            .reserve(Reservation(latch.succeed(()) *> ZIO.never, _ => finalized.set(true)))
             .fork
             .use_(latch.await)
       result <- finalized.get
@@ -617,7 +620,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
               .reserve(
                 Reservation(
                   acquireLatch.succeed(()) *> ZIO.never,
-                  finalized.set(true)
+                  _ => finalized.set(true)
                 )
               )
               .fork
@@ -834,7 +837,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       effects      <- Ref.make(0)
       reserveLatch <- Promise.make[Nothing, Unit]
       baseRes = ZManaged.reserve(
-        Reservation(effects.update(_ + 1) *> ZIO.effectTotal(latch.countDown()) *> reserveLatch.await, ZIO.unit)
+        Reservation(effects.update(_ + 1) *> ZIO.effectTotal(latch.countDown()) *> reserveLatch.await, _ => ZIO.unit)
       )
       res   = f(baseRes)
       _     <- res.use_(ZIO.unit).fork *> ZIO.effectTotal(latch.await())

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -150,6 +150,12 @@ object Managed {
     ZManaged.make(acquire)(release)
 
   /**
+   * See [[zio.ZManaged.makeExit]]
+   */
+  final def makeExit[E, A](acquire: IO[E, A])(release: (A, Exit[_, _]) => UIO[_]): Managed[E, A] =
+    ZManaged.makeExit(acquire)(release)
+
+  /**
    * See [[zio.ZManaged.mergeAll]]
    */
   final def mergeAll[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -117,7 +117,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
    * Acquires `n` permits in a [[zio.ZManaged]] and releases the permits in the finalizer.
    */
   final def withPermitsManaged[R, E](n: Long): ZManaged[R, E, Unit] =
-    ZManaged(prepare(n).map(a => Reservation(a.awaitAcquire, a.release)))
+    ZManaged(prepare(n).map(a => Reservation(a.awaitAcquire, _ => a.release)))
 
   final private def cleanup[E, A](ops: Acquisition, res: Exit[E, A]): UIO[Unit] =
     res match {

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1031,10 +1031,11 @@ object ZManaged {
               } yield b).ensuring((queue.shutdown *> ZIO.foreach_(fibers)(_.interrupt)).uninterruptible)
             }
           },
-          exitU => for {
-            fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_(exitU).run)
-          } yield Exit.collectAllPar(exits)
+          exitU =>
+            for {
+              fs    <- finalizers.get
+              exits <- ZIO.foreach(fs)(_(exitU).run)
+            } yield Exit.collectAllPar(exits)
         )
       }
     }
@@ -1114,10 +1115,11 @@ object ZManaged {
                 } yield result).ensuring((queue.shutdown *> ZIO.foreach_(fibers)(_.interrupt)).uninterruptible)
             }
           },
-          exitU => for {
-            fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_(exitU).run)
-          } yield Exit.collectAllPar(exits)
+          exitU =>
+            for {
+              fs    <- finalizers.get
+              exits <- ZIO.foreach(fs)(_(exitU).run)
+            } yield Exit.collectAllPar(exits)
         )
       }
     }

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -26,7 +26,7 @@ import zio.duration.Duration
  *
  * See [[ZManaged#reserve]] and [[ZIO#reserve]] for details of usage.
  */
-final case class Reservation[-R, +E, +A](acquire: ZIO[R, E, A], release: ZIO[R, Nothing, Any])
+final case class Reservation[-R, +E, +A](acquire: ZIO[R, E, A], release: Exit[_, _] => ZIO[R, Nothing, Any])
 
 /**
  * A `ZManaged[R, E, A]` is a managed resource of type `A`, which may be used by
@@ -191,7 +191,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def ensuring[R1 <: R](f: ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
-        r.copy(release = r.release.ensuring(f))
+        r.copy(release = e => r.release(e).ensuring(f))
       }
     }
 
@@ -204,7 +204,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def ensuringFirst[R1 <: R](f: ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
-        r.copy(release = f.ensuring(r.release))
+        r.copy(release = e => f.ensuring(r.release(e)))
       }
     }
 
@@ -220,7 +220,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
     ZManaged[R1, E1, B] {
-      Ref.make[List[ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = for {
             resR <- reserve
@@ -232,11 +232,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
                       .uninterruptible
             r1 <- resR1.acquire
           } yield r1,
-          release = for {
-            fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_.run)
-            _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
-          } yield ()
+          release = exitU =>
+            for {
+              fs    <- finalizers.get
+              exits <- ZIO.foreach(fs)(_(exitU).run)
+              _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
+            } yield ()
         )
       }
     }
@@ -294,7 +295,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
     success: A => ZManaged[R1, E2, B]
   ): ZManaged[R1, E2, B] =
     ZManaged[R1, E2, B] {
-      Ref.make[List[ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = {
             val direct =
@@ -317,11 +318,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
               }
             direct.foldM(onFailure, onSuccess)
           },
-          release = for {
-            fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_.run)
-            _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
-          } yield ()
+          release = exitU =>
+            for {
+              fs    <- finalizers.get
+              exits <- ZIO.foreach(fs)(_(exitU).run)
+              _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
+            } yield ()
         )
       }
     }
@@ -334,7 +336,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def fork: ZManaged[R, Nothing, Fiber[E, A]] =
     ZManaged {
       for {
-        finalizer <- Ref.make[ZIO[R, Nothing, Any]](UIO.unit)
+        finalizer <- Ref.make[Exit[_, _] => ZIO[R, Nothing, Any]](_ => UIO.unit)
         // The reservation phase of the new `ZManaged` runs uninterruptibly;
         // so to make sure the acquire phase of the original `ZManaged` runs
         // interruptibly, we need to create an interruptible hole in the region.
@@ -348,7 +350,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
                 }.fork
         reservation = Reservation(
           acquire = UIO.succeed(fiber),
-          release = fiber.interrupt *> finalizer.get.flatMap(identity(_))
+          release = e => fiber.interrupt *> finalizer.get.flatMap(f => f(e))
         )
       } yield reservation
     }
@@ -396,17 +398,17 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
     ZManaged {
-      Ref.make[ZIO[R1, Nothing, Any]](UIO.unit).map { finalizer =>
+      Ref.make[Exit[_, _] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
           acquire = ZIO.uninterruptibleMask { restore =>
             for {
               res   <- self.reserve
               exitA <- restore(res.acquire).run
-              _     <- finalizer.set(res.release.ensuring(cleanup(exitA)))
+              _     <- finalizer.set(exitU => res.release(exitU).ensuring(cleanup(exitA)))
               a     <- ZIO.done(exitA)
             } yield a
           },
-          release = finalizer.get.flatten
+          release = e => finalizer.get.flatMap(f => f(e))
         )
       }
     }
@@ -417,17 +419,17 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def onExitFirst[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
     ZManaged {
-      Ref.make[ZIO[R1, Nothing, Any]](UIO.unit).map { finalizer =>
+      Ref.make[Exit[_, _] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
           acquire = ZIO.uninterruptibleMask { restore =>
             for {
               res   <- self.reserve
               exitA <- restore(res.acquire).run
-              _     <- finalizer.set(cleanup(exitA).ensuring(res.release))
+              _     <- finalizer.set(exitU => cleanup(exitA).ensuring(res.release(exitU)))
               a     <- ZIO.done(exitA)
             } yield a
           },
-          release = finalizer.get.flatten
+          release = e => finalizer.get.flatMap(f => f(e))
         )
       }
     }
@@ -478,7 +480,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * leaving the remainder `R0`.
    */
   final def provideSome[R0](f: R0 => R): ZManaged[R0, E, A] =
-    ZManaged(reserve.provideSome(f).map(r => Reservation(r.acquire.provideSome(f), r.release.provideSome(f))))
+    ZManaged(reserve.provideSome(f).map(r => Reservation(r.acquire.provideSome(f), e => r.release(e).provideSome(f))))
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
@@ -583,12 +585,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
                     )
                 )
             }, {
-              case (_, leftFiber) =>
+              case (exit, leftFiber) =>
                 val cleanup = leftFiber.await
                   .flatMap(
                     _.foldM(
                       _ => ZIO.unit,
-                      _.release
+                      _.release(exit)
                     )
                   )
                   .uninterruptible
@@ -603,7 +605,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
           Reservation(acquire.timeout(Duration.fromNanos(d.toNanos - spentTime.toNanos)), release)
         case Some((_, Reservation(_, release))) =>
           Reservation(ZIO.succeed(None), release)
-        case _ => Reservation(ZIO.succeed(None), ZIO.unit)
+        case _ => Reservation(ZIO.succeed(None), _ => ZIO.unit)
       }
     }
 
@@ -625,7 +627,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Run an effect while acquiring the resource before and releasing it after
    */
   final def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    reserve.bracket(_.release)(_.acquire.flatMap(f))
+    reserve.bracketExit((r, e: Exit[_, _]) => r.release(e), _.acquire.flatMap(f))
 
   /**
    *  Run an effect while acquiring the resource before and releasing it after.
@@ -702,7 +704,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def zipWithPar[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f0: (A, A1) => A2): ZManaged[R1, E1, A2] =
     ZManaged[R1, E1, A2] {
-      Ref.make[List[ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = {
             val left = ZIO.uninterruptibleMask { restore =>
@@ -717,11 +719,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
             }
             left.zipWithPar(right)(f0)
           },
-          release = for {
-            fs    <- finalizers.get
-            exits <- ZIO.foreachPar(fs)(_.run)
-            _     <- ZIO.done(Exit.collectAllPar(exits).getOrElse(Exit.unit))
-          } yield ()
+          release = exitU =>
+            for {
+              fs    <- finalizers.get
+              exits <- ZIO.foreachPar(fs)(_(exitU).run)
+              _     <- ZIO.done(Exit.collectAllPar(exits).getOrElse(Exit.unit))
+            } yield ()
         )
       }
     }
@@ -810,7 +813,7 @@ object ZManaged {
    * release action.
    */
   final def finalizer[R](f: ZIO[R, Nothing, _]): ZManaged[R, Nothing, Unit] =
-    ZManaged.reserve(Reservation(ZIO.unit, f))
+    ZManaged.reserve(Reservation(ZIO.unit, _ => f))
 
   /**
    * Returns an effect that performs the outer effect first, followed by the
@@ -922,7 +925,7 @@ object ZManaged {
    * with care.
    */
   final def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
-    ZManaged(IO.succeed(Reservation(fa, IO.unit)))
+    ZManaged(IO.succeed(Reservation(fa, _ => IO.unit)))
 
   /**
    * Lifts an `Either` into a `ZManaged` value.
@@ -961,7 +964,15 @@ object ZManaged {
    * Lifts a `ZIO[R, E, R]` into `ZManaged[R, E, R]` with a release action.
    */
   final def make[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, _]): ZManaged[R, E, A] =
-    ZManaged(acquire.map(r => Reservation(IO.succeed(r), release(r))))
+    ZManaged(acquire.map(r => Reservation(IO.succeed(r), _ => release(r))))
+
+  /**
+   * Lifts a `ZIO[R, E, R]` into `ZManaged[R, E, R]` with a release action that handles `Exit`.
+   */
+  final def makeExit[R, E, A](
+    acquire: ZIO[R, E, A]
+  )(release: (A, Exit[_, _]) => ZIO[R, Nothing, _]): ZManaged[R, E, A] =
+    ZManaged(acquire.map(r => Reservation(IO.succeed(r), e => release(r, e))))
 
   /**
    * Merges an `Iterable[IO]` to a single IO, working sequentially.
@@ -992,7 +1003,7 @@ object ZManaged {
     f: (B, A) => B
   ): ZManaged[R, E, B] =
     ZManaged[R, E, B] {
-      Ref.make[List[ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[_, _] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           Queue.unbounded[(ZManaged[R, E, A], Promise[E, A])].flatMap { queue =>
             val worker = queue.take.flatMap {
@@ -1020,9 +1031,9 @@ object ZManaged {
               } yield b).ensuring((queue.shutdown *> ZIO.foreach_(fibers)(_.interrupt)).uninterruptible)
             }
           },
-          for {
+          exitU => for {
             fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_.run)
+            exits <- ZIO.foreach(fs)(_(exitU).run)
           } yield Exit.collectAllPar(exits)
         )
       }
@@ -1069,7 +1080,7 @@ object ZManaged {
     f: (A, A) => A
   ): ZManaged[R, E, A] =
     ZManaged[R, E, A] {
-      Ref.make[List[ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[_, _] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           Queue.unbounded[(ZManaged[R, E, A], Promise[E, A])].flatMap { queue =>
             val worker = queue.take.flatMap {
@@ -1103,9 +1114,9 @@ object ZManaged {
                 } yield result).ensuring((queue.shutdown *> ZIO.foreach_(fibers)(_.interrupt)).uninterruptible)
             }
           },
-          for {
+          exitU => for {
             fs    <- finalizers.get
-            exits <- ZIO.foreach(fs)(_.run)
+            exits <- ZIO.foreach(fs)(_(exitU).run)
           } yield Exit.collectAllPar(exits)
         )
       }
@@ -1149,13 +1160,13 @@ object ZManaged {
    * Lifts a strict, pure value into a Managed.
    */
   final def succeed[R, A](r: A): ZManaged[R, Nothing, A] =
-    ZManaged(IO.succeed(Reservation(IO.succeed(r), IO.unit)))
+    ZManaged(IO.succeed(Reservation(IO.succeed(r), _ => IO.unit)))
 
   /**
    * Lifts a by-name, pure value into a Managed.
    */
   final def succeedLazy[R, A](r: => A): ZManaged[R, Nothing, A] =
-    ZManaged(IO.succeed(Reservation(IO.succeedLazy(r), IO.unit)))
+    ZManaged(IO.succeed(Reservation(IO.succeedLazy(r), _ => IO.unit)))
 
   /**
    * Returns a lazily constructed Managed.

--- a/docs/datatypes/managed.md
+++ b/docs/datatypes/managed.md
@@ -100,7 +100,7 @@ Whilst having more control, a concurrency primitive such as `Promise` may be nee
 ```scala mdoc:silent
 val data: IO[IOException, String] = for {
   p <- Promise.make[IOException,File]
-  res = Reservation(openFile("x", p), closeFile(p))
+  res = Reservation(openFile("x", p), _ => closeFile(p))
   result <- (for {
       fiber  <- res.acquire.fork
       ex     <- fiber.interrupt

--- a/docs/datatypes/managed.md
+++ b/docs/datatypes/managed.md
@@ -77,34 +77,3 @@ val combined: Managed[IOException, (Queue[Int], File)] = for {
 val usedCombinedRes: IO[IOException, Unit] = combined.use { case (queue, file) => doSomething(queue, file) }
 
 ```
-
-## Reservation
-
-Unlike `Managed`, `Reservation` does not bind `release` to `acquire` allowing interruptible resource acquisition. 
-
-```scala mdoc:invisible
-import java.io.{ File, IOException, InterruptedIOException }
-import scala.util.Try
-
-def openFile(name: String, p: Promise[IOException, File]): IO[IOException, File] = UIO.succeedLazy(new File(name))
-def closeFile(p: Promise[IOException, File]): UIO[Unit] = UIO.unit
-def readFile(file: File): IO[IOException, String] = IO.succeedLazy("Don't forget to clean up!")
-```
-
-```scala mdoc:silent
-import zio._
-```
-
-Whilst having more control, a concurrency primitive such as `Promise` may be needed to help properly manage resource state and clean up.
-
-```scala mdoc:silent
-val data: IO[IOException, String] = for {
-  p <- Promise.make[IOException,File]
-  res = Reservation(openFile("x", p), _ => closeFile(p))
-  result <- (for {
-      fiber  <- res.acquire.fork
-      ex     <- fiber.interrupt
-      data   <- ex.toEither.fold(e => IO.fail(new InterruptedIOException("Stop!")), file => readFile(file))
-    } yield data).ensuring(res.release)
-} yield result
-```

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1681,7 +1681,7 @@ object ZStream extends ZStreamPlatformSpecific {
     new ZStream[R, Nothing, Nothing] {
       def fold[R1 <: R, E1, A1, S]: ZStream.Fold[R1, E1, A1, S] =
         ZManaged.succeedLazy { (s, _, _) =>
-          ZManaged.reserve(Reservation(UIO.succeed(s), finalizer))
+          ZManaged.reserve(Reservation(UIO.succeed(s), _ => finalizer))
         }
     }
 


### PR DESCRIPTION
Resolves #1231.