### PR TITLE
Map aliases

### DIFF
--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -61,11 +61,7 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Replaces the error value with the one provided.
    */
-  final def asError[E1](e1: E1): Exit[E1, A] =
-    self match {
-      case e @ Success(_) => e
-      case Failure(c)     => halt(c.map(_ => e1))
-    }
+  final def asError[E1](e1: E1): Exit[E1, A] = mapError(_ => e1)
 
   /**
    * Maps over both the error and value type.

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -54,17 +54,26 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   final def <*>[E1 >: E, B](that: Exit[E1, B]): Exit[E1, (A, B)] = zipWith(that)((_, _), _ ++ _)
 
   /**
+   * Replaces the success value with the one provided.
+   */
+  final def as[B](b: B): Exit[E, B] = map(_ => b)
+
+  /**
+   * Replaces the error value with the one provided.
+   */
+  final def asError[E1](e1: E1): Exit[E1, A] =
+    self match {
+      case e @ Success(_) => e
+      case Failure(c)     => halt(c.map(_ => e1))
+    }
+
+  /**
    * Maps over both the error and value type.
    */
   final def bimap[E1, A1](f: E => E1, g: A => A1): Exit[E1, A1] = mapError(f).map(g)
 
   @deprecated("use as", "1.0.0")
   final def const[B](b: B): Exit[E, B] = as(b)
-
-  /**
-   * Replaces the value with the one provided.
-   */
-  final def as[B](b: B): Exit[E, B] = map(_ => b)
 
   /**
    * Flat maps over the value type.

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -58,10 +58,13 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
    */
   final def bimap[E1, A1](f: E => E1, g: A => A1): Exit[E1, A1] = mapError(f).map(g)
 
+  @deprecated("use as", "1.0.0")
+  final def const[B](b: B): Exit[E, B] = as(b)
+
   /**
    * Replaces the value with the one provided.
    */
-  final def const[B](b: B): Exit[E, B] = map(_ => b)
+  final def as[B](b: B): Exit[E, B] = map(_ => b)
 
   /**
    * Flat maps over the value type.
@@ -144,7 +147,7 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Discards the value.
    */
-  final def unit: Exit[E, Unit] = const(())
+  final def unit: Exit[E, Unit] = as(())
 
   /**
    * Named alias for `<*>`.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -166,10 +166,14 @@ trait Fiber[+E, +A] { self =>
       def inheritFiberRefs: UIO[Unit]   = self.inheritFiberRefs
     }
 
+  @deprecated("use as", "1.0.0")
+  final def const[B](b: => B): Fiber[E, B] =
+    as(b)
+
   /**
    * Maps the output of this fiber to the specified constant.
    */
-  final def const[B](b: => B): Fiber[E, B] =
+  final def as[B](b: => B): Fiber[E, B] =
     map(_ => b)
 
   /**
@@ -181,7 +185,7 @@ trait Fiber[+E, +A] { self =>
   /**
    * Maps the output of this fiber to `()`.
    */
-  final def unit: Fiber[E, Unit] = const(())
+  final def unit: Fiber[E, Unit] = as(())
 
   /**
    * Converts this fiber into a [[scala.concurrent.Future]].

--- a/core/shared/src/main/scala/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/zio/FunctionIO.scala
@@ -182,22 +182,23 @@ sealed trait FunctionIO[+E, -A, +B] extends Serializable { self =>
   final def |||[E1 >: E, B1 >: B, C](that: FunctionIO[E1, C, B1]): FunctionIO[E1, Either[A, C], B1] =
     FunctionIO.join(self, that)
 
+  @deprecated("use as", "1.0.0")
+  final def const[C](c: => C): FunctionIO[E, A, C] =
+    as(c)
+
   /**
    * Maps the output of this effectful function to the specified constant.
    */
-  final def const[C](c: => C): FunctionIO[E, A, C] =
+  final def as[C](c: => C): FunctionIO[E, A, C] =
     self >>> FunctionIO.fromFunction[B, C](_ => c)
 
