### PR TITLE
Update sbt to 1.3.0-RC4

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0-RC4


### PR DESCRIPTION
sbt 1.3.0-RC4 is quite stable at this point, and the benefit of coursier by default and faster start-ups are just too hard to pass by...