### PR TITLE
CI: Replace ppa with adoptopenjdk artifactory cloud, add timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,17 @@ install_jdk: &install_jdk
         deb http://mirror.math.princeton.edu/pub/ubuntu/ xenial-security main restricted universe
         EOF
 
-        if [ $JDK_VERSION == 11 ]; then sudo add-apt-repository ppa:openjdk-r/ppa -y; fi
-        sudo apt update
-        sudo apt install openjdk-${JDK_VERSION}-jdk -y
+        if [ $JDK_VERSION == 11 ]; then
+          wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+          sudo add-apt-repository https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ -y
+        fi
+        sudo timeout 30s apt update
+        if [ $JDK_VERSION == 11 ]; then
+          sudo timeout 1m apt install -y adoptopenjdk-11-hotspot
+        elif [ $JDK_VERSION == 8 ]; then
+          sudo timeout 1m apt install -y openjdk-8-jdk
+        fi
+        java -version
 
 load_cache: &load_cache
   - restore_cache:


### PR DESCRIPTION
Follow up to #1578 
There was at least one case [here](https://github.com/zio/zio/pull/1578#issuecomment-528485926) where the downloads from the canonical PPAs were too slow, and they aren't exactly very fast in most cases either. 

This attempts to fix it by relying on a different jdk package from adoptopenjdk. It seems to be hosted in Google's servers somewhere in US East, which should be faster than downloading from Canonical's servers in the UK.

Also, add timeout so that it fails early when the build is taking too long, rather than waste precious time from contributors (and money from sponsors).