### PR TITLE
Create `FiberFailure` without stack trace (#1218)

### DIFF
--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -24,6 +24,4 @@ package zio
  * This class is used to wrap ZIO failures into something that can be thrown,
  * to better integrate with Scala exception handling.
  */
-final case class FiberFailure(cause: Cause[Any]) extends Throwable {
-  override final def getMessage: String = cause.prettyPrint
-}
+final case class FiberFailure(cause: Cause[Any]) extends Throwable(cause.toString, null, true, false)

--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -24,4 +24,6 @@ package zio
  * This class is used to wrap ZIO failures into something that can be thrown,
  * to better integrate with Scala exception handling.
  */
-final case class FiberFailure(cause: Cause[Any]) extends Throwable(cause.toString, null, true, false)
+final case class FiberFailure(cause: Cause[Any]) extends Throwable(null, null, true, false) {
+  override final def getMessage: String = cause.prettyPrint
+}


### PR DESCRIPTION
Addresses #1218 

`FiberFailure` now extends `Throwable` calling constructor that does not fill the stack trace.