### PR TITLE
ZIO Test: Fix bug in DefaultTestReporter

### DIFF
--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -63,7 +63,10 @@ case class DefaultTestReporter(console: Console) extends TestReporter[String] {
     whole: PredicateValue,
     offset: Int
   ): ZIO[Console, Nothing, Unit] =
-    reportWhole(fragment, whole, offset) *> reportFragment(fragment, offset)
+    if (whole.predicate == fragment.predicate)
+      reportFragment(fragment, offset)
+    else
+      reportWhole(fragment, whole, offset) *> reportFragment(fragment, offset)
 
   private def reportWhole(fragment: PredicateValue, whole: PredicateValue, offset: Int): ZIO[Console, Nothing, Unit] =
     putStrLn {

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -14,6 +14,7 @@ object DefaultTestReporterSpec extends DefaultRuntime {
     SAssert(reportSuite1, "DefaultTestReporter correctly reports successful test suite")
     SAssert(reportSuite2, "DefaultTestReporter correctly reports failed test suite")
     SAssert(reportSuites, "DefaultTestReporter correctly reports multiple test suites")
+    SAssert(simplePredicate, "DefaultTestReporter correctly reports failure of simple predicate")
   }
 
   def makeTest[L](label: L)(assertion: => TestResult): ZSpec[Any, Nothing, L] =
@@ -55,6 +56,15 @@ object DefaultTestReporterSpec extends DefaultRuntime {
       withOffset(2)("No ZIO Trace available.\n")
   )
 
+  val test5 = makeTest("Addition works fine") {
+    assert(1 + 1, Predicate.equals(3))
+  }
+
+  val test5Expected = Vector(
+    expectedFailure("Addition works fine"),
+    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equals(3)")}\n")
+  )
+
   val suite1 = suite("Suite1")(test1, test2)
 
   val suite1Expected = Vector(
@@ -92,6 +102,12 @@ object DefaultTestReporterSpec extends DefaultRuntime {
       Vector(expectedFailure("Suite3")) ++ suite1Expected.map(withOffset(2)) ++ test3Expected.map(withOffset(2))
     )
 
+  def simplePredicate =
+    check(
+      test5,
+      test5Expected
+    )
+
   def expectedSuccess(label: String): String =
     green("+") + " " + label + "\n"
 
@@ -121,6 +137,17 @@ object DefaultTestReporterSpec extends DefaultRuntime {
       val zio = for {
         _      <- MockTestRunner(r).run(spec)
         output <- MockConsole.output
+        // _      <- ZIO.effectTotal {
+        //   if (output != expected) {
+        //     output.zip(expected)
+        //       .filter { case (x, y) => x != y }
+        //       .foreach { case (x, y) =>
+        //         println(x)
+        //         println(y)
+        //       }
+
+        //   }
+        // }
       } yield output == expected
       zio.provide(r)
     }

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -137,17 +137,6 @@ object DefaultTestReporterSpec extends DefaultRuntime {
       val zio = for {
         _      <- MockTestRunner(r).run(spec)
         output <- MockConsole.output
-        // _      <- ZIO.effectTotal {
-        //   if (output != expected) {
-        //     output.zip(expected)
-        //       .filter { case (x, y) => x != y }
-        //       .foreach { case (x, y) =>
-        //         println(x)
-        //         println(y)
-        //       }
-
-        //   }
-        // }
       } yield output == expected
       zio.provide(r)
     }


### PR DESCRIPTION
`DefaultTestReporter` normally prints one line with the whole failing predicate and a second line with the failing predicate fragment. This results in two identical lines being printed when the predicate is "simple" (i.e. it is not composed of other predicates). This PR fixes that by adding a check for whether the whole predicate is identical to the fragment and only printing one line in that case.

Identified by @ghostdogpr in #1284.

Copying @jdegoes.