### PR TITLE
Deduplicate compier error message

### DIFF
--- a/docs/howto/use_module_pattern.md
+++ b/docs/howto/use_module_pattern.md
@@ -219,7 +219,7 @@ val id = new TemplateId {}
 val recipients = List.empty[EmailAddress]
 ```
 
-```scala mdoc:fail
+```scala mdoc:fail:silent
 val result =
   Helper
     .send(id, recipients)
@@ -241,7 +241,7 @@ it has 2 unimplemented members.
 
 The compiler error clearly states what is missing and where. As a counterexample, let's see would happen had we used the cake pattern:
 
-```scala mdoc:fail
+```scala mdoc:fail:silent
 trait NewsletterLiveCake extends Newsletter { self: EmailRenderer with Postman =>
   /* ... */
 }


### PR DESCRIPTION
The compier error is currently being displayed twice in the [use module pattern](https://zio.dev/docs/howto/howto_use_module_pattern) doc. My intention was to hide the original error and re-type it below, to clean it up a little (remove noise like `$anon: repl.Session.App0`) to get the message across better. 

![image](https://user-images.githubusercontent.com/1419884/66243799-41b96580-e706-11e9-841d-b8b8ee9f4626.png)