### PR TITLE
Add ZStream#interleave, ZStream#interleaveWith, ZStream#combine

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -131,6 +131,9 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   Stream.fromInputStream    $fromInputStream
   Stream.fromIterable       $fromIterable
   Stream.fromQueue          $fromQueue
+
+  Stream.interleave         $interleave
+
   Stream.map                $map
   Stream.mapAccum           $mapAccum
   Stream.mapAccumM          $mapAccumM
@@ -1493,4 +1496,32 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       .either
       .map(_ must_=== Left("Ouch"))
   }
+
+  private def interleave =
+    prop { (b: Stream[String, Boolean], s1: Stream[String, Int], s2: Stream[String, Int]) =>
+      def interleave(b: List[Boolean], s1: => List[Int], s2: => List[Int]): List[Int] =
+        b.headOption.map { hd =>
+          if (hd) s1 match {
+            case h :: t =>
+              h :: interleave(b.tail, t, s2)
+            case _ =>
+              if (s2.isEmpty) List.empty
+              else interleave(b.tail, List.empty, s2)
+          } else
+            s2 match {
+              case h :: t =>
+                h :: interleave(b.tail, s1, t)
+              case _ =>
+                if (s1.isEmpty) List.empty
+                else interleave(b.tail, s1, List.empty)
+            }
+        }.getOrElse(List.empty)
+      val interleavedStream = slurp(Stream.interleave(b, s1, s2))
+      val interleavedLists = for {
+        b  <- slurp(b)
+        s1 <- slurp(s1)
+        s2 <- slurp(s2)
+      } yield interleave(b, s1, s2)
+      (!interleavedLists.succeeded) || (interleavedStream must_=== interleavedLists)
+    }
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -132,7 +132,9 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   Stream.fromIterable       $fromIterable
   Stream.fromQueue          $fromQueue
 
-  Stream.interleave         $interleave
+  Stream interleaving
+    interleave              $interleave
+    interleaveWith          $interleaveWith
 
   Stream.map                $map
   Stream.mapAccum           $mapAccum
@@ -1497,7 +1499,17 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       .map(_ must_=== Left("Ouch"))
   }
 
-  private def interleave =
+  private def interleave = {
+    val s1 = Stream(2, 3)
+    val s2 = Stream(5, 6, 7)
+
+    val interleave = s1.interleave(s2)
+    val list       = slurp(interleave).toEither.fold(_ => List.empty, identity)
+
+    list must_=== List(2, 5, 3, 6, 7)
+  }
+
+  private def interleaveWith =
     prop { (b: Stream[String, Boolean], s1: Stream[String, Int], s2: Stream[String, Int]) =>
       def interleave(b: List[Boolean], s1: => List[Int], s2: => List[Int]): List[Int] =
         b.headOption.map { hd =>
@@ -1516,7 +1528,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
                 else interleave(b.tail, s1, List.empty)
             }
         }.getOrElse(List.empty)
-      val interleavedStream = slurp(Stream.interleave(b, s1, s2))
+      val interleavedStream = slurp(s1.interleaveWith(s2)(b))
       val interleavedLists = for {
         b  <- slurp(b)
         s1 <- slurp(s1)

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -163,6 +163,12 @@ object Stream extends ZStreamPlatformSpecific {
   final def halt[E](cause: Cause[E]): Stream[E, Nothing] = fromEffect(ZIO.halt(cause))
 
   /**
+   * See [[ZStream.interleave]]
+   */
+  final def interleave[E, A](b: Stream[E, Boolean], s1: Stream[E, A], s2: Stream[E, A]): Stream[E, A] =
+    ZStream.interleave(b, s1, s2)
+
+  /**
    * See [[ZStream.managed]]
    */
   final def managed[E, A](managed: Managed[E, A]): Stream[E, A] =

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -163,12 +163,6 @@ object Stream extends ZStreamPlatformSpecific {
   final def halt[E](cause: Cause[E]): Stream[E, Nothing] = fromEffect(ZIO.halt(cause))
 
   /**
-   * See [[ZStream.interleave]]
-   */
-  final def interleave[E, A](b: Stream[E, Boolean], s1: Stream[E, A], s2: Stream[E, A]): Stream[E, A] =
-    ZStream.interleave(b, s1, s2)
-
-  /**
    * See [[ZStream.managed]]
    */
   final def managed[E, A](managed: Managed[E, A]): Stream[E, A] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1402,7 +1402,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
       )
     }
 
-    ZStream.combine(self, that, lc = lc, rc = rc) { (left, right, dest) =>
+    ZStream.combine[R1, E1, A, B, C](self, that, lc = lc, rc = rc) { (left, right, dest) =>
       loop(false, false, left, right, dest)
     }
   }


### PR DESCRIPTION
Adds an `interleave` method on `ZStream` for deterministic merging of streams. Uses a stream of boolean values to determine whether to pull from the left or right stream each time so could be used for simply alternating between two streams, pulling from each stream with different frequency, or using effects to determine which stream to pull from next.

@iravid Would you take a look when you get the chance?