### PR TITLE
Added ZManaged#shared

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -21,7 +21,7 @@ import zio.clock.Clock
 import zio.duration.Duration
 
 /**
- * A `Reservation[-R, +E, +A]` encapsulates resource aquisition and disposal
+ * A `Reservation[-R, +E, +A]` encapsulates resource acquisition and disposal
  * without specifying when or how that resource might be used.
  *
  * See [[ZManaged#reserve]] and [[ZIO#reserve]] for details of usage.
@@ -545,6 +545,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Zips this effect with its environment
    */
   final def second[R1 <: R, A1 >: A]: ZManaged[R1, E, (R1, A1)] = ZManaged.identity[R1] &&& self
+
+  /**
+   * Constructs an inner `ZManaged` that will once, lazily acquire the resource, releasing in the outer scope.
+   */
+  final def shared: ZManaged[R, E, ZManaged[R, E, A]] =
+    map(r => ZManaged.make(ZIO.effectTotal(r))(_ => ZIO.unit))
 
   /**
    * Returns a new effect that executes this one and times the acquisition of the resource.


### PR DESCRIPTION
Addresses #1263 

@jdegoes I found this task a bit harder than the previous. 
I wish to ask whether I understood it correctly. The ugly example:

```scala
case class DB() {
  var isClosed = false

  def close: DB = {
    isClosed = true
    this
  }

  def open: DB = {
    println("DB open")
    this
  }
}

val dbIO = ZIO.succeed(DB())

val program = for {

  _ <- dbIO >>= (db => putStrLn(db.isClosed.toString))                            // false

  manageDb = Managed.make(dbIO.map(_.open))(db => ZIO.effectTotal(db.close)).shared

  _ <- manageDb.use(innerManage => for {                                          // DB open
    _ <- dbIO >>= (db => putStrLn(db.isClosed.toString))                          // false
    r <- innerManage.use(db => putStrLn(db.isClosed.toString) *> UIO.succeed(db)) // false
    _ <- putStrLn(r.isClosed.toString)                                            // false
  } yield ())

  _ <- dbIO >>= (db => putStrLn(db.isClosed.toString))                            // true

} yield ()

```

So according to the issue description there’s constructed an internal `ZManage` which `release` does not release the resource. As shown above the `isClosed` is false no sooner than the outer `use` is done (so it satisfies the requirement for releasing in outer scope). Resource is released (`DB open` println) only once and lazy which addresses first requirement. 

Is it correct? Or right direction? Or have I missed the point?