### PR TITLE
Add ZIO#cached

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSpec.scala
@@ -7,6 +7,7 @@ import org.specs2.execute.Result
 import scala.collection.mutable
 import scala.util.Try
 import zio.Cause.{ die, fail, interrupt, Both }
+import zio.duration._
 
 class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime with GenIO with ScalaCheck {
   import Prop.forAll
@@ -45,6 +46,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
    Check `absolve` method on IO[E, Either[E, A]] returns the same IO[E, Either[E, String]] as `IO.absolve` does. $testAbsolve
    Check non-`memoize`d IO[E, A] returns new instances on repeated calls due to referential transparency. $testNonMemoizationRT
    Check `memoize` method on IO[E, A] returns the same instance on repeated calls. $testMemoization
+   Check `memoizeTimed` method on IO[E, A] returns new instances after duration. $testMemoizeTimed
    Check `raceAll` method returns the same IO[E, A] as `IO.raceAll` does. $testRaceAll
    Check `firstSuccessOf` method returns the same IO[E, A] as `IO.firstSuccessOf` does. $testfirstSuccessOf
    Check `zipPar` method does not swallow exit causes of loser. $testZipParInterupt
@@ -303,6 +305,23 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
         .flatMap(io => io <*> io)
         .map(tuple => tuple._1 must beTheSameAs(tuple._2))
     )
+  }
+
+  def testMemoizeTimed = {
+    def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.modify(n => (n + 1, n + 1))
+    unsafeRun {
+      for {
+        ref             <- Ref.make(0)
+        memoized        <- incrementAndGet(ref).memoizeTimed(100.milliseconds)
+        (cache, cancel) = memoized
+        a               <- cache
+        b               <- cache
+        _               <- clock.sleep(100.milliseconds)
+        c               <- cache
+        d               <- cache
+        _               <- cancel
+      } yield (a must_=== b) && (b must_!== c) && (c must_=== d)
+    }
   }
 
   def testRaceAll = {

--- a/core-tests/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSpec.scala
@@ -307,19 +307,17 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     )
   }
 
-  def testCached = {
-    def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.modify(n => (n + 1, n + 1))
-    unsafeRun {
-      for {
-        ref   <- Ref.make(0)
-        cache <- incrementAndGet(ref).cached(100.milliseconds)
-        a     <- cache
-        b     <- cache
-        _     <- clock.sleep(100.milliseconds)
-        c     <- cache
-        d     <- cache
-      } yield (a must_=== b) && (b must_!== c) && (c must_=== d)
-    }
+  def testCached = flaky {
+    def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.update(_ + 1)
+    for {
+      ref   <- Ref.make(0)
+      cache <- incrementAndGet(ref).cached(100.milliseconds)
+      a     <- cache
+      b     <- cache
+      _     <- clock.sleep(100.milliseconds)
+      c     <- cache
+      d     <- cache
+    } yield (a must_=== b) and (b must_!== c) and (c must_=== d)
   }
 
   def testRaceAll = {

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -1473,13 +1473,4 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(
       IO.mergeAll(List.empty[UIO[Int]])(0)(_ + _)
     ) must_=== 0
-
-  def nonFlaky(v: => ZIO[Environment, Any, org.specs2.matcher.MatchResult[Any]]): org.specs2.matcher.MatchResult[Any] =
-    (1 to 100).foldLeft[org.specs2.matcher.MatchResult[Any]](true must_=== true) {
-      case (acc, _) =>
-        acc and unsafeRun(v)
-    }
-
-  def flaky(v: => ZIO[Environment, Any, org.specs2.matcher.MatchResult[Any]]): org.specs2.matcher.MatchResult[Any] =
-    eventually(unsafeRun(v.timeout(1.second)).get)
 }

--- a/core-tests/jvm/src/test/scala/zio/TestRuntime.scala
+++ b/core-tests/jvm/src/test/scala/zio/TestRuntime.scala
@@ -6,7 +6,9 @@ import org.specs2.matcher.Expectations
 import org.specs2.matcher.TerminationMatchers.terminate
 import org.specs2.specification.{ Around, AroundEach, AroundTimeout }
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.{ Duration => SDuration, MICROSECONDS }
+
+import zio.duration._
 
 abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)
     extends BaseCrossPlatformSpec
@@ -19,15 +21,26 @@ abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)
       case other                                 => other
     }
 
-  override final def aroundTimeout(to: Duration)(implicit ee: ExecutionEnv): Around =
+  override final def aroundTimeout(to: SDuration)(implicit ee: ExecutionEnv): Around =
     new Around {
       def around[T: AsResult](t: => T): Result = {
         lazy val result = t
-        val termination = terminate(retries = 1000, sleep = (to.toMicros / 1000).micros)
+        val termination = terminate(retries = 1000, sleep = SDuration(to.toMicros / 1000, MICROSECONDS))
           .orSkip(_ => "TIMEOUT: " + to)(Expectations.createExpectable(result))
 
         if (!termination.toResult.isSkipped) AsResult(result)
         else termination.toResult
       }
+    }
+
+  final def flaky(
+    v: => ZIO[Environment, Any, org.specs2.matcher.MatchResult[Any]]
+  ): org.specs2.matcher.MatchResult[Any] =
+    eventually(unsafeRun(v.timeout(1.second)).get)
+
+  def nonFlaky(v: => ZIO[Environment, Any, org.specs2.matcher.MatchResult[Any]]): org.specs2.matcher.MatchResult[Any] =
+    (1 to 100).foldLeft[org.specs2.matcher.MatchResult[Any]](true must_=== true) {
+      case (acc, _) =>
+        acc and unsafeRun(v)
     }
 }


### PR DESCRIPTION
@NeQuissimus Is this what you had in mind? There is a risk of a resource leak if the memoized value continues being updated when it is no longer needed so I returned a canceler as well. I think the test takes too long but I was getting flakiness if I used a shorter duration. We can refactor to use `MockClock` when we get #1360 in. 