### PR TITLE
Rename equals to equalTo

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -16,7 +16,7 @@ object ZQueueSpec
             v1    <- queue.take
             o2    <- queue.offer(20)
             v2    <- queue.take
-          } yield assert((v1, v2, o1, o2), Predicate.equals((10, 20, true, true)))
+          } yield assert((v1, v2, o1, o2), Predicate.equalTo((10, 20, true, true)))
         },
         testM("sequential take and offer") {
           for {
@@ -24,7 +24,7 @@ object ZQueueSpec
             f1    <- queue.take.zipWith(queue.take)(_ + _).fork
             _     <- queue.offer("don't ") *> queue.offer("give up :D")
             v     <- f1.join
-          } yield assert(v, Predicate.equals("don't give up :D"))
+          } yield assert(v, Predicate.equalTo("don't give up :D"))
         },
         testM("parallel takes and sequential offers ") {
           for {
@@ -33,7 +33,7 @@ object ZQueueSpec
             values = Range.inclusive(1, 10).toList
             _      <- values.map(queue.offer).foldLeft[UIO[Boolean]](IO.succeed(false))(_ *> _)
             v      <- f.join
-          } yield assert(v.toSet, Predicate.equals(values.toSet))
+          } yield assert(v.toSet, Predicate.equalTo(values.toSet))
         },
         testM("parallel offers and sequential takes") {
           for {
@@ -43,7 +43,7 @@ object ZQueueSpec
             _      <- waitForSize(queue, 10)
             l      <- queue.take.repeat(ZSchedule.recurs(9) *> ZSchedule.identity[Int].collectAll)
             _      <- f.join
-          } yield assert(l.toSet, Predicate.equals(values.toSet))
+          } yield assert(l.toSet, Predicate.equalTo(values.toSet))
         },
         testM("offers are suspended by back pressure") {
           for {
@@ -63,7 +63,7 @@ object ZQueueSpec
             _      <- IO.forkAll(values.map(queue.offer))
             _      <- waitForSize(queue, 10)
             l      <- queue.take.repeat(ZSchedule.recurs(9) *> ZSchedule.identity[Int].collectAll)
-          } yield assert(l.toSet, Predicate.equals(values.toSet))
+          } yield assert(l.toSet, Predicate.equalTo(values.toSet))
         },
         testM("take interruption") {
           for {
@@ -72,7 +72,7 @@ object ZQueueSpec
             _     <- waitForSize(queue, -1)
             _     <- f.interrupt
             size  <- queue.size
-          } yield assert(size, Predicate.equals(0))
+          } yield assert(size, Predicate.equalTo(0))
         },
         testM("offer interruption") {
           for {
@@ -83,7 +83,7 @@ object ZQueueSpec
             _     <- waitForSize(queue, 3)
             _     <- f.interrupt
             size  <- queue.size
-          } yield assert(size, Predicate.equals(2))
+          } yield assert(size, Predicate.equalTo(2))
         },
         testM("queue is ordered") {
           for {
@@ -94,7 +94,7 @@ object ZQueueSpec
             v1    <- queue.take
             v2    <- queue.take
             v3    <- queue.take
-          } yield assert((v1, v2, v3), Predicate.equals((1, 2, 3)))
+          } yield assert((v1, v2, v3), Predicate.equalTo((1, 2, 3)))
         },
         testM("takeAll") {
           for {
@@ -103,7 +103,7 @@ object ZQueueSpec
             _     <- queue.offer(2)
             _     <- queue.offer(3)
             v     <- queue.takeAll
-          } yield assert(v, Predicate.equals(List(1, 2, 3)))
+          } yield assert(v, Predicate.equalTo(List(1, 2, 3)))
         },
         testM("takeAll with empty queue") {
           for {
@@ -112,7 +112,7 @@ object ZQueueSpec
             _     <- queue.offer(1)
             _     <- queue.take
             v     <- queue.takeAll
-          } yield assert((c, v), Predicate.equals((List.empty[Int], List.empty[Int])))
+          } yield assert((c, v), Predicate.equalTo((List.empty[Int], List.empty[Int])))
         },
         testM("takeAll doesn't return more than the queue size") {
           for {
@@ -123,7 +123,7 @@ object ZQueueSpec
             _      <- waitForSize(queue, 5)
             v      <- queue.takeAll
             c      <- queue.take
-          } yield assert((v.toSet, c), Predicate.equals((values.toSet, 5)))
+          } yield assert((v.toSet, c), Predicate.equalTo((values.toSet, 5)))
         },
         testM("takeUpTo") {
           for {
@@ -131,7 +131,7 @@ object ZQueueSpec
             _     <- queue.offer(10)
             _     <- queue.offer(20)
             list  <- queue.takeUpTo(2)
-          } yield assert(list, Predicate.equals(List(10, 20)))
+          } yield assert(list, Predicate.equalTo(List(10, 20)))
         },
         testM("takeUpTo with empty queue") {
           for {
@@ -153,7 +153,7 @@ object ZQueueSpec
             _     <- queue.offer(30)
             _     <- queue.offer(40)
             list  <- queue.takeUpTo(2)
-          } yield assert(list, Predicate.equals(List(10, 20)))
+          } yield assert(list, Predicate.equalTo(List(10, 20)))
         },
         testM("takeUpTo with not enough items") {
           for {
@@ -163,7 +163,7 @@ object ZQueueSpec
             _     <- queue.offer(30)
             _     <- queue.offer(40)
             list  <- queue.takeUpTo(10)
-          } yield assert(list, Predicate.equals(List(10, 20, 30, 40)))
+          } yield assert(list, Predicate.equalTo(List(10, 20, 30, 40)))
         },
         testM("takeUpTo 0") {
           for {
@@ -191,7 +191,7 @@ object ZQueueSpec
             _     <- queue.offer(30)
             _     <- queue.offer(40)
             list2 <- queue.takeUpTo(2)
-          } yield assert((list1, list2), Predicate.equals((List(10, 20), List(30, 40))))
+          } yield assert((list1, list2), Predicate.equalTo((List(10, 20), List(30, 40))))
         },
         testM("consecutive takeUpTo") {
           for {
@@ -202,7 +202,7 @@ object ZQueueSpec
             _     <- queue.offer(40)
             list1 <- queue.takeUpTo(2)
             list2 <- queue.takeUpTo(2)
-          } yield assert((list1, list2), Predicate.equals((List(10, 20), List(30, 40))))
+          } yield assert((list1, list2), Predicate.equalTo((List(10, 20), List(30, 40))))
         },
         testM("takeUpTo doesn't return back-pressured offers") {
           for {
@@ -213,7 +213,7 @@ object ZQueueSpec
             _      <- waitForSize(queue, 5)
             l      <- queue.takeUpTo(5)
             _      <- f.interrupt
-          } yield assert(l, Predicate.equals(List(1, 2, 3, 4)))
+          } yield assert(l, Predicate.equalTo(List(1, 2, 3, 4)))
         },
         testM("offerAll with takeAll") {
           for {
@@ -222,7 +222,7 @@ object ZQueueSpec
             _      <- queue.offerAll(orders)
             _      <- waitForSize(queue, 10)
             l      <- queue.takeAll
-          } yield assert(l, Predicate.equals(orders))
+          } yield assert(l, Predicate.equalTo(orders))
         },
         testM("offerAll with takeAll and back pressure") {
           for {
@@ -232,7 +232,7 @@ object ZQueueSpec
             size   <- waitForSize(queue, 3)
             l      <- queue.takeAll
             _      <- f.interrupt
-          } yield assert((size, l), Predicate.equals((3, List(1, 2))))
+          } yield assert((size, l), Predicate.equalTo((3, List(1, 2))))
         },
         testM("offerAll with takeAll and back pressure + interruption") {
           for {
@@ -245,7 +245,7 @@ object ZQueueSpec
             _       <- f.interrupt
             l1      <- queue.takeAll
             l2      <- queue.takeAll
-          } yield assert((l1, l2), Predicate.equals((orders1, List.empty[Int])))
+          } yield assert((l1, l2), Predicate.equalTo((orders1, List.empty[Int])))
         },
         testM("offerAll with takeAll and back pressure, check ordering") {
           for {
@@ -255,7 +255,7 @@ object ZQueueSpec
             _      <- waitForSize(queue, 128)
             l      <- queue.takeAll
             _      <- f.interrupt
-          } yield assert(l, Predicate.equals(Range.inclusive(1, 64).toList))
+          } yield assert(l, Predicate.equalTo(Range.inclusive(1, 64).toList))
         },
         testM("offerAll with pending takers") {
           for {
@@ -266,7 +266,7 @@ object ZQueueSpec
             _      <- queue.offerAll(orders)
             l      <- takers.join
             s      <- queue.size
-          } yield assert((l.toSet, s), Predicate.equals((orders.toSet, 0)))
+          } yield assert((l.toSet, s), Predicate.equalTo((orders.toSet, 0)))
         },
         testM("offerAll with pending takers, check ordering") {
           for {
@@ -278,7 +278,7 @@ object ZQueueSpec
             l      <- takers.join
             s      <- queue.size
             values = orders.take(64)
-          } yield assert((l.toSet, s), Predicate.equals((values.toSet, 64)))
+          } yield assert((l.toSet, s), Predicate.equalTo((values.toSet, 64)))
         },
         testM("offerAll with pending takers, check ordering of taker resolution") {
           for {
@@ -292,7 +292,7 @@ object ZQueueSpec
             l      <- takers.join
             s      <- queue.size
             _      <- f.interrupt
-          } yield assert((l.toSet, s), Predicate.equals((values.toSet, -100)))
+          } yield assert((l.toSet, s), Predicate.equalTo((values.toSet, -100)))
         },
         testM("offerAll with take and back pressure") {
           for {
@@ -303,7 +303,7 @@ object ZQueueSpec
             v1     <- queue.take
             v2     <- queue.take
             v3     <- queue.take
-          } yield assert((v1, v2, v3), Predicate.equals((1, 2, 3)))
+          } yield assert((v1, v2, v3), Predicate.equalTo((1, 2, 3)))
         },
         testM("multiple offerAll with back pressure") {
           for {
@@ -319,7 +319,7 @@ object ZQueueSpec
             v3      <- queue.take
             v4      <- queue.take
             v5      <- queue.take
-          } yield assert((v1, v2, v3, v4, v5), Predicate.equals((1, 2, 3, 4, 5)))
+          } yield assert((v1, v2, v3, v4, v5), Predicate.equalTo((1, 2, 3, 4, 5)))
         },
         testM("offerAll + takeAll, check ordering") {
           for {
@@ -329,7 +329,7 @@ object ZQueueSpec
             _      <- queue.offerAll(orders)
             _      <- waitForSize(queue, 1000)
             v1     <- queue.takeAll
-          } yield assert(v1, Predicate.equals(Range.inclusive(1, 1000).toList))
+          } yield assert(v1, Predicate.equalTo(Range.inclusive(1, 1000).toList))
         },
         testM("combination of offer, offerAll, take, takeAll") {
           for {
@@ -343,7 +343,7 @@ object ZQueueSpec
             v1     <- queue.take
             v2     <- queue.take
             v3     <- queue.take
-          } yield assert((v, v1, v2, v3), Predicate.equals((Range.inclusive(1, 32).toList, 33, 34, 35)))
+          } yield assert((v, v1, v2, v3), Predicate.equalTo((Range.inclusive(1, 32).toList, 33, 34, 35)))
         },
         testM("shutdown with take fiber") {
           for {
@@ -352,7 +352,7 @@ object ZQueueSpec
             _     <- waitForSize(queue, -1)
             _     <- queue.shutdown
             res   <- f.join.sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with offer fiber") {
           for {
@@ -363,42 +363,42 @@ object ZQueueSpec
             _     <- waitForSize(queue, 3)
             _     <- queue.shutdown
             res   <- f.join.sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with offer") {
           for {
             queue <- Queue.bounded[Int](1)
             _     <- queue.shutdown
             res   <- queue.offer(1).sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with take") {
           for {
             queue <- Queue.bounded[Int](1)
             _     <- queue.shutdown
             res   <- queue.take.sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with takeAll") {
           for {
             queue <- Queue.bounded[Int](1)
             _     <- queue.shutdown
             res   <- queue.takeAll.sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with takeUpTo") {
           for {
             queue <- Queue.bounded[Int](1)
             _     <- queue.shutdown
             res   <- queue.takeUpTo(1).sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("shutdown with size") {
           for {
             queue <- Queue.bounded[Int](1)
             _     <- queue.shutdown
             res   <- queue.size.sandbox.either
-          } yield assert(res, Predicate.isLeft(Predicate.equals(Cause.interrupt)))
+          } yield assert(res, Predicate.isLeft(Predicate.equalTo(Cause.interrupt)))
         },
         testM("back-pressured offer completes after take") {
           for {
@@ -409,7 +409,7 @@ object ZQueueSpec
             v1    <- queue.take
             v2    <- queue.take
             _     <- f.join
-          } yield assert((v1, v2), Predicate.equals((1, 2)))
+          } yield assert((v1, v2), Predicate.equalTo((1, 2)))
         },
         testM("back-pressured offer completes after takeAll") {
           for {
@@ -419,7 +419,7 @@ object ZQueueSpec
             _     <- waitForSize(queue, 3)
             v1    <- queue.takeAll
             _     <- f.join
-          } yield assert(v1, Predicate.equals(List(1, 2)))
+          } yield assert(v1, Predicate.equalTo(List(1, 2)))
         },
         testM("back-pressured offer completes after takeUpTo") {
           for {
@@ -429,7 +429,7 @@ object ZQueueSpec
             _     <- waitForSize(queue, 3)
             v1    <- queue.takeUpTo(2)
             _     <- f.join
-          } yield assert(v1, Predicate.equals(List(1, 2)))
+          } yield assert(v1, Predicate.equalTo(List(1, 2)))
         },
         testM("back-pressured offerAll completes after takeAll") {
           for {
@@ -441,7 +441,7 @@ object ZQueueSpec
             v2    <- queue.takeAll
             v3    <- queue.takeAll
             _     <- f.join
-          } yield assert((v1, v2, v3), Predicate.equals((List(1, 2), List(3, 4), List(5))))
+          } yield assert((v1, v2, v3), Predicate.equalTo((List(1, 2), List(3, 4), List(5))))
         },
         testM("sliding strategy with offer") {
           for {
@@ -450,14 +450,14 @@ object ZQueueSpec
             v1    <- queue.offer(2)
             v2    <- queue.offer(3)
             l     <- queue.takeAll
-          } yield assert((l, v1, v2), Predicate.equals((List(2, 3), true, false)))
+          } yield assert((l, v1, v2), Predicate.equalTo((List(2, 3), true, false)))
         },
         testM("sliding strategy with offerAll") {
           for {
             queue <- Queue.sliding[Int](2)
             v     <- queue.offerAll(List(1, 2, 3))
             size  <- queue.size
-          } yield assert((size, v), Predicate.equals((2, false)))
+          } yield assert((size, v), Predicate.equalTo((2, false)))
         },
         testM("sliding strategy with enough capacity") {
           for {
@@ -466,14 +466,14 @@ object ZQueueSpec
             _     <- queue.offer(2)
             _     <- queue.offer(3)
             l     <- queue.takeAll
-          } yield assert(l, Predicate.equals(List(1, 2, 3)))
+          } yield assert(l, Predicate.equalTo(List(1, 2, 3)))
         },
         testM("sliding strategy with offerAll and takeAll") {
           for {
             queue <- Queue.sliding[Int](2)
             v1    <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
             l     <- queue.takeAll
-          } yield assert((l, v1), Predicate.equals((List(5, 6), false)))
+          } yield assert((l, v1), Predicate.equalTo((List(5, 6), false)))
         },
         testM("awaitShutdown") {
           for {
@@ -494,7 +494,7 @@ object ZQueueSpec
             _     <- queue.shutdown
             res1  <- p1.await
             res2  <- p2.await
-          } yield assert((res1, res2), Predicate.equals((true, true)))
+          } yield assert((res1, res2), Predicate.equalTo((true, true)))
         },
         testM("awaitShutdown when queue is already shutdown") {
           for {
@@ -512,7 +512,7 @@ object ZQueueSpec
             iter     = Range.inclusive(1, 5)
             _        <- queue.offerAll(iter)
             ta       <- queue.takeAll
-          } yield assert(ta, Predicate.equals(List(1, 2, 3, 4)))
+          } yield assert(ta, Predicate.equalTo(List(1, 2, 3, 4)))
         },
         testM("dropping strategy with offerAll, check offer returns false") {
           for {
@@ -529,7 +529,7 @@ object ZQueueSpec
             iter     = Range.inclusive(1, 256)
             _        <- queue.offerAll(iter)
             ta       <- queue.takeAll
-          } yield assert(ta, Predicate.equals(Range.inclusive(1, 128).toList))
+          } yield assert(ta, Predicate.equalTo(Range.inclusive(1, 128).toList))
         },
         testM("dropping strategy with pending taker") {
           for {
@@ -540,7 +540,7 @@ object ZQueueSpec
             _        <- waitForSize(queue, -1)
             oa       <- queue.offerAll(iter.toList)
             j        <- f.join
-          } yield assert((j, oa), Predicate.equals((1, false)))
+          } yield assert((j, oa), Predicate.equalTo((1, false)))
         },
         testM("sliding strategy with pending taker") {
           for {
@@ -551,7 +551,7 @@ object ZQueueSpec
             _        <- waitForSize(queue, -1)
             oa       <- queue.offerAll(iter.toList)
             t        <- queue.take
-          } yield assert((t, oa), Predicate.equals((3, false)))
+          } yield assert((t, oa), Predicate.equalTo((3, false)))
         },
         testM("sliding strategy, check offerAll returns true") {
           for {
@@ -595,7 +595,7 @@ object ZQueueSpec
             t4    <- queue.poll
           } yield assert(
             (t1, t2, t3, t4),
-            Predicate.equals((Option(1), Option(2), Option.empty[Int], Option.empty[Int]))
+            Predicate.equalTo((Option(1), Option(2), Option.empty[Int], Option.empty[Int]))
           )
         },
         testM("queue map") {
@@ -603,35 +603,35 @@ object ZQueueSpec
             q <- Queue.bounded[Int](100).map(_.map(_.toString))
             _ <- q.offer(10)
             v <- q.take
-          } yield assert(v, Predicate.equals("10"))
+          } yield assert(v, Predicate.equalTo("10"))
         },
         testM("queue map identity") {
           for {
             q <- Queue.bounded[Int](100).map(_.map(identity))
             _ <- q.offer(10)
             v <- q.take
-          } yield assert(v, Predicate.equals(10))
+          } yield assert(v, Predicate.equalTo(10))
         },
         testM("queue mapM") {
           for {
             q <- Queue.bounded[Int](100).map(_.mapM(IO.succeed))
             _ <- q.offer(10)
             v <- q.take
-          } yield assert(v, Predicate.equals(10))
+          } yield assert(v, Predicate.equalTo(10))
         },
         testM("queue mapM with success") {
           for {
             q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
             _ <- q.offer(IO.succeed(10))
             v <- q.take.sandbox.either
-          } yield assert(v, Predicate.isRight(Predicate.equals(10)))
+          } yield assert(v, Predicate.isRight(Predicate.equalTo(10)))
         },
         testM("queue mapM with failure") {
           for {
             q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
             _ <- q.offer(IO.fail("Ouch"))
             v <- q.take.sandbox.either
-          } yield assert(v, Predicate.isLeft(Predicate.equals(Cause.fail("Ouch"))))
+          } yield assert(v, Predicate.isLeft(Predicate.equalTo(Cause.fail("Ouch"))))
         },
         testM("queue both") {
           for {
@@ -640,14 +640,14 @@ object ZQueueSpec
             q  = q1 both q2
             _  <- q.offer(10)
             v  <- q.take
-          } yield assert(v, Predicate.equals((10, 10)))
+          } yield assert(v, Predicate.equalTo((10, 10)))
         },
         testM("queue contramap") {
           for {
             q <- Queue.bounded[String](100).map(_.contramap[Int](_.toString))
             _ <- q.offer(10)
             v <- q.take
-          } yield assert(v, Predicate.equals("10"))
+          } yield assert(v, Predicate.equalTo("10"))
         },
         testM("queue filterInput") {
           for {
@@ -656,7 +656,7 @@ object ZQueueSpec
             s1 <- q.size
             _  <- q.offer(2)
             s2 <- q.size
-          } yield assert((s1, s2), Predicate.equals((0, 1)))
+          } yield assert((s1, s2), Predicate.equalTo((0, 1)))
         },
         testM("queue isShutdown") {
           for {
@@ -668,7 +668,7 @@ object ZQueueSpec
             r3    <- queue.isShutdown
             _     <- queue.shutdown
             r4    <- queue.isShutdown
-          } yield assert((r1, r2, r3, r4), Predicate.equals((false, false, false, true)))
+          } yield assert((r1, r2, r3, r4), Predicate.equalTo((false, false, false, true)))
         }
       )
     )

