### PR TITLE
ZIO Test: Add Size Combinators

### DIFF
--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -21,6 +21,7 @@ import scala.collection.immutable.SortedMap
 import zio.{ UIO, ZIO }
 import zio.random._
 import zio.stream.{ Stream, ZStream }
+import zio.test.MathUtils._
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires
@@ -61,6 +62,21 @@ case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
 
   final def map[B](f: A => B): Gen[R, B] =
     Gen(sample.map(_.map(f)))
+
+  /**
+   * Maps an effectual function over a generator.
+   */
+  final def mapM[R1 <: R, B](f: A => ZIO[R1, Nothing, B]): Gen[R1, B] =
+    Gen(sample.mapM(_.traverse(f)))
+
+  /**
+   * Discards the shrinker for this generator and applies a new shrinker by
+   * mapping each value to a sample using the specified function. This is
+   * useful when the process to shrink a value is simpler than the process used
+   * to generate it.
+   */
+  final def reshrink[R1 <: R, B](f: A => Sample[R1, B]): Gen[R1, B] =
+    Gen(sample.map(sample => f(sample.value)))
 
   final def zip[R1 <: R, B](that: Gen[R1, B]): Gen[R1, (A, B)] =
     self.flatMap(a => that.map(b => (a, b)))
@@ -229,14 +245,35 @@ object Gen {
         .map(Sample.shrinkIntegral(min))
     }
 
+  /**
+   * A sized generator that uses a uniform distribution of size values, so a
+   * large number of larger sizes will be generated.
+   */
+  final def large[R <: Random with Sized, A](f: Int => Gen[R, A], min: Int = 0): Gen[R, A] =
+    size.flatMap(max => Gen.int(min, max)).flatMap(f)
+
   final def listOf[R <: Random with Sized, A](g: Gen[R, A]): Gen[R, List[A]] =
-    sized(n => int(0, n max 0)).flatMap(listOfN(_)(g))
+    medium(listOfN(_)(g))
 
   final def listOf1[R <: Random with Sized, A](g: Gen[R, A]): Gen[R, List[A]] =
-    sized(n => int(1, n max 1)).flatMap(listOfN(_)(g))
+    medium(listOfN(_)(g), 1)
 
   final def listOfN[R <: Random, A](n: Int)(g: Gen[R, A]): Gen[R, List[A]] =
     List.fill(n)(g).foldRight[Gen[R, List[A]]](const(Nil))((a, gen) => a.zipWith(gen)(_ :: _))
+
+  /**
+   * A sized generator that uses an exponential distribution of size values, so
+   * the majority of sizes will be towards the lower end of the range but some
+   * larger sizes will be generated as well.
+   */
+  final def medium[R <: Random with Sized, A](f: Int => Gen[R, A], min: Int = 0): Gen[R, A] = {
+    val gen = for {
+      max <- size
+      i   <- Gen.int(log2Floor(min), log2Ceil(max))
+      j   <- Gen.int(min, math.max(min, math.min(pow2(i), max)))
+    } yield j
+    gen.reshrink(Sample.shrinkIntegral(min)).flatMap(f)
+  }
 
   /**
    * A constant generator of the empty value.
@@ -274,6 +311,13 @@ object Gen {
    */
   final def sized[R <: Sized, A](f: Int => Gen[R, A]): Gen[R, A] =
     size.flatMap(f)
+
+  /**
+   * A sized generator that uses a logarithmic distribution of size values, so
+   * all sizes generated will be small.
+   */
+  final def small[R <: Random with Sized, A](f: Int => Gen[R, A], min: Int = 0): Gen[R, A] =
+    size.flatMap(max => Gen.int(min, math.max(min, log2Ceil(max)))).flatMap(f)
 
   final def some[R, A](gen: Gen[R, A]): Gen[R, Option[A]] =
     gen.map(Some(_))

--- a/test/shared/src/main/scala/zio/test/MathUtils.scala
+++ b/test/shared/src/main/scala/zio/test/MathUtils.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import scala.annotation.tailrec
+import scala.math.{ ceil, floor, log, pow }
 
 /**
  * `MathUtils` provides common math functions used in ZIO Test.
@@ -28,36 +28,21 @@ private[test] object MathUtils {
    * the nearest integer. If the specified integer is zero or negative returns
    * zero.
    */
-  final def log2Ceil(n: Int): Int = {
-    @tailrec
-    def loop(i: Int, j: Int): Int =
-      if (i <= 0) j
-      else loop(i >> 1, j + 1)
-    loop(n - 1, 0)
-  }
+  final def log2Ceil(n: Int): Int =
+    if (n <= 0) 0 else ceil(log(n.toDouble) / log(2.0)).toInt
 
   /**
    * Returns the base two logarithm of the specified integer, rounding down to
    * the nearest integer. If the specified integer is zero or negative returns
    * zero.
    */
-  final def log2Floor(n: Int): Int = {
-    @tailrec
-    def loop(i: Int, j: Int): Int =
-      if (i <= 1) j
-      else loop(i >> 1, j + 1)
-    loop(n, 0)
-  }
+  final def log2Floor(n: Int): Int =
+    if (n <= 0) 0 else floor(log(n.toDouble) / log(2.0)).toInt
 
   /**
    * Returns two raised to the specified power. If the specified power is
    * negative returns zero.
    */
