### PR TITLE
Require all builds to pass for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,6 +416,14 @@ workflows:
             - test_211_jdk11_jvm
             - test_211_jdk8_js
             - test_211_jdk11_js
+            - test_212_jdk8_jvm
+            - test_212_jdk11_jvm
+            - test_212_jdk8_js
+            - test_212_jdk11_js
+            - test_213_jdk8_jvm
+            - test_213_jdk11_jvm
+            - test_213_jdk8_js
+            - test_213_jdk11_js
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/1549. 
@ghostdogpr the tests could also be required for each release (`release_212` etc) but that would make it possible to release for 2.11 even if 2.12 tests don't pass