### PR TITLE
ZIO Test: Make Timeout Strategies Test Aspects

### DIFF
--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -1,11 +1,10 @@
 package zio
 
-import zio.duration._
 import zio.test._
 import zio.test.Assertion._
 
 object PromiseSpec
-    extends DefaultRunnableSpec(
+    extends ZIOSpec(
       suite("PromiseSpec")(
         testM("complete a promise using succeed") {
           for {
@@ -90,6 +89,5 @@ object PromiseSpec
             d <- p.isDone
           } yield assert(d, isTrue)
         }
-      ),
-      timeout = TimeoutStrategy.Error(60.seconds)
+      )
     )

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -1,12 +1,11 @@
 package zio
 
-import zio.duration._
 import zio.test._
 import zio.test.Assertion._
 import zio.RefMSpecUtils._
 
 object RefMSpec
-    extends DefaultRunnableSpec(
+    extends ZIOSpec(
       suite("RefMSpec")(
         testM("get") {
           for {
@@ -103,8 +102,7 @@ object RefMSpec
             value <- refM.modifySome("State doesn't change") { case Active => IO.fail(failure) }.run
           } yield assert(value, fails(equalTo(failure)))
         }
-      ),
-      timeout = TimeoutStrategy.Error(60.seconds)
+      )
     )
 
 object RefMSpecUtils {

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -1,12 +1,11 @@
 package zio
 
-import zio.duration._
 import zio.test._
 import zio.test.Assertion._
 import zio.RefSpecUtils._
 
 object RefSpec
-    extends DefaultRunnableSpec(
+    extends ZIOSpec(
       suite("RefSpec")(
         testM("get") {
           for {
@@ -66,8 +65,7 @@ object RefSpec
                      }
           } yield assert(value1, equalTo("changed")) && assert(value2, equalTo("closed"))
         }
-      ),
-      timeout = TimeoutStrategy.Error(60.seconds)
+      )
     )
 
 object RefSpecUtils {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1,0 +1,9 @@
+package zio
+
+import zio.duration._
+
+import zio.test._
+import zio.test.mock._
+
+abstract class ZIOSpec(spec: => ZSpec[MockEnvironment, Any, String, Any])
+    extends DefaultRunnableSpec(spec, List(TestAspect.timeout(60.seconds)))

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -9,7 +9,7 @@ import zio.test.TestUtils.nonFlaky
 import zio.ZQueueSpecUtil.waitForSize
 
 object ZQueueSpec
-    extends DefaultRunnableSpec(
+    extends ZIOSpec(
       suite("ZQueueSpec")(
         testM("sequential offer and take") {
           for {
@@ -731,8 +731,7 @@ object ZQueueSpec
             } yield true
           }.map(assert(_, isTrue))
         }
-      ),
-      timeout = TimeoutStrategy.Error(60.seconds)
+      )
     )
 
 object ZQueueSpecUtil {

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -25,5 +25,7 @@ import zio.test.mock.MockEnvironment
  */
 abstract class DefaultRunnableSpec(
   spec: => ZSpec[MockEnvironment, Any, String, Any],
-  timeout: TimeoutStrategy = TimeoutStrategy.Warn(60.seconds)
-) extends RunnableSpec(DefaultTestRunner)(timeout(spec))
+  defautlTestAspects: List[TestAspect[Nothing, MockEnvironment, Nothing, Any, Nothing, Any]] = List(
+    TestAspect.timeoutWarning(60.seconds)
+  )
+) extends RunnableSpec(DefaultTestRunner)(defautlTestAspects.foldLeft(spec)(_ @@ _))

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -89,7 +89,7 @@ trait TestAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerS, -UpperS] { self =>
   ): TestAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerS1, UpperS1] =
     self >>> that
 }
-object TestAspect {
+object TestAspect extends TimeoutVariants {
 
   /**
    * Constructs an aspect that runs the specified effect after every test.


### PR DESCRIPTION
Resolves #1543.

I made `TimeoutStrategy.Warn` a test aspect and put it in `TimeoutVariants.scala` that `TestAspect.scala` extends, since there are a lot of implementation specific details for printing the timeout warnings that I didn't want to clutter up `TestAspect` with. `TimeoutStrategy.Error` and `TimeoutStrategy.Ignore` go away since they are redundant with `TestAspect.timeout` and `TestAspect.identity`.

I changed the second parameter in `DefaultRunnableSpec` to be `defaultTestAspects` and take a list of test aspects to apply to the spec, with a default parameter of `timeoutWarning(60.seconds)`. So it becomes a little more general if in the future there are other test aspects we want to have as overridable defaults.

We were still figuring out the details of the solution we wanted here so happy to take it in another direction but thought it would be good if we had a starting point.