### PR TITLE
Run ZIO Test test suite in CI builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 addCommandAlias("compileJVM", ";coreJVM/test:compile;stacktracerJVM/test:compile")
-addCommandAlias("testJVM", ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testJVM/test")
+addCommandAlias("testJVM", ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testJVM/test:run")
 addCommandAlias("testJS", ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test")
 
 lazy val root = project


### PR DESCRIPTION
Only enabled for JVM until we resolve Scala.js compatibility issues (in particular #1325) but I think we should get this merged now to prevent regressions in ZIO Test.

@jdegoes