### PR TITLE
Add a link to slf4zio

### DIFF
--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -27,6 +27,7 @@ If you know a useful library that has direct support for ZIO, please consider [s
 - [sttp](https://github.com/softwaremill/sttp): The Scala HTTP client you always wanted!
 - [zio-saga](https://github.com/VladKopanev/zio-saga): Purely functional transaction management with Saga pattern
 - [zio-slf4j](https://github.com/NeQuissimus/zio-slf4j): Referentially transparent logging with slf4j
+- [slf4zio](https://github.com/mlangc/slf4zio): Simple convenience layer on top of SLF4J for ZIO
 - [zio-slick](https://github.com/rleibman/zio-slick): Bridge library between ZIO and Slick Functional Relational Mapping Library
 
 ## ZIO Compatible Libraries


### PR DESCRIPTION
@NeQuissimus I decided not to migrate my code to [zio-slf4j](https://github.com/NeQuissimus/zio-slf4j) for the time being, because for the moment it would generate too much work for too little value. Also, I'm still experimenting with some concepts and APIs, and merging would limit the speed of iterations at this stage. In the long run though, having all ZIO SLF4J compatibility code in one library still makes sense, so we shouldn't loose sight of this.