### PR TITLE
ZIO Test: Fix Bug in TestAspect#nonFlaky

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -232,7 +232,7 @@ object TestAspect extends TimeoutVariants {
       ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
         def repeat(n: Int): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
           if (n <= 1) test
-          else test.flatMap(_ => repeat(n - 1))
+          else test.flatMap(_.fold(e => ZIO.succeed(Left(e)), _ => repeat(n - 1)))
 
         repeat(n0)
       }


### PR DESCRIPTION
When we changed the encoding of `ZSpec` in #1664 to move assertion failures from the value channel to the error channel we introduced a bug in TestAspect#nonFlaky where the test would not fail on the first assertion failure but instead always run for the full number of iterations and pass if the last iteration passed.  This PR fixes that.