### PR TITLE
Fix ZSink#collectAll and add missing ZSink#collectAllWhile tests

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -41,6 +41,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     collectAll
       happy path    $collectAllHappyPath
       init error    $collectAllInitError
+      step error    $collectAllStepError
       extract error $collectAllExtractError
 
     collectAllWhile
@@ -365,6 +366,11 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def collectAllInitError = {
     val sink = initErrorSink.collectAll
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
+  }
+
+  private def collectAllStepError = {
+    val sink = stepErrorSink.collectAll
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -46,6 +46,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
     collectAllWhile
       happy path      $collectAllWhileHappyPath
+      false predicate $collectAllWhileFalsePredicate
       init error      $collectAllWhileInitError
       step error      $collectAllWhileStepError
       extract error   $collectAllWhileExtractError
@@ -382,6 +383,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   private def collectAllWhileHappyPath = {
     val sink = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 10)
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
+  }
+
+  private def collectAllWhileFalsePredicate = {
+    val errorMsg = "No elements have been consumed by the sink"
+    val sink     = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 0).mapError(_ => errorMsg)
+    unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(errorMsg)))
   }
 
   private def collectAllWhileInitError = {


### PR DESCRIPTION
Partially addresses #1312. 

`untilOutput` remains to be fixed. Not part of this PR.