### PR TITLE
Add managed aliases

### DIFF
--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -25,13 +25,18 @@ package object zio extends ZEnvDefinition with EitherCompat {
   type IO[+E, +A]   = ZIO[Any, E, A]
   type UIO[+A]      = ZIO[Any, Nothing, A]
   type Task[+A]     = ZIO[Any, Throwable, A]
-  @deprecated("use RIO", "1.0.0")
-  type TaskR[-R, +A] = RIO[R, A]
 
-  @deprecated("use RIO", "1.0.0")
-  val TaskR = RIO
+  type RManaged[-R, +A]  = ZManaged[R, Throwable, A]
+  type URManaged[-R, +A] = ZManaged[R, Nothing, A]
+  type Managed[+E, +A]   = ZManaged[Any, E, A]
+  type UManaged[+A]      = ZManaged[Any, Nothing, A]
+  type TManaged[+A]      = ZManaged[Any, Throwable, A]
 
-  type Managed[+E, +A] = ZManaged[Any, E, A]
+  type RMan[-R, +A]  = ZManaged[R, Throwable, A]
+  type URMan[-R, +A] = ZManaged[R, Nothing, A]
+  type Man[+E, +A]   = ZManaged[Any, E, A]
+  type UMan[+A]      = ZManaged[Any, Nothing, A]
+  type TMan[+A]      = ZManaged[Any, Throwable, A]
 
   type Schedule[-A, +B] = ZSchedule[Any, A, B]
 
@@ -41,4 +46,10 @@ package object zio extends ZEnvDefinition with EitherCompat {
     def unapply[A, B](ab: (A, B)): Some[(A, B)] =
       Some((ab._1, ab._2))
   }
+
+  @deprecated("use RIO", "1.0.0")
+  type TaskR[-R, +A] = RIO[R, A]
+
+  @deprecated("use RIO", "1.0.0")
+  val TaskR = RIO
 }

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -30,13 +30,7 @@ package object zio extends ZEnvDefinition with EitherCompat {
   type URManaged[-R, +A] = ZManaged[R, Nothing, A]
   type Managed[+E, +A]   = ZManaged[Any, E, A]
   type UManaged[+A]      = ZManaged[Any, Nothing, A]
-  type TManaged[+A]      = ZManaged[Any, Throwable, A]
-
-  type RMan[-R, +A]  = ZManaged[R, Throwable, A]
-  type URMan[-R, +A] = ZManaged[R, Nothing, A]
-  type Man[+E, +A]   = ZManaged[Any, E, A]
-  type UMan[+A]      = ZManaged[Any, Nothing, A]
-  type TMan[+A]      = ZManaged[Any, Throwable, A]
+  type TaskManaged[+A]   = ZManaged[Any, Throwable, A]
 
   type Schedule[-A, +B] = ZSchedule[Any, A, B]
 


### PR DESCRIPTION
I found myself using `Managed[Nothing, A]` very often.

I propose we add all possible managed aliases (same naming schema as for IO).

~A shorter alias `Managed` => `Man` is also included, please let me know if you think its a good idea.
I think having both longer aliases (`Managed`-family) and shorter (`Man`-family) is a good idea - let the developer (user) choose wheater he needs more explicity or more convinience.~ removed after feedback