### PR TITLE
fix deadlock on maxYieldOps less than 3

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -7,6 +7,7 @@ import com.github.ghik.silencer.silent
 import org.specs2.concurrent.ExecutionEnv
 import zio.Cause.{ die, fail, Fail, Then }
 import zio.duration._
+import zio.internal.PlatformLive
 import zio.clock.Clock
 
 import scala.annotation.tailrec
@@ -128,7 +129,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     deadlock regression 1                         $testDeadlockRegression
     check interruption regression 1               $testInterruptionRegression1
     manual sync interruption                      $testManualSyncInterruption
-
+    max yield Ops 1                               $testOneMaxYield
+    
   RTS option tests
     lifting a value to an option                  $testLiftingOptionalValue
     using the none value                          $testLiftingNoneValue
@@ -1359,6 +1361,19 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
       for {
         fiber <- putStr(".").forever.fork
         _     <- fiber.interrupt
+      } yield true
+    )
+  }
+
+  def testOneMaxYield = {
+    val rts = new DefaultRuntime {
+      override val Platform = PlatformLive.Default.withExecutor(PlatformLive.ExecutorUtil.makeDefault(1))
+    }
+
+    rts.unsafeRun(
+      for {
+        _ <- UIO.unit
+        _ <- UIO.unit
       } yield true
     )
   }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2552,6 +2552,7 @@ object ZIO extends ZIOFunctions {
     final val TracingStatus            = 20
     final val CheckTracing             = 21
     final val EffectSuspendTotalWith   = 22
+    final val Resume                   = 23
   }
   private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A])
       extends ZIO[R, E, A] {
@@ -2663,5 +2664,9 @@ object ZIO extends ZIOFunctions {
 
   private[zio] final class CheckTracing[R, E, A](val k: TrasingS => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.CheckTracing
+  }
+
+  private[zio] object Resume extends UIO[Unit] {
+    override def tag: Int = Tags.Resume
   }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2552,7 +2552,6 @@ object ZIO extends ZIOFunctions {
     final val TracingStatus            = 20
     final val CheckTracing             = 21
     final val EffectSuspendTotalWith   = 22
-    final val Resume                   = 23
   }
   private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A])
       extends ZIO[R, E, A] {
@@ -2666,7 +2665,4 @@ object ZIO extends ZIOFunctions {
     override def tag = Tags.CheckTracing
   }
 
-  private[zio] object Resume extends UIO[Unit] {
-    override def tag: Int = Tags.Resume
-  }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2664,5 +2664,4 @@ object ZIO extends ZIOFunctions {
   private[zio] final class CheckTracing[R, E, A](val k: TrasingS => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.CheckTracing
   }
-
 }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -238,12 +238,12 @@ private[zio] final class FiberContext[E, A](
         kTrace
       } else null
 
+    while ((curZio ne null) && (curZio.tag == ZIO.Tags.Resume)) { curZio = nextInstr(()) }
     while (curZio ne null) {
       try {
         var opcount: Int = 0
 
         while (curZio ne null) {
-          while (curZio.tag == ZIO.Tags.Resume) { curZio = nextInstr(()) }
           val tag = curZio.tag
 
           // Check to see if the fiber should continue executing or not:

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -249,10 +249,7 @@ private[zio] final class FiberContext[E, A](
           if (tag == ZIO.Tags.Fail || !shouldInterrupt) {
             // Fiber does not need to be interrupted, but might need to yield:
             if (opcount == maxopcount) {
-              // Cannot capture `curZio` since it will be boxed into `ObjectRef`,
-              // which destroys performance. So put `curZio` into a temp val:
-              val tmpIo = curZio
-              evaluateLater(tmpIo)
+              evaluateLater(curZio)
               curZio = null
             } else {
               // Fiber is neither being interrupted nor needs to yield. Execute

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -238,7 +238,6 @@ private[zio] final class FiberContext[E, A](
         kTrace
       } else null
 
-    while ((curZio ne null) && (curZio.tag == ZIO.Tags.Resume)) { curZio = nextInstr(()) }
     while (curZio ne null) {
       try {
         var opcount: Int = 0
@@ -253,8 +252,7 @@ private[zio] final class FiberContext[E, A](
               // Cannot capture `curZio` since it will be boxed into `ObjectRef`,
               // which destroys performance. So put `curZio` into a temp val:
               val tmpIo = curZio
-              pushContinuation(_ => tmpIo)
-              evaluateLater(ZIO.Resume)
+              evaluateLater(tmpIo)
               curZio = null
             } else {
               // Fiber is neither being interrupted nor needs to yield. Execute


### PR DESCRIPTION
Fixes #1372

This PR removes the indirection via `FlatMap` when `maxopcount` is reached. For resuming, a new tag is introduced, which is handled before entering the evaluation loop and does not contribute to `maxopcount`. 