### PR TITLE
Migrate tests for MutableConcurrentQueueSpec and OneShotSpec

### DIFF
--- a/core-tests/js/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/js/src/test/scala/zio/internal/OneShotSpec.scala
@@ -1,11 +1,8 @@
 package zio.internal
 
 import zio.ZIOBaseSpec
-import zio.internal.OneShotSpecUtils._
 import zio.test.Assertion._
 import zio.test._
-
-import scala.reflect.ClassTag
 
 object OneShotSpec
     extends ZIOBaseSpec(
@@ -47,6 +44,3 @@ object OneShotSpec
         )
       )
     )
-object OneShotSpecUtils {
-  def throwsA[E: ClassTag]: Assertion[Any] = throws(isSubtype[E](anything))
-}

--- a/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
@@ -1,7 +1,9 @@
 package zio.internal
 
-import org.specs2.Specification
 import zio.SerializableSpec._
+import zio.ZIOBaseSpec
+import zio.test._
+import zio.test.Assertion._
 
 /*
  * This spec is just a sanity check and tests RingBuffer correctness
@@ -9,85 +11,80 @@ import zio.SerializableSpec._
  *
  * Concurrent tests are run via jcstress and are in [[RingBufferConcurrencyTests]].
  */
-class MutableConcurrentQueueSpec extends Specification {
-  def is =
-    "MutableConcurrentQueueSpec".title ^ s2"""
-    Make a bounded MutableConcurrentQueue
-     of capacity 1 return a queue of capacity 1. $minSize
-     of capacity 2 returns a queue of capacity 2. $exactSize1
-     of capacity 3 returns a queue of capacity 3. $exactSize2
+object MutableConcurrentQueueSpec2
+    extends ZIOBaseSpec(
+      suite("MutableConcurrentQueueSpec")(
+        suite("Make a bounded MutableConcurrentQueue")(
+          test("of capacity 1 return a queue of capacity 1") {
+            val q = MutableConcurrentQueue.bounded(1)
 
-    With a RingBuffer of capacity 2
-     `offer` of 2 items succeeds, further offers fail. $offerCheck
-     `poll` of 2 items from full queue succeeds, further `poll`s return default value. $pollCheck
+            assert(q.capacity, equalTo(1))
+          },
+          test("of capacity 2 return a queue of capacity 2") {
+            val q = MutableConcurrentQueue.bounded(2)
 
-    Serialization works for
-     a one element queue. $oneElSerDe
-     a pow 2 capacity ring buffer. $pow2SerDe
-     an arbitrary capacity ring buffer. $arbSerDe
-    """
+            assert(q.capacity, equalTo(2))
+          },
+          test("of capacity 3 return a queue of capacity 3") {
+            val q = MutableConcurrentQueue.bounded(3)
 
-  def minSize = {
-    val q = MutableConcurrentQueue.bounded(1)
-    q.capacity must_=== 1
-  }
+            assert(q.capacity, equalTo(3))
+          }
+        ),
+        suite("With a RingBuffer of capacity 2")(
+          test("`offer` of 2 items succeeds, further offers fail") {
+            val q = MutableConcurrentQueue.bounded[Int](2)
 
-  def exactSize1 = {
-    val q = MutableConcurrentQueue.bounded(2)
-    q.capacity must_=== 2
-  }
+            (assert(q.offer(1), isTrue)
+            && assert(q.size(), equalTo(1))
+            && assert(q.offer(2), isTrue)
+            && assert(q.size(), equalTo(2))
+            && assert(q.offer(3), isFalse)
+            && assert(q.isFull(), isTrue))
+          },
+          test(
+            "`poll` of 2 items from full queue succeeds, further `poll`s return default value"
+          ) {
+            val q = MutableConcurrentQueue.bounded[Int](2)
+            q.offer(1)
+            q.offer(2)
 
-  def exactSize2 = {
-    val q = MutableConcurrentQueue.bounded(3)
-    q.capacity must_=== 3
-  }
+            (assert(q.poll(-1), equalTo(1))
+            && assert(q.poll(-1), equalTo(2))
+            && assert(q.poll(-1), equalTo(-1))
+            && assert(q.isEmpty(), isTrue))
+          }
+        ),
+        suite("Serialization works for")(
+          test("a one element queue") {
+            val q = MutableConcurrentQueue.bounded[Int](1)
+            q.offer(1)
+            val returnQ = serializeAndDeserialize(q)
+            returnQ.offer(2)
 
-  def offerCheck = {
-    val q = MutableConcurrentQueue.bounded[Int](2)
-    (q.offer(1) must beTrue)
-      .and(q.size() must_=== 1)
-      .and(q.offer(2) must beTrue)
-      .and(q.size() must_=== 2)
-      .and(q.offer(3) must beFalse)
-      .and(q.isFull() must beTrue)
-  }
+            (assert(returnQ.poll(-1), equalTo(1))
+            && assert(returnQ.poll(-1), equalTo(-1)))
+          },
+          test("a pow 2 capacity ring buffer") {
+            val q = MutableConcurrentQueue.bounded[Int](3)
+            q.offer(1)
+            val returnQ = serializeAndDeserialize(q)
+            returnQ.offer(2)
 
-  def pollCheck = {
-    val q = MutableConcurrentQueue.bounded[Int](2)
-    q.offer(1)
-    q.offer(2)
-    (q.poll(-1) must_=== 1)
-      .and(q.poll(-1) must_=== 2)
-      .and(q.poll(-1) must_=== -1)
-      .and(q.isEmpty() must beTrue)
-  }
+            (assert(returnQ.poll(-1), equalTo(1))
+            && assert(returnQ.poll(-1), equalTo(2))
+            && assert(returnQ.poll(-1), equalTo(-1)))
+          },
+          test("an arbitrary capacity ring buffer") {
+            val q = MutableConcurrentQueue.bounded[Int](2)
+            q.offer(1)
+            val returnQ = serializeAndDeserialize(q)
+            returnQ.offer(2)
 
-  def oneElSerDe = {
-    val q = MutableConcurrentQueue.bounded[Int](1)
-    q.offer(1)
-    val returnQ = serializeAndDeserialize(q)
-    returnQ.offer(2)
-    (returnQ.poll(-1) must_=== 1)
-      .and(returnQ.poll(-1) must_=== -1)
-  }
-
-  def pow2SerDe = {
-    val q = MutableConcurrentQueue.bounded[Int](3)
-    q.offer(1)
-    val returnQ = serializeAndDeserialize(q)
-    returnQ.offer(2)
-    (returnQ.poll(-1) must_=== 1)
-      .and(returnQ.poll(-1) must_=== 2)
-      .and(returnQ.poll(-1) must_=== -1)
-  }
-
-  def arbSerDe = {
-    val q = MutableConcurrentQueue.bounded[Int](2)
-    q.offer(1)
-    val returnQ = serializeAndDeserialize(q)
-    returnQ.offer(2)
-    (returnQ.poll(-1) must_=== 1)
-      .and(returnQ.poll(-1) must_=== 2)
-      .and(returnQ.poll(-1) must_=== -1)
-  }
-}
+            (assert(returnQ.poll(-1), equalTo(1))
+            && assert(returnQ.poll(-1), equalTo(2))
+            && assert(returnQ.poll(-1), equalTo(-1)))
+          }
+        )
+      )
+    )

