### PR TITLE
Implement ZStreamChunk#drop and ZStreamChunk#take

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -52,7 +52,7 @@ sealed trait Chunk[@specialized +A] { self =>
     val len = self.length
 
     if (n <= 0) self
-    else if (n == len) Chunk.empty
+    else if (n >= len) Chunk.empty
     else
       self match {
         case Chunk.Slice(c, o, l)        => Chunk.Slice(c, o + n, l - n)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -19,6 +19,7 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
   StreamChunk.filterNot     $filterNot
   StreamChunk.mapConcat     $mapConcat
   StreamChunk.dropWhile     $dropWhile
+  StreamChunk.take          $take
   StreamChunk.takeWhile     $takeWhile
   StreamChunk.mapAccum      $mapAccum
   StreamChunk.mapM          $mapM
@@ -29,7 +30,7 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
   StreamChunk.monadLaw1     $monadLaw1
   StreamChunk.monadLaw2     $monadLaw2
   StreamChunk.monadLaw3     $monadLaw3
-  StreamChunk.tap    $tap
+  StreamChunk.tap           $tap
   StreamChunk.foldLeft      $foldLeft
   StreamChunk.fold          $fold    
   StreamChunk.flattenChunks $flattenChunks
@@ -70,6 +71,13 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
   private def dropWhile =
     prop { (s: StreamChunk[String, String], p: String => Boolean) =>
       slurp(s.dropWhile(p)) must_=== slurp(s).map(_.dropWhile(p))
+    }
+
+  private def take =
+    prop { (s: StreamChunk[Nothing, String], n: Int) =>
+      val streamTake = slurp(s.take(n))
+      val listTake   = slurp(s).map(_.take(n))
+      streamTake must_=== listTake
     }
 
   private def takeWhile =

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -18,6 +18,7 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
   StreamChunk.filter        $filter
   StreamChunk.filterNot     $filterNot
   StreamChunk.mapConcat     $mapConcat
+  StreamChunk.drop          $drop
   StreamChunk.dropWhile     $dropWhile
   StreamChunk.take          $take
   StreamChunk.takeWhile     $takeWhile
@@ -68,6 +69,11 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
     }
   }
 
+  private def drop =
+    prop { (s: StreamChunk[String, String], n: Int) =>
+      slurp(s.drop(n)) must_=== slurp(s).map(_.drop(n))
+    }
+
   private def dropWhile =
     prop { (s: StreamChunk[String, String], p: String => Boolean) =>
       slurp(s.dropWhile(p)) must_=== slurp(s).map(_.dropWhile(p))
@@ -75,16 +81,12 @@ class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends T
 
   private def take =
     prop { (s: StreamChunk[Nothing, String], n: Int) =>
-      val streamTake = slurp(s.take(n))
-      val listTake   = slurp(s).map(_.take(n))
-      streamTake must_=== listTake
+      slurp(s.take(n)) must_=== slurp(s).map(_.take(n))
     }
 
   private def takeWhile =
     prop { (s: StreamChunk[Nothing, String], p: String => Boolean) =>
-      val streamTakeWhile = slurp(s.takeWhile(p))
-      val listTakeWhile   = slurp(s).map(_.takeWhile(p))
-      streamTakeWhile must_=== listTakeWhile
+      slurp(s.takeWhile(p)) must_=== slurp(s).map(_.takeWhile(p))
     }
 
   private def concat =

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -45,6 +45,35 @@ class ZStreamChunk[-R, +E, @specialized +A](val chunks: ZStream[R, E, Chunk[A]])
     ZStreamChunk(self.chunks.map(chunk => chunk.collect(p)))
 
   /**
+   * Drops the specified number of elements from this stream.
+   */
+  final def drop(n: Int): ZStreamChunk[R, E, A] =
+    ZStreamChunk {
+      ZStream[R, E, Chunk[A]] {
+        for {
+          chunks     <- self.chunks.process
+          counterRef <- Ref.make(n).toManaged_
+          pull = {
+            def go: Pull[R, E, Chunk[A]] =
+              chunks.flatMap { chunk =>
+                counterRef.get.flatMap { cnt =>
+                  if (cnt <= 0) Pull.emit(chunk)
+                  else {
+                    val remaining = chunk.drop(cnt)
+                    val dropped   = chunk.length - remaining.length
+                    counterRef.set(cnt - dropped) *>
+                      (if (remaining.isEmpty) go else Pull.emit(remaining))
+                  }
+                }
+              }
+
+            go
+          }
+        } yield pull
+      }
+    }
+
+  /**
    * Drops all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */


### PR DESCRIPTION
Resolves #1568.
Resolves #1569.

Fixed an interesting bug in `Chunk`. I wonder how it remained unnoticed for so long.
`(Chunk(1) ++ Chunk.empty ++ Chunk(2, 3, 4, 5, 6)).drop(8)` would fail with a `NegativeArraySizeException` (`Slice` chunks weren't checking their length when dropping elements).

@iravid 