### PR TITLE
fatal-warnings based on system property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ compile: &compile
     - <<: *load_cache
     - run:
         name: Compile code
-        command: ./sbt ++${SCALA_VERSION}! compileJVM
+        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! compileJVM
     - <<: *clean_cache
     - <<: *save_cache
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -21,7 +21,6 @@ object BuildHelper {
   )
 
   private val std2xOptions = Seq(
-    "-Xfatal-warnings",
     "-language:higherKinds",
     "-language:existentials",
     "-explaintypes",
@@ -29,7 +28,7 @@ object BuildHelper {
     "-Xlint:_,-type-parameter-shadow",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
-  )
+  ) ++ customOptions
 
   private def optimizerOptions(optimize: Boolean) =
     if (optimize)
@@ -38,6 +37,16 @@ object BuildHelper {
         "-opt-inline-from:zio.internal.**"
       )
     else Nil
+
+  private def propertyFlag(property: String, default: Boolean) =
+    sys.props.get(property).map(_.toBoolean).getOrElse(default)
+
+  private def customOptions =
+    if (propertyFlag("fatal.warnings", false)) {
+      Seq("-Xfatal-warnings")
+    } else {
+      Nil
+    }
 
   def buildInfoSettings(packageName: String) =
     Seq(


### PR DESCRIPTION
This makes fatal-warnings customizable based on a system property (always on in CI though). The motivation being that getting unused import/variable errors while developing locally can get in the way when doing rework.

I was initially going to make the default `true`, but it seems like others are fine with it being `false`. I don't have strong preferences either way.