### PR TITLE
Do we actually need to fork in effectAsyncM?

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1800,9 +1800,8 @@ private[zio] trait ZIOFunctions extends Serializable {
       r <- ZIO.runtime[R]
       a <- ZIO.uninterruptibleMask { restore =>
             val f = register(k => r.unsafeRunAsync_(k.to(p)))
-            restore(f.catchAllCause(p.halt)).fork.flatMap { f =>
-              restore(p.await).onInterrupt(f.interrupt)
-            }
+            restore(f).catchAllCause(p.halt) *>
+              restore(p.await)
           }
     } yield a
 


### PR DESCRIPTION
To me it seems like the essence of the operation is single-threaded – we must post a continuation of the Fiber on EC as a result of invoked callback – which we do via Promise, but there's no reason to evaluate the provided effect on a new fiber – and indeed cats-effect does not do that.