### PR TITLE
Deprecate succeedLazy

### DIFF
--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -122,10 +122,10 @@ class IODeepFlatMapBenchmark {
 
   private[this] def zioDeepFlatMap(runtime: Runtime[Any]): BigInt = {
     def fib(n: Int): UIO[BigInt] =
-      if (n <= 1) ZIO.succeed[BigInt](n)
+      if (n <= 1) ZIO.effectTotal[BigInt](n)
       else
         fib(n - 1).flatMap { a =>
-          fib(n - 2).flatMap(b => ZIO.succeed(a + b))
+          fib(n - 2).flatMap(b => ZIO.effectTotal(a + b))
         }
 
     runtime.unsafeRun(fib(depth))

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -122,10 +122,10 @@ class IODeepFlatMapBenchmark {
 
   private[this] def zioDeepFlatMap(runtime: Runtime[Any]): BigInt = {
     def fib(n: Int): UIO[BigInt] =
-      if (n <= 1) ZIO.succeedLazy[BigInt](n)
+      if (n <= 1) ZIO.succeed[BigInt](n)
       else
         fib(n - 1).flatMap { a =>
-          fib(n - 2).flatMap(b => ZIO.succeedLazy(a + b))
+          fib(n - 2).flatMap(b => ZIO.succeed(a + b))
         }
 
     runtime.unsafeRun(fib(depth))

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -34,9 +34,9 @@ class IODeepLeftBindBenchmark {
 
   def zioDeepLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     var i  = 0
-    var io = IO.succeed(i)
+    var io = IO.effectTotal(i)
     while (i < depth) {
-      io = io.flatMap(i => IO.succeed(i))
+      io = io.flatMap(i => IO.effectTotal(i))
       i += 1
     }
 

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -34,9 +34,9 @@ class IODeepLeftBindBenchmark {
 
   def zioDeepLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     var i  = 0
-    var io = IO.succeedLazy(i)
+    var io = IO.succeed(i)
     while (i < depth) {
-      io = io.flatMap(i => IO.succeedLazy(i))
+      io = io.flatMap(i => IO.succeed(i))
       i += 1
     }
 

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -120,11 +120,11 @@ class IOLeftBindBenchmark {
 
   private[this] def zioLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i % depth == 0) IO.succeed[Int](i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => IO.succeed(i))
-      else IO.succeed(i)
+      if (i % depth == 0) IO.effectTotal[Int](i + 1).flatMap(loop)
+      else if (i < size) loop(i + 1).flatMap(i => IO.effectTotal(i))
+      else IO.effectTotal(i)
 
-    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -120,11 +120,11 @@ class IOLeftBindBenchmark {
 
   private[this] def zioLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i % depth == 0) IO.succeedLazy[Int](i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => IO.succeedLazy(i))
-      else IO.succeedLazy(i)
+      if (i % depth == 0) IO.succeed[Int](i + 1).flatMap(loop)
+      else if (i < size) loop(i + 1).flatMap(i => IO.succeed(i))
+      else IO.succeed(i)
 
-    runtime.unsafeRun(IO.succeedLazy(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -113,7 +113,7 @@ class IOMapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    runtime.unsafeRun(sumTo(IO.succeed(0), depth))
+    runtime.unsafeRun(sumTo(IO.effectTotal(0), depth))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -113,7 +113,7 @@ class IOMapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    runtime.unsafeRun(sumTo(IO.succeedLazy(0), depth))
+    runtime.unsafeRun(sumTo(IO.succeed(0), depth))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -112,10 +112,10 @@ class IONarrowFlatMapBenchmark {
 
   private[this] def zioNarrowFlatMap(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) IO.succeed[Int](i + 1).flatMap(loop)
-      else IO.succeed(i)
+      if (i < size) IO.effectTotal[Int](i + 1).flatMap(loop)
+      else IO.effectTotal(i)
 
-    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -112,10 +112,10 @@ class IONarrowFlatMapBenchmark {
 
   private[this] def zioNarrowFlatMap(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) IO.succeedLazy[Int](i + 1).flatMap(loop)
-      else IO.succeedLazy(i)
+      if (i < size) IO.succeed[Int](i + 1).flatMap(loop)
+      else IO.succeed(i)
 
-    runtime.unsafeRun(IO.succeedLazy(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -130,7 +130,7 @@ class IOShallowAttemptBenchmark {
   def scalazShallowAttempt(): BigInt = {
     def throwup(n: Int): IO[ScalazError, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.succeed(1)
+      else if (n == depth) IO.effectTotal(1)
       else throwup(n + 1).foldM[Any, ScalazError, BigInt](_ => IO.succeed(0), _ => IO.fail(ScalazError("Oh noes!")))
 
     unsafeRun(throwup(0))
@@ -140,7 +140,7 @@ class IOShallowAttemptBenchmark {
   def scalazShallowAttemptBaseline(): BigInt = {
     def throwup(n: Int): IO[Error, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.succeed(1)
+      else if (n == depth) IO.effectTotal(1)
       else throwup(n + 1).foldM[Any, Error, BigInt](_ => IO.succeed(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafeRun(throwup(0))

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -130,7 +130,7 @@ class IOShallowAttemptBenchmark {
   def scalazShallowAttempt(): BigInt = {
     def throwup(n: Int): IO[ScalazError, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.succeedLazy(1)
+      else if (n == depth) IO.succeed(1)
       else throwup(n + 1).foldM[Any, ScalazError, BigInt](_ => IO.succeed(0), _ => IO.fail(ScalazError("Oh noes!")))
 
     unsafeRun(throwup(0))
@@ -140,7 +140,7 @@ class IOShallowAttemptBenchmark {
   def scalazShallowAttemptBaseline(): BigInt = {
     def throwup(n: Int): IO[Error, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.succeedLazy(1)
+      else if (n == depth) IO.succeed(1)
       else throwup(n + 1).foldM[Any, Error, BigInt](_ => IO.succeed(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafeRun(throwup(0))

--- a/core-tests/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSpec.scala
@@ -122,19 +122,19 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   def t2 = {
     val list    = List("1", "2", "3")
     val effects = new mutable.ListBuffer[String]
-    val res     = unsafeRun(IO.foreach(list)(x => IO.effectTotal(effects += x) *> IO.succeed[Int](x.toInt)))
+    val res     = unsafeRun(IO.foreach(list)(x => IO.effectTotal(effects += x) *> IO.effectTotal[Int](x.toInt)))
     (effects.toList, res) must be_===((list, List(1, 2, 3)))
   }
 
   def t3 = {
     val list = List("1", "h", "3")
-    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.effect[Int](x.toInt))))
+    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.effectTotal[Int](x.toInt))))
     res must beAFailedTry.withThrowable[FiberFailure]
   }
 
   def t4 = {
     val list = List("1", "2", "3")
-    val res  = unsafeRun(IO.foreachPar(list)(x => IO.succeed[Int](x.toInt)))
+    val res  = unsafeRun(IO.foreachPar(list)(x => IO.effectTotal[Int](x.toInt)))
     res must be_===(List(1, 2, 3))
   }
 
@@ -144,26 +144,26 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def t6 = {
-    val list = List(1, 2, 3).map(IO.succeed[Int](_))
+    val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
     val res  = unsafeRun(IO.collectAllPar(list))
     res must be_===(List(1, 2, 3))
   }
 
   def t7 = {
-    val list = List(1, 2, 3).map(IO.succeed[Int](_))
+    val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
     val res  = unsafeRun(IO.forkAll(list).flatMap[Any, Nothing, List[Int]](_.join))
     res must be_===(List(1, 2, 3))
   }
 
   def t8 = {
-    val list = List(1, 2, 3).map(IO.succeed[Int](_))
+    val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
     val res  = unsafeRun(IO.collectAllParN(2)(list))
     res must be_===(List(1, 2, 3))
   }
 
   def t9 = {
     val list = List(1, 2, 3)
-    val res  = unsafeRun(IO.foreachParN(2)(list)(x => IO.succeed(x.toString)))
+    val res  = unsafeRun(IO.foreachParN(2)(list)(x => IO.effectTotal(x.toString)))
     res must be_===(List("1", "2", "3"))
   }
 
@@ -275,8 +275,8 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def testFlatten = forAll(Gen.alphaStr) { str =>
     unsafeRun(for {
-      flatten1 <- IO.succeed(IO.succeed(str)).flatten
-      flatten2 <- IO.flatten(IO.succeed(IO.succeed(str)))
+      flatten1 <- IO.effectTotal(IO.effectTotal(str)).flatten
+      flatten2 <- IO.flatten(IO.effectTotal(IO.effectTotal(str)))
     } yield flatten1 must ===(flatten2))
   }
 
@@ -297,7 +297,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def testMemoization = forAll(Gen.alphaStr) { str =>
-    val ioMemo: UIO[UIO[Option[String]]] = IO.succeed(Some(str)).memoize // using `Some` for object allocation
+    val ioMemo: UIO[UIO[Option[String]]] = IO.effectTotal(Some(str)).memoize // using `Some` for object allocation
     unsafeRun(
       ioMemo
         .flatMap(io => io <*> io)
@@ -534,7 +534,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     unsafeRun {
       for {
         release  <- Ref.make(false)
-        result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.succeed(a + 1))
+        result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
         released <- release.get
       } yield (result must_=== 43) and (released must_=== true)
     }
@@ -543,7 +543,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     unsafeRun {
       for {
         release  <- Ref.make(false)
-        result   <- IO.succeed(42).bracket_(release.set(true), ZIO.succeed(0))
+        result   <- IO.succeed(42).bracket_(release.set(true), ZIO.effectTotal(0))
         released <- release.get
       } yield (result must_=== 0) and (released must_=== true)
     }

--- a/core-tests/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSpec.scala
@@ -122,19 +122,19 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   def t2 = {
     val list    = List("1", "2", "3")
     val effects = new mutable.ListBuffer[String]
-    val res     = unsafeRun(IO.foreach(list)(x => IO.effectTotal(effects += x) *> IO.succeedLazy[Int](x.toInt)))
+    val res     = unsafeRun(IO.foreach(list)(x => IO.effectTotal(effects += x) *> IO.succeed[Int](x.toInt)))
     (effects.toList, res) must be_===((list, List(1, 2, 3)))
   }
 
   def t3 = {
     val list = List("1", "h", "3")
-    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.succeedLazy[Int](x.toInt))))
+    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.succeed[Int](x.toInt))))
     res must beAFailedTry.withThrowable[FiberFailure]
   }
 
   def t4 = {
     val list = List("1", "2", "3")
-    val res  = unsafeRun(IO.foreachPar(list)(x => IO.succeedLazy[Int](x.toInt)))
+    val res  = unsafeRun(IO.foreachPar(list)(x => IO.succeed[Int](x.toInt)))
     res must be_===(List(1, 2, 3))
   }
 
@@ -144,26 +144,26 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def t6 = {
-    val list = List(1, 2, 3).map(IO.succeedLazy[Int](_))
+    val list = List(1, 2, 3).map(IO.succeed[Int](_))
     val res  = unsafeRun(IO.collectAllPar(list))
     res must be_===(List(1, 2, 3))
   }
 
   def t7 = {
-    val list = List(1, 2, 3).map(IO.succeedLazy[Int](_))
+    val list = List(1, 2, 3).map(IO.succeed[Int](_))
     val res  = unsafeRun(IO.forkAll(list).flatMap[Any, Nothing, List[Int]](_.join))
     res must be_===(List(1, 2, 3))
   }
 
   def t8 = {
-    val list = List(1, 2, 3).map(IO.succeedLazy[Int](_))
+    val list = List(1, 2, 3).map(IO.succeed[Int](_))
     val res  = unsafeRun(IO.collectAllParN(2)(list))
     res must be_===(List(1, 2, 3))
   }
 
   def t9 = {
     val list = List(1, 2, 3)
-    val res  = unsafeRun(IO.foreachParN(2)(list)(x => IO.succeedLazy(x.toString)))
+    val res  = unsafeRun(IO.foreachParN(2)(list)(x => IO.succeed(x.toString)))
     res must be_===(List("1", "2", "3"))
   }
 
@@ -275,8 +275,8 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def testFlatten = forAll(Gen.alphaStr) { str =>
     unsafeRun(for {
-      flatten1 <- IO.succeedLazy(IO.succeedLazy(str)).flatten
-      flatten2 <- IO.flatten(IO.succeedLazy(IO.succeedLazy(str)))
+      flatten1 <- IO.succeed(IO.succeed(str)).flatten
+      flatten2 <- IO.flatten(IO.succeed(IO.succeed(str)))
     } yield flatten1 must ===(flatten2))
   }
 
@@ -289,7 +289,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def testNonMemoizationRT = forAll(Gen.alphaStr) { str =>
-    val io: UIO[Option[String]] = IO.succeedLazy(Some(str)) // using `Some` for object allocation
+    val io: UIO[Option[String]] = IO.succeed(Some(str)) // using `Some` for object allocation
     unsafeRun(
       (io <*> io)
         .map(tuple => tuple._1 must not beTheSameAs (tuple._2))
@@ -297,7 +297,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def testMemoization = forAll(Gen.alphaStr) { str =>
-    val ioMemo: UIO[UIO[Option[String]]] = IO.succeedLazy(Some(str)).memoize // using `Some` for object allocation
+    val ioMemo: UIO[UIO[Option[String]]] = IO.succeed(Some(str)).memoize // using `Some` for object allocation
     unsafeRun(
       ioMemo
         .flatMap(io => io <*> io)
@@ -534,7 +534,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     unsafeRun {
       for {
         release  <- Ref.make(false)
-        result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.succeedLazy(a + 1))
+        result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.succeed(a + 1))
         released <- release.get
       } yield (result must_=== 43) and (released must_=== true)
     }
@@ -543,7 +543,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
     unsafeRun {
       for {
         release  <- Ref.make(false)
-        result   <- IO.succeed(42).bracket_(release.set(true), ZIO.succeedLazy(0))
+        result   <- IO.succeed(42).bracket_(release.set(true), ZIO.succeed(0))
         released <- release.get
       } yield (result must_=== 0) and (released must_=== true)
     }

--- a/core-tests/jvm/src/test/scala/zio/IOSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSpec.scala
@@ -128,7 +128,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def t3 = {
     val list = List("1", "h", "3")
-    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.succeed[Int](x.toInt))))
+    val res  = Try(unsafeRun(IO.foreach(list)(x => IO.effect[Int](x.toInt))))
     res must beAFailedTry.withThrowable[FiberFailure]
   }
 
@@ -289,7 +289,7 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
   }
 
   def testNonMemoizationRT = forAll(Gen.alphaStr) { str =>
-    val io: UIO[Option[String]] = IO.succeed(Some(str)) // using `Some` for object allocation
+    val io: UIO[Option[String]] = IO.effectTotal(Some(str)) // using `Some` for object allocation
     unsafeRun(
       (io <*> io)
         .map(tuple => tuple._1 must not beTheSameAs (tuple._2))

--- a/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
@@ -62,8 +62,8 @@ class IOCreationLazySyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def t1 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     unsafeRun(for {
-      a <- lazyStr.succeedLazy
-      b <- IO.succeedLazy(lazyStr)
+      a <- lazyStr.succeed
+      b <- IO.succeed(lazyStr)
     } yield a must ===(b))
   }
 

--- a/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
@@ -51,37 +51,28 @@ class IOCreationLazySyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "IOLazySyntaxSpec".title ^ s2"""
    Generate a String:
-      `.point` extension method returns the same UIO[String] as `IO.point` does. $t1
+      `.sync` extension method returns the same UIO[String] as `IO.sync` does. $t1
    Generate a String:
-      `.sync` extension method returns the same UIO[String] as `IO.sync` does. $t2
+      `.sync` extension method returns the same Task[String] as `IO.sync` does. $t2
    Generate a String:
-      `.sync` extension method returns the same Task[String] as `IO.sync` does. $t4
-   Generate a String:
-      `.syncCatch` extension method returns the same PartialFunction[Throwable, E] => IO[E, A] as `IO.sync` does. $t5
+      `.syncCatch` extension method returns the same PartialFunction[Throwable, E] => IO[E, A] as `IO.sync` does. $t3
     """
 
   def t1 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
-    unsafeRun(for {
-      a <- lazyStr.succeed
-      b <- IO.succeed(lazyStr)
-    } yield a must ===(b))
-  }
-
-  def t2 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     unsafeRun(for {
       a <- lazyStr.sync
       b <- IO.effectTotal(lazyStr)
     } yield a must ===(b))
   }
 
-  def t4 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
+  def t2 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     unsafeRun(for {
       a <- lazyStr.sync
       b <- IO.effect(lazyStr)
     } yield a must ===(b))
   }
 
-  def t5 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
+  def t3 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     val partial: PartialFunction[Throwable, Int] = { case _: Throwable => 42 }
     unsafeRun(for {
       a <- lazyStr.sync.refineOrDie(partial)

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -180,7 +180,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testPoint =
-    unsafeRun(IO.succeedLazy(1)) must_=== 1
+    unsafeRun(IO.succeed(1)) must_=== 1
 
   def testWidenNothing = {
     val op1 = IO.effectTotal[String]("1")
@@ -195,7 +195,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testPointIsLazy =
-    IO.succeedLazy(throw new Error("Not lazy")) must not(throwA[Throwable])
+    IO.succeed(throw new Error("Not lazy")) must not(throwA[Throwable])
 
   @silent
   def testNowIsEager =
@@ -216,11 +216,11 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(ZIO.effectSuspendWith[Any, Nothing](_ => throw ExampleError).either) must_=== Left(ExampleError)
 
   def testSuspendIsEvaluatable =
-    unsafeRun(IO.effectSuspendTotal(IO.succeedLazy[Int](42))) must_=== 42
+    unsafeRun(IO.effectSuspendTotal(IO.succeed[Int](42))) must_=== 42
 
   def testSyncEvalLoop = {
     def fibIo(n: Int): Task[BigInt] =
-      if (n <= 1) IO.succeedLazy(n)
+      if (n <= 1) IO.succeed(n)
       else
         for {
           a <- fibIo(n - 1)
@@ -266,7 +266,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testFlipDouble = {
-    val io = IO.succeedLazy(100)
+    val io = IO.succeed(100)
     unsafeRun(io.flip.flip) must_=== unsafeRun(io)
   }
 
@@ -420,7 +420,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     @volatile var reported: Exit[Nothing, Int] = null
 
     unsafeRun {
-      IO.succeedLazy[Int](42)
+      IO.succeed[Int](42)
         .ensuring(IO.die(ExampleError))
         .fork
         .flatMap(_.await.flatMap[Any, Nothing, Any](e => UIO.effectTotal { reported = e }))
@@ -430,7 +430,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testExitIsUsageResult =
-    unsafeRun(IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.succeedLazy[Int](42))) must_=== 42
+    unsafeRun(IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.succeed[Int](42))) must_=== 42
 
   def testBracketErrorInAcquisition =
     unsafeRunSync(IO.bracket(TaskExampleError)(_ => IO.unit)(_ => IO.unit)) must_=== Exit.Failure(fail(ExampleError))
@@ -593,7 +593,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testDeepAbsolveAttemptIsIdentity =
-    unsafeRun((0 until 1000).foldLeft(IO.succeedLazy[Int](42))((acc, _) => IO.absolve(acc.either))) must_=== 42
+    unsafeRun((0 until 1000).foldLeft(IO.succeed[Int](42))((acc, _) => IO.absolve(acc.either))) must_=== 42
 
   def testDeepAsyncAbsolveAttemptIsIdentity =
     unsafeRun(
@@ -648,7 +648,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(clock.sleep(1.nanos)) must_=== ((): Unit)
 
   def testShallowBindOfAsyncChainIsCorrect = {
-    val result = (0 until 10).foldLeft[Task[Int]](IO.succeedLazy[Int](0)) { (acc, _) =>
+    val result = (0 until 10).foldLeft[Task[Int]](IO.succeed[Int](0)) { (acc, _) =>
       acc.flatMap(n => IO.effectAsync[Throwable, Int](_(IO.succeed(n + 1))))
     }
 
@@ -656,7 +656,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
   }
 
   def testForkJoinIsId =
-    unsafeRun(IO.succeedLazy[Int](42).fork.flatMap(_.join)) must_=== 42
+    unsafeRun(IO.succeed[Int](42).fork.flatMap(_.join)) must_=== 42
 
   def testDeepForkJoinIsId = {
     val n = 20
@@ -876,7 +876,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(for {
       ref <- Ref.make(false)
       fiber <- withLatch { release =>
-                (ZIO.succeedLazy(throw new Error).run *> release *> ZIO.never)
+                (ZIO.succeed(throw new Error).run *> release *> ZIO.never)
                   .ensuring(ref.set(true))
                   .fork
               }
@@ -888,7 +888,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(for {
       ref <- Ref.make(false)
       fiber <- withLatch { release =>
-                (ZIO.succeedLazy(throw new Error).run *> release *> ZIO.unit.forever)
+                (ZIO.succeed(throw new Error).run *> release *> ZIO.unit.forever)
                   .ensuring(ref.set(true))
                   .fork
               }
@@ -1210,7 +1210,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(IO.fail(42).race(IO.fail(42)).either) must_=== Left(42)
 
   def testRaceOfValueNever =
-    unsafeRun(IO.succeedLazy(42).race(IO.never)) must_=== 42
+    unsafeRun(IO.succeed(42).race(IO.never)) must_=== 42
 
   def testRaceOfFailNever =
     unsafeRun(IO.fail(24).race(IO.never).timeout(10.milliseconds)) must beNone
@@ -1285,12 +1285,12 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
 
   def testReduceAll =
     unsafeRun(
-      IO.reduceAll(IO.succeedLazy(1), List(2, 3, 4).map(IO.succeedLazy[Int](_)))(_ + _)
+      IO.reduceAll(IO.succeed(1), List(2, 3, 4).map(IO.succeed[Int](_)))(_ + _)
     ) must_=== 10
 
   def testReduceAllEmpty =
     unsafeRun(
-      IO.reduceAll(IO.succeedLazy(1), Seq.empty)(_ + _)
+      IO.reduceAll(IO.succeed(1), Seq.empty)(_ + _)
     ) must_=== 1
 
   def testTimeoutFailure =
@@ -1417,7 +1417,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
       if (n <= 0) acc
       else loop(n - 1, acc.map(_ + 1))
 
-    loop(n, IO.succeedLazy(0))
+    loop(n, IO.succeed(0))
   }
 
   def deepMapNow(n: Int): UIO[Int] = {
@@ -1451,7 +1451,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     else fib(n - 1) + fib(n - 2)
 
   def concurrentFib(n: Int): Task[BigInt] =
-    if (n <= 1) IO.succeedLazy[BigInt](n)
+    if (n <= 1) IO.succeed[BigInt](n)
     else
       for {
         f1 <- concurrentFib(n - 1).fork
@@ -1464,7 +1464,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
 
   def testMergeAll =
     unsafeRun(
-      IO.mergeAll(List("a", "aa", "aaa", "aaaa").map(IO.succeedLazy[String](_)))(0) { (b, a) =>
+      IO.mergeAll(List("a", "aa", "aaa", "aaaa").map(IO.succeed[String](_)))(0) { (b, a) =>
         b + a.length
       }
     ) must_=== 10

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -872,7 +872,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(for {
       ref <- Ref.make(false)
       fiber <- withLatch { release =>
-                (ZIO.succeed(throw new Error).run *> release *> ZIO.never)
+                (ZIO.effect(throw new Error).run *> release *> ZIO.never)
                   .ensuring(ref.set(true))
                   .fork
               }
@@ -884,7 +884,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     unsafeRun(for {
       ref <- Ref.make(false)
       fiber <- withLatch { release =>
-                (ZIO.succeed(throw new Error).run *> release *> ZIO.unit.forever)
+                (ZIO.effect(throw new Error).run *> release *> ZIO.unit.forever)
                   .ensuring(ref.set(true))
                   .fork
               }

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -20,7 +20,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     widen Nothing                                 $testWidenNothing
     evaluation of point                           $testPoint
     blocking caches threads                       $testBlockingThreadCaching
-    point must be lazy                            $testPointIsLazy
     now must be eager                             $testNowIsEager
     effectSuspend must be lazy                    $testSuspendIsLazy
     effectSuspendTotal must not catch throwable   $testSuspendTotalThrowable
@@ -193,9 +192,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
 
     unsafeRun(result) must_=== "12"
   }
-
-  def testPointIsLazy =
-    IO.succeed(throw new Error("Not lazy")) must not(throwA[Throwable])
 
   @silent
   def testNowIsEager =

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -71,7 +71,7 @@ class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends 
 
   def e5 = {
     val list = List("1", "2", "3")
-    val io   = IO.succeedLazy(list)
+    val io   = IO.succeed(list)
     unsafeRun(
       for {
         returnIO <- serializeAndBack(io)

--- a/core-tests/jvm/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZManagedSpec.scala
@@ -450,8 +450,8 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
   private def testFlatten =
     forAll(Gen.alphaStr) { str =>
       unsafeRun((for {
-        flatten1 <- ZManaged.succeedLazy(ZManaged.succeedLazy(str)).flatten
-        flatten2 <- ZManaged.flatten(ZManaged.succeedLazy(ZManaged.succeedLazy(str)))
+        flatten1 <- ZManaged.succeed(ZManaged.succeed(str)).flatten
+        flatten2 <- ZManaged.flatten(ZManaged.succeed(ZManaged.succeed(str)))
       } yield flatten1 must ===(flatten2)).use[Any, Nothing, MatchResult[String]](result => ZIO.succeed(result)))
     }
 

--- a/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
@@ -60,8 +60,8 @@ class FunctionIOSpec extends BaseCrossPlatformSpec {
   def e5 =
     unsafeRun(
       for {
-        v <- succeedLazy(1)
-              .zipWith[Nothing, Int, Int, Int](succeedLazy(2))((a, b) => a + b)
+        v <- succeed(1)
+              .zipWith[Nothing, Int, Int, Int](succeed(2))((a, b) => a + b)
               .run(1)
       } yield v must_=== 3
     )
@@ -99,7 +99,7 @@ class FunctionIOSpec extends BaseCrossPlatformSpec {
     unsafeRun(
       for {
         v1 <- fromFunction[Int, Int](_ * 2).left[Int].run(Left(6))
-        v2 <- succeedLazy(1).left[String].run(Right("hi"))
+        v2 <- succeed(1).left[String].run(Right("hi"))
       } yield (v1 must beLeft(12)) and (v2 must beRight("hi"))
     )
 
@@ -129,11 +129,11 @@ class FunctionIOSpec extends BaseCrossPlatformSpec {
   def e14a =
     unsafeRun(
       for {
-        v1 <- ifThenElse(fromFunction[Int, Boolean](_ > 0))(succeedLazy("is positive"))(
-               succeedLazy("is negative")
+        v1 <- ifThenElse(fromFunction[Int, Boolean](_ > 0))(succeed("is positive"))(
+               succeed("is negative")
              ).run(-1)
-        v2 <- ifThenElse(fromFunction[Int, Boolean](_ > 0))(succeedLazy("is positive"))(
-               succeedLazy("is negative")
+        v2 <- ifThenElse(fromFunction[Int, Boolean](_ > 0))(succeed("is positive"))(
+               succeed("is negative")
              ).run(1)
       } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
     )
@@ -141,11 +141,11 @@ class FunctionIOSpec extends BaseCrossPlatformSpec {
   def e14b =
     unsafeRun(
       for {
-        v1 <- ifThenElse(fromFunctionM[Nothing, Int, Boolean](a => IO.succeed(a > 0)))(succeedLazy("is positive"))(
-               succeedLazy("is negative")
+        v1 <- ifThenElse(fromFunctionM[Nothing, Int, Boolean](a => IO.succeed(a > 0)))(succeed("is positive"))(
+               succeed("is negative")
              ).run(-1)
-        v2 <- ifThenElse(fromFunctionM[Nothing, Int, Boolean](a => IO.succeed(a > 0)))(succeedLazy("is positive"))(
-               succeedLazy("is negative")
+        v2 <- ifThenElse(fromFunctionM[Nothing, Int, Boolean](a => IO.succeed(a > 0)))(succeed("is positive"))(
+               succeed("is negative")
              ).run(1)
       } yield (v1 must_=== "is negative") and (v2 must_=== "is positive")
     )

--- a/core-tests/shared/src/test/scala/zio/GenIO.scala
+++ b/core-tests/shared/src/test/scala/zio/GenIO.scala
@@ -7,7 +7,7 @@ trait GenIO {
   /**
    * Given a generator for `A`, produces a generator for `IO[E, A]` using the `IO.point` constructor.
    */
-  def genSyncSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Arbitrary.arbitrary[A].map(IO.succeedLazy[A](_))
+  def genSyncSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Arbitrary.arbitrary[A].map(IO.succeed[A](_))
 
   /**
    * Given a generator for `A`, produces a generator for `IO[E, A]` using the `IO.async` constructor.
@@ -105,7 +105,7 @@ trait GenIO {
     gen.map(nextIO => io.flatMap(_ => nextIO))
 
   private def genOfIdentityFlatMaps[E, A](io: IO[E, A]): Gen[IO[E, A]] =
-    Gen.const(io.flatMap(a => IO.succeedLazy(a)))
+    Gen.const(io.flatMap(a => IO.succeed(a)))
 
   private def genOfRace[E, A](io: IO[E, A]): Gen[IO[E, A]] =
     Gen.const(io.race(IO.never))

--- a/core-tests/shared/src/test/scala/zio/RetrySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RetrySpec.scala
@@ -139,7 +139,7 @@ class RetrySpec extends BaseCrossPlatformSpec {
     var i                            = 0
     val strategy: Schedule[Any, Int] = Schedule.recurs(10)
     val io = IO.effectTotal[Unit](i += 1).flatMap { _ =>
-      if (i < 5) IO.fail("KeepTryingError") else IO.succeedLazy(i)
+      if (i < 5) IO.fail("KeepTryingError") else IO.succeed(i)
     }
     io.retry(strategy) must_=== 5
   }

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -216,7 +216,7 @@ final class STMSpec extends BaseCrossPlatformSpec {
       fiber <- (STM.atomically {
                 for {
                   v1 <- tvar1.get
-                  _  <- STM.succeedLazy(unsafeRun(latch.succeed(())))
+                  _  <- STM.succeed(unsafeRun(latch.succeed(())))
                   _  <- STM.check(v1 > 42)
                   _  <- tvar2.set("Succeeded!")
                   v2 <- tvar2.get
@@ -307,7 +307,7 @@ final class STMSpec extends BaseCrossPlatformSpec {
       tvar  <- TRef.makeCommit(0)
       fiber <- (for {
                 v <- tvar.get
-                _ <- STM.succeedLazy(unsafeRun(latch.succeed(())))
+                _ <- STM.succeed(unsafeRun(latch.succeed(())))
                 _ <- STM.check(v > 0)
                 _ <- tvar.update(10 / _)
               } yield ()).commit.fork
@@ -323,7 +323,7 @@ final class STMSpec extends BaseCrossPlatformSpec {
       tvar  <- TRef.makeCommit(0)
       fiber <- IO.forkAll(List.fill(100)((for {
                 v <- tvar.get
-                _ <- STM.succeedLazy(unsafeRun(latch.succeed(())))
+                _ <- STM.succeed(unsafeRun(latch.succeed(())))
                 _ <- STM.check(v < 0)
                 _ <- tvar.set(10)
               } yield ()).commit))

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -257,9 +257,9 @@ object Fiber {
    */
   final def done[E, A](exit: => Exit[E, A]): Fiber[E, A] =
     new Fiber[E, A] {
-      def await: UIO[Exit[E, A]]        = IO.succeedLazy(exit)
-      def poll: UIO[Option[Exit[E, A]]] = IO.succeedLazy(Some(exit))
-      def interrupt: UIO[Exit[E, A]]    = IO.succeedLazy(exit)
+      def await: UIO[Exit[E, A]]        = IO.succeed(exit)
+      def poll: UIO[Option[Exit[E, A]]] = IO.succeed(Some(exit))
+      def interrupt: UIO[Exit[E, A]]    = IO.succeed(exit)
       def inheritFiberRefs: UIO[Unit]   = IO.unit
 
     }
@@ -285,11 +285,9 @@ object Fiber {
    */
   final def succeed[E, A](a: A): Fiber[E, A] = done(Exit.succeed(a))
 
-  /**
-   * Returns a fiber that is already succeeded with the specified lazily
-   * evaluated value.
-   */
-  final def succeedLazy[E, A](a: => A): Fiber[E, A] = done(Exit.succeed(a))
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[E, A](a: => A): Fiber[E, A] =
+    succeed(a)
 
   /**
    * Interrupts all fibers, awaiting their interruption.

--- a/core/shared/src/main/scala/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/zio/FunctionIO.scala
@@ -228,10 +228,9 @@ object FunctionIO extends Serializable {
    */
   final def succeed[B](b: B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
 
-  /**
-   * Lifts a non-strictly evaluated value into the monad formed by `FunctionIO`.
-   */
-  final def succeedLazy[B](b: => B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[B](b: => B): FunctionIO[Nothing, Any, B] =
+    succeed(b)
 
   /**
    * Returns a `FunctionIO` representing a failure with the specified `E`.

--- a/core/shared/src/main/scala/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/zio/FunctionIO.scala
@@ -228,9 +228,9 @@ object FunctionIO extends Serializable {
    */
   final def succeed[B](b: B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[B](b: => B): FunctionIO[Nothing, Any, B] =
-    succeed(b)
+    effectTotal(_ => b)
 
   /**
    * Returns a `FunctionIO` representing a failure with the specified `E`.

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -400,10 +400,9 @@ object IO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  /**
-   * @see See [[zio.ZIO.succeedLazy]]
-   */
-  final def succeedLazy[A](a: => A): UIO[A] = ZIO.succeedLazy(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] =
+    succeed(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -400,9 +400,9 @@ object IO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] =
-    succeed(a)
+    effectTotal(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -67,6 +67,12 @@ object Managed {
     ZManaged.done(r)
 
   /**
+   * See [[zio.ZManaged.effectTotal]]
+   */
+  final def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
+    ZManaged.effectTotal(r)
+
+  /**
    * See [[zio.ZManaged.fail]]
    */
   final def fail[E](error: E): Managed[E, Nothing] =
@@ -246,9 +252,9 @@ object Managed {
   final def succeed[A](r: A): Managed[Nothing, A] =
     ZManaged.succeed(r)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](r: => A): Managed[Nothing, A] =
-    succeed(r)
+    effectTotal(r)
 
   /**
    * See [[zio.ZManaged.suspend]]

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -246,11 +246,9 @@ object Managed {
   final def succeed[A](r: A): Managed[Nothing, A] =
     ZManaged.succeed(r)
 
-  /**
-   * See [[zio.ZManaged.succeedLazy]]
-   */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[A](r: => A): Managed[Nothing, A] =
-    ZManaged.succeedLazy(r)
+    succeed(r)
 
   /**
    * See [[zio.ZManaged.suspend]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -445,9 +445,9 @@ object RIO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] =
-    succeed(a)
+    effectTotal(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -445,10 +445,9 @@ object RIO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  /**
-   * @see See [[zio.ZIO.succeedLazy]]
-   */
-  final def succeedLazy[A](a: => A): UIO[A] = ZIO.succeedLazy(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] =
+    succeed(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -166,10 +166,9 @@ object Schedule {
    */
   final def succeed[A](a: A): Schedule[Any, A] = ZSchedule.succeed(a)
 
-  /**
-   * See [[ZSchedule.succeedLazy]]
-   */
-  final def succeedLazy[A](a: => A): Schedule[Any, A] = ZSchedule.succeedLazy(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): Schedule[Any, A] =
+    succeed(a)
 
   /**
    * See [[ZSchedule.unfold]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -388,10 +388,9 @@ object Task {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  /**
-   * @see See [[zio.ZIO.succeedLazy]]
-   */
-  final def succeedLazy[A](a: => A): UIO[A] = ZIO.succeedLazy(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] =
+    succeed(a)
 
   /**
    * @see See [[zio.ZIO.supervised]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -388,9 +388,9 @@ object Task {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] =
-    succeed(a)
+    effectTotal(a)
 
   /**
    * @see See [[zio.ZIO.supervised]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -352,9 +352,9 @@ object UIO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] =
-    succeed(a)
+    effectTotal(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -352,10 +352,9 @@ object UIO {
    */
   final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
-  /**
-   * @see See [[zio.ZIO.succeedLazy]]
-   */
-  final def succeedLazy[A](a: => A): UIO[A] = ZIO.succeedLazy(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] =
+    succeed(a)
 
   /**
    * @see See [[zio.ZIO.interruptChildren]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1816,7 +1816,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * the list of results.
    */
   final def foreach_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
-    ZIO.succeed(as.iterator).flatMap { i =>
+    ZIO.effectTotal(as.iterator).flatMap { i =>
       def loop: ZIO[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
         else ZIO.unit

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2056,7 +2056,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   final def mergeAll[R, E, A, B](
     in: Iterable[ZIO[R, E, A]]
   )(zero: B)(f: (B, A) => B): ZIO[R, E, B] =
-    in.foldLeft[ZIO[R, E, B]](succeedLazy[B](zero))((acc, a) => acc.zip(a).map(f.tupled))
+    in.foldLeft[ZIO[R, E, B]](succeed[B](zero))((acc, a) => acc.zip(a).map(f.tupled))
 
   /**
    * Evaluate each effect in the structure from left to right, and collect
@@ -2065,7 +2065,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   final def mergeAllPar[R, E, A, B](
     in: Iterable[ZIO[R, E, A]]
   )(zero: B)(f: (B, A) => B): ZIO[R, E, B] =
-    in.foldLeft[ZIO[R, E, B]](succeedLazy[B](zero))((acc, a) => acc.zipPar(a).map(f.tupled)).refailWithTrace
+    in.foldLeft[ZIO[R, E, B]](succeed[B](zero))((acc, a) => acc.zipPar(a).map(f.tupled)).refailWithTrace
 
   /**
    * Returns an effect with the empty value.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1050,6 +1050,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * `[[ZIO.effectTotal]]` for capturing total effects, and `[[ZIO.effect]]` for capturing
    * partial effects.
    */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] = new ZIO.EffectTotal(() => a)
 
   /**
@@ -1815,7 +1816,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * the list of results.
    */
   final def foreach_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
-    ZIO.succeedLazy(as.iterator).flatMap { i =>
+    ZIO.succeed(as.iterator).flatMap { i =>
       def loop: ZIO[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
         else ZIO.unit
@@ -1842,7 +1843,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
     ZIO
-      .succeedLazy(as.iterator)
+      .succeed(as.iterator)
       .flatMap { i =>
         def loop(a: A): ZIO[R, E, Unit] =
           if (i.hasNext) f(a).zipWithPar(loop(i.next))((_, _) => ())
@@ -1898,7 +1899,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * composite fiber that produces a list of their results, in order.
    */
   final def forkAll[R, E, A](as: Iterable[ZIO[R, E, A]]): ZIO[R, Nothing, Fiber[E, List[A]]] =
-    as.foldRight[ZIO[R, Nothing, Fiber[E, List[A]]]](succeed(Fiber.succeedLazy[E, List[A]](List()))) {
+    as.foldRight[ZIO[R, Nothing, Fiber[E, List[A]]]](succeed(Fiber.succeed[E, List[A]](List()))) {
       (aIO, asFiberIO) =>
         asFiberIO.zip(aIO.fork).map {
           case (asFiber, aFiber) =>
@@ -2192,13 +2193,9 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def succeed[A](a: A): UIO[A] = new ZIO.Succeed(a)
 
-  /**
-   * Returns an effect that models success with the specified lazily-evaluated
-   * value. This method should not be used to capture effects. See
-   * `[[ZIO.effectTotal]]` for capturing total effects, and `[[ZIO.effect]]` for capturing
-   * partial effects.
-   */
-  final def succeedLazy[A](a: => A): UIO[A] = new ZIO.EffectTotal(() => a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] =
+    succeed(a)
 
   /**
    * Enables supervision for this effect. This will cause fibers forked by

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1899,12 +1899,11 @@ private[zio] trait ZIOFunctions extends Serializable {
    * composite fiber that produces a list of their results, in order.
    */
   final def forkAll[R, E, A](as: Iterable[ZIO[R, E, A]]): ZIO[R, Nothing, Fiber[E, List[A]]] =
-    as.foldRight[ZIO[R, Nothing, Fiber[E, List[A]]]](succeed(Fiber.succeed[E, List[A]](List()))) {
-      (aIO, asFiberIO) =>
-        asFiberIO.zip(aIO.fork).map {
-          case (asFiber, aFiber) =>
-            asFiber.zipWith(aFiber)((as, a) => a :: as)
-        }
+    as.foldRight[ZIO[R, Nothing, Fiber[E, List[A]]]](succeed(Fiber.succeed[E, List[A]](List()))) { (aIO, asFiberIO) =>
+      asFiberIO.zip(aIO.fork).map {
+        case (asFiber, aFiber) =>
+          asFiber.zipWith(aFiber)((as, a) => a :: as)
+      }
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1050,8 +1050,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * `[[ZIO.effectTotal]]` for capturing total effects, and `[[ZIO.effect]]` for capturing
    * partial effects.
    */
-  @deprecated("use succeed", "1.0.0")
-  final def succeedLazy[A](a: => A): UIO[A] = new ZIO.EffectTotal(() => a)
+  @deprecated("use effectTotal", "1.0.0")
+  final def succeedLazy[A](a: => A): UIO[A] = ZIO.effectTotal(a)
 
   /**
    * Companion helper to `sandbox`. Allows recovery, and partial recovery, from
@@ -2192,9 +2192,9 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def succeed[A](a: A): UIO[A] = new ZIO.Succeed(a)
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[A](a: => A): UIO[A] =
-    succeed(a)
+    effectTotal(a)
 
   /**
    * Enables supervision for this effect. This will cause fibers forked by

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -879,7 +879,7 @@ object ZManaged {
    * the list of results.
    */
   final def foreach_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
-    ZManaged.succeedLazy(as.iterator).flatMap { i =>
+    ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
         else ZManaged.unit
@@ -893,7 +893,7 @@ object ZManaged {
    * For a sequential version of this method, see `foreach_`.
    */
   final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
-    ZManaged.succeedLazy(as.iterator).flatMap { i =>
+    ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next).zipWithPar(loop)((_, _) => ())
         else ZManaged.unit
@@ -982,13 +982,13 @@ object ZManaged {
    * Merges an `Iterable[IO]` to a single IO, working sequentially.
    */
   final def mergeAll[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
-    in.foldLeft[ZManaged[R, E, B]](ZManaged.succeedLazy(zero))((acc, a) => acc.zip(a).map(f.tupled))
+    in.foldLeft[ZManaged[R, E, B]](ZManaged.succeed(zero))((acc, a) => acc.zip(a).map(f.tupled))
 
   /**
    * Merges an `Iterable[IO]` to a single IO, working in parallel.
    */
   final def mergeAllPar[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
-    in.foldLeft[ZManaged[R, E, B]](ZManaged.succeedLazy(zero))((acc, a) => acc.zipPar(a).map(f.tupled))
+    in.foldLeft[ZManaged[R, E, B]](ZManaged.succeed(zero))((acc, a) => acc.zipPar(a).map(f.tupled))
 
   /**
    * Merges an `Iterable[IO]` to a single IO, working in parallel.
@@ -1029,7 +1029,7 @@ object ZManaged {
                             _    <- queue.offer((a, prom))
                           } yield prom
                         }
-                b <- proms.foldLeft[ZIO[R, E, B]](ZIO.succeedLazy(zero)) { (acc, prom) =>
+                b <- proms.foldLeft[ZIO[R, E, B]](ZIO.succeed(zero)) { (acc, prom) =>
                       acc.zip(prom.await).map(f.tupled)
                     }
               } yield b).ensuring((queue.shutdown *> ZIO.foreach_(fibers)(_.interrupt)).uninterruptible)
@@ -1168,11 +1168,9 @@ object ZManaged {
   final def succeed[R, A](r: A): ZManaged[R, Nothing, A] =
     ZManaged(IO.succeed(Reservation(IO.succeed(r), _ => IO.unit)))
 
-  /**
-   * Lifts a by-name, pure value into a Managed.
-   */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[R, A](r: => A): ZManaged[R, Nothing, A] =
-    ZManaged(IO.succeed(Reservation(IO.succeedLazy(r), _ => IO.unit)))
+    succeed(a)
 
   /**
    * Returns a lazily constructed Managed.

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1170,7 +1170,7 @@ object ZManaged {
 
   @deprecated("use succeed", "1.0.0")
   final def succeedLazy[R, A](r: => A): ZManaged[R, Nothing, A] =
-    succeed(a)
+    succeed(r)
 
   /**
    * Returns a lazily constructed Managed.

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -800,6 +800,12 @@ object ZManaged {
     ZManaged.fromEffect(ZIO.done(r))
 
   /**
+   * Lifts a by-name, pure value into a Managed.
+   */
+  final def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
+    ZManaged.fromEffect(ZIO.effectTotal(r))
+
+  /**
    * Accesses the whole environment of the effect.
    */
   final def environment[R]: ZManaged[R, Nothing, R] =
@@ -1168,9 +1174,9 @@ object ZManaged {
   final def succeed[R, A](r: A): ZManaged[R, Nothing, A] =
     ZManaged(IO.succeed(Reservation(IO.succeed(r), _ => IO.unit)))
 
-  @deprecated("use succeed", "1.0.0")
+  @deprecated("use effectTotal", "1.0.0")
   final def succeedLazy[R, A](r: => A): ZManaged[R, Nothing, A] =
-    succeed(r)
+    effectTotal(r)
 
   /**
    * Returns a lazily constructed Managed.

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -727,17 +727,16 @@ object ZSchedule {
    */
   final def succeed[A](a: A): Schedule[Any, A] = forever.as(a)
 
-  /**
-   * A schedule that recurs forever, returning the constant for every output (by-name version).
-   */
-  final def succeedLazy[A](a: => A): Schedule[Any, A] = forever.as(a)
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): Schedule[Any, A] =
+    succeed(a)
 
   /**
    * A schedule that always recurs without delay, and computes the output
    * through recured application of a function to a base value.
    */
   final def unfold[A](a: => A)(f: A => A): Schedule[Any, A] =
-    unfoldM(IO.succeedLazy(a))(f.andThen(IO.succeedLazy[A](_)))
+    unfoldM(IO.succeed(a))(f.andThen(IO.succeed[A](_)))
 
   /**
    * A schedule that always recurs without delay, and computes the output

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -707,7 +707,7 @@ object STM {
   /**
    * Kills the fiber running the effect.
    */
-  final def die(t: Throwable): STM[Nothing, Nothing] = succeedLazy(throw t)
+  final def die(t: Throwable): STM[Nothing, Nothing] = succeed(throw t)
 
   /**
    * Kills the fiber running the effect with a `RuntimeException` that contains

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -765,17 +765,14 @@ object STM {
    */
   final def succeed[A](a: A): STM[Nothing, A] = new STM(_ => TRez.Succeed(a))
 
-  /**
-   * Returns an `STM` effect that succeeds with the specified (lazily
-   * evaluated) value.
-   */
-  final def succeedLazy[A](a: => A): STM[Nothing, A] = new STM(_ => TRez.Succeed(a))
+  @deprecated("use succeed", "1.0.0")
+  final def succeedLazy[A](a: => A): STM[Nothing, A] = succeed(a)
 
   /**
    * Suspends creation of the specified transaction lazily.
    */
   final def suspend[E, A](stm: => STM[E, A]): STM[E, A] =
-    STM.succeedLazy(stm).flatten
+    STM.succeed(stm).flatten
 
   /**
    * Returns an `STM` effect that succeeds with `Unit`.

--- a/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
@@ -20,7 +20,8 @@ import zio.{ Fiber, IO, Task, UIO }
 
 object IOSyntax {
   final class IOCreationLazySyntax[A](val a: () => A) extends AnyVal {
-    def succeedLazy: UIO[A] = IO.succeedLazy(a())
+    @deprecated("use succeed", "1.0.0")
+    def succeedLazy: UIO[A] = IO.succeed(a())
     def defer: UIO[A]       = IO.effectTotal(a())
     def sync: Task[A]       = Task.effect(a())
   }

--- a/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
@@ -20,8 +20,8 @@ import zio.{ Fiber, IO, Task, UIO }
 
 object IOSyntax {
   final class IOCreationLazySyntax[A](val a: () => A) extends AnyVal {
-    @deprecated("use succeed", "1.0.0")
-    def succeedLazy: UIO[A] = IO.succeed(a())
+    @deprecated("use effectTotal", "1.0.0")
+    def succeedLazy: UIO[A] = IO.effectTotal(a())
     def defer: UIO[A]       = IO.effectTotal(a())
     def sync: Task[A]       = Task.effect(a())
   }

--- a/docs/datatypes/fiber.md
+++ b/docs/datatypes/fiber.md
@@ -39,7 +39,7 @@ On the JVM, fibers will use threads, but will not consume *unlimited* threads. I
 ```scala mdoc:silent
 def fib(n: Int): UIO[Int] =
   if (n <= 1) {
-    IO.succeedLazy(1)
+    IO.succeed(1)
   } else {
     for {
       fiber1 <- fib(n - 2).fork
@@ -71,7 +71,7 @@ Separately from errors of type `E`, a fiber may be terminated for the following 
  * The fiber failed to handle some error of type `E`. This can happen only when an `IO.fail` is not handled. For values of type `UIO[A]`, this type of failure is impossible.
  * The fiber has a defect that leads to a non-recoverable error. There are only two ways this can happen:
      1. A partial function is passed to a higher-order function such as `map` or `flatMap`. For example, `io.map(_ => throw e)`, or `io.flatMap(a => throw e)`. The solution to this problem is to not to pass impure functions to purely functional libraries like ZIO, because doing so leads to violations of laws and destruction of equational reasoning.
-     2. Error-throwing code was embedded into some value via `IO.succeedLazy`, `IO.sync`, etc. For importing partial effects into `IO`, the proper solution is to use a method such as `syncException`, which safely translates exceptions into values.
+     2. Error-throwing code was embedded into some value via `IO.sync`, etc. For importing partial effects into `IO`, the proper solution is to use a method such as `syncException`, which safely translates exceptions into values.
 
 When a fiber is terminated, the reason for the termination, expressed as a `Throwable`, is passed to the fiber's supervisor, which may choose to log, print the stack trace, restart the fiber, or perform some other action appropriate to the context.
 

--- a/docs/datatypes/io.md
+++ b/docs/datatypes/io.md
@@ -18,14 +18,6 @@ You can lift pure values into `IO` with `IO.succeed`:
 ```scala mdoc:silent
 import zio._
 
-val lazyValue: UIO[String] = IO.succeed("Hello World")
-```
-
-The constructor uses non-strict evaluation, so the parameter will not be evaluated until when and if the `IO` action is executed at runtime, which is useful if the construction is costly and the value may never be needed.
-
-Alternately, you can use the `IO.succeed` constructor to perform strict evaluation of the value:
-
-```scala mdoc:silent
 val value: UIO[String] = IO.succeed("Hello World")
 ```
 
@@ -91,7 +83,7 @@ You can change an `IO[E, A]` to an `IO[E, B]` by calling the `map` method with a
 ```scala mdoc:silent
 import zio._
 
-val mappedLazyValue: UIO[Int] = IO.succeed(21).map(_ * 2)
+val mappedValue: UIO[Int] = IO.succeed(21).map(_ * 2)
 ```
 
 You can transform an `IO[E, A]` into an `IO[E2, A]` by calling the `mapError` method with a function `E => E2`:
@@ -136,8 +128,8 @@ import zio._
 ```scala mdoc:invisible
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeed(???)
-def closeFile(f: File): UIO[Unit] = IO.succeed(???)
+def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]
+def closeFile(f: File): UIO[Unit] = IO.effectTotal(???)
 def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```

--- a/docs/datatypes/io.md
+++ b/docs/datatypes/io.md
@@ -13,12 +13,12 @@ A value of type `IO[E, A]` describes an effect that may fail with an `E`, run fo
 
 ## Pure Values
 
-You can lift pure values into `IO` with `IO.succeedLazy`:
+You can lift pure values into `IO` with `IO.succeed`:
 
 ```scala mdoc:silent
 import zio._
 
-val lazyValue: UIO[String] = IO.succeedLazy("Hello World")
+val lazyValue: UIO[String] = IO.succeed("Hello World")
 ```
 
 The constructor uses non-strict evaluation, so the parameter will not be evaluated until when and if the `IO` action is executed at runtime, which is useful if the construction is costly and the value may never be needed.
@@ -91,7 +91,7 @@ You can change an `IO[E, A]` to an `IO[E, B]` by calling the `map` method with a
 ```scala mdoc:silent
 import zio._
 
-val mappedLazyValue: UIO[Int] = IO.succeedLazy(21).map(_ * 2)
+val mappedLazyValue: UIO[Int] = IO.succeed(21).map(_ * 2)
 ```
 
 You can transform an `IO[E, A]` into an `IO[E2, A]` by calling the `mapError` method with a function `E => E2`:
@@ -105,8 +105,8 @@ val mappedError: IO[Exception, String] = IO.fail("No no!").mapError(msg => new E
 You can execute two actions in sequence with the `flatMap` method. The second action may depend on the value produced by the first action.
 
 ```scala mdoc:silent
-val chainedActionsValue: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
-  IO.succeedLazy(list.map(_ + 1))
+val chainedActionsValue: UIO[List[Int]] = IO.succeed(List(1, 2, 3)).flatMap { list =>
+  IO.succeed(list.map(_ + 1))
 }
 ```
 
@@ -114,8 +114,8 @@ You can use Scala's `for` comprehension syntax to make this type of code more co
 
 ```scala mdoc:silent
 val chainedActionsValueWithForComprehension: UIO[List[Int]] = for {
-  list <- IO.succeedLazy(List(1, 2, 3))
-  added <- IO.succeedLazy(list.map(_ + 1))
+  list <- IO.succeed(List(1, 2, 3))
+  added <- IO.succeed(list.map(_ + 1))
 } yield added
 ```
 
@@ -136,8 +136,8 @@ import zio._
 ```scala mdoc:invisible
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeedLazy(???)
-def closeFile(f: File): UIO[Unit] = IO.succeedLazy(???)
+def openFile(s: String): IO[IOException, File] = IO.succeed(???)
+def closeFile(f: File): UIO[Unit] = IO.succeed(???)
 def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```

--- a/docs/datatypes/managed.md
+++ b/docs/datatypes/managed.md
@@ -26,7 +26,7 @@ As shown in the previous example, a `Managed` can be created by passing an `acqu
 It can also be created from an effect. In this case the release function will do nothing.
 ```scala mdoc:silent
 import zio._
-def acquire: IO[String, Int] = IO.succeed(???)
+def acquire: IO[String, Int] = IO.effect(???).refineToOrDie[String]
 
 val managedFromEffect: Managed[String, Int] = Managed.fromEffect(acquire)
 ```
@@ -60,9 +60,9 @@ import zio._
 ```scala mdoc:invisible
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeed(???)
-def closeFile(f: File): UIO[Unit] = IO.succeed(???)
-def doSomething(queue: Queue[Int], file: File): UIO[Unit] = IO.succeed(???)
+def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]
+def closeFile(f: File): UIO[Unit] = IO.effectTotal(???)
+def doSomething(queue: Queue[Int], file: File): UIO[Unit] = IO.effectTotal(???)
 ```
 
 ```scala mdoc:silent

--- a/docs/datatypes/managed.md
+++ b/docs/datatypes/managed.md
@@ -26,7 +26,7 @@ As shown in the previous example, a `Managed` can be created by passing an `acqu
 It can also be created from an effect. In this case the release function will do nothing.
 ```scala mdoc:silent
 import zio._
-def acquire: IO[String, Int] = IO.succeedLazy(???)
+def acquire: IO[String, Int] = IO.succeed(???)
 
 val managedFromEffect: Managed[String, Int] = Managed.fromEffect(acquire)
 ```
@@ -60,9 +60,9 @@ import zio._
 ```scala mdoc:invisible
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeedLazy(???)
-def closeFile(f: File): UIO[Unit] = IO.succeedLazy(???)
-def doSomething(queue: Queue[Int], file: File): UIO[Unit] = IO.succeedLazy(???)
+def openFile(s: String): IO[IOException, File] = IO.succeed(???)
+def closeFile(f: File): UIO[Unit] = IO.succeed(???)
+def doSomething(queue: Queue[Int], file: File): UIO[Unit] = IO.succeed(???)
 ```
 
 ```scala mdoc:silent

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -23,16 +23,16 @@ You can also create use methods in the companion objects of the `ZIO` type alias
 val s2: Task[Int] = Task.succeed(42)
 ```
 
-The `succeed` method is eager, which means the value passed to `succeed` will be constructed _before_ the method is invoked. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.succeed` method:
+The `succeed` method is eager, which means the value passed to `succeed` will be constructed _before_ the method is invoked. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.effectTotal` method:
 
 ```scala mdoc:silent
 lazy val bigList = (0 to 1000000).toList
 lazy val bigString = bigList.map(_.toString).mkString("\n")
 
-val s3 = ZIO.succeed(bigString)
+val s3 = ZIO.effectTotal(bigString)
 ```
 
-The value inside a successful effect constructed with `ZIO.succeed` will only be constructed if absolutely required.
+The value inside a successful effect constructed with `ZIO.effectTotal` will only be constructed if absolutely required.
 
 ## From Failure Values
 

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -23,16 +23,16 @@ You can also create use methods in the companion objects of the `ZIO` type alias
 val s2: Task[Int] = Task.succeed(42)
 ```
 
-The `succeed` method is eager, which means the value passed to `succeed` will be constructed _before_ the method is invoked. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.succeedLazy` method:
+The `succeed` method is eager, which means the value passed to `succeed` will be constructed _before_ the method is invoked. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.succeed` method:
 
 ```scala mdoc:silent
 lazy val bigList = (0 to 1000000).toList
 lazy val bigString = bigList.map(_.toString).mkString("\n")
 
-val s3 = ZIO.succeedLazy(bigString)
+val s3 = ZIO.succeed(bigString)
 ```
 
-The value inside a successful effect constructed with `ZIO.succeedLazy` will only be constructed if absolutely required.
+The value inside a successful effect constructed with `ZIO.succeed` will only be constructed if absolutely required.
 
 ## From Failure Values
 

--- a/docs/overview/handling_errors.md
+++ b/docs/overview/handling_errors.md
@@ -37,8 +37,8 @@ If you want to catch and recover from all types of errors and effectfully attemp
 ```scala mdoc:invisible
 import java.io.{ FileNotFoundException, IOException }
 
-def openFile(s: String): IO[IOException, Array[Byte]] =   
-  IO.succeed(???)
+def openFile(s: String): IO[IOException, Array[Byte]] = 
+  ZIO.effect(???).refineToOrDie[IOException]
 ```
 
 ```scala mdoc:silent

--- a/docs/overview/handling_errors.md
+++ b/docs/overview/handling_errors.md
@@ -38,7 +38,7 @@ If you want to catch and recover from all types of errors and effectfully attemp
 import java.io.{ FileNotFoundException, IOException }
 
 def openFile(s: String): IO[IOException, Array[Byte]] =   
-  IO.succeedLazy(???)
+  IO.succeed(???)
 ```
 
 ```scala mdoc:silent
@@ -110,7 +110,7 @@ def fetchContent(urls: List[String]): UIO[Content] = IO.succeed(OkContent("Roger
 ```scala mdoc:silent
 val urls: UIO[Content] =
   readUrls("urls.json").foldM(
-    error   => IO.succeedLazy(NoContent(error)), 
+    error   => IO.succeed(NoContent(error)), 
     success => fetchContent(success)
   )
 ```

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -35,7 +35,7 @@ Unlike `try` / `finally`, `ensuring` works across all types of effects, includin
 
 A common use for `try` / `finally` is safely acquiring and releasing resources, such as new socket connections or opened files:
 
-```scala 
+```scala
 val handle = openFile(name)
 
 try {
@@ -51,14 +51,14 @@ The release effect is guaranteed to be executed by the runtime system, even in t
 import zio._
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeedLazy(???)
+def openFile(s: String): IO[IOException, File] = IO.succeed(???)
 def closeFile(f: File): UIO[Unit] = UIO.unit
 def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
 ```scala mdoc:silent
-val groupedFileData: IO[IOException, Unit] = 
+val groupedFileData: IO[IOException, Unit] =
   openFile("data.json").bracket(closeFile(_)) { file =>
     for {
       data    <- decodeData(file)

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -35,7 +35,7 @@ Unlike `try` / `finally`, `ensuring` works across all types of effects, includin
 
 A common use for `try` / `finally` is safely acquiring and releasing resources, such as new socket connections or opened files:
 
-```scala
+```scala 
 val handle = openFile(name)
 
 try {
@@ -51,14 +51,14 @@ The release effect is guaranteed to be executed by the runtime system, even in t
 import zio._
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.succeed(???)
+def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]
 def closeFile(f: File): UIO[Unit] = UIO.unit
 def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
 ```scala mdoc:silent
-val groupedFileData: IO[IOException, Unit] =
+val groupedFileData: IO[IOException, Unit] = 
   openFile("data.json").bracket(closeFile(_)) { file =>
     for {
       data    <- decodeData(file)

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -479,22 +479,22 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def flatMapHappyPath = {
-    val sink = ZSink.identity[Int].flatMap(n => ZSink.succeedLazy(n.toString))
+    val sink = ZSink.identity[Int].flatMap(n => ZSink.succeed(n.toString))
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1"))
   }
 
   private def flatMapInitError = {
-    val sink = initErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    val sink = initErrorSink.flatMap(n => ZSink.succeed(n.toString))
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def flatMapStepError = {
-    val sink = stepErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    val sink = stepErrorSink.flatMap(n => ZSink.succeed(n.toString))
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def flatMapExtractError = {
-    val sink = extractErrorSink.flatMap(n => ZSink.succeedLazy(n.toString))
+    val sink = extractErrorSink.flatMap(n => ZSink.succeed(n.toString))
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
@@ -644,12 +644,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def orElseRight = {
-    val sink = ZSink.fail("Ouch") orElse ZSink.succeedLazy("Hello")
+    val sink = ZSink.fail("Ouch") orElse ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, "whatever").map(_ must_=== Right("Hello")))
   }
 
   private def orElseInitErrorLeft = {
-    val sink = initErrorSink orElse ZSink.succeedLazy("Hello")
+    val sink = initErrorSink orElse ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
   }
 
@@ -664,7 +664,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def orElseStepErrorLeft = {
-    val sink = stepErrorSink orElse ZSink.succeedLazy("Hello")
+    val sink = stepErrorSink orElse ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
   }
 
@@ -679,7 +679,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def orElseExtractErrorLeft = {
-    val sink = extractErrorSink orElse ZSink.succeedLazy("Hello")
+    val sink = extractErrorSink orElse ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== Right("Hello")))
   }
 
@@ -694,7 +694,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def raceBothLeft = {
-    val sink = ZSink.identity[Int] raceBoth ZSink.succeedLazy("Hello")
+    val sink = ZSink.identity[Int] raceBoth ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== Left(1)))
   }
 
@@ -784,7 +784,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def zipHappyPath = {
-    val sink = ZSink.identity[Int] <*> ZSink.succeedLazy("Hello")
+    val sink = ZSink.identity[Int] <*> ZSink.succeed("Hello")
     unsafeRun(sinkIteration(sink, 1).map(t => (t._1 must_=== 1) and (t._2 must_=== "Hello")))
   }
 
@@ -834,17 +834,17 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   }
 
   private def zipLeftHappyPath = {
-    val sink = ZSink.identity[Int].zipLeft(ZSink.succeedLazy("Hello"))
+    val sink = ZSink.identity[Int].zipLeft(ZSink.succeed("Hello"))
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== 1))
   }
 
   private def zipRightHappyPath = {
-    val sink = ZSink.identity[Int].zipRight(ZSink.succeedLazy("Hello"))
+    val sink = ZSink.identity[Int].zipRight(ZSink.succeed("Hello"))
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "Hello"))
   }
 
   private def zipWithHappyPath = {
-    val sink = ZSink.identity[Int].zipWith(ZSink.succeedLazy("Hello"))((x, y) => x.toString + y.toString)
+    val sink = ZSink.identity[Int].zipWith(ZSink.succeed("Hello"))((x, y) => x.toString + y.toString)
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== "1Hello"))
   }
 
@@ -1146,8 +1146,8 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         .map(_._2)
         .chunked
 
-    val src1         = ZStreamChunk.succeedLazy(Chunk.fromArray(Array('[', '1', '2')))
-    val src2         = ZStreamChunk.succeedLazy(Chunk.fromArray(Array('3', ',', '4', ']')))
+    val src1         = ZStreamChunk.succeed(Chunk.fromArray(Array('[', '1', '2')))
+    val src2         = ZStreamChunk.succeed(Chunk.fromArray(Array('3', ',', '4', ']')))
     val partialParse = unsafeRunSync(src1.run(numArrayParser))
     val fullParse    = unsafeRunSync((src1 ++ src2).run(numArrayParser))
 
@@ -1173,8 +1173,8 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         case _                   => ZSink.fail("Expected '['")
       }
 
-    val src1         = ZStreamChunk.succeedLazy(Chunk.fromArray(Array('[', '1', '2')))
-    val src2         = ZStreamChunk.succeedLazy(Chunk.fromArray(Array('3', ',', '4', ']')))
+    val src1         = ZStreamChunk.succeed(Chunk.fromArray(Array('[', '1', '2')))
+    val src2         = ZStreamChunk.succeed(Chunk.fromArray(Array('3', ',', '4', ']')))
     val partialParse = unsafeRunSync(src1.run(start.chunked))
     val fullParse    = unsafeRunSync((src1 ++ src2).run(start.chunked))
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -143,12 +143,12 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
   private def monadLaw1 =
     prop(
       (x: Int, f: Int => StreamChunk[String, Int]) =>
-        slurp(ZStreamChunk.succeedLazy(Chunk(x)).flatMap(f)) must_=== slurp(f(x))
+        slurp(ZStreamChunk.succeed(Chunk(x)).flatMap(f)) must_=== slurp(f(x))
     )
 
   private def monadLaw2 =
     prop(
-      (m: StreamChunk[String, Int]) => slurp(m.flatMap(i => ZStreamChunk.succeedLazy(Chunk(i)))) must_=== slurp(m)
+      (m: StreamChunk[String, Int]) => slurp(m.flatMap(i => ZStreamChunk.succeed(Chunk(i)))) must_=== slurp(m)
     )
 
   private def monadLaw3 =

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -513,7 +513,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         fiber <- ZStream
                   .effectAsyncM[Any, Throwable, Int] { k =>
                     latch.succeed(()) *>
-                      Task.succeedLazy {
+                      Task.succeed {
                         list.foreach(a => k(Task.succeed(a)))
                       }
                   }
@@ -688,11 +688,11 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def flatMapStackSafety = {
     def fib(n: Int): Stream[Nothing, Int] =
-      if (n <= 1) Stream.succeedLazy(n)
+      if (n <= 1) Stream.succeed(n)
       else
         fib(n - 1).flatMap { a =>
           fib(n - 2).flatMap { b =>
-            Stream.succeedLazy(a + b)
+            Stream.succeed(a + b)
           }
         }
 

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -196,11 +196,9 @@ object Sink {
   final def read1[E, A](e: Option[A] => E)(p: A => Boolean): Sink[E, A, A, A] =
     ZSink.read1(e)(p)
 
-  /**
-   * see [[ZSink.succeedLazy]]
-   */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[B](b: => B): Sink[Nothing, Nothing, Any, B] =
-    ZSink.succeedLazy(b)
+    succeed(a)
 
   /**
    * see [[ZSink.throttleEnforce]]

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -196,9 +196,15 @@ object Sink {
   final def read1[E, A](e: Option[A] => E)(p: A => Boolean): Sink[E, A, A, A] =
     ZSink.read1(e)(p)
 
+  /**
+   * see [[ZSink.succeed]]
+   */
+  final def succeed[B](b: B): Sink[Nothing, Nothing, Any, B] =
+    ZSink.succeed(b)
+
   @deprecated("use succeed", "1.0.0")
   final def succeedLazy[B](b: => B): Sink[Nothing, Nothing, Any, B] =
-    succeed(a)
+    succeed(b)
 
   /**
    * see [[ZSink.throttleEnforce]]

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -188,11 +188,9 @@ object Stream extends ZStreamPlatformSpecific {
   final def succeed[A](a: A): Stream[Nothing, A] =
     ZStream.succeed(a)
 
-  /**
-   * See [[ZStream.succeedLazy]]
-   */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[A](a: => A): Stream[Nothing, A] =
-    ZStream.succeedLazy(a)
+    succeed(a)
 
   /**
    * See [[ZStream.unfold]]

--- a/streams/shared/src/main/scala/zio/stream/StreamChunkPure.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamChunkPure.scala
@@ -25,7 +25,7 @@ private[stream] trait StreamChunkPure[@specialized +A] extends ZStreamChunk[Any,
     StreamChunkPure(chunks.map(_.filter(pred)))
 
   override def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): ZManaged[Any, Nothing, S] =
-    ZManaged.succeedLazy(foldPureLazy(s)(_ => true)(f))
+    ZManaged.succeed(foldPureLazy(s)(_ => true)(f))
 
   def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
     chunks.foldPureLazy(s)(cont) { (s, as) =>

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1295,9 +1295,20 @@ object ZSink extends ZSinkPlatformSpecific {
         }
     }
 
+  /**
+   * Creates a single-value sink from a value.
+   */
+  final def succeed[B](b: B): ZSink[Any, Nothing, Nothing, Any, B] =
+    new SinkPure[Nothing, Nothing, Any, B] {
+      type State = Unit
+      val initialPure                                          = Step.done((), Chunk.empty)
+      def stepPure(state: State, a: Any): Step[State, Nothing] = Step.done(state, Chunk.empty)
+      def extractPure(state: State): Either[Nothing, B]        = Right(b)
+    }
+
   @deprecated("use succeed", "1.0.0")
   final def succeedLazy[B](b: => B): ZSink[Any, Nothing, Nothing, Any, B] =
-    succeed(a)
+    succeed(b)
 
   /**
    * Creates a sink which throttles input elements of type A according to the given bandwidth parameters

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1295,16 +1295,9 @@ object ZSink extends ZSinkPlatformSpecific {
         }
     }
 
-  /**
-   * Creates a single-value sink from a lazily-evaluated value.
-   */
+  @deprecated("use succeed", "1.0.0")
   final def succeedLazy[B](b: => B): ZSink[Any, Nothing, Nothing, Any, B] =
-    new SinkPure[Nothing, Nothing, Any, B] {
-      type State = Unit
-      val initialPure                                          = Step.done((), Chunk.empty)
-      def stepPure(state: State, a: Any): Step[State, Nothing] = Step.done(state, Chunk.empty)
-      def extractPure(state: State): Either[Nothing, B]        = Right(b)
-    }
+    succeed(a)
 
   /**
    * Creates a sink which throttles input elements of type A according to the given bandwidth parameters

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -255,7 +255,13 @@ object ZStreamChunk {
   final def fromChunks[A](as: Chunk[A]*): StreamChunk[Nothing, A] =
     StreamChunkPure(StreamPure.fromIterable(as))
 
+  /**
+   * Creates a `ZStreamChunk` from a chunk
+   */
+  final def succeed[A](as: Chunk[A]): StreamChunk[Nothing, A] =
+    StreamChunkPure(StreamPure.succeed(as))
+
   @deprecated("use succeed", "1.0.0")
   final def succeedLazy[A](as: => Chunk[A]): StreamChunk[Nothing, A] =
-    succeed(a)
+    succeed(as)
 }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -42,12 +42,12 @@ object Gen {
   /**
    * A constant generator of the specified value.
    */
-  final def const[A](a: => A): Gen[Any, A] = Gen(ZStream.succeedLazy(Sample.noShrink(a)))
+  final def const[A](a: => A): Gen[Any, A] = Gen(ZStream.succeed(Sample.noShrink(a)))
 
   /**
    * A constant generator of the specified sample.
    */
-  final def constSample[R, A](sample: => Sample[R, A]): Gen[R, A] = fromEffectSample(ZIO.succeedLazy(sample))
+  final def constSample[R, A](sample: => Sample[R, A]): Gen[R, A] = fromEffectSample(ZIO.succeed(sample))
 
   /**
    * Constructs a generator from an effect that constructs a value.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -130,7 +130,7 @@ package object test {
    * Builds a spec with a single pure test.
    */
   final def test[L](label: L)(assertion: => TestResult): ZSpec[Any, Nothing, L] =
-    testM(label)(ZIO.succeedLazy(assertion))
+    testM(label)(ZIO.succeed(assertion))
 
   /**
    * Builds a spec with a single effectful test.


### PR DESCRIPTION
Fixes #1346

* Deprecated all `succeedLazy` methods.
* Delegated all deprecated methods to `succeed`. 
* Added missing `succeed` to `ZSink`, `Sink` and `ZStreamChunk`.
* Removed `succeedLazy` test from `RTSSpec`
* Replaced `succeedLazy` with `effect` or `effectTotal` where laziness was essential and with  `succeed` where lazyness was not required
* Updated docs