### PR TITLE
Add missing testJS to core project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val root = project
     streamsTestsJS,
     benchmarks,
     testJVM,
+    testJS,
     stacktracerJS,
     stacktracerJVM
   )


### PR DESCRIPTION
`zio-test` was not published for ScalaJS, which means we can't upgrade interop-cats to the latest ZIO.