### PR TITLE
ZIO Test: Improve Reporting of Property Based Testing Result

### DIFF
--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -208,9 +208,15 @@ trait CheckVariants {
   private final def checkStream[R, E, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
     test: A => ZIO[R, E, TestResult]
   ): ZIO[R, E, TestResult] =
-    stream
-      .mapM(_.traverse(test(_).either))
-      .dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
+    stream.zipWithIndex.mapM {
+      case (initial, index) =>
+        initial.traverse(
+          input =>
+            test(input)
+              .map(_.map(_.left.map(_.copy(gen = Some(GenFailureDetails(initial.value, input, index))))))
+              .either
+        )
+    }.dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
       .take(1)                                          // Get the first failure
       .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks))
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken failures

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -101,8 +101,21 @@ object DefaultTestReporter {
     withOffset(offset)(red("- " + label))
 
   private def renderFailureDetails(failureDetails: FailureDetails, offset: Int): Seq[String] = failureDetails match {
-    case FailureDetails(fragment, whole) => renderAssertion(fragment, whole, offset)
+    case FailureDetails(fragment, whole, genFailureDetails) =>
+      renderGenFailureDetails(genFailureDetails, offset) ++ renderAssertion(fragment, whole, offset)
   }
+
+  private def renderGenFailureDetails[A](failureDetails: Option[GenFailureDetails], offset: Int): Seq[String] =
+    failureDetails match {
+      case Some(details) =>
+        Seq(
+          withOffset(offset + tabSize)(
+            s"Test failed after ${details.iterations + 1} iteration${if (details.iterations > 0) "s" else ""} with input: ${red(details.shrinkedInput.toString)}"
+          ),
+          withOffset(offset + tabSize)(s"Original input before shrinking was: ${red(details.initialInput.toString)}")
+        )
+      case None => Seq()
+    }
 
   private def renderAssertion(fragment: AssertionValue, whole: AssertionValue, offset: Int): Seq[String] =
     if (whole.assertion == fragment.assertion)

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -108,12 +108,13 @@ object DefaultTestReporter {
   private def renderGenFailureDetails[A](failureDetails: Option[GenFailureDetails], offset: Int): Seq[String] =
     failureDetails match {
       case Some(details) =>
-        Seq(
-          withOffset(offset + tabSize)(
-            s"Test failed after ${details.iterations + 1} iteration${if (details.iterations > 0) "s" else ""} with input: ${red(details.shrinkedInput.toString)}"
-          ),
-          withOffset(offset + tabSize)(s"Original input before shrinking was: ${red(details.initialInput.toString)}")
+        val shrinked = details.shrinkedInput.toString
+        val initial  = details.initialInput.toString
+        val renderShrinked = withOffset(offset + tabSize)(
+          s"Test failed after ${details.iterations + 1} iteration${if (details.iterations > 0) "s" else ""} with input: ${red(shrinked)}"
         )
+        if (initial == shrinked) Seq(renderShrinked)
+        else Seq(renderShrinked, withOffset(offset + tabSize)(s"Original input before shrinking was: ${red(initial)}"))
       case None => Seq()
     }
 

--- a/test/shared/src/main/scala/zio/test/GenFailureDetails.scala
+++ b/test/shared/src/main/scala/zio/test/GenFailureDetails.scala
@@ -17,6 +17,23 @@
 package zio.test
 
 /**
- * `FailureDetails` keeps track of details relevant to failures.
+ * `GenFailureDetails` keeps track of relevant information related to a failure in a generative test.
  */
-final case class FailureDetails(fragment: AssertionValue, whole: AssertionValue, gen: Option[GenFailureDetails] = None)
+sealed trait GenFailureDetails {
+  type Value
+
+  val initialInput: Value
+  val shrinkedInput: Value
+  val iterations: Int
+}
+
+object GenFailureDetails {
+  def apply[A](initialInput0: A, shrinkedInput0: A, iterations0: Int): GenFailureDetails =
+    new GenFailureDetails {
+      type Value = A
+
+      val initialInput: Value  = initialInput0
+      val shrinkedInput: Value = shrinkedInput0
+      val iterations: Int      = iterations0
+    }
+}


### PR DESCRIPTION
Fixes #1585 

Example output:
```
[info]   - test
[info]     Test failed after 3 iterations with input: (0,0)
[info]     Original input before shrinking was: (-396148549,-1142042791)
[info]     0 did not satisfy isGreaterThan(0)
```