### PR TITLE
ZIO Test: Fix Type Inference Issue With ZSpec Syntax

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -19,7 +19,7 @@ package zio.test.sbt
 import sbt.testing._
 import zio.FunctionIO
 import zio.test.sbt.TestingSupport._
-import zio.test.{ Assertion, DefaultRunnableSpec, TestArgs, TestAspect, ZSpecSyntax }
+import zio.test.{ Assertion, DefaultRunnableSpec, TestArgs, TestAspect }
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/TestAspectSpec.scala
@@ -1,13 +1,11 @@
 package zio.test
 
 import scala.concurrent.Future
-import zio.clock.Clock
 import zio.{ Cause, Ref, ZIO }
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
-import zio.test.environment.Live
 
 import scala.reflect.ClassTag
 
@@ -151,17 +149,17 @@ object TestAspectSpec extends AsyncBaseSpec {
 
   def timeoutMakesTestsFailAfterGivenDuration: Future[Boolean] =
     unsafeRunToFuture {
-      val spec = (testM("timeoutMakesTestsFailAfterGivenDuration") {
+      val spec = testM("timeoutMakesTestsFailAfterGivenDuration") {
         assertM(ZIO.never *> ZIO.unit, equalTo(()))
-      }: ZSpec[Live[Clock], Any, String, Any]) @@ timeout(1.nano)
+      } @@ timeout(1.nano)
       failedWith(spec, cause => cause == TestTimeoutException("Timeout of 1 ns exceeded."))
     }
 
   def timeoutReportProblemWithInterruption =
     unsafeRunToFuture {
-      val spec = (testM("timeoutReportProblemWithInterruption") {
+      val spec = testM("timeoutReportProblemWithInterruption") {
         assertM(ZIO.never.uninterruptible *> ZIO.unit, equalTo(()))
-      }: ZSpec[Live[Clock], Any, String, Any]) @@ timeout(10.millis, 1.nano)
+      } @@ timeout(10.millis, 1.nano)
       failedWith(
         spec,
         cause =>

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -34,8 +34,8 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
    * test("foo") { assert(42, equalTo(42)) } @@ ignore
    * }}}
    */
-  final def @@[R1 <: R, E1 >: E, T1 >: T, S](
-    aspect: TestAspect[Nothing, R1, Nothing, E1, S, S]
+  final def @@[R1 <: R, E1 >: E, T1 >: T, S, S1 <: S, S2 >: S](
+    aspect: TestAspect[Nothing, R1, Nothing, E1, S1, S2]
   )(implicit ev: T <:< Either[TestFailure[Nothing], TestSuccess[S]]): Spec[R1, E1, L, T1] = {
     val _ = ev
     aspect(self.asInstanceOf[ZSpec[R, E, L, S]]).asInstanceOf[Spec[R1, E1, L, T1]]

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -29,6 +29,19 @@ import Spec._
 final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E, L, T]]) { self =>
 
   /**
+   * Syntax for adding aspects.
+   * {{{
+   * test("foo") { assert(42, equalTo(42)) } @@ ignore
+   * }}}
+   */
+  final def @@[R1 <: R, E1 >: E, T1 >: T, S](
+    aspect: TestAspect[Nothing, R1, Nothing, E1, S, S]
+  )(implicit ev: T <:< Either[TestFailure[Nothing], TestSuccess[S]]): Spec[R1, E1, L, T1] = {
+    val _ = ev
+    aspect(self.asInstanceOf[ZSpec[R, E, L, S]]).asInstanceOf[Spec[R1, E1, L, T1]]
+  }
+
+  /**
    * Returns a new spec with the suite labels distinguished by `Left`, and the
    * test labels distinguished by `Right`.
    */

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -154,19 +154,6 @@ package object test extends CheckVariants {
       }
     )
 
-  /**
-   * Adds syntax for adding aspects.
-   * {{{
-   * test("foo") { assert(42, equalTo(42)) } @@ ignore
-   * }}}
-   */
-  implicit class ZSpecSyntax[R, E, L, S](spec: ZSpec[R, E, L, S]) {
-    def @@[LowerR <: R, UpperR >: R, LowerE <: E, UpperE >: E, LowerS <: S, UpperS >: S](
-      aspect: TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS]
-    ): ZSpec[R, E, L, S] =
-      aspect(spec)
-  }
-
   val defaultTestRunner: TestRunner[TestEnvironment, String, Either[TestFailure[Nothing], TestSuccess[Any]], Any, Any] =
     TestRunner(TestExecutor.managed(zio.test.environment.testEnvironmentManaged))
 }


### PR DESCRIPTION
Resolves #1978.

I think we can fix the type inference issue with `ZSpecSyntax` by moving `@@` from an implicit syntax class to a concrete method on `Spec` with implicit evidence that the spec is a `ZSpec`. This seems to work but the types are tricky so would appreciate someone else taking a look to make sure this is sound.