### PR TITLE
Remove Wildcard Types

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -47,8 +47,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   "single effectTotal for-comprehension" >> singleEffectTotalForComp
   "single suspendWith for-comprehension" >> singleSuspendWithForComp
 
-  private def show(trace: ZTrace): Unit   = if (debug) println(trace.prettyPrint)
-  private def show(cause: Cause[_]): Unit = if (debug) println(cause.prettyPrint)
+  private def show(trace: ZTrace): Unit     = if (debug) println(trace.prettyPrint)
+  private def show(cause: Cause[Any]): Unit = if (debug) println(cause.prettyPrint)
 
   private def mentionsMethod(method: String, trace: ZTraceElement): Boolean =
     trace match {
@@ -80,8 +80,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   private def mentionedMethod(method: String): Matcher[List[ZTraceElement]] = mentionMethod(method)
 
-  private implicit final class CauseMust[R >: ZEnv](io: ZIO[R, _, _]) {
-    def causeMust(check: Cause[_] => Result): Result =
+  private implicit final class CauseMust[R >: ZEnv](io: ZIO[R, Any, Any]) {
+    def causeMust(check: Cause[Any] => Result): Result =
       unsafeRunSync(io).fold[Result](
         cause => {
           show(cause)

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -68,7 +68,7 @@ object RTSSpec
               bracketed = IO
                 .succeed(21)
                 .bracketExit(
-                  (r: Int, exit: Exit[_, _]) =>
+                  (r: Int, exit: Exit[Any, Any]) =>
                     if (exit.interrupted) exitLatch.succeed(r)
                     else IO.die(new Error("Unexpected case"))
                 )(a => startLatch.succeed(a) *> IO.never *> IO.succeed(1))

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -237,7 +237,7 @@ object SerializableSpec
     )
 
 object SerializableSpecHelpers {
-  def serializeAndBack[T](a: T): IO[_, T] =
+  def serializeAndBack[T](a: T): IO[Any, T] =
     for {
       obj       <- IO.effectTotal(serializeToBytes(a))
       returnObj <- IO.effectTotal(getObjFromBytes[T](obj))

--- a/core-tests/shared/src/test/scala/zio/BracketTypeInferrenceSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BracketTypeInferrenceSpec.scala
@@ -10,37 +10,37 @@ object BracketTypeInferrenceSpec {
   class E1 extends E
 
   def infersEType1: ZIO[R, E, B] = {
-    val acquire: ZIO[R, E, A]            = ???
-    val release: A => ZIO[R, Nothing, _] = ???
-    val use: A => ZIO[R, E1, B]          = ???
+    val acquire: ZIO[R, E, A]              = ???
+    val release: A => ZIO[R, Nothing, Any] = ???
+    val use: A => ZIO[R, E1, B]            = ???
     acquire.bracket(release)(use)
   }
 
   def infersEType2: ZIO[R, E, B] = {
-    val acquire: ZIO[R, E1, A]           = ???
-    val release: A => ZIO[R, Nothing, _] = ???
-    val use: A => ZIO[R, E, B]           = ???
+    val acquire: ZIO[R, E1, A]             = ???
+    val release: A => ZIO[R, Nothing, Any] = ???
+    val use: A => ZIO[R, E, B]             = ???
     acquire.bracket(release, use)
   }
 
   def infersRType1: ZIO[R2, E, B] = {
-    val acquire: ZIO[R, E, A]             = ???
-    val release: A => ZIO[R1, Nothing, _] = ???
-    val use: A => ZIO[R2, E, B]           = ???
+    val acquire: ZIO[R, E, A]               = ???
+    val release: A => ZIO[R1, Nothing, Any] = ???
+    val use: A => ZIO[R2, E, B]             = ???
     acquire.bracket(release)(use)
   }
 
   def infersRType2: ZIO[R2, E, B] = {
-    val acquire: ZIO[R2, E, A]            = ???
-    val release: A => ZIO[R1, Nothing, _] = ???
-    val use: A => ZIO[R, E, B]            = ???
+    val acquire: ZIO[R2, E, A]              = ???
+    val release: A => ZIO[R1, Nothing, Any] = ???
+    val use: A => ZIO[R, E, B]              = ???
     acquire.bracket(release, use)
   }
 
   def infersRType3: ZIO[R2, E, B] = {
-    val acquire: ZIO[R1, E, A]            = ???
-    val release: A => ZIO[R2, Nothing, _] = ???
-    val use: A => ZIO[R, E, B]            = ???
+    val acquire: ZIO[R1, E, A]              = ???
+    val release: A => ZIO[R2, Nothing, Any] = ???
+    val use: A => ZIO[R, E, B]              = ???
     ZIO.bracket(acquire, release, use)
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -35,7 +35,7 @@ object ZIOSpec
               release <- Ref.make(false)
               result <- ZIO.bracketExit(
                          IO.succeed(42),
-                         (_: Int, _: Exit[_, _]) => release.set(true),
+                         (_: Int, _: Exit[Any, Any]) => release.set(true),
                          (_: Int) => IO.succeed(0L)
                        )
               released <- release.get
@@ -740,12 +740,12 @@ object ZIOSpec
             } yield assert(result, equalTo(42))
           },
           testM("supervising returns fiber refs") {
-            def forkAwaitStart(ref: Ref[List[Fiber[_, _]]]) =
+            def forkAwaitStart(ref: Ref[List[Fiber[Any, Any]]]) =
               withLatch(release => (release *> UIO.never).fork.tap(fiber => ref.update(fiber :: _)))
 
             val io =
               for {
-                ref <- Ref.make(List.empty[Fiber[_, _]])
+                ref <- Ref.make(List.empty[Fiber[Any, Any]])
                 f1  <- ZIO.children
                 _   <- forkAwaitStart(ref)
                 f2  <- ZIO.children
@@ -757,18 +757,18 @@ object ZIOSpec
           } @@ flaky,
           testM("supervising in unsupervised returns Nil") {
             for {
-              ref  <- Ref.make(Option.empty[Fiber[_, _]])
+              ref  <- Ref.make(Option.empty[Fiber[Any, Any]])
               _    <- withLatch(release => (release *> UIO.never).fork.tap(fiber => ref.set(Some(fiber))))
               fibs <- ZIO.children
             } yield assert(fibs, isEmpty)
           } @@ flaky,
           testM("supervise fibers") {
-            def makeChild(n: Int, fibers: Ref[List[Fiber[_, _]]]) =
+            def makeChild(n: Int, fibers: Ref[List[Fiber[Any, Any]]]) =
               (clock.sleep(20.millis * n.toDouble) *> IO.unit).fork.tap(fiber => fibers.update(fiber :: _))
 
             val io =
               for {
-                fibers  <- Ref.make(List.empty[Fiber[_, _]])
+                fibers  <- Ref.make(List.empty[Fiber[Any, Any]])
                 counter <- Ref.make(0)
                 _ <- (makeChild(1, fibers) *> makeChild(2, fibers)).handleChildrenWith { fs =>
                       fs.foldLeft(IO.unit)((io, f) => io *> f.join.either *> counter.update(_ + 1).unit)
@@ -988,7 +988,9 @@ object ZIOSpec
               for {
                 promise <- Promise.make[Nothing, Unit]
                 fiber <- IO
-                          .bracketExit(promise.succeed(()) *> IO.never *> IO.succeed(1))((_, _: Exit[_, _]) => IO.unit)(
+                          .bracketExit(promise.succeed(()) *> IO.never *> IO.succeed(1))(
+                            (_, _: Exit[Any, Any]) => IO.unit
+                          )(
                             _ => IO.unit: IO[Nothing, Unit]
                           )
                           .fork
@@ -1005,7 +1007,7 @@ object ZIOSpec
           },
           testM("bracketExit use is interruptible") {
             for {
-              fiber <- IO.bracketExit(IO.unit)((_, _: Exit[_, _]) => IO.unit)(_ => IO.never).fork
+              fiber <- IO.bracketExit(IO.unit)((_, _: Exit[Any, Any]) => IO.unit)(_ => IO.never).fork
               res   <- fiber.interrupt.timeoutTo(42)(_ => 0)(1.second)
             } yield assert(res, equalTo(0))
           },
@@ -1026,7 +1028,7 @@ object ZIOSpec
             for {
               done <- Promise.make[Nothing, Unit]
               fiber <- withLatch { release =>
-                        IO.bracketExit(IO.unit)((_, _: Exit[_, _]) => done.succeed(()))(
+                        IO.bracketExit(IO.unit)((_, _: Exit[Any, Any]) => done.succeed(()))(
                             _ => release *> IO.never
                           )
                           .fork
@@ -1200,7 +1202,7 @@ object ZIOSpec
                 fiber1 <- latch1
                            .succeed(())
                            .bracketExit[Clock, Nothing, Unit](
-                             (_: Boolean, _: Exit[_, _]) => ZIO.unit,
+                             (_: Boolean, _: Exit[Any, Any]) => ZIO.unit,
                              (_: Boolean) => latch2.await *> clock.sleep(10.millis) *> ref.set(true).unit
                            )
                            .uninterruptible
@@ -1290,12 +1292,12 @@ object ZIOSpec
             assertM(io, isTrue)
           } @@ flaky,
           testM("supervision inheritance") {
-            def forkAwaitStart[A](io: UIO[A], refs: Ref[List[Fiber[_, _]]]): UIO[Fiber[Nothing, A]] =
+            def forkAwaitStart[A](io: UIO[A], refs: Ref[List[Fiber[Any, Any]]]): UIO[Fiber[Nothing, A]] =
               withLatch(release => (release *> io).fork.tap(f => refs.update(f :: _)))
 
             val io =
               (for {
-                ref  <- Ref.make[List[Fiber[_, _]]](Nil) // To make strong ref
+                ref  <- Ref.make[List[Fiber[Any, Any]]](Nil) // To make strong ref
                 _    <- forkAwaitStart(forkAwaitStart(forkAwaitStart(IO.succeed(()), ref), ref), ref)
                 fibs <- ZIO.children
               } yield fibs.size == 1).supervised

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -41,7 +41,7 @@ object PlatformLive {
         throw t
       }
 
-      def reportFailure(cause: Cause[_]): Unit =
+      def reportFailure(cause: Cause[Any]): Unit =
         if (!cause.interrupted)
           println(cause.prettyPrint)
 

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -59,7 +59,7 @@ object PlatformLive {
         } catch { case _: Throwable => throw t }
       }
 
-      def reportFailure(cause: Cause[_]): Unit =
+      def reportFailure(cause: Cause[Any]): Unit =
         if (!cause.interrupted)
           System.err.println(cause.prettyPrint)
 

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -454,17 +454,17 @@ object Cause extends Serializable {
     }
     override final def hashCode: Int = Cause.flatten(self).hashCode
 
-    private def eq(that: Cause[_]): Boolean = (self, that) match {
+    private def eq(that: Cause[Any]): Boolean = (self, that) match {
       case (tl: Then[_], tr: Then[_]) => tl.left == tr.left && tl.right == tr.right
       case _                          => false
     }
 
-    private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+    private def assoc(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
       case (Then(Then(al, bl), cl), Then(ar, Then(br, cr))) => al == ar && bl == br && cl == cr
       case _                                                => false
     }
 
-    private def dist(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+    private def dist(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
       case (Then(al, Both(bl, cl)), Both(Then(ar1, br), Then(ar2, cr)))
           if ar1 == ar2 && al == ar1 && bl == br && cl == cr =>
         true
@@ -489,17 +489,17 @@ object Cause extends Serializable {
     }
     override final def hashCode: Int = Cause.flatten(self).hashCode
 
-    private def eq(that: Cause[_]) = (self, that) match {
+    private def eq(that: Cause[Any]) = (self, that) match {
       case (bl: Both[_], br: Both[_]) => bl.left == br.left && bl.right == br.right
       case _                          => false
     }
 
-    private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+    private def assoc(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
       case (Both(Both(al, bl), cl), Both(ar, Both(br, cr))) => al == ar && bl == br && cl == cr
       case _                                                => false
     }
 
-    private def dist(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+    private def dist(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
       case (Both(Then(al1, bl), Then(al2, cl)), Then(ar, Both(br, cr)))
           if al1 == al2 && al1 == ar && bl == br && cl == cr =>
         true
@@ -509,7 +509,7 @@ object Cause extends Serializable {
       case _ => false
     }
 
-    private def comm(that: Cause[_]): Boolean = (self, that) match {
+    private def comm(that: Cause[Any]): Boolean = (self, that) match {
       case (Both(al, bl), Both(ar, br)) => al == br && bl == ar
       case _                            => false
     }
@@ -522,10 +522,10 @@ object Cause extends Serializable {
 
   private final case class Data(stackless: Boolean)
 
-  private[Cause] def sym(f: (Cause[_], Cause[_]) => Boolean): (Cause[_], Cause[_]) => Boolean =
+  private[Cause] def sym(f: (Cause[Any], Cause[Any]) => Boolean): (Cause[Any], Cause[Any]) => Boolean =
     (l, r) => f(l, r) || f(r, l)
 
-  private[Cause] def flatten(c: Cause[_]): Set[Cause[_]] = c match {
+  private[Cause] def flatten(c: Cause[Any]): Set[Cause[Any]] = c match {
     case Then(left, right) => flatten(left) ++ flatten(right)
     case Both(left, right) => flatten(left) ++ flatten(right)
     case Traced(cause, _)  => flatten(cause)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -471,10 +471,10 @@ sealed trait Chunk[+A] { self =>
   /**
    * Effectfully maps the elements of this chunk purely for the effects.
    */
-  final def mapM_[R, E](f: A => ZIO[R, E, _]): ZIO[R, E, Unit] = {
-    val len               = self.length
-    var zio: ZIO[R, E, _] = ZIO.unit
-    var i                 = 0
+  final def mapM_[R, E](f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] = {
+    val len                 = self.length
+    var zio: ZIO[R, E, Any] = ZIO.unit
+    var i                   = 0
 
     while (i < len) {
       val a = self(i)
@@ -495,7 +495,7 @@ sealed trait Chunk[+A] { self =>
    * Effectfully traverses the elements of this chunk purely for the effects.
    */
   @deprecated("use mapM_", "1.0.0")
-  final def traverse_[R, E](f: A => ZIO[R, E, _]): ZIO[R, E, Unit] = mapM_(f)
+  final def traverse_[R, E](f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] = mapM_(f)
 
   /**
    * Zips this chunk with the specified chunk using the specified combiner.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -318,7 +318,7 @@ object Fiber {
     interruptStatus: InterruptStatus,
     superviseStatus: SuperviseStatus,
     executor: Executor,
-    children: UIO[IndexedSeq[Fiber[_, _]]]
+    children: UIO[IndexedSeq[Fiber[Any, Any]]]
   )
 
   /**
@@ -401,7 +401,7 @@ object Fiber {
    * @param fs `Iterable` of fibers to be interrupted
    * @return `UIO[Unit]`
    */
-  final def interruptAll(fs: Iterable[Fiber[_, _]]): UIO[Unit] =
+  final def interruptAll(fs: Iterable[Fiber[Any, Any]]): UIO[Unit] =
     fs.foldLeft(IO.unit)((io, f) => io <* f.interrupt)
 
   /**
@@ -410,7 +410,7 @@ object Fiber {
    * @param fs `Iterable` of fibers to be awaited
    * @return `UIO[Unit]`
    */
-  final def awaitAll(fs: Iterable[Fiber[_, _]]): UIO[Unit] =
+  final def awaitAll(fs: Iterable[Fiber[Any, Any]]): UIO[Unit] =
     fs.foldLeft(IO.unit)((io, f) => io *> f.await.unit)
 
   /**
@@ -421,7 +421,7 @@ object Fiber {
    * @param fs `Iterable` of fibers to be joined
    * @return `UIO[Unit]`
    */
-  final def joinAll[E](fs: Iterable[Fiber[E, _]]): IO[E, Unit] =
+  final def joinAll[E](fs: Iterable[Fiber[E, Any]]): IO[E, Unit] =
     fs.foldLeft[IO[E, Unit]](IO.unit)((io, f) => io *> f.join.unit).refailWithTrace
 
   /**

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -32,7 +32,7 @@ object IO {
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[E, A, B](acquire: IO[E, A], release: A => UIO[_], use: A => IO[E, B]): IO[E, B] =
+  final def bracket[E, A, B](acquire: IO[E, A], release: A => UIO[Any], use: A => IO[E, B]): IO[E, B] =
     ZIO.bracket(acquire, release, use)
 
   /**
@@ -44,7 +44,11 @@ object IO {
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[E, A, B](acquire: IO[E, A], release: (A, Exit[E, B]) => UIO[_], use: A => IO[E, B]): IO[E, B] =
+  final def bracketExit[E, A, B](
+    acquire: IO[E, A],
+    release: (A, Exit[E, B]) => UIO[Any],
+    use: A => IO[E, B]
+  ): IO[E, B] =
     ZIO.bracketExit(acquire, release, use)
 
   /**
@@ -68,7 +72,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = ZIO.children
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
@@ -170,7 +174,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[E, A](register: (IO[E, A] => Unit) => IO[E, _]): IO[E, A] =
+  final def effectAsyncM[E, A](register: (IO[E, A] => Unit) => IO[E, Any]): IO[E, A] =
     ZIO.effectAsyncM(register)
 
   /**
@@ -250,19 +254,19 @@ object IO {
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[E, A](as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  final def foreach_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[E, A, B](as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  final def foreachPar_[E, A, B](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[E, A, B](n: Int)(as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  final def foreachParN_[E, A, B](n: Int)(as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
@@ -480,7 +484,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.handleChildrenWith]]
    */
-  final def handleChildrenWith[E, A](io: IO[E, A])(supervisor: IndexedSeq[Fiber[_, _]] => UIO[_]): IO[E, A] =
+  final def handleChildrenWith[E, A](io: IO[E, A])(supervisor: IndexedSeq[Fiber[Any, Any]] => UIO[Any]): IO[E, A] =
     ZIO.handleChildrenWith(io)(supervisor)
 
   /**
@@ -528,13 +532,13 @@ object IO {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[E, A](as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  final def traverse_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[E, A](as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  final def traversePar_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
@@ -542,7 +546,7 @@ object IO {
    */
   final def traverseParN_[E, A](
     n: Int
-  )(as: Iterable[A])(f: A => IO[E, _]): IO[E, Unit] =
+  )(as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -581,25 +585,25 @@ object IO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when[E](b: Boolean)(io: IO[E, _]): IO[E, Unit] =
+  final def when[E](b: Boolean)(io: IO[E, Any]): IO[E, Unit] =
     ZIO.when(b)(io)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM[E](b: IO[E, Boolean])(io: IO[E, _]): IO[E, Unit] =
+  final def whenM[E](b: IO[E, Boolean])(io: IO[E, Any]): IO[E, Unit] =
     ZIO.whenM(b)(io)
 
   /**
@@ -607,20 +611,20 @@ object IO {
    */
   final val yieldNow: UIO[Unit] = ZIO.yieldNow
 
-  final class BracketAcquire_[E](private val acquire: IO[E, _]) extends AnyVal {
-    def apply(release: IO[Nothing, _]): BracketRelease_[E] =
+  final class BracketAcquire_[E](private val acquire: IO[E, Any]) extends AnyVal {
+    def apply(release: IO[Nothing, Any]): BracketRelease_[E] =
       new BracketRelease_(acquire, release)
   }
-  final class BracketRelease_[E](acquire: IO[E, _], release: IO[Nothing, _]) {
+  final class BracketRelease_[E](acquire: IO[E, Any], release: IO[Nothing, Any]) {
     def apply[E1 >: E, B](use: IO[E1, B]): IO[E1, B] =
       ZIO.bracket(acquire, (_: Any) => release, (_: Any) => use)
   }
 
   final class BracketAcquire[E, A](private val acquire: IO[E, A]) extends AnyVal {
-    def apply(release: A => IO[Nothing, _]): BracketRelease[E, A] =
+    def apply(release: A => IO[Nothing, Any]): BracketRelease[E, A] =
       new BracketRelease[E, A](acquire, release)
   }
-  class BracketRelease[E, A](acquire: IO[E, A], release: A => IO[Nothing, _]) {
+  class BracketRelease[E, A](acquire: IO[E, A], release: A => IO[Nothing, Any]) {
     def apply[E1 >: E, B](use: A => IO[E1, B]): IO[E1, B] =
       ZIO.bracket(acquire, release, use)
   }

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -81,7 +81,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.finalizer]]
    */
-  final def finalizer(f: IO[Nothing, _]): Managed[Nothing, Unit] =
+  final def finalizer(f: IO[Nothing, Any]): Managed[Nothing, Unit] =
     ZManaged.finalizer(f)
 
   /**
@@ -99,7 +99,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.foreach_]]
    */
-  final def foreach_[E, A](as: Iterable[A])(f: A => Managed[E, _]): Managed[E, Unit] =
+  final def foreach_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.foreach_(as)(f)
 
   /**
@@ -111,7 +111,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.foreachPar_]]
    */
-  final def foreachPar_[E, A](as: Iterable[A])(f: A => Managed[E, _]): Managed[E, Unit] =
+  final def foreachPar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.foreachPar_(as)(f)
 
   /**
@@ -158,19 +158,19 @@ object Managed {
   /**
    * See [[zio.ZManaged.make]]
    */
-  final def make[E, A](acquire: IO[E, A])(release: A => UIO[_]): Managed[E, A] =
+  final def make[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Managed[E, A] =
     ZManaged.make(acquire)(release)
 
   /**
    * See [[zio.ZManaged.makeEffect]]
    */
-  final def makeEffect[A](acquire: => A)(release: A => _): Managed[Throwable, A] =
+  final def makeEffect[A](acquire: => A)(release: A => Any): Managed[Throwable, A] =
     ZManaged.makeEffect(acquire)(release)
 
   /**
    * See [[zio.ZManaged.makeExit]]
    */
-  final def makeExit[E, A](acquire: IO[E, A])(release: (A, Exit[_, _]) => UIO[_]): Managed[E, A] =
+  final def makeExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Managed[E, A] =
     ZManaged.makeExit(acquire)(release)
 
   /**
@@ -277,7 +277,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.traverse_]]
    */
-  final def traverse_[E, A](as: Iterable[A])(f: A => Managed[E, _]): Managed[E, Unit] =
+  final def traverse_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traverse_(as)(f)
 
   /**
@@ -289,7 +289,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.traversePar_]]
    */
-  final def traversePar_[E, A](as: Iterable[A])(f: A => Managed[E, _]): Managed[E, Unit] =
+  final def traversePar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traversePar_(as)(f)
 
   /**
@@ -329,25 +329,27 @@ object Managed {
   /**
    * See [[zio.ZManaged.when]]
    */
-  final def when[E](b: Boolean)(managed: Managed[E, _]): Managed[E, Unit] =
+  final def when[E](b: Boolean)(managed: Managed[E, Any]): Managed[E, Unit] =
     ZManaged.when(b)(managed)
 
   /**
    * See [[zio.ZManaged.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, _]]): ZManaged[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     ZManaged.whenCase(a)(pf)
 
   /**
    * See [[zio.ZManaged.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZManaged[R, E, A])(pf: PartialFunction[A, ZManaged[R, E, _]]): ZManaged[R, E, Unit] =
+  final def whenCaseM[R, E, A](
+    a: ZManaged[R, E, A]
+  )(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     ZManaged.whenCaseM(a)(pf)
 
   /**
    * See [[zio.ZManaged.whenM]]
    */
-  final def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, _]): Managed[E, Unit] =
+  final def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, Any]): Managed[E, Unit] =
     ZManaged.whenM(b)(managed)
 
 }

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -236,7 +236,7 @@ object Promise {
     ref: Ref[A]
   )(
     acquire: (Promise[E, B], A) => (UIO[C], A)
-  )(release: (C, Promise[E, B]) => UIO[_]): IO[E, B] =
+  )(release: (C, Promise[E, B]) => UIO[Any]): IO[E, B] =
     for {
       pRef <- Ref.make[Option[(C, Promise[E, B])]](None)
       b <- (for {

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -48,7 +48,7 @@ object RIO {
    */
   final def bracket[R, A, B](
     acquire: RIO[R, A],
-    release: A => ZIO[R, Nothing, _],
+    release: A => ZIO[R, Nothing, Any],
     use: A => RIO[R, B]
   ): RIO[R, B] = ZIO.bracket(acquire, release, use)
 
@@ -63,7 +63,7 @@ object RIO {
    */
   final def bracketExit[R, A, B](
     acquire: RIO[R, A],
-    release: (A, Exit[Throwable, B]) => ZIO[R, Nothing, _],
+    release: (A, Exit[Throwable, B]) => ZIO[R, Nothing, Any],
     use: A => RIO[R, B]
   ): RIO[R, B] =
     ZIO.bracketExit(acquire, release, use)
@@ -89,7 +89,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = ZIO.children
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
@@ -191,7 +191,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[R, A](register: (RIO[R, A] => Unit) => RIO[R, _]): RIO[R, A] =
+  final def effectAsyncM[R, A](register: (RIO[R, A] => Unit) => RIO[R, Any]): RIO[R, A] =
     ZIO.effectAsyncM(register)
 
   /**
@@ -278,19 +278,19 @@ object RIO {
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[R, A](as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  final def foreach_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
@@ -498,7 +498,7 @@ object RIO {
    */
   final def handleChildrenWith[R, A](
     taskr: RIO[R, A]
-  )(supervisor: IndexedSeq[Fiber[_, _]] => ZIO[R, Nothing, _]): RIO[R, A] =
+  )(supervisor: IndexedSeq[Fiber[Any, Any]] => ZIO[R, Nothing, Any]): RIO[R, A] =
     ZIO.handleChildrenWith(taskr)(supervisor)
 
   /**
@@ -576,13 +576,13 @@ object RIO {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[R, A](as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  final def traverse_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[R, A](as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  final def traversePar_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
@@ -590,7 +590,7 @@ object RIO {
    */
   final def traverseParN_[R, A](
     n: Int
-  )(as: Iterable[A])(f: A => RIO[R, _]): RIO[R, Unit] =
+  )(as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -629,25 +629,25 @@ object RIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when[R](b: Boolean)(rio: RIO[R, _]): RIO[R, Unit] =
+  final def when[R](b: Boolean)(rio: RIO[R, Any]): RIO[R, Unit] =
     ZIO.when(b)(rio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM[R](b: RIO[R, Boolean])(rio: RIO[R, _]): RIO[R, Unit] =
+  final def whenM[R](b: RIO[R, Boolean])(rio: RIO[R, Any]): RIO[R, Unit] =
     ZIO.whenM(b)(rio)
 
   /**

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -164,7 +164,7 @@ object RefM extends Serializable {
   final def make[A](
     a: A,
     n: Int = 1000,
-    onDefect: Cause[_] => UIO[Unit] = _ => IO.unit
+    onDefect: Cause[Any] => UIO[Unit] = _ => IO.unit
   ): UIO[RefM[A]] =
     for {
       ref   <- Ref.make(a)

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -136,7 +136,7 @@ trait Runtime[+R] {
   /**
    * Constructs a new `Runtime` with the specified error reporter.
    */
-  final def withReportFailure(f: Cause[_] => Unit): Runtime[R] = mapPlatform(_.withReportFailure(f))
+  final def withReportFailure(f: Cause[Any] => Unit): Runtime[R] = mapPlatform(_.withReportFailure(f))
 
   /**
    * Constructs a new `Runtime` with the specified tracer and tracing configuration.

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -32,7 +32,7 @@ object Task {
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A, B](acquire: Task[A], release: A => UIO[_], use: A => Task[B]): Task[B] =
+  final def bracket[A, B](acquire: Task[A], release: A => UIO[Any], use: A => Task[B]): Task[B] =
     ZIO.bracket(acquire, release, use)
 
   /**
@@ -46,7 +46,7 @@ object Task {
    */
   final def bracketExit[A, B](
     acquire: Task[A],
-    release: (A, Exit[Throwable, B]) => UIO[_],
+    release: (A, Exit[Throwable, B]) => UIO[Any],
     use: A => Task[B]
   ): Task[B] =
     ZIO.bracketExit(acquire, release, use)
@@ -72,7 +72,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = ZIO.children
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
@@ -174,7 +174,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[A](register: (Task[A] => Unit) => Task[_]): Task[A] =
+  final def effectAsyncM[A](register: (Task[A] => Unit) => Task[Any]): Task[A] =
     ZIO.effectAsyncM(register)
 
   /**
@@ -255,19 +255,19 @@ object Task {
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[A](as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  final def foreach_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[A, B](as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  final def foreachPar_[A, B](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[A, B](n: Int)(as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  final def foreachParN_[A, B](n: Int)(as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
@@ -464,7 +464,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.handleChildrenWith]]
    */
-  final def handleChildrenWith[A](task: Task[A])(supervisor: IndexedSeq[Fiber[_, _]] => UIO[_]): Task[A] =
+  final def handleChildrenWith[A](task: Task[A])(supervisor: IndexedSeq[Fiber[Any, Any]] => UIO[Any]): Task[A] =
     ZIO.handleChildrenWith(task)(supervisor)
 
   /**
@@ -529,13 +529,13 @@ object Task {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[A](as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  final def traverse_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[A](as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  final def traversePar_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
@@ -543,7 +543,7 @@ object Task {
    */
   final def traverseParN_[A](
     n: Int
-  )(as: Iterable[A])(f: A => Task[_]): Task[Unit] =
+  )(as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -581,25 +581,25 @@ object Task {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when(b: Boolean)(task: Task[_]): Task[Unit] =
+  final def when(b: Boolean)(task: Task[Any]): Task[Unit] =
     ZIO.when(b)(task)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM(b: Task[Boolean])(task: Task[_]): Task[Unit] =
+  final def whenM(b: Task[Boolean])(task: Task[Any]): Task[Unit] =
     ZIO.whenM(b)(task)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -30,7 +30,7 @@ object UIO {
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A, B](acquire: UIO[A], release: A => UIO[_], use: A => UIO[B]): UIO[B] =
+  final def bracket[A, B](acquire: UIO[A], release: A => UIO[Any], use: A => UIO[B]): UIO[B] =
     ZIO.bracket(acquire, release, use)
 
   /**
@@ -42,7 +42,7 @@ object UIO {
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[A, B](acquire: UIO[A], release: (A, Exit[Nothing, B]) => UIO[_], use: A => UIO[B]): UIO[B] =
+  final def bracketExit[A, B](acquire: UIO[A], release: (A, Exit[Nothing, B]) => UIO[Any], use: A => UIO[B]): UIO[B] =
     ZIO.bracketExit(acquire, release, use)
 
   /**
@@ -66,7 +66,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = ZIO.children
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
@@ -168,7 +168,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[A](register: (UIO[A] => Unit) => UIO[_]): UIO[A] =
+  final def effectAsyncM[A](register: (UIO[A] => Unit) => UIO[Any]): UIO[A] =
     ZIO.effectAsyncM(register)
 
   /**
@@ -225,7 +225,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[A](as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  final def foreach_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreach_(as)(f)
 
   /**
@@ -237,7 +237,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[A](as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  final def foreachPar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
@@ -249,7 +249,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[A](n: Int)(as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  final def foreachParN_[A](n: Int)(as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
@@ -426,7 +426,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.handleChildrenWith]]
    */
-  final def handleChildrenWith[A](uio: UIO[A])(supervisor: IndexedSeq[Fiber[_, _]] => UIO[_]): UIO[A] =
+  final def handleChildrenWith[A](uio: UIO[A])(supervisor: IndexedSeq[Fiber[Any, Any]] => UIO[Any]): UIO[A] =
     ZIO.handleChildrenWith(uio)(supervisor)
 
   /**
@@ -466,7 +466,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[A](as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  final def traverse_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traverse_(as)(f)
 
   /**
@@ -478,7 +478,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[A](as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  final def traversePar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
@@ -494,7 +494,7 @@ object UIO {
    */
   final def traverseParN_[A](
     n: Int
-  )(as: Iterable[A])(f: A => UIO[_]): UIO[Unit] =
+  )(as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -533,25 +533,25 @@ object UIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when(b: Boolean)(uio: UIO[_]): UIO[Unit] =
+  final def when(b: Boolean)(uio: UIO[Any]): UIO[Unit] =
     ZIO.when(b)(uio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM(b: UIO[Boolean])(uio: UIO[_]): UIO[Unit] =
+  final def whenM(b: UIO[Boolean])(uio: UIO[Any]): UIO[Unit] =
     ZIO.whenM(b)(uio)
 
   /**

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -43,7 +43,7 @@ object URIO {
    **/
   final def bracket[R, A, B](
     acquire: URIO[R, A],
-    release: A => URIO[R, _],
+    release: A => URIO[R, Any],
     use: A => URIO[R, B]
   ): URIO[R, B] = ZIO.bracket(acquire, release, use)
 
@@ -58,7 +58,7 @@ object URIO {
    */
   final def bracketExit[R, A, B](
     acquire: URIO[R, A],
-    release: (A, Exit[Throwable, B]) => URIO[R, _],
+    release: (A, Exit[Throwable, B]) => URIO[R, Any],
     use: A => URIO[R, B]
   ): URIO[R, B] = ZIO.bracketExit(acquire, release, use)
 
@@ -83,7 +83,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.children]]
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = ZIO.children
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see [[zio.ZIO.collectAll]]
@@ -180,7 +180,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[R, A](register: (URIO[R, A] => Unit) => URIO[R, _]): URIO[R, A] =
+  final def effectAsyncM[R, A](register: (URIO[R, A] => Unit) => URIO[R, Any]): URIO[R, A] =
     ZIO.effectAsyncM(register)
 
   /**
@@ -250,19 +250,19 @@ object URIO {
   /**
    * @see [[zio.ZIO.foreach_]]
    */
-  final def foreach_[R, A](as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] =
+  final def foreach_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] =
+  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] =
+  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
@@ -442,7 +442,9 @@ object URIO {
   /**
    * @see [[zio.ZIO.handleChildrenWith]]
    */
-  final def handleChildrenWith[R, A](taskr: URIO[R, A])(supervisor: IndexedSeq[Fiber[_, _]] => URIO[R, _]): URIO[R, A] =
+  final def handleChildrenWith[R, A](
+    taskr: URIO[R, A]
+  )(supervisor: IndexedSeq[Fiber[Any, Any]] => URIO[R, Any]): URIO[R, A] =
     ZIO.handleChildrenWith(taskr)(supervisor)
 
   /**
@@ -505,17 +507,17 @@ object URIO {
   /**
    * @see [[zio.ZIO.traverse_]]
    */
-  final def traverse_[R, A](as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] = ZIO.traverse_(as)(f)
+  final def traverse_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traverse_(as)(f)
 
   /**
    * @see [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[R, A](as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] = ZIO.traversePar_(as)(f)
+  final def traversePar_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traversePar_(as)(f)
 
   /**
    * @see [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[R, A](n: Int)(as: Iterable[A])(f: A => URIO[R, _]): URIO[R, Unit] =
+  final def traverseParN_[R, A](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -552,23 +554,23 @@ object URIO {
   /**
    * @see [[zio.ZIO.when]]
    */
-  final def when[R](b: Boolean)(rio: URIO[R, _]): URIO[R, Unit] = ZIO.when(b)(rio)
+  final def when[R](b: Boolean)(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.when(b)(rio)
 
   /**
    * @see [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, A](a: A)(pf: PartialFunction[A, ZIO[R, Nothing, _]]): URIO[R, Unit] = ZIO.whenCase(a)(pf)
+  final def whenCase[R, A](a: A)(pf: PartialFunction[A, ZIO[R, Nothing, Any]]): URIO[R, Unit] = ZIO.whenCase(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, A](a: URIO[R, A])(pf: PartialFunction[A, URIO[R, _]]): URIO[R, Unit] =
+  final def whenCaseM[R, A](a: URIO[R, A])(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenM]]
    */
-  final def whenM[R](b: URIO[R, Boolean])(rio: URIO[R, _]): URIO[R, Unit] = ZIO.whenM(b)(rio)
+  final def whenM[R](b: URIO[R, Boolean])(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.whenM(b)(rio)
 
   /**
    * @see [[zio.ZIO.yieldNow]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -116,7 +116,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Shorthand for the uncurried version of `ZIO.bracket`.
    */
   final def bracket[R1 <: R, E1 >: E, B](
-    release: A => ZIO[R1, Nothing, _],
+    release: A => ZIO[R1, Nothing, Any],
     use: A => ZIO[R1, E1, B]
   ): ZIO[R1, E1, B] = ZIO.bracket(self, release, use)
 
@@ -138,7 +138,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * [[zio.ZIO.BracketAcquire_]] and [[zio.ZIO.BracketRelease_]] objects.
    */
   final def bracket_[R1 <: R, E1 >: E, B](
-    release: ZIO[R1, Nothing, _],
+    release: ZIO[R1, Nothing, Any],
     use: ZIO[R1, E1, B]
   ): ZIO[R1, E1, B] =
     ZIO.bracket(self, (_: A) => release, (_: A) => use)
@@ -147,7 +147,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Shorthand for the uncurried version of `ZIO.bracketExit`.
    */
   final def bracketExit[R1 <: R, E1 >: E, B](
-    release: (A, Exit[E1, B]) => ZIO[R1, Nothing, _],
+    release: (A, Exit[E1, B]) => ZIO[R1, Nothing, Any],
     use: A => ZIO[R1, E1, B]
   ): ZIO[R1, E1, B] = ZIO.bracketExit(self, release, use)
 
@@ -160,7 +160,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Executes the release effect only if there was an error.
    */
   final def bracketOnError[R1 <: R, E1 >: E, B](
-    release: A => ZIO[R1, Nothing, _]
+    release: A => ZIO[R1, Nothing, Any]
   )(use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     ZIO.bracketExit(self)(
       (a: A, eb: Exit[E1, B]) =>
@@ -304,7 +304,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * should generally not be used for releasing resources. For higher-level
    * logic built on `ensuring`, see `ZIO#bracket`.
    */
-  final def ensuring[R1 <: R](finalizer: ZIO[R1, Nothing, _]): ZIO[R1, E, A] =
+  final def ensuring[R1 <: R](finalizer: ZIO[R1, Nothing, Any]): ZIO[R1, E, A] =
     ZIO.uninterruptibleMask(
       restore =>
         restore(self)
@@ -490,7 +490,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Supervises this effect, which ensures that any fibers that are forked by
    * the effect are handled by the provided supervisor.
    */
-  final def handleChildrenWith[R1 <: R](supervisor: Iterable[Fiber[_, _]] => ZIO[R1, Nothing, _]): ZIO[R1, E, A] =
+  final def handleChildrenWith[R1 <: R](supervisor: Iterable[Fiber[Any, Any]] => ZIO[R1, Nothing, Any]): ZIO[R1, E, A] =
     ZIO.handleChildrenWith[R1, E, A](self)(supervisor)
 
   /**
@@ -600,7 +600,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Runs the specified effect if this effect fails, providing the error to the
    * effect if it exists. The provided effect will not be interrupted.
    */
-  final def onError[R1 <: R](cleanup: Cause[E] => ZIO[R1, Nothing, _]): ZIO[R1, E, A] =
+  final def onError[R1 <: R](cleanup: Cause[E] => ZIO[R1, Nothing, Any]): ZIO[R1, E, A] =
     ZIO.bracketExit(ZIO.unit)(
       (_, eb: Exit[E, A]) =>
         eb match {
@@ -633,7 +633,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Runs the specified effect if this effect is terminated, either because of
    * a defect or because of interruption.
    */
-  final def onTermination[R1 <: R](cleanup: Cause[Nothing] => ZIO[R1, Nothing, _]): ZIO[R1, E, A] =
+  final def onTermination[R1 <: R](cleanup: Cause[Nothing] => ZIO[R1, Nothing, Any]): ZIO[R1, E, A] =
     ZIO.bracketExit(ZIO.unit)(
       (_, eb: Exit[E, A]) =>
         eb match {
@@ -845,7 +845,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       winner: Fiber[E1, A1],
       promise: Promise[E1, (A1, Fiber[E1, A1])],
       fails: Ref[Int]
-    )(res: Exit[E1, A1]): ZIO[R1, Nothing, _] =
+    )(res: Exit[E1, A1]): ZIO[R1, Nothing, Any] =
       res.foldM[R1, Nothing, Unit](
         e => ZIO.flatten(fails.modify((c: Int) => (if (c == 0) promise.halt(e).unit else ZIO.unit) -> (c - 1))),
         a =>
@@ -866,7 +866,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               head <- ZIO.interruptible(self).fork
               tail <- ZIO.foreach(ios)(io => ZIO.interruptible(io).fork)
               fs   = head :: tail
-              _ <- fs.foldLeft[ZIO[R1, E1, _]](ZIO.unit) {
+              _ <- fs.foldLeft[ZIO[R1, E1, Any]](ZIO.unit) {
                     case (io, f) =>
                       io *> f.await.flatMap(arbiter(fs, f, done, fails)).fork
                   }
@@ -930,7 +930,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       raceDone: Ref[Boolean],
       inherit: Ref[Option[Boolean]],
       done: Promise[E2, C]
-    )(res: Exit[E0, A]): ZIO[R1, Nothing, _] = {
+    )(res: Exit[E0, A]): ZIO[R1, Nothing, Any] = {
 
       val handleRes =
         winner.poll.flatMap {
@@ -1247,7 +1247,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * readFile("data.json").tap(putStrLn)
    * }}}
    */
-  final def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, _]): ZIO[R1, E1, A] = self.flatMap(new ZIO.TapFn(f))
+  final def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZIO[R1, E1, A] = self.flatMap(new ZIO.TapFn(f))
 
   /**
    * Returns an effect that effectfully "peeks" at the failure or success of
@@ -1256,7 +1256,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * readFile("data.json").tapBoth(logError(_), logData(_))
    * }}}
    */
-  final def tapBoth[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, _], g: A => ZIO[R1, E1, _]): ZIO[R1, E1, A] =
+  final def tapBoth[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any], g: A => ZIO[R1, E1, Any]): ZIO[R1, E1, A] =
     self.foldCauseM(new ZIO.TapErrorRefailFn(f), new ZIO.TapFn(g))
 
   /**
@@ -1265,7 +1265,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * readFile("data.json").tapError(logError(_))
    * }}}
    */
-  final def tapError[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, _]): ZIO[R1, E1, A] =
+  final def tapError[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any]): ZIO[R1, E1, A] =
     self.foldCauseM(new ZIO.TapErrorRefailFn(f), ZIO.succeed)
 
   /**
@@ -1350,7 +1350,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Converts this ZIO to [[zio.Managed]]. This ZIO and the provided release action
    * will be performed uninterruptibly.
    */
-  final def toManaged[R1 <: R](release: A => ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
+  final def toManaged[R1 <: R](release: A => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged.make[R1, E, A](this)(release)
 
   /**
@@ -1660,10 +1660,10 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def bracket[R, E, A, B](
     acquire: ZIO[R, E, A],
-    release: A => ZIO[R, Nothing, _],
+    release: A => ZIO[R, Nothing, Any],
     use: A => ZIO[R, E, B]
   ): ZIO[R, E, B] =
-    bracketExit(acquire, new ZIO.BracketReleaseFn(release): (A, Exit[E, B]) => ZIO[R, Nothing, _], use)
+    bracketExit(acquire, new ZIO.BracketReleaseFn(release): (A, Exit[E, B]) => ZIO[R, Nothing, Any], use)
 
   /**
    * Acquires a resource, uses the resource, and then releases the resource.
@@ -1682,7 +1682,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def bracketExit[R, E, A, B](
     acquire: ZIO[R, E, A],
-    release: (A, Exit[E, B]) => ZIO[R, Nothing, _],
+    release: (A, Exit[E, B]) => ZIO[R, Nothing, Any],
     use: A => ZIO[R, E, B]
   ): ZIO[R, E, B] =
     ZIO.uninterruptibleMask[R, E, B](
@@ -1723,7 +1723,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * '''Note:''' supervision must be enabled (via [[ZIO#supervised]]) on the
    * current fiber for this operation to return non-empty lists.
    */
-  final def children: UIO[IndexedSeq[Fiber[_, _]]] = descriptorWith(_.children)
+  final def children: UIO[IndexedSeq[Fiber[Any, Any]]] = descriptorWith(_.children)
 
   /**
    * Evaluate each effect in the structure from left to right, and collect
@@ -1898,7 +1898,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * necessary when the effect is itself expressed in terms of `ZIO`.
    */
   final def effectAsyncM[R, E, A](
-    register: (ZIO[R, E, A] => Unit) => ZIO[R, E, _]
+    register: (ZIO[R, E, A] => Unit) => ZIO[R, E, Any]
   ): ZIO[R, E, A] =
     for {
       p <- Promise.make[E, A]
@@ -2019,7 +2019,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    * Equivalent to `foreach(as)(f).void`, but without the cost of building
    * the list of results.
    */
-  final def foreach_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def foreach_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     ZIO.effectTotal(as.iterator).flatMap { i =>
       def loop: ZIO[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
@@ -2045,7 +2045,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    *
    * For a sequential version of this method, see `foreach_`.
    */
-  final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     ZIO
       .effectTotal(as.iterator)
       .flatMap { i =>
@@ -2088,7 +2088,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def foreachParN_[R, E, A](
     n: Int
-  )(as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  )(as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     Semaphore
       .make(n.toLong)
       .flatMap { semaphore =>
@@ -2206,7 +2206,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def handleChildrenWith[R, E, A](
     zio: ZIO[R, E, A]
-  )(supervisor: IndexedSeq[Fiber[_, _]] => ZIO[R, Nothing, _]): ZIO[R, E, A] =
+  )(supervisor: IndexedSeq[Fiber[Any, Any]] => ZIO[R, Nothing, Any]): ZIO[R, E, A] =
     zio.ensuring(children.flatMap(supervisor(_))).supervised
 
   /**
@@ -2449,7 +2449,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   /**
    * Alias for [[ZIO.foreach_]]
    */
-  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     foreach_[R, E, A](as)(f)
 
   /**
@@ -2461,7 +2461,7 @@ private[zio] trait ZIOFunctions extends Serializable {
   /**
    * Alias for [[ZIO.foreachPar_]]
    */
-  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     foreachPar_[R, E, A](as)(f)
 
   /**
@@ -2477,7 +2477,7 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def traverseParN_[R, E, A](
     n: Int
-  )(as: Iterable[A])(f: A => ZIO[R, E, _]): ZIO[R, E, Unit] =
+  )(as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     foreachParN_[R, E, A](n)(as)(f)
 
   /**
@@ -2526,25 +2526,25 @@ private[zio] trait ZIOFunctions extends Serializable {
   /**
    * The moral equivalent of `if (p) exp`
    */
-  final def when[R, E](b: Boolean)(zio: ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def when[R, E](b: Boolean)(zio: ZIO[R, E, Any]): ZIO[R, E, Unit] =
     if (b) zio.unit else unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given value, otherwise does nothing.
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     pf.applyOrElse(a, (_: A) => unit).unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given effectful value, otherwise does nothing.
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, _]]): ZIO[R, E, Unit] =
+  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     a.flatMap(whenCase(_)(pf))
 
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  final def whenM[R, E](b: ZIO[R, E, Boolean])(zio: ZIO[R, E, _]): ZIO[R, E, Unit] =
+  final def whenM[R, E](b: ZIO[R, E, Boolean])(zio: ZIO[R, E, Any]): ZIO[R, E, Unit] =
     b.flatMap(b => if (b) zio.unit else unit)
 
   /**
@@ -2604,33 +2604,33 @@ object ZIO extends ZIOFunctions {
         )
   }
 
-  final class BracketAcquire_[-R, +E](private val acquire: ZIO[R, E, _]) extends AnyVal {
-    def apply[R1 <: R](release: ZIO[R1, Nothing, _]): BracketRelease_[R1, E] =
+  final class BracketAcquire_[-R, +E](private val acquire: ZIO[R, E, Any]) extends AnyVal {
+    def apply[R1 <: R](release: ZIO[R1, Nothing, Any]): BracketRelease_[R1, E] =
       new BracketRelease_(acquire, release)
   }
-  final class BracketRelease_[-R, +E](acquire: ZIO[R, E, _], release: ZIO[R, Nothing, _]) {
+  final class BracketRelease_[-R, +E](acquire: ZIO[R, E, Any], release: ZIO[R, Nothing, Any]) {
     def apply[R1 <: R, E1 >: E, B](use: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
       ZIO.bracket(acquire, (_: Any) => release, (_: Any) => use)
   }
 
   final class BracketAcquire[-R, +E, +A](private val acquire: ZIO[R, E, A]) extends AnyVal {
-    def apply[R1 <: R](release: A => ZIO[R1, Nothing, _]): BracketRelease[R1, E, A] =
+    def apply[R1 <: R](release: A => ZIO[R1, Nothing, Any]): BracketRelease[R1, E, A] =
       new BracketRelease[R1, E, A](acquire, release)
   }
-  class BracketRelease[-R, +E, +A](acquire: ZIO[R, E, A], release: A => ZIO[R, Nothing, _]) {
+  class BracketRelease[-R, +E, +A](acquire: ZIO[R, E, A], release: A => ZIO[R, Nothing, Any]) {
     def apply[R1 <: R, E1 >: E, B](use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
       ZIO.bracket(acquire, release, use)
   }
 
   final class BracketExitAcquire[-R, +E, +A](private val acquire: ZIO[R, E, A]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, B](
-      release: (A, Exit[E1, B]) => ZIO[R1, Nothing, _]
+      release: (A, Exit[E1, B]) => ZIO[R1, Nothing, Any]
     ): BracketExitRelease[R1, E, E1, A, B] =
       new BracketExitRelease(acquire, release)
   }
   class BracketExitRelease[-R, +E, E1, +A, B](
     acquire: ZIO[R, E, A],
-    release: (A, Exit[E1, B]) => ZIO[R, Nothing, _]
+    release: (A, Exit[E1, B]) => ZIO[R, Nothing, Any]
   ) {
     def apply[R1 <: R, E2 >: E <: E1, B1 <: B](use: A => ZIO[R1, E2, B1]): ZIO[R1, E2, B1] =
       ZIO.bracketExit(acquire, release, use)
@@ -2672,7 +2672,7 @@ object ZIO extends ZIOFunctions {
     }
   }
 
-  final class TapFn[R, E, A](override val underlying: A => ZIO[R, E, _]) extends ZIOFn1[A, ZIO[R, E, A]] {
+  final class TapFn[R, E, A](override val underlying: A => ZIO[R, E, Any]) extends ZIOFn1[A, ZIO[R, E, A]] {
     def apply(a: A): ZIO[R, E, A] =
       underlying(a).as(a)
   }
@@ -2696,9 +2696,9 @@ object ZIO extends ZIOFunctions {
     }
   }
 
-  final class BracketReleaseFn[R, E, A, B](override val underlying: A => ZIO[R, Nothing, _])
-      extends ZIOFn2[A, Exit[E, B], ZIO[R, Nothing, _]] {
-    override def apply(a: A, exit: Exit[E, B]): ZIO[R, Nothing, _] = {
+  final class BracketReleaseFn[R, E, A, B](override val underlying: A => ZIO[R, Nothing, Any])
+      extends ZIOFn2[A, Exit[E, B], ZIO[R, Nothing, Any]] {
+    override def apply(a: A, exit: Exit[E, B]): ZIO[R, Nothing, Any] = {
       val _ = exit
       underlying(a)
     }
@@ -2725,7 +2725,7 @@ object ZIO extends ZIOFunctions {
       c.failureOrCause.fold(underlying, ZIO.halt)
   }
 
-  final class TapErrorRefailFn[R, E, E1 >: E, A](override val underlying: E => ZIO[R, E1, _])
+  final class TapErrorRefailFn[R, E, E1 >: E, A](override val underlying: E => ZIO[R, E1, Any])
       extends ZIOFn1[Cause[E], ZIO[R, E1, Nothing]] {
     def apply(c: Cause[E]): ZIO[R, E1, Nothing] =
       c.failureOrCause.fold(underlying(_) *> ZIO.halt(c), _ => ZIO.halt(c))

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -26,7 +26,7 @@ import zio.duration.Duration
  *
  * See [[ZManaged#reserve]] and [[ZIO#reserve]] for details of usage.
  */
-final case class Reservation[-R, +E, +A](acquire: ZIO[R, E, A], release: Exit[_, _] => ZIO[R, Nothing, Any])
+final case class Reservation[-R, +E, +A](acquire: ZIO[R, E, A], release: Exit[Any, Any] => ZIO[R, Nothing, Any])
 
 /**
  * A `ZManaged[R, E, A]` is a managed resource of type `A`, which may be used by
@@ -192,7 +192,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#onExit]].
    */
-  final def ensuring[R1 <: R](f: ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
+  final def ensuring[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
         r.copy(release = e => r.release(e).ensuring(f))
@@ -205,7 +205,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#onExitFirst]].
    */
-  final def ensuringFirst[R1 <: R](f: ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
+  final def ensuringFirst[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
         r.copy(release = e => f.ensuring(r.release(e)))
@@ -224,7 +224,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
     ZManaged[R1, E1, B] {
-      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = for {
             resR <- reserve
@@ -299,7 +299,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
     success: A => ZManaged[R1, E2, B]
   ): ZManaged[R1, E2, B] =
     ZManaged[R1, E2, B] {
-      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = {
             val direct =
@@ -340,7 +340,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def fork: ZManaged[R, Nothing, Fiber[E, A]] =
     ZManaged {
       for {
-        finalizer <- Ref.make[Exit[_, _] => ZIO[R, Nothing, Any]](_ => UIO.unit)
+        finalizer <- Ref.make[Exit[Any, Any] => ZIO[R, Nothing, Any]](_ => UIO.unit)
         // The reservation phase of the new `ZManaged` runs uninterruptibly;
         // so to make sure the acquire phase of the original `ZManaged` runs
         // interruptibly, we need to create an interruptible hole in the region.
@@ -406,9 +406,9 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */
-  final def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
+  final def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
-      Ref.make[Exit[_, _] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
+      Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
           acquire = ZIO.uninterruptibleMask { restore =>
             for {
@@ -427,9 +427,9 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Ensures that a cleanup function runs when this ZManaged is finalized, before
    * the existing finalizers.
    */
-  final def onExitFirst[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, _]): ZManaged[R1, E, A] =
+  final def onExitFirst[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
-      Ref.make[Exit[_, _] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
+      Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
           acquire = ZIO.uninterruptibleMask { restore =>
             for {
@@ -561,14 +561,14 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Returns an effect that effectfully peeks at the acquired resource.
    */
-  final def tap[R1 <: R, E1 >: E](f: A => ZManaged[R1, E1, _]): ZManaged[R1, E1, A] =
+  final def tap[R1 <: R, E1 >: E](f: A => ZManaged[R1, E1, Any]): ZManaged[R1, E1, A] =
     flatMap(a => f(a).as(a))
 
   /**
    * Like [[ZManaged#tap]], but uses a function that returns a ZIO value rather than a
    * ZManaged value.
    */
-  final def tapM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, _]): ZManaged[R1, E1, A] =
+  final def tapM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZManaged[R1, E1, A] =
     mapM(a => f(a).as(a))
 
   /**
@@ -650,7 +650,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Run an effect while acquiring the resource before and releasing it after
    */
   final def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    reserve.bracketExit((r, e: Exit[_, _]) => r.release(e), _.acquire.flatMap(f))
+    reserve.bracketExit((r, e: Exit[Any, Any]) => r.release(e), _.acquire.flatMap(f))
 
   /**
    *  Run an effect while acquiring the resource before and releasing it after.
@@ -696,7 +696,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
         case Reservation(acquire, release) =>
           Ref.make(true).map { finalize =>
             val canceler  = (release(exit) *> finalize.set(false)).uninterruptible
-            val finalizer = (e: Exit[_, _]) => release(e).whenM(finalize.get)
+            val finalizer = (e: Exit[Any, Any]) => release(e).whenM(finalize.get)
             Reservation(acquire.map((canceler, _)), finalizer)
           }
       }
@@ -752,7 +752,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    */
   final def zipWithPar[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f0: (A, A1) => A2): ZManaged[R1, E1, A2] =
     ZManaged[R1, E1, A2] {
-      Ref.make[List[Exit[_, _] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           acquire = {
             val left = ZIO.uninterruptibleMask { restore =>
@@ -866,14 +866,14 @@ object ZManaged {
    * Creates an effect that only executes the provided finalizer as its
    * release action.
    */
-  final def finalizer[R](f: ZIO[R, Nothing, _]): ZManaged[R, Nothing, Unit] =
+  final def finalizer[R](f: ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
     finalizerExit(_ => f)
 
   /**
    * Creates an effect that only executes the provided function as its
    * release action.
    */
-  final def finalizerExit[R](f: Exit[_, _] => ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
+  final def finalizerExit[R](f: Exit[Any, Any] => ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
     ZManaged.reserve(Reservation(ZIO.unit, f))
 
   /**
@@ -882,8 +882,8 @@ object ZManaged {
    * mutating finalizers.
    */
   final def finalizerRef[R](
-    initial: Exit[_, _] => ZIO[R, Nothing, Any]
-  ): ZManaged[R, Nothing, Ref[Exit[_, _] => ZIO[R, Nothing, Any]]] =
+    initial: Exit[Any, Any] => ZIO[R, Nothing, Any]
+  ): ZManaged[R, Nothing, Ref[Exit[Any, Any] => ZIO[R, Nothing, Any]]] =
     ZManaged {
       for {
         ref <- Ref.make(initial)
@@ -953,7 +953,7 @@ object ZManaged {
    * Equivalent to `foreach(as)(f).void`, but without the cost of building
    * the list of results.
    */
-  final def foreach_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def foreach_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
@@ -967,7 +967,7 @@ object ZManaged {
    *
    * For a sequential version of this method, see `foreach_`.
    */
-  final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next).zipWithPar(loop)((_, _) => ())
@@ -1051,7 +1051,7 @@ object ZManaged {
    * Lifts a `ZIO[R, E, R]` into `ZManaged[R, E, R]` with a release action.
    * The acquire and release actions will be performed uninterruptibly.
    */
-  final def make[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, _]): ZManaged[R, E, A] =
+  final def make[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, Any]): ZManaged[R, E, A] =
     ZManaged(acquire.map(r => Reservation(IO.succeed(r), _ => release(r))))
 
   /**
@@ -1067,7 +1067,7 @@ object ZManaged {
    */
   final def makeExit[R, E, A](
     acquire: ZIO[R, E, A]
-  )(release: (A, Exit[_, _]) => ZIO[R, Nothing, _]): ZManaged[R, E, A] =
+  )(release: (A, Exit[Any, Any]) => ZIO[R, Nothing, Any]): ZManaged[R, E, A] =
     ZManaged(acquire.map(r => Reservation(IO.succeed(r), e => release(r, e))))
 
   /**
@@ -1099,7 +1099,7 @@ object ZManaged {
     f: (B, A) => B
   ): ZManaged[R, E, B] =
     ZManaged[R, E, B] {
-      Ref.make[List[Exit[_, _] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[Any, Any] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           Queue.unbounded[(ZManaged[R, E, A], Promise[E, A])].flatMap { queue =>
             val worker = queue.take.flatMap {
@@ -1177,7 +1177,7 @@ object ZManaged {
     f: (A, A) => A
   ): ZManaged[R, E, A] =
     ZManaged[R, E, A] {
-      Ref.make[List[Exit[_, _] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
+      Ref.make[List[Exit[Any, Any] => ZIO[R, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
           Queue.unbounded[(ZManaged[R, E, A], Promise[E, A])].flatMap { queue =>
             val worker = queue.take.flatMap {
@@ -1332,7 +1332,7 @@ object ZManaged {
   /**
    * Alias for [[ZManaged.foreach_]]
    */
-  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     foreach_[R, E, A](as)(f)
 
   /**
@@ -1348,7 +1348,7 @@ object ZManaged {
   /**
    * Alias for [[ZManaged.foreachPar_]]
    */
-  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     foreachPar_[R, E, A](as)(f)
 
   /**
@@ -1396,25 +1396,27 @@ object ZManaged {
   /**
    * The moral equivalent of `if (p) exp`
    */
-  final def when[R, E](b: Boolean)(zManaged: ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def when[R, E](b: Boolean)(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     if (b) zManaged.unit else unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given value, otherwise does nothing.
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, _]]): ZManaged[R, E, Unit] =
+  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     pf.applyOrElse(a, (_: A) => unit).unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given effectful value, otherwise does nothing.
    */
-  final def whenCaseM[R, E, A](a: ZManaged[R, E, A])(pf: PartialFunction[A, ZManaged[R, E, _]]): ZManaged[R, E, Unit] =
+  final def whenCaseM[R, E, A](
+    a: ZManaged[R, E, A]
+  )(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     a.flatMap(whenCase(_)(pf))
 
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  final def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, _]): ZManaged[R, E, Unit] =
+  final def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     b.flatMap(b => if (b) zManaged.unit else unit)
 
 }

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -282,7 +282,7 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
    * schedule may not run to completion. However, if the `Schedule` ever
    * decides not to continue, then the finalizer will be run.
    */
-  final def ensuring(finalizer: UIO[_]): ZSchedule[R, A, B] =
+  final def ensuring(finalizer: UIO[Any]): ZSchedule[R, A, B] =
     reconsiderM(
       (_, decision) =>
         (if (decision.cont) UIO.unit else finalizer) *>

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -211,7 +211,7 @@ private[zio] final class FiberContext[E, A](
    *
    * @param io0 The `IO` to evaluate on the fiber.
    */
-  final def evaluateNow(io0: IO[E, _]): Unit = {
+  final def evaluateNow(io0: IO[E, Any]): Unit = {
     // Do NOT accidentally capture `curZio` in a closure, or Scala will wrap
     // it in `ObjectRef` and performance will plummet.
     var curZio: IO[E, Any] = io0
@@ -425,9 +425,9 @@ private[zio] final class FiberContext[E, A](
                   } else ZIO.interrupt
 
                 case ZIO.Tags.Fork =>
-                  val zio = curZio.asInstanceOf[ZIO.Fork[Any, _, Any]]
+                  val zio = curZio.asInstanceOf[ZIO.Fork[Any, Any, Any]]
 
-                  val value: FiberContext[_, Any] = fork(zio.value)
+                  val value: FiberContext[Any, Any] = fork(zio.value)
 
                   supervise(value)
 
@@ -557,10 +557,10 @@ private[zio] final class FiberContext[E, A](
 
   // We make a copy of the supervised fibers set as an array
   // to prevent mutations of the set from propagating to the caller.
-  private[this] final def getFibers: UIO[IndexedSeq[Fiber[_, _]]] =
+  private[this] final def getFibers: UIO[IndexedSeq[Fiber[Any, Any]]] =
     UIO {
       supervised.peek() match {
-        case SuperviseStatus.Unsupervised  => Array.empty[Fiber[_, _]].toIndexedSeq
+        case SuperviseStatus.Unsupervised  => Array.empty[Fiber[Any, Any]].toIndexedSeq
         case s: SuperviseStatus.Supervised => s.fibers
       }
     }
@@ -574,7 +574,7 @@ private[zio] final class FiberContext[E, A](
 
     val childSupervised = supervised.peek() match {
       case SuperviseStatus.Unsupervised  => SuperviseStatus.Unsupervised
-      case SuperviseStatus.Supervised(_) => SuperviseStatus.Supervised(newWeakSet[Fiber[_, _]])
+      case SuperviseStatus.Supervised(_) => SuperviseStatus.Supervised(newWeakSet[Fiber[Any, Any]])
     }
 
     val tracingRegion = inTracingRegion
@@ -638,7 +638,7 @@ private[zio] final class FiberContext[E, A](
   private[this] final def changeSupervision(status: zio.SuperviseStatus): IO[E, Unit] = ZIO.effectTotal {
     status match {
       case zio.SuperviseStatus.Supervised =>
-        val set = newWeakSet[Fiber[_, _]]
+        val set = newWeakSet[Fiber[Any, Any]]
 
         supervised.push(SuperviseStatus.Supervised(set))
       case zio.SuperviseStatus.Unsupervised =>
@@ -647,7 +647,7 @@ private[zio] final class FiberContext[E, A](
 
   }
 
-  private[this] final def supervise(child: FiberContext[_, _]): Unit =
+  private[this] final def supervise(child: FiberContext[Any, Any]): Unit =
     supervised.peek() match {
       case SuperviseStatus.Unsupervised    =>
       case SuperviseStatus.Supervised(set) => set.add(child); ()
@@ -685,7 +685,7 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def exitSupervision: UIO[_] = ZIO.effectTotal(supervised.pop())
+  private[this] final def exitSupervision: UIO[Any] = ZIO.effectTotal(supervised.pop())
 
   @inline
   private[this] final def interruptible: Boolean = interruptStatus.peekOrElse(true)
@@ -832,7 +832,7 @@ private[zio] object FiberContext {
     def initial[E, A] = Executing[E, A](FiberStatus.Running, Nil, false)
   }
 
-  type FiberRefLocals = java.util.Map[FiberRef[_], Any]
+  type FiberRefLocals = java.util.Map[FiberRef[Any], Any]
 
   sealed abstract class SuperviseStatus extends Serializable with Product {
     def convert: zio.SuperviseStatus = this match {
@@ -841,11 +841,11 @@ private[zio] object FiberContext {
     }
   }
   object SuperviseStatus {
-    final case class Supervised(value: java.util.Set[Fiber[_, _]]) extends SuperviseStatus {
-      def fibers: IndexedSeq[Fiber[_, _]] = {
-        val arr = Array.ofDim[Fiber[_, _]](value.size)
+    final case class Supervised(value: java.util.Set[Fiber[Any, Any]]) extends SuperviseStatus {
+      def fibers: IndexedSeq[Fiber[Any, Any]] = {
+        val arr = Array.ofDim[Fiber[Any, Any]](value.size)
         value
-          .toArray[Fiber[_, _]](arr)
+          .toArray[Fiber[Any, Any]](arr)
           .toIndexedSeq
           // In WeakHashMap based sets elements can become null
           .filter(_ != null)

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -77,11 +77,11 @@ trait Platform { self =>
   /**
    * Reports the specified failure.
    */
-  def reportFailure(cause: Cause[_]): Unit
+  def reportFailure(cause: Cause[Any]): Unit
 
-  def withReportFailure(f: Cause[_] => Unit): Platform =
+  def withReportFailure(f: Cause[Any] => Unit): Platform =
     new Platform.Proxy(self) {
-      override def reportFailure(cause: Cause[_]): Unit = f(cause)
+      override def reportFailure(cause: Cause[Any]): Unit = f(cause)
     }
 
   /**
@@ -92,11 +92,11 @@ trait Platform { self =>
 }
 object Platform {
   class Proxy(self: Platform) extends Platform {
-    def executor: Executor                   = self.executor
-    def tracing: Tracing                     = self.tracing
-    def fatal(t: Throwable): Boolean         = self.fatal(t)
-    def reportFatal(t: Throwable): Nothing   = self.reportFatal(t)
-    def reportFailure(cause: Cause[_]): Unit = self.reportFailure(cause)
-    def newWeakHashMap[A, B](): JMap[A, B]   = self.newWeakHashMap[A, B]()
+    def executor: Executor                     = self.executor
+    def tracing: Tracing                       = self.tracing
+    def fatal(t: Throwable): Boolean           = self.fatal(t)
+    def reportFatal(t: Throwable): Nothing     = self.reportFatal(t)
+    def reportFailure(cause: Cause[Any]): Unit = self.reportFailure(cause)
+    def newWeakHashMap[A, B](): JMap[A, B]     = self.newWeakHashMap[A, B]()
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -50,13 +50,13 @@ object Stream {
   /**
    * See [[ZStream.bracket]]
    */
-  final def bracket[E, A](acquire: IO[E, A])(release: A => UIO[_]): Stream[E, A] =
+  final def bracket[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Stream[E, A] =
     ZStream.bracket(acquire)(release)
 
   /**
    * See [[ZStream.bracketExit]]
    */
-  final def bracketExit[E, A](acquire: IO[E, A])(release: (A, Exit[_, _]) => UIO[_]): Stream[E, A] =
+  final def bracketExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Stream[E, A] =
     ZStream.bracketExit(acquire)(release)
 
   /**
@@ -93,7 +93,7 @@ object Stream {
    * See [[ZStream.effectAsyncM]]
    */
   final def effectAsyncM[E, A](
-    register: (IO[Option[E], A] => Unit) => IO[E, _],
+    register: (IO[Option[E], A] => Unit) => IO[E, Any],
     outputBuffer: Int = 16
   ): Stream[E, A] =
     ZStream.effectAsyncM(register, outputBuffer)
@@ -116,7 +116,7 @@ object Stream {
   /**
    * See [[ZStream.finalizer]]
    */
-  final def finalizer(finalizer: UIO[_]): Stream[Nothing, Nothing] =
+  final def finalizer(finalizer: UIO[Any]): Stream[Nothing, Nothing] =
     ZStream.finalizer(finalizer)
 
   /**
@@ -177,7 +177,7 @@ object Stream {
    */
   final def repeatEffectWith[E, A](
     fa: IO[E, A],
-    schedule: Schedule[Unit, _]
+    schedule: Schedule[Unit, Any]
   ): ZStream[Clock, E, A] = ZStream.repeatEffectWith(fa, schedule)
 
   /**
@@ -201,13 +201,13 @@ object Stream {
   /**
    * See [[ZStream.fromQueue]]
    */
-  final def fromQueue[E, A](queue: ZQueue[_, _, Any, E, _, A]): Stream[E, A] =
+  final def fromQueue[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
     ZStream.fromQueue(queue)
 
   /**
    * See [[ZStream.fromQueueWithShutdown]]
    */
-  final def fromQueueWithShutdown[E, A](queue: ZQueue[_, _, Any, E, _, A]): Stream[E, A] =
+  final def fromQueueWithShutdown[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
     ZStream.fromQueueWithShutdown(queue)
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -404,7 +404,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) { self =>
   /**
    * Adds an effect to consumption of every element of the stream.
    */
-  final def tap[R1 <: R, E1 >: E](f0: A => ZIO[R1, E1, _]): ZStreamChunk[R1, E1, A] =
+  final def tap[R1 <: R, E1 >: E](f0: A => ZIO[R1, E1, Any]): ZStreamChunk[R1, E1, A] =
     ZStreamChunk(chunks.tap[R1, E1] { as =>
       as.mapM_(f0)
     })

--- a/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
@@ -139,8 +139,8 @@ object BoolAlgebraSpecHelper {
   val failure1 = BoolAlgebra.failure(value3)
   val failure2 = BoolAlgebra.failure(value4)
 
-  val isSuccess: Assertion[BoolAlgebra[_]] = assertion("isSuccess")()(_.isSuccess)
-  val isFailure: Assertion[BoolAlgebra[_]] = assertion("isFailure")()(_.isFailure)
+  val isSuccess: Assertion[BoolAlgebra[Any]] = assertion("isSuccess")()(_.isSuccess)
+  val isFailure: Assertion[BoolAlgebra[Any]] = assertion("isFailure")()(_.isFailure)
 
   def boolAlgebra: Gen[Random with Sized, BoolAlgebra[Int]] = Gen.small(s => boolAlgebraOfSize(s), 1)
 

--- a/test/shared/src/main/scala/zio/test/BoolAlgebra.scala
+++ b/test/shared/src/main/scala/zio/test/BoolAlgebra.scala
@@ -153,20 +153,20 @@ object BoolAlgebra {
 
   final case class Value[+A](value: A) extends BoolAlgebra[A] { self =>
     override final def equals(that: Any): Boolean = that match {
-      case other: BoolAlgebra[_] =>
+      case other: BoolAlgebra[Any] =>
         equal(other) ||
           doubleNegative(self, other)
       case _ => false
     }
-    private def equal(that: BoolAlgebra[_]): Boolean = (self, that) match {
-      case (a1: Value[_], a2: Value[_]) => a1.value == a2.value
-      case _                            => false
+    private def equal(that: BoolAlgebra[Any]): Boolean = (self, that) match {
+      case (a1: Value[Any], a2: Value[Any]) => a1.value == a2.value
+      case _                                => false
     }
   }
 
   final case class And[+A](left: BoolAlgebra[A], right: BoolAlgebra[A]) extends BoolAlgebra[A] { self =>
     override final def equals(that: Any): Boolean = that match {
-      case other: BoolAlgebra[_] =>
+      case other: BoolAlgebra[Any] =>
         equal(other) ||
           commutative(other) ||
           symmetric(associative)(self, other) ||
@@ -175,29 +175,29 @@ object BoolAlgebra {
           deMorgansLaws(other)
       case _ => false
     }
-    private def equal(that: BoolAlgebra[_]): Boolean = (self, that) match {
-      case (a1: And[_], a2: And[_]) => a1.left == a2.left && a1.right == a2.right
-      case _                        => false
+    private def equal(that: BoolAlgebra[Any]): Boolean = (self, that) match {
+      case (a1: And[Any], a2: And[Any]) => a1.left == a2.left && a1.right == a2.right
+      case _                            => false
     }
-    private def associative(left: BoolAlgebra[_], right: BoolAlgebra[_]): Boolean =
+    private def associative(left: BoolAlgebra[Any], right: BoolAlgebra[Any]): Boolean =
       (left, right) match {
         case (And(And(a1, b1), c1), And(a2, And(b2, c2))) =>
           a1 == a2 && b1 == b2 && c1 == c2
         case _ =>
           false
       }
-    private def commutative(that: BoolAlgebra[_]): Boolean = (self, that) match {
+    private def commutative(that: BoolAlgebra[Any]): Boolean = (self, that) match {
       case (And(al, bl), And(ar, br)) => al == br && bl == ar
       case _                          => false
     }
-    private def distributive(left: BoolAlgebra[_], right: BoolAlgebra[_]): Boolean =
+    private def distributive(left: BoolAlgebra[Any], right: BoolAlgebra[Any]): Boolean =
       (left, right) match {
         case (And(a1, Or(b1, c1)), Or(And(a2, b2), And(a3, c2))) =>
           a1 == a2 && a1 == a3 && b1 == b2 && c1 == c2
         case _ =>
           false
       }
-    private def deMorgansLaws(that: BoolAlgebra[_]): Boolean =
+    private def deMorgansLaws(that: BoolAlgebra[Any]): Boolean =
       (self, that) match {
         case (And(Not(a), Not(b)), Not(Or(c, d))) => a == c && b == d
         case _                                    => false
@@ -206,7 +206,7 @@ object BoolAlgebra {
 
   final case class Or[+A](left: BoolAlgebra[A], right: BoolAlgebra[A]) extends BoolAlgebra[A] { self =>
     override final def equals(that: Any): Boolean = that match {
-      case other: BoolAlgebra[_] =>
+      case other: BoolAlgebra[Any] =>
         equal(other) ||
           commutative(other) ||
           symmetric(associative)(self, other) ||
@@ -215,29 +215,29 @@ object BoolAlgebra {
           deMorgansLaws(other)
       case _ => false
     }
-    private def equal(that: BoolAlgebra[_]): Boolean = (self, that) match {
-      case (o1: Or[_], o2: Or[_]) => o1.left == o2.left && o1.right == o2.right
-      case _                      => false
+    private def equal(that: BoolAlgebra[Any]): Boolean = (self, that) match {
+      case (o1: Or[Any], o2: Or[Any]) => o1.left == o2.left && o1.right == o2.right
+      case _                          => false
     }
-    private def associative(left: BoolAlgebra[_], right: BoolAlgebra[_]): Boolean =
+    private def associative(left: BoolAlgebra[Any], right: BoolAlgebra[Any]): Boolean =
       (left, right) match {
         case (Or(Or(a1, b1), c1), Or(a2, Or(b2, c2))) =>
           a1 == a2 && b1 == b2 && c1 == c2
         case _ =>
           false
       }
-    private def commutative(that: BoolAlgebra[_]): Boolean = (self, that) match {
+    private def commutative(that: BoolAlgebra[Any]): Boolean = (self, that) match {
       case (Or(al, bl), Or(ar, br)) => al == br && bl == ar
       case _                        => false
     }
-    private def distributive(left: BoolAlgebra[_], right: BoolAlgebra[_]): Boolean =
+    private def distributive(left: BoolAlgebra[Any], right: BoolAlgebra[Any]): Boolean =
       (left, right) match {
         case (Or(a1, And(b1, c1)), And(Or(a2, b2), Or(a3, c2))) =>
           a1 == a2 && a1 == a3 && b1 == b2 && c1 == c2
         case _ =>
           false
       }
-    private def deMorgansLaws(that: BoolAlgebra[_]): Boolean = (self, that) match {
+    private def deMorgansLaws(that: BoolAlgebra[Any]): Boolean = (self, that) match {
       case (Or(Not(a), Not(b)), Not(And(c, d))) => a == c && b == d
       case _                                    => false
     }
@@ -245,18 +245,18 @@ object BoolAlgebra {
 
   final case class Not[+A](result: BoolAlgebra[A]) extends BoolAlgebra[A] { self =>
     override final def equals(that: Any): Boolean = that match {
-      case other: BoolAlgebra[_] =>
+      case other: BoolAlgebra[Any] =>
         equal(other) ||
           doubleNegative(other, self) ||
           deMorgansLaws(other)
       case _ =>
         false
     }
-    private def equal(that: BoolAlgebra[_]): Boolean = (self, that) match {
-      case (n1: Not[_], n2: Not[_]) => n1.result == n2.result
-      case _                        => false
+    private def equal(that: BoolAlgebra[Any]): Boolean = (self, that) match {
+      case (n1: Not[Any], n2: Not[Any]) => n1.result == n2.result
+      case _                            => false
     }
-    private def deMorgansLaws(that: BoolAlgebra[_]): Boolean =
+    private def deMorgansLaws(that: BoolAlgebra[Any]): Boolean =
       (self, that) match {
         case (Not(Or(a, b)), And(Not(c), Not(d))) => a == c && b == d
         case (Not(And(a, b)), Or(Not(c), Not(d))) => a == c && b == d


### PR DESCRIPTION
Resolves #1759.

I found it relatively straightforward to to eliminate most uses of wildcard types in our code base by replacing uses for covariant parameters with `Any` and uses for contravariant parameters with `Nothing`.

The areas where I have not currently replaced wildcard types are in pattern matches and invariant type parameters.

Replacing wildcard types with `Any` in pattern matches results in a type erasure warning which I think is spurious but I don't know how we could silence in that particular case. With regard to arrays using `Any` actually won't generate the type erasure warning but results in different semantics where the pattern won't match. That one ends up being quite important in doing the "deep" equality check for arrays in `Assertion#equalTo`.

Invariant types don't appear very frequently in our code base. The two areas where the are used along with wildcard types is `TRef` and some of the private methods related to boxing and unboxing in `Chunk`. Since `TRef` is invariant `TRef[A]` is not a subset of `TRef[Any]` so trying to use `Any` there results in quite a few errors. It looked like it might be possible to make `TRef` covariant but I wasn't entirely sure with the `var` in `TRef` and the fact that it currently wasn't. The issues with `Chunk` could probably be resolved by casting since we are already doing a bunch of casting there but I'm not sure how much value there would be there.