### PR TITLE
Fix Type Inference Issue with ZIO#retry

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -990,8 +990,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1 with Clock, E1, A] =
-    retryOrElse[R1, A, E1, S, E1](policy, (e: E1, _: S) => ZIO.fail(e))
+  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1 with Clock, E, A] =
+    retryOrElse(policy, (e: E, _: S) => ZIO.fail(e))
 
   /**
    * Retries with the specified schedule, until it fails, and then both the
@@ -1000,7 +1000,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def retryOrElse[R1 <: R, A2 >: A, E1 >: E, S, E2](
     policy: ZSchedule[R1, E1, S],
-    orElse: (E1, S) => ZIO[R1, E2, A2]
+    orElse: (E, S) => ZIO[R1, E2, A2]
   ): ZIO[R1 with Clock, E2, A2] =
     retryOrElseEither(policy, orElse).map(_.merge)
 
@@ -1011,7 +1011,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def retryOrElseEither[R1 <: R, E1 >: E, S, E2, B](
     policy: ZSchedule[R1, E1, S],
-    orElse: (E1, S) => ZIO[R1, E2, B]
+    orElse: (E, S) => ZIO[R1, E2, B]
   ): ZIO[R1 with Clock, E2, Either[B, A]] = {
     def loop(state: policy.State): ZIO[R1 with Clock, E2, Either[B, A]] =
       self.foldM(


### PR DESCRIPTION
Resolves #1502.

@jdegoes The issue actually wasn't with the `R` parameter but the `E` parameter.

The previous type signature of `retry` was wrong.

```scala
final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1 with Clock, E1, A]
```

Notice that we are widening `E` to the `E1` type of the `Schedule`, as if the `Schedule` produced errors so the resulting error type needs to be the union of the two. But the `Schedule` doesn't produce errors, it consumes them! Its `E1` type parameter needs to be a superset of `E` so it can handle all the errors that the effect produces, but any actual error that remains is guaranteed to be of type `E`. The correct type signature should be:

```scala
final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1 with Clock, E, A]
```

I made the appropriate changes to `retry`, `retryOrElse`, and `retryOrElseEither` and added a test to prevent regression. Interestingly, the same issue did not exist with `repeat` and related combinators.