-  /**
-   * Maps the output of this effectful function to `Unit`.
-   */
   @deprecated("use unit", "1.0.0")
   final def void: FunctionIO[E, A, Unit] = unit
 
   /**
    * Maps the output of this effectful function to `Unit`.
    */
-  final def unit: FunctionIO[E, A, Unit] = const(())
+  final def unit: FunctionIO[E, A, Unit] = as(())
 
   /**
    * Returns a new effectful function that merely applies this one for its

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -110,13 +110,13 @@ trait Runtime[+R] {
   final def unsafeRunToFuture[E <: Throwable, A](io: ZIO[R, E, A]): scala.concurrent.Future[A] =
     unsafeRun(io.toFuture)
 
-  @deprecated("use as", "1.0.0")
-  final def const[R1](r1: R1): Runtime[R1] = as(r1)
-
   /**
    * Constructs a new `Runtime` with the specified new environment.
    */
   final def as[R1](r1: R1): Runtime[R1] = map(_ => r1)
+
+  @deprecated("use as", "1.0.0")
+  final def const[R1](r1: R1): Runtime[R1] = as(r1)
 
   /**
    * Constructs a new `Runtime` with the specified executor.

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -110,10 +110,13 @@ trait Runtime[+R] {
   final def unsafeRunToFuture[E <: Throwable, A](io: ZIO[R, E, A]): scala.concurrent.Future[A] =
     unsafeRun(io.toFuture)
 
+  @deprecated("use as", "1.0.0")
+  final def const[R1](r1: R1): Runtime[R1] = as(r1)
+
   /**
    * Constructs a new `Runtime` with the specified new environment.
    */
-  final def const[R1](r1: R1): Runtime[R1] = map(_ => r1)
+  final def as[R1](r1: R1): Runtime[R1] = map(_ => r1)
 
   /**
    * Constructs a new `Runtime` with the specified executor.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1360,45 +1360,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   }
 
   /**
-   * Alias for `map`.
-   *
-   * {{{
-   * val answerToLife = UIO.succeed(21) +> (_ * 2)
-   * }}}
-   */
-  final def +>[B](f: A => B): ZIO[R, E, B] = map(f)
-
-  /**
-   * Alias for `as`.
-   *
-   * {{{
-   * val answerToLife = console.getStrLn *+> "42"
-   * }}}
-   */
-  final def *+>[B](v: B): ZIO[R, E, B] = as(v)
-
-  /**
-   * Alias for `mapError`.
-   *
-   * {{{
-   * val result = writeToDisk #> {
-   *   case _: IOException      => WriteFailed(retry = true)
-   *   case _: RuntimeException => WriteFailed(retry = false)
-   * }
-   * }}}
-   */
-  final def #>[E2](f: E => E2): ZIO[R, E2, A] = mapError(f)
-
-  /**
-   * Alias for `asError`.
-   *
-   * {{{
-   * val result = writeToDisk *#> WriteFailed(retry = false)
-   * }}}
-   */
-  final def *#>[E2](v: E2): ZIO[R, E2, A] = asError(v)
-
-  /**
    * Alias for `flatMap`.
    *
    * {{{

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -97,6 +97,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self >>> that
 
   /**
+   * Maps the success value of this effect to the specified constant value.
+   */
+  final def as[B](b: B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstFn(() => b))
+
+  /**
+   * Maps the error value of this effect to the specified constant value.
+   */
+  final def asError[E1](e1: E1): ZIO[R, E1, A] = mapError(_ => e1)
+
+  /**
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
@@ -468,23 +478,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   def map[B](f: A => B): ZIO[R, E, B] = new ZIO.FlatMap(self, new ZIO.MapFn(f))
 
   /**
-   * Returns an effect whose success is replaced by the specified `b` value.
-   */
-  final def as[B](b: B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstFn(() => b))
-
-  /**
    * Returns an effect with its error channel mapped using the specified
    * function. This can be used to lift a "smaller" error into a "larger"
    * error.
    */
   final def mapError[E2](f: E => E2): ZIO[R, E2, A] =
     self.foldCauseM(new ZIO.MapErrorFn(f), new ZIO.SucceedFn(f))
