### PR TITLE
Fixed #1811 Add `effectRetry` to ZIO.

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -151,6 +151,11 @@ object IO {
   final def done[E, A](r: Exit[E, A]): IO[E, A] = ZIO.done(r)
 
   /**
+   * @see See [[zio.ZIO.effectRetry]]
+   */
+  final def effectRetry[R, A](effect: => A, onFailure: URIO[R, Unit]): URIO[R, A] = ZIO.effectRetry(effect, onFailure)
+
+  /**
    * @see See [[zio.ZIO.effect]]
    */
   final def effect[A](effect: => A): Task[A] = ZIO.effect(effect)

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -172,6 +172,11 @@ object RIO {
   final def done[A](r: Exit[Throwable, A]): Task[A] = ZIO.done(r)
 
   /**
+   * @see See [[zio.ZIO.effectRetry]]
+   */
+  final def effectRetry[R, A](effect: => A, onFailure: URIO[R, Unit]): URIO[R, A] = ZIO.effectRetry(effect, onFailure)
+
+  /**
    * @see See [[zio.ZIO.effect]]
    */
   final def effect[A](effect: => A): Task[A] = ZIO.effect(effect)

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -204,6 +204,11 @@ object Task {
   final def effectSuspendWith[A](p: Platform => Task[A]): Task[A] = new ZIO.EffectSuspendPartialWith(p)
 
   /**
+   * @see See [[zio.ZIO.effectRetry]]
+   */
+  final def effectRetry[R, A](effect: => A, onFailure: URIO[R, Unit]): URIO[R, A] = ZIO.effectRetry(effect, onFailure)
+
+  /**
    * @see See [[zio.ZIO.effectTotal]]
    */
   final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -149,6 +149,11 @@ object UIO {
   final def done[A](r: Exit[Nothing, A]): UIO[A] = ZIO.done(r)
 
   /**
+   * @see See [[zio.ZIO.effectRetry]]
+   */
+  final def effectRetry[A](effect: => A, onFailure: UIO[Unit]): UIO[A] = ZIO.effectRetry(effect, onFailure)
+
+  /**
    * @see See [[zio.ZIO.effectTotal]]
    */
   final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -200,6 +200,11 @@ object URIO {
   final def effectSuspendTotalWith[R, A](p: Platform => URIO[R, A]): URIO[R, A] = new ZIO.EffectSuspendTotalWith(p)
 
   /**
+   * @see See [[zio.ZIO.effectRetry]]
+   */
+  final def effectRetry[R, A](effect: => A, onFailure: URIO[R, Unit]): URIO[R, A] = ZIO.effectRetry(effect, onFailure)
+
+  /**
    * @see [[zio.ZIO.effectTotal]]
    */
   final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1889,6 +1889,17 @@ private[zio] trait ZIOFunctions extends Serializable {
     new ZIO.EffectAsync(register)
 
   /**
+   * Attempts to import a synchronous effect into a pure `ZIO` value.  If the
+   * import fails the onFailure effect is composed and the import is retried.
+   *
+   * {{{
+   * val result: URIO[Console, Int] = effectRetry(scala.io.StdIn.readLine().toInt, putStrLn("You didn't enter an integer!"))
+   * }}}
+   */
+  final def effectRetry[R, A](effect: => A, onFailure: URIO[R, Unit]): URIO[R, A] =
+    Task(effect) orElse (onFailure *> effectRetry(effect, onFailure))
+
+  /**
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -141,6 +141,20 @@ val getStrLn: Task[Unit] =
 
 The error type of the resulting effect will always be `Throwable`, because side-effects may throw exceptions with any value of type `Throwable`.
 
+If you want to keep retrying until the effect is converted you can use `effectRetry`, the `onFailure` will be composed before the effect is retried:
+
+```scala mdoc:silent
+import zio.console.putStrLn
+import scala.io.StdIn.readLine
+
+for {
+  _     <- putStrLn("Please input a number")
+  input <- ZIO.effectRetry(readLine().toInt, putStrLn("Not a number.  Please input again. "))
+  _     <- putStrLn(s"You inputted $input")
+} yield ()
+
+```
+
 If a given side-effect is known to not throw any exceptions, then the side-effect can be converted into a ZIO effect using `ZIO.effectTotal`:
 
 ```scala mdoc:silent


### PR DESCRIPTION
Added `effectRetry` to ZIO, during the advanced programming course we used `effectRetry` quite a number of times and it feels missing.   