### PR TITLE
Stream#throttle use clock.nanoTime instead of wall clock time

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -20,7 +20,6 @@ import zio._
 import zio.clock.Clock
 import zio.duration.Duration
 import scala.language.postfixOps
-import java.util.concurrent.TimeUnit
 
 /**
  * A `Sink[E, A0, A, B]` consumes values of type `A`, ultimately producing
@@ -1200,7 +1199,7 @@ object ZSink extends ZSinkPlatformSpecific {
       def step(state: State, a: A) =
         for {
           weight  <- costFn(a)
-          current <- clock.currentTime(TimeUnit.NANOSECONDS)
+          current <- clock.nanoTime
           result <- state._1.modify {
                      case (tokens, timestamp) =>
                        val elapsed   = current - timestamp
@@ -1221,7 +1220,7 @@ object ZSink extends ZSinkPlatformSpecific {
     val sink = for {
       _       <- assertNonNegative(units)
       _       <- assertNonNegative(burst)
-      current <- clock.currentTime(TimeUnit.NANOSECONDS)
+      current <- clock.nanoTime
       bucket  <- Ref.make((units, current))
     } yield bucketSink(bucket)
 
@@ -1260,7 +1259,7 @@ object ZSink extends ZSinkPlatformSpecific {
       def step(state: State, a: A) =
         for {
           weight  <- costFn(a)
-          current <- clock.currentTime(TimeUnit.NANOSECONDS)
+          current <- clock.nanoTime
           delay <- state._1.modify {
                     case (tokens, timestamp) =>
                       val elapsed    = current - timestamp
@@ -1283,7 +1282,7 @@ object ZSink extends ZSinkPlatformSpecific {
     val sink = for {
       _       <- assertPositive(units)
       _       <- assertNonNegative(burst)
-      current <- clock.currentTime(TimeUnit.NANOSECONDS)
+      current <- clock.nanoTime
       bucket  <- Ref.make((units, current))
     } yield bucketSink(bucket)
 


### PR DESCRIPTION
Throttling requires elapsed time, and the throttling sinks are single threaded, so `clock.nanoTime` should be the preferred choice. I've read that wall clock time is affected by daylight saving time, leap seconds, etc... which of course would lead to inconsistencies in the calculations.