### PR TITLE
Fix Test Command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,6 @@ addCommandAlias(
   ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/run;testTestsJS/test;examplesJS/test:compile"
 )
 
-addCommandAlias("test", ";testJVM;testJS")
-
 lazy val root = project
   .in(file("."))
   .settings(
@@ -220,7 +218,10 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(test)
 
 lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
-lazy val testRunnerJS  = testRunner.js
+lazy val testRunnerJS = testRunner.js
+  .settings(
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3" % Test
+  )
 
 /**
  * Examples sub-project that is not included in the root project.


### PR DESCRIPTION
When we added a command alias for `test` in #1935 I didn't realize that alias would apply globally. The result is that using `test` within SBT currently runs tests for all projects even if you are in a particular project, which is not great when a contributor is working on a certain project and only wants to run those tests. This PR removes that command alias and adds `scala-java-time` as a test dependency to the SBT test runner, which makes it available when `test` is called from the root directory so that all tests can be successfully run.

@LGLO Would you please take a look?