### PR TITLE
Use Docker image to run tests and releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ install_nodejs: &install_nodejs
   - run:
       name: Install node.js
       command: |
-        curl -sL https://deb.nodesource.com/setup_10.x | -E bash -
+        curl -sL https://deb.nodesource.com/setup_10.x | bash -
         apt-get install -y nodejs
         node -v
 
@@ -136,11 +136,6 @@ microsite: &microsite
             export TRAVIS_BUILD_NUMBER="${CIRCLE_BUILD_NUM}"
             export TRAVIS_COMMIT="${CIRCLE_SHA1}"
             chown -R $USER:$USER /tmp
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install
-            nvm use
-            node -v
             ./sbt docs/docusaurusCreateSite
             ./sbt docs/docusaurusPublishGhpages
       - <<: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ install_yarn: &install_yarn
   - run:
       name: Install Yarn
       command: |
-        curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-        sudo bash -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list'
-        sudo apt update && sudo apt install yarn -y
+        curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+        bash -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list'
+        apt update && apt install yarn -y
         yarn policies set-version
         yarn -v
 
@@ -49,8 +49,8 @@ install_nodejs: &install_nodejs
   - run:
       name: Install node.js
       command: |
-        curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-        sudo apt-get install -y nodejs
+        curl -sL https://deb.nodesource.com/setup_10.x | -E bash -
+        apt-get install -y nodejs
         node -v
 
 compile: &compile
@@ -135,7 +135,7 @@ microsite: &microsite
             export GIT_USER=${GH_NAME}
             export TRAVIS_BUILD_NUMBER="${CIRCLE_BUILD_NUM}"
             export TRAVIS_COMMIT="${CIRCLE_SHA1}"
-            sudo chown -R $USER:$USER /tmp
+            chown -R $USER:$USER /tmp
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ machine_ubuntu: &machine_ubuntu
 
 docker_jvm: &docker_jvm
   docker:
-    - image: timbru31/java-node:${JDK_VERSION}
+    - image: circleci/openjdk:${JDK_VERSION}-node
 
 install_jdk: &install_jdk
   - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ machine_ubuntu: &machine_ubuntu
 
 docker_jvm: &docker_jvm
   docker:
-    - image: circleci/openjdk:${JDK_VERSION}
+    - image: circleci/openjdk:${JDK_VERSION}-jdk-node
 
 install_jdk: &install_jdk
   - run:
@@ -110,7 +110,6 @@ testJS: &testJS
   steps:
     - checkout
     - <<: *load_cache
-    - <<: *install_nodejs
     - run:
         name: Run tests
         command: ./sbt ++${SCALA_VERSION}! testJS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,22 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
+machine_ubuntu: &machine_ubuntu
+  machine:
+    image: ubuntu-1604:201903-01
+
 docker_jvm: &docker_jvm
   docker:
-    - image: adoptopenjdk/openjdk${JDK_VERSION}:latest
+    - image: timbru31/java-node:${JDK_VERSION}
+
+install_jdk: &install_jdk
+  - run:
+      name: Install JDK
+      command: |
+        while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
+        sudo add-apt-repository ppa:openjdk-r/ppa -y
+        sudo apt update
+        sudo apt install openjdk-${JDK_VERSION}-jdk -y
 
 load_cache: &load_cache
   - restore_cache:
@@ -39,9 +52,9 @@ install_yarn: &install_yarn
   - run:
       name: Install Yarn
       command: |
-        curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-        bash -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list'
-        apt update && apt install yarn -y
+        curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+        sudo bash -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list'
+        sudo apt update && sudo apt install yarn -y
         yarn policies set-version
         yarn -v
 
@@ -49,8 +62,10 @@ install_nodejs: &install_nodejs
   - run:
       name: Install node.js
       command: |
-        curl -sL https://deb.nodesource.com/setup_10.x | bash -
-        apt-get install -y nodejs
+        export NVM_DIR="/opt/circleci/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        nvm install
+        nvm use
         node -v
 
 compile: &compile
@@ -95,7 +110,6 @@ testJS: &testJS
   steps:
     - checkout
     - <<: *load_cache
-    - <<: *install_nodejs
     - run:
         name: Run tests
         command: ./sbt ++${SCALA_VERSION}! testJS
@@ -125,6 +139,7 @@ microsite: &microsite
             - "b3:9b:af:d5:de:74:32:e7:7a:21:77:77:66:fe:2f:42"
       - checkout
       - <<: *load_cache
+      - <<: *install_jdk
       - <<: *install_nodejs
       - <<: *install_yarn
       - run:
@@ -135,7 +150,12 @@ microsite: &microsite
             export GIT_USER=${GH_NAME}
             export TRAVIS_BUILD_NUMBER="${CIRCLE_BUILD_NUM}"
             export TRAVIS_COMMIT="${CIRCLE_SHA1}"
