### PR TITLE
Fix #785, Fix #1441, prevent race condition on `interrupted` variable by moving `interrupted` into atomic state

### DIFF
--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -1,0 +1,54 @@
+package zio
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import zio.IOBenchmarks._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+class IOEmptyRaceBenchmark {
+  @Param(Array("1000"))
+  var size: Int = _
+
+  @Benchmark
+  def monixEmptyRace(): Int = {
+    import monix.eval.Task
+
+    def loop(i: Int): monix.eval.Task[Int] =
+      if (i < size) Task.race(Task.never, Task.eval(i + 1)).flatMap(_ => loop(i + 1))
+      else Task.pure(i)
+
+    loop(0).runSyncUnsafe()
+  }
+
+  @Benchmark
+  def catsEmptyRace(): Int = {
+    import cats.effect.IO
+
+    def loop(i: Int): IO[Int] =
+      if (i < size) IO.race(IO.never, IO.delay(i + 1)).flatMap(_ => loop(i + 1))
+      else IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+
+  @Benchmark
+  def zioEmptyRace(): Int = zioEmptyRace(IOBenchmarks)
+
+  @Benchmark
+  def zioTracedEmptyRace(): Int = zioEmptyRace(TracedRuntime)
+
+  private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
+    def loop(i: Int): UIO[Int] =
+      if (i < size) IO.never.raceAttempt(IO.effectTotal(i + 1)).flatMap(loop)
+      else IO.succeed(i)
+
+    runtime.unsafeRun(loop(0))
+  }
+}

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -1,0 +1,70 @@
+package zio
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect.concurrent.Deferred
+import org.openjdk.jmh.annotations._
+import zio.IOBenchmarks._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+class IOForkInterruptBenchmark {
+  @Param(Array("100"))
+  var size: Int = _
+
+  @Benchmark
+  def monixForkInterrupt(): Unit = {
+    import monix.eval.Task
+
+    def loop(i: Int): monix.eval.Task[Unit] =
+      if (i < size) Deferred[Task, Unit].flatMap { p1 =>
+        Deferred[Task, Unit].flatMap { p2 =>
+          p1.complete(())
+            .flatMap(_ => Task.never)
+            .guarantee(p2.complete(()))
+            .start
+            .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => loop(i + 1)))))
+        }
+      } else Task.unit
+
+    loop(0).runSyncUnsafe()
+  }
+
+  @Benchmark
+  def catsForkInterrupt(): Unit = {
+    import cats.effect.IO
+
+    def loop(i: Int): IO[Unit] =
+      if (i < size)
+        Deferred[IO, Unit].flatMap { p1 =>
+          Deferred[IO, Unit].flatMap { p2 =>
+            p1.complete(())
+              .flatMap(_ => IO.never)
+              .guarantee(p2.complete(()))
+              .start
+              .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => loop(i + 1)))))
+          }
+        } else IO.unit
+
+    loop(0).unsafeRunSync()
+  }
+
+  @Benchmark
+  def zioForkInterrupt(): Unit = zioForkInterrupt(IOBenchmarks)
+
+  @Benchmark
+  def zioTracedForkInterrupt(): Unit = zioForkInterrupt(TracedRuntime)
+
+  private[this] def zioForkInterrupt(runtime: Runtime[Any]): Unit = {
+    def loop(i: Int): UIO[Unit] =
+      if (i < size) IO.never.fork.flatMap(_.interrupt *> loop(i + 1))
+      else IO.unit
+
+    runtime.unsafeRun(loop(0))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -212,7 +212,7 @@ lazy val benchmarks = project.module
   .enablePlugins(JmhPlugin)
   .settings(replSettings)
   .settings(
-    // skip 2.13 benchmarks until monix & twitter-util publish for 2.13
+    // skip 2.13 benchmarks until twitter-util publishes for 2.13
     crossScalaVersions -= "2.13.0",
     //
     skip in publish := true,

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -125,6 +125,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
     deadlock regression 1                         $testDeadlockRegression
     check interruption regression 1               $testInterruptionRegression1
     max yield Ops 1                               $testOneMaxYield
+    simultaneous async+interrupt deadlock #785    $testAsyncInterruptRaceDeadlockRegression
 
   RTS option tests
     lifting a value to an option                  $testLiftingOptionalValue
@@ -1328,6 +1329,12 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime with org.specs2.mat
         _ <- UIO.unit
       } yield true
     )