-
-  /**
-   * Returns an effect whose error channel is replaced by the specified `e2` error.
-   * This can be used to lift a "smaller" error into a "larger" error.
-   */
-  final def asError[E2](e2: E2): ZIO[R, E2, A] = mapError(_ => e2)
 
   /**
    * Returns an effect with its full cause of failure mapped using the

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -619,7 +619,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Return unit while running the effect
    */
   lazy final val unit: ZManaged[R, E, Unit] =
-    const(())
+    as(())
 
   /**
    * The inverse operation `ZManaged.sandboxed`

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -168,11 +168,15 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def compose[R1, E1 >: E](that: ZManaged[R1, E1, R]): ZManaged[R1, E1, A] =
     self <<< that
 
+  @deprecated("use as", "1.0.0")
+  final def const[B](b: => B): ZManaged[R, E, B] =
+    as(b)
+
   /**
    * Maps this effect to the specified constant while preserving the
    * effects of this effect.
    */
-  final def const[B](b: => B): ZManaged[R, E, B] =
+  final def as[B](b: => B): ZManaged[R, E, B] =
     map(_ => b)
 
   /**

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -184,6 +184,11 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
     }
 
   /**
+   * Returns a new schedule that maps this schedule to a constant output.
+   */
+  final def as[C](c: => C): ZSchedule[R, A, C] = map(_ => c)
+
+  /**
    * A named alias for `&&`.
    */
   final def both[R1 <: R, A1 <: A, C](that: ZSchedule[R1, A1, C]): ZSchedule[R1, A1, (B, C)] = self && that
@@ -234,11 +239,6 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
 
   @deprecated("use as", "1.0.0")
   final def const[C](c: => C): ZSchedule[R, A, C] = as(c)
-
-  /**
-   * Returns a new schedule that maps this schedule to a constant output.
-   */
-  final def as[C](c: => C): ZSchedule[R, A, C] = map(_ => c)
 
   /**
    * Returns a new schedule that deals with a narrower class of inputs than

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -232,10 +232,13 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
    */
   final def compose[R1 <: R, C](that: ZSchedule[R1, C, A]): ZSchedule[R1, C, B] = self <<< that
 
+  @deprecated("use as", "1.0.0")
+  final def const[C](c: => C): ZSchedule[R, A, C] = as(c)
+
   /**
    * Returns a new schedule that maps this schedule to a constant output.
    */
-  final def const[C](c: => C): ZSchedule[R, A, C] = map(_ => c)
+  final def as[C](c: => C): ZSchedule[R, A, C] = map(_ => c)
 
   /**
    * Returns a new schedule that deals with a narrower class of inputs than
@@ -476,7 +479,7 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
   /**
    * Returns a new schedule that maps this schedule to a Unit output.
    */
-  final def unit: ZSchedule[R, A, Unit] = const(())
+  final def unit: ZSchedule[R, A, Unit] = as(())
 
   /**
    * Returns a new schedule that continues the schedule only until the predicate
@@ -722,12 +725,12 @@ object ZSchedule {
   /**
    * A schedule that recurs forever, returning the constant for every output.
    */
-  final def succeed[A](a: A): Schedule[Any, A] = forever.const(a)
+  final def succeed[A](a: A): Schedule[Any, A] = forever.as(a)
 
   /**
    * A schedule that recurs forever, returning the constant for every output (by-name version).
    */
-  final def succeedLazy[A](a: => A): Schedule[Any, A] = forever.const(a)
+  final def succeedLazy[A](a: => A): Schedule[Any, A] = forever.as(a)
 
   /**
    * A schedule that always recurs without delay, and computes the output

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -104,6 +104,16 @@ final class STM[+E, +A] private[stm] (
     self flatMap f
 
   /**
+   * Maps the success value of this effect to the specified constant value.
+   */
+  final def as[B](b: => B): STM[E, B] = self map (_ => b)
+
+  /**
+   * Maps the error value of this effect to the specified constant value.
+   */
+  final def asError[E1](e: => E1): STM[E1, A] = self mapError (_ => e)
+
+  /**
    * Simultaneously filters and maps the value produced by this effect.
    */
   final def collect[B](pf: PartialFunction[A, B]): STM[E, B] =
