### PR TITLE
ZIO Test: Support Generators for Functions

### DIFF
--- a/test/js/src/main/scala/zio/test/ConcurrentMap.scala
+++ b/test/js/src/main/scala/zio/test/ConcurrentMap.scala
@@ -1,0 +1,13 @@
+package zio.test
+
+import scala.collection.mutable.Map
+
+private[test] final case class ConcurrentHashMap[K, V] private (private val map: Map[K, V]) {
+  final def getOrElseUpdate(key: K, op: => V): V =
+    map.getOrElseUpdate(key, op)
+}
+
+object ConcurrentHashMap {
+  final def empty[K, V]: ConcurrentHashMap[K, V] =
+    new ConcurrentHashMap[K, V](Map.empty[K, V])
+}

--- a/test/js/src/main/scala/zio/test/ConcurrentMap.scala
+++ b/test/js/src/main/scala/zio/test/ConcurrentMap.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test
 
 import scala.collection.mutable.Map
@@ -7,7 +23,7 @@ private[test] final case class ConcurrentHashMap[K, V] private (private val map:
     map.getOrElseUpdate(key, op)
 }
 
-object ConcurrentHashMap {
+private[test] object ConcurrentHashMap {
   final def empty[K, V]: ConcurrentHashMap[K, V] =
     new ConcurrentHashMap[K, V](Map.empty[K, V])
 }

--- a/test/jvm/src/main/scala/zio/test/ConcurrentMap.scala
+++ b/test/jvm/src/main/scala/zio/test/ConcurrentMap.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test
 
 import java.util.concurrent.{ ConcurrentHashMap => JConcurrentHashMap }
@@ -7,7 +23,7 @@ private[test] final case class ConcurrentHashMap[K, V] private (private val map:
     map.computeIfAbsent(key, _ => op)
 }
 
-object ConcurrentHashMap {
+private[test] object ConcurrentHashMap {
   final def empty[K, V]: ConcurrentHashMap[K, V] =
     new ConcurrentHashMap[K, V](new JConcurrentHashMap[K, V]())
 }

--- a/test/jvm/src/main/scala/zio/test/ConcurrentMap.scala
+++ b/test/jvm/src/main/scala/zio/test/ConcurrentMap.scala
@@ -1,0 +1,13 @@
+package zio.test
+
+import java.util.concurrent.{ ConcurrentHashMap => JConcurrentHashMap }
+
+private[test] final case class ConcurrentHashMap[K, V] private (private val map: JConcurrentHashMap[K, V]) {
+  final def getOrElseUpdate(key: K, op: => V): V =
+    map.computeIfAbsent(key, _ => op)
+}
+
+object ConcurrentHashMap {
+  final def empty[K, V]: ConcurrentHashMap[K, V] =
+    new ConcurrentHashMap[K, V](new JConcurrentHashMap[K, V]())
+}

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -1,0 +1,42 @@
+package zio.test
+
+import java.util.concurrent.ConcurrentHashMap
+
+import zio.ZIO
+
+/**
+ * A `Fun[A, B]` is a referentially transparent version of a potentially
+ * effectual function from `A` to `B`. Each invocation of the function will be
+ * memoized so the function is guaranteed to return the same value for any
+ * given input. The function should not involve asynchronous effects.
+ */
+final case class Fun[-A, +B] private (private val f: A => B, private val hash: A => Int) extends (A => B) {
+
+  final def apply(a: A): B = map.computeIfAbsent(hash(a), _ => f(a))
+
+  private[this] final val map = new ConcurrentHashMap[Int, B]()
+}
+
+object Fun {
+
+  /**
+   * Constructs a new `Fun` from an effectual function. The function should not
+   * involve asynchronous effects.
+   */
+  final def make[R, A, B](f: A => ZIO[R, Nothing, B]): ZIO[R, Nothing, Fun[A, B]] =
+    makeHash(f)(_.hashCode)
+
+  /**
+   * Constructs a new `Fun` from an effectual function and a hashing function.
+   * This is useful when the domain of the function does not implement
+   * `hashCode` in a way that is consistent with equality.
+   */
+  final def makeHash[R, A, B](f: A => ZIO[R, Nothing, B])(hash: A => Int): ZIO[R, Nothing, Fun[A, B]] =
+    ZIO.runtime[R].map(runtime => Fun(a => runtime.unsafeRun(f(a)), hash))
+
+  /**
+   * Constructs a new `Fun` from a pure function.
+   */
+  final def fromFunction[A, B](f: A => B): Fun[A, B] =
+    Fun(f, _.hashCode)
+}

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -1,7 +1,5 @@
 package zio.test
 
-import java.util.concurrent.ConcurrentHashMap
-
 import zio.ZIO
 
 /**
@@ -12,9 +10,9 @@ import zio.ZIO
  */
 final case class Fun[-A, +B] private (private val f: A => B, private val hash: A => Int) extends (A => B) {
 
-  final def apply(a: A): B = map.computeIfAbsent(hash(a), _ => f(a))
+  final def apply(a: A): B = map.getOrElseUpdate(hash(a), f(a))
 
-  private[this] final val map = new ConcurrentHashMap[Int, B]()
+  private[this] final val map = ConcurrentHashMap.empty[Int, B]
 }
 
 object Fun {

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test
 
 import zio.ZIO
@@ -8,14 +24,15 @@ import zio.ZIO
  * memoized so the function is guaranteed to return the same value for any
  * given input. The function should not involve asynchronous effects.
  */
-final case class Fun[-A, +B] private (private val f: A => B, private val hash: A => Int) extends (A => B) {
+private[test] final case class Fun[-A, +B] private (private val f: A => B, private val hash: A => Int)
+    extends (A => B) {
 
   final def apply(a: A): B = map.getOrElseUpdate(hash(a), f(a))
 
   private[this] final val map = ConcurrentHashMap.empty[Int, B]
 }
 
-object Fun {
+private[test] object Fun {
 
   /**
    * Constructs a new `Fun` from an effectual function. The function should not

--- a/test/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test/shared/src/test/scala/zio/test/FunSpec.scala
@@ -1,0 +1,33 @@
+package zio.test
+
+import zio.DefaultRuntime
+
+import scala.concurrent.Future
+import scala.math.abs
+
+import zio.{ random, ZIO }
+import zio.test.TestUtils.{ label }
+
+object FunSpec extends DefaultRuntime {
+
+  val run: List[Async[(Boolean, String)]] = List(
+    label(funConvertsEffectsIntoPureFunctions, "fun converts effects into pure functions"),
+    label(funDoesNotHaveRaceConditions, "fun does not have race conditions")
+  )
+
+  def funConvertsEffectsIntoPureFunctions: Future[Boolean] =
+    unsafeRunToFuture {
+      for {
+        f <- Fun.make((n: Int) => random.nextInt(n))
+        n <- random.nextInt.map(abs(_))
+      } yield f(n) == f(n)
+    }
+
+  def funDoesNotHaveRaceConditions: Future[Boolean] =
+    unsafeRunToFuture {
+      for {
+        f       <- Fun.make((_: Int) => random.nextInt(6))
+        results <- ZIO.foreachPar(List.range(0, 1000))(n => ZIO.effectTotal((n % 6, f(n % 6))))
+      } yield results.distinct.length == 6
+    }
+}

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -16,6 +16,7 @@ object TestMain {
       scope(ConsoleSpec.run, "ConsoleSpec"),
       scope(DefaultTestReporterSpec.run, "DefaultTestReporterSpec"),
       scope(EnvironmentSpec.run, "EnvironmentSpec"),
+      scope(FunSpec.run, "FunSpec"),
       scope(GenSpec.run, "GenSpec"),
       scope(LiveSpec.run, "LiveSpec"),
       scope(RandomSpec.run, "RandomSpec"),


### PR DESCRIPTION
Adds `Gen#function` for generating functions from `A` to `B` given a generator of `B` values.

```scala
final def function[R, A, B](gen: Gen[R, B]): Gen[R, A => B]
```

We do this by evaluating the `Gen[R, B]` for each input and memoizing the results to ensure that the generated function is referentially transparent. Since in some cases the `A` value will not implement `hashCode` in a way that is consistent with equality I also added a variant `functionWith` that allows specifying a hashing function. This is all backed by a new type `Fun` that wraps an effectual functional and memoizes its results.

We could potentially reify the hashing function as the `Cogen` type that exists in other testing frameworks. I didn't do that for now because it is not necessary as long as the `A` type implements `hashCode` in a way that is consistent with your definition of equality. But if people think that would be helpful we could definitely add it along with some nice methods for composing them.

Resolves #1472.