### PR TITLE
ZIO Test: Enable Tracing for Test Execution

### DIFF
--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -217,12 +217,12 @@ trait CheckVariants {
               .either
         )
     }.dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
-      .take(1)                                         // Get the first failure
+      .take(1)                                          // Get the first failure
       .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks))
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken values
-      .flatMap { values =>
+      .flatMap { shrinks =>
         // Get the "last" failure, the smallest according to the shrinker:
-        values
+        shrinks
           .filter(_.fold(_ => true, _.isFailure))
           .lastOption
           .fold[ZIO[R, E, TestResult]](ZIO.succeed(AssertResult.success(())))(ZIO.fromEither(_))

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -219,10 +219,10 @@ trait CheckVariants {
     }.dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
       .take(1)                                         // Get the first failure
       .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks))
-      .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken failures
-      .flatMap { failures =>
+      .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken values
+      .flatMap { values =>
         // Get the "last" failure, the smallest according to the shrinker:
-        failures
+        values
           .filter(_.fold(_ => true, _.isFailure))
           .lastOption
           .fold[ZIO[R, E, TestResult]](ZIO.succeed(AssertResult.success(())))(ZIO.fromEither(_))

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -212,12 +212,12 @@ trait CheckVariants {
       case (initial, index) =>
         initial.traverse(
           input =>
-            test(input)
+            test(input).traced
               .map(_.map(_.left.map(_.copy(gen = Some(GenFailureDetails(initial.value, input, index))))))
               .either
         )
     }.dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
-      .take(1)                                          // Get the first failure
+      .take(1)                                         // Get the first failure
       .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks))
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken failures
       .flatMap { failures =>


### PR DESCRIPTION
Very minor follow up to #1633.  Previously we disabled tracing for random variable generation to improve performance. This PR just reenables tracing for the effect of actually evaluating the test once the random variables have been generated. I think this is nice because it gives the user the default tracing behavior with respect to the effects they create, we just aren't tracing our internal effects. Sorry for the multiple PRs, didn't think of this earlier.

Copying @ghostdogpr.