### PR TITLE
More bracket stuff

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
@@ -655,28 +655,28 @@ class ZIOSpecJvm(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
       val acquire: ZIO[R, E, A]            = ???
       val release: A => ZIO[R, Nothing, _] = ???
       val use: A => ZIO[R, E1, B]          = ???
-      ZIO.bracket(acquire, release, use)
+      acquire.bracket(release)(use)
     }
 
     def infersEType2: ZIO[R, E, B] = {
       val acquire: ZIO[R, E1, A]           = ???
       val release: A => ZIO[R, Nothing, _] = ???
       val use: A => ZIO[R, E, B]           = ???
-      ZIO.bracket(acquire, release, use)
+      acquire.bracket(release, use)
     }
 
     def infersRType1: ZIO[R2, E, B] = {
       val acquire: ZIO[R, E, A]             = ???
       val release: A => ZIO[R1, Nothing, _] = ???
       val use: A => ZIO[R2, E, B]           = ???
-      ZIO.bracket(acquire, release, use)
+      acquire.bracket(release)(use)
     }
 
     def infersRType2: ZIO[R2, E, B] = {
       val acquire: ZIO[R2, E, A]            = ???
       val release: A => ZIO[R1, Nothing, _] = ???
       val use: A => ZIO[R, E, B]            = ???
-      ZIO.bracket(acquire, release, use)
+      acquire.bracket(release, use)
     }
 
     def infersRType3: ZIO[R2, E, B] = {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2527,7 +2527,7 @@ object ZIO extends ZIOFunctions {
      * This resource will get automatically closed, because it implements `AutoCloseable`.
      */
     def bracketAuto[R1 <: R, E1 >: E, B](use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-      io.bracket[R1, E1, B](a => UIO(a.close()), use)
+      io.bracket[R1, E1](a => UIO(a.close()))(use)
 
     /**
      * Converts this ZIO value to a ZManaged value. See [[ZManaged.fromAutoCloseable]].

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2527,7 +2527,8 @@ object ZIO extends ZIOFunctions {
      * This resource will get automatically closed, because it implements `AutoCloseable`.
      */
     def bracketAuto[R1 <: R, E1 >: E, B](use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-      io.bracket[R1, E1](a => UIO(a.close()))(use)
+      // TODO: Dotty doesn't infer this properly: io.bracket[R1, E1](a => UIO(a.close()))(use)
+      bracket(io)(a => UIO(a.close()))(use)
 
     /**
      * Converts this ZIO value to a ZManaged value. See [[ZManaged.fromAutoCloseable]].


### PR DESCRIPTION
Looking at the tests, none were using the `io.bracket(release)(use)` version. I rewrote some of them to prove type inference works well. In the auto-closeable syntax class, for some reason I have to specify the types but it seems like an exception.