### PR TITLE
ZIO Test: Implement Generators for Effects

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -38,7 +38,7 @@ class QueueSequentialBenchmark {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
     zioTQ = unsafeRun(TQueue.make(totalSize).commit)
-    monixQ = monix.catnap.ConcurrentQueue.custom[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
+    monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 
   @Benchmark

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -84,7 +84,7 @@ case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
     self.zip(that).map(f.tupled)
 }
 
-object Gen {
+object Gen extends GenZIO {
 
   /**
    * A generator of alphanumeric characters. Shrinks toward '0'.
@@ -397,6 +397,12 @@ object Gen {
    */
   final def suspend[R, A](gen: => Gen[R, A]): Gen[R, A] =
     fromEffect(ZIO.effectTotal(gen)).flatten
+
+  /**
+   * A generator of throwables.
+   */
+  final def throwable: Gen[Random, Throwable] =
+    Gen.const(new Throwable)
 
   /**
    * A generator of uniformly distributed doubles between [0, 1].

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -401,7 +401,7 @@ object Gen extends GenZIO {
   /**
    * A generator of throwables.
    */
-  final def throwable: Gen[Random, Throwable] =
+  final val throwable: Gen[Random, Throwable] =
     Gen.const(new Throwable)
 
   /**

--- a/test/shared/src/main/scala/zio/test/GenZIO.scala
+++ b/test/shared/src/main/scala/zio/test/GenZIO.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio._
+import zio.random.Random
+
+trait GenZIO {
+
+  /**
+   * Constructs a generator of `IO[E, A]` effects given generators of `E` and
+   * `A` values.
+   */
+  final def io[R <: Random, E, A](e: Gen[R, E], a: Gen[R, A]): Gen[R, IO[E, A]] =
+    Gen.either(e, a).map(ZIO.fromEither(_))
+
+  /**
+   * Constructs a generator of `RIO[R, A]` effects given a generator of `A`
+   * values.
+   */
+  final def rio[R <: Random, R1, A](a: Gen[R, A]): Gen[R, RIO[R1, A]] =
+    Gen
+      .function[R, R1, Either[Throwable, A]](Gen.either(Gen.throwable, a))
+      .map(f => ZIO.fromFunctionM(r => ZIO.fromEither(f(r))))
+
+  /**
+   * Constructs a generator of `Task[A]` effects given a generator of `A`
+   * values.
+   */
+  final def task[R <: Random, A](a: Gen[R, A]): Gen[R, Task[A]] =
+    Gen.either(Gen.throwable, a).map(ZIO.fromEither(_))
+
+  /**
+   * Constructs a generator of `UIO[A]` effects given a generator of `A`
+   * values.
+   */
+  final def uio[R <: Random, A](a: Gen[R, A]): Gen[R, UIO[A]] =
+    a.map(ZIO.succeed)
+
+  /**
+   * Constructs a generator of `URIO[A]` effects given a generator of `A`
+   * values.
+   */
+  final def urio[R <: Random, R1, A](a: Gen[R, A]): Gen[R, URIO[R1, A]] =
+    Gen.function[R, R1, A](a).map(f => ZIO.fromFunction(f))
+
+  /**
+   * Constructs a generator of `ZIO[R, E, A]` effects given generators of
+   * `E` and `A` values.
+   */
+  final def zio[R <: Random, R1, E, A](e: Gen[R, E], a: Gen[R, A]): Gen[R, ZIO[R1, E, A]] =
+    Gen
+      .function[R, R1, Either[E, A]](Gen.either(e, a))
+      .map(f => ZIO.fromFunctionM(r => ZIO.fromEither(f(r))))
+}

--- a/test/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test/shared/src/test/scala/zio/test/FunSpec.scala
@@ -13,7 +13,8 @@ object FunSpec extends DefaultRuntime {
   val run: List[Async[(Boolean, String)]] = List(
     label(funConvertsEffectsIntoPureFunctions, "fun converts effects into pure functions"),
     label(funDoesNotHaveRaceConditions, "fun does not have race conditions"),
-    label(funIsShowable, "fun is showable")
+    label(funIsShowable, "fun is showable"),
+    label(funIsSupportedOnScalaJS, "fun is supported on Scala.js")
   )
 
   def funConvertsEffectsIntoPureFunctions: Future[Boolean] =
@@ -40,5 +41,13 @@ object FunSpec extends DefaultRuntime {
         q = f("Haskell")
       } yield f.toString == s"Fun(Scala -> $p, Haskell -> $q)" ||
         f.toString == s"Fun(Haskell -> $q, Scala -> $p)"
+    }
+
+  def funIsSupportedOnScalaJS: Future[Boolean] =
+    unsafeRunToFuture {
+      for {
+        f <- Fun.make((_: Int) => ZIO.foreach(List.range(0, 100000))(ZIO.succeed))
+        _ = f(1)
+      } yield true
     }
 }

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -2,14 +2,14 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ DefaultRuntime, Managed, UIO, ZIO }
 import zio.random.Random
 import zio.stream.ZStream
