### PR TITLE
Add `Gen.anyUnicodeChar`

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -24,6 +24,7 @@ object GenSpec extends ZIOBaseSpec {
     label(anyLongShrinksToZero, "anyLong shrinks to zero"),
     label(anyShortShrinksToZero, "anyShort shrinks to zero"),
     label(anyStringShrinksToEmptyString, "anyString shrinks to empty string"),
+    label(anyUnicodeCharShrinksToZero, "anyChar shrinks to zero"),
     label(booleanGeneratesTrueAndFalse, "boolean generates true and false"),
     label(booleanShrinksToFalse, "boolean shrinks to false"),
     label(byteGeneratesValuesInRange, "byte generates values in range"),
@@ -154,6 +155,9 @@ object GenSpec extends ZIOBaseSpec {
 
   def anyStringShrinksToEmptyString: Future[Boolean] =
     checkShrink(Gen.anyString)("")
+
+  def anyUnicodeCharShrinksToZero: Future[Boolean] =
+    checkShrink(Gen.anyUnicodeChar)(0)
 
   def booleanGeneratesTrueAndFalse: Future[Boolean] =
     checkSample(Gen.boolean)(ps => ps.exists(identity) && ps.exists(!_))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -24,7 +24,7 @@ object GenSpec extends ZIOBaseSpec {
     label(anyLongShrinksToZero, "anyLong shrinks to zero"),
     label(anyShortShrinksToZero, "anyShort shrinks to zero"),
     label(anyStringShrinksToEmptyString, "anyString shrinks to empty string"),
-    label(anyUnicodeCharShrinksToZero, "anyChar shrinks to zero"),
+    label(anyUnicodeCharShrinksToZero, "anyUnicodeChar shrinks to zero"),
     label(booleanGeneratesTrueAndFalse, "boolean generates true and false"),
     label(booleanShrinksToFalse, "boolean shrinks to false"),
     label(byteGeneratesValuesInRange, "byte generates values in range"),


### PR DESCRIPTION
Some values in the `[Char.MinValue .. Char.MaxValue]` range are not valid Unicode characters. This was detected in the `utf8Decode` tests in the `ZSink` spec [here](https://github.com/zio/zio/pull/1887/files).