### PR TITLE
Add discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | CI | Coverage | Release | Issues | Scaladex |
 | --- | --- | --- | --- | --- |
-| [![Build Status][Badge-Circle]][Link-Circle] | [![Coverage Status][Badge-Codecov]][Link-Codecov] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladex-page]][Link-Scaladex-page]
+| [![Build Status][Badge-Circle]][Link-Circle] | [![Coverage Status][Badge-Codecov]][Link-Codecov] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord]
 
 # Welcome to ZIO
 
@@ -51,9 +51,9 @@ See the [Code of Conduct](./docs/about/code_of_conduct.md)
 
 ---
 
-## Support 
+## Support
 
-Come chat with us on [Discord][Link-Discord]
+Come chat with us on [![Badge-Discord]][Link-Discord].
 
 ---
 
@@ -76,6 +76,7 @@ Copyright 2017 - 2019 John A. De Goes and the ZIO Contributors. All rights reser
 [Badge-Scaladex-page]: https://index.scala-lang.org/zio/zio/zio/latest.svg "Scaladex"
 [Badge-SonatypeReleases]: https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio_2.12.svg "Sonatype Releases"
 [Badge-Circle]: https://circleci.com/gh/zio/zio.svg?style=svg "circleci"
+[Badge-Discord]: https://img.shields.io/discord/629491597070827530?logo=discord "chat on discord"
 
 [Image-SoftwareMill]: ./website/static/img/softwaremill.svg "SoftwareMill"
 [Image-SeptimalMind]: ./website/static/img/septimal_mind.svg "Septimal Mind"


### PR DESCRIPTION
Adding the discord badge to README. Requires enabling the widget to work.

> To use the Discord badge a Discord server admin must enable the widget setting on the server.

# Preview

Come chat with us on [![Badge-Discord]][Link-Discord].

[Link-Discord]: https://discord.gg/2ccFBr4 "Discord"
[Badge-Discord]: https://img.shields.io/discord/629491597070827530?logo=discord "chat on discord"