### PR TITLE
Add PlatformLive.Benchmark for use by benchmarks

### DIFF
--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -9,12 +9,10 @@ import monix.eval.{ Task => MTask }
 import zio.internal._
 
 object IOBenchmarks extends DefaultRuntime {
-  override val Platform: Platform = PlatformLive
-    .makeDefault(Int.MaxValue)
-    .withTracing(Tracing.disabled)
+  override val Platform: Platform = PlatformLive.Benchmark
 
   val TracedRuntime = new DefaultRuntime {
-    override val Platform = PlatformLive.makeDefault(Int.MaxValue).withTracing(Tracing.enabled)
+    override val Platform = PlatformLive.Benchmark.withTracing(Tracing.enabled)
   }
 
   import monix.execution.Scheduler

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -25,11 +25,20 @@ import zio.internal.tracing.TracingConfig
 
 import scala.concurrent.ExecutionContext
 
-import scala.concurrent.ExecutionContext
-
 object PlatformLive {
   lazy val Default = makeDefault()
   lazy val Global  = fromExecutionContext(ExecutionContext.global)
+
+  /**
+   * A Runtime with settings suitable for benchmarks, specifically
+   * with Tracing & auto-yielding disabled.
+   *
+   * Tracing adds a constant ~2x overhead on FlatMaps, however it's
+   * an optional feature and it's not valid to compare performance
+   * of ZIO with enabled Tracing with effect types _without_ a comparable
+   * feature.
+   * */
+  lazy val Benchmark = makeDefault(Int.MaxValue).withReportFailure(_ => ()).withTracing(Tracing.disabled)
 
   final def makeDefault(yieldOpCount: Int = 2048): Platform = fromExecutor(ExecutorUtil.makeDefault(yieldOpCount))
 


### PR DESCRIPTION
One of the initial fears with enabling tracing by default was that it'll make us look bad in benchmarks if the people doing the benchmark do not turn it off, when comparing us with effect types that do not have any debugging facilities. Well, that did happen recently, e.g. in [this](https://www.iteratorshq.com/blog/benchmarking-functional-error-handling-in-scala/) post ZIO is benchmarked with tracing on, so I propose to add a `PlatformLive.Bencmark` platform that might hopefully be discovered by future benchmarking posts!