### PR TITLE
resolves #1533 update zstream repeat

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1471,7 +1471,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
       Stream(1)
         .repeatEither(Schedule.recurs(4))
         .run(Sink.collectAll[Either[Int, Int]])
-        .map(_ must_=== List(Right(1), Right(1), Left(1), Right(1), Left(2), Right(1), Left(3), Right(1), Left(4)))
+        .map(_ must_=== List(Right(1), Left(1), Right(1), Left(2), Right(1), Left(3), Right(1), Left(4), Right(1)))
     )
 
   private def repeatEitherShortCircuits =
@@ -1481,7 +1481,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
         _ <- Stream
               .fromEffect(ref.update(1 :: _))
               .repeatEither(Schedule.spaced(10.millis))
-              .take(2)
+              .take(3) // take one schedule output
               .run(Sink.drain)
         result <- ref.get
       } yield result must_=== List(1, 1)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1471,7 +1471,7 @@ class ZStreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestR
       Stream(1)
         .repeatEither(Schedule.recurs(4))
         .run(Sink.collectAll[Either[Int, Int]])
-        .map(_ must_=== List(Right(1), Left(1), Right(1), Left(2), Right(1), Left(3), Right(1), Left(4), Right(1)))
+        .map(_ must_=== List(Right(1), Right(1), Left(1), Right(1), Left(2), Right(1), Left(3), Right(1), Left(4)))
     )
 
   private def repeatEitherShortCircuits =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1490,14 +1490,14 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
 
   /**
    * Repeats the entire stream using the specified schedule. The stream will execute normally,
-   * and then repeat again according to the provided schedule. The schedule output will be emitted at the end of each repetition.
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at the beginning of each repetition.
    */
   final def repeatEither[R1 <: R, B](schedule: ZSchedule[R1, Unit, B]): ZStream[R1 with Clock, E, Either[B, A]] =
     repeatWith(schedule)(Right(_), Left(_))
 
   /**
    * Repeats the entire stream using the specified schedule. The stream will execute normally,
-   * and then repeat again according to the provided schedule. The schedule output will be emitted at the end of each repetition and
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at the beginning of each repetition and
    * can be unified with the stream elements using the provided functions
    */
   final def repeatWith[R1 <: R, B, C](
@@ -1515,7 +1515,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
               s2 = if (decision.cont)
                 ZStream
                   .fromEffect(schedStateRef.set(decision.state) *> clock.sleep(decision.delay))
-                  .drain ++ self.map(f) ++ ZStream.succeed(g(decision.finish())) ++ repeated
+                  .drain ++ ZStream.succeed(g(decision.finish())) ++ self.map(f) ++ repeated
               else
                 ZStream.empty
             } yield s2

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1490,14 +1490,14 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
 
   /**
    * Repeats the entire stream using the specified schedule. The stream will execute normally,
-   * and then repeat again according to the provided schedule. The schedule output will be emitted at the beginning of each repetition.
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at the end of each repetition.
    */
   final def repeatEither[R1 <: R, B](schedule: ZSchedule[R1, Unit, B]): ZStream[R1 with Clock, E, Either[B, A]] =
     repeatWith(schedule)(Right(_), Left(_))
 
   /**
    * Repeats the entire stream using the specified schedule. The stream will execute normally,
-   * and then repeat again according to the provided schedule. The schedule output will be emitted at the beginning of each repetition and
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at the end of each repetition and
    * can be unified with the stream elements using the provided functions
    */
   final def repeatWith[R1 <: R, B, C](
@@ -1515,7 +1515,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
               s2 = if (decision.cont)
                 ZStream
                   .fromEffect(schedStateRef.set(decision.state) *> clock.sleep(decision.delay))
-                  .drain ++ ZStream.succeed(g(decision.finish())) ++ self.map(f) ++ repeated
+                  .drain ++ self.map(f) ++ Stream.succeed(g(decision.finish())) ++ repeated
               else
                 ZStream.empty
             } yield s2


### PR DESCRIPTION
One thing I'm not quite sure about is how we want to handle emitting schedule output.
Behavior in this pr is that the output will be emitted at the beginning of each repetition but not at
the end when the schedule decides to stop.
So:
```scala
      Stream(1)
        .repeatEither(Schedule.recurs(4))
        .run(Sink.collectAll[Either[Int, Int]])
        .map(_ must_=== List(Right(1), Left(1), Right(1), Left(2), Right(1), Left(3), Right(1), Left(4), Right(1)))
``` 

cc @iravid 