### PR TITLE
Return Managed.apply & Managed.unapply methods lost when moving to separate object

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -21,7 +21,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See bracket [[zio.ZIO]]

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -25,6 +25,12 @@ object Managed {
     ZManaged.absolve(v)
 
   /**
+   * See [[zio.ZManaged]]
+   */
+  final def apply[E, A](reserve: IO[E, Reservation[Any, E, A]]): Managed[E, A] =
+    ZManaged.apply(reserve)
+
+  /**
    * See [[zio.ZManaged.collectAll]]
    */
   final def collectAll[E, A1, A2](ms: Iterable[Managed[E, A2]]): Managed[E, List[A2]] =
@@ -287,6 +293,12 @@ object Managed {
    */
   final def traverseParN_[E, A](n: Int)(as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traverseParN_(n)(as)(f)
+
+  /**
+   * See [[zio.ZManaged]]
+   */
+  final def unapply[E, A](v: Managed[E, A]): Option[IO[E, Reservation[Any, E, A]]] =
+    ZManaged.unapply(v)
 
   /**
    * See [[zio.ZManaged.unit]]

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -297,8 +297,7 @@ object Managed {
   /**
    * See [[zio.ZManaged]]
    */
-  final def unapply[E, A](v: Managed[E, A]): Option[IO[E, Reservation[Any, E, A]]] =
-    ZManaged.unapply(v)
+  final def unapply[E, A](v: Managed[E, A]) = ZManaged.unapply(v)
 
   /**
    * See [[zio.ZManaged.unit]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -23,7 +23,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See [[zio.ZIO.access]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -21,7 +21,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See bracket [[zio.ZIO]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -19,7 +19,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
+  final def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
 
   /**
    * @see See bracket [[zio.ZIO]]


### PR DESCRIPTION
We forgot to copy case class .apply/.unapply methods for ZManaged when moving to a separate Managed object

As reported on gitter:

```
Boris V.Kuznetsov @tampler 11:41
Hi guys. ZManaged has changed in RC11-1 and my code stopped to compile. I had an integration with Doobie Hikari, see below:
def mkTransactor(
    cfg: DBConfig,
    connectEC: ExecutionContext,
    transactEC: Blocker
  ): Managed[Throwable, Transactor[Task]] = {
    val xa =
      HikariTransactor.newHikariTransactor[Task](cfg.driver, cfg.url, cfg.user, cfg.password, connectEC, transactEC)

    val res = xa.allocated.map {
      case (transactor, cleanupM) =>
        Reservation(ZIO.succeed(transactor), cleanupM.orDie) // <<---------- Error 1 here
    }.uninterruptible

    Managed(res) // << ----------- Error 2 here
  }
Now, in RC11-1 I get an error:
[error] /home/bku/work/clover/zio_front/src/main/scala/config.scala:51:55: polymorphic expression cannot be instantiated to expected type;
[error]  found   : [E1 >: Throwable]zio.ZIO[Any,Nothing,Unit]
[error]  required: zio.Exit[_, _] => zio.ZIO[?,Nothing,Any]
[error]         Reservation(ZIO.succeed(transactor), cleanupM.orDie)
[error]                                                       ^
[info] zio.ZIO[Any,Nothing,Unit] <: zio.Exit[_, _] => zio.ZIO[?,Nothing,Any]?
[info] false
[error] /home/bku/work/clover/zio_front/src/main/scala/config.scala:54:12: zio.Managed.type does not take parameters
[error]     Managed(res)
[error]            ^
[error] two errors found
How to fix ?
```