-import zio.test.mock.MockRandom
 import zio.test.Assertion._
+import zio.test.GenUtils._
 import zio.test.TestUtils.{ label, succeeded }
+import zio.ZIO
 
-object GenSpec extends DefaultRuntime {
+object GenSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(monadLeftIdentity, "monad left identity"),
@@ -463,68 +463,4 @@ object GenSpec extends DefaultRuntime {
       succeeded(takeWhileProp)
     }
   }
-
-  def checkEqual[A](left: Gen[Random, A], right: Gen[Random, A]): Future[Boolean] =
-    unsafeRunToFuture(equal(left, right))
-
-  def checkSample[A](gen: Gen[Random with Sized, A], size: Int = 100)(f: List[A] => Boolean): Future[Boolean] =
-    unsafeRunToFuture(provideSize(sample(gen).map(f))(size))
-
-  def checkFinite[A](gen: Gen[Random, A])(f: List[A] => Boolean): Future[Boolean] =
-    unsafeRunToFuture(gen.sample.map(_.value).runCollect.map(f))
-
-  def checkShrink[A](gen: Gen[Random with Sized, A])(a: A): Future[Boolean] =
-    unsafeRunToFuture(provideSize(alwaysShrinksTo(gen)(a: A))(100))
-
-  def sample[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).forever.take(100).runCollect
-
-  def alwaysShrinksTo[R, A](gen: Gen[R, A])(a: A): ZIO[R, Nothing, Boolean] = {
-    val shrinks = if (TestPlatform.isJS) 1 else 100
-    ZIO.collectAll(List.fill(shrinks)(shrinksTo(gen))).map(_.forall(_ == a))
-  }
-
-  def shrinksTo[R, A](gen: Gen[R, A]): ZIO[R, Nothing, A] =
-    shrinks(gen).map(_.reverse.head)
-
-  def shrinks[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.forever.take(1).flatMap(_.shrinkSearch(_ => true)).take(1000).runCollect
-
-  def equal[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] =
-    equalSample(left, right).zipWith(equalShrink(left, right))(_ && _)
-
-  def forAll[E <: Throwable, A](zio: ZIO[Random, E, Boolean]): Future[Boolean] =
-    unsafeRunToFuture(ZIO.collectAll(List.fill(100)(zio)).map(_.forall(identity)))
-
-  def equalSample[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
-    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
-    for {
-      leftSample  <- sample(left).provideManaged(mockRandom)
-      rightSample <- sample(right).provideManaged(mockRandom)
-    } yield leftSample == rightSample
-  }
-
-  def equalShrink[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
-    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
-    for {
-      leftShrinks  <- ZIO.collectAll(List.fill(100)(shrinks(left))).provideManaged(mockRandom)
-      rightShrinks <- ZIO.collectAll(List.fill(100)(shrinks(right))).provideManaged(mockRandom)
-    } yield leftShrinks == rightShrinks
-  }
-
-  def showTree[R, A](sample: Sample[R, A], offset: Int = 0): ZIO[R, Nothing, String] = {
-    val head = " " * offset + sample.value + "\n"
-    val tail = sample.shrink.mapM(showTree(_, offset + 2)).runCollect.map(_.mkString("\n"))
-    tail.map(head + _)
-  }
-
-  def provideSize[A](zio: ZIO[Random with Sized, Nothing, A])(n: Int): ZIO[Random, Nothing, A] =
-    Sized.makeService(n).flatMap { service =>
-      zio.provideSome[Random] { r =>
-        new Random with Sized {
-          val random = r.random
-          val sized  = service
-        }
-      }
-    }
 }

