### PR TITLE
ZIO Test: Harden MockClock

### DIFF
--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -291,7 +291,7 @@ object MockClock {
   def makeMock(data: Data): UIO[Mock] =
     for {
       ref      <- Ref.make(data)
-      fiberRef <- FiberRef.make(FiberData(data.nanoTime))
+      fiberRef <- FiberRef.make(FiberData(data.nanoTime), FiberData.combine)
     } yield Mock(ref, fiberRef)
 
   /**
@@ -342,6 +342,11 @@ object MockClock {
   )
 
   case class FiberData(nanoTime: Long)
+
+  object FiberData {
+    def combine(first: FiberData, last: FiberData): FiberData =
+      FiberData(first.nanoTime max last.nanoTime)
+  }
 
   private def offset(millis: Long, timeZone: ZoneId): OffsetDateTime =
     OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), timeZone)

--- a/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
@@ -29,7 +29,8 @@ object ClockSpec extends ZIOBaseSpec {
     label(e14, "setTimeZone correctly sets timeZone"),
     label(e15, "setTimeZone does not produce sleeps "),
     label(e16, "timeout example from documentation works correctly"),
-    label(e17, "recurrence example from documentation works correctly")
+    label(e17, "recurrence example from documentation works correctly"),
+    label(e18, "fiber time is not subject to race conditions")
   )
 
   def e1 =
@@ -219,6 +220,20 @@ object ClockSpec extends ZIOBaseSpec {
           d <- q.take.as(true)
           e <- q.poll.map(_.isEmpty)
         } yield a && b && c && d && e
+        io.provideM(MockClock.make(MockClock.DefaultData))
+      }
+    }
+
+  def e18 =
+    unsafeRunToFuture {
+      nonFlaky {
+        val io = for {
+          mockClock <- MockClock.makeMock(DefaultData)
+          fiber     <- mockClock.sleep(2.millis).zipPar(mockClock.sleep(1.millis)).fork
+          _         <- mockClock.adjust(2.millis)
+          _         <- fiber.join
+          result    <- mockClock.fiberState.get
+        } yield result.nanoTime == 2000000L
         io.provideM(MockClock.make(MockClock.DefaultData))
       }
     }

--- a/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
+++ b/test/shared/src/test/scala/zio/test/mock/ClockSpec.scala
@@ -227,14 +227,13 @@ object ClockSpec extends ZIOBaseSpec {
   def e18 =
     unsafeRunToFuture {
       nonFlaky {
-        val io = for {
+        for {
           mockClock <- MockClock.makeMock(DefaultData)
           fiber     <- mockClock.sleep(2.millis).zipPar(mockClock.sleep(1.millis)).fork
           _         <- mockClock.adjust(2.millis)
           _         <- fiber.join
           result    <- mockClock.fiberState.get
         } yield result.nanoTime == 2000000L
-        io.provideM(MockClock.make(MockClock.DefaultData))
       }
     }
 }


### PR DESCRIPTION
The current implementation of `MockClock` could be subject to a race condition in some circumstances. Consider the following snippet:

```scala
for {
  mockClock <- MockClock.makeMock(DefaultData)
  fiber     <- mockClock.sleep(2.millis).zipPar(mockClock.sleep(1.millis)).fork
  _         <- mockClock.adjust(2.millis)
  _         <- fiber.join
  result    <- mockClock.fiberState.get
} yield result.nanoTime == 2000000L
```

In the current implementation this would be flaky. When we adjust the `MockClock` we wake up both the left and the right effects in `zipPar`. Although we wake up the right effect first, since the effects are on separate fibers their order of completion is indeterminate. So if the left effect completes first, the right effect will set the fiber time to 1 millisecond, leading to data corruption.

With the new functionality for specifying custom logic for inheriting `FiberRef` instances implemented in #1879 we can address this by always using the maximum fiber time when combining data from two fibers.