--- a/examples/js/src/test/scala/zio/examples/test/ExampleJsSpec.scala
+++ b/examples/js/src/test/scala/zio/examples/test/ExampleJsSpec.scala
@@ -5,10 +5,10 @@ import zio.test.{DefaultRunnableSpec, Predicate, assert, suite, test}
 object ExampleJsSpec extends DefaultRunnableSpec (
   suite("some suite")(
     test("failing test") {
-      assert(1, Predicate.equals(2))
+      assert(1, Predicate.equalTo(2))
     },
     test("passing test") {
-      assert(1, Predicate.equals(1))
+      assert(1, Predicate.equalTo(1))
     }
   )
 )

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -5,10 +5,10 @@ import zio.test.{DefaultRunnableSpec, Predicate, assert, suite, test}
 object ExampleSpec extends DefaultRunnableSpec(
   suite("some suite") (
     test("failing test") {
-      assert(1, Predicate.equals(2))
+      assert(1, Predicate.equalTo(2))
     },
     test("passing test") {
-      assert(1, Predicate.equals(1))
+      assert(1, Predicate.equalTo(1))
     }
   )
 )

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -67,7 +67,7 @@ object ZTestFrameworkSpec {
           List(
             s"info: ${red("- some suite")}",
             s"info:   ${red("- failing test")}",
-            s"info:     ${blue("1")} did not satisfy ${cyan("equals(2)")}",
+            s"info:     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
             s"info:   ${green("+")} passing test",
             s"info: ${cyan("Ran 3 tests in 0 seconds: 1 succeeded, 1 ignored, 1 failed")}"
           )
@@ -90,13 +90,13 @@ object ZTestFrameworkSpec {
       extends DefaultRunnableSpec(
         zio.test.suite("some suite")(
           zio.test.test("failing test") {
-            zio.test.assert(1, Predicate.equals(2))
+            zio.test.assert(1, Predicate.equalTo(2))
           },
           zio.test.test("passing test") {
-            zio.test.assert(1, Predicate.equals(1))
+            zio.test.assert(1, Predicate.equalTo(1))
           },
           zio.test.test("ignored test") {
-            zio.test.assert(1, Predicate.equals(2))
+            zio.test.assert(1, Predicate.equalTo(2))
           } @@ TestAspect.ignore
         )
       )

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -100,8 +100,17 @@ object Predicate {
       else Assertion.success
     }
 
-  @deprecated("use isEqualTo", "1.0.0")
-  final def equals[A](expected: A): Predicate[A] = isEqualTo(expected)
+  @deprecated("use equalTo", "1.0.0")
+  final def equals[A](expected: A): Predicate[A] = equalTo(expected)
+
+  /**
+   * Makes a new predicate that requires a value equal the specified value.
+   */
+  final def equalTo[A](expected: A): Predicate[A] =
+    Predicate.predicate(s"equalTo(${expected})") { actual =>
+      if (actual == expected) Assertion.success
+      else Assertion.failure(())
+    }
 
   /**
    * Makes a new predicate that requires an iterable contain one element
@@ -139,6 +148,26 @@ object Predicate {
           }
         case Nil => Assertion.success
       }
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def greaterThan[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"greaterThan(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) > 0) Assertion.success
+      else Assertion.failure(())
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * or equal to the specified reference value.
+   */
+  final def greaterThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"greaterThanEqualTo(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) >= 0) Assertion.success
+      else Assertion.failure(())
     }
 
   /**
@@ -180,44 +209,19 @@ object Predicate {
     }
 
   /**
-   * Makes a new predicate that requires a value equal the specified value.
-   */
-  final def isEqualTo[A](expected: A): Predicate[A] =
-    Predicate.predicate(s"isEqualTo(${expected})") { actual =>
-      if (actual == expected) Assertion.success
-      else Assertion.failure(())
-    }
-
-  /**
    * Makes a new predicate that requires a value be true.
    */
   final def isFalse: Predicate[Boolean] = Predicate.predicate(s"isFalse") { actual =>
     if (!actual) Assertion.success else Assertion.failure(())
   }
 
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
+  @deprecated("use greaterThan", "1.0.0")
   final def isGreaterThan[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isGreaterThan(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) > 0) Assertion.success
-      else Assertion.failure(())
-    }
+    greaterThan(reference)
 
