### PR TITLE
Support a custom executor in StreamEffect

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1083,9 +1083,11 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
 
   private def fromInputStream = unsafeRun {
     import java.io.ByteArrayInputStream
+
     val chunkSize = ZStreamChunk.DefaultChunkSize
     val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
-    val is        = new ByteArrayInputStream(data)
+    val is        = UIO(new ByteArrayInputStream(data))
+
     ZStream.fromInputStream(is, chunkSize).run(Sink.collectAll[Chunk[Byte]]) map { chunks =>
       chunks.flatMap(_.toArray[Byte]).toArray must_=== data
     }

--- a/streams/js/src/main/scala/zio/platform.scala
+++ b/streams/js/src/main/scala/zio/platform.scala
@@ -1,4 +1,6 @@
 package zio.stream
 
+trait StreamEffectPlatformSpecific
+trait StreamPlatformSpecific
 trait ZStreamPlatformSpecific
 trait ZSinkPlatformSpecific

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -16,13 +16,11 @@
 
 package zio.stream
 
-import java.io.{ IOException, InputStream }
-
 import zio._
 import zio.clock.Clock
 import zio.Cause
 
-object Stream {
+object Stream extends StreamPlatformSpecific {
   import ZStream.Pull
 
   /**
@@ -126,15 +124,6 @@ object Stream {
     fa: Stream[E, Stream[E, A]]
   ): Stream[E, A] =
     ZStream.flattenPar(n, outputBuffer)(fa)
-
-  /**
-   * See [[ZStream.fromInputStream]]
-   */
-  final def fromInputStream(
-    is: InputStream,
-    chunkSize: Int = ZStreamChunk.DefaultChunkSize
-  ): StreamEffectChunk[Any, IOException, Byte] =
-    ZStream.fromInputStream(is, chunkSize)
 
   /**
    * See [[ZStream.fromChunk]]

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -16,8 +16,6 @@
 
 package zio.stream
 
-import java.io.{ IOException, InputStream }
-
 import com.github.ghik.silencer.silent
 import zio._
 import zio.clock.Clock
@@ -1237,7 +1235,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
    *  Stream(1).forever.foldWhile(0)(_ <= 4)(_ + _) // UIO[Int] == 5
    * }}}
    */
-  final def foldWhile[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): ZIO[R, E, S] =
+  def foldWhile[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): ZIO[R, E, S] =
     foldWhileManagedM[R, E, A1, S](s)(cont)((s, a) => ZIO.succeed(f(s, a))).use(ZIO.succeed)
 
   /**
@@ -2398,7 +2396,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     self zipRight that
 }
 
-object ZStream {
+object ZStream extends ZStreamPlatformSpecific {
 
   /**
    * Describes an effectful pull from a stream. The optionality of the error channel denotes
@@ -2687,15 +2685,6 @@ object ZStream {
     fa: ZStream[R, E, ZStream[R, E, A]]
   ): ZStream[R, E, A] =
     flattenPar(Int.MaxValue, outputBuffer)(fa)
-
-  /**
-   * Creates a stream from a [[java.io.InputStream]]
-   */
-  final def fromInputStream(
-    is: InputStream,
-    chunkSize: Int = ZStreamChunk.DefaultChunkSize
-  ): StreamEffectChunk[Any, IOException, Byte] =
-    StreamEffect.fromInputStream(is, chunkSize)
 
   /**
    * Creates a stream from a [[zio.Chunk]] of values


### PR DESCRIPTION
This is needed to support running the thunk on the blocking executor in `fromInputStream`.

@jdegoes - wdyt? It's a bit patchy, but I'm not sure if we need anything more than this for now.

cc @vasilmkd 