### PR TITLE
Remove Explicit Delay in ZSchedule

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -50,8 +50,8 @@ object Schedule {
 
   final def apply[S, A, B](
     initial0: UIO[S],
-    update0: (A, S) => UIO[ZSchedule.Decision[S, B]]
-  ): Schedule[A, B] =
+    update0: (A, S) => UIO[ZSchedule.Decision[Any, S, B]]
+  ): ZSchedule[Any, A, B] =
     ZSchedule(initial0, update0)
 
   /**
@@ -78,12 +78,6 @@ object Schedule {
    * See [[ZSchedule.collectUntilM]]
    */
   final def collectUntilM[A](f: A => UIO[Boolean]): Schedule[A, List[A]] = ZSchedule.collectUntilM(f)
-
-  /**
-   * See [[ZSchedule.delayed]]
-   */
-  final def delayed[A](s: Schedule[A, Duration]): Schedule[A, Duration] =
-    ZSchedule.delayed(s)
 
   /**
    * See [[ZSchedule.doWhile]]
@@ -128,18 +122,6 @@ object Schedule {
     ZSchedule.doUntil(pf)
 
   /**
-   * See [[ZSchedule.exponential]]
-   */
-  final def exponential(base: Duration, factor: Double = 2.0): Schedule[Any, Duration] =
-    ZSchedule.exponential(base, factor)
-
-  /**
-   * See [[ZSchedule.fibonacci]]
-   */
-  final def fibonacci(one: Duration): Schedule[Any, Duration] =
-    ZSchedule.fibonacci(one)
-
-  /**
    * See [[ZSchedule.fromFunction]]
    */
   final def fromFunction[A, B](f: A => B): Schedule[A, B] = ZSchedule.fromFunction(f)
