### PR TITLE
collectWhile in Chunk, ZStreamChunk, StreamChunkEffect

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -104,6 +104,15 @@ object ChunkSpec
         test("collect for empty Chunk") {
           assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty, Assertion.isTrue)
         },
+        test("collect chunk") {
+          assert(Chunk(1, 2, 3, 4, 5, 6).collect { case x if x % 2 == 0 => 2 * x }, equalTo(Chunk(4, 8, 12)))
+        },
+        test("collectWhile for empty Chunk") {
+          assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty, Assertion.isTrue)
+        },
+        test("collectWhile chunk") {
+          assert(Chunk(1, 2, 3, 4, 5, 6).collectWhile { case x if x < 4 => 2 * x }, equalTo(Chunk(2, 4, 6)))
+        },
         testM("foreach") {
           check(mediumChunks(intGen)) { c =>
             var sum = 0

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -104,14 +104,20 @@ object ChunkSpec
         test("collect for empty Chunk") {
           assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty, Assertion.isTrue)
         },
-        test("collect chunk") {
-          assert(Chunk(1, 2, 3, 4, 5, 6).collect { case x if x % 2 == 0 => 2 * x }, equalTo(Chunk(4, 8, 12)))
+        testM("collect chunk") {
+          val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
+          check(mediumChunks(intGen), pfGen) { (c, pf) =>
+            assert(c.collect(pf).toSeq, equalTo(c.toSeq.collect(pf)))
+          }
         },
         test("collectWhile for empty Chunk") {
           assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty, Assertion.isTrue)
         },
-        test("collectWhile chunk") {
-          assert(Chunk(1, 2, 3, 4, 5, 6).collectWhile { case x if x < 4 => 2 * x }, equalTo(Chunk(2, 4, 6)))
+        testM("collectWhile chunk") {
+          val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
+          check(mediumChunks(intGen), pfGen) { (c, pf) =>
+            assert(c.collectWhile(pf).toSeq, equalTo(c.toSeq.takeWhile(pf.isDefinedAt).map(pf.apply)))
+          }
         },
         testM("foreach") {
           check(mediumChunks(intGen)) { c =>

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -229,6 +229,17 @@ object StreamChunkSpec
             } yield assert(res1, equalTo(res2))
           }
         },
+        testM("StreamChunk.collectWhile") {
+          checkM(
+            pureStreamChunkGen(smallChunks(intGen)),
+            Gen.partialFunction[Random with Sized, Int, String](stringGen)
+          ) { (s, pf) =>
+            for {
+              res1 <- slurp(s.collectWhile(pf))
+              res2 <- slurp(s).map(_.takeWhile(pf.isDefinedAt).map(pf.apply))
+            } yield assert(res1, equalTo(res2))
+          }
+        },
         testM("StreamChunk.toInputStream") {
           val orig1  = List(1, 2, 3).map(_.toByte)
           val orig2  = List(4).map(_.toByte)


### PR DESCRIPTION
I wanted to feel useful again.

@iravid 

I also have a suggestion. I noticed that `Chunk#collect` allocates an array of the same size as the original chunk, and slices it at the end. I'm curious to know if sacrificing runtime for improved memory complexity is a better alternative. We could count the number of _defined_ elements (the ones that satisfy `pf.isDefinedAt`) and then map them to the destination array by doing another pass over the original.