-            chown -R $USER:$USER /tmp
+            sudo chown -R $USER:$USER /tmp
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install
+            nvm use
+            node -v
             ./sbt docs/docusaurusCreateSite
             ./sbt docs/docusaurusPublishGhpages
       - <<: *save_cache
@@ -241,7 +261,7 @@ jobs:
 
   microsite:
     <<: *microsite
-    <<: *docker_jvm
+    <<: *machine_ubuntu
     environment:
       - <<: *jdk_8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ testJVM: &testJVM
   steps:
     - checkout
     - <<: *load_cache
-    - <<: *install_jdk
     - run:
         name: Run tests
         command: ./sbt ++${SCALA_VERSION}! testJVM
@@ -111,7 +110,6 @@ testJS: &testJS
   steps:
     - checkout
     - <<: *load_cache
-    - <<: *install_jdk
     - <<: *install_nodejs
     - run:
         name: Run tests
@@ -142,6 +140,7 @@ microsite: &microsite
             - "b3:9b:af:d5:de:74:32:e7:7a:21:77:77:66:fe:2f:42"
       - checkout
       - <<: *load_cache
+      - <<: *install_jdk
       - <<: *install_nodejs
       - <<: *install_yarn
       - run:
@@ -179,7 +178,7 @@ jobs:
 
   mdoc:
     <<: *mdoc
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01
 
+docker_jvm: &docker_jvm
+  docker:
+    - image: circleci/openjdk:${JDK_VERSION}
+
 install_jdk: &install_jdk
   - run:
       name: Install JDK
@@ -161,14 +165,14 @@ microsite: &microsite
 jobs:
   lint:
     <<: *lint
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_8
 
   compile_dotty:
     <<: *compile
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
@@ -182,77 +186,77 @@ jobs:
 
   test_211_jdk8_jvm:
     <<: *testJVM
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_211
       - <<: *jdk_8
 
   test_212_jdk8_jvm:
     <<: *testJVM
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_8
 
   test_213_jdk8_jvm:
     <<: *testJVM
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_213
       - <<: *jdk_8
 
   test_dotty_jdk8_jvm:
     <<: *testJVM
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
 
   test_212_jdk11_jvm:
     <<: *testJVM
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_11
 
   test_211_jdk8_js:
     <<: *testJS
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_211
       - <<: *jdk_8
 
   test_212_jdk8_js:
     <<: *testJS
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_8
 
   test_213_jdk8_js:
     <<: *testJS
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_213
       - <<: *jdk_8
 
   release_211:
     <<: *release
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_211
       - <<: *jdk_8
 
   release_212:
     <<: *release
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_212
       - <<: *jdk_8
 
   release_213:
     <<: *release
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *scala_213
       - <<: *jdk_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,22 +18,9 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
-machine_ubuntu: &machine_ubuntu
-  machine:
-    image: ubuntu-1604:201903-01
-
 docker_jvm: &docker_jvm
   docker:
-    - image: circleci/openjdk:${JDK_VERSION}-jdk-node
-
-install_jdk: &install_jdk
-  - run:
-      name: Install JDK
-      command: |
-        while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
-        sudo add-apt-repository ppa:openjdk-r/ppa -y
-        sudo apt update
-        sudo apt install openjdk-${JDK_VERSION}-jdk -y
+    - image: adoptopenjdk/openjdk${JDK_VERSION}:latest
 
 load_cache: &load_cache
   - restore_cache:
@@ -62,10 +49,8 @@ install_nodejs: &install_nodejs
   - run:
       name: Install node.js
       command: |
-        export NVM_DIR="/opt/circleci/.nvm"
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-        nvm install
-        nvm use
+        curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+        sudo apt-get install -y nodejs
         node -v
 
 compile: &compile
@@ -139,7 +124,6 @@ microsite: &microsite
             - "b3:9b:af:d5:de:74:32:e7:7a:21:77:77:66:fe:2f:42"
       - checkout
       - <<: *load_cache
-      - <<: *install_jdk
       - <<: *install_nodejs
       - <<: *install_yarn
       - run:
@@ -261,7 +245,7 @@ jobs:
 
   microsite:
     <<: *microsite
-    <<: *machine_ubuntu
+    <<: *docker_jvm
     environment:
       - <<: *jdk_8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ testJS: &testJS
   steps:
     - checkout
     - <<: *load_cache
+    - <<: *install_nodejs
     - run:
         name: Run tests
         command: ./sbt ++${SCALA_VERSION}! testJS


### PR DESCRIPTION
Installing the JDK frequently takes over 10 min, sometimes 25 min or even fails.
This PR uses pre-built docker images with JDK installed.