### PR TITLE
Fix and test ZStream#optional leftover logic

### DIFF
--- a/docs/datatypes/sink.md
+++ b/docs/datatypes/sink.md
@@ -82,7 +82,7 @@ Sink.fold[Nothing, Int, Int](0)((acc, e) => ZSink.Step.more(acc + e))
 Mapping over the received input elements:
 
 ```scala mdoc:silent
-Sink.fromFunction[Int, Int](_ * 2).collectAll[Int, Int]
+Sink.fromFunction[Int, Int](_ * 2).collectAll
 ```
 
 `pull1` fails with given type in case of empty stream, otherwise continues with provided sink:

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -387,7 +387,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
   }
 
   private def collectAllHappyPath = {
-    val sink = ZSink.identity[Int].collectAll[Int, Int]
+    val sink = ZSink.identity[Int].collectAll
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
   }
 
@@ -407,12 +407,12 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
   }
 
   private def collectAllNHappyPath = {
-    val sink = ZSink.identity[Int].collectAllN[Int, Int](5)
+    val sink = ZSink.identity[Int].collectAllN(5)
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
   }
 
   private def collectAllNEmptyList = {
-    val sink = ZSink.identity[Int].collectAllN[Int, Int](0)
+    val sink = ZSink.identity[Int].collectAllN(0)
     val test = for {
       init     <- sink.initial
       step     <- sink.step(Step.state(init), 1)
@@ -423,43 +423,43 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
   }
 
   private def collectAllNInitError = {
-    val sink = initErrorSink.collectAllN[Int, Int](1)
+    val sink = initErrorSink.collectAllN(1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllNStepError = {
-    val sink = stepErrorSink.collectAllN[Int, Int](1)
+    val sink = stepErrorSink.collectAllN(1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllNExtractErrorEmptyList = {
-    val sink = extractErrorSink.collectAllN[Int, Int](1)
+    val sink = extractErrorSink.collectAllN(1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileHappyPath = {
-    val sink = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 10)
+    val sink = ZSink.identity[Int].collectAllWhile(_ < 10)
     unsafeRun(sinkIteration(sink, 1).map(_ must_=== List(1)))
   }
 
   private def collectAllWhileFalsePredicate = {
     val errorMsg = "No elements have been consumed by the sink"
-    val sink     = ZSink.identity[Int].collectAllWhile[Int, Int](_ < 0).mapError(_ => errorMsg)
+    val sink     = ZSink.identity[Int].collectAllWhile(_ < 0).mapError(_ => errorMsg)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left(errorMsg)))
   }
 
   private def collectAllWhileInitError = {
-    val sink = initErrorSink.collectAllWhile[Int, Int](_ > 1)
+    val sink = initErrorSink.collectAllWhile(_ > 1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileStepError = {
-    val sink = stepErrorSink.collectAllWhile[Int, Int](_ > 1)
+    val sink = stepErrorSink.collectAllWhile(_ > 1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
   private def collectAllWhileExtractError = {
-    val sink = extractErrorSink.collectAllWhile[Int, Int](_ > 1)
+    val sink = extractErrorSink.collectAllWhile(_ > 1)
     unsafeRun(sinkIteration(sink, 1).either.map(_ must_=== Left("Ouch")))
   }
 
@@ -1331,7 +1331,7 @@ class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
       ZSink.read1[String, Char](a => s"Expected closing brace; instead: $a")((_: Char) == ']')
     val number: ZSink[Any, String, Char, Char, Int] =
       ZSink.collectAllWhile[Char](_.isDigit).map(_.mkString.toInt)
-    val numbers = (number <*> (comma *> number).collectAllWhile[Char, Char](_ != ']'))
+    val numbers = (number <*> (comma *> number).collectAllWhile(_ != ']'))
       .map(tp => tp._1 :: tp._2)
 
     val elements = numbers <* brace

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -137,13 +137,12 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
    * will not improve performance, but can be used to adapt non-chunked sinks
    * wherever chunked sinks are required.
    */
-  final def chunked[A1 >: A0, A2 <: A]: ZSink[R, E, A1, Chunk[A2], B] =
-    new ZSink[R, E, A1, Chunk[A2], B] {
+  final def chunked: ZSink[R, E, A0, Chunk[A], B] =
+    new ZSink[R, E, A0, Chunk[A], B] {
       type State = self.State
-      val initial = self.initial
-      def step(state: State, a: Chunk[A2]): ZIO[R, E, Step[State, A1]] =
-        self.stepChunk(state, a)
-      def extract(state: State): ZIO[R, E, B] = self.extract(state)
+      val initial                         = self.initial
+      def step(state: State, a: Chunk[A]) = self.stepChunk(state, a)
+      def extract(state: State)           = self.extract(state)
     }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -210,7 +210,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
 
               self.extract(s).flatMap { b =>
                 self.initial.flatMap { init =>
-                  self.stepChunk[A1](Step.state(init), as.map(ev)).map(Step.leftMap(_)((f(state._1, b), _)))
+                  self.stepChunk(Step.state(init), as.map(ev)).map(Step.leftMap(_)((f(state._1, b), _)))
                 }
               }
             }
@@ -239,7 +239,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
 
               self.extract(s).flatMap { b =>
                 self.initial.flatMap { init =>
-                  self.stepChunk[A1](Step.state(init), as.map(ev)).map(Step.leftMap(_)((f(state._1, b), _)))
+                  self.stepChunk(Step.state(init), as.map(ev)).map(Step.leftMap(_)((f(state._1, b), _)))
                 }
               }
             }
@@ -341,7 +341,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
                 that.initial.flatMap(
                   s2 =>
                     that
-                      .stepChunk[A1](Step.state(s2), as.map(ev))
+                      .stepChunk(Step.state(s2), as.map(ev))
                       .map(Step.leftMap(_)(s2 => Right((that, s2)))): ZIO[R1, E1, Step[State, A00]] // TODO: Dotty doesn't infer this properly
                 )
               }
@@ -653,7 +653,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Steps through a chunk of iterations of the sink
    */
-  final def stepChunk[A1 <: A](state: State, as: Chunk[A1]): ZIO[R, E, Step[State, A0]] = {
+  final def stepChunk(state: State, as: Chunk[A]): ZIO[R, E, Step[State, A0]] = {
     val len = as.length
 
     def loop(s: Step[State, A0], i: Int): ZIO[R, E, Step[State, A0]] =


### PR DESCRIPTION
Proposed solution for Sinks that produce remainder of the same type (with more combinators to be migrated later) and Sinks that produce no remainder at all, to help with type inference.

@iravid and I already tried adding implicit evidence, and there are other combinators that don't infer properly.

@iravid Please take a look.

Tests for lefotvers issue #1313.

cc @jdegoes 