@@ -123,11 +133,6 @@ final class STM[+E, +A] private[stm] (
 
   @deprecated("use as", "1.0.0")
   final def const[B](b: => B): STM[E, B] = as(b)
-
-  /**
-   * Maps the success value of this effect to the specified constant value.
-   */
-  final def as[B](b: => B): STM[E, B] = self map (_ => b)
 
   /**
    * Converts the failure channel into an `Either`.

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -121,10 +121,13 @@ final class STM[+E, +A] private[stm] (
    */
   final def commit: IO[E, A] = STM.atomically(self)
 
+  @deprecated("use as", "1.0.0")
+  final def const[B](b: => B): STM[E, B] = as(b)
+
   /**
    * Maps the success value of this effect to the specified constant value.
    */
-  final def const[B](b: => B): STM[E, B] = self map (_ => b)
+  final def as[B](b: => B): STM[E, B] = self map (_ => b)
 
   /**
    * Converts the failure channel into an `Either`.
@@ -261,7 +264,7 @@ final class STM[+E, +A] private[stm] (
   /**
    * Maps the success value of this effect to unit.
    */
-  final def unit: STM[E, Unit] = const(())
+  final def unit: STM[E, Unit] = as(())
 
   /**
    * Maps the success value of this effect to unit.

--- a/docs/datatypes/io.md
+++ b/docs/datatypes/io.md
@@ -172,7 +172,7 @@ object Main extends App {
 
   // run my bracket
   def run(args: List[String]) =
-    mybracket.orDie.const(0)
+    mybracket.orDie.as(0)
 
   def closeStream(is: FileInputStream) =
     UIO(is.close())

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -47,12 +47,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       init error    $contramapMInitError
       step error    $contramapMStepError
       extract error $contramapMExtractError
-    
-    const
-      happy path    $constHappyPath
-      init error    $constInitError
-      step error    $constStepError
-      extract error $constExtractError
+
+    as
+      happy path    $asHappyPath
+      init error    $asInitError
+      step error    $asStepError
+      extract error $asExtractError
 
     dimap
       happy path    $dimapHappyPath
@@ -345,22 +345,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
   }
 
-  private def constHappyPath = {
+  private def asHappyPath = {
     val sink = ZSink.identity[Int].as("const")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "const"))
   }
 
-  private def constInitError = {
+  private def asInitError = {
     val sink = initErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
-  private def constStepError = {
+  private def asStepError = {
     val sink = stepErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
-  private def constExtractError = {
+  private def asExtractError = {
     val sink = extractErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -346,22 +346,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def constHappyPath = {
-    val sink = ZSink.identity[Int].const("const")
+    val sink = ZSink.identity[Int].as("const")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "const"))
   }
 
   private def constInitError = {
-    val sink = initErrorSink.const("const")
+    val sink = initErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def constStepError = {
-    val sink = stepErrorSink.const("const")
+    val sink = stepErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def constExtractError = {
-    val sink = extractErrorSink.const("const")
+    val sink = extractErrorSink.as("const")
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -18,6 +18,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "SinkSpec".title ^ s2"""
   Combinators
+    as
+      happy path    $asHappyPath
+      init error    $asInitError
+      step error    $asStepError
+      extract error $asExtractError
+
+    asError
+      init error    $asErrorInitError
+      step error    $asErrorStepError
+      extract error $asErrorExtractError
+
     chunked
       happy path    $chunkedHappyPath
       empty         $chunkedEmpty
@@ -47,12 +58,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       init error    $contramapMInitError
       step error    $contramapMStepError
       extract error $contramapMExtractError
-
-    as
-      happy path    $asHappyPath
-      init error    $asInitError
-      step error    $asStepError
-      extract error $asExtractError
 
     dimap
       happy path    $dimapHappyPath
@@ -175,7 +180,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   Constructors
     foldLeft $foldLeft
-    
+
     fold             $fold
       short circuits $foldShortCircuits
 
@@ -244,6 +249,41 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       step   <- sink.step(Step.state(init), a)
       result <- sink.extract(Step.state(step))
     } yield result
+
+  private def asHappyPath = {
+    val sink = ZSink.identity[Int].as("const")
+    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "const"))
+  }
+
+  private def asInitError = {
+    val sink = initErrorSink.as("const")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
+  }
+
+  private def asStepError = {
+    val sink = stepErrorSink.as("const")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
+  }
+
+  private def asErrorInitError = {
+    val sink = initErrorSink.asError("Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def asErrorStepError = {
+    val sink = stepErrorSink.asError("Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def asErrorExtractError = {
+    val sink = extractErrorSink.asError("Error")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Error")))
+  }
+
+  private def asExtractError = {
+    val sink = extractErrorSink.as("const")
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
+  }
 
   private def chunkedHappyPath = {
     val sink = ZSink.collectAll[Int].chunked
@@ -343,26 +383,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def contramapMExtractError = {
     val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
     unsafeRun(sinkIteration(sink, "1").either.map(_ must_=== Left("Ouch")))
-  }
-
-  private def asHappyPath = {
-    val sink = ZSink.identity[Int].as("const")
-    unsafeRun(sinkIteration(sink, 1).map(_ must_=== "const"))
-  }
-
-  private def asInitError = {
-    val sink = initErrorSink.as("const")
-    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
-  }
-
-  private def asStepError = {
-    val sink = stepErrorSink.as("const")
-    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
-  }
-
-  private def asExtractError = {
-    val sink = extractErrorSink.as("const")
-    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def dimapHappyPath = {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -770,7 +770,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       inner = Stream
         .bracket(execution.update("InnerAcquire" :: _))(_ => execution.update("InnerRelease" :: _))
       _ <- Stream
-            .bracket(execution.update("OuterAcquire" :: _).const(inner))(_ => execution.update("OuterRelease" :: _))
+            .bracket(execution.update("OuterAcquire" :: _).as(inner))(_ => execution.update("OuterRelease" :: _))
             .flatMapPar(2)(identity)
             .runDrain
       results <- execution.get
@@ -892,7 +892,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       execution <- Ref.make(List.empty[String])
       inner     = Stream.bracket(execution.update("InnerAcquire" :: _))(_ => execution.update("InnerRelease" :: _))
       _ <- Stream
-            .bracket(execution.update("OuterAcquire" :: _).const(inner))(_ => execution.update("OuterRelease" :: _))
+            .bracket(execution.update("OuterAcquire" :: _).as(inner))(_ => execution.update("OuterRelease" :: _))
             .flatMapParSwitch(2)(identity)
             .runDrain
       results <- execution.get
@@ -1421,7 +1421,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     val stream = ZStream(1, 2, 3, 4)
     val test = for {
       resource <- Ref.make(0)
-      sink     = ZManaged.make(resource.set(1000).const(new TestSink(resource)))(_ => resource.set(2000))
+      sink     = ZManaged.make(resource.set(1000).as(new TestSink(resource)))(_ => resource.set(2000))
       result   <- stream.transduceManaged(sink).runCollect
       i        <- resource.get
       _        <- if (i != 2000) IO.fail(new IllegalStateException(i.toString)) else IO.unit

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -263,10 +263,13 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
       def extract(state: State): ZIO[R1, E1, B] = self.extract(state)
     }
 
+  @deprecated("use as", "1.0.0")
+  final def const[C](c: => C): ZSink[R, E, A0, A, C] = as(c)
+
   /**
    * Creates a sink that always produces `c`
    */
-  final def const[C](c: => C): ZSink[R, E, A0, A, C] = self.map(_ => c)
+  final def as[C](c: => C): ZSink[R, E, A0, A, C] = self.map(_ => c)
 
   /**
    * Creates a sink that transforms entering values with `f` and
@@ -698,7 +701,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Creates a sink that ignores all produced elements.
    */
-  final def unit: ZSink[R, E, A0, A, Unit] = const(())
+  final def unit: ZSink[R, E, A0, A, Unit] = as(())
 
   /**
    * Creates a sink that produces values until one verifies

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -133,18 +133,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Replaces any error produced by this sink.
    */
-  final def asError[E1](e1: E1): ZSink[R, E1, A0, A, B] =
-    new ZSink[R, E1, A0, A, B] {
-      type State = self.State
-
-      val initial = self.initial.asError(e1)
-
-      def step(state: State, a: A): ZIO[R, E1, Step[State, A0]] =
-        self.step(state, a).asError(e1)
-
-      def extract(state: State): ZIO[R, E1, B] =
-        self.extract(state).asError(e1)
-    }
+  final def asError[E1](e1: E1): ZSink[R, E1, A0, A, B] = self.mapError(_ => e1)
 
   /**
    * Takes a `Sink`, and lifts it to be chunked in its input. This

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -119,7 +119,7 @@ trait ZStreamChunk[-R, +E, @specialized +A] { self =>
    * Consumes all elements of the stream, passing them to the specified callback.
    */
   final def foreach[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Unit]): ZIO[R1, E1, Unit] =