--- a/test/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test/shared/src/test/scala/zio/test/GenUtils.scala
@@ -1,0 +1,85 @@
+package zio.test
+
+import scala.concurrent.Future
+
+import zio.{ DefaultRuntime, Managed, UIO, ZIO }
+import zio.random.Random
+import zio.test.mock.MockRandom
+
+object GenUtils extends DefaultRuntime {
+
+  def checkEqual[A](left: Gen[Random, A], right: Gen[Random, A]): Future[Boolean] =
+    unsafeRunToFuture(equal(left, right))
+
+  def checkSample[A](gen: Gen[Random with Sized, A], size: Int = 100)(f: List[A] => Boolean): Future[Boolean] =
+    unsafeRunToFuture(provideSize(sample(gen).map(f))(size))
+
+  def checkFinite[A](gen: Gen[Random, A])(f: List[A] => Boolean): Future[Boolean] =
+    unsafeRunToFuture(gen.sample.map(_.value).runCollect.map(f))
+
+  def checkShrink[A](gen: Gen[Random with Sized, A])(a: A): Future[Boolean] =
+    unsafeRunToFuture(provideSize(alwaysShrinksTo(gen)(a: A))(100))
+
+  def sample[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
+    gen.sample.map(_.value).forever.take(100).runCollect
+
+  def alwaysShrinksTo[R, A](gen: Gen[R, A])(a: A): ZIO[R, Nothing, Boolean] = {
+    val shrinks = if (TestPlatform.isJS) 1 else 100
+    ZIO.collectAll(List.fill(shrinks)(shrinksTo(gen))).map(_.forall(_ == a))
+  }
+
+  def shrinksTo[R, A](gen: Gen[R, A]): ZIO[R, Nothing, A] =
+    shrinks(gen).map(_.reverse.head)
+
+  def shrinks[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
+    gen.sample.forever.take(1).flatMap(_.shrinkSearch(_ => true)).take(1000).runCollect
+
+  def equal[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] =
+    equalSample(left, right).zipWith(equalShrink(left, right))(_ && _)
+
+  def forAll[E <: Throwable, A](zio: ZIO[Random, E, Boolean]): Future[Boolean] =
+    unsafeRunToFuture(ZIO.collectAll(List.fill(100)(zio)).map(_.forall(identity)))
+
+  def equalSample[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
+    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
+    for {
+      leftSample  <- sample(left).provideManaged(mockRandom)
+      rightSample <- sample(right).provideManaged(mockRandom)
+    } yield leftSample == rightSample
+  }
+
+  def equalShrink[A](left: Gen[Random, A], right: Gen[Random, A]): UIO[Boolean] = {
+    val mockRandom = Managed.fromEffect(MockRandom.make(MockRandom.DefaultData))
+    for {
+      leftShrinks  <- ZIO.collectAll(List.fill(100)(shrinks(left))).provideManaged(mockRandom)
+      rightShrinks <- ZIO.collectAll(List.fill(100)(shrinks(right))).provideManaged(mockRandom)
+    } yield leftShrinks == rightShrinks
+  }
+
+  def showTree[R, A](sample: Sample[R, A], offset: Int = 0): ZIO[R, Nothing, String] = {
+    val head = " " * offset + sample.value + "\n"
+    val tail = sample.shrink.mapM(showTree(_, offset + 2)).runCollect.map(_.mkString("\n"))
+    tail.map(head + _)
+  }
+
+  def provideSize[A](zio: ZIO[Random with Sized, Nothing, A])(n: Int): ZIO[Random, Nothing, A] =
+    Sized.makeService(n).flatMap { service =>
+      zio.provideSome[Random] { r =>
+        new Random with Sized {
+          val random = r.random
+          val sized  = service
+        }
+      }
+    }
+
+  def checkSampleEffect[E, A](gen: Gen[Random with Sized, ZIO[Random with Sized, E, A]], size: Int = 100)(
+    f: List[Either[E, A]] => Boolean
+  ): Future[Boolean] =
+    unsafeRunToFuture(provideSize(sample(gen).flatMap(effects => ZIO.collectAll(effects.map(_.either)).map(f)))(size))
+
+  def partitionEither[E, A](eas: List[Either[E, A]]): (List[E], List[A]) =
+    eas.foldRight((List.empty[E], List.empty[A])) {
+      case (Left(e), (es, as))  => (e :: es, as)
+      case (Right(a), (es, as)) => (es, a :: as)
+    }
+}

--- a/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
@@ -1,0 +1,82 @@
+package zio.test
+
+import scala.concurrent.Future
+
+import zio.random.Random
+import zio.test.GenUtils.{ checkSampleEffect, partitionEither }
+import zio.test.TestUtils.label
+
+object GenZIOSpec {
+
+  val run: List[Async[(Boolean, String)]] = List(
+    label(ioGeneratesIOEffects, "io generates IO effects"),
+    label(rioGeneratesRIOEffects, "rio generates RIO effects"),
+    label(taskGeneratesTaskEffects, "task generates Task effects"),
+    label(uioGeneratesUIOEffects, "uio generates UIO effects"),
+    label(urioGeneratesURIOEffects, "urio generates URIO effects"),
+    label(zioGeneratesZIOEffects, "zio generates ZIO effects")
+  )
+
+  def ioGeneratesIOEffects: Future[Boolean] = {
+    val gen = Gen.io(Gen.string(Gen.alphaNumericChar), Gen.int(-10, 10))
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.nonEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+
+  def rioGeneratesRIOEffects: Future[Boolean] = {
+    val gen = Gen.rio(Gen.int(-10, 10))
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.nonEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+
+  def taskGeneratesTaskEffects: Future[Boolean] = {
+    val gen = Gen.task(Gen.int(-10, 10))
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.nonEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+
+  def uioGeneratesUIOEffects: Future[Boolean] = {
+    val gen = Gen.uio(Gen.int(-10, 10))
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.isEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+
+  def urioGeneratesURIOEffects: Future[Boolean] = {
+    val gen = Gen.urio(Gen.int(-10, 10))
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.isEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+
+  def zioGeneratesZIOEffects: Future[Boolean] = {
+    val gen = Gen.zio[Random with Sized, Any, String, Int](
+      Gen.string(Gen.alphaNumericChar),
+      Gen.int(-10, 10)
+    )
+    checkSampleEffect(gen) { results =>
+      val (failures, successes) = partitionEither(results)
+      failures.nonEmpty &&
+      successes.nonEmpty &&
+      successes.forall(n => -10 <= n && n <= 10)
+    }
+  }
+}

--- a/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
@@ -2,79 +2,42 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.random.Random
+import zio.test.Gen._
 import zio.test.GenUtils.{ checkSampleEffect, partitionEither }
 import zio.test.TestUtils.label
 
 object GenZIOSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
-    label(ioGeneratesIOEffects, "io generates IO effects"),
-    label(rioGeneratesRIOEffects, "rio generates RIO effects"),
-    label(taskGeneratesTaskEffects, "task generates Task effects"),
-    label(uioGeneratesUIOEffects, "uio generates UIO effects"),
-    label(urioGeneratesURIOEffects, "urio generates URIO effects"),
-    label(zioGeneratesZIOEffects, "zio generates ZIO effects")
+    label(failuresGeneratesFailedEffects, "died generates died effects"),
+    label(failuresGeneratesFailedEffects, "failures generates failed effects"),
+    label(successesGeneratesSuccessfulEffects, "successes generates successful effects")
   )
 
-  def ioGeneratesIOEffects: Future[Boolean] = {
-    val gen = Gen.io(Gen.string(Gen.alphaNumericChar), Gen.int(-10, 10))
+  def diedGeneratesDiedEffects: Future[Boolean] = {
+    val gen = died(Gen.throwable)
     checkSampleEffect(gen) { results =>
       val (failures, successes) = partitionEither(results)
       failures.nonEmpty &&
-      successes.nonEmpty &&
-      successes.forall(n => -10 <= n && n <= 10)
+      successes.isEmpty &&
+      failures.forall { case _: Throwable => true }
     }
   }
 
-  def rioGeneratesRIOEffects: Future[Boolean] = {
-    val gen = Gen.rio(Gen.int(-10, 10))
+  def failuresGeneratesFailedEffects: Future[Boolean] = {
+    val gen = failures(anyString)
     checkSampleEffect(gen) { results =>
       val (failures, successes) = partitionEither(results)
       failures.nonEmpty &&
-      successes.nonEmpty &&
-      successes.forall(n => -10 <= n && n <= 10)
+      successes.isEmpty
     }
   }
 
-  def taskGeneratesTaskEffects: Future[Boolean] = {
-    val gen = Gen.task(Gen.int(-10, 10))
-    checkSampleEffect(gen) { results =>
-      val (failures, successes) = partitionEither(results)
-      failures.nonEmpty &&
-      successes.nonEmpty &&
-      successes.forall(n => -10 <= n && n <= 10)
-    }
-  }
-
-  def uioGeneratesUIOEffects: Future[Boolean] = {
-    val gen = Gen.uio(Gen.int(-10, 10))
+  def successesGeneratesSuccessfulEffects: Future[Boolean] = {
+    val gen = successes(int(-10, 10))
     checkSampleEffect(gen) { results =>
       val (failures, successes) = partitionEither(results)
       failures.isEmpty &&
-      successes.nonEmpty &&
-      successes.forall(n => -10 <= n && n <= 10)
-    }
-  }
-
-  def urioGeneratesURIOEffects: Future[Boolean] = {
-    val gen = Gen.urio(Gen.int(-10, 10))
-    checkSampleEffect(gen) { results =>
-      val (failures, successes) = partitionEither(results)
-      failures.isEmpty &&
-      successes.nonEmpty &&
-      successes.forall(n => -10 <= n && n <= 10)
-    }
-  }
-
-  def zioGeneratesZIOEffects: Future[Boolean] = {
-    val gen = Gen.zio[Random with Sized, Any, String, Int](
-      Gen.string(Gen.alphaNumericChar),
-      Gen.int(-10, 10)
-    )
-    checkSampleEffect(gen) { results =>
-      val (failures, successes) = partitionEither(results)
-      failures.nonEmpty &&
       successes.nonEmpty &&
       successes.forall(n => -10 <= n && n <= 10)
     }

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -18,6 +18,7 @@ object TestMain {
       scope(EnvironmentSpec.run, "EnvironmentSpec"),
       scope(FunSpec.run, "FunSpec"),
       scope(GenSpec.run, "GenSpec"),
+      scope(GenZIOSpec.run, "GenZIOSpec"),
       scope(LiveSpec.run, "LiveSpec"),
       scope(RandomSpec.run, "RandomSpec"),
       scope(SampleSpec.run, "SampleSpec"),


### PR DESCRIPTION
Implements generators for `ZIO` and its various type aliases.

I took a somewhat different approach from the existing generators in the test suites. I think we need to make a distinction between generators that `ZIO` uses internally to test its own correctness and generators that users of `ZIO` should use. I would argue that for a user, if a `ZIO` produces an `A` and doesn't perform any actual effects then it should be indistinguishable to a user how that `A` was produced (e.g. if it was there all along or created through a complex chain or transformations). If it is possible for a user to distinguish those then that is an internal error in `ZIO` that needs to be addressed. If this is correct then to generate `ZIO` values we only need to be concerned with producing the right results and not in producing different computations to produce those results. This simplifies the implementation considerably and will also make these generators faster and shrink better for users.

Internally, `ZIO` can use more complex generators to verify that various different sequences of computations produce the expected results, but that shouldn't be exposed to users. At least that is my current thinking. Interested if others have different points of view.

Resolves #1653.
