### PR TITLE
Rename InputStream to Pull

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -555,7 +555,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
 
   private def catchAllCauseScopeErrors =
     unsafeRun {
-      val s1 = Stream(1, 2) ++ ZStream.fromInputStreamManaged(ZManaged.fail("Boom"))
+      val s1 = Stream(1, 2) ++ ZStream.fromPullManaged(ZManaged.fail("Boom"))
       val s2 = Stream(3, 4)
 
       s1.catchAllCause(_ => s2).runCollect.map(_ must_=== List(1, 2, 3, 4))

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -555,7 +555,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
 
   private def catchAllCauseScopeErrors =
     unsafeRun {
-      val s1 = Stream(1, 2) ++ ZStream.fromPullManaged(ZManaged.fail("Boom"))
+      val s1 = Stream(1, 2) ++ ZStream(ZManaged.fail("Boom"))
       val s2 = Stream(3, 4)
 
       s1.catchAllCause(_ => s2).runCollect.map(_ must_=== List(1, 2, 3, 4))

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -138,6 +138,12 @@ object Stream extends ZStreamPlatformSpecific {
     ZStream.fromEffect(fa)
 
   /**
+   * See [[ZStream.fromPull]]
+   */
+  final def fromPull[E, A](pull: Pull[Any, E, A]): Stream[E, A] =
+    ZStream.fromPull(pull)
+
+  /**
    * See [[ZStream.repeatEffect]]
    */
   final def repeatEffect[E, A](fa: IO[E, A]): Stream[E, A] =
@@ -162,6 +168,12 @@ object Stream extends ZStreamPlatformSpecific {
    */
   final def fromQueue[E, A](queue: ZQueue[_, _, Any, E, _, A]): Stream[E, A] =
     ZStream.fromQueue(queue)
+
+  /**
+   * See [[ZStream.fromQueueWithShutdown]]
+   */
+  final def fromQueueWithShutdown[E, A](queue: ZQueue[_, _, Any, E, _, A]): Stream[E, A] =
+    ZStream.fromQueueWithShutdown(queue)
 
   /**
    * See [[ZStream.halt]]
@@ -215,4 +227,10 @@ object Stream extends ZStreamPlatformSpecific {
    */
   final def unwrap[E, A](fa: IO[E, Stream[E, A]]): Stream[E, A] =
     ZStream.unwrap(fa)
+
+  /**
+   * See [[ZStream.unwrapManaged]]
+   */
+  final def unwrapManaged[E, A](fa: Managed[E, ZStream[Any, E, A]]): Stream[E, A] =
+    ZStream.unwrapManaged(fa)
 }

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -21,6 +21,7 @@ import zio.clock.Clock
 import zio.Cause
 
 object Stream extends ZStreamPlatformSpecific {
+  import ZStream.Pull
 
   /**
    * See [[ZStream.empty]]
@@ -38,6 +39,11 @@ object Stream extends ZStreamPlatformSpecific {
    * See [[ZStream.apply]]
    */
   final def apply[A](as: A*): Stream[Nothing, A] = ZStream(as: _*)
+
+  /**
+   * See [[ZStream.apply]]
+   */
+  final def apply[E, A](pull: Managed[E, Pull[Any, E, A]]): Stream[E, A] = ZStream(pull)
 
   /**
    * See [[ZStream.bracket]]

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -36,12 +36,12 @@ object Stream extends ZStreamPlatformSpecific {
     ZStream.never
 
   /**
-   * See [[ZStream.apply]]
+   * See [[ZStream.apply[A]*]]
    */
   final def apply[A](as: A*): Stream[Nothing, A] = ZStream(as: _*)
 
   /**
-   * See [[ZStream.apply]]
+   * See [[ZStream.apply[R,E,A]*]]
    */
   final def apply[E, A](pull: Managed[E, Pull[Any, E, A]]): Stream[E, A] = ZStream(pull)
 

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -17,13 +17,13 @@
 package zio.stream
 
 import zio._
-import zio.stream.ZStream.InputStream
+import zio.stream.ZStream.Pull
 
 private[stream] trait StreamEffect[+E, +A] extends ZStream[Any, E, A] { self =>
 
   def processEffect: Managed[E, () => A]
 
-  def process: Managed[E, InputStream[Any, E, A]] =
+  def process: Managed[E, Pull[Any, E, A]] =
     processEffect.map { thunk =>
       UIO.effectTotal {
         try UIO.succeed(thunk())

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -17,93 +17,86 @@
 package zio.stream
 
 import zio._
-import zio.stream.ZStream.Pull
 
-private[stream] trait StreamEffect[+E, +A] extends ZStream[Any, E, A] { self =>
-
-  def processEffect: Managed[E, () => A]
-
-  def process: Managed[E, Pull[Any, E, A]] =
-    processEffect.map { thunk =>
-      UIO.effectTotal {
-        try UIO.succeed(thunk())
-        catch {
-          case StreamEffect.Failure(e) => IO.fail(Some(e.asInstanceOf[E]))
-          case StreamEffect.End        => IO.fail(None)
-        }
-      }.flatten
-    }
+private[stream] class StreamEffect[+E, +A](val processEffect: Managed[E, () => A])
+    extends ZStream[Any, E, A](
+      processEffect.map { thunk =>
+        UIO.effectTotal {
+          try UIO.succeed(thunk())
+          catch {
+            case StreamEffect.Failure(e) => IO.fail(Some(e.asInstanceOf[E]))
+            case StreamEffect.End        => IO.fail(None)
+          }
+        }.flatten
+      }
+    ) { self =>
 
   override def collect[B](pf: PartialFunction[A, B]): StreamEffect[E, B] =
-    new StreamEffect[E, B] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal { () =>
-            {
-              var ob: Option[B]                        = None
-              val pfOpt: PartialFunction[A, Option[B]] = pf.andThen(Some(_))
+    StreamEffect[E, B] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal { () =>
+          {
+            var ob: Option[B]                        = None
+            val pfOpt: PartialFunction[A, Option[B]] = pf.andThen(Some(_))
 
-              while (ob.isEmpty) {
-                ob = pfOpt.applyOrElse(thunk(), (_: A) => None)
-              }
-
-              ob.get
+            while (ob.isEmpty) {
+              ob = pfOpt.applyOrElse(thunk(), (_: A) => None)
             }
+
+            ob.get
           }
         }
+      }
     }
 
   override def collectWhile[B](pred: PartialFunction[A, B]): StreamEffect[E, B] =
-    new StreamEffect[E, B] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            var done = false
+    StreamEffect[E, B] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          var done = false
 
-            () => {
-              if (done) StreamEffect.end
-              else pred.applyOrElse(thunk(), (_: A) => { done = true; StreamEffect.end })
-            }
+          () => {
+            if (done) StreamEffect.end
+            else pred.applyOrElse(thunk(), (_: A) => { done = true; StreamEffect.end })
           }
         }
+      }
     }
 
   override def dropWhile(pred: A => Boolean): StreamEffect[E, A] =
-    new StreamEffect[E, A] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            var drop = true
+    StreamEffect[E, A] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          var drop = true
 
-            @annotation.tailrec
-            def pull(): A = {
-              val a = thunk()
-              if (!drop) a
-              else if (!pred(a)) {
-                drop = false
-                a
-              } else pull()
-            }
-
-            () => pull()
+          @annotation.tailrec
+          def pull(): A = {
+            val a = thunk()
+            if (!drop) a
+            else if (!pred(a)) {
+              drop = false
+              a
+            } else pull()
           }
+
+          () => pull()
         }
+      }
     }
 
   override def filter(pred: A => Boolean): StreamEffect[E, A] =
-    new StreamEffect[E, A] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            @annotation.tailrec
-            def pull(): A = {
-              val a = thunk()
-              if (pred(a)) a else pull()
-            }
-
-            () => pull()
+    StreamEffect[E, A] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          @annotation.tailrec
+          def pull(): A = {
+            val a = thunk()
+            if (pred(a)) a else pull()
           }
+
+          () => pull()
         }
+      }
     }
 
   final def foldLazyPure[S](s: S)(cont: S => Boolean)(f: (S, A) => S): Managed[E, S] =
@@ -130,50 +123,47 @@ private[stream] trait StreamEffect[+E, +A] extends ZStream[Any, E, A] { self =>
     }
 
   override def map[B](f0: A => B): StreamEffect[E, B] =
-    new StreamEffect[E, B] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal { () =>
-            f0(thunk())
-          }
+    StreamEffect[E, B] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal { () =>
+          f0(thunk())
         }
