### PR TITLE
ZIO Test: Improve RunnableSpec

### DIFF
--- a/test/js/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/js/src/main/scala/zio/test/RunnableSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+/**
+ * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
+ */
+abstract class RunnableSpec[L, T](runner0: TestRunner[L, T])(spec0: => Spec[L, T]) extends AbstractRunnableSpec {
+  override type Label = L
+  override type Test  = T
+
+  override def runner = runner0
+  override def spec   = spec0
+
+  /**
+   * A simple main function that can be used to run the spec.
+   *
+   * TODO: Parse command line options.
+   */
+  final def main(args: Array[String]): Unit =
+    runner.unsafeRunAsync(spec)(_ => ())
+}

--- a/test/jvm/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/jvm/src/main/scala/zio/test/RunnableSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.test.Spec.TestCase
+
+/**
+ * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
+ */
+abstract class RunnableSpec[L, T](runner0: TestRunner[L, T])(spec0: => Spec[L, T]) extends AbstractRunnableSpec {
+  override type Label = L
+  override type Test  = T
+
+  override def runner = runner0
+  override def spec   = spec0
+
+  /**
+   * A simple main function that can be used to run the spec.
+   *
+   * TODO: Parse command line options.
+   */
+  final def main(args: Array[String]): Unit = {
+    val results     = runner.unsafeRun(spec)
+    val hasFailures = results.exists { case TestCase(_, test) => test.failure; case _ => false }
+    try if (hasFailures) sys.exit(1) else sys.exit(0)
+    catch { case _: SecurityException => }
+  }
+}

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -20,9 +20,6 @@ import zio.URIO
 import zio.clock.Clock
 import zio.test.reflect.Reflect.EnableReflectiveInstantiation
 
-/**
- * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
- */
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {
 
@@ -33,13 +30,6 @@ abstract class AbstractRunnableSpec {
   def spec: Spec[Label, Test]
 
   /**
-   * A simple main function that can be used to run the spec.
-   *
-   * TODO: Parse command line options.
-   */
-  final def main(args: Array[String]): Unit = { val _ = runner.unsafeRunSync(spec) }
-
-  /**
    * Returns an effect that executes the spec, producing the results of the execution.
    */
   final def run: URIO[TestLogger with Clock, ExecutedSpec[Label]] = runner.run(spec)
@@ -48,12 +38,4 @@ abstract class AbstractRunnableSpec {
    * the platform used by the runner
    */
   final def platform = runner.platform
-}
-
-abstract class RunnableSpec[L, T](runner0: TestRunner[L, T])(spec0: => Spec[L, T]) extends AbstractRunnableSpec {
-  override type Label = L
-  override type Test  = T
-
-  override def runner = runner0
-  override def spec   = spec0
 }


### PR DESCRIPTION
Following up on discussions in #1435 this PR addresses two issues with `RunnableSpec`.

First, running tests directly doesn't currently working on Scala.js because the `main` method is implemented in terms of `unsafeRun`, which is not safe on Scala.js. This PR provides separate platform specific implementations of `RunnableSpec` that use `unsafeRunAsync` on Scala.js to address this.

Second, running tests directly currently results in a success exit code even if one or more tests failed. This PR corrects that behavior on the JVM so the `main` method exits with an error code if any test failed.