### PR TITLE
ZIO Test: Fix Bug in Gen#filter

### DIFF
--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -25,7 +25,7 @@ import zio.test.mock.MockEnvironment
  */
 abstract class DefaultRunnableSpec(
   spec: => ZSpec[MockEnvironment, Any, String, Any],
-  defautlTestAspects: List[TestAspect[Nothing, MockEnvironment, Nothing, Any, Nothing, Any]] = List(
+  defaultTestAspects: List[TestAspect[Nothing, MockEnvironment, Nothing, Any, Nothing, Any]] = List(
     TestAspect.timeoutWarning(60.seconds)
   )
-) extends RunnableSpec(DefaultTestRunner)(defautlTestAspects.foldLeft(spec)(_ @@ _))
+) extends RunnableSpec(DefaultTestRunner)(defaultTestAspects.foldLeft(spec)(_ @@ _))

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -31,8 +31,22 @@ case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
   final def <*>[R1 <: R, B](that: Gen[R1, B]): Gen[R1, (A, B)] =
     self.zip(that)
 
-  final def filter(f: A => Boolean): Gen[R, A] =
-    Gen(sample.flatMap(_.filter(f)))
+  /**
+   * Filters the values produced by this generator, discarding any values that
+   * do not meet the specified predicate. Using `filter` can reduce test
+   * performance, especially if many values must be discarded. It is
+   * recommended to use combinators such as `map` and `flatMap` to create
+   * generators of the desired values instead.
+   *
+   * {{{
+   * val evens: Gen[Random, Int] = Gen.anyInt.map(_ * 2)
+   * }}}
+   */
+  final def filter(f: A => Boolean): Gen[R, A] = Gen {
+    sample.flatMap { sample =>
+      if (f(sample.value)) sample.filter(f) else ZStream.empty
+    }
+  }
 
   final def flatMap[R1 <: R, B](f: A => Gen[R1, B]): Gen[R1, B] = Gen {
     self.sample.flatMap { sample =>

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -28,6 +28,11 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
   final def <*>[R1 <: R, B](that: Sample[R1, B]): Sample[R1, (A, B)] =
     self.zip(that)
 
+  /**
+   * Filters this sample by replacing it with its shrink tree if the value does
+   * not meet the specified predicate and recursively filtering the shrink
+   * tree.
+   */
   final def filter(f: A => Boolean): ZStream[R, Nothing, Sample[R, A]] =
     if (f(value)) ZStream(Sample(value, shrink.flatMap(_.filter(f))))
     else shrink.flatMap(_.filter(f))

--- a/test/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -4,14 +4,15 @@ import scala.concurrent.Future
 
 import zio.{ random, Chunk, DefaultRuntime }
 import zio.test.Assertion.{ equalTo, isLessThan }
-import zio.test.TestUtils.{ label, succeeded }
+import zio.test.TestUtils.{ failed, label, succeeded }
 
 object CheckSpec extends DefaultRuntime {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(effectualPropertiesCanBeTests, "effectual properties can be tested"),
     label(overloadedCheckMethodsWork, "overloaded check methods work"),
-    label(testsCanBeWrittenInPropertyBasedStyle, "tests can be written in property based style")
+    label(testsCanBeWrittenInPropertyBasedStyle, "tests can be written in property based style"),
+    label(testsWithFilteredGeneratorsTerminate, "tests with filtered generators terminate")
   )
 
   def effectualPropertiesCanBeTests: Future[Boolean] =
@@ -51,5 +52,15 @@ object CheckSpec extends DefaultRuntime {
         }
       }
       succeeded(chunkApply)
+    }
+
+  def testsWithFilteredGeneratorsTerminate: Future[Boolean] =
+    unsafeRunToFuture {
+      val filtered = testM("filtered") {
+        check(Gen.anyInt.filter(_ > 0), Gen.anyInt.filter(_ > 0)) { (a, b) =>
+          assert(a, equalTo(b))
+        }
+      }
+      failed(filtered)
     }
 }

--- a/test/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test/shared/src/test/scala/zio/test/TestUtils.scala
@@ -11,6 +11,9 @@ object TestUtils {
   final def execute[L, E, S](spec: ZSpec[MockEnvironment, E, L, S]): UIO[ExecutedSpec[L, E, S]] =
     TestExecutor.managed(mock.mockEnvironmentManaged)(spec, ExecutionStrategy.Sequential)
 
+  final def failed[L, E, S](spec: ZSpec[mock.MockEnvironment, E, L, S]): ZIO[Any, Nothing, Boolean] =
+    succeeded(spec).map(!_)
+
   final def forAllTests[L, E, S](
     execSpec: UIO[ExecutedSpec[L, E, S]]
   )(f: Either[TestFailure[E], TestSuccess[S]] => Boolean): ZIO[Any, Nothing, Boolean] =


### PR DESCRIPTION
As reported by @ghostdogpr, property based tests involving filtered generators were not terminating in certain circumstances.

The issue was that we need to use slightly different concepts of filtering for generating versus shrinking random values. For shrinking if a value doesn't satisfy the predicate we want to continue to examine its shrinks because even if a value doesn't satisfy the predicate its shrinks might and could be part of the optimal solution. In contrast, for generating random values if the value doesn't satisfy the predicate we just want to discard the entire thing, including its shrink tree. Previously we weren't doing this so if the predicate was `_ > 0` and the initial random value was a negative number we would fruitlessly search its shrinks for a value satisfying the predicate.

I also added some documentation on transforming generators generally being preferable to filtering them.