### PR TITLE
Implement repeatUntil and repeatUntilM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -78,10 +78,9 @@ object ZIOSpec
           val res = for {
             ref <- Ref.make(0)
             num <- ref.get
-            io = if (num < 5) ref.get.flatMap(a => ref.set(a + 1) *> UIO(a))
-            else UIO(num)
+            io = if (num < 5) ref.update(_ + 1) else UIO(num)
             res <- io.repeatUntil {
-                    case i if i == 5 => i
+                    case i if i == 5 => ZIO.succeed(i)
                   }
           } yield res
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -78,7 +78,7 @@ object ZIOSpec
           val res = for {
             ref <- Ref.make(0)
             num <- ref.get
-            io = if (num < 5) ref.update(_ + 1) else UIO(num)
+            io  = if (num < 5) ref.update(_ + 1) else UIO(num)
             res <- io.repeatUntil {
                     case i if i == 5 => ZIO.succeed(i)
                   }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1060,7 +1060,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def repeatUntil[R1 <: R, E1 >: E, B](f: PartialFunction[A, ZIO[R1, E1, B]]): ZIO[R1, Nothing, B] =
     self.flatMap { a =>
       f.lift(a) match {
-        case Some(value) => value.eventually
+        case Some(value) => value
         case None        => repeatUntil(f)
       }
     }.eventually

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1055,8 +1055,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   }
 
   /**
-   * Repeats this effect until the result exists in the partial function
-   * codomain.
+   * Repeats this effect until the partial function succeeds on the result.
    */
   final def repeatUntil[B](f: PartialFunction[A, B]): ZIO[R, E, B] =
     self.flatMap { a =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1065,16 +1065,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       }
     }.eventually
 
-
   /**
    * Effectful version of `repeatUntil`. Will repeat until `f` succeeds
    */
-    final def repeatUntilM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, Nothing, B] = {
-      (self >>= f).eventually
-    }
-
-
-
+  final def repeatUntilM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, Nothing, B] =
+    (self >>= f).eventually
 
   /**
    * Retries with the specified retry policy.


### PR DESCRIPTION
This PR adds two combinators to the API surface. These combinators came up as useful during John's ZIO Workshop and I thought it was worth implementing

- `repeatUntil`: Takes a `PartialFunction[A, B]` and repeats until the effect is in the codomain of the partial function
- `repeatUntilM`: Same as `repeatUntil` but takes an effect instead, evaluating it until it yields a success.