+      }
     }
 
   override def mapAccum[S1, B](s1: S1)(f1: (S1, A) => (S1, B)): StreamEffect[E, B] =
-    new StreamEffect[E, B] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            var state = s1
+    StreamEffect[E, B] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          var state = s1
 
-            () => {
-              val (s2, b) = f1(state, thunk())
-              state = s2
-              b
-            }
+          () => {
+            val (s2, b) = f1(state, thunk())
+            state = s2
+            b
           }
         }
+      }
     }
 
   override def mapConcat[B](f: A => Chunk[B]): StreamEffect[E, B] =
-    new StreamEffect[E, B] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            var chunk: Chunk[B] = Chunk.empty
-            var index           = 0
+    StreamEffect[E, B] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          var chunk: Chunk[B] = Chunk.empty
+          var index           = 0
 
-            () => {
-              while (index == chunk.length) {
-                chunk = f(thunk())
-                index = 0
-              }
-              val b = chunk(index)
-              index += 1
-              b
+          () => {
+            while (index == chunk.length) {
+              chunk = f(thunk())
+              index = 0
             }
+            val b = chunk(index)
+            index += 1
+            b
           }
         }
+      }
     }
 
   override def run[R, E1 >: E, A0, A1 >: A, B](sink: ZSink[R, E1, A0, A1, B]): ZIO[R, E1, B] =
@@ -189,35 +179,33 @@ private[stream] trait StreamEffect[+E, +A] extends ZStream[Any, E, A] { self =>
     }
 
   override def take(n: Int): StreamEffect[E, A] =
-    new StreamEffect[E, A] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal {
-            var counter = 0
+    StreamEffect[E, A] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal {
+          var counter = 0
 
-            () => {
-              if (counter >= n) StreamEffect.end
-              else {
-                counter += 1
-                thunk()
-              }
+          () => {
+            if (counter >= n) StreamEffect.end
+            else {
+              counter += 1
+              thunk()
             }
           }
         }
+      }
     }
 
   override def takeWhile(pred: A => Boolean): StreamEffect[E, A] =
