### PR TITLE
ZIO Test: Simplify TestAspect#around

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -103,12 +103,15 @@ object TestAspect extends TimeoutVariants {
   /**
    * Constructs an aspect that evaluates every test inside the context of a `Managed`.
    */
-  def around[R0, E0](managed: ZManaged[R0, E0, Any]) =
-    new TestAspect.PerTest[Any, R0, E0, Any, Nothing, Any] {
-      def perTest[R >: Any <: R0, E >: E0 <: Any, S >: Nothing <: Any](
+  def around[R0, E0](before: ZIO[R0, E0, Any], after: ZIO[R0, Nothing, Any]) =
+    new TestAspect.PerTest[Nothing, R0, E0, Any, Nothing, Any] {
+      def perTest[R >: Nothing <: R0, E >: E0 <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
-        managed.foldCauseM(c => ZManaged.fail(TestFailure.Runtime(c)), ZManaged.succeed).use(_ => test)
+        ZManaged
+          .make(before)(_ => after)
+          .foldCauseM(c => ZManaged.fail(TestFailure.Runtime(c)), ZManaged.succeed)
+          .use(_ => test)
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -101,9 +101,20 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
+   * Constructs an aspect that evaluates every test inside the context of a `Managed`.
+   */
+  def around[R0, E0](managed: ZManaged[R0, E0, Any]) =
+    new TestAspect.PerTest[Any, R0, E0, Any, Nothing, Any] {
+      def perTest[R >: Any <: R0, E >: E0 <: Any, S >: Nothing <: Any](
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        managed.foldCauseM(c => ZManaged.fail(TestFailure.Runtime(c)), ZManaged.succeed).use(_ => test)
+    }
+
+  /**
    * Constructs an aspect that evaluates every test inside the context of the managed function.
    */
-  def around[R0, E0, S0](
+  def aroundTest[R0, E0, S0](
     managed: ZManaged[R0, TestFailure[E0], TestSuccess[S0] => ZIO[R0, TestFailure[E0], TestSuccess[S0]]]
   ) =
     new TestAspect.PerTest[Nothing, R0, E0, Any, S0, S0] {

--- a/test/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ DefaultRuntime, Managed, Ref }
+import zio.{ DefaultRuntime, Ref }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils.{ execute, ignored, label, succeeded }
@@ -23,7 +23,7 @@ object TestAspectSpec extends DefaultRuntime {
         ref <- Ref.make(0)
         spec = testM("test") {
           assertM(ref.get, equalTo(1))
-        } @@ around(Managed.make(ref.set(1))(_ => ref.set(-1)))
+        } @@ around(ref.set(1), ref.set(-1))
         _      <- execute(spec)
         result <- succeeded(spec)
         after  <- ref.get


### PR DESCRIPTION
Simplifies the type signature of `TestAspect#around` so it becomes a combined version of `TestAspect#before` and `TestAspect#after` where the `before` and `after` effects correspond to the `acquire` and `release` effects of the specified `Managed`. The existing version that also allows for modifying the test result goes to `TestAspect#aroundTest`.