### PR TITLE
Ignore Flaky Supervision Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -7,7 +7,7 @@ import zio.duration._
 import zio.test._
 import zio.test.mock.live
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, jvm, nonFlaky }
+import zio.test.TestAspect.{ flaky, ignore, jvm, nonFlaky }
 
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success }
@@ -641,7 +641,7 @@ object ZIOSpec
                   } yield ()).interruptChildren
               r <- pa.await zip pb.await
             } yield assert(r, equalTo((1, 2)))
-          } @@ flaky,
+          } @@ ignore,
           testM("supervise fibers in race") {
             for {
               pa <- Promise.make[Nothing, Int]


### PR DESCRIPTION
The "supervise fibers in supervised" test is flaky and repeated evaluations using `TestAspect#flaky` are exceeding the timeout. Since an overhaul of supervision is right around the corner ignoring this test for now to avoid spurious failures in CI.