### PR TITLE
Follow up #1905 enable tracing of asError by-name

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -104,7 +104,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps the error value of this effect to the specified constant value.
    */
-  final def asError[E1](e1: => E1): ZIO[R, E1, A] = mapError(_ => e1)
+  final def asError[E1](e1: => E1): ZIO[R, E1, A] = mapError(new ZIO.ConstFn(() => e1))
 
   /**
    * Returns an effect whose failure and success channels have been mapped by

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -125,7 +125,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Replaces any error produced by this sink.
    */
-  final def asError[E1](e1: => E1): ZSink[R, E1, A0, A, B] = self.mapError(_ => e1)
+  final def asError[E1](e1: => E1): ZSink[R, E1, A0, A, B] = self.mapError(new ZIO.ConstFn(() => e1))
 
   /**
    * Creates a sink where every element of type `A` entering the sink is first


### PR DESCRIPTION
`asError` argument needs additional wrapping to show up in traces (because Function1 `_ => e1` passed to mapError is a different lambda from user's `e1` Function0)