### PR TITLE
Signal stream end ZStream.effectAsync

### DIFF
--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -64,6 +64,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     effectAsync                 $effectAsync
 
   Stream.effectAsyncMaybe
+    effectAsyncMaybeEmptyStream $effectAsyncMaybeEmptyStream
     effectAsyncMaybe Some       $effectAsyncMaybeSome
     effectAsyncMaybe None       $effectAsyncMaybeNone
 
@@ -514,6 +515,17 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
                  .effectAsyncM[Nothing, Int] { k =>
                    k(IO.fail(None))
                    UIO.succeed(())
+                 }
+                 .runCollect
+    } yield result must_=== List()
+  }
+
+  private def effectAsyncMaybeEmptyStream = unsafeRun {
+    for {
+      result <- Stream
+                 .effectAsyncMaybe[Nothing, Int] { k =>
+                   k(IO.fail(None))
+                   None
                  }
                  .runCollect
     } yield result must_=== List()

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -69,6 +69,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   Stream.effectAsyncM
     effectAsyncM                $effectAsyncM
+    effectAsyncMEmptyStream     $effectAsyncMEmptyStream
 
   Stream.effectAsyncInterrupt
     effectAsyncInterruptEmptyStream $effectAsyncInterruptEmptyStream
@@ -505,6 +506,17 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         s <- fiber.join
       } yield s must_=== list
     }
+  }
+
+  private def effectAsyncMEmptyStream = unsafeRun {
+    for {
+      result <- Stream
+                 .effectAsyncM[Nothing, Int] { k =>
+                   k(IO.fail(None))
+                   UIO.succeed(())
+                 }
+                 .runCollect
+    } yield result must_=== List()
   }
 
   private def effectAsyncMaybeSome =

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -71,8 +71,9 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     effectAsyncM                $effectAsyncM
 
   Stream.effectAsyncInterrupt
-    effectAsyncInterrupt Left   $effectAsyncInterruptLeft
-    effectAsyncInterrupt Right  $effectAsyncInterruptRight
+    effectAsyncInterruptEmptyStream $effectAsyncInterruptEmptyStream
+    effectAsyncInterrupt Left       $effectAsyncInterruptLeft
+    effectAsyncInterrupt Right      $effectAsyncInterruptRight
 
   Stream.ensuring $ensuring
 
@@ -524,6 +525,17 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
       slurp(s.take(list.size)) must_=== Success(list)
     }
+
+  private def effectAsyncInterruptEmptyStream = unsafeRun {
+    for {
+      result <- Stream
+                 .effectAsyncInterrupt[Nothing, Int] { k =>
+                   k(IO.fail(None))
+                   Left(UIO.succeed(()))
+                 }
+                 .runCollect
+    } yield result must_=== List()
+  }
 
   private def effectAsyncInterruptLeft = unsafeRun {
     for {

--- a/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -64,18 +64,18 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     effectAsync                 $effectAsync
 
   Stream.effectAsyncMaybe
-    effectAsyncMaybeEmptyStream $effectAsyncMaybeEmptyStream
-    effectAsyncMaybe Some       $effectAsyncMaybeSome
-    effectAsyncMaybe None       $effectAsyncMaybeNone
+    effectAsyncMaybe signal end stream $effectAsyncMaybeSignalEndStream
+    effectAsyncMaybe Some              $effectAsyncMaybeSome
+    effectAsyncMaybe None              $effectAsyncMaybeNone
 
   Stream.effectAsyncM
-    effectAsyncM                $effectAsyncM
-    effectAsyncMEmptyStream     $effectAsyncMEmptyStream
+    effectAsyncM                   $effectAsyncM
+    effectAsyncM signal end stream $effectAsyncMSignalEndStream
 
   Stream.effectAsyncInterrupt
-    effectAsyncInterruptEmptyStream $effectAsyncInterruptEmptyStream
-    effectAsyncInterrupt Left       $effectAsyncInterruptLeft
-    effectAsyncInterrupt Right      $effectAsyncInterruptRight
+    effectAsyncInterrupt Left              $effectAsyncInterruptLeft
+    effectAsyncInterrupt Right             $effectAsyncInterruptRight
+    effectAsyncInterrupt signal end stream $effectAsyncInterruptSignalEndStream
 
   Stream.ensuring $ensuring
 
@@ -509,7 +509,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     }
   }
 
