### PR TITLE
Fix Bug in Sample#shrinkSearch and Add ZStream#takeUntil and ZStream#dropUntil

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -67,7 +67,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
 
   Stream.dropUntil
     dropUntil         $dropUntil
-    short circuits    $dropUntilShortCircuiting
 
   Stream.dropWhile
     dropWhile         $dropWhile
@@ -204,7 +203,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
     take(0) short circuits   $take0ShortCircuitsStreamNever
     take(1) short circuits   $take1ShortCircuitsStreamNever
     takeUntil                $takeUntil
-    takeUntil short circuits $takeUntilShortCircuits
     takeWhile                $takeWhile
     takeWhile short circuits $takeWhileShortCircuits
 
@@ -622,16 +620,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
       unsafeRunSync(s.dropUntil(p).runCollect) must_=== unsafeRunSync(s.runCollect.map(dropUntil(_)(p)))
     }
   }
-
-  private def dropUntilShortCircuiting =
-    unsafeRun {
-      (Stream(1) ++ Stream.fail("Ouch"))
-        .take(1)
-        .dropUntil(_ => false)
-        .runDrain
-        .either
-        .map(_ must beRight(()))
-    }
 
   private def dropWhile =
     prop { (s: Stream[String, Byte], p: Byte => Boolean) =>
@@ -1605,15 +1593,6 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
       listTakeWhile.succeeded ==> (streamTakeWhile must_=== listTakeWhile)
     }
   }
-
-  private def takeUntilShortCircuits =
-    unsafeRun(
-      (Stream(1) ++ Stream.fail("Ouch"))
-        .takeUntil(_ => true)
-        .runDrain
-        .either
-        .map(_ must beRight(()))
-    )
 
   private def takeWhile =
     prop { (s: Stream[String, Byte], p: Byte => Boolean) =>

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -222,7 +222,10 @@ trait CheckVariants {
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken failures
       .flatMap { failures =>
         // Get the "last" failure, the smallest according to the shrinker:
-        failures.reverse.headOption
+        failures
+          .filter(_.fold(_ => true, _.isFailure))
+          .reverse
+          .headOption
           .fold[ZIO[R, E, TestResult]](ZIO.succeed(AssertResult.success(())))(ZIO.fromEither(_))
       }
 

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -224,8 +224,7 @@ trait CheckVariants {
         // Get the "last" failure, the smallest according to the shrinker:
         failures
           .filter(_.fold(_ => true, _.isFailure))
-          .reverse
-          .headOption
+          .lastOption
           .fold[ZIO[R, E, TestResult]](ZIO.succeed(AssertResult.success(())))(ZIO.fromEither(_))
       }
 

--- a/test/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -58,7 +58,7 @@ object CheckSpec extends DefaultRuntime {
     }
 
   def maxShrinksIsRespected: Future[Boolean] = {
-    val gen = Gen.listOfN(100)(Gen.int(-10, 10))
+    val gen = Gen.listOfN(10)(Gen.int(-10, 10))
     unsafeRunToFuture {
       for {
         ref <- Ref.make(0)


### PR DESCRIPTION
Fixes a bug in shrinking logic for property based testing that could lead to very slow tests in some cases. Previously, we had a parameter `maxShrinks = 1000`. However, `shrinkSearch` was producing a stream of failing shrinks and then we were taking 1,000 elements from that. In some cases where failures were rare, this could mean that `shrinkSearch` actually explored much more than 1,000 potential values (@ghostdogpr was reporting more than 5,000 in one case). This changes that to have `shrinkSearch` return a stream of all potential shrinks explored, whether or not they are failures, and then the client, in this case the `checkStream` method, can take 1,000 of those and filter them for failures.

To support this, I also implemented a `takeUntil` method on `ZStream` that basically takes one more value than `takeWhile` would. So `ZStream("A", "A", "A", "B", "B", "B").takeUntil(_ == "B") == ZStream("A", "A", "A", "B")`. This has bounced around discussions about the Scala collections library as either `takeUntil` or `takeTo` so I'm open to naming suggestions. I think this method is pretty useful for something like `geolocationData.takeUntil(_.precision < x)` to give you a stream with a value satisfying your predicate if one exists and all the intermediate results leading up to it, and I don't think it is easily implemented in terms of existing combinators. I also added a `dropUntil` method for symmetry but I think it is much less useful and is easily implemented in terms of `dropWhile` and `drop`.