### PR TITLE
TestClock depends on Java Time API, adding dependency for ScalaJS project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJS",
-  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile"
+  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile;testRunnerJS/test:run"
 )
 
 lazy val root = project
@@ -214,7 +214,7 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "org.scala-js"      %% "scalajs-test-interface" % "0.6.29",
-      "io.github.cquiroz" %%% "scala-java-time"       % "2.0.0-RC3"
+      "io.github.cquiroz" %%% "scala-java-time"       % "2.0.0-RC3" % Test
     )
   )
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
@@ -233,6 +233,7 @@ lazy val examples = crossProject(JVMPlatform, JSPlatform)
   .in(file("examples"))
   .settings(stdSettings("examples"))
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
+  .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3" % Test)
   .dependsOn(testRunner)
 
 lazy val examplesJS  = examples.js

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,8 @@ addCommandAlias(
   ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile"
 )
 
+addCommandAlias("test", ";testJVM;testJS")
+
 lazy val root = project
   .in(file("."))
   .settings(
@@ -211,12 +213,7 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
     ),
     mainClass in (Test, run) := Some("zio.test.sbt.TestMain")
   )
-  .jsSettings(
-    libraryDependencies ++= Seq(
-      "org.scala-js"      %% "scalajs-test-interface" % "0.6.29",
-      "io.github.cquiroz" %%% "scala-java-time"       % "2.0.0-RC3" % Test
-    )
-  )
+  .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % "0.6.29"))
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
   .dependsOn(core)
   .dependsOn(test)

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJS",
-  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile;testRunnerJS/test:run"
+  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile"
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,12 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
     ),
     mainClass in (Test, run) := Some("zio.test.sbt.TestMain")
   )
-  .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % "0.6.29"))
+  .jsSettings(
+    libraryDependencies ++= Seq(
+      "org.scala-js"      %% "scalajs-test-interface" % "0.6.29",
+      "io.github.cquiroz" %%% "scala-java-time"       % "2.0.0-RC3"
+    )
+  )
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
   .dependsOn(core)
   .dependsOn(test)

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -13,6 +13,9 @@ println(s"""libraryDependencies += "dev.zio" %%% "zio" % "${zio.BuildInfo.versio
 println(s"""```""")
 ```
 
+Java Time API which is not a part of ScalaJS. You might have to add dependecy that provides `java.time` package to
+avoid linker errors when using `Clock`.
+
 ## Example
 
 Your main function can extend `App` as follows.
@@ -25,13 +28,13 @@ import zio.{App, IO}
 
 object MyApp extends App {
 
-  def run(args: List[String]): IO[Nothing, Unit] =
+  def run(args: List[String]): IO[Nothing, Int] =
     for {
-      p <- IO.defer(document.createElement("p"))
-      t <- IO.defer(document.createTextNode("Hello World"))
-      _ <- IO.defer(p.appendChild(t))
-      _ <- IO.defer(document.body.appendChild(p))
-    } yield ()
+      p <- IO.effectSuspendTotal(document.createElement("p"))
+      t <- IO.effectSuspendTotal(document.createTextNode("Hello World"))
+      _ <- IO.effectSuspendTotal(p.appendChild(t))
+      _ <- IO.effectSuspendTotal(document.body.appendChild(p))
+    } yield 0
 }
 
 ```

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -14,7 +14,8 @@ println(s"""```""")
 ```
 
 Java Time API which is not a part of ScalaJS. You might have to add dependecy that provides `java.time` package to
-avoid linker errors when using `Clock`.
+avoid linker errors when using `Clock`. ZIO uses [scala-java-time](https://github.com/cquiroz/scala-java-time) for
+running it's test.
 
 ## Example
 


### PR DESCRIPTION
I'm trying to fix #1934 
Please run `sbt` and then `test` to see linking error.
TestClock clearly depends on Java Time API that is not in vanilla ScalaJS.
