### PR TITLE
Add ZSchedule.elapsed example to docs

### DIFF
--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -96,3 +96,9 @@ recur, using the minimum of the two delays between recurrences:
 ```scala mdoc:silent
 val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.second)
 ```
+
+Stops trying to retry after a specified amount of time has elapsed:
+
+```scala mdoc:silent
+val expMaxElapsed = Schedule.exponential(10.milliseconds) && ZSchedule.elapsed.whileOutput(_ < 30.seconds)
+```

--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -97,7 +97,7 @@ recur, using the minimum of the two delays between recurrences:
 val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.second)
 ```
 
-Stops trying to retry after a specified amount of time has elapsed:
+Stops retrying after a specified amount of time has elapsed:
 
 ```scala mdoc:silent
 val expMaxElapsed = Schedule.exponential(10.milliseconds) && ZSchedule.elapsed.whileOutput(_ < 30.seconds)


### PR DESCRIPTION
Since I struggled with this one, I thought it would be helpful to include at least one example of a `ZSchedule`-specific method (such as needing `Clock`) so that people know to look at the additional methods in `ZSchedule` and not just `Schedule`.