### PR TITLE
Fix for #1403 - mute regular console output from DefaultTestRunner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,6 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
   .dependsOn(core % "test->test;compile->compile")
   .dependsOn(test % "test->test;compile->compile")
-  .dependsOn(coreTests % "test->test;compile->compile")
 
 lazy val testRunnerJVM = testRunner.jvm
 lazy val testRunnerJS  = testRunner.js

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -2,7 +2,7 @@ package zio.test.sbt
 
 import sbt.testing.{ EventHandler, Logger, Task, TaskDef }
 import zio.test.RenderedResult.CaseType
-import zio.test.{ AbstractRunnableSpec, DefaultTestReporter, RenderedResult }
+import zio.test.{ AbstractRunnableSpec, DefaultTestReporter, RenderedResult, TestReporter }
 import zio.{ Runtime, ZIO }
 
 abstract class BaseTestTask(val taskDef: TaskDef, testClassLoader: ClassLoader) extends Task {
@@ -42,7 +42,7 @@ abstract class BaseTestTask(val taskDef: TaskDef, testClassLoader: ClassLoader) 
       }
 
     for {
-      result   <- spec.run
+      result   <- spec.runWith(TestReporter.silent)
       rendered = DefaultTestReporter.render(result.mapLabel(_.toString))
       _        <- reportResults(rendered)
     } yield ()

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -44,6 +44,12 @@ abstract class AbstractRunnableSpec {
   final def run: UIO[ExecutedSpec[Label]] = runner.run(spec)
 
   /**
+   * Returns an effect that executes the spec, using the given TestReporter, producing the results of the execution.
+   */
+  final def runWith(reporter: TestReporter[Label]): UIO[ExecutedSpec[Label]] =
+    runner.withReporter(reporter).run(spec)
+
+  /**
    * the platform used by the runner
    */
   final def platform = runner.platform

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -25,9 +25,9 @@ import zio.internal.{ Platform, PlatformLive }
  * require an environment `R` and may fail with an error `E`, using labels of
  * type `L`. Test runners require a test executor, a platform, and a reporter.
  */
-abstract class TestRunner[L, -T](
+case class TestRunner[L, -T](
   executor: TestExecutor[L, T],
-  val platform: Platform = PlatformLive.makeDefault().withReportFailure(_ => ()),
+  platform: Platform = PlatformLive.makeDefault().withReportFailure(_ => ()),
   reporter: TestReporter[L] = DefaultTestReporter(Console.Live)
 ) { self =>
 
@@ -59,4 +59,9 @@ abstract class TestRunner[L, -T](
    */
   final def unsafeRunSync(spec: Spec[L, T]): Exit[Nothing, ExecutedSpec[L]] =
     Runtime((), platform).unsafeRunSync(run(spec))
+
+  /**
+   * Creates a copy of this runner replacing the reporter.
+   */
+  final def withReporter(reporter: TestReporter[L]) = copy(reporter = reporter)
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -51,6 +51,14 @@ package object test {
    */
   type TestReporter[-L] = ExecutedSpec[L] => UIO[Unit]
 
+  object TestReporter {
+
+    /**
+     * TestReporter that does nothing
+     */
+    def silent[L]: TestReporter[L] = _ => ZIO.unit
+  }
+
   /**
    * A `TestExecutor[L, T]` is capable of executing specs containing tests of
    * type `T`, annotated with labels of type `L`.
@@ -167,4 +175,7 @@ package object test {
         failures.reverse.headOption.fold[TestResult](Assertion.Success)(identity)
       }
   }
+
+  val DefaultTestRunner: TestRunner[String, ZTest[mock.MockEnvironment, Any]] =
+    TestRunner(TestExecutor.managed(zio.test.mock.mockEnvironmentManaged))
 }

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -145,9 +145,9 @@ object DefaultTestReporterSpec extends DefaultRuntime {
   def unsafeRunWith[R, E <: Throwable, A](r: Managed[Nothing, R])(f: R => IO[E, A]): Future[A] =
     unsafeRunToFuture(r.use[Any, E, A](f))
 
-  case class MockTestRunner(mockEnvironment: MockEnvironment)
-      extends TestRunner[String, ZTest[MockEnvironment, Any]](
-        executor = TestExecutor.managed(Managed.succeed(mockEnvironment)),
-        reporter = DefaultTestReporter(mockEnvironment)
-      )
+  def MockTestRunner(mockEnvironment: MockEnvironment) =
+    TestRunner[String, ZTest[MockEnvironment, Any]](
+      executor = TestExecutor.managed(Managed.succeed(mockEnvironment)),
+      reporter = DefaultTestReporter(mockEnvironment)
+    )
 }


### PR DESCRIPTION
* Made TestRunner a case class, so that reporter can be replaced.
* New `RunnableSpec` method: runWith(reporter).
* Also removed dependency by `testRunner` on `coreTests` (wasn't required).

#1403 

cc: @ghostdogpr 