### PR TITLE
ZIO Test: Improve Ergonomics of Property Based Testing

### DIFF
--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,14 +1,14 @@
 package zio.examples.test
 
-import zio.test.{DefaultRunnableSpec, Predicate, assert, suite, test}
+import zio.test.{ Assertion, DefaultRunnableSpec, assert, suite, test}
 
 object ExampleSpec extends DefaultRunnableSpec(
   suite("some suite") (
     test("failing test") {
-      assert(1, Predicate.equalTo(2))
+      assert(1, Assertion.equalTo(2))
     },
     test("passing test") {
-      assert(1, Predicate.equalTo(1))
+      assert(1, Assertion.equalTo(1))
     }
   )
 )

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -25,160 +25,154 @@ trait CheckVariants {
    * Checks the test passes for "sufficient" numbers of samples from the
    * given random variable.
    */
-  final def check[R, A](rv: Gen[R, A])(test: (=> A) => TestResult): ZTest[R, Nothing] =
+  final def check[R, A](rv: Gen[R, A])(test: A => TestResult): ZTest[R, Nothing] =
     checkSome(rv)(200)(test)
 
   /**
    * A version of `check` that accepts two random variables.
    */
-  final def check[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
-    check(rv1 <*> rv2) { case (a, b) => test(a, b) }
+  final def check[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZTest[R, Nothing] =
+    check(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `check` that accepts three random variables.
    */
   final def check[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (=> A, => B, => C) => TestResult
+    test: (A, B, C) => TestResult
   ): ZTest[R, Nothing] =
-    check(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+    check(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `check` that accepts four random variables.
    */
   final def check[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (=> A, => B, => C, => D) => TestResult
+    test: (A, B, C, D) => TestResult
   ): ZTest[R, Nothing] =
-    check(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+    check(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the effectual test passes for "sufficient" numbers of samples from
    * the given random variable.
    */
-  final def checkM[R, A](rv: Gen[R, A])(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+  final def checkM[R, A](rv: Gen[R, A])(test: A => ZTest[R, Nothing]): ZTest[R, Nothing] =
     checkSomeM(rv)(200)(test)
 
   /**
    * A version of `checkM` that accepts two random variables.
    */
-  final def checkM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (=> A, => B) => ZTest[R, Nothing]
-  ): ZTest[R, Nothing] =
-    checkM(rv1 <*> rv2) { case (a, b) => test(a, b) }
+  final def checkM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkM(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkM` that accepts three random variables.
    */
   final def checkM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (=> A, => B, => C) => ZTest[R, Nothing]
+    test: (A, B, C) => ZTest[R, Nothing]
   ): ZTest[R, Nothing] =
-    checkM(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+    checkM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `checkM` that accepts four random variables.
    */
   final def checkM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (=> A, => B, => C, => D) => ZTest[R, Nothing]
+    test: (A, B, C, D) => ZTest[R, Nothing]
   ): ZTest[R, Nothing] =
-    checkM(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+    checkM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the test passes for all values from the given random variable. This
    * is useful for deterministic `Gen` that comprehensively explore all
    * possibilities in a given domain.
    */
-  final def checkAll[R, A](rv: Gen[R, A])(test: (=> A) => TestResult): ZTest[R, Nothing] =
+  final def checkAll[R, A](rv: Gen[R, A])(test: A => TestResult): ZTest[R, Nothing] =
     checkAllM(rv)(test andThen ZIO.succeed)
 
   /**
    * A version of `checkAll` that accepts two random variables.
    */
-  final def checkAll[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
-    checkAll(rv1 <*> rv2) { case (a, b) => test(a, b) }
+  final def checkAll[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZTest[R, Nothing] =
+    checkAll(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkAll` that accepts three random variables.
    */
   final def checkAll[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (=> A, => B, => C) => TestResult
+    test: (A, B, C) => TestResult
   ): ZTest[R, Nothing] =
-    checkAll(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+    checkAll(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `checkAll` that accepts four random variables.
    */
   final def checkAll[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (=> A, => B, => C, => D) => TestResult
+    test: (A, B, C, D) => TestResult
   ): ZTest[R, Nothing] =
-    checkAll(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+    checkAll(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the effectual test passes for all values from the given random
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
-  final def checkAllM[R, A](rv: Gen[R, A])(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+  final def checkAllM[R, A](rv: Gen[R, A])(test: A => ZTest[R, Nothing]): ZTest[R, Nothing] =
     checkStream(rv.sample)(test)
 
   /**
    * A version of `checkAllM` that accepts two random variables.
    */
-  final def checkAllM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (=> A, => B) => ZTest[R, Nothing]
-  ): ZTest[R, Nothing] =
-    checkAllM(rv1 <*> rv2) { case (a, b) => test(a, b) }
+  final def checkAllM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkAllM(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkAllM` that accepts three random variables.
    */
   final def checkAllM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (=> A, => B, => C) => ZTest[R, Nothing]
+    test: (A, B, C) => ZTest[R, Nothing]
   ): ZTest[R, Nothing] =
-    checkAllM(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+    checkAllM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `checkAllM` that accepts four random variables.
    */
   final def checkAllM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (=> A, => B, => C, => D) => ZTest[R, Nothing]
+    test: (A, B, C, D) => ZTest[R, Nothing]
   ): ZTest[R, Nothing] =
-    checkAllM(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+    checkAllM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the test passes for the specified number of samples from the given
    * random variable.
    */
-  final def checkSome[R, A](rv: Gen[R, A])(n: Int)(test: (=> A) => TestResult): ZTest[R, Nothing] =
+  final def checkSome[R, A](rv: Gen[R, A])(n: Int)(test: A => TestResult): ZTest[R, Nothing] =
     checkSomeM(rv)(n)(test andThen ZIO.succeed)
 
   /**
    * A version of `checkSome` that accepts two random variables.
    */
-  final def checkSome[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    n: Int
-  )(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
-    checkSome(rv1 <*> rv2)(n) { case (a, b) => test(a, b) }
+  final def checkSome[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(n: Int)(test: (A, B) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2)(n)(test.tupled)
 
   /**
    * A version of `checkSome` that accepts three random variables.
    */
   final def checkSome[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (=> A, => B, => C) => TestResult): ZTest[R, Nothing] =
-    checkSome(rv1 <*> rv2 <*> rv3)(n) { case ((a, b), c) => test(a, b, c) }
+  )(test: (A, B, C) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2 <*> rv3)(n)(reassociate(test))
 
   /**
    * A version of `checkSome` that accepts four random variables.
    */
   final def checkSome[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (=> A, => B, => C, => D) => TestResult): ZTest[R, Nothing] =
-    checkSome(rv1 <*> rv2 <*> rv3 <*> rv4)(n) { case (((a, b), c), d) => test(a, b, c, d) }
+  )(test: (A, B, C, D) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2 <*> rv3 <*> rv4)(n)(reassociate(test))
 
   /**
    * Checks the effectual test passes for the specified number of samples from
    * the given random variable.
    */
-  final def checkSomeM[R, A](rv: Gen[R, A])(n: Int)(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+  final def checkSomeM[R, A](rv: Gen[R, A])(n: Int)(test: A => ZTest[R, Nothing]): ZTest[R, Nothing] =
     checkStream(rv.sample.forever.take(n))(test)
 
   /**
@@ -186,30 +180,30 @@ trait CheckVariants {
    */
   final def checkSomeM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
-  )(test: (=> A, => B) => ZTest[R, Nothing]): ZTest[R, Nothing] =
-    checkSomeM(rv1 <*> rv2)(n) { case (a, b) => test(a, b) }
+  )(test: (A, B) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2)(n)(test.tupled)
 
   /**
    * A version of `checkSomeM` that accepts three random variables.
    */
   final def checkSomeM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (=> A, => B, => C) => ZTest[R, Nothing]): ZTest[R, Nothing] =
-    checkSomeM(rv1 <*> rv2 <*> rv3)(n) { case ((a, b), c) => test(a, b, c) }
+  )(test: (A, B, C) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2 <*> rv3)(n)(reassociate(test))
 
   /**
    * A version of `checkSomeM` that accepts four random variables.
    */
   final def checkSomeM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (=> A, => B, => C, => D) => ZTest[R, Nothing]): ZTest[R, Nothing] =
-    checkSomeM(rv1 <*> rv2 <*> rv3 <*> rv4)(n) { case (((a, b), c), d) => test(a, b, c, d) }
+  )(test: (A, B, C, D) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2 <*> rv3 <*> rv4)(n)(reassociate(test))
 
   private final def checkStream[R, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
-    test: (=> A) => ZTest[R, Nothing]
+    test: A => ZTest[R, Nothing]
   ): ZIO[R, Nothing, TestResult] =
     stream
-      .mapM(_.traverse(test(_)))
+      .mapM(_.traverse(test))
       .dropWhile(!_.value.failure) // Drop until we get to a failure
       .take(1)                     // Get the first failure
       .flatMap(_.shrinkSearch(_.failure).take(maxShrinks))
@@ -218,4 +212,12 @@ trait CheckVariants {
         // Get the "last" failure, the smallest according to the shrinker:
         failures.reverse.headOption.fold[TestResult](AssertResult.Success)(identity)
       }
+
+  private final def reassociate[A, B, C, D](f: (A, B, C) => D): (((A, B), C)) => D = {
+    case ((a, b), c) => f(a, b, c)
+  }
+
+  private final def reassociate[A, B, C, D, E](f: (A, B, C, D) => E): ((((A, B), C), D)) => E = {
+    case (((a, b), c), d) => f(a, b, c, d)
+  }
 }

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.ZIO
+import zio.stream.{ ZSink, ZStream }
+
+trait CheckVariants {
+
+  /**
+   * Checks the test passes for "sufficient" numbers of samples from the
+   * given random variable.
+   */
+  final def check[R, A](rv: Gen[R, A])(test: (=> A) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv)(200)(test)
+
+  /**
+   * A version of `check` that accepts two random variables.
+   */
+  final def check[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
+    check(rv1 <*> rv2) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `check` that accepts three random variables.
+   */
+  final def check[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (=> A, => B, => C) => TestResult
+  ): ZTest[R, Nothing] =
+    check(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `check` that accepts four random variables.
+   */
+  final def check[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (=> A, => B, => C, => D) => TestResult
+  ): ZTest[R, Nothing] =
+    check(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  /**
+   * Checks the effectual test passes for "sufficient" numbers of samples from
+   * the given random variable.
+   */
+  final def checkM[R, A](rv: Gen[R, A])(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv)(200)(test)
+
+  /**
+   * A version of `checkM` that accepts two random variables.
+   */
+  final def checkM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (=> A, => B) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkM(rv1 <*> rv2) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `checkM` that accepts three random variables.
+   */
+  final def checkM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (=> A, => B, => C) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkM(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `checkM` that accepts four random variables.
+   */
+  final def checkM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (=> A, => B, => C, => D) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkM(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  /**
+   * Checks the test passes for all values from the given random variable. This
+   * is useful for deterministic `Gen` that comprehensively explore all
+   * possibilities in a given domain.
+   */
+  final def checkAll[R, A](rv: Gen[R, A])(test: (=> A) => TestResult): ZTest[R, Nothing] =
+    checkAllM(rv)(test andThen ZIO.succeed)
+
+  /**
+   * A version of `checkAll` that accepts two random variables.
+   */
+  final def checkAll[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
+    checkAll(rv1 <*> rv2) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `checkAll` that accepts three random variables.
+   */
+  final def checkAll[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (=> A, => B, => C) => TestResult
+  ): ZTest[R, Nothing] =
+    checkAll(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `checkAll` that accepts four random variables.
+   */
+  final def checkAll[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (=> A, => B, => C, => D) => TestResult
+  ): ZTest[R, Nothing] =
+    checkAll(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  /**
+   * Checks the effectual test passes for all values from the given random
+   * variable. This is useful for deterministic `Gen` that comprehensively
+   * explore all possibilities in a given domain.
+   */
+  final def checkAllM[R, A](rv: Gen[R, A])(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkStream(rv.sample)(test)
+
+  /**
+   * A version of `checkAllM` that accepts two random variables.
+   */
+  final def checkAllM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (=> A, => B) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkAllM(rv1 <*> rv2) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `checkAllM` that accepts three random variables.
+   */
+  final def checkAllM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (=> A, => B, => C) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkAllM(rv1 <*> rv2 <*> rv3) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `checkAllM` that accepts four random variables.
+   */
+  final def checkAllM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (=> A, => B, => C, => D) => ZTest[R, Nothing]
+  ): ZTest[R, Nothing] =
+    checkAllM(rv1 <*> rv2 <*> rv3 <*> rv4) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  /**
+   * Checks the test passes for the specified number of samples from the given
+   * random variable.
+   */
+  final def checkSome[R, A](rv: Gen[R, A])(n: Int)(test: (=> A) => TestResult): ZTest[R, Nothing] =
+    checkSomeM(rv)(n)(test andThen ZIO.succeed)
+
+  /**
+   * A version of `checkSome` that accepts two random variables.
+   */
+  final def checkSome[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    n: Int
+  )(test: (=> A, => B) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2)(n) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `checkSome` that accepts three random variables.
+   */
+  final def checkSome[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    n: Int
+  )(test: (=> A, => B, => C) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2 <*> rv3)(n) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `checkSome` that accepts four random variables.
+   */
+  final def checkSome[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    n: Int
+  )(test: (=> A, => B, => C, => D) => TestResult): ZTest[R, Nothing] =
+    checkSome(rv1 <*> rv2 <*> rv3 <*> rv4)(n) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  /**
+   * Checks the effectual test passes for the specified number of samples from
+   * the given random variable.
+   */
+  final def checkSomeM[R, A](rv: Gen[R, A])(n: Int)(test: (=> A) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkStream(rv.sample.forever.take(n))(test)
+
+  /**
+   * A version of `checkSomeM` that accepts two random variables.
+   */
+  final def checkSomeM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    n: Int
+  )(test: (=> A, => B) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2)(n) { case (a, b) => test(a, b) }
+
+  /**
+   * A version of `checkSomeM` that accepts three random variables.
+   */
+  final def checkSomeM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    n: Int
+  )(test: (=> A, => B, => C) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2 <*> rv3)(n) { case ((a, b), c) => test(a, b, c) }
+
+  /**
+   * A version of `checkSomeM` that accepts four random variables.
+   */
+  final def checkSomeM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    n: Int
+  )(test: (=> A, => B, => C, => D) => ZTest[R, Nothing]): ZTest[R, Nothing] =
+    checkSomeM(rv1 <*> rv2 <*> rv3 <*> rv4)(n) { case (((a, b), c), d) => test(a, b, c, d) }
+
+  private final def checkStream[R, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
+    test: (=> A) => ZTest[R, Nothing]
+  ): ZIO[R, Nothing, TestResult] =
+    stream
+      .mapM(_.traverse(test(_)))
+      .dropWhile(!_.value.failure) // Drop until we get to a failure
+      .take(1)                     // Get the first failure
+      .flatMap(_.shrinkSearch(_.failure).take(maxShrinks))
+      .run(ZSink.collectAll[TestResult]) // Collect all the shrunken failures
+      .map { failures =>
+        // Get the "last" failure, the smallest according to the shrinker:
+        failures.reverse.headOption.fold[TestResult](AssertResult.Success)(identity)
+      }
+}

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -16,6 +16,7 @@
 
 package zio.test
 
+import zio.ZIO
 import zio.stream.ZStream
 
 /**
@@ -40,6 +41,9 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
       ZStream.empty
     else
       ZStream(value) ++ shrink.dropWhile(v => !(f(v.value))).take(1).flatMap(_.shrinkSearch(f))
+
+  final def traverse[R1 <: R, B](f: A => ZIO[R1, Nothing, B]): ZIO[R1, Nothing, Sample[R1, B]] =
+    f(value).map(Sample(_, shrink.mapM(_.traverse(f))))
 
   final def zip[R1 <: R, B](that: Sample[R1, B]): Sample[R1, (A, B)] =
     self.flatMap(a => that.map(b => (a, b)))

--- a/test/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -1,0 +1,49 @@
+package zio.test
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+import zio.{ random, Chunk, DefaultRuntime }
+import zio.test.Assertion.{ equalTo, isLessThan }
+import zio.test.TestUtils.label
+
+object CheckSpec extends DefaultRuntime {
+
+  def run(implicit ec: ExecutionContext): List[Future[(Boolean, String)]] = List(
+    label(effectualPropertiesCanBeTests, "effectual properties can be tested"),
+    label(overloadedCheckMethodsWork, "overloaded check methods work"),
+    label(testsCanBeWrittenInPropertyBasedStyle, "tests can be written in property based style")
+  )
+
+  def effectualPropertiesCanBeTests: Future[Boolean] =
+    unsafeRunToFuture {
+      val nextInt = checkM(Gen.int(1, 100)) { n =>
+        for {
+          r <- random.nextInt(n)
+        } yield assert(r, isLessThan(n))
+      }
+      nextInt.map(_.success)
+    }
+
+  def overloadedCheckMethodsWork: Future[Boolean] =
+    unsafeRunToFuture {
+      val associativity = check(Gen.anyInt, Gen.anyInt, Gen.anyInt) { (x, y, z) =>
+        assert((x + y) + z, equalTo(x + (y + z)))
+      }
+      associativity.map(_.success)
+    }
+
+  def testsCanBeWrittenInPropertyBasedStyle: Future[Boolean] =
+    unsafeRunToFuture {
+      val chunkWithLength = for {
+        n      <- Gen.int(1, 100)
+        i      <- Gen.int(0, n - 1)
+        vector <- Gen.vectorOfN(n)(Gen.int(0, 100))
+        chunk  = Chunk.fromIterable(vector)
+      } yield (chunk, i)
+      val chunkApply = check(chunkWithLength) {
+        case (chunk, i) =>
+          assert(chunk.apply(i), equalTo(chunk.toSeq.apply(i)))
+      }
+      chunkApply.map(_.success)
+    }
+}

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -295,7 +295,7 @@ object GenSpec extends DefaultRuntime {
       as <- Gen.int(0, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
       bs <- Gen.int(0, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
     } yield (as, bs)
-    def test(a: => (List[Int], List[Int])): TestResult = a match {
+    def test(a: (List[Int], List[Int])): TestResult = a match {
       case (as, bs) =>
         val p = (as ++ bs).reverse == (as.reverse ++ bs.reverse)
         if (p) AssertResult.success else assert((as, bs), Assertion.nothing)
@@ -312,8 +312,8 @@ object GenSpec extends DefaultRuntime {
   }
 
   def testShrinkingNonEmptyList: Future[Boolean] = {
-    val gen                               = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
-    def test(a: => List[Int]): TestResult = assert(a, Assertion.nothing)
+    val gen                            = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
+    def test(a: List[Int]): TestResult = assert(a, Assertion.nothing)
     val property = checkSome(gen)(100)(test).map {
       case AssertResult.Failure(FailureDetails.Assertion(fragment, _)) =>
         fragment.value.toString == "List(0)"
@@ -324,7 +324,7 @@ object GenSpec extends DefaultRuntime {
 
   def testBogusEvenProperty: Future[Boolean] = {
     val gen = Gen.int(0, 100)
-    def test(n: => Int): TestResult = {
+    def test(n: Int): TestResult = {
       val p = n % 2 == 0
       if (p) AssertResult.success else assert(n, Assertion.nothing)
     }

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -295,12 +295,12 @@ object GenSpec extends DefaultRuntime {
       as <- Gen.int(0, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
       bs <- Gen.int(0, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
     } yield (as, bs)
-    val assertion = Assertion.assertion[(List[Int], List[Int])]("") {
+    def test(a: => (List[Int], List[Int])): TestResult = a match {
       case (as, bs) =>
         val p = (as ++ bs).reverse == (as.reverse ++ bs.reverse)
-        if (p) AssertResult.success else AssertResult.Failure(())
+        if (p) AssertResult.success else assert((as, bs), Assertion.nothing)
     }
-    val test = checkSome(100)(gen)(assertion).map {
+    val property = checkSome(gen)(100)(test).map {
       case AssertResult.Failure(FailureDetails.Assertion(fragment, _)) =>
         fragment.value.toString == "(List(0),List(1))" ||
           fragment.value.toString == "(List(1),List(0))" ||
@@ -308,32 +308,32 @@ object GenSpec extends DefaultRuntime {
           fragment.value.toString == "(List(-1),List(0))"
       case _ => false
     }
-    unsafeRunToFuture(test)
+    unsafeRunToFuture(property)
   }
 
   def testShrinkingNonEmptyList: Future[Boolean] = {
-    val gen       = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
-    val assertion = Assertion.assertion[List[Int]]("")(_ => AssertResult.Failure(()))
-    val test = checkSome(100)(gen)(assertion).map {
+    val gen                               = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
+    def test(a: => List[Int]): TestResult = assert(a, Assertion.nothing)
+    val property = checkSome(gen)(100)(test).map {
       case AssertResult.Failure(FailureDetails.Assertion(fragment, _)) =>
         fragment.value.toString == "List(0)"
       case _ => false
     }
-    unsafeRunToFuture(test)
+    unsafeRunToFuture(property)
   }
 
   def testBogusEvenProperty: Future[Boolean] = {
     val gen = Gen.int(0, 100)
-    val assertion = Assertion.assertion[Int]("") { n =>
+    def test(n: => Int): TestResult = {
       val p = n % 2 == 0
-      if (p) AssertResult.Success else AssertResult.Failure(())
+      if (p) AssertResult.success else assert(n, Assertion.nothing)
     }
-    val test = checkSome(100)(gen)(assertion).map {
+    val property = checkSome(gen)(100)(test).map {
       case AssertResult.Failure(FailureDetails.Assertion(fragment, _)) =>
         fragment.value.toString == "1"
       case _ => false
     }
-    unsafeRunToFuture(test)
+    unsafeRunToFuture(property)
   }
 
   def checkEqual[A](left: Gen[Random, A], right: Gen[Random, A]): Future[Boolean] =

--- a/test/shared/src/test/scala/zio/test/SampleSpec.scala
+++ b/test/shared/src/test/scala/zio/test/SampleSpec.scala
@@ -1,0 +1,67 @@
+package zio.test
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+import zio.{ DefaultRuntime, UIO, ZIO }
+import zio.stream.ZStream
+import zio.test.TestUtils.label
+
+object SampleSpec extends DefaultRuntime {
+
+  def run(implicit ec: ExecutionContext): List[Future[(Boolean, String)]] = List(
+    label(monadLeftIdentity, "monad left identity"),
+    label(monadRightIdentity, "monad right identity"),
+    label(monadAssociativity, "monad associativity"),
+    label(traverseFusion, "traverse fusion")
+  )
+
+  def monadLeftIdentity: Future[Boolean] =
+    unsafeRunToFuture {
+      val sample = Sample.shrinkIntegral(0)(5)
+      equal(sample.flatMap(Sample.noShrink), sample)
+    }
+
+  def monadRightIdentity: Future[Boolean] =
+    unsafeRunToFuture {
+      val n                           = 5
+      def f(n: Int): Sample[Any, Int] = Sample.shrinkIntegral(0)(n)
+      equal(Sample.noShrink(n).flatMap(f), f(n))
+    }
+
+  def monadAssociativity: Future[Boolean] =
+    unsafeRunToFuture {
+      val sample                      = Sample.shrinkIntegral(0)(2)
+      def f(n: Int): Sample[Any, Int] = Sample.shrinkIntegral(0)(n + 3)
+      def g(n: Int): Sample[Any, Int] = Sample.shrinkIntegral(0)(n + 5)
+      equal(sample.flatMap(f).flatMap(g), sample.flatMap(a => f(a).flatMap(g)))
+    }
+
+  def traverseFusion: Future[Boolean] =
+    unsafeRunToFuture {
+      val sample              = Sample.shrinkIntegral(0)(5)
+      def f(n: Int): UIO[Int] = ZIO.succeed(n + 2)
+      def g(n: Int): UIO[Int] = ZIO.succeed(n * 3)
+      equal(
+        sample.traverse(a => f(a).flatMap(g)),
+        sample.traverse(f).flatMap(_.traverse(g))
+      )
+    }
+
+  def equal[A, B](a: ZIO[Any, Nothing, Sample[Any, A]], b: ZIO[Any, Nothing, Sample[Any, B]]): UIO[Boolean] =
+    for {
+      a      <- a
+      b      <- b
+      result <- equal(a, b)
+    } yield result
+
+  def equal[A, B](a: Sample[Any, A], b: Sample[Any, B]): UIO[Boolean] =
+    equal(a.shrink, b.shrink).map(_ && (a.value == b.value))
+
+  def equal[A, B](a: ZStream[Any, Nothing, Sample[Any, A]], b: ZStream[Any, Nothing, Sample[Any, B]]): UIO[Boolean] =
+    for {
+      as <- a.runCollect
+      bs <- b.runCollect
+      result <- if (as.length != bs.length) ZIO.succeed(false)
+               else ZIO.foreach(as.zip(bs)) { case (a, b) => equal(a, b) }.map(_.forall(identity))
+    } yield result
+}

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -10,6 +10,7 @@ object TestMain {
   def main(args: Array[String]): Unit = {
     val testResults = List(
       scope(AssertionSpec.run, "Assertion"),
+      scope(CheckSpec.run, "Check"),
       scope(ClockSpec.run, "MockClock"),
       scope(ConsoleSpec.run, "MockConsole"),
       scope(DefaultTestReporterSpec.run, "DefaultTestReporter"),
@@ -17,6 +18,7 @@ object TestMain {
       scope(GenSpec.run, "Gen"),
       scope(LiveSpec.run, "Live"),
       scope(RandomSpec.run, "MockRandom"),
+      scope(SampleSpec.run, "Sample"),
       scope(SchedulerSpec.run, "MockScheduler"),
       scope(SystemSpec.run, "MockSystem")
     ).flatten


### PR DESCRIPTION
Changes `check` methods to accept a function that produces a test result instead of an assertion. Adds `checkM`, `checkAllM`, and `checkSomeM` methods for testing effectual properties. Adds overloaded methods that accept multiple generators. Resolves #1527. Resolves #1528.