### PR TITLE
Adding Stream.retry

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1,9 +1,9 @@
 package zio.stream
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{ Arbitrary, Gen }
 import org.specs2.ScalaCheck
 
-import scala.{Stream => _}
+import scala.{ Stream => _ }
 import zio._
 import zio.duration._
 import zio.ZQueueSpecUtil.waitForSize
@@ -1601,12 +1601,13 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     var i = -1
     def errorOnce(): ZIO[Any, String, Int] = {
       i = i + 1
-      if(i == 0) ZIO.fail("error")
+      if (i == 0) ZIO.fail("error")
       else ZIO.succeed(i)
     }
 
     unsafeRun {
-      ZStream.repeatEffect(errorOnce())
+      ZStream
+        .repeatEffect(errorOnce())
         .retry(Schedule.once)
         .take(3)
         .run(Sink.collectAll[Int])
@@ -1618,13 +1619,13 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     val value: ZStream[Any, String, Int] = Stream(1) ++ Stream.fail("error") ++ Stream(2, 3)
 
     val result: Exit[String, List[Int]] = unsafeRunSync {
-      value.toQueue(10)
-        .use { q =>
-          Stream.fromQueue(q)
-            .retry(Schedule.once)
-            .unTake
-            .run(Sink.collectAll[Int])
-        }
+      value.toQueue(10).use { q =>
+        Stream
+          .fromQueue(q)
+          .retry(Schedule.once)
+          .unTake
+          .run(Sink.collectAll[Int])
+      }
     }
 
     result must_=== Exit.succeed((List(1, 2, 3)))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1613,6 +1613,14 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     }
 
   /**
+    * Retries the Pull given the retry policy
+    */
+  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZStream[R1 with Clock, E, A] = {
+    ZStream(ZManaged(self.process.reserve.retry(policy)))
+  }
+
+
+  /**
    * Runs the sink on the stream to produce either the sink's result or an error.
    */
   def run[R1 <: R, E1 >: E, A0, A1 >: A, B](sink: ZSink[R1, E1, A0, A1, B]): ZIO[R1, E1, B] =


### PR DESCRIPTION
Naive stab at: #1711 two test fail with:
```
Fiber:76254 was supposed to continue to:
  a future continuation at zio.ZIO.run(ZIO.scala:1075)
  a future continuation at zio.ZManaged.use(ZManaged.scala:640)
  a future continuation at zio.stream.StreamSpec.retry2(StreamSpec.scala:1612)
  a future continuation at zio.stream.StreamSpec.retry2(StreamSpec.scala:1608)

Fiber:76254 execution trace:
  at zio.stream.ZStream.run(ZStream.scala:1641)
  at zio.stream.ZStream.flatMap(ZStream.scala:928)
  at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:156)
  at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:147)
```
which totally goes over my head.