### PR TITLE
Switch ZStream to use `process` as its abstract method

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1011,7 +1011,6 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
       val sinkResult = unsafeRunSync(z.flatMap(z => s.run(ZSink.foldM(z)(ff))))
       val foldResult = unsafeRunSync {
         s.foldLeft(List[Int]())((acc, el) => el :: acc)
-          .use(IO.succeed)
           .map(_.reverse)
           .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
       }


### PR DESCRIPTION
Resolves #1388.

@vasilmkd 