### PR TITLE
Use faster Ubuntu mirrors during initial setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ install_jdk: &install_jdk
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-updates main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-backports main universe
-        deb http://security.ubuntu.com/ubuntu/ xenial-security main restricted universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-security main restricted universe
         EOF
 
         if [ $JDK_VERSION == 11 ]; then sudo add-apt-repository ppa:openjdk-r/ppa -y; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,7 @@ install_jdk: &install_jdk
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
 
-        sudo rm -rf /etc/apt/sources.list.d
-
+        sudo rm /etc/apt/sources.list.d/*
         sudo tee /etc/apt/sources.list > /dev/null \<< 'EOF'
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-updates main universe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ install_jdk: &install_jdk
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
 
+        sudo rm -rf /etc/apt/sources.list.d
+
         sudo tee /etc/apt/sources.list > /dev/null \<< 'EOF'
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-updates main universe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ install_jdk: &install_jdk
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
 
-        sudo tee /etc/apt/sources.list > /dev/null << 'EOF'
+        sudo tee /etc/apt/sources.list > /dev/null \<< 'EOF'
         deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-updates main universe
         deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-backports main universe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,13 @@ install_jdk: &install_jdk
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
 
         sudo tee /etc/apt/sources.list > /dev/null \<< 'EOF'
-        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic main universe
-        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-updates main universe
-        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-backports main universe
-        deb http://security.ubuntu.com/ubuntu/ bionic-security main restricted universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial main universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-updates main universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-backports main universe
+        deb http://security.ubuntu.com/ubuntu/ xenial-security main restricted universe
         EOF
 
-        sudo add-apt-repository ppa:openjdk-r/ppa -y
+        if [ $JDK_VERSION == 11 ]; then sudo add-apt-repository ppa:openjdk-r/ppa -y; fi
         sudo apt update
         sudo apt install openjdk-${JDK_VERSION}-jdk -y
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,14 @@ install_jdk: &install_jdk
       name: Install JDK
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
+
+        sudo tee /etc/apt/sources.list > /dev/null << 'EOF'
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic main universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-updates main universe
+        deb http://mirror.math.princeton.edu/pub/ubuntu/ bionic-backports main universe
+        deb http://security.ubuntu.com/ubuntu/ bionic-security main restricted universe
+        EOF
+
         sudo add-apt-repository ppa:openjdk-r/ppa -y
         sudo apt update
         sudo apt install openjdk-${JDK_VERSION}-jdk -y


### PR DESCRIPTION
Change the Ubuntu initial setup to use a mirror for jvm install, instead of the default `archive.ubuntu.com`. 

I assumed that the build server is located in the US, and chose `Princeton Mathematics` mirror that has a large bandwidth, and located in NJ. I expect that the download speed would be fast and stable across runs.

The concern that I have is that the mirror of choice might not have the latest packages. At this point, Princeton Mathematics is one day behind, which seems acceptable, but it might not always be the case. 