### PR TITLE
Suspend ZIO.as & ZStream.as again

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -99,7 +99,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps the success value of this effect to the specified constant value.
    */
-  final def as[B](b: => B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstFn(() => b))
+  final def as[B](b: => B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstZIOFn(() => b))
 
   /**
    * Maps the error value of this effect to the specified constant value.
@@ -2649,10 +2649,17 @@ object ZIO extends ZIOFunctions {
       new ZIO.Succeed(underlying(a))
   }
 
-  final class ConstFn[R, E, A, B](override val underlying: () => B) extends ZIOFn1[A, ZIO[R, E, B]] {
+  final class ConstZIOFn[R, E, A, B](override val underlying: () => B) extends ZIOFn1[A, ZIO[R, E, B]] {
     def apply(a: A): ZIO[R, E, B] = {
       val _ = a
       new ZIO.Succeed(underlying())
+    }
+  }
+
+  final class ConstFn[A, B](override val underlying: () => B) extends ZIOFn1[A, B] {
+    def apply(a: A): B = {
+      val _ = a
+      underlying()
     }
   }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -99,7 +99,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps the success value of this effect to the specified constant value.
    */
-  final def as[B](b: B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstFn(() => b))
+  final def as[B](b: => B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstFn(() => b))
 
   /**
    * Maps the error value of this effect to the specified constant value.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -550,7 +550,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
   /**
    * Maps the success values of this stream to the specified constant value.
    */
-  final def as[B](b: => B): ZStream[R, E, B] = map(_ => b)
+  final def as[B](b: => B): ZStream[R, E, B] = map(new ZIO.ConstFn(() => b))
 
   /**
    * Returns a stream whose failure and success channels have been mapped by

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -550,7 +550,7 @@ class ZStream[-R, +E, +A](val process: ZManaged[R, E, Pull[R, E, A]]) extends Se
   /**
    * Maps the success values of this stream to the specified constant value.
    */
-  final def as[B](b: B): ZStream[R, E, B] = map(_ => b)
+  final def as[B](b: => B): ZStream[R, E, B] = map(_ => b)
 
   /**
    * Returns a stream whose failure and success channels have been mapped by


### PR DESCRIPTION
I don't know why `.as` was unsuspended when moving from const, but this messes with tracing, so...