### PR TITLE
Run JVM Tests with more resources in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jdk_11: &jdk_11
   JDK_VERSION: 11
 
 machine_resource: &machine_resource
-  resource_class: medium+
+  resource_class: large
 
 machine_ubuntu: &machine_ubuntu
   machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
+machine_resource: &machine_resource
+  resource_class: medium+
+
 machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01
@@ -204,6 +207,7 @@ jobs:
   test_211_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8
@@ -211,6 +215,7 @@ jobs:
   test_212_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_8
@@ -218,6 +223,7 @@ jobs:
   test_213_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_213
       - <<: *jdk_8
@@ -225,6 +231,7 @@ jobs:
   test_dotty_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
@@ -232,6 +239,7 @@ jobs:
   test_212_jdk11_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_11


### PR DESCRIPTION
Change circleci config to: 

- make resource class used configurable
- make `testJVM` tests use a bigger resource to solve this timeout issue discussed in #1654 
