### PR TITLE
ZIO Test: Add suite selection and support multiple search terms

### DIFF
--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -67,8 +67,26 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
         val filtered = SuiteCase(label, specs.map(_.flatMap(_.filterTestLabels(f))), exec)
         Some(Spec(filtered))
 
-      case t @ TestCase(_, _) =>
-        if (f(t.label)) Some(Spec(t)) else None
+      case t @ TestCase(label, _) =>
+        if (f(label)) Some(Spec(t)) else None
+    }
+
+  /**
+   * Returns a new Spec containing only tests/suites with labels satisfying the specified predicate.
+   */
+  final def filterLabels(f: L => Boolean): Option[Spec[R, E, L, T]] =
+    caseValue match {
+      case s @ SuiteCase(label, specs, exec) =>
+        // If the suite matched the label, no need to filter anything underneath it.
+        if (f(label)) {
+          Some(Spec(s))
+        } else {
+          val filtered = SuiteCase(label, specs.map(_.flatMap(_.filterLabels(f))), exec)
+          Some(Spec(filtered))
+        }
+
+      case t @ TestCase(label, _) =>
+        if (f(label)) Some(Spec(t)) else None
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -1,19 +1,24 @@
 package zio.test
 
-case class TestArgs(testSearchTerm: Option[String])
+case class TestArgs(testSearchTerms: List[String])
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(Option.empty[String])
+  def empty: TestArgs = TestArgs(List.empty[String])
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term) => Map("testSearchTerm" -> term)
+        case Array("-t", term) => ("testSearchTerm", term)
       }
-      .foldLeft(Map.empty[String, String])(_ ++ _)
+      .toList
+      .groupBy(_._1)
+      .map {
+        case (k, v) =>
+          (k, v.map(_._2))
+      }
 
-    TestArgs(parsedArgs.get("testSearchTerm"))
+    TestArgs(parsedArgs.getOrElse("testSearchTerm", Nil))
   }
 }


### PR DESCRIPTION
This is an extension in functionality of #1918.

It mainly consists of 2 things:
- Adds the ability to do test selection on suite labels too (not just the test labels)
- Allows passing in multiple `-t` arguments if you want to select 2 or more nodes in the tree.

It'll be clearer with examples:

Selects a test by label:

```
sbt:core-tests> testOnly *.ZIOSpec -- -t "interrupts effects on first failure"
[info] + ZIO
[info]   + foreachPar
[info]     + interrupts effects on first failure
[info] Ran 1 test in 432 ms: 1 succeeded, 0 ignored, 0 failed
```

Selects a suite by label:

```
sbt:core-tests> testOnly *.ZIOSpec -- -t "foreachPar"
[info] + ZIO
[info]   + foreachPar
[info]     + runs effects in parallel
[info]     + propagates error
[info]     + interrupts effects on first failure
[info] Ran 3 tests in 412 ms: 3 succeeded, 0 ignored, 0 failed
```

Selects 2 suites by label:

```
sbt:core-tests> testOnly *.ZIOSpec -- -t "foreachPar" -t "forkAll"
[info] + ZIO
[info]   + foreachPar
[info]     + runs effects in parallel
[info]     + propagates error
[info]     + interrupts effects on first failure
[info]   + forkAll
[info]     + happy-path
[info]     + empty input
[info]     + propagate failures
[info]     + propagates defects
[info] Ran 7 tests in 584 ms: 7 succeeded, 0 ignored, 0 failed
```

I find this is to be more usable than the idea that I was considering before of having a separate `-s` option for filtering by suite.

The basic idea here is that if the suite label matches, everything under that suite will be selected. Otherwise, if it's a test label, then select just that node (the original behavior).

Also, we added `filterTestLabels` last time. I no longer need it though as I created a more general `filterLabels`. Should we remove `filterTestLabels`?