### PR TITLE
Udpate Scala version and silencer-plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ scala_211: &scala_211
   SCALA_VERSION: 2.11.12
 
 scala_212: &scala_212
-  SCALA_VERSION: 2.12.9
+  SCALA_VERSION: 2.12.10
 
 scala_213: &scala_213
-  SCALA_VERSION: 2.13.0
+  SCALA_VERSION: 2.13.1
 
 scala_dotty: &scala_dotty
   SCALA_VERSION: 0.19.0-RC1

--- a/build.sbt
+++ b/build.sbt
@@ -257,7 +257,7 @@ lazy val docs = project.module
     scalacOptions ~= { _ filterNot (_ startsWith "-Ywarn") },
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
     libraryDependencies ++= Seq(
-      "com.github.ghik"     %% "silencer-lib"                % "1.4.2" % "provided",
+      "com.github.ghik"     %% "silencer-lib"                % "1.4.4" % "provided" cross CrossVersion.full,
       "commons-io"          % "commons-io"                   % "2.6" % "provided",
       "org.jsoup"           % "jsoup"                        % "1.12.1" % "provided",
       "org.reactivestreams" % "reactive-streams-examples"    % "1.0.3" % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -253,8 +253,13 @@ lazy val docs = project.module
     scalacOptions -= "-Xfatal-warnings",
     scalacOptions ~= { _ filterNot (_ startsWith "-Ywarn") },
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq()
+      else
+        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full))
+    },
     libraryDependencies ++= Seq(
-      "com.github.ghik"     %% "silencer-lib"                % "1.4.4" % "provided" cross CrossVersion.full,
       "commons-io"          % "commons-io"                   % "2.6" % "provided",
       "org.jsoup"           % "jsoup"                        % "1.12.1" % "provided",
       "org.reactivestreams" % "reactive-streams-examples"    % "1.0.3" % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -246,9 +246,6 @@ lazy val benchmarks = project.module
 lazy val docs = project.module
   .in(file("zio-docs"))
   .settings(
-    // skip 2.13 mdoc until mdoc is available for 2.13
-    crossScalaVersions -= "2.13.1",
-    //
     skip.in(publish) := true,
     moduleName := "zio-docs",
     unusedCompileDependenciesFilter -= moduleFilter("org.scalameta", "mdoc"),

--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,7 @@ lazy val benchmarks = project.module
   .settings(replSettings)
   .settings(
     // skip 2.13 benchmarks until twitter-util publishes for 2.13
-    crossScalaVersions -= "2.13.0",
+    crossScalaVersions -= "2.13.1",
     //
     skip in publish := true,
     libraryDependencies ++=
@@ -247,7 +247,7 @@ lazy val docs = project.module
   .in(file("zio-docs"))
   .settings(
     // skip 2.13 mdoc until mdoc is available for 2.13
-    crossScalaVersions -= "2.13.0",
+    crossScalaVersions -= "2.13.1",
     //
     skip.in(publish) := true,
     moduleName := "zio-docs",

--- a/build.sbt
+++ b/build.sbt
@@ -253,13 +253,8 @@ lazy val docs = project.module
     scalacOptions -= "-Xfatal-warnings",
     scalacOptions ~= { _ filterNot (_ startsWith "-Ywarn") },
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
-    libraryDependencies ++= {
-      if (isDotty.value)
-        Seq()
-      else
-        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full))
-    },
     libraryDependencies ++= Seq(
+      "com.github.ghik"     %% "silencer-lib"                % "1.4.4" % "provided" cross CrossVersion.full,
       "commons-io"          % "commons-io"                   % "2.6" % "provided",
       "org.jsoup"           % "jsoup"                        % "1.12.1" % "provided",
       "org.reactivestreams" % "reactive-streams-examples"    % "1.0.3" % "provided",

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -9,8 +9,7 @@ import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
 
 object BuildHelper {
-  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.2" % "test")
-  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.4"  % "provided" cross CrossVersion.full)
+  val testDeps = Seq("org.scalacheck" %% "scalacheck" % "1.14.2" % "test")
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -155,12 +154,15 @@ object BuildHelper {
     crossScalaVersions := Seq("2.12.10", "2.13.1", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
-    libraryDependencies ++= compileOnlyDeps ++ testDeps,
+    libraryDependencies ++= testDeps,
     libraryDependencies ++= {
       if (isDotty.value)
         Seq()
       else
-        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full))
+        Seq(
+          compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full),
+          "com.github.ghik" %% "silencer-lib" % "1.4.4" % "provided" cross CrossVersion.full
+        )
     },
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -152,7 +152,7 @@ object BuildHelper {
   def stdSettings(prjName: String) = Seq(
     name := s"$prjName",
     scalacOptions := stdOptions,
-    crossScalaVersions := Seq("2.12.9", "2.13.0", "2.11.12"),
+    crossScalaVersions := Seq("2.12.10", "2.13.1", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= compileOnlyDeps ++ testDeps,

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -9,7 +9,8 @@ import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
 
 object BuildHelper {
-  val testDeps = Seq("org.scalacheck" %% "scalacheck" % "1.14.2" % "test")
+  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.2" % "test")
+  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.4"  % "provided" cross CrossVersion.full)
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -154,7 +155,7 @@ object BuildHelper {
     crossScalaVersions := Seq("2.12.10", "2.13.1", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
-    libraryDependencies ++= testDeps,
+    libraryDependencies ++= compileOnlyDeps ++ testDeps,
     libraryDependencies ++= {
       if (isDotty.value)
         Seq()

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -10,7 +10,7 @@ import BuildInfoKeys._
 
 object BuildHelper {
   val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.2" % "test")
-  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.2"  % "provided")
+  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.4"  % "provided" cross CrossVersion.full)
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -160,7 +160,7 @@ object BuildHelper {
       if (isDotty.value)
         Seq()
       else
-        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2"))
+        Seq(compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full))
     },
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -9,8 +9,7 @@ import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
 
 object BuildHelper {
-  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.2" % "test")
-  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.4"  % "provided" cross CrossVersion.full)
+  val testDeps = Seq("org.scalacheck" %% "scalacheck" % "1.14.2" % "test")
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -155,7 +154,7 @@ object BuildHelper {
     crossScalaVersions := Seq("2.12.10", "2.13.1", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
-    libraryDependencies ++= compileOnlyDeps ++ testDeps,
+    libraryDependencies ++= testDeps,
     libraryDependencies ++= {
       if (isDotty.value)
         Seq()


### PR DESCRIPTION
Update Scala 2.12 and 2.13 to new minor release.
Silencer plugin is now fully cross versioned and released for every minor Scala version. Waiting for `2.13.1` to be released.

## TODO 
[x] Remove `crossScalaVersions -= "2.13.1"` from mdoc project since mdoc has been published for 2.13.