### PR TITLE
Add Assertion.dies and Gen.anyString

### DIFF
--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import scala.reflect.ClassTag
 
-import zio.Exit
+import zio.{ Cause, Exit }
 import zio.test.Assertion._
 import zio.test.Assertion.Render._
 
@@ -232,6 +232,22 @@ object Assertion {
     Assertion.assertionRec[Exit[E, Any]]("fails")(param(assertion)) { (self, actual) =>
       actual match {
         case Exit.Failure(cause) if cause.failures.length > 0 => assertion.run(cause.failures.head)
+
+        case _ => AssertResult.failure(AssertionValue(self, actual))
+      }
+    }
+
+  /**
+   * Makes a new assertion that requires an exit value to die.
+   */
+  final def dies(assertion: Assertion[Throwable]): Assertion[Exit[Nothing, Any]] =
+    Assertion.assertionRec[Exit[Nothing, Any]]("dies")(param(assertion)) { (self, actual) =>
+      actual match {
+        case Exit.Failure(cause) if cause.died =>
+          cause.untraced match {
+            case Cause.Die(t) => assertion.run(t)
+            case _            => AssertResult.failure(AssertionValue(self, actual))
+          }
 
         case _ => AssertResult.failure(AssertionValue(self, actual))
       }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -142,6 +142,12 @@ object Gen {
     }
 
   /**
+   * A generator of shorts. Shrinks towards the empty string.
+   */
+  final val anyString: Gen[Random with Sized, String] =
+    Gen.string(Gen.anyChar)
+
+  /**
    * A generator of booleans. Shrinks toward 'false'.
    */
   final val boolean: Gen[Random, Boolean] =

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -142,7 +142,7 @@ object Gen {
     }
 
   /**
-   * A generator of shorts. Shrinks towards the empty string.
+   * A generator of strings. Shrinks towards the empty string.
    */
   final val anyString: Gen[Random with Sized, String] =
     Gen.string(Gen.anyChar)

--- a/test/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -71,11 +71,11 @@ object AssertionSpec {
       message = "fails must fail when error value does not satisfy specified assertion"
     ),
     testSuccess(
-      assert(Exit.die(someException), fails(equalTo(someException))),
+      assert(Exit.die(someException), dies(equalTo(someException))),
       message = "dies must succeed when exception satisfy specified assertion"
     ),
     testFailure(
-      assert(Exit.die(new RuntimeException("Bam!")), fails(equalTo(someException))),
+      assert(Exit.die(new RuntimeException("Bam!")), dies(equalTo(someException))),
       message = "fails must fail when exception does not satisfy specified assertion"
     ),
     testSuccess(

--- a/test/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -26,6 +26,8 @@ object AssertionSpec {
   val ageLessThan20    = hasField[SampleUser, Int]("age", _.age, isLessThan(20))
   val ageGreaterThan20 = hasField[SampleUser, Int]("age", _.age, isGreaterThan(20))
 
+  val someException = new RuntimeException("Boom!")
+
   def run: List[Async[(Boolean, String)]] = List(
     testSuccess(assert(42, anything), message = "anything must always succeeds"),
     testSuccess(
@@ -67,6 +69,14 @@ object AssertionSpec {
     testFailure(
       assert(Exit.fail("Other Error"), fails(equalTo("Some Error"))),
       message = "fails must fail when error value does not satisfy specified assertion"
+    ),
+    testSuccess(
+      assert(Exit.die(someException), fails(equalTo(someException))),
+      message = "dies must succeed when exception satisfy specified assertion"
+    ),
+    testFailure(
+      assert(Exit.die(new RuntimeException("Bam!")), fails(equalTo(someException))),
+      message = "fails must fail when exception does not satisfy specified assertion"
     ),
     testSuccess(
       assert(Seq("a", "bb", "ccc"), forall(hasField[String, Int]("length", _.length, isWithin(0, 3)))),

--- a/test/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -76,7 +76,7 @@ object AssertionSpec {
     ),
     testFailure(
       assert(Exit.die(new RuntimeException("Bam!")), dies(equalTo(someException))),
-      message = "fails must fail when exception does not satisfy specified assertion"
+      message = "dies must fail when exception does not satisfy specified assertion"
     ),
     testSuccess(
       assert(Seq("a", "bb", "ccc"), forall(hasField[String, Int]("length", _.length, isWithin(0, 3)))),

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -23,6 +23,7 @@ object GenSpec extends DefaultRuntime {
     label(anyIntShrinksToZero, "anyInt shrinks to zero"),
     label(anyLongShrinksToZero, "anyLong shrinks to zero"),
     label(anyShortShrinksToZero, "anyShort shrinks to zero"),
+    label(anyStringShrinksToEmptyString, "anyString shrinks to empty string"),
     label(booleanGeneratesTrueAndFalse, "boolean generates true and false"),
     label(booleanShrinksToFalse, "boolean shrinks to false"),
     label(byteGeneratesValuesInRange, "byte generates values in range"),
@@ -146,6 +147,9 @@ object GenSpec extends DefaultRuntime {
 
   def anyShortShrinksToZero: Future[Boolean] =
     checkShrink(Gen.anyShort)(0)
+
+  def anyStringShrinksToEmptyString: Future[Boolean] =
+    checkShrink(Gen.anyString)("")
 
   def booleanGeneratesTrueAndFalse: Future[Boolean] =
     checkSample(Gen.boolean)(ps => ps.exists(identity) && ps.exists(!_))


### PR DESCRIPTION
Taken from #1595 

- `Assertion.dies` helps with checking the unchecked error channel in a `Cause[E]`.
- `Gen.anyString` seems like a recurring use case for a generator (perhaps `asciiString` too?)

cc @adamgfraser  