### PR TITLE
Implement `ZManaged.memoize`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -101,6 +101,12 @@ object RefMSpec
             refM  <- RefM.make[State](Active)
             value <- refM.modifySome("State doesn't change") { case Active => IO.fail(failure) }.run
           } yield assert(value, fails(equalTo(failure)))
+        },
+        testM("modifySome with fatal error") {
+          for {
+            refM  <- RefM.make[State](Active)
+            value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
+          } yield assert(value, dies(hasMessage(fatalError)))
         }
       )
     )
@@ -109,6 +115,7 @@ object RefMSpecUtils {
 
   val (current, update) = ("value", "new value")
   val failure           = "failure"
+  val fatalError        = ":-0"
 
   sealed trait State
   case object Active  extends State

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -3,6 +3,8 @@ package zio
 import zio.test._
 import zio.test.Assertion._
 import zio.RefMSpecUtils._
+import zio.clock.Clock
+import zio.duration.durationInt
 
 object RefMSpec
     extends ZIOBaseSpec(
@@ -107,6 +109,17 @@ object RefMSpec
             refM  <- RefM.make[State](Active)
             value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
           } yield assert(value, dies(hasMessage(fatalError)))
+        },
+        testM("interrupt parent fiber and update") {
+          for {
+            promise     <- Promise.make[Nothing, RefM[State]]
+            latch       <- Promise.make[Nothing, Unit]
+            makeAndWait = promise.complete(RefM.make[State](Active)) *> latch.await
+            fiber       <- makeAndWait.fork
+            refM        <- promise.await
+            _           <- fiber.interrupt
+            value       <- refM.update(_ => ZIO.succeed(Closed)).timeout(1.second).provide(Clock.Live)
+          } yield assert(value, equalTo(Some(Closed)))
         }
       )
     )

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -974,7 +974,7 @@ object ZManagedSpec
                       }.fork
               _    <- latch1.await
               res1 <- assertM(resource.get, equalTo(1))
-              _    <- fiber.interrupt
+              _    <- fiber.interrupt.fork
               _    <- latch3.await
               res2 <- assertM(resource.get, equalTo(0))
               res3 <- assertM(latch2.isDone, isFalse)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -974,7 +974,7 @@ object ZManagedSpec
                       }.fork
               _    <- latch1.await
               res1 <- assertM(resource.get, equalTo(1))
-              _    <- fiber.interrupt.fork
+              _    <- fiber.interrupt
               _    <- latch3.await
               res2 <- assertM(resource.get, equalTo(0))
               res3 <- assertM(latch2.isDone, isFalse)

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -169,7 +169,7 @@ object RefM extends Serializable {
     for {
       ref   <- Ref.make(a)
       queue <- Queue.bounded[Bundle[_, A, _]](n)
-      _     <- queue.take.flatMap(b => ref.get.flatMap(a => b.run(a, ref, onDefect))).forever.fork
+      _     <- queue.take.flatMap(b => ref.get.flatMap(a => b.run(a, ref, onDefect))).forever.fork.daemon
     } yield new RefM[A](ref, queue)
 
 }

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -146,7 +146,7 @@ object RefM extends Serializable {
       interrupted.get.flatMap {
         case Some(cause) => onDefect(cause)
         case None =>
-          update(a).foldM(e => onDefect(Cause.fail(e)) <* promise.fail(e), {
+          update(a).foldCauseM(c => onDefect(c).ensuring(promise.halt(c)), {
             case (b, a) => ref.set(a) <* promise.succeed(b)
           })
       }

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -886,10 +886,8 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
               }
           }.flatMap(ZIO.done)
 
-        val release1 = (_: Exit[_, _]) => ZIO.unit
-
         val acquire2: ZIO[R, E, ZManaged[R, E, A]] =
-          ZIO.succeed(ZManaged(ZIO.succeed(Reservation(acquire1, release1))))
+          ZIO.succeed(acquire1.toManaged_)
 
         val release2 = (_: Exit[_, _]) =>
           ref.updateSome {

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -872,6 +872,33 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
       }
     }
 
+  def memoize: ZManaged[R, E, ZManaged[R, E, A]] =
+    ZManaged {
+      RefM.make[Option[(Reservation[R, E, A], Exit[E, A])]](None).map { ref =>
+        val acquire1: ZIO[R, E, A] =
+          ref.modify {
+            case v @ Some((_, e)) => ZIO.succeed(e -> v)
+            case None =>
+              ZIO.uninterruptibleMask { restore =>
+                self.reserve.flatMap { res =>
+                  restore(res.acquire).run.map(e => e -> Some(res -> e))
+                }
+              }
+          }.flatMap(ZIO.done)
+
+        val release1 = (_: Exit[_, _]) => ZIO.unit
+
+        val acquire2: ZIO[R, E, ZManaged[R, E, A]] =
+          ZIO.succeed(ZManaged(ZIO.succeed(Reservation(acquire1, release1))))
+
+        val release2 = (_: Exit[_, _]) =>
+          ref.updateSome {
+            case Some((res, e)) => res.release(e).as(None)
+          }
+
+        Reservation(acquire2, release2)
+      }
+    }
 }
 
 object ZManaged {

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -258,6 +258,12 @@ object Assertion {
     }
 
   /**
+   * Makes a new assertion that requires an exception to have a certain message.
+   */
+  final def hasMessage(message: String): Assertion[Throwable] =
+    assertion[Throwable]("hasMessage")(param(message))(th => th.getMessage == message)
+
+  /**
    * Makes a new assertion that requires a given string to end with the specified suffix.
    */
   final def endsWith(suffix: String): Assertion[String] =


### PR DESCRIPTION
Originally, I tried to implement this like `ZIO.memoize`. While this approach looks mean and lean for the happy path, getting this right for fatal errors and interruptions is far less trivial (see https://github.com/mlangc/zio/commit/016e2640712feb49c9c49a6fd3a0bab495b2a365#diff-ba99038d96380b834448ea7c9ddd3c05R776 to get an impression).

The current implementation uses a different approach, that is based on a `RefM` (this PR also fixes a `RefM` bug related to fatal errors that hit me). Maybe a normal `Ref` together with one or more `Promises` could be used too, at the cost of added complexity.

One last note on the naming: I choose `ZManaged.memoize` over `ZManaged.shared`, to emphasize that `ZManaged.memoize` corresponds directly to `ZIO.memoize`. Also, `shared` reminds me of reference counters (maybe from my old C++ times), and might be used to implement different semantics in the future.

Fixes #1263


