### PR TITLE
Add isUnit predicate

### DIFF
--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -296,6 +296,17 @@ object Predicate {
   }
 
   /**
+   * Makes a new predicate that requires the value be unit.
+   */
+  final def isUnit: Predicate[Any] =
+    Predicate.predicate(s"isUnit") { actual =>
+      actual match {
+        case () => Assertion.success
+        case _  => Assertion.failure(())
+      }
+    }
+
+  /**
    * Returns a new predicate that requires a numeric value to fall within a
    * specified min and max (inclusive).
    */

--- a/test/shared/src/main/scala/zio/test/Predicate.scala
+++ b/test/shared/src/main/scala/zio/test/Predicate.scala
@@ -299,7 +299,7 @@ object Predicate {
    * Makes a new predicate that requires the value be unit.
    */
   final def isUnit: Predicate[Any] =
-    Predicate.predicate(s"isUnit") { actual =>
+    Predicate.predicate("isUnit") { actual =>
       actual match {
         case () => Assertion.success
         case _  => Assertion.failure(())

--- a/test/shared/src/test/scala/zio/test/PredicateSpec.scala
+++ b/test/shared/src/test/scala/zio/test/PredicateSpec.scala
@@ -167,6 +167,14 @@ object PredicateSpec {
       message = "succeeds must fail when supplied value is Exit.fail"
     ),
     testSuccess(
+      assert((), isUnit),
+      message = "isUnit must succeed when supplied value is ()"
+    ),
+    testFailure(
+      assert(10, isUnit),
+      message = "isUnit must fail when supplied value is not ()"
+    ),
+    testSuccess(
       assert(10, isWithin(0, 10)),
       message = "isWithin must succeed when supplied value is within range (inclusive)"
     ),


### PR DESCRIPTION
`Task[Unit]` is a very common type for commands/statements (if we prefer more imperative style) or at least at the impure edges of our program (if we prefer functional style). Either way its cumbersome to assert with `isEqual(())`. In pair with `ZIO.unit` we should add `isUnit` for convinience.