@@ -151,12 +133,6 @@ object Schedule {
     ZSchedule.identity
 
   /**
-   * See [[ZSchedule.linear]]
-   */
-  final def linear(base: Duration): Schedule[Any, Duration] =
-    ZSchedule.linear(base)
-
-  /**
    * See [[ZSchedule.logInput]]
    */
   final def logInput[A](f: A => UIO[Unit]): Schedule[A, A] =
@@ -166,12 +142,6 @@ object Schedule {
    * See [[ZSchedule.recurs]]
    */
   final def recurs(n: Int): Schedule[Any, Int] = ZSchedule.recurs(n)
-
-  /**
-   * See [[ZSchedule.spaced]]
-   */
-  final def spaced(interval: Duration): Schedule[Any, Int] =
-    ZSchedule.spaced(interval)
 
   /**
    * See [[ZSchedule.succeed]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -993,7 +993,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Repeats are done in addition to the first execution so that
    * `io.repeat(Schedule.once)` means "execute io and in case of success repeat `io` once".
    */
-  final def repeat[R1 <: R, B](schedule: ZSchedule[R1, A, B]): ZIO[R1 with Clock, E, B] =
+  final def repeat[R1 <: R, B](schedule: ZSchedule[R1, A, B]): ZIO[R1, E, B] =
     repeatOrElse[R1, E, B](schedule, (e, _) => ZIO.fail(e))
 
   /**
@@ -1004,7 +1004,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def repeatOrElse[R1 <: R, E2, B](
     schedule: ZSchedule[R1, A, B],
     orElse: (E, Option[B]) => ZIO[R1, E2, B]
-  ): ZIO[R1 with Clock, E2, B] =
+  ): ZIO[R1, E2, B] =
     repeatOrElseEither[R1, B, E2, B](schedule, orElse).map(_.merge)
 
   /**
@@ -1014,15 +1014,15 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def repeatOrElseEither[R1 <: R, B, E2, C](
     schedule: ZSchedule[R1, A, B],
-    orElse: (E, Option[B]) => ZIO[R1 with Clock, E2, C]
-  ): ZIO[R1 with Clock, E2, Either[C, B]] = {
-    def loop(last: Option[() => B], state: schedule.State): ZIO[R1 with Clock, E2, Either[C, B]] =
+    orElse: (E, Option[B]) => ZIO[R1, E2, C]
+  ): ZIO[R1, E2, Either[C, B]] = {
+    def loop(last: Option[() => B], state: schedule.State): ZIO[R1, E2, Either[C, B]] =
       self.foldM(
         e => orElse(e, last.map(_())).map(Left(_)),
         a =>
           schedule.update(a, state).flatMap { step =>
             if (!step.cont) ZIO.succeedRight(step.finish())
-            else ZIO.succeed(step.state).delay(step.delay).flatMap(s => loop(Some(step.finish), s))
+            else step.delay(step.duration) *> loop(Some(step.finish), step.state)
           }
       )
 
@@ -1035,7 +1035,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1 with Clock, E, A] =
+  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZIO[R1, E, A] =
     retryOrElse(policy, (e: E, _: S) => ZIO.fail(e))
 
   /**
@@ -1046,7 +1046,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def retryOrElse[R1 <: R, A2 >: A, E1 >: E, S, E2](
     policy: ZSchedule[R1, E1, S],
     orElse: (E, S) => ZIO[R1, E2, A2]
-  ): ZIO[R1 with Clock, E2, A2] =
+  ): ZIO[R1, E2, A2] =
     retryOrElseEither(policy, orElse).map(_.merge)
 
   /**
@@ -1057,15 +1057,15 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def retryOrElseEither[R1 <: R, E1 >: E, S, E2, B](
     policy: ZSchedule[R1, E1, S],
     orElse: (E, S) => ZIO[R1, E2, B]
-  ): ZIO[R1 with Clock, E2, Either[B, A]] = {
-    def loop(state: policy.State): ZIO[R1 with Clock, E2, Either[B, A]] =
+  ): ZIO[R1, E2, Either[B, A]] = {
+    def loop(state: policy.State): ZIO[R1, E2, Either[B, A]] =
       self.foldM(
         err =>
           policy
             .update(err, state)
             .flatMap(
               decision =>
-                if (decision.cont) clock.sleep(decision.delay) *> loop(decision.state)
+                if (decision.cont) decision.delay(decision.duration) *> loop(decision.state)
                 else orElse(err, decision.finish()).map(Left(_))
             ),
         succ => ZIO.succeedRight(succ)

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -519,15 +519,15 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZManaged[R1 with Clock, E1, A] = {
-    def loop[B](zio: ZIO[R, E1, B], state: policy.State): ZIO[R1 with Clock, E1, (policy.State, B)] =
+  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZManaged[R1, E1, A] = {
+    def loop[B](zio: ZIO[R, E1, B], state: policy.State): ZIO[R1, E1, (policy.State, B)] =
       zio.foldM(
         err =>
           policy
             .update(err, state)
             .flatMap(
               decision =>
-                if (decision.cont) clock.sleep(decision.delay) *> loop(zio, decision.state)
+                if (decision.cont) decision.delay(decision.duration) *> loop(zio, decision.state)
                 else ZIO.fail(err)
             ),
         succ => ZIO.succeed((state, succ))

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -770,7 +770,7 @@ object ZSchedule {
 
     final def unary_! = copy(cont = !cont)
 
-    final def delayed(f: Duration => Duration): Decision[R, A, B] = copy(duration = f(duration))
+    final def delayed(f: Duration => Duration): Decision[Clock, A, B] = copy(duration = f(duration), delay = Live)
 
     final def combineWith[R1 <: R, C, D](
       that: Decision[R1, C, D]
@@ -796,7 +796,8 @@ object ZSchedule {
   final case object Live extends Delay[Clock] {
     def apply(d: Duration): ZIO[Clock, Nothing, Unit] =
       clock.sleep(d)
-    def combine[R1 <: Clock](that: Delay[R1]): Delay[R1] = this
+    def combine[R1 <: Clock](that: Delay[R1]): Delay[R1] =
+      this
   }
   final case object Mock extends Delay[Any] {
     def apply(d: Duration): ZIO[Any, Nothing, Unit] =

--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -31,37 +31,37 @@ import zio.duration._
 A schedule that always recurs:
 
 ```scala mdoc:silent
-val forever = Schedule.forever
+val forever = ZSchedule.forever
 ```
 
 A schedule that never executes:
 
 ```scala mdoc:silent
-val never = Schedule.never
+val never = ZSchedule.never
 ```
 
 A schedule that recurs 10 times:
 
 ```scala mdoc:silent
-val upTo10 = Schedule.recurs(10)
+val upTo10 = ZSchedule.recurs(10)
 ```
 
 A schedule that recurs every 10 milliseconds:
 
 ```scala mdoc:silent
-val spaced = Schedule.spaced(10.milliseconds)
+val spaced = ZSchedule.spaced(10.milliseconds)
 ```
 
 A schedule that recurs using exponential backoff:
 
 ```scala mdoc:silent
-val exponential = Schedule.exponential(10.milliseconds)
+val exponential = ZSchedule.exponential(10.milliseconds)
 ```
 
 A schedule that recurs using fibonacci backoff:
 
 ```scala mdoc:silent
-val fibonacci = Schedule.fibonacci(10.milliseconds)
+val fibonacci = ZSchedule.fibonacci(10.milliseconds)
 ```
 
 ## Schedule Combinators
@@ -69,30 +69,30 @@ val fibonacci = Schedule.fibonacci(10.milliseconds)
 Applying random jitter to a schedule:
 
 ```scala mdoc:silent
-val jitteredExp = Schedule.exponential(10.milliseconds).jittered
+val jitteredExp = ZSchedule.exponential(10.milliseconds).jittered
 ```
 
 Modifies the delay of a schedule:
 
 ```scala mdoc:silent
-val boosted = Schedule.spaced(1.second).delayed(_ + 100.milliseconds)
+val boosted = ZSchedule.spaced(1.second).delayed(_ + 100.milliseconds)
 ```
 
 Combines two schedules sequentially, by following the first policy until it ends, and then following the second policy:
 
 ```scala mdoc:silent
-val sequential = Schedule.recurs(10) andThen Schedule.spaced(1.second)
+val sequential = ZSchedule.recurs(10) andThen ZSchedule.spaced(1.second)
 ```
 
 Combines two schedules through intersection, by recurring only if both schedules want to recur, using the maximum of the two delays between recurrences:
 
 ```scala mdoc:silent
-val expUpTo10 = Schedule.exponential(1.second) && Schedule.recurs(10)
+val expUpTo10 = ZSchedule.exponential(1.second) && ZSchedule.recurs(10)
 ```
 
 Combines two schedules through union, by recurring if either schedule wants to
 recur, using the minimum of the two delays between recurrences:
 
 ```scala mdoc:silent
-val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.second)
+val expCapped = ZSchedule.exponential(100.milliseconds) || ZSchedule.spaced(1.second)
 ```

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -357,7 +357,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     unsafeRun {
       val e = new RuntimeException("Boom")
       Stream(1, 1, 1, 1)
-        .aggregateWithinEither(ZSink.die(e), Schedule.spaced(30.minutes))
+        .aggregateWithinEither(ZSink.die(e), ZSchedule.spaced(30.minutes))
         .runCollect
         .run
         .map(_ must_=== Exit.Failure(Cause.Die(e)))
@@ -370,7 +370,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     }
 
     Stream(1, 1)
-      .aggregateWithinEither(sink, Schedule.spaced(30.minutes))
+      .aggregateWithinEither(sink, ZSchedule.spaced(30.minutes))
       .runCollect
       .run
       .map(_ must_=== Exit.Failure(Cause.Die(e)))
@@ -386,7 +386,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
           (latch.succeed(()) *> UIO.never)
             .onInterrupt(cancelled.set(true))
       }
-      fiber  <- Stream(1, 1, 2).aggregateWithinEither(sink, Schedule.spaced(30.minutes)).runCollect.untraced.fork
+      fiber  <- Stream(1, 1, 2).aggregateWithinEither(sink, ZSchedule.spaced(30.minutes)).runCollect.untraced.fork
       _      <- latch.await
       _      <- fiber.interrupt
       result <- cancelled.get
@@ -401,7 +401,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
         (latch.succeed(()) *> UIO.never)
           .onInterrupt(cancelled.set(true))
       }
-      fiber  <- Stream(1, 1, 2).aggregateWithinEither(sink, Schedule.spaced(30.minutes)).runCollect.untraced.fork
+      fiber  <- Stream(1, 1, 2).aggregateWithinEither(sink, ZSchedule.spaced(30.minutes)).runCollect.untraced.fork
       _      <- latch.await
       _      <- fiber.interrupt
       result <- cancelled.get
@@ -417,7 +417,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
             el :: acc
           }
           .map(_.reverse),
-        Schedule.spaced(100.millis)
+        ZSchedule.spaced(100.millis)
       )
       .collect {
         case Right(v) => v
@@ -1528,7 +1528,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
         ref <- Ref.make[List[Int]](Nil)
         _ <- Stream
               .fromEffect(ref.update(1 :: _))
-              .repeat(Schedule.spaced(10.millis))
+              .repeat(ZSchedule.spaced(10.millis))
               .take(2)
               .run(Sink.drain)
         result <- ref.get
@@ -1549,7 +1549,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
         ref <- Ref.make[List[Int]](Nil)
         _ <- Stream
               .fromEffect(ref.update(1 :: _))
-              .repeatEither(Schedule.spaced(10.millis))
+              .repeatEither(ZSchedule.spaced(10.millis))
               .take(3) // take one schedule output
               .run(Sink.drain)
         result <- ref.get
@@ -1570,7 +1570,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
       for {
         ref <- Ref.make[List[Int]](Nil)
         _ <- Stream
-              .repeatEffectWith(ref.update(1 :: _), Schedule.spaced(10.millis))
+              .repeatEffectWith(ref.update(1 :: _), ZSchedule.spaced(10.millis))
               .take(2)
               .run(Sink.drain)
         result <- ref.get

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -17,7 +17,6 @@
 package zio.stream
 
 import zio._
-import zio.clock.Clock
 import zio.Cause
 
 object Stream extends ZStreamPlatformSpecific {
@@ -152,10 +151,10 @@ object Stream extends ZStreamPlatformSpecific {
   /**
    * See [[ZStream.repeatEffectWith]]
    */
-  final def repeatEffectWith[E, A](
+  final def repeatEffectWith[R, E, A](
     fa: IO[E, A],
-    schedule: Schedule[Unit, _]
-  ): ZStream[Clock, E, A] = ZStream.repeatEffectWith(fa, schedule)
+    schedule: ZSchedule[R, Unit, _]
+  ): ZStream[R, E, A] = ZStream.repeatEffectWith(fa, schedule)
 
   /**
    * See [[ZStream.fromIterable]]

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1713,6 +1713,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
             case Some((a, sched)) =>
               for {
                 decision <- schedule.update(a, sched)
+                _        <- decision.delay(decision.duration)
                 _        <- state.set(if (decision.cont) Some(a -> decision.state) else None)
               } yield if (decision.cont) f(a) else g(decision.finish())
           }

--- a/test/shared/src/main/scala/zio/test/MyApp.scala
+++ b/test/shared/src/main/scala/zio/test/MyApp.scala
@@ -1,0 +1,26 @@
+import java.util.concurrent.TimeUnit
+
+import zio._
+import zio.clock.Clock
+import zio.console.Console
+import zio.duration._
+import zio.random.Random
+
+object MyApp extends App {
+
+  def run(args: List[String]): ZIO[Environment, Nothing, Int] =
+    myAppLogic.as(0)
+
+  val myAppLogic: ZIO[Clock with Console with Random, Nothing, Any] =
+    for {
+      start <- clock.currentTime(TimeUnit.MILLISECONDS)
+      _     <- elapsed(start).repeat((ZSchedule.fixed(1.second) && ZSchedule.fixed(1.second)) && ZSchedule.recurs(6))
+    } yield ()
+
+  def elapsed(start: Long): ZIO[Clock with Console, Nothing, Unit] =
+    for {
+      time       <- clock.currentTime(TimeUnit.MILLISECONDS)
+      difference = (time - start) / 1000.0
+      _          <- console.putStrLn(difference.toString)
+    } yield ()
+}


### PR DESCRIPTION
I took a slightly different approach to this one. `ZSchedule` continues to be a description of a sequence of delays rather than delaying itself, but now each `Decision` is also responsible for providing an effect that the client can "run". Schedules that use time provide an effect that accesses the `Clock` and sleeps for the specified duration whereas schedules that don't use time provide an effect that does nothing. These effects compose so that combining effects that don't use the `Clock` yields another effect that doesn't use the `Clock`, whereas any other combination yields an effect that does use the `Clock`, similar to how environment types compose. This allows us to have a relatively minimal change from a client perspective while removing the hard coded dependency on `Clock` in methods like `repeat` and `retry`.

```scala
sealed trait Delay[-R] extends (Duration => ZIO[R, Nothing, Unit]) {
  def combine[R1 <: R](that: Delay[R1]): Delay[R1]
}
final case object Live extends Delay[Clock] {
  def apply(d: Duration): ZIO[Clock, Nothing, Unit] =
    clock.sleep(d)
  def combine[R1 <: Clock](that: Delay[R1]): Delay[R1] =
    this
}
final case object Mock extends Delay[Any] {
  def apply(d: Duration): ZIO[Any, Nothing, Unit] =
    ZIO.unit
  def combine[R1 <: Any](that: Delay[R1]): Delay[R1] =
    that
}
```