### PR TITLE
Adopt Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+ ## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://www.scala-lang.org/conduct/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ To learn more about ZIO, see the following references:
 
 ---
 
+## Code of Conduct
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+---
+
 ### Legal
 
 Copyright 2017 - 2019 John A. De Goes and the ZIO Contributors. All rights reserved.


### PR DESCRIPTION
I want to open a discussion with regards to adopting a Code of Conduct across ZIO projects, I have 2 goals in mind with this PR:

1. Secure the long-term health of the project. ZIO is currently one of the most kind, safe and inclusive communities in Scala and I want to ensure that this continues to be the case, even as time goes by and new contributors join the project.
2. Secure cooperation with other projects and organizations. By adopting a Code of Conduct compatible with most other Scala projects we can help friendly and professional cooperation with other projects occur within and without the ZIO organization.

I think the Scala Code of Conduct is a natural choice towards achieving both of these goals, as it already promotes a set of values that has arisen naturally in ZIO and, quite luckily for us, it's already adopted by an overwhelming amount of other Scala projects, so we wouldn't have to worry about compatibility.

I would very much like to hear every ZIO contributor's thoughts about this change, and if you agree please approve the PR. :+1:
