### PR TITLE
Catch defects in effectAsyncM (could cause deadlocks)

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1799,10 +1799,8 @@ private[zio] trait ZIOFunctions extends Serializable {
       p <- Promise.make[E, A]
       r <- ZIO.runtime[R]
       a <- ZIO.uninterruptibleMask { restore =>
-            restore(
-              register(k => r.unsafeRunAsync_(k.to(p)))
-                .catchAll(p.fail)
-            ).fork.flatMap { f =>
+            val f = register(k => r.unsafeRunAsync_(k.to(p)))
+            restore(f.catchAllCause(p.halt)).fork.flatMap { f =>
               restore(p.await).onInterrupt(f.interrupt)
             }
           }


### PR DESCRIPTION
added test did not pass before the change