-    foreachWhile[R1, E1](f(_).const(true))
+    foreachWhile[R1, E1](f(_).as(true))
 
   /**
    * Consumes elements of the stream, passing them to the specified callback,

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -23,10 +23,13 @@ package zio.test
 sealed trait Assertion[+A] { self =>
   import Assertion._
 
+  @deprecated("use as", "1.0.0")
+  final def const[L2](l2: L2): Assertion[L2] = as(l2)
+
   /**
    * Returns a new result, with the message mapped to the specified constant.
    */
-  final def const[L2](l2: L2): Assertion[L2] = self.map(_ => l2)
+  final def as[L2](l2: L2): Assertion[L2] = self.map(_ => l2)
 
   /**
    * Combines this result with the specified result.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -23,13 +23,13 @@ package zio.test
 sealed trait Assertion[+A] { self =>
   import Assertion._
 
-  @deprecated("use as", "1.0.0")
-  final def const[L2](l2: L2): Assertion[L2] = as(l2)
-
   /**
    * Returns a new result, with the message mapped to the specified constant.
    */
   final def as[L2](l2: L2): Assertion[L2] = self.map(_ => l2)
+
+  @deprecated("use as", "1.0.0")
+  final def const[L2](l2: L2): Assertion[L2] = as(l2)
 
   /**
    * Combines this result with the specified result.


### PR DESCRIPTION
This proposition consists of two parts:

1. Adding the `as` and `asError` operators.

Similar to `*>` and `<*` operators, sometimes we just don't care about the value in the success/error channel and wish to replace it. With these operators, we can express that more clearly.

```scala
val answerToLive1 = getStrLn map (_ => "42")
// vs
val answerToLive2 = getStrLn as "42"
```

2. Adding symbolic aliases for `map`, `mapError`, `as` and `asError`.

The symbolic aliases are more readable when chaining lots of operations.

```scala
val result1 = foo flatMap bar flatMap baz map wrap
// vs
val result2 = foo >>= bar >>= baz +> wrap
// or even

val result3 = (
  foo 
    >>= bar
    >>= baz
    +> wrap
)
```

The choice of symbols is somewhat arbitrary. Among many alternatives I propose these (`+>`, `*+>`, `#>`, `*#>`) follwing this reasoning:

* the right arrow `>` indicates the direction of the flow, similar to `*>` operator
* the `+` and `#` indicates the channel being mapped (respectively success and error)
* the `*` prefix indicates the previous value is being ignored, similar to `*>` operator 

I'm open to discuss alternatives.