### PR TITLE
Add doUntilEquals and doWhileEquals methods

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
@@ -16,8 +16,10 @@ class ZScheduleSpec extends BaseCrossPlatformSpec {
       for 'recurs(a positive given number)' repeats that additional number of time $repeatN
       for 'doWhile(cond)' repeats while the cond still holds $repeatWhile
       for 'doWhileM(cond)' repeats while the effectul cond still holds $repeatWhileM
+      for 'doWhileEquals(cond)' repeats while the cond is equal $repeatWhileEquals
       for 'doUntil(cond)' repeats until the cond is satisfied $repeatUntil
       for 'doUntilM(cond)' repeats until the effectful cond is satisfied $repeatUntilM
+      for 'doUntilEquals(cond)' repeats until the cond is equal $repeatUntilEquals
    Collect all inputs into a list
       as long as the condition f holds $collectWhile
       as long as the effectful condition f holds $collectWhile
@@ -141,6 +143,12 @@ class ZScheduleSpec extends BaseCrossPlatformSpec {
     } yield i must_=== 11
   }
 
+  def repeatUntilEquals =
+    for {
+      ref <- Ref.make(0)
+      i   <- ref.update(_ + 1).repeat(Schedule.doUntilEquals(1))
+    } yield i must_=== 1
+
   def repeatWhile = {
     def cond: Int => Boolean = _ < 10
     for {
@@ -156,6 +164,12 @@ class ZScheduleSpec extends BaseCrossPlatformSpec {
       i   <- ref.update(_ + 1).repeat(Schedule.doWhileM(cond))
     } yield i must_=== 1
   }
+
+  def repeatWhileEquals =
+    for {
+      ref <- Ref.make(0)
+      i   <- ref.update(_ + 1).repeat(Schedule.doWhileEquals(1))
+    } yield i must_=== 2
 
   def collectWhile = {
     def cond: Int => Boolean = _ < 10

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -98,6 +98,12 @@ object Schedule {
     ZSchedule.doWhileM(f)
 
   /**
+   * See [[ZSchedule.doWhileEquals]]
+   */
+  final def doWhileEquals[A](a: A): Schedule[A, A] =
+    ZSchedule.doWhileEquals(a)
+
+  /**
    * See [[[ZSchedule.doUntil[A](f:* ZSchedule.doUntil]]]
    */
   final def doUntil[A](f: A => Boolean): Schedule[A, A] =
@@ -108,6 +114,12 @@ object Schedule {
    */
   final def doUntilM[A](f: A => UIO[Boolean]): Schedule[A, A] =
     ZSchedule.doUntilM(f)
+
+  /**
+   * See [[ZSchedule.doUntilEquals]]
+   */
+  final def doUntilEquals[A](a: A): Schedule[A, A] =
+    ZSchedule.doUntilEquals(a)
 
   /**
    * See [[ZSchedule.doUntil[A,B](pf:* ZSchedule.doUntil]]]

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -634,6 +634,12 @@ object ZSchedule {
     identity[A].whileInputM(f)
 
   /**
+   * A schedule that recurs for as long as the predicate is equal.
+   */
+  final def doWhileEquals[A](a: A): Schedule[A, A] =
+    identity[A].whileInput(_ == a)
+
+  /**
    * A schedule that recurs for until the predicate evaluates to true.
    */
   final def doUntil[A](f: A => Boolean): Schedule[A, A] =
@@ -644,6 +650,12 @@ object ZSchedule {
    */
   final def doUntilM[A](f: A => UIO[Boolean]): Schedule[A, A] =
     identity[A].untilInputM(f)
+
+  /**
+   * A schedule that recurs for until the predicate is equal.
+   */
+  final def doUntilEquals[A](a: A): Schedule[A, A] =
+    identity[A].untilInput(_ == a)
 
   /**
    * A schedule that recurs for until the input value becomes applicable to partial function


### PR DESCRIPTION
#1219 
New methods for `ZSchedule`:
```
def doWhileEquals[A](a: A): Schedule[A, A]
def doUntilEquals[A](a: A): Schedule[A, A]
```