### PR TITLE
#1257  Renamed Test* prefixed classes in zio.test.mock to Mock*

### DIFF
--- a/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -6,7 +6,7 @@ import scala.{ Stream => _ }
 import zio._
 import zio.clock.Clock
 import zio.duration._
-import zio.test.mock.TestClock
+import zio.test.mock.MockClock
 import java.util.concurrent.TimeUnit
 
 class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
@@ -264,7 +264,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     unsafeRun {
       for {
-        clock <- Ref.make(TestClock.DefaultData).map(ref => new Clock { val clock = TestClock(ref) })
+        clock <- Ref.make(MockClock.DefaultData).map(ref => new Clock { val clock = MockClock(ref) })
         test <- ZSink
                  .throttleEnforce[Int](1, 10.milliseconds)(_ => 1)
                  .use(sinkTest)
@@ -298,7 +298,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     unsafeRun {
       for {
-        clock <- Ref.make(TestClock.DefaultData).map(ref => new Clock { val clock = TestClock(ref) })
+        clock <- Ref.make(MockClock.DefaultData).map(ref => new Clock { val clock = MockClock(ref) })
         test <- ZSink
                  .throttleEnforce[Int](1, 10.milliseconds, 1)(_ => 1)
                  .use(sinkTest)
@@ -326,7 +326,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     unsafeRun {
       for {
-        clock <- Ref.make(TestClock.DefaultData).map(ref => new Clock { val clock = TestClock(ref) })
+        clock <- Ref.make(MockClock.DefaultData).map(ref => new Clock { val clock = MockClock(ref) })
         test <- ZSink
                  .throttleShape[Int](1, 1.second)(_.toLong)
                  .use(sinkTest)
@@ -350,7 +350,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     unsafeRun {
       for {
-        clock <- Ref.make(TestClock.DefaultData).map(ref => new Clock { val clock = TestClock(ref) })
+        clock <- Ref.make(MockClock.DefaultData).map(ref => new Clock { val clock = MockClock(ref) })
         test <- ZSink
                  .throttleShape[Int](1, 0.seconds)(_ => 100000L)
                  .use(sinkTest)
@@ -378,7 +378,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     unsafeRun {
       for {
-        clock <- Ref.make(TestClock.DefaultData).map(ref => new Clock { val clock = TestClock(ref) })
+        clock <- Ref.make(MockClock.DefaultData).map(ref => new Clock { val clock = MockClock(ref) })
         test <- ZSink
                  .throttleShape[Int](1, 1.second, 2)(_.toLong)
                  .use(sinkTest)

--- a/test/jvm/src/test/scala/zio/test/mock/ClockSpec.scala
+++ b/test/jvm/src/test/scala/zio/test/mock/ClockSpec.scala
@@ -5,7 +5,7 @@ import java.time.ZoneId
 
 import zio._
 import zio.duration._
-import zio.test.mock.TestClock.DefaultData
+import zio.test.mock.MockClock.DefaultData
 
 class ClockSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
 
@@ -30,140 +30,140 @@ class ClockSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRun
   def e1 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        result    <- testClock.sleep(10.hours).timeout(100.milliseconds)
+        mockClock <- MockClock.make(DefaultData)
+        result    <- mockClock.sleep(10.hours).timeout(100.milliseconds)
       } yield result.nonEmpty must beTrue
     )
 
   def e2 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.nanoTime
-        _         <- testClock.sleep(1.millis)
-        time2     <- testClock.nanoTime
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.nanoTime
+        _         <- mockClock.sleep(1.millis)
+        time2     <- mockClock.nanoTime
       } yield (time2 - time1) must_== 1000000L
     )
 
   def e3 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.currentTime(TimeUnit.MILLISECONDS)
-        _         <- testClock.sleep(1.millis)
-        time2     <- testClock.currentTime(TimeUnit.MILLISECONDS)
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.currentTime(TimeUnit.MILLISECONDS)
+        _         <- mockClock.sleep(1.millis)
+        time2     <- mockClock.currentTime(TimeUnit.MILLISECONDS)
       } yield (time2 - time1) must_== 1L
     )
 
   def e4 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.currentDateTime
-        _         <- testClock.sleep(1.millis)
-        time2     <- testClock.currentDateTime
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.currentDateTime
+        _         <- mockClock.sleep(1.millis)
+        time2     <- mockClock.currentDateTime
       } yield (time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli) must_== 1L
     )
 
   def e5 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.sleep(1.millis)
-        sleeps    <- testClock.sleeps
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.sleep(1.millis)
+        sleeps    <- mockClock.sleeps
       } yield sleeps must_== List(1.milliseconds)
     )
 
   def e6 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.nanoTime
