### PR TITLE
Move PlatformLive.ExecutorUtil to Executor companion object

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -1333,7 +1333,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
 
   def testOneMaxYield = {
     val rts = new DefaultRuntime {
-      override val Platform = PlatformLive.Default.withExecutor(PlatformLive.ExecutorUtil.makeDefault(1))
+      override val Platform = PlatformLive.makeDefault(1)
     }
 
     rts.unsafeRun(

--- a/core/js/src/main/scala/zio/internal/DefaultExecutors.scala
+++ b/core/js/src/main/scala/zio/internal/DefaultExecutors.scala
@@ -1,0 +1,3 @@
+package zio.internal
+
+private[internal] abstract class DefaultExecutors

--- a/core/js/src/main/scala/zio/internal/Sync.scala
+++ b/core/js/src/main/scala/zio/internal/Sync.scala
@@ -1,6 +1,6 @@
 package zio.internal
 
-object Sync {
+private[zio] object Sync {
   def apply[A](anyRef: AnyRef)(f: => A): A = {
     val _ = anyRef
     f

--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -19,12 +19,12 @@ package zio.blocking
 import java.util.concurrent._
 
 import zio.internal.tracing.ZIOFn
-import zio.internal.{ Executor, NamedThreadFactory, PlatformLive }
+import zio.internal.{ Executor, NamedThreadFactory }
 import zio.{ IO, UIO, ZIO }
 
 private[blocking] object internal {
   private[blocking] val blockingExecutor0 =
-    PlatformLive.ExecutorUtil.fromThreadPoolExecutor(_ => Int.MaxValue) {
+    Executor.fromThreadPoolExecutor(_ => Int.MaxValue) {
       val corePoolSize  = 0
       val maxPoolSize   = Int.MaxValue
       val keepAliveTime = 1000L

--- a/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
+++ b/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
@@ -1,0 +1,68 @@
+package zio.internal
+
+import java.util.concurrent.{ LinkedBlockingQueue, RejectedExecutionException, ThreadPoolExecutor, TimeUnit }
+
+private[internal] abstract class DefaultExecutors {
+  final def makeDefault(yieldOpCount: Int): Executor =
+    fromThreadPoolExecutor(_ => yieldOpCount) {
+      val corePoolSize  = Runtime.getRuntime.availableProcessors() * 2
+      val maxPoolSize   = corePoolSize
+      val keepAliveTime = 1000L
+      val timeUnit      = TimeUnit.MILLISECONDS
+      val workQueue     = new LinkedBlockingQueue[Runnable]()
+      val threadFactory = new NamedThreadFactory("zio-default-async", true)
+
+      val threadPool = new ThreadPoolExecutor(
+        corePoolSize,
+        maxPoolSize,
+        keepAliveTime,
+        timeUnit,
+        workQueue,
+        threadFactory
+      )
+      threadPool.allowCoreThreadTimeOut(true)
+
+      threadPool
+    }
+
+  final def fromThreadPoolExecutor(yieldOpCount0: ExecutionMetrics => Int)(
+    es: ThreadPoolExecutor
+  ): Executor =
+    new Executor {
+      private[this] def metrics0 = new ExecutionMetrics {
+        def concurrency: Int = es.getMaximumPoolSize()
+
+        def capacity: Int = {
+          val queue = es.getQueue()
+
+          val remaining = queue.remainingCapacity()
+
+          if (remaining == Int.MaxValue) remaining
+          else remaining + queue.size
+        }
+
+        def size: Int = es.getQueue().size
+
+        def workersCount: Int = es.getPoolSize()
+
+        def enqueuedCount: Long = es.getTaskCount()
+
+        def dequeuedCount: Long = enqueuedCount - size.toLong
+      }
+
+      def metrics = Some(metrics0)
+
+      def yieldOpCount = yieldOpCount0(metrics0)
+
+      def submit(runnable: Runnable): Boolean =
+        try {
+          es.execute(runnable)
+
+          true
+        } catch {
+          case _: RejectedExecutionException => false
+        }
+
+      def here = false
+    }
+}

--- a/core/jvm/src/main/scala/zio/internal/Sync.scala
+++ b/core/jvm/src/main/scala/zio/internal/Sync.scala
@@ -1,5 +1,5 @@
 package zio.internal
 
-object Sync {
+private[zio] object Sync {
   def apply[A](anyRef: AnyRef)(f: => A): A = anyRef.synchronized { f }
 }

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -65,7 +65,7 @@ trait Executor {
 
 }
 
-object Executor extends Serializable {
+object Executor extends DefaultExecutors with Serializable {
 
   /**
    * Creates an `Executor` from a Scala `ExecutionContext`.


### PR DESCRIPTION
This ExecutorUtil has always been an eyesore, I think we don't want to keep it like that for all of 1.0 😅

also private zio.internal.Sync
[API breaking change]

Also change default `yieldOpCount` for ExecutionContext to 2048 (same as for ThreadPoolExecutor)