### PR TITLE
Properly name ZStream#mapConcat* combinators

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1079,7 +1079,7 @@ object SinkSpec
               assertM(
                 Stream("\n")
                   .transduce(ZSink.splitLines)
-                  .mapConcat(identity)
+                  .mapConcatChunk(identity)
                   .runCollect,
                 equalTo(List(""))
               )
@@ -1088,7 +1088,7 @@ object SinkSpec
               assertM(
                 Stream("abc", "abc", "abc")
                   .transduce(ZSink.splitLines)
-                  .mapConcat(identity)
+                  .mapConcatChunk(identity)
                   .runCollect,
                 equalTo(List("abcabcabc"))
               )
@@ -1097,7 +1097,7 @@ object SinkSpec
               assertM(
                 Stream("abc\r", "\nabc")
                   .transduce(ZSink.splitLines)
-                  .mapConcat(identity)
+                  .mapConcatChunk(identity)
                   .runCollect,
                 equalTo(List("abc", "abc"))
               )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1021,6 +1021,12 @@ object StreamSpec
             equalTo(List(1, 2, 3))
           )
         },
+        testM("Stream.mapConcat")(checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+          for {
+            res1 <- s.mapConcat(f).runCollect
+            res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+          } yield assert(res1, equalTo(res2))
+        }),
         testM("Stream.mapConcatChunk")(checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
           for {
             res1 <- s.mapConcatChunk(f).runCollect

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1021,9 +1021,9 @@ object StreamSpec
             equalTo(List(1, 2, 3))
           )
         },
-        testM("Stream.mapConcat")(checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
+        testM("Stream.mapConcatChunk")(checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
           for {
-            res1 <- s.mapConcat(f).runCollect
+            res1 <- s.mapConcatChunk(f).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
           } yield assert(res1, equalTo(res2))
         }),

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1050,6 +1050,23 @@ object StreamSpec
               .map(assert(_, equalTo(Left("Ouch"))))
           }
         ),
+        suite("Stream.mapConcatM")(
+          testM("mapConcatM happy path") {
+            checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+              for {
+                res1 <- s.mapConcatM(b => UIO.succeed(f(b))).runCollect
+                res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+              } yield assert(res1, equalTo(res2))
+            }
+          },
+          testM("mapConcatM error") {
+            Stream(1, 2, 3)
+              .mapConcatM(_ => IO.fail("Ouch"))
+              .runCollect
+              .either
+              .map(assert(_, equalTo(Left("Ouch"))))
+          }
+        ),
         testM("Stream.mapM") {
           checkM(Gen.small(Gen.listOfN(_)(Gen.anyByte)), Gen.function(successes(Gen.anyByte))) { (data, f) =>
             val s = Stream.fromIterable(data)

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -149,7 +149,7 @@ private[stream] class StreamEffect[-R, +E, +A](val processEffect: ZManaged[R, E,
       }
     }
 
-  override def mapConcat[B](f: A => Chunk[B]): StreamEffect[R, E, B] =
+  override def mapConcatChunk[B](f: A => Chunk[B]): StreamEffect[R, E, B] =
     StreamEffect[R, E, B] {
       self.processEffect.flatMap { thunk =>
         Managed.effectTotal {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1537,6 +1537,13 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
     }
 
   /**
+   * Maps each element to an iterable, and flattens the iterables into the
+   * output of this stream.
+   */
+  final def mapConcat[B](f: A => Iterable[B]): ZStream[R, E, B] =
+    mapConcatChunk(f andThen Chunk.fromIterable)
+
+  /**
    * Maps each element to a chunk, and flattens the chunks into the output of
    * this stream.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -238,7 +238,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                      .fork
         bs <- ZStream
                .fromPull(consume(stateVar, permits))
-               .mapConcat(identity)
+               .mapConcatChunk(identity)
                .process
                .ensuringFirst(producer.interrupt.fork)
       } yield bs
@@ -478,7 +478,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                    }
           stream = ZStream
             .unfoldM(UnfoldState(None, scheduleInit, notify))(consume(_, out, permits))
-            .mapConcat(identity)
+            .mapConcatChunk(identity)
         } yield stream
       }
 
@@ -1540,15 +1540,15 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Maps each element to a chunk, and flattens the chunks into the output of
    * this stream.
    */
-  def mapConcat[B](f: A => Chunk[B]): ZStream[R, E, B] =
+  def mapConcatChunk[B](f: A => Chunk[B]): ZStream[R, E, B] =
     flatMap(a => ZStream.fromChunk(f(a)))
 
   /**
    * Effectfully maps each element to a chunk, and flattens the chunks into
    * the output of this stream.
    */
-  final def mapConcatM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, Chunk[B]]): ZStream[R1, E1, B] =
-    mapM(f).mapConcat(identity)
+  final def mapConcatChunkM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, Chunk[B]]): ZStream[R1, E1, B] =
+    mapM(f).mapConcatChunk(identity)
 
   /**
    * Transforms the errors that possibly result from this stream.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1558,6 +1558,13 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
     mapM(f).mapConcatChunk(identity)
 
   /**
+   * Effectfully maps each element to an iterable, and flattens the iterables into
+   * the output of this stream.
+   */
+  final def mapConcatM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, Iterable[B]]): ZStream[R1, E1, B] =
+    mapM(a => f(a).map(Chunk.fromIterable(_))).mapConcatChunk(identity)
+
+  /**
    * Transforms the errors that possibly result from this stream.
    */
   final def mapError[E1](f: E => E1): ZStream[R, E1, A] =


### PR DESCRIPTION
I noticed a discrepancy between the function signatures of
`ZStream#mapConcat` and `ZStreamChunk#mapConcat` (which is actually `ZStreamChunk#mapConcatChunk`.

@iravid WDYT we should do? Is there a good use case for `ZStreamChunk#mapConcat` that accepts a function that returns an `Iterable`, instead of a `Chunk`?