### PR TITLE
Add unit tests for Sink combinators

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -117,6 +117,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $optionalStepError
       extract error $optionalExtractError
 
+    takeWhile
+      happy path      $takeWhileHappyPath
+      false predicate $takeWhileFalsePredicate
+      init error      $takeWhileInitError
+      step error      $takeWhileStepError
+      extract error   $takeWhileExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -506,6 +513,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def optionalExtractError = {
     val sink = extractErrorSink.optional
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
+  }
+
+  private def takeWhileHappyPath = {
+    val sink = ZSink.identity[Int].takeWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def takeWhileFalsePredicate = {
+    val sink = ZSink.identity[Int].takeWhile[Int](_ > 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def takeWhileInitError = {
+    val sink = initErrorSink.takeWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def takeWhileStepError = {
+    val sink = stepErrorSink.takeWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def takeWhileExtractError = {
+    val sink = extractErrorSink.takeWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -95,6 +95,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $filterMStepError
       extractError    $filterMExtractError
 
+    map
+      happy path    $mapHappyPath
+      init error    $mapInitError
+      step error    $mapStepError
+      extract error $mapExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -413,6 +419,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def filterMExtractError = {
     val sink = extractErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapHappyPath = {
+    val sink = ZSink.identity[Int].map(_.toString)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1"))
+  }
+
+  private def mapInitError = {
+    val sink = initErrorSink.map(_.toString)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapStepError = {
+    val sink = stepErrorSink.map(_.toString)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapExtractError = {
+    val sink = extractErrorSink.map(_.toString)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -131,6 +131,9 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $untilOutputStepError
       extract error   $untilOutputExtractError
 
+    zip
+      happy path $zipHappyPath
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -572,6 +575,11 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def untilOutputExtractError = {
     val sink = extractErrorSink.untilOutput(_ == 0)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipHappyPath = {
+    val sink = ZSink.identity[Int].zip(ZSink.succeedLazy("Hello"))
+    unsafeRun(sinkIteration(sink, 1).map(t => (t._1 must_=== 1) and (t._2 must_=== "Hello")))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -44,6 +44,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $collectAllWhileStepError
       extract error   $collectAllWhileExtractError
 
+    Sink#contramap
+      happy path    $contramapHappyPath
+      init error    $contramapInitError
+      step error    $contramapStepError
+      extract error $contramapExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -188,6 +194,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def collectAllWhileExtractError = {
     val sink = extractErrorSink.collectAllWhile[Int, Int](_ > 1)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def contramapHappyPath = {
+    val sink = ZSink.identity[Int].contramap[String](_.toInt)
+    unsafeRun(sinkIteration(sink, "1").map(_ must_=== 1))
+  }
+
+  private def contramapInitError = {
+    val sink = initErrorSink.contramap[String](_.toInt)
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def contramapStepError = {
+    val sink = stepErrorSink.contramap[String](_.toInt)
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def contramapExtractError = {
+    val sink = extractErrorSink.contramap[String](_.toInt)
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -18,12 +18,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "SinkSpec".title ^ s2"""
   Combinators
-    ? (optional)
-      happy path    $optionalHappyPath
-      init error    $optionalInitError
-      step error    $optionalStepError
-      extract error $optionalExtractError
-
     chunked
       happy path    $chunkedHappyPath
       empty         $chunkedEmpty
@@ -112,6 +106,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $mapMStepError
       extract error $mapMExtractError
 
+    optional
+      happy path    $optionalHappyPath
+      init error    $optionalInitError
+      step error    $optionalStepError
+      extract error $optionalExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -162,26 +162,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step   <- sink.step(Step.state(init), a)
       result <- sink.extract(Step.state(step))
     } yield result
-
-  private def optionalHappyPath = {
-    val sink = ZSink.identity[Int].?
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Some(1)))
-  }
-
-  private def optionalInitError = {
-    val sink = initErrorSink.?
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
-  }
-
-  private def optionalStepError = {
-    val sink = stepErrorSink.?
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
-  }
-
-  private def optionalExtractError = {
-    val sink = extractErrorSink.?
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
-  }
 
   private def chunkedHappyPath = {
     val sink = ZSink.collectAll[Int].chunked
@@ -486,6 +466,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def mapMExtractError = {
     val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def optionalHappyPath = {
+    val sink = ZSink.identity[Int].optional
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Some(1)))
+  }
+
+  private def optionalInitError = {
+    val sink = initErrorSink.optional
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
+  }
+
+  private def optionalStepError = {
+    val sink = stepErrorSink.optional
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
+  }
+
+  private def optionalExtractError = {
+    val sink = extractErrorSink.optional
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -50,6 +50,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $contramapStepError
       extract error $contramapExtractError
 
+    Sink#contramapM
+      happy path    $contramapMHappyPath
+      init error    $contramapMInitError
+      step error    $contramapMStepError
+      extract error $contramapMExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -213,6 +219,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def contramapExtractError = {
     val sink = extractErrorSink.contramap[String](_.toInt)
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def contramapMHappyPath = {
+    val sink = ZSink.identity[Int].contramapM[Any, Unit, String](s => UIO.succeed(s.toInt))
+    unsafeRun(sinkIteration(sink, "1").map(_ must_=== 1))
+  }
+
+  private def contramapMInitError = {
+    val sink = initErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def contramapMStepError = {
+    val sink = stepErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
+    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def contramapMExtractError = {
+    val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
     unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -124,6 +124,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $takeWhileStepError
       extract error   $takeWhileExtractError
 
+    untilOutput
+      happy path      $untilOutputHappyPath
+      false predicate $untilOutputFalsePredicate
+      init error      $untilOutputInitError
+      step error      $untilOutputStepError
+      extract error   $untilOutputExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -537,6 +544,33 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def takeWhileExtractError = {
     val sink = extractErrorSink.takeWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def untilOutputHappyPath = {
+    // This test needs to be verified for correctness.
+    val sink = ZSink.identity[Int].untilOutput(_ % 2 == 0)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def untilOutputFalsePredicate = {
+    // This test needs to be verified for correctness.
+    val sink = ZSink.identity[Int].untilOutput(_ % 2 != 0)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def untilOutputInitError = {
+    val sink = initErrorSink.untilOutput(_ == 0)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def untilOutputStepError = {
+    val sink = stepErrorSink.untilOutput(_ == 0)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def untilOutputExtractError = {
+    val sink = extractErrorSink.untilOutput(_ == 0)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -101,6 +101,11 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $mapStepError
       extract error $mapExtractError
 
+    mapError
+      init error    $mapErrorInitError
+      step error    $mapErrorStepError
+      extract error $mapErrorExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -440,6 +445,21 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def mapExtractError = {
     val sink = extractErrorSink.map(_.toString)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapErrorInitError = {
+    val sink = initErrorSink.mapError(_ => "Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def mapErrorStepError = {
+    val sink = stepErrorSink.mapError(_ => "Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def mapErrorExtractError = {
+    val sink = extractErrorSink.mapError(_ => "Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -88,6 +88,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $filterStepError
       extractError    $filterExtractError
 
+    filterM
+      happy path      $filterMHappyPath
+      false predicate $filterMFalsePredicate
+      init error      $filterMInitError
+      step error      $filterMStepError
+      extractError    $filterMExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -381,6 +388,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def filterExtractError = {
     val sink = extractErrorSink.filter[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterMHappyPath = {
+    val sink = ZSink.identity[Int].filterM[Any, Unit, Int](n => UIO.succeed(n < 5))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def filterMFalsePredicate = {
+    val sink = ZSink.identity[Int].filterM[Any, Unit, Int](n => UIO.succeed(n > 5))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterMInitError = {
+    val sink = initErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterMStepError = {
+    val sink = stepErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterMExtractError = {
+    val sink = extractErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -18,43 +18,49 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "SinkSpec".title ^ s2"""
   Combinators
-    Sink#? (Sink#optional)
+    ? (optional)
       happy path    $optionalHappyPath
       init error    $optionalInitError
       step error    $optionalStepError
       extract error $optionalExtractError
 
-    Sink#chunked
+    chunked
       happy path    $chunkedHappyPath
       empty         $chunkedEmpty
       init error    $chunkedInitError
       step error    $chunkedStepError
       extract error $chunkedExtractError
 
-    Sink#collectAll
+    collectAll
       happy path         $collectAllHappyPath
       init error         $collectAllInitError
       step error         $collectAllStepError
       extract error      $collectAllExtractError
 
-    Sink#collectAllWhile
+    collectAllWhile
       happy path      $collectAllWhileHappyPath
       false predicate $collectAllWhileFalsePredicate
       init error      $collectAllWhileInitError
       step error      $collectAllWhileStepError
       extract error   $collectAllWhileExtractError
 
-    Sink#contramap
+    contramap
       happy path    $contramapHappyPath
       init error    $contramapInitError
       step error    $contramapStepError
       extract error $contramapExtractError
 
-    Sink#contramapM
+    contramapM
       happy path    $contramapMHappyPath
       init error    $contramapMInitError
       step error    $contramapMStepError
       extract error $contramapMExtractError
+    
+    const
+      happy path    $constHappyPath
+      init error    $constInitError
+      step error    $constStepError
+      extract error $constExtractError
 
   Constructors
     Sink.foldLeft                         $foldLeft
@@ -240,6 +246,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def contramapMExtractError = {
     val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
     unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+  }
+
+  private def constHappyPath = {
+    val sink = ZSink.identity[Int].const("const")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "const"))
+  }
+
+  private def constInitError = {
+    val sink = initErrorSink.const("const")
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def constStepError = {
+    val sink = stepErrorSink.const("const")
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def constExtractError = {
+    val sink = extractErrorSink.const("const")
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -68,6 +68,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $dimapStepError
       extract error $dimapExtractError
 
+    dropWhile
+      happy path      $dropWhileHappyPath
+      false predicate $dropWhileFalsePredicate
+      init error      $dropWhileInitError
+      step error      $dropWhileStepError
+      extract error   $dropWhileExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -292,6 +299,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def dimapExtractError = {
     val sink = extractErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
     unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+  }
+
+  private def dropWhileHappyPath = {
+    val sink = ZSink.identity[Int].dropWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def dropWhileFalsePredicate = {
+    val sink = ZSink.identity[Int].dropWhile[Int](_ > 5)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def dropWhileInitError = {
+    val sink = initErrorSink.dropWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def dropWhileStepError = {
+    val sink = stepErrorSink.dropWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def dropWhileExtractError = {
+    val sink = extractErrorSink.dropWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -75,6 +75,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $dropWhileStepError
       extract error   $dropWhileExtractError
 
+    flatMap
+      happy path    $flatMapHappyPath
+      init error    $flatMapInitError
+      step error    $flatMapStepError
+      extract error $flatMapExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -323,6 +329,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def dropWhileExtractError = {
     val sink = extractErrorSink.dropWhile[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def flatMapHappyPath = {
+    val sink = ZSink.identity[Int].flatMap(n => ZSink.succeedLazy(n.toString))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1"))
+  }
+
+  private def flatMapInitError = {
+    val sink = initErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def flatMapStepError = {
+    val sink = stepErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def flatMapExtractError = {
+    val sink = extractErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -130,6 +130,18 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       extract error right $orElseExtractErrorRight
       extract error both  $orElseExtractErrorBoth
 
+    raceBoth
+      left                $raceBothLeft
+      init error left     $raceBothInitErrorLeft
+      init error right    $raceBothInitErrorRight
+      init error both     $raceBothInitErrorBoth
+      step error left     $raceBothStepErrorLeft
+      step error right    $raceBothStepErrorRight
+      step error both     $raceBothStepErrorBoth
+      extract error left  $raceBothExtractErrorLeft
+      extract error right $raceBothExtractErrorRight
+      extract error both  $raceBothExtractErrorBoth
+
     takeWhile
       happy path      $takeWhileHappyPath
       false predicate $takeWhileFalsePredicate
@@ -599,6 +611,56 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def orElseExtractErrorBoth = {
     val sink = extractErrorSink orElse extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def raceBothLeft = {
+    val sink = ZSink.identity[Int] raceBoth ZSink.succeedLazy("Hello")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def raceBothInitErrorLeft = {
+    val sink = initErrorSink raceBoth ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right(1)))
+  }
+
+  private def raceBothInitErrorRight = {
+    val sink = ZSink.identity[Int] raceBoth initErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def raceBothInitErrorBoth = {
+    val sink = initErrorSink race initErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def raceBothStepErrorLeft = {
+    val sink = stepErrorSink raceBoth ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def raceBothStepErrorRight = {
+    val sink = ZSink.identity[Int] raceBoth stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def raceBothStepErrorBoth = {
+    val sink = stepErrorSink race stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def raceBothExtractErrorLeft = {
+    val sink = extractErrorSink raceBoth ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def raceBothExtractErrorRight = {
+    val sink = ZSink.identity[Int] raceBoth extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def raceBothExtractErrorBoth = {
+    val sink = extractErrorSink race extractErrorSink
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -106,6 +106,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $mapErrorStepError
       extract error $mapErrorExtractError
 
+    mapM
+      happy path    $mapMHappyPath
+      init error    $mapMInitError
+      step error    $mapMStepError
+      extract error $mapMExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -460,6 +466,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def mapErrorExtractError = {
     val sink = extractErrorSink.mapError(_ => "Error")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def mapMHappyPath = {
+    val sink = ZSink.identity[Int].mapM[Any, Unit, String](n => UIO.succeed(n.toString))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1"))
+  }
+
+  private def mapMInitError = {
+    val sink = initErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapMStepError = {
+    val sink = stepErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapMExtractError = {
+    val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -131,8 +131,14 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error      $untilOutputStepError
       extract error   $untilOutputExtractError
 
-    zip
+    zip (<*>)
       happy path $zipHappyPath
+
+    zipLeft (<*)
+      happy path $zipLeftHappyPath
+
+    zipRight (*>)
+      happy path $zipRightHappyPath
 
   Constructors
     Sink.foldLeft                         $foldLeft
@@ -580,6 +586,16 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def zipHappyPath = {
     val sink = ZSink.identity[Int].zip(ZSink.succeedLazy("Hello"))
     unsafeRun(sinkIteration(sink, 1).map(t => (t._1 must_=== 1) and (t._2 must_=== "Hello")))
+  }
+
+  private def zipLeftHappyPath = {
+    val sink = ZSink.identity[Int].zipLeft(ZSink.succeedLazy("Hello"))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def zipRightHappyPath = {
+    val sink = ZSink.identity[Int].zipRight(ZSink.succeedLazy("Hello"))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "Hello"))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -106,6 +106,11 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $mapMStepError
       extract error $mapMExtractError
 
+    mapRemainder
+      init error    $mapRemainderInitError
+      step error    $mapRemainderStepError
+      extract error $mapRemainderExtractError
+
     optional
       happy path    $optionalHappyPath
       init error    $optionalInitError
@@ -465,6 +470,21 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def mapMExtractError = {
     val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapRemainderInitError = {
+    val sink = initErrorSink.mapRemainder(_.toLong)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapRemainderStepError = {
+    val sink = stepErrorSink.mapRemainder(_.toLong)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def mapRemainderExtractError = {
+    val sink = extractErrorSink.mapRemainder(_.toLong)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -62,6 +62,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $constStepError
       extract error $constExtractError
 
+    dimap
+      happy path    $dimapHappyPath
+      init error    $dimapInitError
+      step error    $dimapStepError
+      extract error $dimapExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -266,6 +272,26 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def constExtractError = {
     val sink = extractErrorSink.const("const")
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def dimapHappyPath = {
+    val sink = ZSink.identity[Int].dimap[String, String](_.toInt)(_.toString.reverse)
+    unsafeRun(sinkIteration(sink, "123").map(_ must_=== "321"))
+  }
+
+  private def dimapInitError = {
+    val sink = initErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
+    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+  }
+
+  private def dimapStepError = {
+    val sink = stepErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
+    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+  }
+
+  private def dimapExtractError = {
+    val sink = extractErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
+    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -28,12 +28,10 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     collectAll
       happy path    $collectAllHappyPath
       init error    $collectAllInitError
-      step error    $collectAllStepError
       extract error $collectAllExtractError
 
     collectAllWhile
       happy path      $collectAllWhileHappyPath
-      false predicate $collectAllWhileFalsePredicate
       init error      $collectAllWhileInitError
       step error      $collectAllWhileStepError
       extract error   $collectAllWhileExtractError
@@ -150,8 +148,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       extract error   $takeWhileExtractError
 
     untilOutput
-      happy path      $untilOutputHappyPath
-      false predicate $untilOutputFalsePredicate
       init error      $untilOutputInitError
       step error      $untilOutputStepError
       extract error   $untilOutputExtractError
@@ -275,12 +271,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
-  private def collectAllStepError = {
-    // This test needs to be verified for correctness.
-    val sink = stepErrorSink.collectAll
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Nil))
-  }
-
   private def collectAllExtractError = {
     val sink = extractErrorSink.collectAll
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
@@ -289,15 +279,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def collectAllWhileHappyPath = {
     val sink = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 10)
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
-  }
-
-  private def collectAllWhileFalsePredicate = {
-    // This test needs to be verified for correctness.
-    // I find this behavior to be surprising.
-    val sink = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 0)
-    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
-    // Fails instead of returning empty list.
-    // I would presume that sinkIteration(sink, 1).map(_ must_=== Nil) is the correct behavior.
   }
 
   private def collectAllWhileInitError = {
@@ -708,18 +689,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def takeWhileExtractError = {
     val sink = extractErrorSink.takeWhile[Int](_ < 5)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
-  }
-
-  private def untilOutputHappyPath = {
-    // This test needs to be verified for correctness.
-    val sink = ZSink.identity[Int].untilOutput(_ % 2 == 0)
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
-  }
-
-  private def untilOutputFalsePredicate = {
-    // This test needs to be verified for correctness.
-    val sink = ZSink.identity[Int].untilOutput(_ % 2 != 0)
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
   }
 
   private def untilOutputInitError = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -24,6 +24,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $optionalStepError
       extract error $optionalExtractError
 
+    Sink#chunked
+      happy path    $chunkedHappyPath
+      empty         $chunkedEmpty
+      init error    $chunkedInitError
+      step error    $chunkedStepError
+      extract error $chunkedExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -93,6 +100,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def optionalExtractError = {
     val sink = extractErrorSink.?
     unsafeRun(sinkIteration(sink, ()).map(_ must_=== None))
+  }
+
+  private def chunkedHappyPath = {
+    val sink = ZSink.collectAll[Int].chunked
+    unsafeRun(sinkIteration(sink, Chunk(1, 2, 3, 4, 5)).map(_ must_=== List(1, 2, 3, 4, 5)))
+  }
+
+  private def chunkedEmpty = {
+    val sink = ZSink.collectAll[Int].chunked
+    unsafeRun(sinkIteration(sink, Chunk.empty).map(_ must_=== Nil))
+  }
+
+  private def chunkedInitError = {
+    val sink = initErrorSink.chunked
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
+  }
+
+  private def chunkedStepError = {
+    val sink = stepErrorSink.chunked
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
+  }
+
+  private def chunkedExtractError = {
+    val sink = extractErrorSink.chunked
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -252,17 +252,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def chunkedInitError = {
     val sink = initErrorSink.chunked
-    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).either.map(_ must_=== Left("Ouch")))
   }
 
   private def chunkedStepError = {
     val sink = stepErrorSink.chunked
-    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).either.map(_ must_=== Left("Ouch")))
   }
 
   private def chunkedExtractError = {
     val sink = extractErrorSink.chunked
-    unsafeRun(sinkIteration(sink, Chunk.single(1)).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, Chunk.single(1)).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllHappyPath = {
@@ -272,18 +272,18 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def collectAllInitError = {
     val sink = initErrorSink.collectAll
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllStepError = {
     // This test needs to be verified for correctness.
     val sink = stepErrorSink.collectAll
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== Some(Nil)))
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Nil))
   }
 
   private def collectAllExtractError = {
     val sink = extractErrorSink.collectAll
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileHappyPath = {
@@ -295,24 +295,24 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     // This test needs to be verified for correctness.
     // I find this behavior to be surprising.
     val sink = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 0)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
     // Fails instead of returning empty list.
     // I would presume that sinkIteration(sink, 1).map(_ must_=== Nil) is the correct behavior.
   }
 
   private def collectAllWhileInitError = {
     val sink = initErrorSink.collectAllWhile[Int, Int](_ > 1)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileStepError = {
     val sink = stepErrorSink.collectAllWhile[Int, Int](_ > 1)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileExtractError = {
     val sink = extractErrorSink.collectAllWhile[Int, Int](_ > 1)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapHappyPath = {
@@ -322,17 +322,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def contramapInitError = {
     val sink = initErrorSink.contramap[String](_.toInt)
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapStepError = {
     val sink = stepErrorSink.contramap[String](_.toInt)
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapExtractError = {
     val sink = extractErrorSink.contramap[String](_.toInt)
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapMHappyPath = {
@@ -342,17 +342,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def contramapMInitError = {
     val sink = initErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapMStepError = {
     val sink = stepErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def contramapMExtractError = {
     val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-    unsafeRun(sinkIteration(sink, "1").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
   private def constHappyPath = {
@@ -362,17 +362,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def constInitError = {
     val sink = initErrorSink.const("const")
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def constStepError = {
     val sink = stepErrorSink.const("const")
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def constExtractError = {
     val sink = extractErrorSink.const("const")
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def dimapHappyPath = {
@@ -382,22 +382,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def dimapInitError = {
     val sink = initErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "123").either.map(_ must_=== Left("Ouch")))
   }
 
   private def dimapStepError = {
     val sink = stepErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "123").either.map(_ must_=== Left("Ouch")))
   }
 
   private def dimapExtractError = {
     val sink = extractErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-    unsafeRun(sinkIteration(sink, "123").option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, "123").either.map(_ must_=== Left("Ouch")))
   }
 
   private def dropWhileHappyPath = {
     val sink = ZSink.identity[Int].dropWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
   }
 
   private def dropWhileFalsePredicate = {
@@ -407,17 +407,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def dropWhileInitError = {
     val sink = initErrorSink.dropWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def dropWhileStepError = {
     val sink = stepErrorSink.dropWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def dropWhileExtractError = {
     val sink = extractErrorSink.dropWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def flatMapHappyPath = {
@@ -427,17 +427,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def flatMapInitError = {
     val sink = initErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def flatMapStepError = {
     val sink = stepErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def flatMapExtractError = {
     val sink = extractErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterHappyPath = {
@@ -447,22 +447,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def filterFalsePredicate = {
     val sink = ZSink.identity[Int].filter[Int](_ > 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
   }
 
   private def filterInitError = {
     val sink = initErrorSink.filter[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterStepError = {
     val sink = stepErrorSink.filter[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterExtractError = {
     val sink = extractErrorSink.filter[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterMHappyPath = {
@@ -472,22 +472,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def filterMFalsePredicate = {
     val sink = ZSink.identity[Int].filterM[Any, Unit, Int](n => UIO.succeed(n > 5))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
   }
 
   private def filterMInitError = {
     val sink = initErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterMStepError = {
     val sink = stepErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def filterMExtractError = {
     val sink = extractErrorSink.filterM[Any, String, Int](n => UIO.succeed(n < 5))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapHappyPath = {
@@ -497,17 +497,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def mapInitError = {
     val sink = initErrorSink.map(_.toString)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapStepError = {
     val sink = stepErrorSink.map(_.toString)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapExtractError = {
     val sink = extractErrorSink.map(_.toString)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapErrorInitError = {
@@ -532,32 +532,32 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def mapMInitError = {
     val sink = initErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapMStepError = {
     val sink = stepErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapMExtractError = {
     val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapRemainderInitError = {
     val sink = initErrorSink.mapRemainder(_.toLong)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapRemainderStepError = {
     val sink = stepErrorSink.mapRemainder(_.toLong)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def mapRemainderExtractError = {
     val sink = extractErrorSink.mapRemainder(_.toLong)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def optionalHappyPath = {
@@ -602,7 +602,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def orElseInitErrorBoth = {
     val sink = initErrorSink orElse initErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def orElseStepErrorLeft = {
@@ -617,7 +617,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def orElseStepErrorBoth = {
     val sink = stepErrorSink orElse stepErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def orElseExtractErrorLeft = {
@@ -632,7 +632,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def orElseExtractErrorBoth = {
     val sink = extractErrorSink orElse extractErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def raceBothLeft = {
@@ -652,12 +652,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def raceBothInitErrorBoth = {
     val sink = initErrorSink race initErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def raceBothStepErrorLeft = {
     val sink = stepErrorSink raceBoth ZSink.identity[Int]
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def raceBothStepErrorRight = {
@@ -667,12 +667,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def raceBothStepErrorBoth = {
     val sink = stepErrorSink race stepErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def raceBothExtractErrorLeft = {
     val sink = extractErrorSink raceBoth ZSink.identity[Int]
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def raceBothExtractErrorRight = {
@@ -682,7 +682,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def raceBothExtractErrorBoth = {
     val sink = extractErrorSink race extractErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def takeWhileHappyPath = {
@@ -692,22 +692,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def takeWhileFalsePredicate = {
     val sink = ZSink.identity[Int].takeWhile[Int](_ > 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(())))
   }
 
   private def takeWhileInitError = {
     val sink = initErrorSink.takeWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def takeWhileStepError = {
     val sink = stepErrorSink.takeWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def takeWhileExtractError = {
     val sink = extractErrorSink.takeWhile[Int](_ < 5)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def untilOutputHappyPath = {
@@ -724,17 +724,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def untilOutputInitError = {
     val sink = initErrorSink.untilOutput(_ == 0)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def untilOutputStepError = {
     val sink = stepErrorSink.untilOutput(_ == 0)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def untilOutputExtractError = {
     val sink = extractErrorSink.untilOutput(_ == 0)
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipHappyPath = {
@@ -744,47 +744,47 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def zipInitErrorLeft = {
     val sink = initErrorSink <*> ZSink.identity[Int]
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipInitErrorRight = {
     val sink = ZSink.identity[Int] <*> initErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipInitErrorBoth = {
     val sink = initErrorSink <*> initErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipStepErrorLeft = {
     val sink = stepErrorSink <*> ZSink.identity[Int]
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipStepErrorRight = {
     val sink = ZSink.identity[Int] <*> stepErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipStepErrorBoth = {
     val sink = stepErrorSink <*> stepErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipExtractErrorLeft = {
     val sink = extractErrorSink <*> ZSink.identity[Int]
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipExtractErrorRight = {
     val sink = ZSink.identity[Int] <*> extractErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipExtractErrorBoth = {
     val sink = extractErrorSink <*> extractErrorSink
-    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def zipLeftHappyPath = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -117,6 +117,19 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $optionalStepError
       extract error $optionalExtractError
 
+    orElse
+      left                $orElseLeft
+      right               $orElseRight
+      init error left     $orElseInitErrorLeft
+      init error right    $orElseInitErrorRight
+      init error both     $orElseInitErrorBoth
+      step error left     $orElseStepErrorLeft
+      step error right    $orElseStepErrorRight
+      step error both     $orElseStepErrorBoth
+      extract error left  $orElseExtractErrorLeft
+      extract error right $orElseExtractErrorRight
+      extract error both  $orElseExtractErrorBoth
+
     takeWhile
       happy path      $takeWhileHappyPath
       false predicate $takeWhileFalsePredicate
@@ -532,6 +545,61 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def optionalExtractError = {
     val sink = extractErrorSink.optional
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== None))
+  }
+
+  private def orElseLeft = {
+    val sink = ZSink.identity[Int] orElse ZSink.fail("Ouch")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def orElseRight = {
+    val sink = ZSink.fail("Ouch") orElse ZSink.succeedLazy("Hello")
+    unsafeRun(sinkIteration(sink, "whatever").map(_ must_=== Right("Hello")))
+  }
+
+  private def orElseInitErrorLeft = {
+    val sink = initErrorSink orElse ZSink.succeedLazy("Hello")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
+  }
+
+  private def orElseInitErrorRight = {
+    val sink = ZSink.identity[Int] orElse initErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def orElseInitErrorBoth = {
+    val sink = initErrorSink orElse initErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def orElseStepErrorLeft = {
+    val sink = stepErrorSink orElse ZSink.succeedLazy("Hello")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
+  }
+
+  private def orElseStepErrorRight = {
+    val sink = ZSink.identity[Int] orElse stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def orElseStepErrorBoth = {
+    val sink = stepErrorSink orElse stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def orElseExtractErrorLeft = {
+    val sink = extractErrorSink orElse ZSink.succeedLazy("Hello")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
+  }
+
+  private def orElseExtractErrorRight = {
+    val sink = ZSink.identity[Int] orElse extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
+  }
+
+  private def orElseExtractErrorBoth = {
+    val sink = extractErrorSink orElse extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def takeWhileHappyPath = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -169,22 +169,32 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       happy path $zipWithHappyPath
 
   Constructors
-    Sink.foldLeft                         $foldLeft
-    Sink.fold                             $fold
-    Sink.fold short circuits              $foldShortCircuits
-    Sink.foldM                            $foldM
-    Sink.foldM short circuits             $foldMShortCircuits
-    Sink.collectAllWhile                  $collectAllWhile
-    Sink.foldWeighted                     $foldWeighted
-    Sink.foldWeightedM                    $foldWeightedM
-    Sink.foldUntil                        $foldUntil
-    Sink.foldUntilM                       $foldUntilM
-    Sink.fromOutputStream                 $sinkFromOutputStream
-    Sink.throttleEnforce                  $throttleEnforce
-    Sink.throttleEnforce with burst       $throttleEnforceWithBurst
-    Sink.throttleShape                    $throttleShape
-    Sink.throttleShape infinite bandwidth $throttleShapeInfiniteBandwidth
-    Sink.throttleShape with burst         $throttleShapeWithBurst
+    foldLeft $foldLeft
+    
+    fold             $fold
+      short circuits $foldShortCircuits
+
+    foldM            $foldM
+      short circuits $foldMShortCircuits
+
+    collectAllWhile $collectAllWhile
+
+    foldWeighted $foldWeighted
+
+    foldWeightedM $foldWeightedM
+
+    foldUntil $foldUntil
+
+    foldUntilM $foldUntilM
+
+    fromOutputStream $fromOutputStream
+
+    throttleEnforce $throttleEnforce
+      with burst    $throttleEnforceWithBurst
+
+    throttleShape        $throttleShape
+      infinite bandwidth $throttleShapeInfiniteBandwidth
+      with burst         $throttleShapeWithBurst
 
   Usecases
     Number array parsing with Sink.foldM  $jsonNumArrayParsingSinkFoldM
@@ -923,7 +933,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       (fullParse must_=== (Exit.Success(List(123, 4))))
   }
 
-  private def sinkFromOutputStream = unsafeRun {
+  private def fromOutputStream = unsafeRun {
     import java.io.ByteArrayOutputStream
 
     val output = new ByteArrayOutputStream()

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -26,10 +26,10 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       extract error $chunkedExtractError
 
     collectAll
-      happy path         $collectAllHappyPath
-      init error         $collectAllInitError
-      step error         $collectAllStepError
-      extract error      $collectAllExtractError
+      happy path    $collectAllHappyPath
+      init error    $collectAllInitError
+      step error    $collectAllStepError
+      extract error $collectAllExtractError
 
     collectAllWhile
       happy path      $collectAllWhileHappyPath
@@ -157,7 +157,16 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       extract error   $untilOutputExtractError
 
     zip (<*>)
-      happy path $zipHappyPath
+      happy path          $zipHappyPath
+      init error left     $zipInitErrorLeft
+      init error right    $zipInitErrorRight
+      init error both     $zipInitErrorBoth
+      step error left     $zipStepErrorLeft
+      step error right    $zipStepErrorRight
+      step error both     $zipStepErrorBoth
+      extract error left  $zipExtractErrorLeft
+      extract error right $zipExtractErrorRight
+      extract error both  $zipExtractErrorBoth
 
     zipLeft (<*)
       happy path $zipLeftHappyPath
@@ -257,7 +266,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def collectAllHappyPath = {
-    val sink = ZSink.identity[Int].collectAll
+    val sink = ZSink.identity[Int].collectAll[Int, Int]
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
   }
 
@@ -731,6 +740,51 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def zipHappyPath = {
     val sink = ZSink.identity[Int] <*> ZSink.succeedLazy("Hello")
     unsafeRun(sinkIteration(sink, 1).map(t => (t._1 must_=== 1) and (t._2 must_=== "Hello")))
+  }
+
+  private def zipInitErrorLeft = {
+    val sink = initErrorSink <*> ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipInitErrorRight = {
+    val sink = ZSink.identity[Int] <*> initErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipInitErrorBoth = {
+    val sink = initErrorSink <*> initErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipStepErrorLeft = {
+    val sink = stepErrorSink <*> ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipStepErrorRight = {
+    val sink = ZSink.identity[Int] <*> stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipStepErrorBoth = {
+    val sink = stepErrorSink <*> stepErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipExtractErrorLeft = {
+    val sink = extractErrorSink <*> ZSink.identity[Int]
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipExtractErrorRight = {
+    val sink = ZSink.identity[Int] <*> extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def zipExtractErrorBoth = {
+    val sink = extractErrorSink <*> extractErrorSink
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 
   private def zipLeftHappyPath = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -81,6 +81,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step error    $flatMapStepError
       extract error $flatMapExtractError
 
+    filter
+      happy path      $filterHappyPath
+      false predicate $filterFalsePredicate
+      init error      $filterInitError
+      step error      $filterStepError
+      extractError    $filterExtractError
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -349,6 +356,31 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def flatMapExtractError = {
     val sink = extractErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterHappyPath = {
+    val sink = ZSink.identity[Int].filter[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
+  }
+
+  private def filterFalsePredicate = {
+    val sink = ZSink.identity[Int].filter[Int](_ > 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterInitError = {
+    val sink = initErrorSink.filter[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterStepError = {
+    val sink = stepErrorSink.filter[Int](_ < 5)
+    unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
+  }
+
+  private def filterExtractError = {
+    val sink = extractErrorSink.filter[Int](_ < 5)
     unsafeRun(sinkIteration(sink, 1).option.map(_ must_=== None))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -187,6 +187,8 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     foldUntilM $foldUntilM
 
+    fromFunction $fromFunction
+
     fromOutputStream $fromOutputStream
 
     throttleEnforce $throttleEnforce
@@ -861,6 +863,13 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       .transduce(Sink.foldUntilM(0L, 3)((s, a: Long) => UIO.succeed(s + a)))
       .runCollect
       .map(_ must_=== List(3, 3))
+  }
+
+  private def fromFunction = unsafeRun {
+    Stream(1, 2, 3, 4, 5)
+      .transduce(Sink.fromFunction[Int, String](_.toString))
+      .runCollect
+      .map(_ must_=== List("1", "2", "3", "4", "5"))
   }
 
   private def jsonNumArrayParsingSinkFoldM = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -140,6 +140,9 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     zipRight (*>)
       happy path $zipRightHappyPath
 
+    zipWith
+      happy path $zipWithHappyPath
+
   Constructors
     Sink.foldLeft                         $foldLeft
     Sink.fold                             $fold
@@ -596,6 +599,11 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def zipRightHappyPath = {
     val sink = ZSink.identity[Int].zipRight(ZSink.succeedLazy("Hello"))
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "Hello"))
+  }
+
+  private def zipWithHappyPath = {
+    val sink = ZSink.identity[Int].zipWith(ZSink.succeedLazy("Hello"))((x, y) => x.toString + y.toString)
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1Hello"))
   }
 
   private def foldLeft =

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -587,7 +587,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def zipHappyPath = {
-    val sink = ZSink.identity[Int].zip(ZSink.succeedLazy("Hello"))
+    val sink = ZSink.identity[Int] <*> ZSink.succeedLazy("Hello")
     unsafeRun(sinkIteration(sink, 1).map(t => (t._1 must_=== 1) and (t._2 must_=== "Hello")))
   }
 

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -137,7 +137,7 @@ object Sink {
   /**
    * see [[ZSink.identity]]
    */
-  final def identity[A]: Sink[Unit, A, A, A] =
+  final def identity[A]: Sink[Unit, Nothing, A, A] =
     ZSink.identity
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1068,12 +1068,12 @@ object ZSink extends ZSinkPlatformSpecific {
   /**
    * Creates a sink by that merely passes on incoming values.
    */
-  final def identity[A]: ZSink[Any, Unit, A, A, A] =
-    new SinkPure[Unit, A, A, A] {
+  final def identity[A]: ZSink[Any, Unit, Nothing, A, A] =
+    new SinkPure[Unit, Nothing, A, A] {
       type State = Option[A]
-      val initialPure                                  = Step.more(None)
-      def stepPure(state: State, a: A): Step[State, A] = Step.done(Some(a), Chunk.empty)
-      def extractPure(state: State): Either[Unit, A]   = state.fold[Either[Unit, A]](Left(()))(a => Right(a))
+      val initialPure                  = Step.more(None)
+      def stepPure(state: State, a: A) = Step.done(Some(a), Chunk.empty)
+      def extractPure(state: State)    = state.fold[Either[Unit, A]](Left(()))(a => Right(a))
     }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -126,7 +126,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
     zip(that)
 
   /**
-   * Takes a `Sink`, and lifts it to be chunked in its input and output. This
+   * Takes a `Sink`, and lifts it to be chunked in its input. This
    * will not improve performance, but can be used to adapt non-chunked sinks
    * wherever chunked sinks are required.
    */


### PR DESCRIPTION
I know this doesn't contain property checks with generated streams, so it partially addresses #429.

These tests will be crucial for the refactoring in #538.

Some tests exhibit surprising behavior, at least to me. Maybe they show bugs in the implementation of some of the combinators, or I may have just misunderstood their use. Anyways, I'd appreciate a second look.