### PR TITLE
ZIO Test: Enable Assertion#equalTo for Arrays

### DIFF
--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -208,8 +208,11 @@ object Assertion {
    */
   final def equalTo[A](expected: A): Assertion[A] =
     Assertion.assertion("equalTo")(param(expected)) { actual =>
-      if (actual == expected) AssertResult.success(())
-      else AssertResult.failure(())
+      val equal = (expected, actual) match {
+        case (left: Array[_], right: Array[_]) => left.sameElements[Any](right)
+        case (left, right)                     => left == right
+      }
+      if (equal) AssertResult.success(()) else AssertResult.failure(())
     }
 
   /**

--- a/test/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -45,6 +45,14 @@ object AssertionSpec {
       message = "equalTo must fail when value does not equal specified value"
     ),
     testSuccess(
+      assert(Array(1, 2, 3), equalTo(Array(1, 2, 3))),
+      message = "equalTo must succeed when array equals specified array"
+    ),
+    testFailure(
+      assert(Array(1, 2, 3), equalTo(Array(1, 2, 4))),
+      message = "equalTo must fail when array does not equal specified array"
+    ),
+    testSuccess(
       assert(Seq(1, 42, 5), exists(equalTo(42))),
       message = "exists must succeed when at least one element of iterable satisfy specified assertion"
     ),


### PR DESCRIPTION
As pointed out by @regiskuckaertz, `Assertion#equalTo` was not working for arrays due to `equalTo` being implemented in terms of universal equality and arrays using reference versus value equality. Adds a pattern match to determine if both values are arrays and if so checks equality using `sameElements`.  It is a little ad hoc but I don't know how we do it in a more systematic way without some kind of equality type class that I think is out of scope. The alternative would be we could just say that `equalTo` is not supported for arrays and provide a `sameElements` assertion.