### PR TITLE
ZIO Test: Default Sized Generators to Small

### DIFF
--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -302,7 +302,7 @@ object GenSpec extends DefaultRuntime {
 
   def smallGeneratesSizesInRange: Future[Boolean] = {
     val gen = Gen.small(Gen.listOfN(_)(Gen.int(-10, 10)))
-    checkSample(gen)(_.forall(_.length < 8))
+    checkSample(gen)(_.forall(_.length <= 50))
   }
 
   def someShrinksToSmallestValue: Future[Boolean] =


### PR DESCRIPTION
Following up on feedback from @jdegoes, changes the default sized combinator for sized generators from `medium` to `small`.  Also changes the `small` generator so that nine times out of ten it gives the same logarithmic distribution as before but the other time it uses a uniform distribution up to half the max size parameter. The idea is to strongly concentrate values on smaller sizes but still occasionally test larger sizes. This should speed up tests, especially in cases with complex types where generating large sized values for individual fields had little value.

I've included a sample run below.

```
5
2
0
7
3
7
7
4
5
5
9
3
6
2
1
5
6
3
1
0
24
1
3
2
5
4
4
5
1
4
2
1
1
0
1
7
7
5
4
5
4
7
0
7
12
22
5
5
7
6
42
5
1
4
28
1
2
7
2
1
4
5
4
1
0
6
24
6
5
4
6
0
0
46
0
3
5
6
2
3
2
3
5
0
0
29
7
7
3
6
11
7
6
5
2
7
2
39
4
0
1
45
2
6
0
3
1
1
5
2
2
3
5
5
28
7
4
3
3
4
5
2
1
2
3
7
44
0
6
3
2
2
5
7
2
0
2
6
4
5
3
7
3
5
3
4
7
0
4
2
2
3
2
7
5
5
2
1
4
0
1
0
1
27
44
5
4
6
0
6
3
5
7
5
1
16
6
32
7
3
6
2
2
7
2
5
2
6
49
6
7
4
4
1
0
2
3
27
5
0
```