-        _         <- testClock.adjust(1.millis)
-        time2     <- testClock.nanoTime
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.nanoTime
+        _         <- mockClock.adjust(1.millis)
+        time2     <- mockClock.nanoTime
       } yield (time2 - time1) must_== 1000000L
     )
 
   def e7 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.currentTime(TimeUnit.MILLISECONDS)
-        _         <- testClock.adjust(1.millis)
-        time2     <- testClock.currentTime(TimeUnit.MILLISECONDS)
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.currentTime(TimeUnit.MILLISECONDS)
+        _         <- mockClock.adjust(1.millis)
+        time2     <- mockClock.currentTime(TimeUnit.MILLISECONDS)
       } yield (time2 - time1) must_== 1L
     )
 
   def e8 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        time1     <- testClock.currentDateTime
-        _         <- testClock.adjust(1.millis)
-        time2     <- testClock.currentDateTime
+        mockClock <- MockClock.make(DefaultData)
+        time1     <- mockClock.currentDateTime
+        _         <- mockClock.adjust(1.millis)
+        time2     <- mockClock.currentDateTime
       } yield (time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli) must_== 1L
     )
 
   def e9 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.adjust(1.millis)
-        sleeps    <- testClock.sleeps
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.adjust(1.millis)
+        sleeps    <- mockClock.sleeps
       } yield sleeps must_== Nil
     )
 
   def e10 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTime(1.millis)
-        time      <- testClock.nanoTime
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTime(1.millis)
+        time      <- mockClock.nanoTime
       } yield time must_== 1000000L
     )
 
   def e11 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTime(1.millis)
-        time      <- testClock.currentTime(TimeUnit.MILLISECONDS)
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTime(1.millis)
+        time      <- mockClock.currentTime(TimeUnit.MILLISECONDS)
       } yield time must_== 1L
     )
 
   def e12 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTime(1.millis)
-        time      <- testClock.currentDateTime
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTime(1.millis)
+        time      <- mockClock.currentDateTime
       } yield time.toInstant.toEpochMilli must_== 1L
     )
 
   def e13 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTime(1.millis)
-        sleeps    <- testClock.sleeps
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTime(1.millis)
+        sleeps    <- mockClock.sleeps
       } yield sleeps must_== Nil
     )
 
   def e14 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTimeZone(ZoneId.of("America/New_York"))
-        timeZone  <- testClock.timeZone
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTimeZone(ZoneId.of("America/New_York"))
+        timeZone  <- mockClock.timeZone
       } yield timeZone must_== ZoneId.of("America/New_York")
     )
 
   def e15 =
     unsafeRun(
       for {
-        testClock <- TestClock.make(DefaultData)
-        _         <- testClock.setTimeZone(ZoneId.of("America/New_York"))
-        sleeps    <- testClock.sleeps
+        mockClock <- MockClock.make(DefaultData)
+        _         <- mockClock.setTimeZone(ZoneId.of("America/New_York"))
+        sleeps    <- mockClock.sleeps
       } yield sleeps must_== Nil
     )
 }

--- a/test/jvm/src/test/scala/zio/test/mock/ConsoleSpec.scala
+++ b/test/jvm/src/test/scala/zio/test/mock/ConsoleSpec.scala
@@ -4,7 +4,7 @@ import java.io.{ ByteArrayOutputStream, PrintStream }
 
 import zio._
 import zio.TestRuntime
-import zio.test.mock.TestConsole.Data
+import zio.test.mock.MockConsole.Data
 
 class ConsoleSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
 
@@ -24,45 +24,45 @@ class ConsoleSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
   def emptyOutput =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data())
-        output      <- testConsole.output
+        mockConsole <- MockConsole.make(Data())
+        output      <- mockConsole.output
       } yield output must beEmpty
     )
 
   def putStr =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data())
-        _           <- testConsole.putStr("First line")
-        _           <- testConsole.putStr("Second line")
-        output      <- testConsole.output
+        mockConsole <- MockConsole.make(Data())
+        _           <- mockConsole.putStr("First line")
+        _           <- mockConsole.putStr("Second line")
+        output      <- mockConsole.output
       } yield output must_=== Vector("First line", "Second line")
     )
 
   def putStrLn =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data())