-  final def pow2(n: Int): Int = {
-    @tailrec
-    def loop(i: Int, j: Int): Int =
-      if (j <= 0) i
-      else loop(i << 1, j - 1)
-    if (n < 0) 0 else loop(1, n)
-  }
+  final def pow2(n: Int): Int =
+    pow(2.0, n.toDouble).toInt
 }

--- a/test/shared/src/main/scala/zio/test/MathUtils.scala
+++ b/test/shared/src/main/scala/zio/test/MathUtils.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import scala.annotation.tailrec
+
+/**
+ * `MathUtils` provides common math functions used in ZIO Test.
+ */
+private[test] object MathUtils {
+
+  /**
+   * Returns the base two logarithm of the specified integer, rounding up to
+   * the nearest integer. If the specified integer is zero or negative returns
+   * zero.
+   */
+  final def log2Ceil(n: Int): Int = {
+    @tailrec
+    def loop(i: Int, j: Int): Int =
+      if (i <= 0) j
+      else loop(i >> 1, j + 1)
+    loop(n - 1, 0)
+  }
+
+  /**
+   * Returns the base two logarithm of the specified integer, rounding down to
+   * the nearest integer. If the specified integer is zero or negative returns
+   * zero.
+   */
+  final def log2Floor(n: Int): Int = {
+    @tailrec
+    def loop(i: Int, j: Int): Int =
+      if (i <= 1) j
+      else loop(i >> 1, j + 1)
+    loop(n, 0)
+  }
+
+  /**
+   * Returns two raised to the specified power. If the specified power is
+   * negative returns zero.
+   */
+  final def pow2(n: Int): Int = {
+    @tailrec
+    def loop(i: Int, j: Int): Int =
+      if (j <= 0) i
+      else loop(i << 1, j - 1)
+    if (n < 0) 0 else loop(1, n)
+  }
+}

--- a/test/shared/src/test/scala/zio/test/MathUtilsSpec.scala
+++ b/test/shared/src/test/scala/zio/test/MathUtilsSpec.scala
@@ -1,0 +1,49 @@
+package zio.test
+
+import scala.concurrent.Future
+
+import zio.DefaultRuntime
+import zio.test.MathUtils._
+import zio.test.TestUtils.label
+
+object MathUtilsSpec extends DefaultRuntime {
+
+  val run: List[Async[(Boolean, String)]] = List(
+    label(logCeilComputesBaseTwoLogarithmRoundingUp, "logCeil computes base two logarithm rounding up"),
+    label(logFloorComputesBaseTwoLogarithmRoundingDown, "logFloor computes base two logarithm rounding down"),
+    label(pow2ComputesTwoRaisedToSpecifiedPower, "pow2 computes two raised to specified power")
+  )
+
+  def logCeilComputesBaseTwoLogarithmRoundingUp: Future[Boolean] =
+    Future.successful {
+      val positive = List
+        .range(1, 100)
+        .map(n => log2Ceil(n) == math.ceil((math.log(n.toDouble) / math.log(2))))
+        .forall(identity)
+      val zero     = log2Ceil(0) == 0
+      val negative = log2Ceil(-1) == 0
+      positive && zero && negative
+    }
+
+  def logFloorComputesBaseTwoLogarithmRoundingDown: Future[Boolean] =
+    Future.successful {
+      val positive = List
+        .range(1, 100)
+        .map(n => log2Floor(n) == math.floor((math.log(n.toDouble) / math.log(2))))
+        .forall(identity)
+      val zero     = log2Floor(0) == 0
+      val negative = log2Floor(-1) == 0
+      positive && zero && negative
+    }
+
+  def pow2ComputesTwoRaisedToSpecifiedPower: Future[Boolean] =
+    Future.successful {
+      val positive = List
+        .range(1, 10)
+        .map(n => pow2(n) == math.pow(2, n.toDouble))
+        .forall(identity)
+      val zero     = pow2(0) == 1
+      val negative = pow2(-1) == 0
+      positive && zero && negative
+    }
+}

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -18,6 +18,7 @@ object TestMain {
       scope(EnvironmentSpec.run, "EnvironmentSpec"),
       scope(GenSpec.run, "GenSpec"),
       scope(LiveSpec.run, "LiveSpec"),
+      scope(MathUtilsSpec.run, "MathSpec"),
       scope(RandomSpec.run, "RandomSpec"),
       scope(SampleSpec.run, "SampleSpec"),
       scope(SchedulerSpec.run, "SchedulerSpec"),


### PR DESCRIPTION
Adds `small`, `medium`, and `large` sized combinators for generators to generate a distribution of sizes based on the size parameter. The `large` combinator mimics the current behavior and with the size configured at `100` generates uniform sizes between `0` and `100`. The `medium` combinator uses an exponential distribution and so generate values between `0` and `100` but with most values towards the smaller end of the range and some larger values. The `small` combinator uses a logarithmic distribution and generates values between `0` and `7` with the default configuration.

I changed the collection generators like `listOf` to use new `medium` combinator. I think this should be a win-win in terms of performance and test coverage. We will be generating fewer larger collections which should speed up tests. And there are a lot of bugs that can be easier to catch with smaller collections that I don't think we weren't testing enough before.

Resolves #1601.