+  }
+
+  def testAsyncInterruptRaceDeadlockRegression = {
+    val io = IO.never.fork.flatMap(_.interrupt).repeat(ZSchedule.recurs(10000))
+
+    unsafeRun(io.as(true).untraced)
   }
 
   def testBlockingThreadCaching = {

--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -87,7 +87,7 @@ object Blocking extends Serializable {
     def effectBlocking[A](effect: => A): ZIO[R, Throwable, A] =
       // Reference user's lambda for the tracer
       ZIOFn.recordTrace(() => effect) {
-        ZIO.flatten(ZIO.effectTotal {
+        ZIO.effectSuspendTotal {
           import java.util.concurrent.atomic.AtomicReference
           import java.util.concurrent.locks.ReentrantLock
 
@@ -145,7 +145,7 @@ object Blocking extends Serializable {
                   a <- fiber.join.flatten
                 } yield a).ensuring(interruptThread *> awaitInterruption)
           } yield a
-        })
+        }
       }
 
     /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1857,7 +1857,7 @@ private[zio] trait ZIOFunctions extends Serializable {
               case Right(io) => Some(ZIO.succeed(io))
             } finally if (!cancel.isSet) cancel.set(ZIO.unit)
           })
-        }.onInterrupt(flatten(effectTotal(if (started.get) cancel.get() else ZIO.unit)))
+        }.onInterrupt(effectSuspendTotal(if (started.get) cancel.get() else ZIO.unit))
     }
   }
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -145,7 +145,7 @@ private[zio] final class FiberContext[E, A](
       case v    => k(v)
     }
 
-  private object InterruptExit extends Function[Any, IO[E, Any]] {
+  private[this] object InterruptExit extends Function[Any, IO[E, Any]] {
     final def apply(v: Any): IO[E, Any] = {
       val isInterruptible = interruptStatus.peekOrElse(true)
 
@@ -159,7 +159,7 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private object TracingRegionExit extends Function[Any, IO[E, Any]] {
+  private[this] object TracingRegionExit extends Function[Any, IO[E, Any]] {
     final def apply(v: Any): IO[E, Any] = {
       // don't use effectTotal to avoid TracingRegionExit appearing in execution trace twice with traceEffects=true
       tracingStatus.popDrop(())
@@ -172,7 +172,7 @@ private[zio] final class FiberContext[E, A](
    * Unwinds the stack, looking for the first error handler, and exiting
    * interruptible / uninterruptible regions.
    */
-  final def unwindStack(): Unit = {
+  private[this] final def unwindStack(): Unit = {
     var unwinding = true
 
     // Unwind the stack, looking for an error handler:

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -607,8 +607,8 @@ private[zio] final class FiberContext[E, A](
    * @param value The value produced by the asynchronous computation.
    */
   private[this] final def resumeAsync: IO[E, Any] => Unit = {
-    val a = new AtomicBoolean(true)
-    zio => if (a.getAndSet(false) && exitAsync()) evaluateLater(zio)
+    val neverRan = new AtomicBoolean(true)
+    zio => if (neverRan.getAndSet(false) && exitAsync()) evaluateLater(zio)
   }
 
   final def interrupt: UIO[Exit[E, A]] = ZIO.effectAsyncMaybe[Any, Nothing, Exit[E, A]] { k =>
@@ -676,7 +676,7 @@ private[zio] final class FiberContext[E, A](
     val oldState = state.get
 
     oldState match {
-      case Executing(_: FiberStatus.Suspended, observers, interrupt) =>
+      case Executing(FiberStatus.Suspended(_), observers, interrupt) =>
         if (!state.compareAndSet(oldState, Executing(FiberStatus.Running, observers, interrupt))) exitAsync()
         else true
 


### PR DESCRIPTION
Also, prevent potential volatility problems with accessing interruptStack from multiple threads by moving `interruptible` state into Suspended