### PR TITLE
WIP - Implement `FiberRef.asThreadLocal` for interop with side effecting code

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -1,0 +1,40 @@
+package zio
+
+import java.util.concurrent.atomic.AtomicReference
+
+import zio.FiberRefSpecUtil._
+import zio.test.Assertion._
+import zio.test._
+
+object FiberRefSpecJvm
+    extends ZIOBaseSpec(
+      suite("FiberRefSpecJvm")(
+        testM("unsafe handles properly invoke fallback functions if fiber specific data cannot be accessed") {
+          for {
+            fiberRef    <- FiberRef.make(initial)
+            handle      <- fiberRef.unsafeHandle
+            fallbackRef <- UIO(new AtomicReference(update1))
+            resRef      <- UIO(new AtomicReference("" -> ""))
+
+            unsafelyGetSetGet = new Runnable {
+              def run(): Unit = {
+                val v1 = handle.unsafeGet(fallbackRef.get())
+                handle.unsafeSet(update2, fallbackRef.set)
+                val v2 = handle.unsafeGet(fallbackRef.get())
+                resRef.set(v1 -> v2)
+              }
+            }
+
+            thread <- UIO(new Thread(unsafelyGetSetGet))
+            _      <- UIO(thread.start()).ensuring(UIO(thread.join()))
+
+            value0           <- fiberRef.get
+            values           <- UIO(resRef.get())
+            (value1, value2) = values
+          } yield assert((value0, value1, value2), equalTo((initial, update1, update2)))
+        }
+      )
+    ) {
+  override def runner =
+    super.runner.withPlatform(_.withFiberContextPropagation(true))
+}

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -36,7 +36,4 @@ object FiberRefSpecJvm
           } yield assert((value0, value1, value2, value3), equalTo((update1, initial, update2, initial)))
         }
       )
-    ) {
-  override def runner =
-    super.runner.withPlatform(_.withFiberContextPropagation(true))
-}
+    )

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -9,29 +9,31 @@ import zio.test._
 object FiberRefSpecJvm
     extends ZIOBaseSpec(
       suite("FiberRefSpecJvm")(
-        testM("unsafe handles properly invoke fallback functions if fiber specific data cannot be accessed") {
+        testM("unsafe handles behave properly if fiber specific data cannot be accessed") {
           for {
-            fiberRef    <- FiberRef.make(initial)
-            handle      <- fiberRef.unsafeHandle
-            fallbackRef <- UIO(new AtomicReference(update1))
-            resRef      <- UIO(new AtomicReference("" -> ""))
+            fiberRef <- FiberRef.make(initial)
+            handle   <- fiberRef.unsafeAsThreadLocal
+            resRef   <- UIO(new AtomicReference(("", "", "")))
 
             unsafelyGetSetGet = new Runnable {
               def run(): Unit = {
-                val v1 = handle.unsafeGet(fallbackRef.get())
-                handle.unsafeSet(update2, fallbackRef.set)
-                val v2 = handle.unsafeGet(fallbackRef.get())
-                resRef.set(v1 -> v2)
+                val v1 = handle.get()
+                handle.set(update2)
+                val v2 = handle.get()
+                handle.remove()
+                val v3 = handle.get()
+                resRef.set((v1, v2, v3))
               }
             }
 
+            _      <- fiberRef.set(update1)
             thread <- UIO(new Thread(unsafelyGetSetGet))
             _      <- UIO(thread.start()).ensuring(UIO(thread.join()))
 
-            value0           <- fiberRef.get
-            values           <- UIO(resRef.get())
-            (value1, value2) = values
-          } yield assert((value0, value1, value2), equalTo((initial, update1, update2)))
+            value0                   <- fiberRef.get
+            values                   <- UIO(resRef.get())
+            (value1, value2, value3) = values
+          } yield assert((value0, value1, value2, value3), equalTo((update1, initial, update2, initial)))
         }
       )
     ) {

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -313,11 +313,7 @@ object FiberRefSpec
           }
         )
       )
-    ) {
-
-  override def runner =
-    super.runner.withPlatform(_.withFiberContextPropagation(true))
-}
+    )
 
 object FiberRefSpecUtil {
   val (initial, update, update1, update2) = ("initial", "update", "update1", "update2")

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -44,6 +44,9 @@ object PlatformLive {
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)
+
+      def fiberContextPropagation: Boolean =
+        false
     }
 
   final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -44,9 +44,6 @@ object PlatformLive {
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)
-
-      def fiberContextPropagation: Boolean =
-        false
     }
 
   final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.FiberRef.UnsafeHandle
 import zio.internal.FiberContext
 
 /**
@@ -108,67 +107,56 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
   }
 
   /**
-   * Returns a handle that can be used to interact with this `FiberRef` from side effecting code.
+   * Returns a `ThreadLocal` that can be used to interact with this `FiberRef` from side effecting code.
    *
    * This feature is meant to be used for integration with side effecting code, that needs to access fiber specific data,
-   * like MDC contexts and the like.
+   * like MDC contexts and the like. The returned `ThreadLocal` will be backed by this `FiberRef` on all threads that are
+   * currently managed by ZIO, and behave like an ordinary `ThreadLocal` on all other threads.
    *
    * Important: Enable `Platform.fiberContextPropagation` if you want to use this.
    */
