### PR TITLE
Generalize and add variance to a few ZIO Test signatures

### DIFF
--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -22,7 +22,7 @@ import scala.util.control.NonFatal
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
  */
-abstract class RunnableSpec[R, L](runner: TestRunner[L, ZTest[R, Any]])(spec: => ZSpec[R, Nothing, L]) {
+abstract class RunnableSpec[+L, +T](runner: TestRunner[L, T])(spec: => Spec[L, T]) {
 
   /**
    * A simple main function that can be used to run the spec.

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -25,7 +25,7 @@ import zio.internal.{ Platform, PlatformLive }
  * require an environment `R` and may fail with an error `E`, using labels of
  * type `L`. Test runners require a test executor, a platform, and a reporter.
  */
-abstract class TestRunner[L, T](
+abstract class TestRunner[L, -T](
   executor: TestExecutor[L, T],
   platform: Platform = PlatformLive.makeDefault().withReportFailure(_ => ()),
   reporter: TestReporter[L] = DefaultTestReporter(Console.Live)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -84,7 +84,7 @@ package object test {
   /**
    * Builds a suite containing a number of other specs.
    */
-  final def suite[R, E, L](label: L)(specs: ZSpec[R, E, L]*): ZSpec[R, E, L] = Spec.suite(label, specs.toVector, None)
+  final def suite[L, T](label: L)(specs: Spec[L, T]*): Spec[L, T] = Spec.suite(label, specs.toVector, None)
 
   /**
    * Builds a spec with a single pure test.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -95,5 +95,5 @@ package object test {
   /**
    * Builds a spec with a single effectful test.
    */
-  final def testM[R, E, L](label: L)(assertion: ZIO[R, E, TestResult]): ZSpec[R, E, L] = Spec.test(label, assertion)
+  final def testM[L, T](label: L)(assertion: T): Spec[L, T] = Spec.test(label, assertion)
 }


### PR DESCRIPTION
@jdegoes 
Following up on https://github.com/zio/zio/pull/1238#issuecomment-515411952, I think you've succeeded at making ZIO Test general enough so that a `distage-testkit` TestExecutor is implementable with rather minimal fuss, thank you very much!  - https://github.com/7mind/izumi/pull/600/files#diff-322276ed019865eea4a966fbc5f03ef7R22 although using a non-ZIO type in `T` means losing access to `TestAspect`...

I think now we need to think about

1. test discovery & SBT integration
2. online test reporting – to support tooling test results must be reported during execution, not afterwards
