### PR TITLE
ZIO Test: Fix Issue with AssertM

### DIFF
--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -25,13 +25,13 @@ trait CheckVariants {
    * Checks the test passes for "sufficient" numbers of samples from the
    * given random variable.
    */
-  final def check[R, A](rv: Gen[R, A])(test: A => TestResult): ZTest[R, Nothing, Unit] =
+  final def check[R, A](rv: Gen[R, A])(test: A => TestResult): ZIO[R, Nothing, TestResult] =
     checkSome(rv)(200)(test)
 
   /**
    * A version of `check` that accepts two random variables.
    */
-  final def check[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZTest[R, Nothing, Unit] =
+  final def check[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZIO[R, Nothing, TestResult] =
     check(rv1 <*> rv2)(test.tupled)
 
   /**
@@ -39,7 +39,7 @@ trait CheckVariants {
    */
   final def check[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => TestResult
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     check(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
@@ -47,14 +47,14 @@ trait CheckVariants {
    */
   final def check[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => TestResult
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the effectual test passes for "sufficient" numbers of samples from
    * the given random variable.
    */
-  final def checkM[R, A](rv: Gen[R, A])(test: A => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  final def checkM[R, A](rv: Gen[R, A])(test: A => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkSomeM(rv)(200)(test)
 
   /**
@@ -62,7 +62,7 @@ trait CheckVariants {
    */
   final def checkM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkM(rv1 <*> rv2)(test.tupled)
 
   /**
@@ -70,7 +70,7 @@ trait CheckVariants {
    */
   final def checkM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
@@ -78,7 +78,7 @@ trait CheckVariants {
    */
   final def checkM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
@@ -86,13 +86,13 @@ trait CheckVariants {
    * is useful for deterministic `Gen` that comprehensively explore all
    * possibilities in a given domain.
    */
-  final def checkAll[R, A](rv: Gen[R, A])(test: A => TestResult): ZTest[R, Nothing, Unit] =
+  final def checkAll[R, A](rv: Gen[R, A])(test: A => TestResult): ZIO[R, Nothing, TestResult] =
     checkAllM(rv)(test andThen ZIO.succeed)
 
   /**
    * A version of `checkAll` that accepts two random variables.
    */
-  final def checkAll[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZTest[R, Nothing, Unit] =
+  final def checkAll[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(test: (A, B) => TestResult): ZIO[R, Nothing, TestResult] =
     checkAll(rv1 <*> rv2)(test.tupled)
 
   /**
@@ -100,7 +100,7 @@ trait CheckVariants {
    */
   final def checkAll[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => TestResult
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
@@ -108,7 +108,7 @@ trait CheckVariants {
    */
   final def checkAll[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => TestResult
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
@@ -116,7 +116,7 @@ trait CheckVariants {
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
-  final def checkAllM[R, A](rv: Gen[R, A])(test: A => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  final def checkAllM[R, A](rv: Gen[R, A])(test: A => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkStream(rv.sample)(test)
 
   /**
@@ -124,7 +124,7 @@ trait CheckVariants {
    */
   final def checkAllM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkAllM(rv1 <*> rv2)(test.tupled)
 
   /**
@@ -132,7 +132,7 @@ trait CheckVariants {
    */
   final def checkAllM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkAllM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
@@ -140,14 +140,14 @@ trait CheckVariants {
    */
   final def checkAllM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     checkAllM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
    * Checks the test passes for the specified number of samples from the given
    * random variable.
    */
-  final def checkSome[R, A](rv: Gen[R, A])(n: Int)(test: A => TestResult): ZTest[R, Nothing, Unit] =
+  final def checkSome[R, A](rv: Gen[R, A])(n: Int)(test: A => TestResult): ZIO[R, Nothing, TestResult] =
     checkSomeM(rv)(n)(test andThen ZIO.succeed)
 
   /**
@@ -155,7 +155,7 @@ trait CheckVariants {
    */
   final def checkSome[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
-  )(test: (A, B) => TestResult): ZTest[R, Nothing, Unit] =
+  )(test: (A, B) => TestResult): ZIO[R, Nothing, TestResult] =
     checkSome(rv1 <*> rv2)(n)(test.tupled)
 
   /**
@@ -163,7 +163,7 @@ trait CheckVariants {
    */
   final def checkSome[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (A, B, C) => TestResult): ZTest[R, Nothing, Unit] =
+  )(test: (A, B, C) => TestResult): ZIO[R, Nothing, TestResult] =
     checkSome(rv1 <*> rv2 <*> rv3)(n)(reassociate(test))
 
   /**
@@ -171,14 +171,16 @@ trait CheckVariants {
    */
   final def checkSome[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (A, B, C, D) => TestResult): ZTest[R, Nothing, Unit] =
+  )(test: (A, B, C, D) => TestResult): ZIO[R, Nothing, TestResult] =
     checkSome(rv1 <*> rv2 <*> rv3 <*> rv4)(n)(reassociate(test))
 
   /**
    * Checks the effectual test passes for the specified number of samples from
    * the given random variable.
    */
-  final def checkSomeM[R, A](rv: Gen[R, A])(n: Int)(test: A => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  final def checkSomeM[R, A](
+    rv: Gen[R, A]
+  )(n: Int)(test: A => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkStream(rv.sample.forever.take(n))(test)
 
   /**
@@ -186,7 +188,7 @@ trait CheckVariants {
    */
   final def checkSomeM[R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
-  )(test: (A, B) => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  )(test: (A, B) => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkSomeM(rv1 <*> rv2)(n)(test.tupled)
 
   /**
@@ -194,7 +196,7 @@ trait CheckVariants {
    */
   final def checkSomeM[R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (A, B, C) => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  )(test: (A, B, C) => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkSomeM(rv1 <*> rv2 <*> rv3)(n)(reassociate(test))
 
   /**
@@ -202,25 +204,21 @@ trait CheckVariants {
    */
   final def checkSomeM[R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (A, B, C, D) => ZIO[R, Nothing, TestResult]): ZTest[R, Nothing, Unit] =
+  )(test: (A, B, C, D) => ZIO[R, Nothing, TestResult]): ZIO[R, Nothing, TestResult] =
     checkSomeM(rv1 <*> rv2 <*> rv3 <*> rv4)(n)(reassociate(test))
 
   private final def checkStream[R, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
     test: A => ZIO[R, Nothing, TestResult]
-  ): ZTest[R, Nothing, Unit] =
+  ): ZIO[R, Nothing, TestResult] =
     stream
       .mapM(_.traverse(test))
       .dropWhile(!_.value.isFailure) // Drop until we get to a failure
       .take(1)                       // Get the first failure
       .flatMap(_.shrinkSearch(_.isFailure).take(maxShrinks))
       .run(ZSink.collectAll[TestResult]) // Collect all the shrunken failures
-      .flatMap { failures =>
+      .map { failures =>
         // Get the "last" failure, the smallest according to the shrinker:
-        failures.reverse.headOption.fold[ZTest[R, Nothing, Unit]] {
-          ZIO.succeed(TestSuccess.Succeeded(AssertResult.unit))
-        } { result =>
-          ZIO.fail(TestFailure.Assertion(result.failures.get))
-        }
+        failures.reverse.headOption.fold[TestResult](AssertResult.success(()))(identity)
       }
 
   private final def reassociate[A, B, C, D](f: (A, B, C) => D): (((A, B), C)) => D = {

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -103,13 +103,8 @@ package object test extends CheckVariants {
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  final def assertM[R, A](value: ZIO[R, Nothing, A], assertion: Assertion[A]): ZTest[R, Nothing, Unit] =
-    value.flatMap { a =>
-      assert(a, assertion).failures match {
-        case None           => ZIO.succeed(TestSuccess.Succeeded(AssertResult.unit))
-        case Some(failures) => ZIO.fail(TestFailure.Assertion(failures))
-      }
-    }
+  final def assertM[R, A](value: ZIO[R, Nothing, A], assertion: Assertion[A]): ZIO[R, Nothing, TestResult] =
+    value.map(assert(_, assertion))
 
   /**
    * Creates a failed test result with the specified runtime cause.

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -300,33 +300,25 @@ object GenSpec extends DefaultRuntime {
         val p = (as ++ bs).reverse == (as.reverse ++ bs.reverse)
         if (p) AssertResult.success(()) else assert((as, bs), Assertion.nothing)
     }
-    val property = checkSome(gen)(100)(test).fold(
-      {
-        case TestFailure.Assertion(AssertResult.Value(failureDetails)) =>
-          failureDetails.fragment.value.toString == "(List(0),List(1))" ||
-            failureDetails.fragment.value.toString == "(List(1),List(0))" ||
-            failureDetails.fragment.value.toString == "(List(0),List(-1))" ||
-            failureDetails.fragment.value.toString == "(List(-1),List(0))"
-        case _ => false
-      }, { _ =>
-        false
-      }
-    )
+    val property = checkSome(gen)(100)(test).map {
+      case AssertResult.Value(Left(failureDetails)) =>
+        failureDetails.fragment.value.toString == "(List(0),List(1))" ||
+          failureDetails.fragment.value.toString == "(List(1),List(0))" ||
+          failureDetails.fragment.value.toString == "(List(0),List(-1))" ||
+          failureDetails.fragment.value.toString == "(List(-1),List(0))"
+      case _ => false
+    }
     unsafeRunToFuture(property)
   }
 
   def testShrinkingNonEmptyList: Future[Boolean] = {
     val gen                            = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
     def test(a: List[Int]): TestResult = assert(a, Assertion.nothing)
-    val property = checkSome(gen)(100)(test).fold(
-      {
-        case TestFailure.Assertion(AssertResult.Value(failureDetails)) =>
-          failureDetails.fragment.value.toString == "List(0)"
-        case _ => false
-      }, { _ =>
-        false
-      }
-    )
+    val property = checkSome(gen)(100)(test).map {
+      case AssertResult.Value(Left(failureDetails)) =>
+        failureDetails.fragment.value.toString == "List(0)"
+      case _ => false
+    }
     unsafeRunToFuture(property)
   }
 
@@ -336,15 +328,11 @@ object GenSpec extends DefaultRuntime {
       val p = n % 2 == 0
       if (p) AssertResult.success(()) else assert(n, Assertion.nothing)
     }
-    val property = checkSome(gen)(100)(test).fold(
-      {
-        case TestFailure.Assertion(AssertResult.Value(failureDetails)) =>
-          failureDetails.fragment.value.toString == "1"
-        case _ => false
-      }, { _ =>
-        false
-      }
-    )
+    val property = checkSome(gen)(100)(test).map {
+      case AssertResult.Value(Left(failureDetails)) =>
+        failureDetails.fragment.value.toString == "1"
+      case _ => false
+    }
     unsafeRunToFuture(property)
   }
 

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -22,7 +22,8 @@ object TestMain {
       scope(SampleSpec.run, "SampleSpec"),
       scope(SchedulerSpec.run, "SchedulerSpec"),
       scope(SystemSpec.run, "SystemSpec"),
-      scope(TestAspectSpec.run, "TestAspectSpec")
+      scope(TestAspectSpec.run, "TestAspectSpec"),
+      scope(TestSpec.run, "TestSpec")
     )
     report(testResults)
   }

--- a/test/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test/shared/src/test/scala/zio/test/TestSpec.scala
@@ -1,0 +1,24 @@
+package zio.test
+
+import scala.concurrent.Future
+
+import zio.DefaultRuntime
+import zio.test.Assertion.equalTo
+import zio.test.TestUtils.{ label, succeeded }
+import zio.clock._
+import zio.test.Assertion._
+
+object TestSpec extends DefaultRuntime {
+
+  val run: List[Async[(Boolean, String)]] = List(
+    label(assertMWorksCorrectly, "assertM works correctly")
+  )
+
+  def assertMWorksCorrectly: Future[Boolean] =
+    unsafeRunToFuture {
+      val spec = testM("time is non-zero") {
+        assertM(nanoTime, equalTo(0L))
+      }
+      succeeded(spec)
+    }
+}


### PR DESCRIPTION
Our nice syntax from the documentation of being able to write the below is not currently working because `testM` expects a `ZIO[R, Nothing, TestResult]` but assertM returns a `ZIO[R, TestFailure[E], TestSuccess[S]]`. It is important for `testM` to accept a `ZIO[R, Nothing, TestResult]` so that assertion failures can still be on the "happy path" and users can write tests using `assert` with nice monadic syntax, as is already common in the test suites that have been migrated to ZIO Test.

This PR modifies `assertM` to return a `ZIO[R, Nothing, TestResult]` to fix this. I also made the same change to the `check` variants so they can also be used with `testM` and added tests for this.

```scala
testM("time is zero") {
  assertM(nanoTime, equalTo(0L))
}
```

Thanks to @DmytroOrlov for identifying the issue!