### PR TITLE
Remove most remaining Dotty workarounds

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -17,10 +17,7 @@ class FiberSpec extends BaseCrossPlatformSpec {
     for {
       ref <- Ref.make(false)
       fiber <- withLatch { release =>
-                (release *> IO.unit)
-                  .bracket_[Any, Nothing]
-                  .apply[Any](ref.set(true))(IO.never)
-                  .fork //    TODO: Dotty doesn't infer this properly
+                (release *> IO.unit).bracket_(ref.set(true))(IO.never).fork
               }
       _     <- fiber.toManaged.use(_ => IO.unit)
       _     <- fiber.await

--- a/core/shared/src/main/scala/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/zio/FiberLocal.scala
@@ -58,7 +58,7 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    * Guarantees that fiber-local data is properly freed via `bracket`.
    */
   final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
-    set(value).bracket_[Any, Nothing].apply[Any](empty)(use) //    TODO: Dotty doesn't infer this properly
+    set(value).bracket_(empty)(use)
 }
 
 @deprecated("use FiberRef", "1.0.0")

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -48,11 +48,7 @@ final class FiberRef[A](private[zio] val initial: A) extends Serializable {
   final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
     for {
       oldValue <- get
-      b <- {
-        // TODO: Dotty doesn't infer this properly
-        val i0: ZIO.BracketAcquire_[R, E] = set(value).bracket_[R, E]
-        i0(set(oldValue))(use)
-      }
+      b        <- set(value).bracket_(set(oldValue))(use)
     } yield b
 
   /**

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -46,6 +46,7 @@ object BuildHelper {
   )
 
   val dottySettings = Seq(
+    // Keep this consistent with the version in .circleci/config.yml
     crossScalaVersions += "0.19.1-bin-20190904-beba63a-NIGHTLY",
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
     sources in (Compile, doc) := {


### PR DESCRIPTION
The recent Dotty upgrade includes
https://github.com/lampepfl/dotty/pull/6756 which fixes overload
selection for `bracket_`.