### PR TITLE
Prototype annotations

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -38,7 +38,7 @@ class QueueSequentialBenchmark {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
     zioTQ = unsafeRun(TQueue.make(totalSize).commit)
-    monixQ = monix.catnap.ConcurrentQueue.custom[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
+    monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 
   @Benchmark

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.duration._
+
+import scala.reflect.ClassTag
+
+/**
+ * A type of annotation.
+ */
+final class TestAnnotation[V] private (
+  val identifier: String,
+  val initial: V,
+  val combine: (V, V) => V,
+  private val classTag: ClassTag[V]
+) {
+  override final def equals(that: Any): Boolean = that match {
+    case that: TestAnnotation[_] => (identifier, classTag) == ((identifier, that.classTag))
+  }
+
+  override final lazy val hashCode = (identifier, classTag).hashCode
+}
+object TestAnnotation {
+  /**
+   * An annotation for timing.
+   */
+  val Timing: TestAnnotation[Duration] = TestAnnotation("timing", Duration.Zero, _ + _)
+
+  def apply[V](identifier: String, initial: V, combine: (V, V) => V)(
+    implicit classTag: ClassTag[V]
+  ): TestAnnotation[V] =
+    new TestAnnotation(identifier, initial, combine, classTag)
+}

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -36,6 +36,7 @@ final class TestAnnotation[V] private (
   override final lazy val hashCode = (identifier, classTag).hashCode
 }
 object TestAnnotation {
+
   /**
    * An annotation for timing.
    */

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+/**
+ * An annotation map keeps track of annotations of different types.
+ */
+class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRef]) { self =>
+  final def ++(that: TestAnnotationMap): TestAnnotationMap =
+    new TestAnnotationMap((self.map.toVector ++ that.map.toVector).foldLeft[Map[TestAnnotation[Any], AnyRef]](Map()) {
+      case (acc, (key, value)) =>
+        acc + (key -> acc.get(key).fold(value)(key.combine(_, value).asInstanceOf[AnyRef]))
+    })
+
+  /**
+   * Appends the specified annotation to the annotation map.8
+   */
+  final def annotate[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
+    update(key, key.combine(_, value))
+
+  /**
+   * Retrieves the annotation of the specified type, or its default value if there is none.
+   */
+  final def get[V](key: TestAnnotation[V]): V =
+    map.get(key.asInstanceOf[TestAnnotation[Any]]).fold(key.initial)(_.asInstanceOf[V])
+
+  private final def overwrite[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
+    new TestAnnotationMap(map + (key.asInstanceOf[TestAnnotation[Any]] -> value.asInstanceOf[AnyRef]))
+
+  private final def update[V](key: TestAnnotation[V], f: V => V): TestAnnotationMap = overwrite(key, f(get(key)))
+}
+object TestAnnotationMap {
+  /**
+   * An empty annotation map.
+   */
+  val empty = new TestAnnotationMap(Map())
+}

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -30,7 +30,7 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
    * Appends the specified annotation to the annotation map.
    */
   final def annotate[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
-    update(key, key.combine(_, value))
+    update[V](key, key.combine(_, value))
 
   /**
    * Retrieves the annotation of the specified type, or its default value if there is none.

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -27,7 +27,7 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
     })
 
   /**
-   * Appends the specified annotation to the annotation map.8
+   * Appends the specified annotation to the annotation map.
    */
   final def annotate[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
     update(key, key.combine(_, value))

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -44,6 +44,7 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
   private final def update[V](key: TestAnnotation[V], f: V => V): TestAnnotationMap = overwrite(key, f(get(key)))
 }
 object TestAnnotationMap {
+
   /**
    * An empty annotation map.
    */


### PR DESCRIPTION
Annotations are monoids. Annotation maps collect annotations and could in theory be attached to each node, so that aspects could add arbitrary annotations.

Some annotations we might like to have:

 - timing, both per test, and per suite
 - how many checks, for property tests
 - distribution of values, for property tests
 - seeds for property checks
 - aggregate of succeeded / failed / ignored
 - etc.

/cc @adamgfraser 