### PR TITLE
Add ZIO#provideM

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -677,6 +677,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def provide(r: R): IO[E, A] = ZIO.provide(r)(self)
 
   /**
+   * An effectual version of `provide`, useful when the act of provision
+   * requires an effect.
+   */
+  final def provideM[E1 >: E](r: ZIO[Any, E1, R]): ZIO[Any, E1, A] =
+    r.flatMap(self.provide)
+
+  /**
    * Uses the given Managed[E1, R] to the environment required to run this effect,
    * leaving no outstanding environments and returning IO[E1, A]
    */

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,14 +1,14 @@
 package zio.examples.test
 
-import zio.test.{DefaultRunnableSpec, Predicate, assert, suite, test}
+import zio.test.{ Assertion, DefaultRunnableSpec, assert, suite, test}
 
 object ExampleSpec extends DefaultRunnableSpec(
   suite("some suite") (
     test("failing test") {
-      assert(1, Predicate.equalTo(2))
+      assert(1, Assertion.equalTo(2))
     },
     test("passing test") {
-      assert(1, Predicate.equalTo(1))
+      assert(1, Assertion.equalTo(1))
     }
   )
 )

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,14 +1,14 @@
 package zio.examples.test
 
-import zio.test.{ Assertion, DefaultRunnableSpec, assert, suite, test}
+import zio.test.{DefaultRunnableSpec, Predicate, assert, suite, test}
 
 object ExampleSpec extends DefaultRunnableSpec(
   suite("some suite") (
     test("failing test") {
-      assert(1, Assertion.equalTo(2))
+      assert(1, Predicate.equalTo(2))
     },
     test("passing test") {
-      assert(1, Assertion.equalTo(1))
+      assert(1, Predicate.equalTo(1))
     }
   )
 )

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1418,6 +1418,13 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     ZStream(self.process.provide(r).map(_.provide(r)))
 
   /**
+   * An effectual version of `provide`, useful when the act of provision
+   * requires an effect.
+   */
+  final def provideM[E1 >: E](r: ZIO[Any, E1, R]): Stream[E1, A] =
+    provideSomeM(r)
+
+  /**
    * Uses the given [[Managed]] to provide the environment required to run this stream,
    * leaving no outstanding environments.
    */

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-import zio.{ DefaultRuntime, Managed, UIO, ZIO }
+import zio.{ DefaultRuntime, UIO, ZIO }
 import zio.random.Random
 import zio.stream.ZStream
 import zio.test.mock.MockRandom
@@ -367,18 +367,18 @@ object GenSpec extends DefaultRuntime {
     unsafeRunToFuture(ZIO.collectAll(List.fill(100)(zio)).map(_.forall(identity)))
 
   def equalSample[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
-    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
+    val mockRandom = MockRandom.make(MockRandom.DefaultData)
     for {
-      leftSample  <- sample(left).provideManaged(mockRandom)
-      rightSample <- sample(right).provideManaged(mockRandom)
+      leftSample  <- sample(left).provideM(mockRandom)
+      rightSample <- sample(right).provideM(mockRandom)
     } yield leftSample == rightSample
   }
 
   def equalShrink[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
-    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
+    val mockRandom = MockRandom.make(MockRandom.DefaultData)
     for {
-      leftShrinks  <- ZIO.collectAll(List.fill(100)(shrinks(left))).provideManaged(mockRandom)
-      rightShrinks <- ZIO.collectAll(List.fill(100)(shrinks(right))).provideManaged(mockRandom)
+      leftShrinks  <- ZIO.collectAll(List.fill(100)(shrinks(left))).provideM(mockRandom)
+      rightShrinks <- ZIO.collectAll(List.fill(100)(shrinks(right))).provideM(mockRandom)
     } yield leftShrinks == rightShrinks
   }
 

--- a/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
@@ -202,7 +202,7 @@ object ClockSpec extends DefaultRuntime {
           _      <- MockClock.adjust(1.minute)
           result <- fiber.join
         } yield result == None
-        io.provideSomeM(MockClock.make(MockClock.DefaultData))
+        io.provideM(MockClock.make(MockClock.DefaultData))
       }
     }
 
@@ -220,7 +220,7 @@ object ClockSpec extends DefaultRuntime {
           d <- q.take.as(true)
           e <- q.poll.map(_.isEmpty)
         } yield a && b && c && d && e
-        io.provideSomeM(MockClock.make(MockClock.DefaultData))
+        io.provideM(MockClock.make(MockClock.DefaultData))
       }
     }
 }


### PR DESCRIPTION
As discussed on Gitter, this PR adds a `provideM` method on `ZIO` and `ZStream` that provides all of the required environment to an effect where the act of creating the environment itself requires an effect. This can already be accomplished using `flatMap` and then `provide` or `provideSomeM` but I think this is a nice convenience method. Using `flatMap` and then `provide` can sometimes generate spurious warnings about types being inferred as `Any`. And while `provideSomeM` works, the name doesn't make clear that you can or are providing the whole environment and the compiler won't enforce that the whole environment has been provided.

Overall I think understanding how to work with the environment parameter is one of the harder things for newcomers so we should make it as easy as possible.