### PR TITLE
ZIO Test: Fix Potential Early Initialization Error

### DIFF
--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -326,7 +326,7 @@ object Gen {
   final def short(min: Short, max: Short): Gen[Random, Short] =
     integral(min, max)
 
-  final val size: Gen[Sized, Int] =
+  final def size: Gen[Sized, Int] =
     Gen.fromEffect(Sized.size)
 
   /**


### PR DESCRIPTION
In some situations it was possible to get a null pointer exception due to `Gen#size` not being initialized yet. Changes it from a `val` to a `def` to prevent that. Thanks to @regiskuckaertz for reporting!