-  private def effectAsyncMEmptyStream = unsafeRun {
+  private def effectAsyncMSignalEndStream = unsafeRun {
     for {
       result <- Stream
                  .effectAsyncM[Nothing, Int] { k =>
@@ -520,7 +520,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     } yield result must_=== List()
   }
 
-  private def effectAsyncMaybeEmptyStream = unsafeRun {
+  private def effectAsyncMaybeSignalEndStream = unsafeRun {
     for {
       result <- Stream
                  .effectAsyncMaybe[Nothing, Int] { k =>
@@ -550,17 +550,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       slurp(s.take(list.size)) must_=== Success(list)
     }
 
-  private def effectAsyncInterruptEmptyStream = unsafeRun {
-    for {
-      result <- Stream
-                 .effectAsyncInterrupt[Nothing, Int] { k =>
-                   k(IO.fail(None))
-                   Left(UIO.succeed(()))
-                 }
-                 .runCollect
-    } yield result must_=== List()
-  }
-
   private def effectAsyncInterruptLeft = unsafeRun {
     for {
       cancelled <- Ref.make(false)
@@ -586,6 +575,17 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
       slurp(s.take(list.size)) must_=== Success(list)
     }
+
+  private def effectAsyncInterruptSignalEndStream = unsafeRun {
+    for {
+      result <- Stream
+                 .effectAsyncInterrupt[Nothing, Int] { k =>
+                   k(IO.fail(None))
+                   Left(UIO.succeed(()))
+                 }
+                 .runCollect
+    } yield result must_=== List()
+  }
 
   private def ensuring =
     unsafeRun {

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -88,7 +88,7 @@ object Stream extends ZStreamPlatformSpecific {
    * See [[ZStream.effectAsyncInterrupt]]
    */
   final def effectAsyncInterrupt[E, A](
-    register: (IO[E, A] => Unit) => Either[Canceler, Stream[E, A]],
+    register: (IO[Option[E], A] => Unit) => Either[Canceler, Stream[E, A]],
     outputBuffer: Int = 16
   ): Stream[E, A] =
     ZStream.effectAsyncInterrupt(register, outputBuffer)

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -61,7 +61,7 @@ object Stream extends ZStreamPlatformSpecific {
    * See [[ZStream.effectAsync]]
    */
   final def effectAsync[E, A](
-    register: (IO[E, A] => Unit) => Unit,
+    register: (IO[Option[E], A] => Unit) => Unit,
     outputBuffer: Int = 16
   ): Stream[E, A] =
     ZStream.effectAsync(register, outputBuffer)
@@ -70,7 +70,7 @@ object Stream extends ZStreamPlatformSpecific {
    * See [[ZStream.effectAsyncMaybe]]
    */
   final def effectAsyncMaybe[E, A](
-    register: (IO[E, A] => Unit) => Option[Stream[E, A]],
+    register: (IO[Option[E], A] => Unit) => Option[Stream[E, A]],
     outputBuffer: Int = 16
   ): Stream[E, A] =
     ZStream.effectAsyncMaybe(register, outputBuffer)

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -79,7 +79,7 @@ object Stream extends ZStreamPlatformSpecific {
    * See [[ZStream.effectAsyncM]]
    */
   final def effectAsyncM[E, A](
-    register: (IO[E, A] => Unit) => IO[E, _],
+    register: (IO[Option[E], A] => Unit) => IO[E, _],
     outputBuffer: Int = 16
   ): Stream[E, A] =
     ZStream.effectAsyncM(register, outputBuffer)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1558,7 +1558,7 @@ object ZStream extends ZStreamPlatformSpecific {
                              register(
                                k =>
                                  runtime.unsafeRunAsync_(
-                                   k.foldM[R, E, Option[A]](
+                                   k.foldM(
                                        _.fold[ZIO[R, E, Option[A]]](UIO.succeed(None))(e => IO.fail(e)),
                                        a => UIO.succeed(Some(a))
                                      )

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1496,14 +1496,14 @@ object ZStream extends ZStreamPlatformSpecific {
                             register(
                               k =>
                                 runtime.unsafeRunAsync_(
-                                  k.foldM(
-                                      _.fold[ZIO[R, E, Option[A]]](UIO.succeed(None))(e => IO.fail(e)),
-                                      a => UIO.succeed(Some(a))
-                                    )
-                                    .foldCauseM(
-                                      cause => output.offer(Take.Fail(cause)).unit,
-                                      _.fold(output.offer(Take.End).unit)(a => output.offer(Take.Value(a)).unit)
-                                    )
+                                  k.foldCauseM(
+                                    _.failureOrCause match {
+                                      case Left(None)    => output.offer(Take.End).unit
+                                      case Left(Some(e)) => output.offer(Take.Fail(Cause.fail(e))).unit
+                                      case Right(cause)  => output.offer(Take.Fail(cause)).unit
+                                    },
+                                    a => output.offer(Take.Value(a)).unit
+                                  )
                                 )
                             )
                           ).toManaged_
@@ -1535,14 +1535,14 @@ object ZStream extends ZStreamPlatformSpecific {
             _ <- register(
                   k =>
                     runtime.unsafeRunAsync_(
-                      k.foldM(
-                          _.fold[ZIO[R, E, Option[A]]](UIO.succeed(None))(e => IO.fail(e)),
-                          a => UIO.succeed(Some(a))
-                        )
-                        .foldCauseM(
-                          cause => output.offer(Take.Fail(cause)).unit,
-                          _.fold(output.offer(Take.End).unit)(a => output.offer(Take.Value(a)).unit)
-                        )
+                      k.foldCauseM(
+                        _.failureOrCause match {
+                          case Left(None)    => output.offer(Take.End).unit
+                          case Left(Some(e)) => output.offer(Take.Fail(Cause.fail(e))).unit
+                          case Right(cause)  => output.offer(Take.Fail(cause)).unit
+                        },
+                        a => output.offer(Take.Value(a)).unit
+                      )
                     )
                 ).toManaged_
             s <- ZStream.fromQueue(output).unTake.fold[R1, E1, A1, S].flatMap(fold => fold(s, cont, g))
@@ -1570,14 +1570,14 @@ object ZStream extends ZStreamPlatformSpecific {
                              register(
                                k =>
                                  runtime.unsafeRunAsync_(
-                                   k.foldM(
-                                       _.fold[ZIO[R, E, Option[A]]](UIO.succeed(None))(e => IO.fail(e)),
-                                       a => UIO.succeed(Some(a))
-                                     )
-                                     .foldCauseM(
-                                       cause => output.offer(Take.Fail(cause)).unit,
-                                       _.fold(output.offer(Take.End).unit)(a => output.offer(Take.Value(a)).unit)
-                                     )
+                                   k.foldCauseM(
+                                     _.failureOrCause match {
+                                       case Left(None)    => output.offer(Take.End).unit
+                                       case Left(Some(e)) => output.offer(Take.Fail(Cause.fail(e))).unit
+                                       case Right(cause)  => output.offer(Take.Fail(cause)).unit
+                                     },
+                                     a => output.offer(Take.Value(a)).unit
+                                   )
                                  )
                              )
                            }.toManaged_

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1464,6 +1464,8 @@ object ZStream extends ZStreamPlatformSpecific {
 
   /**
    * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The optionality of the error type `E` can be used to signal the end of the stream,
+   * by setting it to `None`.
    */
   final def effectAsync[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => Unit,
@@ -1476,7 +1478,9 @@ object ZStream extends ZStreamPlatformSpecific {
 
   /**
    * Creates a stream from an asynchronous callback that can be called multiple times.
-   * The registration of the callback can possibly return the stream synchronously
+   * The registration of the callback can possibly return the stream synchronously.
+   * The optionality of the error type `E` can be used to signal the end of the stream,
+   * by setting it to `None`.
    */
   final def effectAsyncMaybe[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => Option[ZStream[R, E, A]],


### PR DESCRIPTION
Resolves #1200. 

The PR currently does not introduce overloaded effectAsync methods. Let me know if you want to add them and keep the original type signatures.