-    new StreamEffect[E, A] {
-      def processEffect =
-        self.processEffect.flatMap { thunk =>
-          Managed.effectTotal { () =>
-            {
-              val a = thunk()
-              if (pred(a)) a
-              else StreamEffect.end
-            }
+    StreamEffect[E, A] {
+      self.processEffect.flatMap { thunk =>
+        Managed.effectTotal { () =>
+          {
+            val a = thunk()
+            if (pred(a)) a
+            else StreamEffect.end
           }
         }
+      }
     }
 }
 
@@ -236,15 +224,18 @@ private[stream] object StreamEffect extends Serializable {
   def fail[E, A](e: E): A = throw Failure(e)
 
   final val empty: StreamEffect[Nothing, Nothing] =
-    new StreamEffect[Nothing, Nothing] {
-      def processEffect = Managed.effectTotal { () =>
+    StreamEffect[Nothing, Nothing] {
+      Managed.effectTotal { () =>
         end
       }
     }
 
+  final def apply[E, A](pull: Managed[E, () => A]): StreamEffect[E, A] =
+    new StreamEffect[E, A](pull)
+
   final def fromChunk[@specialized A](c: Chunk[A]): StreamEffect[Nothing, A] =
-    new StreamEffect[Nothing, A] {
-      def processEffect = Managed.effectTotal {
+    StreamEffect[Nothing, A] {
+      Managed.effectTotal {
         var index = 0
         val len   = c.length
 
@@ -260,44 +251,41 @@ private[stream] object StreamEffect extends Serializable {
     }
 
   final def fromIterable[A](as: Iterable[A]): StreamEffect[Nothing, A] =
-    new StreamEffect[Nothing, A] {
-      def processEffect =
-        Managed.effectTotal {
-          val thunk = as.iterator
+    StreamEffect[Nothing, A] {
+      Managed.effectTotal {
+        val thunk = as.iterator
 
-          () => if (thunk.hasNext) thunk.next() else end
-        }
+        () => if (thunk.hasNext) thunk.next() else end
+      }
     }
 
   final def unfold[S, A](s: S)(f0: S => Option[(A, S)]): StreamEffect[Nothing, A] =
-    new StreamEffect[Nothing, A] {
-      def processEffect =
-        Managed.effectTotal {
-          var state = s
+    StreamEffect[Nothing, A] {
+      Managed.effectTotal {
+        var state = s
 
-          () => {
-            val opt = f0(state)
-            if (opt.isDefined) {
-              val res = opt.get
-              state = res._2
-              res._1
-            } else end
-          }
+        () => {
+          val opt = f0(state)
+          if (opt.isDefined) {
+            val res = opt.get
+            state = res._2
+            res._1
+          } else end
         }
+      }
     }
 
   final def succeed[A](a: A): StreamEffect[Nothing, A] =
-    new StreamEffect[Nothing, A] {
-      def processEffect =
-        Managed.effectTotal {
-          var done = false
+    StreamEffect[Nothing, A] {
+      Managed.effectTotal {
+        var done = false
 
-          () => {
-            if (!done) {
-              done = true
-              a
-            } else end
-          }
+        () => {
+          if (!done) {
+            done = true
+            a
+          } else end
         }
+      }
     }
 }

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -17,7 +17,7 @@
 package zio.stream
 
 import zio.{ Cause, IO, ZIO }
-import zio.stream.ZStream.InputStream
+import zio.stream.ZStream.Pull
 
 /**
  * A `Take[E, A]` represents a single `take` from a queue modeling a stream of
@@ -60,8 +60,8 @@ object Take {
   final case class Value[A](value: A)       extends Take[Nothing, A]
   case object End                           extends Take[Nothing, Nothing]
 
-  final def fromInputStream[R, E, A](is: InputStream[R, E, A]): ZIO[R, Nothing, Take[E, A]] =
-    is.fold(_.fold[Take[E, A]](Take.End)(e => Take.Fail(Cause.fail(e))), Take.Value(_))
+  final def fromPull[R, E, A](pull: Pull[R, E, A]): ZIO[R, Nothing, Take[E, A]] =
+    pull.fold(_.fold[Take[E, A]](Take.End)(e => Take.Fail(Cause.fail(e))), Take.Value(_))
 
   final def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
     io.flatMap {

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -21,7 +21,6 @@ import zio.clock.Clock
 import zio.duration.Duration
 
 import scala.collection.mutable
-import scala.language.postfixOps
 
 /**
  * A `Sink[E, A0, A, B]` consumes values of type `A`, ultimately producing
@@ -487,7 +486,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * A named alias for `?`.
    */
-  final def optional: ZSink[R, Nothing, A0, A, Option[B]] = self ?
+  final def optional: ZSink[R, Nothing, A0, A, Option[B]] = self.?
 
   /**
    * Runs both sinks in parallel on the same input. If the left one succeeds,

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -19,6 +19,7 @@ package zio.stream
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
+import ZStream.Pull
 
 /**
  * A `Stream[E, A]` represents an effectful stream that can produce values of
@@ -35,28 +36,24 @@ import zio.duration.Duration
  * specialized effect type (ZIO), streams feature extremely good type inference
  * and should almost never require specification of any type parameters.
  *
+ * `process` is a low-level consumption method, usually used for creating combinators
+ * and constructors. For most usage, [[ZStream#fold]], [[ZStream#foreach]] or [[ZStream#run]]
+ * should be preferred.
+ *
+ * The contract for the returned `Pull` is as follows:
+ * - It must not be evaluted concurrently from multiple fibers - it is (usually)
+ *   not thread-safe;
+ * - If an evaluation of the `Pull` is interrupted, it is not safe to
+ *   evaluate it again - it is (usually) not interruption-safe;
+ * - Once the `Pull` has failed with a `None`, it is not safe
+ *   to evaluate it again.
+ *
+ * The managed `Pull` can be used to read from the stream until it is empty
+ * (or possibly forever, if the stream is infinite). The provided `Pull`
+ * is valid only inside the scope of the managed resource.
  */
-trait ZStream[-R, +E, +A] extends Serializable { self =>
-  import ZStream.{ GroupBy, Pull }
-
-  /**
-   * Obtain a managed input stream that can be used to read from the stream until it is
-   * empty (or possibly forever, if the stream is infinite). The provided `Pull`
-   * is valid only inside the scope of the managed resource.
-   *
-   * This is a low-level consumption method, usually used for creating combinators
-   * and constructors. For most usage, [[ZStream#fold]], [[ZStream#foreach]] or [[ZStream#run]]
-   * should be preferred.
-   *
-   * The contract for the returned `Pull` is as follows:
-   * - It must not be evaluted concurrently from multiple fibers - it is (usually)
-   *   not thread-safe;
-   * - If an evaluation of the `Pull` is interrupted, it is not safe to
-   *   evaluate it again - it is (usually) not interruption-safe;
-   * - Once the `Pull` has failed with a `None`, it is not safe
-   *   to evaluate it again.
-   */
-  def process: ZManaged[R, E, Pull[R, E, A]]
+class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Serializable { self =>
+  import ZStream.GroupBy
 
   /**
    * Concatenates with another stream in strict order
@@ -202,30 +199,28 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
         case _ => UIO.succeed((UIO.unit, s))
       }.flatten
 
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          initSink  <- sink.initial.map(Step.state(_)).toManaged_
-          initAwait <- Promise.make[Nothing, Unit].toManaged_
-          stateVar  <- Ref.make[State](State.Empty(initSink, initAwait)).toManaged_
-          permits   <- Semaphore.make(1).toManaged_
-          producer <- self
-                       .foreachWhileManaged(produce(stateVar, permits, _))
-                       .foldCauseM(
-                         // At this point, we're done working but we can't just overwrite the
-                         // state because the consumer might not have taken the last batch. So
-                         // we need to wait for the state to be drained.
-                         c => drainAndSet(stateVar, permits, State.Error(c)).toManaged_,
-                         _ => drainAndSet(stateVar, permits, State.End).toManaged_
-                       )
-                       .fork
-          bs <- ZStream
-                 .unfoldM(())(_ => consume(stateVar, permits).map(_.map((_, ()))))
-                 .mapConcat(identity)
-                 .process
-                 .ensuringFirst(producer.interrupt.fork)
-        } yield bs
-
+    ZStream[R1, E1, B] {
+      for {
+        initSink  <- sink.initial.map(Step.state(_)).toManaged_
+        initAwait <- Promise.make[Nothing, Unit].toManaged_
+        stateVar  <- Ref.make[State](State.Empty(initSink, initAwait)).toManaged_
+        permits   <- Semaphore.make(1).toManaged_
+        producer <- self
+                     .foreachWhileManaged(produce(stateVar, permits, _))
+                     .foldCauseM(
+                       // At this point, we're done working but we can't just overwrite the
+                       // state because the consumer might not have taken the last batch. So
+                       // we need to wait for the state to be drained.
+                       c => drainAndSet(stateVar, permits, State.Error(c)).toManaged_,
+                       _ => drainAndSet(stateVar, permits, State.End).toManaged_
+                     )
+                     .fork
+        bs <- ZStream
+               .unfoldM(())(_ => consume(stateVar, permits).map(_.map((_, ()))))
+               .mapConcat(identity)
+               .process
+               .ensuringFirst(producer.interrupt.fork)
+      } yield bs
     }
   }
 
@@ -451,24 +446,22 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
         case _ => UIO.succeed((UIO.unit, s))
       }.flatten
 
-    new ZStream[R1 with Clock, E1, Either[C, B]] {
-      def process =
-        for {
-          initSink  <- sink.initial.map(Step.state(_)).toManaged_
-          initAwait <- Promise.make[Nothing, Unit].toManaged_
-          permits   <- Semaphore.make(1).toManaged_
-          stateVar  <- Ref.make[State](State.Empty(initSink, initAwait)).toManaged_
-          producer <- self
-                       .foreachWhileManaged(produce(stateVar, permits, _))
-                       .foldCauseM(
-                         cause => drainAndSet(stateVar, permits, State.Error(cause)).toManaged_,
-                         _ => drainAndSet(stateVar, permits, State.End).toManaged_
-                       )
-                       .fork
-          bs <- consumerStream(stateVar, permits).process
-                 .ensuringFirst(producer.interrupt.fork)
-        } yield bs
-
+    ZStream[R1 with Clock, E1, Either[C, B]] {
+      for {
+        initSink  <- sink.initial.map(Step.state(_)).toManaged_
+        initAwait <- Promise.make[Nothing, Unit].toManaged_
+        permits   <- Semaphore.make(1).toManaged_
+        stateVar  <- Ref.make[State](State.Empty(initSink, initAwait)).toManaged_
+        producer <- self
+                     .foreachWhileManaged(produce(stateVar, permits, _))
+                     .foldCauseM(
+                       cause => drainAndSet(stateVar, permits, State.Error(cause)).toManaged_,
+                       _ => drainAndSet(stateVar, permits, State.End).toManaged_
+                     )
+                     .fork
+        bs <- consumerStream(stateVar, permits).process
+               .ensuringFirst(producer.interrupt.fork)
+      } yield bs
     }
   }
 
@@ -529,7 +522,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
       case object Other      extends State
     }
 
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         finalizer <- ZManaged.finalizerRef[R1](_ => UIO.unit)
         selfPull  <- Ref.make[Pull[R, E, A]](Pull.end).toManaged_
@@ -583,24 +576,23 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Performs a filter and map in a single step.
    */
   def collect[B](pf: PartialFunction[A, B]): ZStream[R, E, B] =
-    new ZStream[R, E, B] {
-      def process =
-        self.process.map { as =>
-          val pfIO: PartialFunction[A, Pull[R, E, B]] = pf.andThen(Pull.emit(_))
-          def pull: Pull[R, E, B] =
-            as.flatMap { a =>
-              pfIO.applyOrElse(a, (_: A) => pull)
-            }
+    ZStream[R, E, B] {
+      self.process.map { as =>
+        val pfIO: PartialFunction[A, Pull[R, E, B]] = pf.andThen(Pull.emit(_))
+        def pull: Pull[R, E, B] =
+          as.flatMap { a =>
+            pfIO.applyOrElse(a, (_: A) => pull)
+          }
 
-          pull
-        }
+        pull
+      }
     }
 
   /**
    * Transforms all elements of the stream for as long as the specified partial function is defined.
    */
-  def collectWhile[B](pred: PartialFunction[A, B]): ZStream[R, E, B] = new ZStream[R, E, B] {
-    def process =
+  def collectWhile[B](pred: PartialFunction[A, B]): ZStream[R, E, B] =
+    ZStream[R, E, B] {
       for {
         as   <- self.process
         done <- Ref.make(false).toManaged_
@@ -614,7 +606,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                      }
         } yield result
       } yield pull
-  }
+    }
 
   /**
    * Combines this stream and the specified stream by converting both streams
@@ -626,21 +618,20 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   final def combine[R1 <: R, E1 >: E, A1 >: A, S1, B, C](that: ZStream[R1, E1, B])(s1: S1)(
     f0: (S1, Pull[R, E, A], Pull[R1, E1, B]) => ZIO[R1, E1, (S1, Take[E1, C])]
   ): ZStream[R1, E1, C] =
-    new ZStream[R1, E1, C] {
-      def process =
-        for {
-          left  <- self.process
-          right <- that.process
-          pull <- ZStream
-                   .unfoldM((s1, left, right)) {
-                     case (s1, left, right) =>
-                       f0(s1, left, right).flatMap {
-                         case (s1, take) =>
-                           Take.option(UIO.succeed(take)).map(_.map((_, (s1, left, right))))
-                       }
-                   }
-                   .process
-        } yield pull
+    ZStream[R1, E1, C] {
+      for {
+        left  <- self.process
+        right <- that.process
+        pull <- ZStream
+                 .unfoldM((s1, left, right)) {
+                   case (s1, left, right) =>
+                     f0(s1, left, right).flatMap {
+                       case (s1, take) =>
+                         Take.option(UIO.succeed(take)).map(_.map((_, (s1, left, right))))
+                     }
+                 }
+                 .process
+      } yield pull
     }
 
   /**
@@ -718,7 +709,6 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                 )
                 .fork
         } yield add.get.flatten
-
       }
 
   /**
@@ -732,10 +722,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * }}}
    */
   final def drain: ZStream[R, E, Nothing] =
-    new ZStream[R, E, Nothing] {
-      def process =
-        self.process.map(_.forever)
-    }
+    ZStream[R, E, Nothing](self.process.map(_.forever))
 
   /**
    * Drops the specified number of elements from this stream.
@@ -747,8 +734,8 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Drops all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-  def dropWhile(pred: A => Boolean): ZStream[R, E, A] = new ZStream[R, E, A] {
-    def process =
+  def dropWhile(pred: A => Boolean): ZStream[R, E, A] =
+    ZStream[R, E, A] {
       for {
         as              <- self.process
         keepDroppingRef <- Ref.make(true).toManaged_
@@ -765,30 +752,26 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
           go
         }
       } yield pull
-  }
+    }
 
   /**
    * Executes the provided finalizer after this stream's finalizers run.
    */
   final def ensuring[R1 <: R](fin: ZIO[R1, Nothing, _]): ZStream[R1, E, A] =
-    new ZStream[R1, E, A] {
-      def process = self.process.ensuring(fin)
-    }
+    ZStream[R1, E, A](self.process.ensuring(fin))
 
   /**
    * Executes the provided finalizer before this stream's finalizers run.
    */
   final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, _]): ZStream[R1, E, A] =
-    new ZStream[R1, E, A] {
-      def process = self.process.ensuringFirst(fin)
-    }
+    ZStream[R1, E, A](self.process.ensuringFirst(fin))
 
   /**
    * Filters this stream by the specified predicate, retaining all elements for
    * which the predicate evaluates to true.
    */
-  def filter(pred: A => Boolean): ZStream[R, E, A] = new ZStream[R, E, A] {
-    def process =
+  def filter(pred: A => Boolean): ZStream[R, E, A] =
+    ZStream[R, E, A] {
       self.process.map { as =>
         def pull: Pull[R, E, A] = as.flatMap { a =>
           if (pred(a)) Pull.emit(a)
@@ -797,14 +780,14 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
 
         pull
       }
-  }
+    }
 
   /**
    * Filters this stream by the specified effectful predicate, retaining all elements for
    * which the predicate evaluates to true.
    */
-  final def filterM[R1 <: R, E1 >: E](pred: A => ZIO[R1, E1, Boolean]): ZStream[R1, E1, A] = new ZStream[R1, E1, A] {
-    def process =
+  final def filterM[R1 <: R, E1 >: E](pred: A => ZIO[R1, E1, Boolean]): ZStream[R1, E1, A] =
+    ZStream[R1, E1, A] {
       self.process.map { as =>
         def pull: Pull[R1, E1, A] =
           as.flatMap { a =>
@@ -816,7 +799,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
 
         pull
       }
-  }
+    }
 
   /**
    * Filters this stream by the specified predicate, removing all elements for
@@ -829,36 +812,36 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * produced by passing each element of this stream to `f0`
    */
   final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZStream[R1, E1, B]): ZStream[R1, E1, B] =
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          currPull  <- Ref.make[Pull[R1, E1, B]](Pull.end).toManaged_
-          as        <- self.process
-          finalizer <- ZManaged.finalizerRef[R1](_ => UIO.unit)
-          pullOuter = ZIO.uninterruptibleMask { restore =>
-            restore(as).flatMap { a =>
-              (for {
-                reservation <- f0(a).process.reserve
-                bs          <- restore(reservation.acquire)
-                _           <- finalizer.set(reservation.release)
-                _           <- currPull.set(bs)
-              } yield ()).mapError(Some(_))
+    ZStream[R1, E1, B] {
+      for {
+        currPull  <- Ref.make[Pull[R1, E1, B]](Pull.end).toManaged_
+        as        <- self.process
+        finalizer <- ZManaged.finalizerRef[R1](_ => UIO.unit)
+        pullOuter = ZIO.uninterruptibleMask { restore =>
+          restore(as).flatMap { a =>
+            (for {
+              reservation <- f0(a).process.reserve
+              bs          <- restore(reservation.acquire)
+              _           <- finalizer.set(reservation.release)
+              _           <- currPull.set(bs)
+            } yield ()).mapError(Some(_))
+          }
+        }
+        bs = {
+          def go: Pull[R1, E1, B] =
+            currPull.get.flatten.catchAll {
+              case e @ Some(e1) =>
+                (finalizer.get.flatMap(_(Exit.fail(e1))) *> finalizer.set(_ => UIO.unit)).uninterruptible *> ZIO.fail(
+                  e
+                )
+              case None =>
+                (finalizer.get.flatMap(_(Exit.succeed(()))) *> finalizer
+                  .set(_ => UIO.unit)).uninterruptible *> pullOuter *> go
             }
-          }
-          bs = {
-            def go: Pull[R1, E1, B] =
-              currPull.get.flatten.catchAll {
-                case e @ Some(e1) =>
-                  (finalizer.get.flatMap(_(Exit.fail(e1))) *> finalizer.set(_ => UIO.unit)).uninterruptible *> ZIO.fail(
-                    e
-                  )
-                case None =>
-                  (finalizer.get.flatMap(_(Exit.succeed(()))) *> finalizer.set(_ => UIO.unit)).uninterruptible *> pullOuter *> go
-              }
 
-            go
-          }
-        } yield bs
+          go
+        }
+      } yield bs
     }
 
   /**
@@ -870,68 +853,67 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   final def flatMapPar[R1 <: R, E1 >: E, B](n: Int, outputBuffer: Int = 16)(
     f: A => ZStream[R1, E1, B]
   ): ZStream[R1, E1, B] =
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          out             <- Queue.bounded[Pull[R1, E1, B]](outputBuffer).toManaged(_.shutdown)
-          permits         <- Semaphore.make(n.toLong).toManaged_
-          innerFailure    <- Promise.make[Cause[E1], Nothing].toManaged_
-          interruptInners <- Promise.make[Nothing, Unit].toManaged_
+    ZStream[R1, E1, B] {
+      for {
+        out             <- Queue.bounded[Pull[R1, E1, B]](outputBuffer).toManaged(_.shutdown)
+        permits         <- Semaphore.make(n.toLong).toManaged_
+        innerFailure    <- Promise.make[Cause[E1], Nothing].toManaged_
+        interruptInners <- Promise.make[Nothing, Unit].toManaged_
 
-          // - The driver stream forks an inner fiber for each stream created
-          //   by f, with an upper bound of n concurrent fibers, enforced by the semaphore.
-          //   - On completion, the driver stream tries to acquire all permits to verify
-          //     that all inner fibers have finished.
-          //     - If one of them failed (signalled by a promise), all other fibers are interrupted
-          //     - If they all succeeded, Take.End is enqueued
-          //   - On error, the driver stream interrupts all inner fibers and emits a
-          //     Take.Fail value
-          //   - Interruption is handled by running the finalizers which take care of cleanup
-          // - Inner fibers enqueue Take values from their streams to the output queue
-          //   - On error, an inner fiber enqueues a Take.Fail value and signals its failure
-          //     with a promise. The driver will pick that up and interrupt all other fibers.
-          //   - On interruption, an inner fiber does nothing
-          //   - On completion, an inner fiber does nothing
-          _ <- self.foreachManaged { a =>
-                for {
-                  latch <- Promise.make[Nothing, Unit]
-                  innerStream = Stream
-                    .managed(permits.withPermitManaged)
-                    .flatMap(_ => Stream.bracket(latch.succeed(()))(_ => UIO.unit))
-                    .flatMap(_ => f(a))
-                    .foreach(b => out.offer(Pull.emit(b)).unit)
-                    .foldCauseM(
-                      cause => out.offer(Pull.halt(cause)) *> innerFailure.fail(cause).unit,
-                      _ => ZIO.unit
+        // - The driver stream forks an inner fiber for each stream created
+        //   by f, with an upper bound of n concurrent fibers, enforced by the semaphore.
+        //   - On completion, the driver stream tries to acquire all permits to verify
+        //     that all inner fibers have finished.
+        //     - If one of them failed (signalled by a promise), all other fibers are interrupted
+        //     - If they all succeeded, Take.End is enqueued
+        //   - On error, the driver stream interrupts all inner fibers and emits a
+        //     Take.Fail value
+        //   - Interruption is handled by running the finalizers which take care of cleanup
+        // - Inner fibers enqueue Take values from their streams to the output queue
+        //   - On error, an inner fiber enqueues a Take.Fail value and signals its failure
+        //     with a promise. The driver will pick that up and interrupt all other fibers.
+        //   - On interruption, an inner fiber does nothing
+        //   - On completion, an inner fiber does nothing
+        _ <- self.foreachManaged { a =>
+              for {
+                latch <- Promise.make[Nothing, Unit]
+                innerStream = Stream
+                  .managed(permits.withPermitManaged)
+                  .flatMap(_ => Stream.bracket(latch.succeed(()))(_ => UIO.unit))
+                  .flatMap(_ => f(a))
+                  .foreach(b => out.offer(Pull.emit(b)).unit)
+                  .foldCauseM(
+                    cause => out.offer(Pull.halt(cause)) *> innerFailure.fail(cause).unit,
+                    _ => ZIO.unit
+                  )
+                _ <- (innerStream race interruptInners.await).fork
+                // Make sure that the current inner stream has actually succeeded in acquiring
+                // a permit before continuing. Otherwise we could reach the end of the stream and
+                // acquire the permits ourselves before the inners had a chance to start.
+                _ <- latch.await
+              } yield ()
+            }.foldCauseM(
+                cause => (interruptInners.succeed(()) *> out.offer(Pull.halt(cause))).unit.toManaged_,
+                _ =>
+                  innerFailure.await
+                  // Important to use `withPermits` here because the finalizer below may interrupt
+                  // the driver, and we want the permits to be released in that case
+                    .raceWith(permits.withPermits(n.toLong)(ZIO.unit))(
+                      // One of the inner fibers failed. It already enqueued its failure, so we
+                      // signal the inner fibers to interrupt. The finalizer below will make sure
+                      // that they actually end.
+                      leftDone =
+                        (_, permitAcquisition) => interruptInners.succeed(()) *> permitAcquisition.interrupt.unit,
+                      // All fibers completed successfully, so we signal that we're done.
+                      rightDone = (_, failureAwait) => out.offer(Pull.end) *> failureAwait.interrupt.unit
                     )
-                  _ <- (innerStream race interruptInners.await).fork
-                  // Make sure that the current inner stream has actually succeeded in acquiring
-                  // a permit before continuing. Otherwise we could reach the end of the stream and
-                  // acquire the permits ourselves before the inners had a chance to start.
-                  _ <- latch.await
-                } yield ()
-              }.foldCauseM(
-                  cause => (interruptInners.succeed(()) *> out.offer(Pull.halt(cause))).unit.toManaged_,
-                  _ =>
-                    innerFailure.await
-                    // Important to use `withPermits` here because the finalizer below may interrupt
-                    // the driver, and we want the permits to be released in that case
-                      .raceWith(permits.withPermits(n.toLong)(ZIO.unit))(
-                        // One of the inner fibers failed. It already enqueued its failure, so we
-                        // signal the inner fibers to interrupt. The finalizer below will make sure
-                        // that they actually end.
-                        leftDone =
-                          (_, permitAcquisition) => interruptInners.succeed(()) *> permitAcquisition.interrupt.unit,
-                        // All fibers completed successfully, so we signal that we're done.
-                        rightDone = (_, failureAwait) => out.offer(Pull.end) *> failureAwait.interrupt.unit
-                      )
-                      .toManaged_
-                )
-                // This finalizer makes sure that in all cases, the driver stops spawning new streams
-                // and the inner fibers are signalled to interrupt and actually exit.
-                .ensuringFirst(interruptInners.succeed(()) *> permits.withPermits(n.toLong)(ZIO.unit))
-                .fork
-        } yield out.take.flatten
+                    .toManaged_
+              )
+              // This finalizer makes sure that in all cases, the driver stops spawning new streams
+              // and the inner fibers are signalled to interrupt and actually exit.
+              .ensuringFirst(interruptInners.succeed(()) *> permits.withPermits(n.toLong)(ZIO.unit))
+              .fork
+      } yield out.take.flatten
     }
 
   /**
@@ -943,49 +925,48 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   final def flatMapParSwitch[R1 <: R, E1 >: E, B](n: Int, bufferSize: Int = 16)(
     f: A => ZStream[R1, E1, B]
   ): ZStream[R1, E1, B] =
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          // Modeled after flatMapPar.
-          out             <- Queue.bounded[Pull[R1, E1, B]](bufferSize).toManaged(_.shutdown)
-          permits         <- Semaphore.make(n.toLong).toManaged_
-          innerFailure    <- Promise.make[Cause[E1], Nothing].toManaged_
-          interruptInners <- Promise.make[Nothing, Unit].toManaged_
-          cancelers       <- Queue.bounded[Promise[Nothing, Unit]](n).toManaged(_.shutdown)
-          _ <- self.foreachManaged { a =>
-                for {
-                  canceler <- Promise.make[Nothing, Unit]
-                  latch    <- Promise.make[Nothing, Unit]
-                  size     <- cancelers.size
-                  _ <- if (size < n) UIO.unit
-                      else cancelers.take.flatMap(_.succeed(())).unit
-                  _ <- cancelers.offer(canceler)
-                  innerStream = Stream
-                    .managed(permits.withPermitManaged)
-                    .flatMap(_ => Stream.bracket(latch.succeed(()))(_ => UIO.unit))
-                    .flatMap(_ => f(a))
-                    .foreach(b => out.offer(Pull.emit(b)).unit)
-                    .foldCauseM(
-                      cause => out.offer(Pull.halt(cause)) *> innerFailure.fail(cause).unit,
-                      _ => UIO.unit
+    ZStream[R1, E1, B] {
+      for {
+        // Modeled after flatMapPar.
+        out             <- Queue.bounded[Pull[R1, E1, B]](bufferSize).toManaged(_.shutdown)
+        permits         <- Semaphore.make(n.toLong).toManaged_
+        innerFailure    <- Promise.make[Cause[E1], Nothing].toManaged_
+        interruptInners <- Promise.make[Nothing, Unit].toManaged_
+        cancelers       <- Queue.bounded[Promise[Nothing, Unit]](n).toManaged(_.shutdown)
+        _ <- self.foreachManaged { a =>
+              for {
+                canceler <- Promise.make[Nothing, Unit]
+                latch    <- Promise.make[Nothing, Unit]
+                size     <- cancelers.size
+                _ <- if (size < n) UIO.unit
+                    else cancelers.take.flatMap(_.succeed(())).unit
+                _ <- cancelers.offer(canceler)
+                innerStream = Stream
+                  .managed(permits.withPermitManaged)
+                  .flatMap(_ => Stream.bracket(latch.succeed(()))(_ => UIO.unit))
+                  .flatMap(_ => f(a))
+                  .foreach(b => out.offer(Pull.emit(b)).unit)
+                  .foldCauseM(
+                    cause => out.offer(Pull.halt(cause)) *> innerFailure.fail(cause).unit,
+                    _ => UIO.unit
+                  )
+                _ <- innerStream.raceAll(List(canceler.await, interruptInners.await)).fork
+                _ <- latch.await
+              } yield ()
+            }.foldCauseM(
+                cause => (interruptInners.succeed(()) *> out.offer(Pull.halt(cause))).unit.toManaged_,
+                _ =>
+                  innerFailure.await
+                    .raceWith(permits.withPermits(n.toLong)(UIO.unit))(
+                      leftDone =
+                        (_, permitAcquisition) => interruptInners.succeed(()) *> permitAcquisition.interrupt.unit,
+                      rightDone = (_, failureAwait) => out.offer(Pull.end) *> failureAwait.interrupt.unit
                     )
-                  _ <- innerStream.raceAll(List(canceler.await, interruptInners.await)).fork
-                  _ <- latch.await
-                } yield ()
-              }.foldCauseM(
-                  cause => (interruptInners.succeed(()) *> out.offer(Pull.halt(cause))).unit.toManaged_,
-                  _ =>
-                    innerFailure.await
-                      .raceWith(permits.withPermits(n.toLong)(UIO.unit))(
-                        leftDone =
-                          (_, permitAcquisition) => interruptInners.succeed(()) *> permitAcquisition.interrupt.unit,
-                        rightDone = (_, failureAwait) => out.offer(Pull.end) *> failureAwait.interrupt.unit
-                      )
-                      .toManaged_
-                )
-                .ensuringFirst(interruptInners.succeed(()) *> permits.withPermits(n.toLong)(UIO.unit))
-                .fork
-        } yield out.take.flatten
+                    .toManaged_
+              )
+              .ensuringFirst(interruptInners.succeed(()) *> permits.withPermits(n.toLong)(UIO.unit))
+              .fork
+      } yield out.take.flatten
     }
 
   /**
@@ -1164,7 +1145,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
         case Take.End => ZIO.succeed(((leftDone, rightDone, s), Take.End))
       }
 
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         sides <- b.process
         result <- self
@@ -1202,10 +1183,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Returns a stream made of the elements of this stream transformed with `f0`
    */
   def map[B](f0: A => B): ZStream[R, E, B] =
-    new ZStream[R, E, B] {
-      def process =
-        self.process.map(_.map(f0))
-    }
+    ZStream[R, E, B](self.process.map(_.map(f0)))
 
   /**
    * Statefully maps over the elements of this stream to produce new elements.
@@ -1218,18 +1196,17 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * new elements.
    */
   final def mapAccumM[R1 <: R, E1 >: E, S1, B](s1: S1)(f1: (S1, A) => ZIO[R1, E1, (S1, B)]): ZStream[R1, E1, B] =
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          state <- Ref.make(s1).toManaged_
-          as    <- self.process
-        } yield as.flatMap { a =>
-          (for {
-            s <- state.get
-            t <- f1(s, a)
-            _ <- state.set(t._1)
-          } yield t._2).mapError(Some(_))
-        }
+    ZStream[R1, E1, B] {
+      for {
+        state <- Ref.make(s1).toManaged_
+        as    <- self.process
+      } yield as.flatMap { a =>
+        (for {
+          s <- state.get
+          t <- f1(s, a)
+          _ <- state.set(t._1)
+        } yield t._2).mapError(Some(_))
+      }
     }
 
   /**
@@ -1250,13 +1227,13 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Transforms the errors that possibly result from this stream.
    */
   final def mapError[E1](f: E => E1): ZStream[R, E1, A] =
-    ZStream.fromPullManaged(self.process.mapError(f).map(_.mapError(_.map(f))))
+    ZStream(self.process.mapError(f).map(_.mapError(_.map(f))))
 
   /**
    * Transforms the errors that possibly result from this stream.
    */
   final def mapErrorCause[E1](f: Cause[E] => Cause[E1]): ZStream[R, E1, A] =
-    ZStream.fromPullManaged {
+    ZStream {
       self.process
         .mapErrorCause(f)
         .map(_.mapErrorCause(Pull.sequenceCauseOption(_) match {
@@ -1268,9 +1245,8 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps over elements of the stream with the specified effectful function.
    */
-  final def mapM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] = new ZStream[R1, E1, B] {
-    def process = self.process.map(_.flatMap(f(_).mapError(Some(_))))
-  }
+  final def mapM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
+    ZStream[R1, E1, B](self.process.map(_.flatMap(f(_).mapError(Some(_)))))
 
   /**
    * Maps over elements of the stream with the specified effectful function,
@@ -1278,25 +1254,24 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * will be emitted in the original order.
    */
   final def mapMPar[R1 <: R, E1 >: E, B](n: Int)(f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
-    new ZStream[R1, E1, B] {
-      def process =
-        for {
-          out              <- Queue.bounded[Pull[R1, E1, B]](n).toManaged(_.shutdown)
-          permits          <- Semaphore.make(n.toLong).toManaged_
-          interruptWorkers <- Promise.make[Nothing, Unit].toManaged_
-          _ <- self.foreachManaged { a =>
-                for {
-                  p <- Promise.make[E1, B]
-                  _ <- out.offer(Pull.fromPromise(p))
-                  _ <- (permits.withPermit(f(a).to(p)) race interruptWorkers.await).fork
-                } yield ()
-              }.foldCauseM(
-                  c => (interruptWorkers.succeed(()) *> out.offer(Pull.halt(c))).unit.toManaged_,
-                  _ => out.offer(Pull.end).unit.toManaged_
-                )
-                .ensuringFirst(interruptWorkers.succeed(()) *> permits.withPermits(n.toLong)(ZIO.unit))
-                .fork
-        } yield out.take.flatten
+    ZStream[R1, E1, B] {
+      for {
+        out              <- Queue.bounded[Pull[R1, E1, B]](n).toManaged(_.shutdown)
+        permits          <- Semaphore.make(n.toLong).toManaged_
+        interruptWorkers <- Promise.make[Nothing, Unit].toManaged_
+        _ <- self.foreachManaged { a =>
+              for {
+                p <- Promise.make[E1, B]
+                _ <- out.offer(Pull.fromPromise(p))
+                _ <- (permits.withPermit(f(a).to(p)) race interruptWorkers.await).fork
+              } yield ()
+            }.foldCauseM(
+                c => (interruptWorkers.succeed(()) *> out.offer(Pull.halt(c))).unit.toManaged_,
+                _ => out.offer(Pull.end).unit.toManaged_
+              )
+              .ensuringFirst(interruptWorkers.succeed(()) *> permits.withPermits(n.toLong)(ZIO.unit))
+              .fork
+      } yield out.take.flatten
     }
 
   /**
@@ -1439,14 +1414,14 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * its dependency on `R`.
    */
   final def provide(r: R): Stream[E, A] =
-    ZStream.fromPullManaged(self.process.provide(r).map(_.provide(r)))
+    ZStream(self.process.provide(r).map(_.provide(r)))
 
   /**
    * Uses the given [[Managed]] to provide the environment required to run this stream,
    * leaving no outstanding environments.
    */
   final def provideManaged[E1 >: E](m: Managed[E1, R]): Stream[E1, A] =
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         r  <- m
         as <- self.process.provide(r)
@@ -1458,7 +1433,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * leaving the remainder `R0`.
    */
   final def provideSome[R0](env: R0 => R): ZStream[R0, E, A] =
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         r0 <- ZManaged.environment[R0]
         as <- self.process.provide(env(r0))
@@ -1470,7 +1445,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * leaving the remainder `R0`.
    */
   final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R]): ZStream[R0, E1, A] =
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         r  <- env.toManaged_
         as <- self.process.provide(r)
@@ -1482,7 +1457,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * this stream, leaving the remainder `R0`.
    */
   final def provideSomeManaged[R0, E1 >: E](env: ZManaged[R0, E1, R]): ZStream[R0, E1, A] =
-    ZStream.fromPullManaged {
+    ZStream {
       for {
         r  <- env
         as <- self.process.provide(r)
@@ -1494,31 +1469,28 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * and then repeat again according to the provided schedule.
    */
   final def repeat[R1 <: R](schedule: ZSchedule[R1, Unit, Any]): ZStream[R1 with Clock, E, A] =
-    new ZStream[R1 with Clock, E, A] {
-      import clock.sleep
-
-      def process =
-        for {
-          scheduleInit  <- schedule.initial.toManaged_
-          schedStateRef <- Ref.make(scheduleInit).toManaged_
-          stream = {
-            def repeated: ZStream[R1 with Clock, E, A] = ZStream.unwrap {
-              for {
-                scheduleState <- schedStateRef.get
-                decision      <- schedule.update((), scheduleState)
-                s2 = if (decision.cont)
-                  ZStream
-                    .fromEffect(schedStateRef.set(decision.state) *> sleep(decision.delay))
-                    .drain ++ self ++ repeated
-                else
-                  ZStream.empty
-              } yield s2
-            }
-
-            self ++ repeated
+    ZStream[R1 with Clock, E, A] {
+      for {
+        scheduleInit  <- schedule.initial.toManaged_
+        schedStateRef <- Ref.make(scheduleInit).toManaged_
+        stream = {
+          def repeated: ZStream[R1 with Clock, E, A] = ZStream.unwrap {
+            for {
+              scheduleState <- schedStateRef.get
+              decision      <- schedule.update((), scheduleState)
+              s2 = if (decision.cont)
+                ZStream
+                  .fromEffect(schedStateRef.set(decision.state) *> clock.sleep(decision.delay))
+                  .drain ++ self ++ repeated
+              else
+                ZStream.empty
+            } yield s2
           }
-          as <- stream.process
-        } yield as
+
+          self ++ repeated
+        }
+        as <- stream.process
+      } yield as
     }
 
   /**
@@ -1571,7 +1543,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Analogical to `spaced` but with distinction of stream elements and schedule output represented by Either
    */
   final def spacedEither[R1 <: R, B](schedule: ZSchedule[R1, A, B]): ZStream[R1 with Clock, E, Either[B, A]] =
-    new ZStream[R1 with Clock, E, Either[B, A]] {
+    ZStream {
       sealed trait State
       object State {
         case class Initial(sched: schedule.State)                               extends State
@@ -1583,57 +1555,55 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
         if (decision.cont) State.SleepAndRepeat(decision.state, decision.delay, a)
         else State.SleepAndFinish(decision.delay, decision.finish())
 
-      def process =
-        for {
-          as    <- self.process
-          init  <- schedule.initial.toManaged_
-          state <- Ref.make[State](State.Initial(init)).toManaged_
-          pull = state.get.flatMap {
-            case State.Initial(sched) =>
-              for {
-                a        <- as
-                decision <- schedule.update(a, sched)
-                _        <- state.set(decide(decision, a))
-              } yield Right(a)
+      for {
+        as    <- self.process
+        init  <- schedule.initial.toManaged_
+        state <- Ref.make[State](State.Initial(init)).toManaged_
+        pull = state.get.flatMap {
+          case State.Initial(sched) =>
+            for {
+              a        <- as
+              decision <- schedule.update(a, sched)
+              _        <- state.set(decide(decision, a))
+            } yield Right(a)
 
-            case State.SleepAndRepeat(sched, delay, a) =>
-              for {
-                _        <- clock.sleep(delay)
-                decision <- schedule.update(a, sched)
-                _        <- state.set(decide(decision, a))
-              } yield Right(a)
+          case State.SleepAndRepeat(sched, delay, a) =>
+            for {
+              _        <- clock.sleep(delay)
+              decision <- schedule.update(a, sched)
+              _        <- state.set(decide(decision, a))
+            } yield Right(a)
 
-            case State.SleepAndFinish(delay, b) =>
-              for {
-                _ <- clock.sleep(delay)
-                _ <- state.set(State.Initial(init))
-              } yield Left(b)
-          }
-        } yield pull
+          case State.SleepAndFinish(delay, b) =>
+            for {
+              _ <- clock.sleep(delay)
+              _ <- state.set(State.Initial(init))
+            } yield Left(b)
+        }
+      } yield pull
     }
 
   /**
    * Takes the specified number of elements from this stream.
    */
   def take(n: Int): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          as      <- self.process
-          counter <- Ref.make(0).toManaged_
-          pull = counter.modify { c =>
-            if (c >= n) (Pull.end, c)
-            else (as, c + 1)
-          }.flatten
-        } yield pull
+    ZStream[R, E, A] {
+      for {
+        as      <- self.process
+        counter <- Ref.make(0).toManaged_
+        pull = counter.modify { c =>
+          if (c >= n) (Pull.end, c)
+          else (as, c + 1)
+        }.flatten
+      } yield pull
     }
 
   /**
    * Takes all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-  def takeWhile(pred: A => Boolean): ZStream[R, E, A] = new ZStream[R, E, A] {
-    def process =
+  def takeWhile(pred: A => Boolean): ZStream[R, E, A] =
+    ZStream[R, E, A] {
       self.process.map { as =>
         for {
           a <- as
@@ -1641,15 +1611,13 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                    else Pull.end
         } yield result
       }
-  }
+    }
 
   /**
    * Adds an effect to consumption of every element of the stream.
    */
   final def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, _]): ZStream[R1, E1, A] =
-    new ZStream[R1, E1, A] {
-      def process = self.process.map(_.tap(f(_).mapError(Some(_))))
-    }
+    ZStream[R1, E1, A](self.process.map(_.tap(f(_).mapError(Some(_)))))
 
   /**
    * Throttles elements of type A according to the given bandwidth parameters using the token bucket
@@ -1698,14 +1666,13 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Interrupts the stream if it does not produce a value after d duration.
    */
   final def timeout(d: Duration): ZStream[R with Clock, E, A] =
-    new ZStream[R with Clock, E, A] {
-      def process =
-        self.process.map { next =>
-          next.timeout(d).flatMap {
-            case Some(a) => ZIO.succeed(a)
-            case None    => ZIO.interrupt
-          }
+    ZStream[R with Clock, E, A] {
+      self.process.map { next =>
+        next.timeout(d).flatMap {
+          case Some(a) => ZIO.succeed(a)
+          case None    => ZIO.interrupt
         }
+      }
     }
 
   /**
@@ -1725,46 +1692,45 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   final def transduceManaged[R1 <: R, E1 >: E, A1 >: A, C](
     managedSink: ZManaged[R1, E1, ZSink[R1, E1, A1, A1, C]]
   ): ZStream[R1, E1, C] =
-    new ZStream[R1, E1, C] {
-      def process =
-        for {
-          as           <- self.process
-          sink         <- managedSink
-          init         <- sink.initial.toManaged_
-          sinkStateRef <- Ref.make[(ZSink.Step[sink.State, A1], Boolean)]((init, false)).toManaged_
-          done         <- Ref.make(false).toManaged_
-          pull = {
-            def go(step: ZSink.Step[sink.State, A1], needsExtractOnEnd: Boolean): Pull[R1, E1, C] =
-              if (!ZSink.Step.cont(step))
-                (for {
-                  c        <- sink.extract(ZSink.Step.state(step))
-                  leftover = ZSink.Step.leftover(step)
-                  newInit  <- sink.initial
-                  _ <- sink
-                        .stepChunk(ZSink.Step.state(newInit), leftover)
-                        .tap(leftoverStep => sinkStateRef.set((leftoverStep, !leftover.isEmpty)))
-                } yield c).mapError(Some(_))
-              else
-                as.foldM(
-                  {
-                    case None =>
-                      done.set(true) *>
-                        (if (needsExtractOnEnd) sink.extract(ZSink.Step.state(step)).mapError(Some(_))
-                         else Pull.end)
-                    case Some(e) => Pull.fail(e)
-                  },
-                  sink.step(ZSink.Step.state(step), _).mapError(Some(_)).flatMap(go(_, true))
-                )
+    ZStream[R1, E1, C] {
+      for {
+        as           <- self.process
+        sink         <- managedSink
+        init         <- sink.initial.toManaged_
+        sinkStateRef <- Ref.make[(ZSink.Step[sink.State, A1], Boolean)]((init, false)).toManaged_
+        done         <- Ref.make(false).toManaged_
+        pull = {
+          def go(step: ZSink.Step[sink.State, A1], needsExtractOnEnd: Boolean): Pull[R1, E1, C] =
+            if (!ZSink.Step.cont(step))
+              (for {
+                c        <- sink.extract(ZSink.Step.state(step))
+                leftover = ZSink.Step.leftover(step)
+                newInit  <- sink.initial
+                _ <- sink
+                      .stepChunk(ZSink.Step.state(newInit), leftover)
+                      .tap(leftoverStep => sinkStateRef.set((leftoverStep, !leftover.isEmpty)))
+              } yield c).mapError(Some(_))
+            else
+              as.foldM(
+                {
+                  case None =>
+                    done.set(true) *>
+                      (if (needsExtractOnEnd) sink.extract(ZSink.Step.state(step)).mapError(Some(_))
+                       else Pull.end)
+                  case Some(e) => Pull.fail(e)
+                },
+                sink.step(ZSink.Step.state(step), _).mapError(Some(_)).flatMap(go(_, true))
+              )
 
-            done.get.flatMap {
-              if (_) Pull.end
-              else
-                sinkStateRef.get.flatMap {
-                  case (lastStep, needsExtractOnEnd) => go(lastStep, needsExtractOnEnd)
-                }
-            }
+          done.get.flatMap {
+            if (_) Pull.end
+            else
+              sinkStateRef.get.flatMap {
+                case (lastStep, needsExtractOnEnd) => go(lastStep, needsExtractOnEnd)
+              }
           }
-        } yield pull
+        }
+      } yield pull
     }
 
   /**
@@ -1936,14 +1902,18 @@ object ZStream extends ZStreamPlatformSpecific {
    * The stream that never produces any value or fails with any error.
    */
   final val never: Stream[Nothing, Nothing] =
-    new Stream[Nothing, Nothing] {
-      def process = ZManaged.succeed(UIO.never)
-    }
+    Stream[Nothing, Nothing](ZManaged.succeed(UIO.never))
 
   /**
    * Creates a pure stream from a variable list of values
    */
   final def apply[A](as: A*): Stream[Nothing, A] = fromIterable(as)
+
+  /**
+   * Creates a stream from a scoped [[Pull]].
+   */
+  final def apply[R, E, A](pull: ZManaged[R, E, Pull[R, E, A]]): ZStream[R, E, A] =
+    new ZStream[R, E, A](pull)
 
   /**
    * Creates a stream from a single value that will get cleaned up after the
@@ -1988,30 +1958,29 @@ object ZStream extends ZStreamPlatformSpecific {
     register: (ZIO[R, Option[E], A] => Unit) => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
-          runtime <- ZIO.runtime[R].toManaged_
-          maybeStream <- UIO(
-                          register(
-                            k =>
-                              runtime.unsafeRunAsync_(
-                                k.foldCauseM(
-                                  Pull.sequenceCauseOption(_) match {
-                                    case None    => output.offer(Pull.end).unit
-                                    case Some(c) => output.offer(Pull.halt(c)).unit
-                                  },
-                                  a => output.offer(Pull.emit(a)).unit
-                                )
+    ZStream[R, E, A] {
+      for {
+        output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        maybeStream <- UIO(
+                        register(
+                          k =>
+                            runtime.unsafeRunAsync_(
+                              k.foldCauseM(
+                                Pull.sequenceCauseOption(_) match {
+                                  case None    => output.offer(Pull.end).unit
+                                  case Some(c) => output.offer(Pull.halt(c)).unit
+                                },
+                                a => output.offer(Pull.emit(a)).unit
                               )
-                          )
-                        ).toManaged_
-          is <- maybeStream match {
+                            )
+                        )
+                      ).toManaged_
+        pull <- maybeStream match {
                  case Some(stream) => output.shutdown.toManaged_ *> stream.process
                  case None         => ZManaged.succeed(output.take.flatten)
                }
-        } yield is
+      } yield pull
     }
 
   /**
@@ -2023,24 +1992,23 @@ object ZStream extends ZStreamPlatformSpecific {
     register: (ZIO[R, Option[E], A] => Unit) => ZIO[R, E, _],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
-          runtime <- ZIO.runtime[R].toManaged_
-          _ <- register(
-                k =>
-                  runtime.unsafeRunAsync_(
-                    k.foldCauseM(
-                      Pull.sequenceCauseOption(_) match {
-                        case None    => output.offer(Pull.end).unit
-                        case Some(c) => output.offer(Pull.halt(c)).unit
-                      },
-                      a => output.offer(Pull.emit(a)).unit
-                    )
+    ZStream[R, E, A] {
+      for {
+        output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        _ <- register(
+              k =>
+                runtime.unsafeRunAsync_(
+                  k.foldCauseM(
+                    Pull.sequenceCauseOption(_) match {
+                      case None    => output.offer(Pull.end).unit
+                      case Some(c) => output.offer(Pull.halt(c)).unit
+                    },
+                    a => output.offer(Pull.emit(a)).unit
                   )
-              ).toManaged_
-        } yield output.take.flatten
+                )
+            ).toManaged_
+      } yield output.take.flatten
     }
 
   /**
@@ -2053,31 +2021,30 @@ object ZStream extends ZStreamPlatformSpecific {
     register: (ZIO[R, Option[E], A] => Unit) => Either[Canceler, ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
-          runtime <- ZIO.runtime[R].toManaged_
-          eitherStream <- UIO(
-                           register(
-                             k =>
-                               runtime.unsafeRunAsync_(
-                                 k.foldCauseM(
-                                   Pull.sequenceCauseOption(_) match {
-                                     case None    => output.offer(Pull.end).unit
-                                     case Some(c) => output.offer(Pull.halt(c)).unit
-                                   },
-                                   a => output.offer(Pull.emit(a)).unit
-                                 )
+    ZStream[R, E, A] {
+      for {
+        output  <- Queue.bounded[Pull[R, E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        eitherStream <- UIO(
+                         register(
+                           k =>
+                             runtime.unsafeRunAsync_(
+                               k.foldCauseM(
+                                 Pull.sequenceCauseOption(_) match {
+                                   case None    => output.offer(Pull.end).unit
+                                   case Some(c) => output.offer(Pull.halt(c)).unit
+                                 },
+                                 a => output.offer(Pull.emit(a)).unit
                                )
-                           )
-                         ).toManaged_
-          is <- eitherStream match {
+                             )
+                         )
+                       ).toManaged_
+        pull <- eitherStream match {
                  case Left(canceler) =>
                    ZManaged.succeed(output.take.flatten).ensuring(canceler)
                  case Right(stream) => output.shutdown.toManaged_ *> stream.process
                }
-        } yield is
+      } yield pull
     }
 
   /**
@@ -2090,13 +2057,12 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates an empty stream that never fails and executes the finalizer when it ends.
    */
   final def finalizer[R](finalizer: ZIO[R, Nothing, _]): ZStream[R, Nothing, Nothing] =
-    new ZStream[R, Nothing, Nothing] {
-      def process =
-        for {
-          finalizerRef <- Ref.make[ZIO[R, Nothing, Any]](UIO.unit).toManaged_
-          _            <- ZManaged.finalizer[R](finalizerRef.get.flatten)
-          pull         = (finalizerRef.set(finalizer) *> Pull.end).uninterruptible
-        } yield pull
+    ZStream[R, Nothing, Nothing] {
+      for {
+        finalizerRef <- Ref.make[ZIO[R, Nothing, Any]](UIO.unit).toManaged_
+        _            <- ZManaged.finalizer[R](finalizerRef.get.flatten)
+        pull         = (finalizerRef.set(finalizer) *> Pull.end).uninterruptible
+      } yield pull
     }
 
   /**
@@ -2131,15 +2097,7 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates a stream from a [[Pull]].
    */
   final def fromPull[R, E, A](pull: Pull[R, E, A]): ZStream[R, E, A] =
-    fromPullManaged(ZManaged.succeed(pull))
-
-  /**
-   * Creates a stream from a scoped [[Pull]].
-   */
-  final def fromPullManaged[R, E, A](pull: ZManaged[R, E, Pull[R, E, A]]): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process = pull
-    }
+    ZStream(ZManaged.succeed(pull))
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats forever
@@ -2183,7 +2141,7 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates a stream from a [[zio.ZQueue]] of values. The queue will be shutdown once the stream is closed.
    */
   final def fromQueueWithShutdown[R, E, A](queue: ZQueue[_, _, R, E, _, A]): ZStream[R, E, A] =
-    fromPullManaged(fromQueue(queue).process.ensuringFirst(queue.shutdown))
+    ZStream(fromQueue(queue).process.ensuringFirst(queue.shutdown))
 
   /**
    * The stream that always halts with `cause`.
@@ -2194,24 +2152,23 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates a single-valued stream from a managed resource
    */
   final def managed[R, E, A](managed: ZManaged[R, E, A]): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          doneRef   <- Ref.make(false).toManaged_
-          finalizer <- ZManaged.finalizerRef[R](_ => UIO.unit)
-          pull = ZIO.uninterruptibleMask { restore =>
-            doneRef.get.flatMap { done =>
-              if (done) Pull.end
-              else
-                (for {
-                  reservation <- managed.reserve
-                  _           <- finalizer.set(reservation.release)
-                  a           <- restore(reservation.acquire)
-                  _           <- doneRef.set(true)
-                } yield a).mapError(Some(_))
-            }
+    ZStream[R, E, A] {
+      for {
+        doneRef   <- Ref.make(false).toManaged_
+        finalizer <- ZManaged.finalizerRef[R](_ => UIO.unit)
+        pull = ZIO.uninterruptibleMask { restore =>
+          doneRef.get.flatMap { done =>
+            if (done) Pull.end
+            else
+              (for {
+                reservation <- managed.reserve
+                _           <- finalizer.set(reservation.release)
+                a           <- restore(reservation.acquire)
+                _           <- doneRef.set(true)
+              } yield a).mapError(Some(_))
           }
-        } yield pull
+        }
+      } yield pull
     }
 
   /**
@@ -2250,20 +2207,19 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates a stream by effectfully peeling off the "layers" of a value of type `S`
    */
   final def unfoldM[R, E, A, S](s: S)(f0: S => ZIO[R, E, Option[(A, S)]]): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process =
-        for {
-          ref <- Ref.make(s).toManaged_
-        } yield ref.get
-          .flatMap(f0)
-          .foldM(
-            e => Pull.fail(e),
-            opt =>
-              opt match {
-                case Some((a, s)) => ref.set(s) *> Pull.emit(a)
-                case None         => Pull.end
-              }
-          )
+    ZStream[R, E, A] {
+      for {
+        ref <- Ref.make(s).toManaged_
+      } yield ref.get
+        .flatMap(f0)
+        .foldM(
+          e => Pull.fail(e),
+          opt =>
+            opt match {
+              case Some((a, s)) => ref.set(s) *> Pull.emit(a)
+              case None         => Pull.end
+            }
+        )
     }
 
   /**
@@ -2276,7 +2232,5 @@ object ZStream extends ZStreamPlatformSpecific {
    * Creates a stream produced from a [[ZManaged]]
    */
   final def unwrapManaged[R, E, A](fa: ZManaged[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
-    new ZStream[R, E, A] {
-      def process = fa.flatMap(_.process)
-    }
+    ZStream[R, E, A](fa.flatMap(_.process))
 }


### PR DESCRIPTION
Also, address stack safety by changing ZStream from being a trait to a class.

Resolves #1461.

@iravid @jdegoes 