### PR TITLE
Fix build issues introduced by bundling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,9 @@ release: &release
           name: Fetch git tags
           command: git fetch --tags
       - <<: *load_cache
+      - run: 
+          name: Write sonatype credentials
+          command: echo "credentials += Credentials(\"Sonatype Nexus Repository Manager\", \"oss.sonatype.org\", \"$SONATYPE_USER\", \"$SONATYPE_PASSWORD\")" > ~/.sbt/1.0/sonatype.sbt
       - run:
           name: Write PGP public key
           command: echo -n "${PGP_PUBLIC}" | base64 -d > /tmp/public.asc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ release: &release
           command: echo -n "${PGP_SECRET}" | base64 -d > /tmp/secret.asc
       - run:
           name: Release artifacts
-          command: ./sbt ++${SCALA_VERSION}! +clean +sonatypeBundleClean +publishSigned +sonatypeBundleRelease
+          command: ./sbt ++${SCALA_VERSION}! clean sonatypeBundleClean +publishSigned sonatypeBundleRelease
 
 microsite: &microsite
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,21 +254,7 @@ jobs:
       - <<: *scala_213
       - <<: *jdk_8
 
-  release_211:
-    <<: *release
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_211
-      - <<: *jdk_8
-
-  release_212:
-    <<: *release
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_212
-      - <<: *jdk_8
-
-  release_213:
+  release:
     <<: *release
     <<: *machine_ubuntu
     environment:
@@ -349,7 +335,7 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - release_211:
+      - release:
           context: Sonatype
           requires:
             - test_211_jdk8_jvm
@@ -364,31 +350,10 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - release_212:
-          context: Sonatype
-          requires:
-            - release_211
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - release_213:
-          context: Sonatype
-          requires:
-            - release_212
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-
       - microsite:
           context: Website
           requires:
-            - release_211
-            - release_212
-            - release_213
+            - release
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ release: &release
       - <<: *load_cache
       - run: 
           name: Write sonatype credentials
-          command: echo "credentials += Credentials(\"Sonatype Nexus Repository Manager\", \"oss.sonatype.org\", \"$SONATYPE_USER\", \"$SONATYPE_PASSWORD\")" > ~/.sbt/1.0/sonatype.sbt
+          command: echo "credentials += Credentials(\"Sonatype Nexus Repository Manager\", \"oss.sonatype.org\", \"${SONATYPE_USER}\", \"${SONATYPE_PASSWORD}\")" > ~/.sbt/1.0/sonatype.sbt
       - run:
           name: Write PGP public key
           command: echo -n "${PGP_PUBLIC}" | base64 -d > /tmp/public.asc

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ inThisBuild(
         url("http://degoes.net")
       )
     ),
+    pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(
@@ -27,9 +28,7 @@ inThisBuild(
   )
 )
 
-publishTo in ThisBuild := {
-  if (!isSnapshot.value) sonatypePublishToBundle.value else Some(Opts.resolver.sonatypeSnapshots)
-}
+ThisBuild / publishTo := sonatypePublishToBundle.value
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,5 +13,5 @@ addSbtPlugin("ch.epfl.lamp"                      % "sbt-dotty"                 %
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                  % "1.3.2")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                 % "1.3.2")
 addSbtPlugin("com.dwijnand"                      % "sbt-dynver"                % "4.0.0")
-addSbtPlugin("com.jsuereth"                      % "sbt-pgp"                   % "2.0.0")
+addSbtPlugin("com.jsuereth"                      % "sbt-pgp"                   % "1.1.0")
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"              % "3.7")


### PR DESCRIPTION
Follow-up of #1728 .

As verified in `interop-monix`, the following changes needed to be introduced:
- `sbt-pgp` has to be downgraded to `1.1.0` in order to avoid issues with keys.
- `PGP_PASSPHRASE` needs to be explicitly loaded.
- Sonatype credentials has to be set on release.
- Only one workflow is required.