### PR TITLE
ZIO Test: Seed MockRandom with Live System Time in MockEnvironment

### DIFF
--- a/test/js/src/main/scala/zio/test/mock/MockEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/mock/MockEnvironment.scala
@@ -45,6 +45,8 @@ object MockEnvironment {
         console <- MockConsole.makeMock(MockConsole.DefaultData)
         live    <- Live.makeService(new DefaultRuntime {}.Environment)
         random  <- MockRandom.makeMock(MockRandom.DefaultData)
+        time    <- live.provide(zio.clock.nanoTime)
+        _       <- random.setSeed(time)
         size    <- Sized.makeService(100)
         system  <- MockSystem.makeMock(MockSystem.DefaultData)
       } yield new MockEnvironment(clock, console, live, random, clock, size, system)

--- a/test/jvm/src/main/scala/zio/test/mock/MockEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/mock/MockEnvironment.scala
@@ -48,6 +48,8 @@ object MockEnvironment {
         console  <- MockConsole.makeMock(MockConsole.DefaultData)
         live     <- Live.makeService(new DefaultRuntime {}.Environment)
         random   <- MockRandom.makeMock(MockRandom.DefaultData)
+        time     <- live.provide(zio.clock.nanoTime)
+        _        <- random.setSeed(time)
         size     <- Sized.makeService(100)
         system   <- MockSystem.makeMock(MockSystem.DefaultData)
         blocking = Blocking.Live.blocking

--- a/test/shared/src/test/scala/zio/test/mock/EnvironmentSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/EnvironmentSpec.scala
@@ -3,7 +3,6 @@ package zio.test.mock
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Future
-import scala.util.{ Random => SRandom }
 
 import zio._
 import zio.duration._
@@ -16,7 +15,7 @@ object EnvironmentSpec extends DefaultRuntime {
     label(currentTime, "Clock returns time when it is set"),
     label(putStrLn, "Console writes line to output"),
     label(getStrLn, "Console reads line from input"),
-    label(nextInt, "Random returns next integer when data is fed"),
+    label(nextInt, "Random returns next pseudorandom integer"),
     label(env, "System returns an environment variable when it is set"),
     label(property, "System returns a property when it is set "),
     label(lineSeparator, "System returns the line separator when it is set ")
@@ -52,11 +51,11 @@ object EnvironmentSpec extends DefaultRuntime {
     }
 
   def nextInt =
-    withEnvironment {
+    unsafeRunToFuture {
       for {
-        _ <- MockRandom.setSeed(4491842685265857478L)
-        n <- random.nextInt
-      } yield n == new SRandom(4491842685265857478L).nextInt()
+        i <- random.nextInt.provideManaged(MockEnvironment.Value)
+        j <- random.nextInt.provideManaged(MockEnvironment.Value)
+      } yield i != j
     }
 
   def env =


### PR DESCRIPTION
Right now `MockRandom` is seeded with an arbitrary random seed. This is great for repeatability and simple tests but as we use it to power property based testing it means if you run your tests twice you are running them with the same values. I think this is against user expectations that running the tests again would get you more coverage in sampling a greater variety of random numbers.

This PR accesses the live `Clock` when `MockEnvironment` is created and uses the time to seed `MockRandom` similarly to how `scala.util.Random` works. We should work to add functionality to report the seed for failing tests and make it easy to replay particular seeds but right now I think this just gets us in line with user expectations.