-  @deprecated("use isGreaterThanEqualTo", "1.0.0")
+  @deprecated("use greaterThanEqualTo", "1.0.0")
   final def isGreaterThanEqual[A: Numeric](reference: A): Predicate[A] =
-    isGreaterThanEqualTo(reference)
-
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * or equal to the specified reference value.
-   */
-  final def isGreaterThanEqualTo[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isGreaterThanEqualTo(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) >= 0) Assertion.success
-      else Assertion.failure(())
-    }
+    greaterThanEqualTo(reference)
 
   /**
    * Makes a new predicate that requires a Left value satisfying a specified
@@ -231,29 +235,13 @@ object Predicate {
       }
     }
 
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
+  @deprecated("use lessThan", "1.0.0")
   final def isLessThan[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isLessThan(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) < 0) Assertion.success
-      else Assertion.failure(())
-    }
+    lessThan(reference)
 
-  @deprecated("use isLessThanEqualTo", "1.0.0")
+  @deprecated("use lessThanEqualTo", "1.0.0")
   final def isLessThanEqual[A: Numeric](reference: A): Predicate[A] =
-    isLessThanEqualTo(reference)
-
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
-  final def isLessThanEqualTo[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isLessThanEqualTo(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) <= 0) Assertion.success
-      else Assertion.failure(())
-    }
+    lessThanEqualTo(reference)
 
   /**
    * Makes a new predicate that requires a Some value satisfying the specified
@@ -326,6 +314,26 @@ object Predicate {
       if (implicitly[Numeric[A]].compare(actual, min) < 0) Assertion.failure(())
       else if (implicitly[Numeric[A]].compare(actual, max) > 0) Assertion.failure(())
       else Assertion.success
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def lessThan[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"lessThan(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) < 0) Assertion.success
+      else Assertion.failure(())
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def lessThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"lessThanEqualTo(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) <= 0) Assertion.success
+      else Assertion.failure(())
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -100,14 +100,8 @@ object Predicate {
       else Assertion.success
     }
 
-  /**
-   * Makes a new predicate that requires a value equal the specified value.
-   */
-  final def equals[A](expected: A): Predicate[A] =
-    Predicate.predicate(s"equals(${expected})") { actual =>
-      if (actual == expected) Assertion.success
-      else Assertion.failure(())
-    }
+  @deprecated("use isEqual", "1.0.0")
+  final def equals[A](expected: A): Predicate[A] = isEqual(expected)
 
   /**
    * Makes a new predicate that requires an iterable contain one element
@@ -183,6 +177,15 @@ object Predicate {
     Predicate.predicateRec[Sum]("isCase(\"" + termName + "\", " + s"${termName}.unapply, ${predicate})") {
       (self, actual) =>
         term(actual).fold(Assertion.failure(PredicateValue(self, actual)))(predicate(_))
+    }
+
+  /**
+   * Makes a new predicate that requires a value equal the specified value.
+   */
+  final def isEqual[A](expected: A): Predicate[A] =
+    Predicate.predicate(s"isEqual(${expected})") { actual =>
+      if (actual == expected) Assertion.success
+      else Assertion.failure(())
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -100,8 +100,8 @@ object Predicate {
       else Assertion.success
     }
 
-  @deprecated("use isEqual", "1.0.0")
-  final def equals[A](expected: A): Predicate[A] = isEqual(expected)
+  @deprecated("use isEqualTo", "1.0.0")
+  final def equals[A](expected: A): Predicate[A] = isEqualTo(expected)
 
   /**
    * Makes a new predicate that requires an iterable contain one element
@@ -182,8 +182,8 @@ object Predicate {
   /**
    * Makes a new predicate that requires a value equal the specified value.
    */
-  final def isEqual[A](expected: A): Predicate[A] =
-    Predicate.predicate(s"isEqual(${expected})") { actual =>
+  final def isEqualTo[A](expected: A): Predicate[A] =
+    Predicate.predicate(s"isEqualTo(${expected})") { actual =>
       if (actual == expected) Assertion.success
       else Assertion.failure(())
     }
@@ -205,12 +205,16 @@ object Predicate {
       else Assertion.failure(())
     }
 
+  @deprecated("use isGreaterThanEqualTo", "1.0.0")
+  final def isGreaterThanEqual[A: Numeric](reference: A): Predicate[A] =
+    isGreaterThanEqualTo(reference)
+
   /**
    * Makes a new predicate that requires the numeric value be greater than
    * or equal to the specified reference value.
    */
-  final def isGreaterThanEqual[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isGreaterThanEqual(${reference})") { actual =>
+  final def isGreaterThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isGreaterThanEqualTo(${reference})") { actual =>
       if (implicitly[Numeric[A]].compare(reference, actual) >= 0) Assertion.success
       else Assertion.failure(())
     }
@@ -237,12 +241,16 @@ object Predicate {
       else Assertion.failure(())
     }
 
+  @deprecated("use isLessThanEqualTo", "1.0.0")
+  final def isLessThanEqual[A: Numeric](reference: A): Predicate[A] =
+    isLessThanEqualTo(reference)
+
   /**
    * Makes a new predicate that requires the numeric value be greater than
    * the specified reference value.
    */
-  final def isLessThanEqual[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"isLessThanEqual(${reference})") { actual =>
+  final def isLessThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isLessThanEqualTo(${reference})") { actual =>
       if (implicitly[Numeric[A]].compare(reference, actual) <= 0) Assertion.success
       else Assertion.failure(())
     }

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -148,26 +148,6 @@ object Predicate {
     }
 
   /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
-  final def greaterThan[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"greaterThan(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) > 0) Assertion.success
-      else Assertion.failure(())
-    }
-
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * or equal to the specified reference value.
-   */
-  final def greaterThanEqualTo[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"greaterThanEqualTo(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) >= 0) Assertion.success
-      else Assertion.failure(())
-    }
-
-  /**
    * Makes a new predicate that focuses in on a field in a case class.
    *
    * {{{
@@ -213,6 +193,26 @@ object Predicate {
   }
 
   /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def isGreaterThan[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isGreaterThan(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) > 0) Assertion.success
+      else Assertion.failure(())
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * or equal to the specified reference value.
+   */
+  final def isGreaterThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isGreaterThanEqualTo(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) >= 0) Assertion.success
+      else Assertion.failure(())
+    }
+
+  /**
    * Makes a new predicate that requires a Left value satisfying a specified
    * predicate.
    */
