### PR TITLE
ZIO Test: Fix Issues in Test Migration

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -38,7 +38,7 @@ class QueueSequentialBenchmark {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
     zioTQ = unsafeRun(TQueue.make(totalSize).commit)
-    monixQ = monix.catnap.ConcurrentQueue.custom[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
+    monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 
   @Benchmark

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -8,7 +8,7 @@ import BlockingSpecUtil._
 import zio.test._
 import zio.test.Assertion._
 
-class BlockingSpec
+object BlockingSpec
     extends ZIOBaseSpec(
       suite("BlockingSpec")(
         suite("Make a Blocking Service and verify that")(

--- a/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
@@ -2,32 +2,33 @@ package zio
 package system
 
 import zio.test._
+import zio.test.mock._
 import zio.test.Assertion._
 
 import scala.reflect.io.File
 
-class SystemSpec
+object SystemSpec
     extends ZIOBaseSpec(
       suite("SystemSpec")(
         suite("Fetch an environment variable and check that")(
           testM("If it exists, return a reasonable value") {
-            assertM(system.env("PATH"), isSome(containsString(File.separator + "bin")))
+            assertM(live(system.env("PATH")), isSome(containsString(File.separator + "bin")))
           },
           testM("If it does not exist, return None") {
-            assertM(system.env("QWERTY"), isNone)
+            assertM(live(system.env("QWERTY")), isNone)
           }
         ),
         suite("Fetch a VM property and check that")(
           testM("If it exists, return a reasonable value") {
-            assertM(property("java.vm.name"), isSome(equalTo("VM")))
+            assertM(live(property("java.vm.name")), isSome(containsString("VM")))
           },
           testM("If it does not exist, return None") {
-            assertM(property("qwerty"), isNone)
+            assertM(live(property("qwerty")), isNone)
           }
         ),
         suite("Fetch the system's line separator and check that")(
           testM("it is identical to System.lineSeparator") {
-            assertM(lineSeparator, equalTo(java.lang.System.lineSeparator))
+            assertM(live(lineSeparator), equalTo(java.lang.System.lineSeparator))
           }
         )
       )


### PR DESCRIPTION
A couple of the tests migrated to ZIO Test earlier today were defined in classes instead of objects so they weren't getting picked up by the SBT test runner. Fixing that led to identifying a couple of issues with the tests that were migrated in `SystemSpec` which are now fixed.