### PR TITLE
Make `asError` argument call-by-name to match `as`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -104,7 +104,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps the error value of this effect to the specified constant value.
    */
-  final def asError[E1](e1: E1): ZIO[R, E1, A] = mapError(_ => e1)
+  final def asError[E1](e1: => E1): ZIO[R, E1, A] = mapError(_ => e1)
 
   /**
    * Returns an effect whose failure and success channels have been mapped by

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -125,7 +125,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Replaces any error produced by this sink.
    */
-  final def asError[E1](e1: E1): ZSink[R, E1, A0, A, B] = self.mapError(_ => e1)
+  final def asError[E1](e1: => E1): ZSink[R, E1, A0, A, B] = self.mapError(_ => e1)
 
   /**
    * Creates a sink where every element of type `A` entering the sink is first


### PR DESCRIPTION
I stumbled upon this because I wanted to avoid constructing an unnecessary error object when doing something like `someSuccessfulIO.asError(createError(...))`. But I also noticed `ZIO.as` is currently call-by-name but not `asError`. So seems like a good thing to do for consistency's sake anyway.

I noticed this same mismatch in `ZSink`.