--- a/core-tests/jvm/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/OneShotSpec.scala
@@ -1,46 +1,48 @@
 package zio.internal
 
-import org.specs2.Specification
+import zio.ZIOBaseSpec
+import zio.test.Assertion._
+import zio.test._
 
-class OneShotSpec extends Specification {
-  def is =
-    "OneShotSpec".title ^ s2"""
-      Make a new OneShot
-         set must accept a non-null value.              $setNonNull
-         set must not accept a null value.              $setNull
-         isSet must report if a value is set.           $isSet
-         get must fail if no value is set.              $getWithNoValue
-         cannot set value twice                         $setTwice
-    """
+object OneShotSpec
+    extends ZIOBaseSpec(
+      suite("OneShotSpec")(
+        suite("OneShotSpec")(
+          suite("Make a new OneShot")(
+            test("set must accept a non-null value") {
+              val oneShot = OneShot.make[Int]
+              oneShot.set(1)
 
-  def setNonNull = {
-    val oneShot = OneShot.make[Int]
-    oneShot.set(1)
+              assert(oneShot.get(), equalTo(1))
+            },
+            test("set must not accept a null value") {
+              val oneShot = OneShot.make[Object]
 
-    oneShot.get() must_=== 1
-  }
+              assert(oneShot.set(null), throwsA[Error])
+            },
+            test("isSet must report if a value is set") {
+              val oneShot = OneShot.make[Int]
 
-  def setNull = {
-    val oneShot = OneShot.make[Object]
-    oneShot.set(null) must throwA[Error]
-  }
+              val resultBeforeSet = oneShot.isSet
 
-  def isSet = {
-    val oneShot = OneShot.make[Int]
-    oneShot.isSet must beFalse
-    oneShot.set(1)
-    oneShot.isSet must beTrue
-  }
+              oneShot.set(1)
 
-  def getWithNoValue = {
-    val oneShot = OneShot.make[Object]
-    oneShot.get(10000L) must throwA[Error]
+              val resultAfterSet = oneShot.isSet
 
-  }
+              assert(resultBeforeSet, isFalse) && assert(resultAfterSet, isTrue)
+            },
+            test("get must fail if no value is set") {
+              val oneShot = OneShot.make[Object]
 
-  def setTwice = {
-    val oneShot = OneShot.make[Int]
-    oneShot.set(1)
-    oneShot.set(2) must throwA[Error]
-  }
-}
+              assert(oneShot.get(10000L), throwsA[Error])
+            },
+            test("cannot set value twice") {
+              val oneShot = OneShot.make[Int]
+              oneShot.set(1)
+
+              assert(oneShot.set(2), throwsA[Error])
+            }
+          )
+        )
+      )
+    )

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -555,4 +555,9 @@ object Assertion {
         case t: Throwable => assertion(t)
       }
     }
+
+  /**
+   * Returns a new assertion that requires the expression to throw an instance of given type (or its subtype)
+   */
+  final def throwsA[E: ClassTag]: Assertion[Any] = throws(isSubtype[E](anything))
 }


### PR DESCRIPTION
There's a question though - should shortcut `throwsA[E]` be added to `Assertions`? 