@@ -222,6 +222,26 @@ object Predicate {
         case Left(a)  => predicate.run(a)
         case Right(_) => Assertion.failure(PredicateValue(self, actual))
       }
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def isLessThan[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isLessThan(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) < 0) Assertion.success
+      else Assertion.failure(())
+    }
+
+  /**
+   * Makes a new predicate that requires the numeric value be greater than
+   * the specified reference value.
+   */
+  final def isLessThanEqualTo[A: Numeric](reference: A): Predicate[A] =
+    Predicate.predicate(s"isLessThanEqualTo(${reference})") { actual =>
+      if (implicitly[Numeric[A]].compare(reference, actual) <= 0) Assertion.success
+      else Assertion.failure(())
     }
 
   /**
@@ -295,26 +315,6 @@ object Predicate {
       if (implicitly[Numeric[A]].compare(actual, min) < 0) Assertion.failure(())
       else if (implicitly[Numeric[A]].compare(actual, max) > 0) Assertion.failure(())
       else Assertion.success
-    }
-
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
-  final def lessThan[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"lessThan(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) < 0) Assertion.success
-      else Assertion.failure(())
-    }
-
-  /**
-   * Makes a new predicate that requires the numeric value be greater than
-   * the specified reference value.
-   */
-  final def lessThanEqualTo[A: Numeric](reference: A): Predicate[A] =
-    Predicate.predicate(s"lessThanEqualTo(${reference})") { actual =>
-      if (implicitly[Numeric[A]].compare(reference, actual) <= 0) Assertion.success
-      else Assertion.failure(())
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -100,9 +100,6 @@ object Predicate {
       else Assertion.success
     }
 
-  @deprecated("use equalTo", "1.0.0")
-  final def equals[A](expected: A): Predicate[A] = equalTo(expected)
-
   /**
    * Makes a new predicate that requires a value equal the specified value.
    */
@@ -215,14 +212,6 @@ object Predicate {
     if (!actual) Assertion.success else Assertion.failure(())
   }
 
-  @deprecated("use greaterThan", "1.0.0")
-  final def isGreaterThan[A: Numeric](reference: A): Predicate[A] =
-    greaterThan(reference)
-
-  @deprecated("use greaterThanEqualTo", "1.0.0")
-  final def isGreaterThanEqual[A: Numeric](reference: A): Predicate[A] =
-    greaterThanEqualTo(reference)
-
   /**
    * Makes a new predicate that requires a Left value satisfying a specified
    * predicate.
@@ -234,14 +223,6 @@ object Predicate {
         case Right(_) => Assertion.failure(PredicateValue(self, actual))
       }
     }
-
-  @deprecated("use lessThan", "1.0.0")
-  final def isLessThan[A: Numeric](reference: A): Predicate[A] =
-    lessThan(reference)
-
-  @deprecated("use lessThanEqualTo", "1.0.0")
-  final def isLessThanEqual[A: Numeric](reference: A): Predicate[A] =
-    lessThanEqualTo(reference)
 
   /**
    * Makes a new predicate that requires a Some value satisfying the specified

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -149,7 +149,7 @@ package object test {
   /**
    * Adds syntax for adding aspects.
    * {{{
-   * test("foo") { assert(42, isEqual(42)) } @@ ignore
+   * test("foo") { assert(42, isEqualTo(42)) } @@ ignore
    * }}}
    */
   implicit class ZSpecSyntax[R, E, L](spec: ZSpec[R, E, L]) {

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -149,7 +149,7 @@ package object test {
   /**
    * Adds syntax for adding aspects.
    * {{{
-   * test("foo") { assert(42, isEqualTo(42)) } @@ ignore
+   * test("foo") { assert(42, equalTo(42)) } @@ ignore
    * }}}
    */
   implicit class ZSpecSyntax[R, E, L](spec: ZSpec[R, E, L]) {

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -149,7 +149,7 @@ package object test {
   /**
    * Adds syntax for adding aspects.
    * {{{
-   * test("foo") { assert(42, equals(42)) } @@ ignore
+   * test("foo") { assert(42, isEqual(42)) } @@ ignore
    * }}}
    */
   implicit class ZSpecSyntax[R, E, L](spec: ZSpec[R, E, L]) {

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -6,7 +6,7 @@ import scala.{ Console => SConsole }
 import zio.clock.Clock
 import zio.test.mock._
 import zio.test.TestUtils.label
-import zio.test.Predicate.{isEqual, isGreaterThan, isLessThan}
+import zio.test.Predicate.{ isEqual, isGreaterThan, isLessThan }
 
 object DefaultTestReporterSpec extends DefaultRuntime {
 

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -6,6 +6,7 @@ import scala.{ Console => SConsole }
 import zio.clock.Clock
 import zio.test.mock._
 import zio.test.TestUtils.label
+import zio.test.Predicate.{isEqual, isGreaterThan, isLessThan}
 
 object DefaultTestReporterSpec extends DefaultRuntime {
 
@@ -23,25 +24,25 @@ object DefaultTestReporterSpec extends DefaultRuntime {
     zio.test.test(label)(assertion)
 
   val test1 = makeTest("Addition works fine") {
-    assert(1 + 1, Predicate.equals(2))
+    assert(1 + 1, isEqual(2))
   }
 
   val test1Expected = expectedSuccess("Addition works fine")
 
   val test2 = makeTest("Subtraction works fine") {
-    assert(1 - 1, Predicate.equals(0))
+    assert(1 - 1, isEqual(0))
   }
 
   val test2Expected = expectedSuccess("Subtraction works fine")
 
   val test3 = makeTest("Value falls within range") {
-    assert(52, Predicate.equals(42) || (Predicate.isGreaterThan(5) && Predicate.isLessThan(10)))
+    assert(52, isEqual(42) || (isGreaterThan(5) && isLessThan(10)))
   }
 
   val test3Expected = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(equals(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(isEqual(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
     ),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isGreaterThan(5)")}\n")
   )
@@ -59,12 +60,12 @@ object DefaultTestReporterSpec extends DefaultRuntime {
   )
 
   val test5 = makeTest("Addition works fine") {
-    assert(1 + 1, Predicate.equals(3))
+    assert(1 + 1, isEqual(3))
   }
 
   val test5Expected = Vector(
     expectedFailure("Addition works fine"),
-    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equals(3)")}\n")
+    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("isEqual(3)")}\n")
   )
 
   val suite1 = suite("Suite1")(test1, test2)

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -6,7 +6,7 @@ import scala.{ Console => SConsole }
 import zio.clock.Clock
 import zio.test.mock._
 import zio.test.TestUtils.label
-import zio.test.Predicate.{ isEqualTo, isGreaterThan, isLessThan }
+import zio.test.Predicate.{ equalTo, greaterThan, lessThan }
 
 object DefaultTestReporterSpec extends DefaultRuntime {
 
@@ -24,27 +24,27 @@ object DefaultTestReporterSpec extends DefaultRuntime {
     zio.test.test(label)(assertion)
 
   val test1 = makeTest("Addition works fine") {
-    assert(1 + 1, isEqualTo(2))
+    assert(1 + 1, equalTo(2))
   }
 
   val test1Expected = expectedSuccess("Addition works fine")
 
   val test2 = makeTest("Subtraction works fine") {
-    assert(1 - 1, isEqualTo(0))
+    assert(1 - 1, equalTo(0))
   }
 
   val test2Expected = expectedSuccess("Subtraction works fine")
 
   val test3 = makeTest("Value falls within range") {
-    assert(52, isEqualTo(42) || (isGreaterThan(5) && isLessThan(10)))
+    assert(52, equalTo(42) || (greaterThan(5) && lessThan(10)))
   }
 
   val test3Expected = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(isEqualTo(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (" + yellow("greaterThan(5)") + " && lessThan(10)))")}\n"
     ),
-    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isGreaterThan(5)")}\n")
+    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("greaterThan(5)")}\n")
   )
 
   val test4 = makeTest("Failing test") {
@@ -60,12 +60,12 @@ object DefaultTestReporterSpec extends DefaultRuntime {
   )
 
   val test5 = makeTest("Addition works fine") {
-    assert(1 + 1, isEqualTo(3))
+    assert(1 + 1, equalTo(3))
   }
 
   val test5Expected = Vector(
     expectedFailure("Addition works fine"),
-    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("isEqualTo(3)")}\n")
+    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n")
   )
 
   val suite1 = suite("Suite1")(test1, test2)

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -6,7 +6,7 @@ import scala.{ Console => SConsole }
 import zio.clock.Clock
 import zio.test.mock._
 import zio.test.TestUtils.label
-import zio.test.Predicate.{ isEqual, isGreaterThan, isLessThan }
+import zio.test.Predicate.{ isEqualTo, isGreaterThan, isLessThan }
 
 object DefaultTestReporterSpec extends DefaultRuntime {
 
@@ -24,25 +24,25 @@ object DefaultTestReporterSpec extends DefaultRuntime {
     zio.test.test(label)(assertion)
 
   val test1 = makeTest("Addition works fine") {
-    assert(1 + 1, isEqual(2))
+    assert(1 + 1, isEqualTo(2))
   }
 
   val test1Expected = expectedSuccess("Addition works fine")
 
   val test2 = makeTest("Subtraction works fine") {
-    assert(1 - 1, isEqual(0))
+    assert(1 - 1, isEqualTo(0))
   }
 
   val test2Expected = expectedSuccess("Subtraction works fine")
 
   val test3 = makeTest("Value falls within range") {
-    assert(52, isEqual(42) || (isGreaterThan(5) && isLessThan(10)))
+    assert(52, isEqualTo(42) || (isGreaterThan(5) && isLessThan(10)))
   }
 
   val test3Expected = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(isEqual(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(isEqualTo(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
     ),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isGreaterThan(5)")}\n")
   )
@@ -60,12 +60,12 @@ object DefaultTestReporterSpec extends DefaultRuntime {
   )
 
   val test5 = makeTest("Addition works fine") {
-    assert(1 + 1, isEqual(3))
+    assert(1 + 1, isEqualTo(3))
   }
 
   val test5Expected = Vector(
     expectedFailure("Addition works fine"),
-    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("isEqual(3)")}\n")
+    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("isEqualTo(3)")}\n")
   )
 
   val suite1 = suite("Suite1")(test1, test2)

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -6,7 +6,7 @@ import scala.{ Console => SConsole }
 import zio.clock.Clock
 import zio.test.mock._
 import zio.test.TestUtils.label
-import zio.test.Predicate.{ equalTo, greaterThan, lessThan }
+import zio.test.Predicate.{ equalTo, isGreaterThan, isLessThan }
 
 object DefaultTestReporterSpec extends DefaultRuntime {
 
@@ -36,15 +36,15 @@ object DefaultTestReporterSpec extends DefaultRuntime {
   val test2Expected = expectedSuccess("Subtraction works fine")
 
   val test3 = makeTest("Value falls within range") {
-    assert(52, equalTo(42) || (greaterThan(5) && lessThan(10)))
+    assert(52, equalTo(42) || (isGreaterThan(5) && isLessThan(10)))
   }
 
   val test3Expected = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (" + yellow("greaterThan(5)") + " && lessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (" + yellow("isGreaterThan(5)") + " && isLessThan(10)))")}\n"
     ),
-    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("greaterThan(5)")}\n")
+    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isGreaterThan(5)")}\n")
   )
 
   val test4 = makeTest("Failing test") {

--- a/test/shared/src/test/scala/zio/test/PredicateSpec.scala
+++ b/test/shared/src/test/scala/zio/test/PredicateSpec.scala
@@ -26,8 +26,8 @@ object PredicateSpec {
 
   val nameStartsWithA  = hasField[SampleUser, Boolean]("name", _.name.startsWith("A"), isTrue)
   val nameStartsWithU  = hasField[SampleUser, Boolean]("name", _.name.startsWith("U"), isTrue)
-  val ageLessThen20    = hasField[SampleUser, Int]("age", _.age, lessThan(20))
-  val ageGreaterThen20 = hasField[SampleUser, Int]("age", _.age, greaterThan(20))
+  val ageLessThen20    = hasField[SampleUser, Int]("age", _.age, isLessThan(20))
+  val ageGreaterThen20 = hasField[SampleUser, Int]("age", _.age, isGreaterThan(20))
 
   def run(implicit ec: ExecutionContext): List[Future[(Boolean, String)]] = List(
     testSuccess(assert(42, anything), message = "anything must always succeeds"),
@@ -38,6 +38,14 @@ object PredicateSpec {
     testFailure(
       assert(Seq("zio", "scala"), contains("java")),
       message = "contains must fail when iterable does not contain specified element"
+    ),
+    testSuccess(
+      assert(42, equalTo(42)),
+      message = "equalTo must succeed when value equals specified value"
+    ),
+    testFailure(
+      assert(0, equalTo(42)),
+      message = "equalTo must fail when value does not equal specified value"
     ),
     testSuccess(
       assert(Seq(1, 42, 5), exists(equalTo(42))),
@@ -56,16 +64,16 @@ object PredicateSpec {
       message = "fails must fail when error value does not satisfy specified predicate"
     ),
     testSuccess(
-      assert(SampleUser("User", 23), hasField[SampleUser, Int]("age", _.age, isWithin(0, 99))),
-      message = "hasField must succeed when field value satisfy specified predicate"
-    ),
-    testSuccess(
       assert(Seq("a", "bb", "ccc"), forall(hasField[String, Int]("length", _.length, isWithin(0, 3)))),
       message = "forall must succeed when all elements of iterable satisfy specified predicate"
     ),
     testFailure(
       assert(Seq("a", "bb", "dddd"), forall(hasField[String, Int]("length", _.length, isWithin(0, 3)))),
       message = "forall must fail when one element of iterable do not satisfy specified predicate"
+    ),
+    testSuccess(
+      assert(SampleUser("User", 23), hasField[SampleUser, Int]("age", _.age, isWithin(0, 99))),
+      message = "hasField must succeed when field value satisfy specified predicate"
     ),
     testSuccess(
       assert(Seq(1, 2, 3), hasSize(equalTo(3))),
@@ -87,32 +95,36 @@ object PredicateSpec {
       message = "isCase must succeed when unapplied Proj satisfy specified predicate"
     ),
     testSuccess(
-      assert(42, equalTo(42)),
-      message = "equalTo must succeed when value equals specified value"
-    ),
-    testFailure(
-      assert(0, equalTo(42)),
-      message = "equalTo must fail when value does not equal specified value"
-    ),
-    testSuccess(
-      assert(0, greaterThan(42)),
-      message = "greaterThan must succeed when specified value is greater than supplied value"
-    ),
-    testFailure(
-      assert(42, greaterThan(42)),
-      message = "greaterThan must fail when specified value is less than or equal supplied value"
-    ),
-    testSuccess(
-      assert(42, greaterThanEqualTo(42)),
-      message = "greaterThanEqualTo must succeed when specified value is greater than or equal supplied value"
-    ),
-    testSuccess(
       assert(false, isFalse),
       message = "isFalse must succeed when supplied value is false"
     ),
     testSuccess(
+      assert(0, isGreaterThan(42)),
+      message = "isGreaterThan must succeed when specified value is greater than supplied value"
+    ),
+    testFailure(
+      assert(42, isGreaterThan(42)),
+      message = "isGreaterThan must fail when specified value is less than or equal supplied value"
+    ),
+    testSuccess(
+      assert(42, isGreaterThanEqualTo(42)),
+      message = "greaterThanEqualTo must succeed when specified value is greater than or equal supplied value"
+    ),
+    testSuccess(
       assert(Left(42), isLeft(equalTo(42))),
       message = "isLeft must succeed when supplied value is Left and satisfy specified predicate"
+    ),
+    testSuccess(
+      assert(42, isLessThan(0)),
+      message = "isLessThan must succeed when specified value is less than supplied value"
+    ),
+    testFailure(
+      assert(42, isLessThan(42)),
+      message = "isLessThan must fail when specified value is greater than or equal supplied value"
+    ),
+    testSuccess(
+      assert(42, isLessThanEqualTo(42)),
+      message = "isLessThanEqualTo must succeed when specified value is less than or equal supplied value"
     ),
     testSuccess(
       assert(None, isNone),
@@ -155,28 +167,12 @@ object PredicateSpec {
       message = "isWithin must fail when supplied value is out of range"
     ),
     testSuccess(
-      assert(42, lessThan(0)),
-      message = "lessThan must succeed when specified value is less than supplied value"
-    ),
-    testFailure(
-      assert(42, lessThan(42)),
-      message = "lessThan must fail when specified value is greater than or equal supplied value"
-    ),
-    testSuccess(
-      assert(42, lessThanEqualTo(42)),
-      message = "lessThanEqualTo must succeed when specified value is less than or equal supplied value"
-    ),
-    testSuccess(
       assert(0, not(equalTo(42))),
       message = "not must succeed when negation of specified predicate is true"
     ),
     testFailure(
       assert(42, nothing),
       message = "nothing must always fail"
-    ),
-    testSuccess(
-      assert(Right(42), isRight(equalTo(42))),
-      message = "isRight must succeed when supplied value is Right and satisfy specified predicate"
     ),
     testSuccess(
       assert(Exit.succeed("Some Error"), succeeds(equalTo("Some Error"))),

--- a/test/shared/src/test/scala/zio/test/PredicateSpec.scala
+++ b/test/shared/src/test/scala/zio/test/PredicateSpec.scala
@@ -40,27 +40,19 @@ object PredicateSpec {
       message = "contains must fail when iterable does not contain specified element"
     ),
     testSuccess(
-      assert(42, Predicate.equals(42)),
-      message = "equals must succeed when value equals specified value"
-    ),
-    testFailure(
-      assert(0, Predicate.equals(42)),
-      message = "equals must fail when value does not equal specified value"
-    ),
-    testSuccess(
-      assert(Seq(1, 42, 5), exists(Predicate.equals(42))),
+      assert(Seq(1, 42, 5), exists(isEqual(42))),
       message = "exists must succeed when at least one element of iterable satisfy specified predicate"
     ),
     testFailure(
-      assert(Seq(1, 42, 5), exists(Predicate.equals(0))),
+      assert(Seq(1, 42, 5), exists(isEqual(0))),
       message = "exists must fail when all elements of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Exit.fail("Some Error"), fails(Predicate.equals("Some Error"))),
+      assert(Exit.fail("Some Error"), fails(isEqual("Some Error"))),
       message = "fails must succeed when error value satisfy specified predicate"
     ),
     testFailure(
-      assert(Exit.fail("Other Error"), fails(Predicate.equals("Some Error"))),
+      assert(Exit.fail("Other Error"), fails(isEqual("Some Error"))),
       message = "fails must fail when error value does not satisfy specified predicate"
     ),
     testSuccess(
@@ -76,8 +68,35 @@ object PredicateSpec {
       message = "forall must fail when one element of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Seq(1, 2, 3), hasSize(Predicate.equals(3))),
+      assert(Seq(1, 2, 3), hasSize(isEqual(3))),
       message = "hasSize must succeed when iterable size is equal to specified predicate"
+    ),
+    testFailure(
+      assert(42, isCase[Int, String](termName = "term", _ => None, isEqual("number: 42"))),
+      message = "isCase must fail when unapply fails (returns None)"
+    ),
+    testSuccess(
+      assert(
+        sampleUser,
+        isCase[SampleUser, (String, Int)](
+          termName = "SampleUser",
+          SampleUser.unapply,
+          isEqual((sampleUser.name, sampleUser.age))
+        )
+      ),
+      message = "isCase must succeed when unapplied Proj satisfy specified predicate"
+    ),
+    testSuccess(
+      assert(42, isEqual(42)),
+      message = "isEqual must succeed when value equals specified value"
+    ),
+    testFailure(
+      assert(0, isEqual(42)),
+      message = "isEqual must fail when value does not equal specified value"
+    ),
+    testSuccess(
+      assert(false, isFalse),
+      message = "isFalse must succeed when supplied value is false"
     ),
     testSuccess(
       assert(0, isGreaterThan(42)),
@@ -92,43 +111,20 @@ object PredicateSpec {
       message = "isGreaterThanEqual must succeed when specified value is greater than or equal supplied value"
     ),
     testSuccess(
-      assert(
-        sampleUser,
-        isCase[SampleUser, (String, Int)](
-          termName = "SampleUser",
-          SampleUser.unapply,
-          Predicate.equals((sampleUser.name, sampleUser.age))
-        )
-      ),
-      message = "isCase must succeed when unapplied Proj satisfy specified predicate"
-    ),
-    testFailure(
-      assert(42, isCase[Int, String](termName = "term", _ => None, Predicate.equals("number: 42"))),
-      message = "isCase must fail when unapply fails (returns None)"
-    ),
-    testSuccess(
-      assert(true, isTrue),
-      message = "isTrue must succeed when supplied value is true"
-    ),
-    testSuccess(
-      assert(false, isFalse),
-      message = "isFalse must succeed when supplied value is false"
-    ),
-    testSuccess(
-      assert(Left(42), isLeft(Predicate.equals(42))),
+      assert(Left(42), isLeft(isEqual(42))),
       message = "isLeft must succeed when supplied value is Left and satisfy specified predicate"
     ),
     testSuccess(
       assert(42, isLessThan(0)),
-      message = "lt must succeed when specified value is less than supplied value"
+      message = "isLessThan must succeed when specified value is less than supplied value"
     ),
     testFailure(
       assert(42, isLessThan(42)),
       message = "isLessThan must fail when specified value is greater than or equal supplied value"
     ),
     testSuccess(
-      assert(42, isGreaterThanEqual(42)),
-      message = "isGreaterThanEqual must succeed when specified value is less than or equal supplied value"
+      assert(42, isLessThanEqual(42)),
+      message = "isLessThanEqual must succeed when specified value is less than or equal supplied value"
     ),
     testSuccess(
       assert(None, isNone),
@@ -139,32 +135,20 @@ object PredicateSpec {
       message = "isNone must fail when specified value is not None"
     ),
     testSuccess(
-      assert(0, not(Predicate.equals(42))),
-      message = "not must succeed when negation of specified predicate is true"
-    ),
-    testFailure(
-      assert(42, nothing),
-      message = "nothing must always fail"
+      assert(Right(42), isRight(isEqual(42))),
+      message = "isRight must succeed when supplied value is Right and satisfy specified predicate"
     ),
     testSuccess(
-      assert(Right(42), isRight(Predicate.equals(42))),
-      message = "right must succeed when supplied value is Right and satisfy specified predicate"
-    ),
-    testSuccess(
-      assert(Some("zio"), isSome(Predicate.equals("zio"))),
+      assert(Some("zio"), isSome(isEqual("zio"))),
       message = "isSome must succeed when supplied value is Some and satisfy specified predicate"
     ),
     testFailure(
-      assert(None, isSome(Predicate.equals("zio"))),
+      assert(None, isSome(isEqual("zio"))),
       message = "isSome must fail when supplied value is None"
     ),
     testSuccess(
-      assert(Exit.succeed("Some Error"), succeeds(Predicate.equals("Some Error"))),
-      message = "succeeds must succeed when supplied value is Exit.succeed and satisfy specified predicate"
-    ),
-    testFailure(
-      assert(Exit.fail("Some Error"), succeeds(Predicate.equals("Some Error"))),
-      message = "succeeds must fail when supplied value is Exit.fail"
+      assert(true, isTrue),
+      message = "isTrue must succeed when supplied value is true"
     ),
     testSuccess(
       assert((), isUnit),
@@ -181,6 +165,22 @@ object PredicateSpec {
     testFailure(
       assert(42, isWithin(0, 10)),
       message = "isWithin must fail when supplied value is out of range"
+    ),
+    testSuccess(
+      assert(0, not(isEqual(42))),
+      message = "not must succeed when negation of specified predicate is true"
+    ),
+    testFailure(
+      assert(42, nothing),
+      message = "nothing must always fail"
+    ),
+    testSuccess(
+      assert(Exit.succeed("Some Error"), succeeds(isEqual("Some Error"))),
+      message = "succeeds must succeed when supplied value is Exit.succeed and satisfy specified predicate"
+    ),
+    testFailure(
+      assert(Exit.fail("Some Error"), succeeds(isEqual("Some Error"))),
+      message = "succeeds must fail when supplied value is Exit.fail"
     ),
     testSuccess(
       assert(sampleUser, nameStartsWithU && ageLessThen20),
@@ -208,5 +208,4 @@ object PredicateSpec {
       message = "test must return false when given element does not satisfy predicate"
     )
   )
-
 }

--- a/test/shared/src/test/scala/zio/test/PredicateSpec.scala
+++ b/test/shared/src/test/scala/zio/test/PredicateSpec.scala
@@ -40,19 +40,19 @@ object PredicateSpec {
       message = "contains must fail when iterable does not contain specified element"
     ),
     testSuccess(
-      assert(Seq(1, 42, 5), exists(isEqual(42))),
+      assert(Seq(1, 42, 5), exists(isEqualTo(42))),
       message = "exists must succeed when at least one element of iterable satisfy specified predicate"
     ),
     testFailure(
-      assert(Seq(1, 42, 5), exists(isEqual(0))),
+      assert(Seq(1, 42, 5), exists(isEqualTo(0))),
       message = "exists must fail when all elements of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Exit.fail("Some Error"), fails(isEqual("Some Error"))),
+      assert(Exit.fail("Some Error"), fails(isEqualTo("Some Error"))),
       message = "fails must succeed when error value satisfy specified predicate"
     ),
     testFailure(
-      assert(Exit.fail("Other Error"), fails(isEqual("Some Error"))),
+      assert(Exit.fail("Other Error"), fails(isEqualTo("Some Error"))),
       message = "fails must fail when error value does not satisfy specified predicate"
     ),
     testSuccess(
@@ -68,11 +68,11 @@ object PredicateSpec {
       message = "forall must fail when one element of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Seq(1, 2, 3), hasSize(isEqual(3))),
+      assert(Seq(1, 2, 3), hasSize(isEqualTo(3))),
       message = "hasSize must succeed when iterable size is equal to specified predicate"
     ),
     testFailure(
-      assert(42, isCase[Int, String](termName = "term", _ => None, isEqual("number: 42"))),
+      assert(42, isCase[Int, String](termName = "term", _ => None, isEqualTo("number: 42"))),
       message = "isCase must fail when unapply fails (returns None)"
     ),
     testSuccess(
@@ -81,18 +81,18 @@ object PredicateSpec {
         isCase[SampleUser, (String, Int)](
           termName = "SampleUser",
           SampleUser.unapply,
-          isEqual((sampleUser.name, sampleUser.age))
+          isEqualTo((sampleUser.name, sampleUser.age))
         )
       ),
       message = "isCase must succeed when unapplied Proj satisfy specified predicate"
     ),
     testSuccess(
-      assert(42, isEqual(42)),
-      message = "isEqual must succeed when value equals specified value"
+      assert(42, isEqualTo(42)),
+      message = "isEqualTo must succeed when value equals specified value"
     ),
     testFailure(
-      assert(0, isEqual(42)),
-      message = "isEqual must fail when value does not equal specified value"
+      assert(0, isEqualTo(42)),
+      message = "isEqualTo must fail when value does not equal specified value"
     ),
     testSuccess(
       assert(false, isFalse),
@@ -107,11 +107,11 @@ object PredicateSpec {
       message = "isGreaterThan must fail when specified value is less than or equal supplied value"
     ),
     testSuccess(
-      assert(42, isGreaterThanEqual(42)),
-      message = "isGreaterThanEqual must succeed when specified value is greater than or equal supplied value"
+      assert(42, isGreaterThanEqualTo(42)),
+      message = "isGreaterThanEqualTo must succeed when specified value is greater than or equal supplied value"
     ),
     testSuccess(
-      assert(Left(42), isLeft(isEqual(42))),
+      assert(Left(42), isLeft(isEqualTo(42))),
       message = "isLeft must succeed when supplied value is Left and satisfy specified predicate"
     ),
     testSuccess(
@@ -123,8 +123,8 @@ object PredicateSpec {
       message = "isLessThan must fail when specified value is greater than or equal supplied value"
     ),
     testSuccess(
-      assert(42, isLessThanEqual(42)),
-      message = "isLessThanEqual must succeed when specified value is less than or equal supplied value"
+      assert(42, isLessThanEqualTo(42)),
+      message = "isLessThanEqualTo must succeed when specified value is less than or equal supplied value"
     ),
     testSuccess(
       assert(None, isNone),
@@ -135,15 +135,15 @@ object PredicateSpec {
       message = "isNone must fail when specified value is not None"
     ),
     testSuccess(
-      assert(Right(42), isRight(isEqual(42))),
+      assert(Right(42), isRight(isEqualTo(42))),
       message = "isRight must succeed when supplied value is Right and satisfy specified predicate"
     ),
     testSuccess(
-      assert(Some("zio"), isSome(isEqual("zio"))),
+      assert(Some("zio"), isSome(isEqualTo("zio"))),
       message = "isSome must succeed when supplied value is Some and satisfy specified predicate"
     ),
     testFailure(
-      assert(None, isSome(isEqual("zio"))),
+      assert(None, isSome(isEqualTo("zio"))),
       message = "isSome must fail when supplied value is None"
     ),
     testSuccess(
@@ -167,7 +167,7 @@ object PredicateSpec {
       message = "isWithin must fail when supplied value is out of range"
     ),
     testSuccess(
-      assert(0, not(isEqual(42))),
+      assert(0, not(isEqualTo(42))),
       message = "not must succeed when negation of specified predicate is true"
     ),
     testFailure(
@@ -175,11 +175,11 @@ object PredicateSpec {
       message = "nothing must always fail"
     ),
     testSuccess(
-      assert(Exit.succeed("Some Error"), succeeds(isEqual("Some Error"))),
+      assert(Exit.succeed("Some Error"), succeeds(isEqualTo("Some Error"))),
       message = "succeeds must succeed when supplied value is Exit.succeed and satisfy specified predicate"
     ),
     testFailure(
-      assert(Exit.fail("Some Error"), succeeds(isEqual("Some Error"))),
+      assert(Exit.fail("Some Error"), succeeds(isEqualTo("Some Error"))),
       message = "succeeds must fail when supplied value is Exit.fail"
     ),
     testSuccess(

--- a/test/shared/src/test/scala/zio/test/PredicateSpec.scala
+++ b/test/shared/src/test/scala/zio/test/PredicateSpec.scala
@@ -26,8 +26,8 @@ object PredicateSpec {
 
   val nameStartsWithA  = hasField[SampleUser, Boolean]("name", _.name.startsWith("A"), isTrue)
   val nameStartsWithU  = hasField[SampleUser, Boolean]("name", _.name.startsWith("U"), isTrue)
-  val ageLessThen20    = hasField[SampleUser, Int]("age", _.age, isLessThan(20))
-  val ageGreaterThen20 = hasField[SampleUser, Int]("age", _.age, isGreaterThan(20))
+  val ageLessThen20    = hasField[SampleUser, Int]("age", _.age, lessThan(20))
+  val ageGreaterThen20 = hasField[SampleUser, Int]("age", _.age, greaterThan(20))
 
   def run(implicit ec: ExecutionContext): List[Future[(Boolean, String)]] = List(
     testSuccess(assert(42, anything), message = "anything must always succeeds"),
@@ -40,19 +40,19 @@ object PredicateSpec {
       message = "contains must fail when iterable does not contain specified element"
     ),
     testSuccess(
-      assert(Seq(1, 42, 5), exists(isEqualTo(42))),
+      assert(Seq(1, 42, 5), exists(equalTo(42))),
       message = "exists must succeed when at least one element of iterable satisfy specified predicate"
     ),
     testFailure(
-      assert(Seq(1, 42, 5), exists(isEqualTo(0))),
+      assert(Seq(1, 42, 5), exists(equalTo(0))),
       message = "exists must fail when all elements of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Exit.fail("Some Error"), fails(isEqualTo("Some Error"))),
+      assert(Exit.fail("Some Error"), fails(equalTo("Some Error"))),
       message = "fails must succeed when error value satisfy specified predicate"
     ),
     testFailure(
-      assert(Exit.fail("Other Error"), fails(isEqualTo("Some Error"))),
+      assert(Exit.fail("Other Error"), fails(equalTo("Some Error"))),
       message = "fails must fail when error value does not satisfy specified predicate"
     ),
     testSuccess(
@@ -68,11 +68,11 @@ object PredicateSpec {
       message = "forall must fail when one element of iterable do not satisfy specified predicate"
     ),
     testSuccess(
-      assert(Seq(1, 2, 3), hasSize(isEqualTo(3))),
+      assert(Seq(1, 2, 3), hasSize(equalTo(3))),
       message = "hasSize must succeed when iterable size is equal to specified predicate"
     ),
     testFailure(
-      assert(42, isCase[Int, String](termName = "term", _ => None, isEqualTo("number: 42"))),
+      assert(42, isCase[Int, String](termName = "term", _ => None, equalTo("number: 42"))),
       message = "isCase must fail when unapply fails (returns None)"
     ),
     testSuccess(
@@ -81,50 +81,38 @@ object PredicateSpec {
         isCase[SampleUser, (String, Int)](
           termName = "SampleUser",
           SampleUser.unapply,
-          isEqualTo((sampleUser.name, sampleUser.age))
+          equalTo((sampleUser.name, sampleUser.age))
         )
       ),
       message = "isCase must succeed when unapplied Proj satisfy specified predicate"
     ),
     testSuccess(
-      assert(42, isEqualTo(42)),
-      message = "isEqualTo must succeed when value equals specified value"
+      assert(42, equalTo(42)),
+      message = "equalTo must succeed when value equals specified value"
     ),
     testFailure(
-      assert(0, isEqualTo(42)),
-      message = "isEqualTo must fail when value does not equal specified value"
+      assert(0, equalTo(42)),
+      message = "equalTo must fail when value does not equal specified value"
+    ),
+    testSuccess(
+      assert(0, greaterThan(42)),
+      message = "greaterThan must succeed when specified value is greater than supplied value"
+    ),
+    testFailure(
+      assert(42, greaterThan(42)),
+      message = "greaterThan must fail when specified value is less than or equal supplied value"
+    ),
+    testSuccess(
+      assert(42, greaterThanEqualTo(42)),
+      message = "greaterThanEqualTo must succeed when specified value is greater than or equal supplied value"
     ),
     testSuccess(
       assert(false, isFalse),
       message = "isFalse must succeed when supplied value is false"
     ),
     testSuccess(
-      assert(0, isGreaterThan(42)),
-      message = "isGreaterThan must succeed when specified value is greater than supplied value"
-    ),
-    testFailure(
-      assert(42, isGreaterThan(42)),
-      message = "isGreaterThan must fail when specified value is less than or equal supplied value"
-    ),
-    testSuccess(
-      assert(42, isGreaterThanEqualTo(42)),
-      message = "isGreaterThanEqualTo must succeed when specified value is greater than or equal supplied value"
-    ),
-    testSuccess(
-      assert(Left(42), isLeft(isEqualTo(42))),
+      assert(Left(42), isLeft(equalTo(42))),
       message = "isLeft must succeed when supplied value is Left and satisfy specified predicate"
-    ),
-    testSuccess(
-      assert(42, isLessThan(0)),
-      message = "isLessThan must succeed when specified value is less than supplied value"
-    ),
-    testFailure(
-      assert(42, isLessThan(42)),
-      message = "isLessThan must fail when specified value is greater than or equal supplied value"
-    ),
-    testSuccess(
-      assert(42, isLessThanEqualTo(42)),
-      message = "isLessThanEqualTo must succeed when specified value is less than or equal supplied value"
     ),
     testSuccess(
       assert(None, isNone),
@@ -135,15 +123,15 @@ object PredicateSpec {
       message = "isNone must fail when specified value is not None"
     ),
     testSuccess(
-      assert(Right(42), isRight(isEqualTo(42))),
+      assert(Right(42), isRight(equalTo(42))),
       message = "isRight must succeed when supplied value is Right and satisfy specified predicate"
     ),
     testSuccess(
-      assert(Some("zio"), isSome(isEqualTo("zio"))),
+      assert(Some("zio"), isSome(equalTo("zio"))),
       message = "isSome must succeed when supplied value is Some and satisfy specified predicate"
     ),
     testFailure(
-      assert(None, isSome(isEqualTo("zio"))),
+      assert(None, isSome(equalTo("zio"))),
       message = "isSome must fail when supplied value is None"
     ),
     testSuccess(
@@ -167,7 +155,19 @@ object PredicateSpec {
       message = "isWithin must fail when supplied value is out of range"
     ),
     testSuccess(
-      assert(0, not(isEqualTo(42))),
+      assert(42, lessThan(0)),
+      message = "lessThan must succeed when specified value is less than supplied value"
+    ),
+    testFailure(
+      assert(42, lessThan(42)),
+      message = "lessThan must fail when specified value is greater than or equal supplied value"
+    ),
+    testSuccess(
+      assert(42, lessThanEqualTo(42)),
+      message = "lessThanEqualTo must succeed when specified value is less than or equal supplied value"
+    ),
+    testSuccess(
+      assert(0, not(equalTo(42))),
       message = "not must succeed when negation of specified predicate is true"
     ),
     testFailure(
@@ -175,11 +175,15 @@ object PredicateSpec {
       message = "nothing must always fail"
     ),
     testSuccess(
-      assert(Exit.succeed("Some Error"), succeeds(isEqualTo("Some Error"))),
+      assert(Right(42), isRight(equalTo(42))),
+      message = "isRight must succeed when supplied value is Right and satisfy specified predicate"
+    ),
+    testSuccess(
+      assert(Exit.succeed("Some Error"), succeeds(equalTo("Some Error"))),
       message = "succeeds must succeed when supplied value is Exit.succeed and satisfy specified predicate"
     ),
     testFailure(
-      assert(Exit.fail("Some Error"), succeeds(isEqualTo("Some Error"))),
+      assert(Exit.fail("Some Error"), succeeds(equalTo("Some Error"))),
       message = "succeeds must fail when supplied value is Exit.fail"
     ),
     testSuccess(


### PR DESCRIPTION
Becouse `equals` method is defined for Any object the `Predicate.equals` gets shadowed when imported:

```scala
import zio.test.{assert, suite, test, DefaultRunnableSpec}
import zio.test.Predicate.equals

object ExampleSpec {
  def squaredScenario(n: Int, expected: Int) =
    assert(n * n, equals(expected))

  object spec extends DefaultRunnableSpec(
    suite("square")(
      test("two squared") { squaredScenario(2, 4) }
    )
  )
}
```

This will fail at compile time:
```
[error] (...): type mismatch;
[error]  found   : Boolean
[error]  required: zio.test.Predicate[?]
[error]     assert(n * n, equals(expected))
[error]                         ^
```

The workaround is to explicitly state `Predicate.equals`, but this is clunky. It's also unexpected and might cause quite a headache to scala beginners.

I propose to rename it to `isEqual` following already estabilished pattern from `isSome`, `isNone`, `isTrue`, `isFalse`, etc.