### PR TITLE
Allow to specify a single spec of all test/test to be executed

### DIFF
--- a/test/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -6,7 +6,7 @@ import zio.Exit
 import zio.test.Assertion._
 import zio.test.TestUtils.label
 
-object AssertionSpec {
+object AssertionSpec extends BaseSpec {
 
   private def test(assertion: Boolean, message: String): Async[(Boolean, String)] =
     label(Future.successful(assertion), s"AssertionTest: $message")

--- a/test/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
+++ b/test/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
@@ -3,10 +3,9 @@ package zio.test
 import scala.concurrent.Future
 import scala.util.Random
 
-import zio.DefaultRuntime
 import zio.test.TestUtils.label
 
-object BoolAlgebraSpec extends DefaultRuntime {
+object BoolAlgebraSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(allReturnsConjunctionOfValues, "all returns conjunction of values"),

--- a/test/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -2,11 +2,11 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ random, Chunk, DefaultRuntime, Ref, ZIO }
+import zio.{ random, Chunk, Ref, ZIO }
 import zio.test.Assertion._
 import zio.test.TestUtils.{ execute, failed, forAllTests, label, succeeded }
 
-object CheckSpec extends DefaultRuntime {
+object CheckSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(checkMIsPolymorphicInErrorType, "checkM is polymorphic in error type"),

--- a/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -8,7 +8,7 @@ import zio.test.mock._
 import zio.test.TestUtils.label
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan }
 
-object DefaultTestReporterSpec extends DefaultRuntime {
+object DefaultTestReporterSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(reportSuccess, "correctly reports a successful test"),

--- a/test/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test/shared/src/test/scala/zio/test/FunSpec.scala
@@ -1,14 +1,12 @@
 package zio.test
 
-import zio.DefaultRuntime
-
 import scala.concurrent.Future
 import scala.math.abs
 
 import zio.{ random, ZIO }
 import zio.test.TestUtils.{ label }
 
-object FunSpec extends DefaultRuntime {
+object FunSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(funConvertsEffectsIntoPureFunctions, "fun converts effects into pure functions"),

--- a/test/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenSpec.scala
@@ -9,7 +9,7 @@ import zio.test.GenUtils._
 import zio.test.TestUtils.{ label, succeeded }
 import zio.ZIO
 
-object GenSpec {
+object GenSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(monadLeftIdentity, "monad left identity"),

--- a/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
+++ b/test/shared/src/test/scala/zio/test/GenZIOSpec.scala
@@ -6,7 +6,7 @@ import zio.test.Gen._
 import zio.test.GenUtils.{ checkSampleEffect, partitionEither }
 import zio.test.TestUtils.label
 
-object GenZIOSpec {
+object GenZIOSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(failuresGeneratesFailedEffects, "died generates died effects"),

--- a/test/shared/src/test/scala/zio/test/SampleSpec.scala
+++ b/test/shared/src/test/scala/zio/test/SampleSpec.scala
@@ -2,11 +2,11 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ DefaultRuntime, UIO, ZIO }
+import zio.{ UIO, ZIO }
 import zio.stream.ZStream
 import zio.test.TestUtils.label
 
-object SampleSpec extends DefaultRuntime {
+object SampleSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(monadLeftIdentity, "monad left identity"),

--- a/test/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -3,14 +3,14 @@ package zio.test
 import zio.Cause.{ Die, Traced }
 
 import scala.concurrent.Future
-import zio.{ Cause, DefaultRuntime, Ref }
+import zio.{ Cause, Ref }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils.{ execute, failed, ignored, label, succeeded }
 
 import scala.reflect.ClassTag
 
-object TestAspectSpec extends DefaultRuntime {
+object TestAspectSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(jsAppliesTestAspectOnlyOnJS, "js applies test aspect only on ScalaJS"),

--- a/test/shared/src/test/scala/zio/test/TestMain.scala
+++ b/test/shared/src/test/scala/zio/test/TestMain.scala
@@ -8,25 +8,41 @@ import zio.test.TestUtils.{ report, scope }
 object TestMain {
 
   def main(args: Array[String]): Unit = {
-    val testResults = List(
-      scope(AssertionSpec.run, "AssertionSpec"),
-      scope(BoolAlgebraSpec.run, "BoolAlgebraSpec"),
-      scope(CheckSpec.run, "CheckSpec"),
-      scope(ClockSpec.run, "ClockSpec"),
-      scope(ConsoleSpec.run, "ConsoleSpec"),
-      scope(DefaultTestReporterSpec.run, "DefaultTestReporterSpec"),
-      scope(EnvironmentSpec.run, "EnvironmentSpec"),
-      scope(FunSpec.run, "FunSpec"),
-      scope(GenSpec.run, "GenSpec"),
-      scope(GenZIOSpec.run, "GenZIOSpec"),
-      scope(LiveSpec.run, "LiveSpec"),
-      scope(RandomSpec.run, "RandomSpec"),
-      scope(SampleSpec.run, "SampleSpec"),
-      scope(SchedulerSpec.run, "SchedulerSpec"),
-      scope(SystemSpec.run, "SystemSpec"),
-      scope(TestAspectSpec.run, "TestAspectSpec"),
-      scope(TestSpec.run, "TestSpec")
+    val allTests: List[(String, BaseSpec)] = List(
+      ("AssertionSpec", AssertionSpec),
+      ("BoolAlgebraSpec", AssertionSpec),
+      ("CheckSpec", CheckSpec),
+      ("ClockSpec", ClockSpec),
+      ("ConsoleSpec", ConsoleSpec),
+      ("DefaultTestReporterSpec", DefaultTestReporterSpec),
+      ("EnvironmentSpec", EnvironmentSpec),
+      ("FunSpec", FunSpec),
+      ("GenSpec", GenSpec),
+      ("GenZIOSpec", GenZIOSpec),
+      ("LiveSpec", LiveSpec),
+      ("RandomSpec", RandomSpec),
+      ("SampleSpec", SampleSpec),
+      ("SchedulerSpec", SchedulerSpec),
+      ("SystemSpec", SystemSpec),
+      ("TestAspectSpec", TestAspectSpec),
+      ("TestSpec", TestSpec)
     )
+
+    val selectedTests = args match {
+      case Array() =>
+        allTests
+      case Array(spec) =>
+        val found = allTests.filter(_._1 == spec)
+        if (found.isEmpty)
+          sys.error("Unknown specfication: " ++ spec)
+
+        found
+      case _ =>
+        sys.error("Only one or no arguments are supported")
+    }
+
+    val testResults = selectedTests.map { case (label, spec) => scope(spec.run, label) }
+
     report(testResults)
   }
 }

--- a/test/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test/shared/src/test/scala/zio/test/TestSpec.scala
@@ -2,13 +2,13 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ DefaultRuntime, ZIO }
+import zio.ZIO
 import zio.test.Assertion.equalTo
 import zio.test.TestUtils.{ failed, label, succeeded }
 import zio.clock._
 import zio.test.Assertion._
 
-object TestSpec extends DefaultRuntime {
+object TestSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(assertMWorksCorrectly, "assertM works correctly"),

--- a/test/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test/shared/src/test/scala/zio/test/TestUtils.scala
@@ -39,7 +39,7 @@ object TestUtils {
     if (TestPlatform.isJS) test
     else test.repeat(Schedule.recurs(100) *> Schedule.identity[Boolean])
 
-  final def report(suites: List[Async[List[(Boolean, String)]]])(implicit ec: ExecutionContext): Unit = {
+  final def report(suites: Iterable[Async[List[(Boolean, String)]]])(implicit ec: ExecutionContext): Unit = {
     val async = Async
       .sequence(suites)
       .map(_.flatten)

--- a/test/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
+++ b/test/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
@@ -1,0 +1,7 @@
+package zio.test
+
+import zio.DefaultRuntime
+
+trait BaseSpec extends DefaultRuntime {
+  def run: List[Async[(Boolean, String)]]
+}

--- a/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
@@ -6,10 +6,11 @@ import java.time.ZoneId
 import zio._
 import zio.duration._
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.mock.MockClock.DefaultData
 import zio.test.TestUtils.{ label, nonFlaky }
 
-object ClockSpec extends DefaultRuntime {
+object ClockSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(e1, "sleep does not require passage of clock time"),

--- a/test/shared/src/test/scala/zio/test/mock/ConsoleSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/ConsoleSpec.scala
@@ -2,12 +2,12 @@ package zio.test.mock
 
 import java.io.{ ByteArrayOutputStream, PrintStream }
 
-import zio._
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.mock.MockConsole.Data
 import zio.test.TestUtils.label
 
-object ConsoleSpec extends DefaultRuntime {
+object ConsoleSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(emptyOutput, "outputs nothing"),

--- a/test/shared/src/test/scala/zio/test/mock/EnvironmentSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/EnvironmentSpec.scala
@@ -8,8 +8,9 @@ import zio._
 import zio.duration._
 import zio.test.Async
 import zio.test.TestUtils.label
+import zio.test.BaseSpec
 
-object EnvironmentSpec extends DefaultRuntime {
+object EnvironmentSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(currentTime, "Clock returns time when it is set"),

--- a/test/shared/src/test/scala/zio/test/mock/LiveSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/LiveSpec.scala
@@ -4,12 +4,13 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Future
 
-import zio.{ clock, console, DefaultRuntime }
+import zio.{ clock, console }
 import zio.duration._
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.TestUtils.label
 
-object LiveSpec extends DefaultRuntime {
+object LiveSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(liveCanAccessRealEnvironment, "live can access real environment"),

--- a/test/shared/src/test/scala/zio/test/mock/RandomSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/RandomSpec.scala
@@ -3,12 +3,13 @@ package zio.test.mock
 import scala.concurrent.Future
 import scala.util.{ Random => SRandom }
 
-import zio.{ Chunk, DefaultRuntime, UIO }
+import zio.{ Chunk, UIO }
 import zio.test.mock.MockRandom.{ DefaultData, Mock }
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.TestUtils.label
 
-object RandomSpec extends DefaultRuntime {
+object RandomSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(_.nextBoolean), "clearBooleans"),

--- a/test/shared/src/test/scala/zio/test/mock/SchedulerSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/SchedulerSpec.scala
@@ -5,9 +5,10 @@ import zio.duration._
 import zio.internal.{ Scheduler => IScheduler }
 import zio.internal.Scheduler.CancelToken
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.TestUtils.label
 
-object SchedulerSpec extends DefaultRuntime {
+object SchedulerSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(e1, "scheduled tasks get executed"),

--- a/test/shared/src/test/scala/zio/test/mock/SystemSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/SystemSpec.scala
@@ -1,11 +1,11 @@
 package zio.test.mock
 
-import zio.DefaultRuntime
 import zio.test.Async
+import zio.test.BaseSpec
 import zio.test.mock.MockSystem.Data
 import zio.test.TestUtils.label
 
-object SystemSpec extends DefaultRuntime {
+object SystemSpec extends BaseSpec {
 
   val run: List[Async[(Boolean, String)]] = List(
     label(env1, "fetch an environment variable and check that if it exists, return a reasonable value"),


### PR DESCRIPTION
Invocation example: testJVM/test:run GenSpec

Throws an exception if more than one argument is given or the single one argument doesn't match a spec name.

This is a split of #1756 

Question: where should this behaviour / feature be documented?