### PR TITLE
Remove spurious exceptions in `ZStream.effect*`

### DIFF
--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -168,6 +168,12 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   final def unit: Exit[E, Unit] = as(())
 
   /**
+   * Shorthand to remove any trace from the underlying cause, if
+   * this is a failure.
+   */
+  final def untraced: Exit[E, A] = fold(c => Failure(c.untraced), Success(_))
+
+  /**
    * Named alias for `<*>`.
    */
   final def zip[E1 >: E, B](that: Exit[E1, B]): Exit[E1, (A, B)] = self <*> that

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -7,6 +7,7 @@ import zio.{ IO, Promise, Ref, Task, UIO, ZIO }
 import zio.test._
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import StreamUtils.inParallel
+import zio.Exit.{ Cause => _, _ }
 
 object StreamEffectAsyncSpec
     extends ZIOBaseSpec(
@@ -182,8 +183,8 @@ object StreamEffectAsyncSpec
               run    <- stream.run(ZSink.fromEffect(ZIO.never)).fork
               _      <- waitForValue(refCnt.get, 7)
               isDone <- refDone.get
-              _      <- run.interrupt
-            } yield assert(isDone, isFalse)
+              exit   <- run.interrupt
+            } yield assert(isDone, isFalse) && assert(exit.untraced, equalTo(Failure(Cause.Interrupt)))
           }
         )
       )

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2642,16 +2642,20 @@ object ZStream {
         maybeStream <- UIO(
                         register(
                           k =>
-                            runtime.unsafeRun(
-                              k.foldCauseM(
-                                  Cause.sequenceCauseOption(_) match {
-                                    case None    => output.offer(Pull.end)
-                                    case Some(c) => output.offer(Pull.halt(c))
-                                  },
-                                  a => output.offer(Pull.emit(a))
-                                )
-                                .unit
-                            )
+                            try {
+                              runtime.unsafeRun(
+                                k.foldCauseM(
+                                    Cause.sequenceCauseOption(_) match {
+                                      case None    => output.offer(Pull.end)
+                                      case Some(c) => output.offer(Pull.halt(c))
+                                    },
+                                    a => output.offer(Pull.emit(a))
+                                  )
+                                  .unit
+                              )
+                            } catch {
+                              case FiberFailure(Cause.Interrupt) =>
+                            }
                         )
                       ).toManaged_
         pull <- maybeStream match {
@@ -2676,16 +2680,20 @@ object ZStream {
         runtime <- ZIO.runtime[R].toManaged_
         _ <- register(
               k =>
-                runtime.unsafeRun(
-                  k.foldCauseM(
-                      Cause.sequenceCauseOption(_) match {
-                        case None    => output.offer(Pull.end)
-                        case Some(c) => output.offer(Pull.halt(c))
-                      },
-                      a => output.offer(Pull.emit(a))
-                    )
-                    .unit
-                )
+                try {
+                  runtime.unsafeRun(
+                    k.foldCauseM(
+                        Cause.sequenceCauseOption(_) match {
+                          case None    => output.offer(Pull.end)
+                          case Some(c) => output.offer(Pull.halt(c))
+                        },
+                        a => output.offer(Pull.emit(a))
+                      )
+                      .unit
+                  )
+                } catch {
+                  case FiberFailure(Cause.Interrupt) =>
+                }
             ).toManaged_
       } yield output.take.flatten
     }
@@ -2707,16 +2715,20 @@ object ZStream {
         eitherStream <- UIO(
                          register(
                            k =>
-                             runtime.unsafeRun(
-                               k.foldCauseM(
-                                   Cause.sequenceCauseOption(_) match {
-                                     case None    => output.offer(Pull.end)
-                                     case Some(c) => output.offer(Pull.halt(c))
-                                   },
-                                   a => output.offer(Pull.emit(a))
-                                 )
-                                 .unit
-                             )
+                             try {
+                               runtime.unsafeRun(
+                                 k.foldCauseM(
+                                     Cause.sequenceCauseOption(_) match {
+                                       case None    => output.offer(Pull.end)
+                                       case Some(c) => output.offer(Pull.halt(c))
+                                     },
+                                     a => output.offer(Pull.emit(a))
+                                   )
+                                   .unit
+                               )
+                             } catch {
+                               case FiberFailure(Cause.Interrupt) =>
+                             }
                          )
                        ).toManaged_
         pull <- eitherStream match {


### PR DESCRIPTION
`unsafeRun` [can throw](https://github.com/zio/zio/blob/master/core/shared/src/main/scala/zio/Runtime.scala#L57), but the way it is used inside `ZStream.effectAsync[Maybe|Interrupt]` means any error makes it in the error channel. However, when the operation is interrupted from the outside, a spurious exception will be thrown anyway.

cc @vasilmkd 