-  final def unsafeHandle: UIO[UnsafeHandle[A]] =
+  final def unsafeAsThreadLocal: UIO[ThreadLocal[A]] =
     ZIO.effectSuspendTotalWith { platform =>
       if (platform.fiberContextPropagation) ZIO.unit
       else ZIO.dieMessage("Unsafe handles require Platform.fiberContextPropagation to be enabled.")
     } *> ZIO.effectTotal {
-      new UnsafeHandle[A](initial) {
-        def unsafeGet(fallback: => A): A = {
+      new ThreadLocal[A] {
+        override def get(): A = {
           val fiberContext = FiberContext.current.get()
 
           Option {
             if (fiberContext eq null) null
             else fiberContext.fiberRefLocals.get(self)
-          }.map(_.asInstanceOf[A]).getOrElse(fallback)
+          }.map(_.asInstanceOf[A]).getOrElse(super.get())
         }
 
-        def unsafeSet(a: A, fallback: A => Unit): Unit = {
+        override def set(a: A): Unit = {
           val fiberContext = FiberContext.current.get()
           val fiberRef     = self.asInstanceOf[FiberRef[Any]]
 
-          if (fiberContext eq null) fallback(a)
+          if (fiberContext eq null) super.set(a)
           else fiberContext.fiberRefLocals.put(fiberRef, a)
 
           ()
         }
+
+        override def remove(): Unit = {
+          val fiberContext = FiberContext.current.get()
+          val fiberRef     = self.asInstanceOf[FiberRef[Any]]
+
+          if (fiberContext eq null) super.remove()
+          else {
+            fiberContext.fiberRefLocals.remove(fiberRef)
+            ()
+          }
+        }
+
+        override def initialValue(): A = initial
       }
     }
 }
 
 object FiberRef extends Serializable {
-
-  /**
-   * A handle that allows interaction with fiber refs from side effecting code
-   */
-  abstract class UnsafeHandle[A] private[FiberRef] (initial: A) {
-
-    /**
-     * Unsafely reads from the associated `FiberRef`
-     *
-     * @param fallback a fallback that is used if reading from the `FiberRef` is not possible, for example because the ZIO
-     *                 interpreter has already exited, or because the handle is read from a thread not managed by ZIO.
-     */
-    def unsafeGet(fallback: => A = initial): A
-
-    /**
-     * Unsafely writes to the associated `FiberRef`
-     *
-     * @param fallback a fallback that is used if writing to the `FiberRef` is not possible, for example because the ZIO
-     *                 interpreter has already exited, or because the handle is accessed from a thread not managed by ZIO.
-     */
-    def unsafeSet(
-      a: A,
-      fallback: A => Unit = _ => throw new IllegalStateException("Cannot set fiber ref via unsafe handle")
-    ): Unit
-  }
 
   /**
    * Creates a new `FiberRef` with given initial value.

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -153,12 +153,6 @@ trait Runtime[+R] {
    * Constructs a new `Runtime` with the specified tracing configuration.
    */
   final def withTracingConfig(config: TracingConfig): Runtime[R] = mapPlatform(_.withTracingConfig(config))
-
-  /**
-   * Constructs a new `Runtime` with fiber context propagation enabled/disabled.
-   */
-  final def withFiberContextPropagation(enabled: Boolean): Runtime[R] =
-    mapPlatform(_.withFiberContextPropagation(enabled))
 }
 
 object Runtime {

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -154,6 +154,11 @@ trait Runtime[+R] {
    */
   final def withTracingConfig(config: TracingConfig): Runtime[R] = mapPlatform(_.withTracingConfig(config))
 
+  /**
+   * Constructs a new `Runtime` with fiber context propagation enabled/disabled.
+   */
+  final def withFiberContextPropagation(enabled: Boolean): Runtime[R] =
+    mapPlatform(_.withFiberContextPropagation(enabled))
 }
 
 object Runtime {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -41,7 +41,7 @@ private[zio] final class FiberContext[E, A](
   startDStatus: Boolean,
   parentTrace: Option[ZTrace],
   initialTracingStatus: Boolean,
-  fiberRefLocals: FiberRefLocals
+  val fiberRefLocals: FiberRefLocals
 ) extends Fiber[E, A] { self =>
 
   import FiberContext._

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -84,6 +84,12 @@ case class TestRunner[R, L, -T, E, S](
   final def withReporter[L1 >: L, E1 >: E, S1 >: S](reporter: TestReporter[L1, E1, S1]) =
     copy(reporter = reporter)
 
+  /**
+   * Creates a copy of this runner replacing the platform
+   */
+  final def withPlatform(f: Platform => Platform): TestRunner[R, L, T, E, S] =
+    copy(platform = f(platform))
+
   private[test] def buildRuntime(
     loggerSvc: TestLogger = defaultTestLogger,
     clockSvc: Clock = Clock.Live


### PR DESCRIPTION
The purpose if this PR is to discuss and eventually merge APIs that expose information about the current ZIO fiber stack to side effecting code. More concretely, I've added an impure method
```scala
def unsafeGetFiberStack: List[FiberId]
```
to `Runtime`, that can be used from side effecting code. The implementation, as well as the tests are just prototypes, that have known shortcomings (see below). I didn't want to invest too much time on the implementation before there is agreement on the API and the general direction of this PR. The primary use case I have in mind is implementing fully transparent, fiber aware MDC logging for `log4j2` (see https://logging.apache.org/log4j/2.x/manual/extending.html#Custom_ContextDataInjector).

These are the shortcomings of the current proof of concept implementation that I'm aware of:
* The implementation does not clear the `ThreadLocal` variable when the interpreter exits. 
* The implementation does not currently handle nested interpreter calls, that is when someone does `unsafeRun(Task(unsafeRun(whatever)))`. 
* I suspect that you are not too happy with the way I added `ThreadLocal` support for ScalaJS.

None of the implementation related points above poses a serious problem as far as I can see, so I would like to discuss the API first:
* Do you think an API like this makes sense at all, or would you prefer an entirely different approach? 
* Maybe it would make sense to indicate which fibers in the stack are still alive (for children that outlive their parents)?
* Everything that's exposed in an impure API should also be exposed in a pure API. Mabe `Fiber.Descripter` should be extended accordingly?