-        _           <- testConsole.putStrLn("First line")
-        _           <- testConsole.putStrLn("Second line")
-        output      <- testConsole.output
+        mockConsole <- MockConsole.make(Data())
+        _           <- mockConsole.putStrLn("First line")
+        _           <- mockConsole.putStrLn("Second line")
+        output      <- mockConsole.output
       } yield output must_=== Vector("First line\n", "Second line\n")
     )
 
   def getStr1 =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data(List("Input 1", "Input 2"), Vector.empty))
-        input1      <- testConsole.getStrLn
-        input2      <- testConsole.getStrLn
+        mockConsole <- MockConsole.make(Data(List("Input 1", "Input 2"), Vector.empty))
+        input1      <- mockConsole.getStrLn
+        input2      <- mockConsole.getStrLn
       } yield (input1 must_=== "Input 1") and (input2 must_=== "Input 2")
     )
 
   def getStr2 =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data())
-        failed      <- testConsole.getStrLn.either
+        mockConsole <- MockConsole.make(Data())
+        failed      <- mockConsole.getStrLn.either
         message     = failed.fold(_.getMessage, identity)
       } yield (failed must beLeft) and (message must_=== "There is no more input left to read")
     )
@@ -70,19 +70,19 @@ class ConsoleSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
   def feedLine =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data())
-        _           <- testConsole.feedLines("Input 1", "Input 2")
-        input1      <- testConsole.getStrLn
-        input2      <- testConsole.getStrLn
+        mockConsole <- MockConsole.make(Data())
+        _           <- mockConsole.feedLines("Input 1", "Input 2")
+        input1      <- mockConsole.getStrLn
+        input2      <- mockConsole.getStrLn
       } yield (input1 must_=== "Input 1") and (input2 must_=== "Input 2")
     )
 
   def clearInput =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data(List("Input 1", "Input 2"), Vector.empty))
-        _           <- testConsole.clearInput
-        failed      <- testConsole.getStrLn.either
+        mockConsole <- MockConsole.make(Data(List("Input 1", "Input 2"), Vector.empty))
+        _           <- mockConsole.clearInput
+        failed      <- mockConsole.getStrLn.either
         message     = failed.fold(_.getMessage, identity)
       } yield (failed must beLeft) and (message must_=== "There is no more input left to read")
     )
@@ -90,9 +90,9 @@ class ConsoleSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
   def clearOutput =
     unsafeRun(
       for {
-        testConsole <- TestConsole.make(Data(List.empty, Vector("First line", "Second line")))
-        _           <- testConsole.clearOutput
-        output      <- testConsole.output
+        mockConsole <- MockConsole.make(Data(List.empty, Vector("First line", "Second line")))
+        _           <- mockConsole.clearOutput
+        output      <- mockConsole.output
       } yield output must_=== Vector.empty
     )
 }

--- a/test/jvm/src/test/scala/zio/test/mock/RandomSpec.scala
+++ b/test/jvm/src/test/scala/zio/test/mock/RandomSpec.scala
@@ -1,7 +1,7 @@
 package zio.test.mock
 
 import zio.random.Random
-import zio.test.mock.TestRandom.Data
+import zio.test.mock.MockRandom.Data
 import zio.{ TestRuntime, UIO, _ }
 
 class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
