### PR TITLE
Added .cache to circle directories to be cached

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,15 +50,16 @@ install_jdk: &install_jdk
 
 load_cache: &load_cache
   - restore_cache:
-      key: sbt-cache
+      key: sbt-cache-v2
 
 save_cache: &save_cache
   - save_cache:
-      key: sbt-cache
+      key: sbt-cache-v2
       paths:
           - "~/.ivy2/cache"
           - "~/.sbt"
           - "~/.m2"
+          - "~/.cache"
           - "~/website/node_modules"
 
 install_yarn: &install_yarn


### PR DESCRIPTION
Now that coursier is part of sbt adding its cache directory to to our circleci build to cache it between builds. 

Ref: <https://twitter.com/alxarchambault/status/1172609389439725568?s=21>
