### PR TITLE
(#1375) fromFuture does not kill fiber when exception is thrown on creation

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -542,7 +542,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
       f <- ZIO fail "Uh oh!"
     } yield f) catchAllCause ZIO.succeed) must_=== Fail("Uh oh!")
 
-  def testFromFutureDoesNotKillFibre  = {
+  def testFromFutureDoesNotKillFibre = {
     val e = new RuntimeException("Foo")
     unsafeRun(ZIO.fromFuture(_ => throw e).either) must_=== Left(e)
   }

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -57,6 +57,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     run swallows inner interruption               $testRunSwallowsInnerInterrupt
     timeout a long computation                    $testTimeoutOfLongComputation
     catchAllCause                                 $testCatchAllCause
+    exception in fromFuture does not kill fiber   $testFromFutureDoesNotKillFibre 
 
   RTS finalizers
     fail ensuring                                 $testEvalOfFailEnsuring
@@ -540,6 +541,11 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
       _ <- ZIO succeed 42
       f <- ZIO fail "Uh oh!"
     } yield f) catchAllCause ZIO.succeed) must_=== Fail("Uh oh!")
+
+  def testFromFutureDoesNotKillFibre  = {
+    val e = new RuntimeException("Foo")
+    unsafeRun(ZIO.fromFuture(_ => throw e).either) must_=== Left(e)
+  }
 
   def testEvalOfDeepSyncEffect = {
     def incLeft(n: Int, ref: Ref[Int]): Task[Int] =

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -57,7 +57,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     run swallows inner interruption               $testRunSwallowsInnerInterrupt
     timeout a long computation                    $testTimeoutOfLongComputation
     catchAllCause                                 $testCatchAllCause
-    exception in fromFuture does not kill fiber   $testFromFutureDoesNotKillFibre 
+    exception in fromFuture does not kill fiber   $testFromFutureDoesNotKillFiber 
 
   RTS finalizers
     fail ensuring                                 $testEvalOfFailEnsuring
@@ -542,7 +542,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
       f <- ZIO fail "Uh oh!"
     } yield f) catchAllCause ZIO.succeed) must_=== Fail("Uh oh!")
 
-  def testFromFutureDoesNotKillFibre = {
+  def testFromFutureDoesNotKillFiber = {
     val e = new RuntimeException("Foo")
     unsafeRun(ZIO.fromFuture(_ => throw e).either) must_=== Left(e)
   }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1954,7 +1954,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   final def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     Task.descriptorWith { d =>
       val ec = d.executor.asEC
-      effect(make(ec)).flatMap { f => 
+      effect(make(ec)).flatMap { f =>
         f.value
           .fold(
             Task.effectAsync { (cb: Task[A] => Unit) =>


### PR DESCRIPTION
Fixes #1375 