### PR TITLE
ZIO Test: Disable traces in generators

### DIFF
--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -227,6 +227,7 @@ trait CheckVariants {
           .lastOption
           .fold[ZIO[R, E, TestResult]](ZIO.succeed(AssertResult.success(())))(ZIO.fromEither(_))
       }
+      .untraced
 
   private final def reassociate[A, B, C, D](f: (A, B, C) => D): (((A, B), C)) => D = {
     case ((a, b), c) => f(a, b, c)


### PR DESCRIPTION
Generators execute a lot of IO loops, so the time taken by generating traces is quite significant. I don't think they're useful and we could enable them locally if we want to debug generators.

I tested this on a work project where I generate a massive nested case class and it cut down time by 40%.