### PR TITLE
Add ChunkN to ZStream

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -68,6 +68,8 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     concat                  $concat
     finalizer order         $concatFinalizerOrder
 
+  Stream.chunkN       $chunkN
+
   Stream.drain              $drain
 
   Stream.dropUntil
@@ -669,6 +671,13 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
         execution <- log.get
       } yield execution must_=== List("First", "Second")
     }
+
+  private def chunkN =
+    unsafeRun(
+      Stream(1, 2, 3, 4).chunkN(2).run(ZSink.collectAll[List[Int]]).map { result =>
+        result must_=== List(List(1, 2), List(3, 4))
+      }
+    )
 
   private def drain =
     unsafeRun(

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -68,7 +68,7 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     concat                  $concat
     finalizer order         $concatFinalizerOrder
 
-  Stream.chunkN       $chunkN
+  Stream.chunkN             $chunkN
 
   Stream.drain              $drain
 
@@ -157,6 +157,8 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     first                                                 $groupByFirst
     filter                                                $groupByFilter
     outer errors                                          $groupByErrorsOuter
+
+  Stream.grouped            $grouped
 
   Stream interleaving
     interleave              $interleave
@@ -674,8 +676,8 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
 
   private def chunkN =
     unsafeRun(
-      Stream(1, 2, 3, 4).chunkN(2).run(ZSink.collectAll[List[Int]]).map { result =>
-        result must_=== List(List(1, 2), List(3, 4))
+      Stream(1, 2, 3, 4).chunkN(2).map(_.toSeq).run(ZSink.collectAll[Seq[Int]]).map { result =>
+        result must_=== List(Seq(1, 2), Seq(3, 4))
       }
     )
 
@@ -1316,6 +1318,13 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
         .either
         .map(_ must_=== Left("Boom"))
     }
+
+  private def grouped =
+    unsafeRun(
+      Stream(1, 2, 3, 4).grouped(2).run(ZSink.collectAll[List[Int]]).map { result =>
+        result must_=== List(List(1, 2), List(3, 4))
+      }
+    )
 
   private def map =
     prop { (s: Stream[String, Byte], f: Byte => Int) =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -664,7 +664,8 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     }
   }
 
-  /*** Chunks the stream with specifed chunkSize
+  /**
+   * Chunks the stream with specifed chunkSize
    * @parm chunkSize size of the chunk
    */
   def chunkN(chunkSize: Long): ZStream[R, E, Chunk[A]] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -666,7 +666,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
 
   /**
    * Chunks the stream with specifed chunkSize
-   * @parm chunkSize size of the chunk
+   * @param chunkSize size of the chunk
    */
   def chunkN(chunkSize: Long): ZStream[R, E, Chunk[A]] =
     transduce(ZSink.collectAllN[A](chunkSize).map(Chunk.fromIterable))
@@ -1277,7 +1277,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
 
   /**
    * Partitions the stream with specifed chunkSize
-   * @parm chunkSize size of the chunk
+   * @param chunkSize size of the chunk
    */
   def grouped(chunkSize: Long): ZStream[R, E, List[A]] =
     transduce(ZSink.collectAllN[A](chunkSize))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -664,6 +664,12 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     }
   }
 
+  /*** Chunks the stream with specifed chunkSize
+   * @parm chunkSize size of the chunk
+   */
+  def chunkN(chunkSize: Long): ZStream[R, E, List[A]] =
+    transduce(ZSink.collectAllN[A](chunkSize))
+
   /**
    * Performs a filter and map in a single step.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -667,8 +667,8 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
   /*** Chunks the stream with specifed chunkSize
    * @parm chunkSize size of the chunk
    */
-  def chunkN(chunkSize: Long): ZStream[R, E, List[A]] =
-    transduce(ZSink.collectAllN[A](chunkSize))
+  def chunkN(chunkSize: Long): ZStream[R, E, Chunk[A]] =
+    transduce(ZSink.collectAllN[A](chunkSize).map(Chunk.fromIterable))
 
   /**
    * Performs a filter and map in a single step.
@@ -1273,6 +1273,12 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
     buffer: Int = 16
   ): GroupBy[R1, E1, K, A] =
     self.groupBy(a => ZIO.succeed((f(a), a)), buffer)
+
+  /*** Partitions the stream with specifed chunkSize
+   * @parm chunkSize size of the chunk
+   */
+  def grouped(chunkSize: Long): ZStream[R, E, List[A]] =
+    transduce(ZSink.collectAllN[A](chunkSize))
 
   /**
    * Interleaves this stream and the specified stream deterministically by

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1274,7 +1274,8 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
   ): GroupBy[R1, E1, K, A] =
     self.groupBy(a => ZIO.succeed((f(a), a)), buffer)
 
-  /*** Partitions the stream with specifed chunkSize
+  /**
+   * Partitions the stream with specifed chunkSize
    * @parm chunkSize size of the chunk
    */
   def grouped(chunkSize: Long): ZStream[R, E, List[A]] =


### PR DESCRIPTION
Adds a small helper method to provide user friendly way to chunk the input stream into batches.

Resolves: #1732 