### PR TITLE
Add tuple syntax that includes environment types

### DIFF
--- a/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/IOSyntax.scala
@@ -16,7 +16,7 @@
 
 package zio.syntax
 
-import zio.{ Fiber, IO, Task, UIO }
+import zio.{ Fiber, IO, Task, UIO, ZIO }
 
 object IOSyntax {
   final class IOCreationLazySyntax[A](val a: () => A) extends AnyVal {
@@ -39,12 +39,12 @@ object IOSyntax {
     def collectAll: IO[E, List[A]]                     = IO.collectAll(ios)
   }
 
-  final class IOTuple2[E, A, B](val ios2: (IO[E, A], IO[E, B])) extends AnyVal {
-    def map2[C](f: (A, B) => C): IO[E, C] = ios2._1.flatMap(a => ios2._2.map(f(a, _)))
+  final class IOTuple2[R, E, A, B](val ios2: (ZIO[R, E, A], ZIO[R, E, B])) extends AnyVal {
+    def map2[C](f: (A, B) => C): ZIO[R, E, C] = ios2._1.flatMap(a => ios2._2.map(f(a, _)))
   }
 
-  final class IOTuple3[E, A, B, C](val ios3: (IO[E, A], IO[E, B], IO[E, C])) extends AnyVal {
-    def map3[D](f: (A, B, C) => D): IO[E, D] =
+  final class IOTuple3[R, E, A, B, C](val ios3: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C])) extends AnyVal {
+    def map3[D](f: (A, B, C) => D): ZIO[R, E, D] =
       for {
         a <- ios3._1
         b <- ios3._2
@@ -52,8 +52,10 @@ object IOSyntax {
       } yield f(a, b, c)
   }
 
-  final class IOTuple4[E, A, B, C, D](val ios4: (IO[E, A], IO[E, B], IO[E, C], IO[E, D])) extends AnyVal {
-    def map4[F](f: (A, B, C, D) => F): IO[E, F] =
+  final class IOTuple4[R, E, A, B, C, D](
+    val ios4: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C], ZIO[R, E, D])
+  ) extends AnyVal {
+    def map4[F](f: (A, B, C, D) => F): ZIO[R, E, F] =
       for {
         a <- ios4._1
         b <- ios4._2

--- a/core/shared/src/main/scala/zio/syntax/syntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/syntax.scala
@@ -23,11 +23,14 @@ package object syntax {
   implicit final def ioEagerSyntax[A](a: A): IOCreationEagerSyntax[A]                        = new IOCreationEagerSyntax[A](a)
   implicit final def ioLazySyntax[A](a: => A): IOCreationLazySyntax[A]                       = new IOCreationLazySyntax[A](() => a)
   implicit final def ioIterableSyntax[E, A](ios: Iterable[IO[E, A]]): IOIterableSyntax[E, A] = new IOIterableSyntax(ios)
-  implicit final def ioTuple2Syntax[E, A, B](ios: (IO[E, A], IO[E, B])): IOTuple2[E, A, B]   = new IOTuple2(ios)
-  implicit final def ioTuple3Syntax[E, A, B, C](ios: (IO[E, A], IO[E, B], IO[E, C])): IOTuple3[E, A, B, C] =
+  implicit final def ioTuple2Syntax[R, E, A, B](ios: (ZIO[R, E, A], ZIO[R, E, B])): IOTuple2[R, E, A, B] =
+    new IOTuple2(ios)
+  implicit final def ioTuple3Syntax[R, E, A, B, C](
+    ios: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C])
+  ): IOTuple3[R, E, A, B, C] =
     new IOTuple3(ios)
-  implicit final def ioTuple4Syntax[E, A, B, C, D](
-    ios: (IO[E, A], IO[E, B], IO[E, C], IO[E, D])
-  ): IOTuple4[E, A, B, C, D] =
+  implicit final def ioTuple4Syntax[R, E, A, B, C, D](
+    ios: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C], ZIO[R, E, D])
+  ): IOTuple4[R, E, A, B, C, D] =
     new IOTuple4(ios)
 }


### PR DESCRIPTION
I did this so that `.map[2|3|4]` extension methods can be available on tuples which include environment types. The `R` of the result is simply the intersection of `R`s of the tuple elements.

I made new value classes and implicit defs for this, so as to avoid any binary compatibility complications. This entailed putting the new implicit conversions in a trait to be inherited, so that they wouldn't conflict with the existing implicit defs (they should only be used when one or more tuple elements have R =!:= Any, which currently wouldn't work at all). I think this ought to be binary compatible, but to be honest I'm not 100% sure.