### PR TITLE
#1606 - deprecated sync extension method in favor of effect

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/IOSyntaxSpec.scala
@@ -51,23 +51,23 @@ class IOCreationLazySyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "IOLazySyntaxSpec".title ^ s2"""
    Generate a String:
-      `.sync` extension method returns the same UIO[String] as `IO.sync` does. $t1
+      `.effect` extension method returns the same UIO[String] as `IO.effect` does. $t1
    Generate a String:
-      `.sync` extension method returns the same Task[String] as `IO.sync` does. $t2
+      `.effect` extension method returns the same Task[String] as `IO.effect` does. $t2
    Generate a String:
-      `.syncCatch` extension method returns the same PartialFunction[Throwable, E] => IO[E, A] as `IO.sync` does. $t3
+      `.effect` extension method returns the same PartialFunction[Throwable, E] => IO[E, A] as `IO.effect` does. $t3
     """
 
   def t1 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     unsafeRun(for {
-      a <- lazyStr.sync
+      a <- lazyStr.effect
       b <- IO.effectTotal(lazyStr)
     } yield a must ===(b))
   }
 
   def t2 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     unsafeRun(for {
-      a <- lazyStr.sync
+      a <- lazyStr.effect
       b <- IO.effect(lazyStr)
     } yield a must ===(b))
   }
@@ -75,11 +75,10 @@ class IOCreationLazySyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   def t3 = forAll(Gen.lzy(Gen.alphaStr)) { lazyStr =>
     val partial: PartialFunction[Throwable, Int] = { case _: Throwable => 42 }
     unsafeRun(for {
-      a <- lazyStr.sync.refineOrDie(partial)
+      a <- lazyStr.effect.refineOrDie(partial)
       b <- IO.effect(lazyStr).refineOrDie(partial)
     } yield a must ===(b))
   }
-
 }
 
 class IOIterableSyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)

--- a/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
@@ -27,7 +27,9 @@ object ZIOSyntax {
 
   final class LazyCreationSyntax[A](val a: () => A) extends AnyVal {
     def effectTotal[R, E]: ZIO[R, E, A] = ZIO.effectTotal(a())
-    def sync[R]: ZIO[R, Throwable, A]   = ZIO.effect(a())
+    def effect[R]: ZIO[R, Throwable, A] = ZIO.effect(a())
+    @deprecated("use effect", "1.0.0")
+    def sync[R]: ZIO[R, Throwable, A]   = effect
   }
 
   final class IterableSyntax[R, E, A](val ios: Iterable[ZIO[R, E, A]]) extends AnyVal {

--- a/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
@@ -29,7 +29,7 @@ object ZIOSyntax {
     def effectTotal[R, E]: ZIO[R, E, A] = ZIO.effectTotal(a())
     def effect[R]: ZIO[R, Throwable, A] = ZIO.effect(a())
     @deprecated("use effect", "1.0.0")
-    def sync[R]: ZIO[R, Throwable, A]   = effect
+    def sync[R]: ZIO[R, Throwable, A] = effect
   }
 
   final class IterableSyntax[R, E, A](val ios: Iterable[ZIO[R, E, A]]) extends AnyVal {


### PR DESCRIPTION
Fixes issue #1606 
- `sync` extension method was renamed to `effect` to match `IO.effect`. 
- added deprecation warning to `sync` to be removed in the future