@@ -88,15 +88,15 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
      """
 
   def nextIntWithEmptyData =
-    checkWith(Data(integers = Nil), List(TestRandom.defaultInteger))(_.nextInt)
+    checkWith(Data(integers = Nil), List(MockRandom.defaultInteger))(_.nextInt)
 
   def nextIntWithLimit =
     unsafeRun(
       for {
-        testRandom <- TestRandom.make(Data(integers = List(5, 6, 7)))
-        next1      <- testRandom.nextInt(2)
-        next2      <- testRandom.nextInt(6)
-        next3      <- testRandom.nextInt(99)
+        mockRandom <- MockRandom.make(Data(integers = List(5, 6, 7)))
+        next1      <- mockRandom.nextInt(2)
+        next2      <- mockRandom.nextInt(6)
+        next3      <- mockRandom.nextInt(99)
       } yield List(next1, next2, next3) must_=== List(2, 6, 7)
     )
 
@@ -113,10 +113,10 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedInts, List(6, 7, 8, 9, 10))(_.nextInt)
 
   def nextIntWithClear =
-    checkClear(_.clearInts, TestRandom.defaultInteger)(_.nextInt)
+    checkClear(_.clearInts, MockRandom.defaultInteger)(_.nextInt)
 
   def nextBooleanWithEmptyData =
-    checkWith(Data(booleans = Nil), List(TestRandom.defaultBoolean))(_.nextBoolean)
+    checkWith(Data(booleans = Nil), List(MockRandom.defaultBoolean))(_.nextBoolean)
 
   def nextBooleanWithDefault =
     checkWith(Data(), List(true, false, true, false, true))(_.nextBoolean)
@@ -131,10 +131,10 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedBooleans, List(false, true))(_.nextBoolean)
 
   def nextBooleanWithClear =
-    checkClear(_.clearBooleans, TestRandom.defaultBoolean)(_.nextBoolean)
+    checkClear(_.clearBooleans, MockRandom.defaultBoolean)(_.nextBoolean)
 
   def nextDoubleWithEmptyData =
-    checkWith(Data(doubles = Nil), List(TestRandom.defaultDouble))(_.nextDouble)
+    checkWith(Data(doubles = Nil), List(MockRandom.defaultDouble))(_.nextDouble)
 
   def nextDoubleWithDefault =
     checkWith(Data(), List(0.1d, 0.2d, 0.3d, 0.4d, 0.5d))(_.nextDouble)
@@ -149,13 +149,13 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedDoubles, List(0.6d, 0.7d, 0.8d, 0.9d, 1.0d))(_.nextDouble)
 
   def nextDoubleWithClear =
-    checkClear(_.clearDoubles, TestRandom.defaultDouble)(_.nextDouble)
+    checkClear(_.clearDoubles, MockRandom.defaultDouble)(_.nextDouble)
 
   def nextGaussian =
     checkWith(Data(doubles = List(0.1, 0.2)), List(0.1, 0.2, 0.1))(_.nextGaussian)
 
   def nextFloatWithEmptyData =
-    checkWith(Data(floats = Nil), List(TestRandom.defaultFloat))(_.nextFloat)
+    checkWith(Data(floats = Nil), List(MockRandom.defaultFloat))(_.nextFloat)
 
   def nextFloatWithDefault =
     checkWith(Data(), List(0.1f, 0.2f, 0.3f, 0.4f, 0.5f))(_.nextFloat)
@@ -170,10 +170,10 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedFloats, List(0.6f, 0.7f, 0.8f, 0.9f, 1.0f))(_.nextFloat)
 
   def nextFloatWithClear =
-    checkClear(_.clearFloats, TestRandom.defaultFloat)(_.nextFloat)
+    checkClear(_.clearFloats, MockRandom.defaultFloat)(_.nextFloat)
 
   def nextLongWithEmptyData =
-    checkWith(Data(longs = Nil), List(TestRandom.defaultLong))(_.nextLong)
+    checkWith(Data(longs = Nil), List(MockRandom.defaultLong))(_.nextLong)
 
   def nextLongWithDefault =
     checkWith(Data(), List(1L, 2L, 3L, 4L, 5L))(_.nextLong)
@@ -188,10 +188,10 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedLongs, List(6L, 7L, 8L, 9L, 10L))(_.nextLong)
 
   def nextLongWithClear =
-    checkClear(_.clearLongs, TestRandom.defaultLong)(_.nextLong)
+    checkClear(_.clearLongs, MockRandom.defaultLong)(_.nextLong)
 
   def nextCharWithEmptyData =
-    checkWith(Data(chars = Nil), List(TestRandom.defaultChar))(_.nextPrintableChar)
+    checkWith(Data(chars = Nil), List(MockRandom.defaultChar))(_.nextPrintableChar)
 
   def nextCharWithDefault =
     checkWith(Data(), List('a', 'b', 'c', 'd', 'e'))(_.nextPrintableChar)
@@ -206,10 +206,10 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedChars, List('f', 'g', 'h', 'i', 'j'))(_.nextPrintableChar)
 
   def nextCharWithClear =
-    checkClear(_.clearChars, TestRandom.defaultChar)(_.nextPrintableChar)
+    checkClear(_.clearChars, MockRandom.defaultChar)(_.nextPrintableChar)
 
   def nextStringWithEmptyData =
-    checkWith(Data(strings = Nil), List(TestRandom.defaultString))(_.nextString(1))
+    checkWith(Data(strings = Nil), List(MockRandom.defaultString))(_.nextString(1))
 
   def nextStringWithLength =
     checkWith(Data(strings = List("longer string")), List("longer s"))(_.nextString(8))
@@ -230,13 +230,13 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedStrings, List("f", "g", "h", "i", "j"))(_.nextString(1))
 
   def nextStringWithClear =
-    checkClear(_.clearStrings, TestRandom.defaultString)(_.nextString(1))
+    checkClear(_.clearStrings, MockRandom.defaultString)(_.nextString(1))
 
   def nextBytesWithEmptyData =
-    checkWith(Data(bytes = Nil), List(TestRandom.defaultBytes))(_.nextBytes(1))
+    checkWith(Data(bytes = Nil), List(MockRandom.defaultBytes))(_.nextBytes(1))
 
   def nextBytesLengthIsOver =
-    checkWith(Data(bytes = Nil), List(TestRandom.defaultBytes))(_.nextBytes(99))
+    checkWith(Data(bytes = Nil), List(MockRandom.defaultBytes))(_.nextBytes(99))
 
   def nextBytesWithLength =
     checkWith(Data(bytes = List(Chunk(1.toByte, 2.toByte, 3.toByte))), List(Chunk(1.toByte, 2.toByte)))(_.nextBytes(2))
@@ -256,13 +256,13 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     checkFeed(_.feedBytes, List(Chunk(6.toByte), Chunk(7.toByte), Chunk(8.toByte)))(_.nextBytes(1))
 
   def nextBytesWithClear =
-    checkClear(_.clearBytes, TestRandom.defaultBytes)(_.nextBytes(1))
+    checkClear(_.clearBytes, MockRandom.defaultBytes)(_.nextBytes(1))
 
   def checkWith[A](data: Data, expected: List[A])(f: Random.Service[Any] => UIO[A]) =
     unsafeRun(
       for {
-        testRandom    <- TestRandom.make(data)
-        randomResults <- IO.foreach(1 to expected.length)(_ => f(testRandom))
+        mockRandom    <- MockRandom.make(data)
+        randomResults <- IO.foreach(1 to expected.length)(_ => f(mockRandom))
       } yield randomResults must_=== expected
     )
 
@@ -296,8 +296,8 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
 
     unsafeRun(
       for {
-        testRandom <- TestRandom.make(Data(integers = identitySwapIndexes))
-        shuffled   <- testRandom.shuffle(input)
+        mockRandom <- MockRandom.make(Data(integers = identitySwapIndexes))
+        shuffled   <- mockRandom.shuffle(input)
       } yield shuffled must_=== input
     )
   }
@@ -311,27 +311,27 @@ class RandomSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
 
     unsafeRun(
       for {
-        testRandom <- TestRandom.make(Data(integers = reverseSwapIndexes))
-        shuffled   <- testRandom.shuffle(input)
+        mockRandom <- MockRandom.make(Data(integers = reverseSwapIndexes))
+        shuffled   <- mockRandom.shuffle(input)
       } yield shuffled must_=== input.reverse
     )
   }
 
-  def checkFeed[A](feed: TestRandom => Seq[A] => UIO[Unit], expected: List[A])(f: Random.Service[Any] => UIO[A]) =
+  def checkFeed[A](feed: MockRandom => Seq[A] => UIO[Unit], expected: List[A])(f: Random.Service[Any] => UIO[A]) =
     unsafeRun(
       for {
-        testRandom <- TestRandom.make(Data())
-        _          <- feed(testRandom)(expected)
-        results    <- UIO.foreach(1 to expected.length)(_ => f(testRandom))
+        mockRandom <- MockRandom.make(Data())
+        _          <- feed(mockRandom)(expected)
+        results    <- UIO.foreach(1 to expected.length)(_ => f(mockRandom))
       } yield results must_=== expected
     )
 
-  def checkClear[A](clear: TestRandom => UIO[Unit], default: A)(f: Random.Service[Any] => UIO[A]) =
+  def checkClear[A](clear: MockRandom => UIO[Unit], default: A)(f: Random.Service[Any] => UIO[A]) =
     unsafeRun(
       for {
-        testRandom <- TestRandom.make(Data())
-        _          <- clear(testRandom)
-        result     <- f(testRandom)
+        mockRandom <- MockRandom.make(Data())
+        _          <- clear(mockRandom)
+        result     <- f(mockRandom)
       } yield result must_=== default
     )
 }

--- a/test/jvm/src/test/scala/zio/test/mock/SchedulerSpec.scala
+++ b/test/jvm/src/test/scala/zio/test/mock/SchedulerSpec.scala
@@ -85,11 +85,11 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
 
 object SchedulerSpec {
 
-  def mkScheduler(runtime: Runtime[Clock]): UIO[(TestClock, TestScheduler)] =
+  def mkScheduler(runtime: Runtime[Clock]): UIO[(MockClock, MockScheduler)] =
     for {
-      clockData <- Ref.make(TestClock.DefaultData)
-      clock     = TestClock(clockData)
-      scheduler = TestScheduler(clockData, runtime)
+      clockData <- Ref.make(MockClock.DefaultData)
+      clock     = MockClock(clockData)
+      scheduler = MockScheduler(clockData, runtime)
     } yield (clock, scheduler)
 
 }

--- a/test/jvm/src/test/scala/zio/test/mock/SystemSpec.scala
+++ b/test/jvm/src/test/scala/zio/test/mock/SystemSpec.scala
@@ -1,6 +1,6 @@
 package zio.test.mock
 
-import zio.test.mock.TestSystem.Data
+import zio.test.mock.MockSystem.Data
 import zio.TestRuntime
 
 class SystemSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
@@ -26,85 +26,85 @@ class SystemSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
   def env1 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data(envs = Map("k1" -> "v1")))
-        env        <- testSystem.env("k1")
+        mockSystem <- MockSystem.make(Data(envs = Map("k1" -> "v1")))
+        env        <- mockSystem.env("k1")
       } yield env must_=== Option("v1")
     )
 
   def env2 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data())
-        env        <- testSystem.env("k1")
+        mockSystem <- MockSystem.make(Data())
+        env        <- mockSystem.env("k1")
       } yield env must_=== Option.empty
     )
 
   def env3 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data())
-        _          <- testSystem.putEnv("k1", "v1")
-        env        <- testSystem.env("k1")
+        mockSystem <- MockSystem.make(Data())
+        _          <- mockSystem.putEnv("k1", "v1")
+        env        <- mockSystem.env("k1")
       } yield env must_=== Option("v1")
     )
 
   def env4 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data(envs = Map("k1" -> "v1")))
-        _          <- testSystem.clearEnv("k1")
-        env        <- testSystem.env("k1")
+        mockSystem <- MockSystem.make(Data(envs = Map("k1" -> "v1")))
+        _          <- mockSystem.clearEnv("k1")
+        env        <- mockSystem.env("k1")
       } yield env must_=== None
     )
 
   def prop1 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data(properties = Map("k1" -> "v1")))
-        prop       <- testSystem.property("k1")
+        mockSystem <- MockSystem.make(Data(properties = Map("k1" -> "v1")))
+        prop       <- mockSystem.property("k1")
       } yield prop must_=== Option("v1")
     )
 
   def prop2 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data())
-        prop       <- testSystem.property("k1")
+        mockSystem <- MockSystem.make(Data())
+        prop       <- mockSystem.property("k1")
       } yield prop must_=== Option.empty
     )
 
   def prop3 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data())
-        _          <- testSystem.putProperty("k1", "v1")
-        prop       <- testSystem.property("k1")
+        mockSystem <- MockSystem.make(Data())
+        _          <- mockSystem.putProperty("k1", "v1")
+        prop       <- mockSystem.property("k1")
       } yield prop must_=== Option("v1")
     )
 
   def prop4 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data(properties = Map("k1" -> "v1")))
-        _          <- testSystem.clearProperty("k1")
-        prop       <- testSystem.property(("k1"))
+        mockSystem <- MockSystem.make(Data(properties = Map("k1" -> "v1")))
+        _          <- mockSystem.clearProperty("k1")
+        prop       <- mockSystem.property(("k1"))
       } yield prop must_=== None
     )
 
   def lineSep1 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data(lineSeparator = ","))
-        lineSep    <- testSystem.lineSeparator
+        mockSystem <- MockSystem.make(Data(lineSeparator = ","))
+        lineSep    <- mockSystem.lineSeparator
       } yield lineSep must_=== ","
     )
 
   def lineSep2 =
     unsafeRun(
       for {
-        testSystem <- TestSystem.make(Data())
-        _          <- testSystem.setLineSeparator(",")
-        lineSep    <- testSystem.lineSeparator
+        mockSystem <- MockSystem.make(Data())
+        _          <- mockSystem.setLineSeparator(",")
+        lineSep    <- mockSystem.lineSeparator
       } yield lineSep must_=== ","
     )
 }

--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -22,16 +22,16 @@ import java.time.ZoneId
 import zio._
 import zio.duration.Duration
 import zio.clock.Clock
-import zio.test.mock.TestClock.Data
+import zio.test.mock.MockClock.Data
 import java.time.{ Instant, OffsetDateTime }
 
-case class TestClock(clockState: Ref[TestClock.Data]) extends Clock.Service[Any] {
+case class MockClock(clockState: Ref[MockClock.Data]) extends Clock.Service[Any] {
 
   final def currentTime(unit: TimeUnit): UIO[Long] =
     clockState.get.map(data => unit.convert(data.currentTimeMillis, TimeUnit.MILLISECONDS))
 
   final def currentDateTime: UIO[OffsetDateTime] =
-    clockState.get.map(data => TestClock.offset(data.currentTimeMillis, data.timeZone))
+    clockState.get.map(data => MockClock.offset(data.currentTimeMillis, data.timeZone))
 
   final val nanoTime: IO[Nothing, Long] =
     clockState.get.map(_.nanoTime)
@@ -61,10 +61,10 @@ case class TestClock(clockState: Ref[TestClock.Data]) extends Clock.Service[Any]
     clockState.get.map(_.timeZone)
 }
 
-object TestClock {
+object MockClock {
 
-  def make(data: Data): UIO[TestClock] =
-    Ref.make(data).map(TestClock(_))
+  def make(data: Data): UIO[MockClock] =
+    Ref.make(data).map(MockClock(_))
 
   val DefaultData = Data(0, 0, Nil, ZoneId.of("UTC"))
 

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -21,9 +21,9 @@ import java.io.EOFException
 
 import zio.console._
 import zio._
-import TestConsole.Data
+import MockConsole.Data
 
-case class TestConsole(consoleState: Ref[TestConsole.Data]) extends Console.Service[Any] {
+case class MockConsole(consoleState: Ref[MockConsole.Data]) extends Console.Service[Any] {
 
   override def putStr(line: String): UIO[Unit] =
     consoleState.update { data =>
@@ -61,10 +61,10 @@ case class TestConsole(consoleState: Ref[TestConsole.Data]) extends Console.Serv
     consoleState.update(data => data.copy(output = Vector.empty)).unit
 }
 
-object TestConsole {
+object MockConsole {
 
-  def make(data: Data): UIO[TestConsole] =
-    Ref.make(data).map(TestConsole(_))
+  def make(data: Data): UIO[MockConsole] =
+    Ref.make(data).map(MockConsole(_))
 
   val DefaultData: Data = Data(Nil, Vector())
 

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -18,9 +18,9 @@ package zio.test.mock
 
 import zio._
 import zio.random.Random
-import zio.test.mock.TestRandom.Data
+import zio.test.mock.MockRandom.Data
 
-final case class TestRandom(randomState: Ref[TestRandom.Data]) extends Random.Service[Any] {
+final case class MockRandom(randomState: Ref[MockRandom.Data]) extends Random.Service[Any] {
 
   val nextBoolean: UIO[Boolean] = nextRandom(shiftBooleans)
 
@@ -100,35 +100,35 @@ final case class TestRandom(randomState: Ref[TestRandom.Data]) extends Random.Se
     } yield next
 
   private def shiftBooleans(data: Data) =
-    (data.booleans.headOption.fold(TestRandom.defaultBoolean)(identity), data.copy(booleans = shiftLeft(data.booleans)))
+    (data.booleans.headOption.fold(MockRandom.defaultBoolean)(identity), data.copy(booleans = shiftLeft(data.booleans)))
 
   private def shiftIntegers(data: Data) =
-    (data.integers.headOption.fold(TestRandom.defaultInteger)(identity), data.copy(integers = shiftLeft(data.integers)))
+    (data.integers.headOption.fold(MockRandom.defaultInteger)(identity), data.copy(integers = shiftLeft(data.integers)))
 
   private def shiftIntWithLimit(limit: Int)(data: Data) = {
-    val next = data.integers.headOption.fold(TestRandom.defaultInteger)(identity)
+    val next = data.integers.headOption.fold(MockRandom.defaultInteger)(identity)
     (Math.min(limit, next), data.copy(integers = shiftLeft(data.integers)))
   }
 
   private def shiftDoubles(data: Data) =
-    (data.doubles.headOption.fold(TestRandom.defaultDouble)(identity), data.copy(doubles = shiftLeft(data.doubles)))
+    (data.doubles.headOption.fold(MockRandom.defaultDouble)(identity), data.copy(doubles = shiftLeft(data.doubles)))
 
   private def shiftFloats(data: Data) =
-    (data.floats.headOption.fold(TestRandom.defaultFloat)(identity), data.copy(floats = shiftLeft(data.floats)))
+    (data.floats.headOption.fold(MockRandom.defaultFloat)(identity), data.copy(floats = shiftLeft(data.floats)))
 
   private def shiftLongs(data: Data) =
-    (data.longs.headOption.fold(TestRandom.defaultLong)(identity), data.copy(longs = shiftLeft(data.longs)))
+    (data.longs.headOption.fold(MockRandom.defaultLong)(identity), data.copy(longs = shiftLeft(data.longs)))
 
   private def shiftChars(data: Data) =
-    (data.chars.headOption.fold(TestRandom.defaultChar)(identity), data.copy(chars = shiftLeft(data.chars)))
+    (data.chars.headOption.fold(MockRandom.defaultChar)(identity), data.copy(chars = shiftLeft(data.chars)))
 
   private def shiftStrings(length: Int)(data: Data) = {
-    val next = data.strings.headOption.fold(TestRandom.defaultString)(identity)
+    val next = data.strings.headOption.fold(MockRandom.defaultString)(identity)
     (next.substring(0, Math.min(length, next.length)), data.copy(strings = shiftLeft(data.strings)))
   }
 
   private def shiftBytes(length: Int)(data: Data) = {
-    val next = data.bytes.headOption.fold(TestRandom.defaultBytes)(identity)
+    val next = data.bytes.headOption.fold(MockRandom.defaultBytes)(identity)
     (next.take(length), data.copy(bytes = shiftLeft(data.bytes)))
   }
 
@@ -138,11 +138,11 @@ final case class TestRandom(randomState: Ref[TestRandom.Data]) extends Random.Se
   }
 }
 
-object TestRandom {
+object MockRandom {
   val DefaultData: Data = Data()
 
-  def make(data: Data): UIO[TestRandom] =
-    Ref.make(data).map(TestRandom(_))
+  def make(data: Data): UIO[MockRandom] =
+    Ref.make(data).map(MockRandom(_))
 
   val defaultInteger = 1
   val randomIntegers = defaultInteger :: 2 :: 3 :: 4 :: 5 :: Nil

--- a/test/shared/src/main/scala/zio/test/mock/MockScheduler.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockScheduler.scala
@@ -6,13 +6,13 @@ import zio.duration.{ Duration, _ }
 import zio.internal.Scheduler.CancelToken
 import zio.internal.{ Scheduler => IScheduler }
 import zio.scheduler.Scheduler
-import zio.test.mock.TestScheduler._
+import zio.test.mock.MockScheduler._
 
 /**
  * Implementation of Scheduler.Service for testing. The passed Ref[TestClock.Data] will be used to determine when
  * to run the scheduled runnables. Make sure to call shutdown() to force execution of all remaining tasks.
  */
-final case class TestScheduler(ref: Ref[TestClock.Data], runtime: Runtime[Clock]) extends Scheduler.Service[Any] {
+final case class MockScheduler(ref: Ref[MockClock.Data], runtime: Runtime[Clock]) extends Scheduler.Service[Any] {
 
   private[this] val ConstFalse = () => false
 
@@ -69,7 +69,7 @@ final case class TestScheduler(ref: Ref[TestClock.Data], runtime: Runtime[Clock]
     } yield scheduler
 }
 
-object TestScheduler {
+object MockScheduler {
 
   trait TestIScheduler extends IScheduler {
 
@@ -77,7 +77,7 @@ object TestScheduler {
 
   }
 
-  private[TestScheduler] def runWhile(
+  private[MockScheduler] def runWhile(
     task: UIO[Unit],
     ref: Ref[Boolean],
     pause: Duration = 10.milliseconds

--- a/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
@@ -3,7 +3,7 @@ package zio.test.mock
 import zio.{ Ref, UIO, ZIO }
 import zio.system.System
 
-case class TestSystem(systemState: Ref[TestSystem.Data]) extends System.Service[Any] {
+case class MockSystem(systemState: Ref[MockSystem.Data]) extends System.Service[Any] {
 
   override def env(variable: String): ZIO[Any, SecurityException, Option[String]] =
     systemState.get.map(_.envs.get(variable))
@@ -30,11 +30,11 @@ case class TestSystem(systemState: Ref[TestSystem.Data]) extends System.Service[
     systemState.update(data => data.copy(properties = data.properties - prop)).unit
 }
 
-object TestSystem {
+object MockSystem {
   val DefaultData: Data = Data(Map(), Map(), "\n")
 
-  def make(data: Data): UIO[TestSystem] =
-    Ref.make(data).map(TestSystem(_))
+  def make(data: Data): UIO[MockSystem] =
+    Ref.make(data).map(MockSystem(_))
 
   case class Data(
     properties: Map[String, String] = Map.empty,


### PR DESCRIPTION
Simple renaming as requested in #1257 
Note that the PR with `TestEnvironment` is not merged yet - https://github.com/zio/zio/pull/1255 
