### PR TITLE
Minor Cleanup Changes Following Up on New Mocking Framework

### DIFF
--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -292,7 +292,7 @@ object TestClock {
     ZIO.accessM(_.clock.adjust(duration))
 
   /**
-   * Access a `TestClock` instance in the envirnoment and returns the current
+   * Accesses a `TestClock` instance in the environment and returns the current
    * fiber time for this fiber.
    */
   val fiberTime: ZIO[TestClock, Nothing, Duration] =

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -144,18 +144,22 @@ object TestClock {
       clockState.get.map(data => unit.convert(data.currentTimeMillis, TimeUnit.MILLISECONDS))
 
     /**
-     * Returns how much time must have passed for the fiber to reach its current state.
-     * This basically accumulates all sleeps and handles sleeps of fork/joined fibers correctly.
+     * Returns the current fiber time for this fiber. The fiber time is backed
+     * by a `FiberRef` and is incremented for the duration each fiber is
+     * sleeping. When a fiber is joined the fiber time will be set to the
+     * maximum of the fiber time of the parent and child fibers. Thus, the
+     * fiber time reflects the duration of sleeping that has occurred for this
+     * fiber to reach its current state, properly reflecting forks and joins.
      *
+     * {{{
      * for {
-     *   mockClock <- MockClock.makeMock(DefaultData)
-     *   _         <- mockClock.set(Duration.Infinity)
-     *   fiber     <- mockClock.sleep(2.millis).zipPar(mockClock.sleep(1.millis)).fork
-     *   _         <- fiber.join
-     *   result    <- mockClock.fiberTime
+     *   _      <- TestClock.set(Duration.Infinity)
+     *   _      <- ZIO.sleep(2.millis).zipPar(ZIO.sleep(1.millis))
+     *   result <- TestClock.fiberTime
      * } yield result.toNanos == 2000000L
+     * }}}
      */
-    final def fiberTime: UIO[Duration] =
+    final val fiberTime: UIO[Duration] =
       fiberState.get.map(_.nanoTime.nanos)
 
     /**
@@ -286,6 +290,13 @@ object TestClock {
    */
   def adjust(duration: Duration): ZIO[TestClock, Nothing, Unit] =
     ZIO.accessM(_.clock.adjust(duration))
+
+  /**
+   * Access a `TestClock` instance in the envirnoment and returns the current
+   * fiber time for this fiber.
+   */
+  val fiberTime: ZIO[TestClock, Nothing, Duration] =
+    ZIO.accessM(_.clock.fiberTime)
 
   /**
    * Constructs a new `TestClock` with the specified initial state. This can

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -40,8 +40,8 @@ import zio.Managed
  * Then all environmental effects, such as printing to the console or
  * generating random numbers, will be implemented by the `TestEnvironment` and
  * will be fully testable. When you do need to access the "live" environment,
- * for example to print debugging information to the close, just use the `live`
- * combinator along with the effect as your normally would.
+ * for example to print debugging information to the console, just use the
+ * `live` combinator along with the effect as your normally would.
  *
  * If you are only interested in one of the test implementations for your
  * application, you can also access them a la carte through the `make` method

--- a/test/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -227,13 +227,12 @@ object ClockSpec extends ZIOBaseSpec {
   def e18 =
     unsafeRunToFuture {
       nonFlaky {
-        for {
-          testClock <- TestClock.makeTest(DefaultData)
-          fiber     <- testClock.sleep(2.millis).zipPar(testClock.sleep(1.millis)).fork
-          _         <- testClock.adjust(2.millis)
-          _         <- fiber.join
-          result    <- testClock.fiberTime
+        val io = for {
+          _      <- TestClock.adjust(Duration.Infinity)
+          _      <- ZIO.sleep(2.millis).zipPar(ZIO.sleep(1.millis))
+          result <- TestClock.fiberTime
         } yield result.toNanos == 2000000L
+        io.provideM(TestClock.make(TestClock.DefaultData))
       }
     }
 }


### PR DESCRIPTION
Some of the documentation for the recent changes we made to The Artist Formerly Known As MockClock didn't get updated with everything else going on with getting #1830 merged. Fixes that and cleans things up slightly by adding a convenience method to get the fiber time using a `TestClock` in the environment.