### PR TITLE
introduce ZEnv decorators

### DIFF
--- a/core/js/src/main/scala/zio/ZEnv.scala
+++ b/core/js/src/main/scala/zio/ZEnv.scala
@@ -53,6 +53,9 @@ object ZEnv {
   def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(randomDecorator = f)
 
+  /**
+   * Create a decorator which modifies chosen parts of a Zenv.
+   */
   def zEnvDecorator(
     clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
     consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,

--- a/core/js/src/main/scala/zio/ZEnv.scala
+++ b/core/js/src/main/scala/zio/ZEnv.scala
@@ -1,0 +1,95 @@
+package zio
+
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import zio.clock.Clock
+import zio.console.Console
+import zio.system.System
+import zio.random.Random
+
+object ZEnv {
+
+  /**
+   * Lifts a function that decorates a [[Clock.Service[Any]]] to a function that decoratec an entire ZEnv.
+   *
+   * Use this with [[ZIO#provideSome]] for maximum effect.
+   * {{{
+   *   clock.sleep(1.second).provideSome(ZEnv.clockDecorator(oldClock => ???))
+   * }}}
+   */
+  def clockDecorator(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = f(old.clock),
+        console0 = old.console,
+        system0 = old.system,
+        random0 = old.random
+      )
+
+  /**
+   * Lifts a function that decorates a [[Console.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = f(old.console),
+        system0 = old.system,
+        random0 = old.random
+      )
+
+  /**
+   * Lifts a function that decorates a [[System.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = old.console,
+        system0 = f(old.system),
+        random0 = old.random
+      )
+
+  /**
+   * Lifts a function that decorates a [[Random.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = old.console,
+        system0 = old.system,
+        random0 = f(old.random)
+      )
+  private[ZEnv] class ZEnvImpl(
+    clock0: Clock.Service[Any],
+    console0: Console.Service[Any],
+    system0: System.Service[Any],
+    random0: Random.Service[Any]
+  ) extends Clock
+      with Console
+      with System
+      with Random
+      with Blocking {
+    val clock    = clock0
+    val console  = console0
+    val system   = system0
+    val random   = random0
+    val blocking = blocking0
+  }
+}

--- a/core/js/src/main/scala/zio/ZEnv.scala
+++ b/core/js/src/main/scala/zio/ZEnv.scala
@@ -1,5 +1,3 @@
-package zio
-
 /*
  * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
  *
@@ -25,7 +23,7 @@ import zio.random.Random
 object ZEnv {
 
   /**
-   * Lifts a function that decorates a [[Clock.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Clock.Service]] to a function that decoratec an entire ZEnv.
    *
    * Use this with [[ZIO#provideSome]] for maximum effect.
    * {{{
@@ -36,19 +34,19 @@ object ZEnv {
     zEnvDecorator(clockDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[Console.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Console.Service]] to a function that decoratec an entire ZEnv.
    */
   def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(consoleDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[System.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[System.Service]] to a function that decoratec an entire ZEnv.
    */
   def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(systemDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[Random.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Random.Service]] to a function that decoratec an entire ZEnv.
    */
   def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(randomDecorator = f)

--- a/core/js/src/main/scala/zio/ZEnv.scala
+++ b/core/js/src/main/scala/zio/ZEnv.scala
@@ -23,48 +23,48 @@ import zio.random.Random
 object ZEnv {
 
   /**
-   * Lifts a function that decorates a [[Clock.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Clock.Service]] component of a ZEnv, keeping all other services the same.
    *
    * Use this with [[ZIO#provideSome]] for maximum effect.
    * {{{
-   *   clock.sleep(1.second).provideSome(ZEnv.clockDecorator(oldClock => ???))
+   *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  def clockDecorator(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(clockDecorator = f)
+  def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapClock = f)
 
   /**
-   * Lifts a function that decorates a [[Console.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(consoleDecorator = f)
+  def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapConsole = f)
 
   /**
-   * Lifts a function that decorates a [[System.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(systemDecorator = f)
+  def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapSystem = f)
 
   /**
-   * Lifts a function that decorates a [[Random.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(randomDecorator = f)
+  def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapRandom = f)
 
   /**
-   * Create a decorator which modifies chosen parts of a Zenv.
+   * Map all components of a ZEnv individually.
    */
-  def zEnvDecorator(
-    clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
-    consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,
-    systemDecorator: System.Service[Any] => System.Service[Any] = identity,
-    randomDecorator: Random.Service[Any] => Random.Service[Any] = identity
+  def mapAll(
+    mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
+    mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
+    mapSystem: System.Service[Any] => System.Service[Any] = identity,
+    mapRandom: Random.Service[Any] => Random.Service[Any] = identity
   ): ZEnv => ZEnv =
     old =>
       new Clock with Console with System with Random {
-        val clock   = clockDecorator(old.clock)
-        val console = consoleDecorator(old.console)
-        val system  = systemDecorator(old.system)
-        val random  = randomDecorator(old.random)
+        val clock   = mapClock(old.clock)
+        val console = mapConsole(old.console)
+        val system  = mapSystem(old.system)
+        val random  = mapRandom(old.random)
       }
 }

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -61,7 +61,7 @@ object ZEnv {
   /**
    * Create a decorator that modifies chosen parts of a Zenv.
    */
-  def zEnvDecoratesor(
+  def zEnvDecorator(
     clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
     consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,
     systemDecorator: System.Service[Any] => System.Service[Any] = identity,

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -32,81 +32,45 @@ object ZEnv {
    * }}}
    */
   def clockDecorator(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
-    old =>
-      new ZEnvImpl(
-        clock0 = f(old.clock),
-        console0 = old.console,
-        system0 = old.system,
-        random0 = old.random,
-        blocking0 = old.blocking
-      )
+    zEnvDecorator(clockDecorator = f)
 
   /**
    * Lifts a function that decorates a [[Console.Service[Any]]] to a function that decoratec an entire ZEnv.
    */
   def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
-    old =>
-      new ZEnvImpl(
-        clock0 = old.clock,
-        console0 = f(old.console),
-        system0 = old.system,
-        random0 = old.random,
-        blocking0 = old.blocking
-      )
+    zEnvDecorator(consoleDecorator = f)
 
   /**
    * Lifts a function that decorates a [[System.Service[Any]]] to a function that decoratec an entire ZEnv.
    */
   def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
-    old =>
-      new ZEnvImpl(
-        clock0 = old.clock,
-        console0 = old.console,
-        system0 = f(old.system),
-        random0 = old.random,
-        blocking0 = old.blocking
-      )
+    zEnvDecorator(systemDecorator = f)
 
   /**
    * Lifts a function that decorates a [[Random.Service[Any]]] to a function that decoratec an entire ZEnv.
    */
   def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
-    old =>
-      new ZEnvImpl(
-        clock0 = old.clock,
-        console0 = old.console,
-        system0 = old.system,
-        random0 = f(old.random),
-        blocking0 = old.blocking
-      )
+    zEnvDecorator(randomDecorator = f)
 
   /**
    * Lifts a function that decorates a [[Blocking.Service[Any]]] to a function that decoratec an entire ZEnv.
    */
   def blockingDecorator(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
+    zEnvDecorator(blockingDecorator = f)
+
+  def zEnvDecorator(
+    clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
+    consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,
+    systemDecorator: System.Service[Any] => System.Service[Any] = identity,
+    randomDecorator: Random.Service[Any] => Random.Service[Any] = identity,
+    blockingDecorator: Blocking.Service[Any] => Blocking.Service[Any] = identity
+  ): ZEnv => ZEnv =
     old =>
-      new ZEnvImpl(
-        clock0 = old.clock,
-        console0 = old.console,
-        system0 = old.system,
-        random0 = old.random,
-        blocking0 = f(old.blocking)
-      )
-  private[ZEnv] class ZEnvImpl(
-    clock0: Clock.Service[Any],
-    console0: Console.Service[Any],
-    system0: System.Service[Any],
-    random0: Random.Service[Any],
-    blocking0: Blocking.Service[Any]
-  ) extends Clock
-      with Console
-      with System
-      with Random
-      with Blocking {
-    val clock    = clock0
-    val console  = console0
-    val system   = system0
-    val random   = random0
-    val blocking = blocking0
-  }
+      new Clock with Console with System with Random with Blocking {
+        val clock    = clockDecorator(old.clock)
+        val console  = consoleDecorator(old.console)
+        val system   = systemDecorator(old.system)
+        val random   = randomDecorator(old.random)
+        val blocking = blockingDecorator(old.blocking)
+      }
 }

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -58,7 +58,10 @@ object ZEnv {
   def blockingDecorator(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(blockingDecorator = f)
 
-  def zEnvDecorator(
+  /**
+   * Create a decorator that modifies chosen parts of a Zenv.
+   */
+  def zEnvDecoratesor(
     clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
     consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,
     systemDecorator: System.Service[Any] => System.Service[Any] = identity,

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -24,56 +24,56 @@ import zio.blocking.Blocking
 object ZEnv {
 
   /**
-   * Lifts a function that decorates a [[Clock.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Clock.Service]] component of a ZEnv, keeping all other services the same.
    *
    * Use this with [[ZIO#provideSome]] for maximum effect.
    * {{{
-   *   clock.sleep(1.second).provideSome(ZEnv.clockDecorator(oldClock => ???))
+   *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  def clockDecorator(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(clockDecorator = f)
+  def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapClock = f)
 
   /**
-   * Lifts a function that decorates a [[Console.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(consoleDecorator = f)
+  def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapConsole = f)
 
   /**
-   * Lifts a function that decorates a [[System.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(systemDecorator = f)
+  def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapSystem = f)
 
   /**
-   * Lifts a function that decorates a [[Random.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(randomDecorator = f)
+  def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapRandom = f)
 
   /**
-   * Lifts a function that decorates a [[Blocking.Service]] to a function that decoratec an entire ZEnv.
+   * Map the [[Blocking.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def blockingDecorator(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
-    zEnvDecorator(blockingDecorator = f)
+  def mapBlocking(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
+    mapAll(mapBlocking = f)
 
   /**
-   * Create a decorator that modifies chosen parts of a Zenv.
+   * Map all components of a ZEnv individually.
    */
-  def zEnvDecorator(
-    clockDecorator: Clock.Service[Any] => Clock.Service[Any] = identity,
-    consoleDecorator: Console.Service[Any] => Console.Service[Any] = identity,
-    systemDecorator: System.Service[Any] => System.Service[Any] = identity,
-    randomDecorator: Random.Service[Any] => Random.Service[Any] = identity,
-    blockingDecorator: Blocking.Service[Any] => Blocking.Service[Any] = identity
+  def mapAll(
+    mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
+    mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
+    mapSystem: System.Service[Any] => System.Service[Any] = identity,
+    mapRandom: Random.Service[Any] => Random.Service[Any] = identity,
+    mapBlocking: Blocking.Service[Any] => Blocking.Service[Any] = identity
   ): ZEnv => ZEnv =
     old =>
       new Clock with Console with System with Random with Blocking {
-        val clock    = clockDecorator(old.clock)
-        val console  = consoleDecorator(old.console)
-        val system   = systemDecorator(old.system)
-        val random   = randomDecorator(old.random)
-        val blocking = blockingDecorator(old.blocking)
+        val clock    = mapClock(old.clock)
+        val console  = mapConsole(old.console)
+        val system   = mapSystem(old.system)
+        val random   = mapRandom(old.random)
+        val blocking = mapBlocking(old.blocking)
       }
 }

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import zio.clock.Clock
+import zio.console.Console
+import zio.system.System
+import zio.random.Random
+import zio.blocking.Blocking
+
+object ZEnv {
+
+  /**
+   * Lifts a function that decorates a [[Clock.Service[Any]]] to a function that decoratec an entire ZEnv.
+   *
+   * Use this with [[ZIO#provideSome]] for maximum effect.
+   * {{{
+   *   clock.sleep(1.second).provideSome(ZEnv.clockDecorator(oldClock => ???))
+   * }}}
+   */
+  def clockDecorator(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = f(old.clock),
+        console0 = old.console,
+        system0 = old.system,
+        random0 = old.random,
+        blocking0 = old.blocking
+      )
+
+  /**
+   * Lifts a function that decorates a [[Console.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = f(old.console),
+        system0 = old.system,
+        random0 = old.random,
+        blocking0 = old.blocking
+      )
+
+  /**
+   * Lifts a function that decorates a [[System.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = old.console,
+        system0 = f(old.system),
+        random0 = old.random,
+        blocking0 = old.blocking
+      )
+
+  /**
+   * Lifts a function that decorates a [[Random.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = old.console,
+        system0 = old.system,
+        random0 = f(old.random),
+        blocking0 = old.blocking
+      )
+
+  /**
+   * Lifts a function that decorates a [[Blocking.Service[Any]]] to a function that decoratec an entire ZEnv.
+   */
+  def blockingDecorator(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
+    old =>
+      new ZEnvImpl(
+        clock0 = old.clock,
+        console0 = old.console,
+        system0 = old.system,
+        random0 = old.random,
+        blocking0 = f(old.blocking)
+      )
+  private[ZEnv] class ZEnvImpl(
+    clock0: Clock.Service[Any],
+    console0: Console.Service[Any],
+    system0: System.Service[Any],
+    random0: Random.Service[Any],
+    blocking0: Blocking.Service[Any]
+  ) extends Clock
+      with Console
+      with System
+      with Random
+      with Blocking {
+    val clock    = clock0
+    val console  = console0
+    val system   = system0
+    val random   = random0
+    val blocking = blocking0
+  }
+}

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -24,7 +24,7 @@ import zio.blocking.Blocking
 object ZEnv {
 
   /**
-   * Lifts a function that decorates a [[Clock.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Clock.Service]] to a function that decoratec an entire ZEnv.
    *
    * Use this with [[ZIO#provideSome]] for maximum effect.
    * {{{
@@ -35,25 +35,25 @@ object ZEnv {
     zEnvDecorator(clockDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[Console.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Console.Service]] to a function that decoratec an entire ZEnv.
    */
   def consoleDecorator(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(consoleDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[System.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[System.Service]] to a function that decoratec an entire ZEnv.
    */
   def systemDecorator(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(systemDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[Random.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Random.Service]] to a function that decoratec an entire ZEnv.
    */
   def randomDecorator(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(randomDecorator = f)
 
   /**
-   * Lifts a function that decorates a [[Blocking.Service[Any]]] to a function that decoratec an entire ZEnv.
+   * Lifts a function that decorates a [[Blocking.Service]] to a function that decoratec an entire ZEnv.
    */
   def blockingDecorator(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
     zEnvDecorator(blockingDecorator = f)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -80,7 +80,7 @@ object BuildHelper {
        |import zio.duration._
        |object replRTS extends DefaultRuntime {}
        |import replRTS._
-       |implicit class RunSyntax[R >: replRTS.Environment, E, A](io: ZIO[R, E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
+       |implicit class RunSyntax[R >: ZEnv, E, A](io: ZIO[R, E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
     """.stripMargin
   }
 
@@ -91,7 +91,7 @@ object BuildHelper {
        |import zio.stream._
        |object replRTS extends DefaultRuntime {}
        |import replRTS._
-       |implicit class RunSyntax[R >: replRTS.Environment, E, A](io: ZIO[R, E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
+       |implicit class RunSyntax[R >: ZEnv, E, A](io: ZIO[R, E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
     """.stripMargin
   }
 
@@ -230,7 +230,7 @@ object BuildHelper {
     def item(text: String): String = s"${Console.GREEN}▶ ${Console.CYAN}$text${Console.RESET}"
 
     s"""|${header(" ________ ___")}
-        |${header("|__  /_ _/ _ \\")} 
+        |${header("|__  /_ _/ _ \\")}
         |${header("  / / | | | | |")}
         |${header(" / /_ | | |_| |")}
         |${header(s"/____|___\\___/   ${version.value}")}

--- a/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
@@ -1,7 +1,5 @@
 package zio.test
 
-import zio.Cause._
-
 import scala.concurrent.Future
 import zio.clock.Clock
 import zio.{ Cause, Ref, ZIO }


### PR DESCRIPTION
#resolve #1953 

Also, there was a stray reference to DefaultRuntime#Environment that I missed in the BuildHelper.

Interestingly, we can write a fully generic version of this in zio-macros without introducing any new macros. I'll open a pr there later.

/cc @adamgfraser @jdegoes 