### PR TITLE
Implement ZIO#forkInternal to Prevent Spurious Warnings

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -308,7 +308,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     uploadUsers(List(new User)) causeMust { cause =>
       (cause.traces.head.stackTrace must have size 2) and
         (cause.traces.head.stackTrace.head must mentionMethod("uploadUsers")) and
-        (cause.traces(1).stackTrace must beEmpty) and
+        (cause.traces(1).stackTrace must have size 1) and
         (cause.traces(1).executionTrace must have size 1) and
         (cause.traces(1).executionTrace.head must mentionMethod("uploadTo")) and
         (cause.traces(1).parentTrace must not be empty) and

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -150,6 +150,12 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   }
 
   /**
+   * Traverses the `Exit` with an effectual function.
+   */
+  def traverse[R, E1 >: E, B](f: A => ZIO[R, E1, B]): ZIO[R, Nothing, Exit[E1, B]] =
+    fold(c => ZIO.succeed(halt(c)), a => f(a).run)
+
+  /**
    * Discards the value.
    */
   final def unit: Exit[E, Unit] = as(())

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -99,6 +99,13 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
     }
 
   /**
+   * Applies the function `f` to the successful result of the `Exit` and
+   * returns the result in a new `Exit`.
+   */
+  final def foreach[R, E1 >: E, B](f: A => ZIO[R, E1, B]): ZIO[R, Nothing, Exit[E1, B]] =
+    fold(c => ZIO.succeed(halt(c)), a => f(a).run)
+
+  /**
    * Retrieves the `A` if succeeded, or else returns the specified default `A`.
    */
   final def getOrElse[A1 >: A](orElse: Cause[E] => A1): A1 = self match {
@@ -150,10 +157,10 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   }
 
   /**
-   * Traverses the `Exit` with an effectual function.
+   * Alias for [[Exit.foreach]]
    */
-  def traverse[R, E1 >: E, B](f: A => ZIO[R, E1, B]): ZIO[R, Nothing, Exit[E1, B]] =
-    fold(c => ZIO.succeed(halt(c)), a => f(a).run)
+  final def traverse[R, E1 >: E, B](f: A => ZIO[R, E1, B]): ZIO[R, Nothing, Exit[E1, B]] =
+    foreach(f)
 
   /**
    * Discards the value.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -220,7 +220,7 @@ trait Fiber[+E, +A] { self =>
     mapM(f andThen UIO.succeed)
 
   /**
-   * Effectually maps over the favlue the fiber computes.
+   * Effectually maps over the value the fiber computes.
    */
   def mapM[E1 >: E, B](f: A => IO[E1, B]): Fiber[E1, B] =
     new Fiber[E1, B] {

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -225,13 +225,13 @@ trait Fiber[+E, +A] { self =>
   def mapM[E1 >: E, B](f: A => IO[E1, B]): Fiber[E1, B] =
     new Fiber[E1, B] {
       def await: UIO[Exit[E1, B]] =
-        self.await.flatMap(_.traverse(f))
+        self.await.flatMap(_.foreach(f))
       def inheritFiberRefs: UIO[Unit] =
         self.inheritFiberRefs
       def interrupt: UIO[Exit[E1, B]] =
-        self.interrupt.flatMap(_.traverse(f))
+        self.interrupt.flatMap(_.foreach(f))
       def poll: UIO[Option[Exit[E1, B]]] =
-        self.poll.flatMap(_.fold[UIO[Option[Exit[E1, B]]]](UIO.succeed(None))(_.traverse(f).map(Some(_))))
+        self.poll.flatMap(_.fold[UIO[Option[Exit[E1, B]]]](UIO.succeed(None))(_.foreach(f).map(Some(_))))
     }
 
   @deprecated("use as", "1.0.0")

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -217,11 +217,21 @@ trait Fiber[+E, +A] { self =>
    * @return `Fiber[E, B]` mapped fiber
    */
   final def map[B](f: A => B): Fiber[E, B] =
-    new Fiber[E, B] {
-      def await: UIO[Exit[E, B]]        = self.await.map(_.map(f))
-      def poll: UIO[Option[Exit[E, B]]] = self.poll.map(_.map(_.map(f)))
-      def interrupt: UIO[Exit[E, B]]    = self.interrupt.map(_.map(f))
-      def inheritFiberRefs: UIO[Unit]   = self.inheritFiberRefs
+    mapM(f andThen UIO.succeed)
+
+  /**
+   * Effectually maps over the favlue the fiber computes.
+   */
+  def mapM[E1 >: E, B](f: A => IO[E1, B]): Fiber[E1, B] =
+    new Fiber[E1, B] {
+      def await: UIO[Exit[E1, B]] =
+        self.await.flatMap(_.traverse(f))
+      def inheritFiberRefs: UIO[Unit] =
+        self.inheritFiberRefs
+      def interrupt: UIO[Exit[E1, B]] =
+        self.interrupt.flatMap(_.traverse(f))
+      def poll: UIO[Option[Exit[E1, B]]] =
+        self.poll.flatMap(_.fold[UIO[Option[Exit[E1, B]]]](UIO.succeed(None))(_.traverse(f).map(Some(_))))
     }
 
   @deprecated("use as", "1.0.0")

--- a/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
@@ -1,7 +1,5 @@
 package zio.test
 
-import zio.Cause._
-
 import scala.concurrent.Future
 import zio.clock.Clock
 import zio.{ Cause, Ref, ZIO }


### PR DESCRIPTION
Currently we generate a lot of spurious fiber failure warnings. For example, consider:

```scala
ZIO.fail("fail").zipPar(ZIO.succeed("succeed")).foldCause(_ => 0, _ => 0)
```

This will succeed because `foldCause` recovers from all errors. But a fiber failure warning will still be printed to the console because one of the forked fibers in `raceWith`, which `zipPar` is implemented in terms of, ended in failure. This is undesirable in general and particularly confusing to new users who don't understand why the warning is displayed or that the success of their effect is independent of this warning.

This PR implements a new combinator `forkInternal` that forks an effect that will be executed without unhandled failures being reported. This can be use in combinators such as `raceWith` that implement their own logic for handling failures to avoid these spurious warnings being generated.

So far I have only used this in `raceWith`, which seems to be the cause of most of the spurious warnings that are being reported, but we should be able to use this in other combinators as well.