### PR TITLE
Mark ZStream#zipwithLatest Test as Flaky

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1900,7 +1900,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
       .map(_ must_=== Left("Ouch"))
   }
 
-  private def zipWithLatest = unsafeRun {
+  private def zipWithLatest = flaky {
     val s1 = Stream.iterate(0)(_ + 1).fixed(100.millis)
     val s2 = Stream.iterate(0)(_ + 1).fixed(70.millis)
 


### PR DESCRIPTION
I saw this test failing again [here](https://circleci.com/gh/zio/zio/25046?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). Until we can fix it we should mark it as flaky.

Copying @iravid.