### PR TITLE
WIP fix nonFlaky fiberTime issue

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -5,7 +5,7 @@ import zio.test.environment.{ Live, TestClock }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
-import zio.{ Cause, Promise, Ref, Schedule, ZIO }
+import zio.{ Cause, Ref, Schedule, ZIO }
 
 import scala.reflect.ClassTag
 
@@ -154,21 +154,6 @@ object TestAspectSpec extends ZIOBaseSpec {
       val spec   = test("JVM-only")(assert(TestPlatform.isJVM, isTrue)) @@ jvmOnly
       val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
       assertM(result, isTrue)
-    },
-    testM("nonFlakyPar runs a test a specified number of times in parallel") {
-      for {
-        ref <- Ref.make(0)
-        p   <- Promise.make[Nothing, Unit]
-        spec = testM("test") {
-          for {
-            n <- ref.update(_ + 1)
-            _ <- p.succeed(()).when(n > 1)
-            _ <- p.await
-          } yield assertCompletes
-        } @@ TestAspect.nonFlakyPar
-        _ <- execute(spec)
-        n <- ref.get
-      } yield assert(n, equalTo(100))
     },
     testM("retry retries failed tests according to a schedule") {
       for {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -17,7 +17,7 @@ object TestAspectSpec extends ZIOBaseSpec {
         ref <- Ref.make(0)
         spec = testM("test") {
           assertM(ref.get, equalTo(1))
-        } @@ around(ref.set(1), ref.set(-1))
+        } @@ around_(ref.set(1), ref.set(-1))
         result <- isSuccess(spec)
         after  <- ref.get
       } yield {

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -2,6 +2,7 @@ package zio.test.environment
 
 import zio.console._
 import zio.test.Assertion._
+import zio.test.TestAspect.nonFlaky
 import zio.test._
 import zio.test.environment.TestConsole._
 
@@ -74,6 +75,12 @@ object ConsoleSpec extends ZIOBaseSpec {
         _      <- clearOutput
         output <- TestConsole.output
       } yield assert(output, isEmpty)
-    }
+    },
+    testM("output is empty at the start of repeating tests") {
+      for {
+        output <- TestConsole.output
+        _      <- putStrLn("Input")
+      } yield assert(output, isEmpty)
+    } @@ nonFlaky
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -4,10 +4,17 @@ import zio.system
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestSystem._
+import zio.test.TestAspect.nonFlaky
 
 object SystemSpec extends ZIOBaseSpec {
 
   def spec = suite("SystemSpec")(
+    testM("check set values are cleared at the start of repeating tests") {
+      for {
+        env <- system.env("k1")
+        _   <- putEnv("k1", "v1")
+      } yield assert(env, isNone)
+    } @@ nonFlaky,
     testM("fetch an environment variable and check that if it exists, return a reasonable value") {
       for {
         _   <- putEnv("k1", "v1")

--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -100,6 +100,7 @@ case class TestEnvironment(
         def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
         val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
         val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
+        override val save: UIO[UIO[Unit]]                    = UIO(UIO.unit)
         def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
         def setTime(duration: Duration): UIO[Unit]           = UIO.unit
         def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
@@ -125,6 +126,7 @@ case class TestEnvironment(
         val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
         def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
         def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
+        override val save: UIO[UIO[Unit]]        = UIO(UIO.unit)
       }
     }
 
@@ -163,6 +165,7 @@ case class TestEnvironment(
         def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
         val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
         def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
+        override val save: UIO[UIO[Unit]]               = UIO(UIO.unit)
         def setSeed(seed: Long): UIO[Unit]              = UIO.unit
         def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
       }
@@ -183,6 +186,7 @@ case class TestEnvironment(
         def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
         def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
         def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
+        override val save: UIO[UIO[Unit]]                                = UIO(UIO.unit)
         def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
       }
     }

--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -100,7 +100,7 @@ case class TestEnvironment(
         def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
         val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
         val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
-        override val save: UIO[UIO[Unit]]                    = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                             = UIO.succeed(UIO.unit)
         def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
         def setTime(duration: Duration): UIO[Unit]           = UIO.unit
         def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
@@ -126,7 +126,7 @@ case class TestEnvironment(
         val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
         def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
         def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
-        override val save: UIO[UIO[Unit]]        = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                 = UIO.succeed(UIO.unit)
       }
     }
 
@@ -165,7 +165,7 @@ case class TestEnvironment(
         def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
         val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
         def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
-        override val save: UIO[UIO[Unit]]               = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                        = UIO.succeed(UIO.unit)
         def setSeed(seed: Long): UIO[Unit]              = UIO.unit
         def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
       }
@@ -186,7 +186,7 @@ case class TestEnvironment(
         def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
         def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
         def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
-        override val save: UIO[UIO[Unit]]                                = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                                         = UIO.succeed(UIO.unit)
         def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
       }
     }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -104,6 +104,7 @@ case class TestEnvironment(
         def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
         val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
         val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
+        override val save: UIO[UIO[Unit]]                    = UIO(UIO.unit)
         def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
         def setTime(duration: Duration): UIO[Unit]           = UIO.unit
         def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
@@ -129,6 +130,7 @@ case class TestEnvironment(
         val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
         def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
         def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
+        override val save: UIO[UIO[Unit]]        = UIO(UIO.unit)
       }
     }
 
@@ -167,6 +169,7 @@ case class TestEnvironment(
         def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
         val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
         def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
+        override val save: UIO[UIO[Unit]]               = UIO(UIO.unit)
         def setSeed(seed: Long): UIO[Unit]              = UIO.unit
         def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
       }
@@ -187,6 +190,7 @@ case class TestEnvironment(
         def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
         def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
         def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
+        override val save: UIO[UIO[Unit]]                                = UIO(UIO.unit)
         def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
       }
     }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -104,7 +104,7 @@ case class TestEnvironment(
         def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
         val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
         val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
-        override val save: UIO[UIO[Unit]]                    = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                             = UIO.succeed(UIO.unit)
         def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
         def setTime(duration: Duration): UIO[Unit]           = UIO.unit
         def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
@@ -130,7 +130,7 @@ case class TestEnvironment(
         val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
         def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
         def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
-        override val save: UIO[UIO[Unit]]        = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                 = UIO.succeed(UIO.unit)
       }
     }
 
@@ -169,7 +169,7 @@ case class TestEnvironment(
         def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
         val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
         def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
-        override val save: UIO[UIO[Unit]]               = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                        = UIO.succeed(UIO.unit)
         def setSeed(seed: Long): UIO[Unit]              = UIO.unit
         def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
       }
@@ -190,7 +190,7 @@ case class TestEnvironment(
         def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
         def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
         def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
-        override val save: UIO[UIO[Unit]]                                = UIO(UIO.unit)
+        val save: UIO[UIO[Unit]]                                         = UIO.succeed(UIO.unit)
         def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
       }
     }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -300,7 +300,7 @@ object TestAspect extends TimeoutVariants {
    * satisfies the specified assertion.
    */
   def ifEnv(env: String, assertion: Assertion[String]): TestAspectAtLeastR[Live[System]] =
-    new PerTest.AtLeast[Live[System]] {
+    new PerTest.AtLeastR[Live[System]] {
       def perTest[R <: Live[System], E, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -338,7 +338,7 @@ object TestAspect extends TimeoutVariants {
     prop: String,
     assertion: Assertion[String]
   ): TestAspectAtLeastR[Live[System]] =
-    new PerTest.AtLeast[Live[System]] {
+    new PerTest.AtLeastR[Live[System]] {
       def perTest[R <: Live[System], E, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -530,7 +530,7 @@ object TestAspect extends TimeoutVariants {
     duration: Duration,
     interruptDuration: Duration = 1.second
   ): TestAspectAtLeastR[Live[Clock]] =
-    new PerTest.AtLeast[Live[Clock]] {
+    new PerTest.AtLeastR[Live[Clock]] {
       def perTest[R >: Nothing <: Live[Clock], E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
@@ -575,7 +575,7 @@ object TestAspect extends TimeoutVariants {
     /**
      * A `PerTest.AtLeast[R]` is a `TestAspect.PerTest` that that requires at least an R in its environment
      */
-    type AtLeast[R] =
+    type AtLeastR[R] =
       TestAspect.PerTest[Nothing, R, Nothing, Any, Nothing, Any]
 
     /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -90,15 +90,12 @@ trait TestAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerS, -UpperS] { self =>
     self >>> that
 }
 object TestAspect extends TimeoutVariants {
-  type ZTestEnv = TestClock with TestConsole with TestRandom with TestSystem
-  type TestAspectTE =
-    TestAspect[Nothing, ZTestEnv, Nothing, Any, Nothing, Any]
 
   /**
    * An aspect that returns the tests unchanged
    */
   val identity: TestAspectPoly =
-    new TestAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+    new TestAspectPoly {
       def some[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any, L](
         predicate: L => Boolean,
         spec: ZSpec[R, E, L, S]
@@ -109,7 +106,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that marks tests as ignored.
    */
   val ignore: TestAspectPoly =
-    new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
+    new PerTestPoly {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -128,8 +125,8 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
-   * Constructs an aspect that evaluates every test is evaluated between two effects, `before` and `after`,
-   * where the result of `before` can be used in `after`.
+   * Constructs an aspect that evaluates every test between two effects, `before` and `after`,
+   * where the result of `before` can be `used` in after.
    */
   def around[R0, E0, A0](
     before: ZIO[R0, E0, A0]
@@ -138,10 +135,7 @@ object TestAspect extends TimeoutVariants {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
-        ZManaged
-          .make(before)(after)
-          .catchAllCause(c => ZManaged.fail(TestFailure.Runtime(c)))
-          .use(_ => test)
+        before.catchAllCause(c => ZIO.fail(TestFailure.Runtime(c))).bracket(after)(_ => test)
     }
 
   /**
@@ -207,8 +201,8 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that retries a test until success, without limit.
    */
-  val eventually: TestAspectTE = {
-    val eventually = new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
+  val eventually: TestAspectAtLeastR[ZRTestEnv] = {
+    val eventually = new PerTestPoly {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -246,7 +240,7 @@ object TestAspect extends TimeoutVariants {
    * if their current strategy is inherited (undefined).
    */
   def executionStrategy(exec: ExecutionStrategy): TestAspectPoly =
-    new TestAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+    new TestAspectPoly {
       def some[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any, L](
         predicate: L => Boolean,
         spec: ZSpec[R, E, L, S]
@@ -289,7 +283,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that retries a test until success, with a default limit, for use
    * with flaky tests.
    */
-  val flaky: TestAspectTE =
+  val flaky: TestAspectAtLeastR[ZRTestEnv] =
     flaky(100)
 
   /**
@@ -298,15 +292,15 @@ object TestAspect extends TimeoutVariants {
    */
   def flaky(
     n: Int
-  ): TestAspectTE =
+  ): TestAspectAtLeastR[ZRTestEnv] =
     retry(Schedule.recurs(n))
 
   /**
    * An aspect that only runs a test if the specified environment variable
    * satisfies the specified assertion.
    */
-  def ifEnv(env: String, assertion: Assertion[String]): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
-    new TestAspect.PerTest[Nothing, Live[System], Nothing, Any, Nothing, Any] {
+  def ifEnv(env: String, assertion: Assertion[String]): TestAspectAtLeastR[Live[System]] =
+    new PerTestAtLeastR[Live[System]] {
       def perTest[R <: Live[System], E, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -333,7 +327,7 @@ object TestAspect extends TimeoutVariants {
    * As aspect that only runs a test if the specified environment variable is
    * set.
    */
-  def ifEnvSet(env: String): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
+  def ifEnvSet(env: String): TestAspectAtLeastR[Live[System]] =
     ifEnv(env, Assertion.anything)
 
   /**
@@ -343,8 +337,8 @@ object TestAspect extends TimeoutVariants {
   def ifProp(
     prop: String,
     assertion: Assertion[String]
-  ): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
-    new TestAspect.PerTest[Nothing, Live[System], Nothing, Any, Nothing, Any] {
+  ): TestAspectAtLeastR[Live[System]] =
+    new PerTestAtLeastR[Live[System]] {
       def perTest[R <: Live[System], E, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -369,7 +363,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * As aspect that only runs a test if the specified Java property is set.
    */
-  def ifPropSet(prop: String): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
+  def ifPropSet(prop: String): TestAspectAtLeastR[Live[System]] =
     ifProp(prop, Assertion.anything)
 
   /**
@@ -404,7 +398,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that repeats the test a default number of times, ensuring it is
    * stable ("non-flaky"). Stops at the first failure.
    */
-  val nonFlaky: TestAspectTE =
+  val nonFlaky: TestAspectAtLeastR[ZRTestEnv] =
     nonFlaky(100)
 
   /**
@@ -413,8 +407,8 @@ object TestAspect extends TimeoutVariants {
    */
   def nonFlaky(
     n: Int
-  ): TestAspectTE = {
-    val nonFlaky = new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
+  ): TestAspectAtLeastR[ZRTestEnv] = {
+    val nonFlaky = new PerTestPoly {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
@@ -443,45 +437,45 @@ object TestAspect extends TimeoutVariants {
    * An aspect that restores a given [[Restorable]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restore[R0](service: R0 => Restorable): TestAspect[Nothing, R0, Nothing, Any, Nothing, Any] =
+  def restore[R0](service: R0 => Restorable): TestAspectAtLeastR[R0] =
     around(ZIO.accessM[R0](r => service(r).save))(restore => restore)
 
   /**
    * An aspect that restores the [[TestClock]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestClock: TestAspect[Nothing, TestClock, Nothing, Any, Nothing, Any] = restore[TestClock](_.clock)
+  def restoreTestClock: TestAspectAtLeastR[TestClock] = restore[TestClock](_.clock)
 
   /**
    * An aspect that restores the [[TestConsole]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestConsole: TestAspect[Nothing, TestConsole, Nothing, Any, Nothing, Any] = restore[TestConsole](_.console)
+  def restoreTestConsole: TestAspectAtLeastR[TestConsole] = restore[TestConsole](_.console)
 
   /**
    * An aspect that restores the [[TestRandom]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestRandom: TestAspect[Nothing, TestRandom, Nothing, Any, Nothing, Any] = restore[TestRandom](_.random)
+  def restoreTestRandom: TestAspectAtLeastR[TestRandom] = restore[TestRandom](_.random)
 
   /**
    * An aspect that restores the [[TestSystem]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestSystem: TestAspect[Nothing, TestSystem, Nothing, Any, Nothing, Any] = restore[TestSystem](_.system)
+  def restoreTestSystem: TestAspectAtLeastR[ZRTestEnv] = restore[TestSystem](_.system)
 
   /**
    * An aspect that restores all state in the standard provided test environments
    * ([[TestClock]], [[TestConsole]], [[TestRandom]] and [[TestSystem]]) to their starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestEnvironment: TestAspectTE =
+  def restoreTestEnvironment: TestAspectAtLeastR[ZRTestEnv] =
     restoreTestClock >>> restoreTestConsole >>> restoreTestRandom >>> restoreTestSystem
 
   /**
    * An aspect that retries failed tests according to a schedule.
    */
-  def retry[R0 <: ZTestEnv, E0, S0](
+  def retry[R0 <: ZRTestEnv, E0, S0](
     schedule: Schedule[R0, TestFailure[E0], S0]
   ): TestAspect[Nothing, R0, Nothing, E0, Nothing, Any] = {
     val retry = new TestAspect.PerTest[Nothing, R0, Nothing, E0, Nothing, Any] {
@@ -516,7 +510,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that converts ignored tests into test failures.
    */
   val success: TestAspectPoly =
-    new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
+    new PerTestPoly {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
@@ -535,8 +529,8 @@ object TestAspect extends TimeoutVariants {
   def timeout(
     duration: Duration,
     interruptDuration: Duration = 1.second
-  ): TestAspect[Nothing, Live[Clock], Nothing, Any, Nothing, Any] =
-    new TestAspect.PerTest[Nothing, Live[Clock], Nothing, Any, Nothing, Any] {
+  ): TestAspectAtLeastR[Live[Clock]] =
+    new PerTestAtLeastR[Live[Clock]] {
       def perTest[R >: Nothing <: Live[Clock], E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] = {

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -90,6 +90,9 @@ trait TestAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerS, -UpperS] { self =>
     self >>> that
 }
 object TestAspect extends TimeoutVariants {
+  type ZTestEnv = TestClock with TestConsole with TestRandom with TestSystem
+  type TestAspectTE =
+    TestAspect[Nothing, ZTestEnv, Nothing, Any, Nothing, Any]
 
   /**
    * An aspect that returns the tests unchanged
@@ -125,16 +128,8 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
-   * Constructs an aspect that evaluates every test inside the context of a `Managed`.
-   */
-  def around[R0, E0](
-    before: ZIO[R0, E0, Any],
-    after: ZIO[R0, Nothing, Any]
-  ): PerTest[Nothing, R0, E0, Any, Nothing, Any] = around(before)(_ => after)
-
-  /**
-   * Constructs an aspect that evaluates every test inside the context of a `Managed` where the result of `before` can
-   * be used in `after`.
+   * Constructs an aspect that evaluates every test is evaluated between two effects, `before` and `after`,
+   * where the result of `before` can be used in `after`.
    */
   def around[R0, E0, A0](
     before: ZIO[R0, E0, A0]
@@ -148,6 +143,14 @@ object TestAspect extends TimeoutVariants {
           .catchAllCause(c => ZManaged.fail(TestFailure.Runtime(c)))
           .use(_ => test)
     }
+
+  /**
+   * A less powerful variant of `around` where the result of `before` is not required by after.
+   */
+  def around_[R0, E0](
+    before: ZIO[R0, E0, Any],
+    after: ZIO[R0, Nothing, Any]
+  ): PerTest[Nothing, R0, E0, Any, Nothing, Any] = around(before)(_ => after)
 
   /**
    * Constructs an aspect that evaluates every test inside the context of the managed function.
@@ -204,8 +207,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that retries a test until success, without limit.
    */
-  val eventually
-    : TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] = {
+  val eventually: TestAspectTE = {
     val eventually = new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
@@ -287,8 +289,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that retries a test until success, with a default limit, for use
    * with flaky tests.
    */
-  val flaky
-    : TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] =
+  val flaky: TestAspectTE =
     flaky(100)
 
   /**
@@ -297,7 +298,7 @@ object TestAspect extends TimeoutVariants {
    */
   def flaky(
     n: Int
-  ): TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] =
+  ): TestAspectTE =
     retry(Schedule.recurs(n))
 
   /**
@@ -403,8 +404,7 @@ object TestAspect extends TimeoutVariants {
    * An aspect that repeats the test a default number of times, ensuring it is
    * stable ("non-flaky"). Stops at the first failure.
    */
-  val nonFlaky
-    : TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] =
+  val nonFlaky: TestAspectTE =
     nonFlaky(100)
 
   /**
@@ -413,7 +413,7 @@ object TestAspect extends TimeoutVariants {
    */
   def nonFlaky(
     n: Int
-  ): TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] = {
+  ): TestAspectTE = {
     val nonFlaky = new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
@@ -450,39 +450,38 @@ object TestAspect extends TimeoutVariants {
    * An aspect that restores the [[TestClock]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestClock = restore[TestClock](_.clock)
+  def restoreTestClock: TestAspect[Nothing, TestClock, Nothing, Any, Nothing, Any] = restore[TestClock](_.clock)
 
   /**
    * An aspect that restores the [[TestConsole]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestConsole = restore[TestConsole](_.console)
+  def restoreTestConsole: TestAspect[Nothing, TestConsole, Nothing, Any, Nothing, Any] = restore[TestConsole](_.console)
 
   /**
    * An aspect that restores the [[TestRandom]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestRandom = restore[TestRandom](_.random)
+  def restoreTestRandom: TestAspect[Nothing, TestRandom, Nothing, Any, Nothing, Any] = restore[TestRandom](_.random)
 
   /**
    * An aspect that restores the [[TestSystem]]'s state to its starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestSystem = restore[TestSystem](_.system)
+  def restoreTestSystem: TestAspect[Nothing, TestSystem, Nothing, Any, Nothing, Any] = restore[TestSystem](_.system)
 
   /**
    * An aspect that restores all state in the standard provided test environments
    * ([[TestClock]], [[TestConsole]], [[TestRandom]] and [[TestSystem]]) to their starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
-  def restoreTestEnvironment
-    : TestAspect[Nothing, TestClock with TestConsole with TestRandom with TestSystem, Nothing, Any, Nothing, Any] =
+  def restoreTestEnvironment: TestAspectTE =
     restoreTestClock >>> restoreTestConsole >>> restoreTestRandom >>> restoreTestSystem
 
   /**
    * An aspect that retries failed tests according to a schedule.
    */
-  def retry[R0 <: TestClock with TestConsole with TestRandom with TestSystem, E0, S0](
+  def retry[R0 <: ZTestEnv, E0, S0](
     schedule: Schedule[R0, TestFailure[E0], S0]
   ): TestAspect[Nothing, R0, Nothing, E0, Nothing, Any] = {
     val retry = new TestAspect.PerTest[Nothing, R0, Nothing, E0, Nothing, Any] {

--- a/test/shared/src/main/scala/zio/test/environment/Restorable.scala
+++ b/test/shared/src/main/scala/zio/test/environment/Restorable.scala
@@ -1,0 +1,7 @@
+package zio.test.environment
+
+import zio.UIO
+
+trait Restorable {
+  val save: UIO[UIO[Unit]]
+}

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -48,18 +48,6 @@ package object test extends CompileVariants {
   type AssertResult = BoolAlgebraM[Any, Nothing, AssertionValue]
 
   /**
-   * A `PerTestAtLeastR[R]` is a `TestAspect.PerTest` that that requires at least an R in its environment
-   */
-  type PerTestAtLeastR[R] =
-    TestAspect.PerTest[Nothing, R, Nothing, Any, Nothing, Any]
-
-  /**
-   * A `PerTestPoly` is a `TestAspect.PerTest` that is completely polymorphic,
-   * having no requirements on error or environment.
-   */
-  type PerTestPoly = TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any]
-
-  /**
    * A `TestAspectAtLeast[R]` is a `TestAspect` that requires at least an `R` in its environment.
    */
   type TestAspectAtLeastR[R] =
@@ -97,7 +85,7 @@ package object test extends CompileVariants {
   /**
    * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable]] [[TestEnvironment]] objects
    */
-  type ZRTestEnv = TestClock with TestConsole with TestRandom with TestSystem
+  type ZTestEnv = TestClock with TestConsole with TestRandom with TestSystem
 
   /**
    * A `ZTest[R, E, S]` is an effectfully produced test that requires an `R`

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -18,6 +18,7 @@ package zio
 
 import zio.duration.Duration
 import zio.stream.{ ZSink, ZStream }
+import zio.test.environment.{ TestClock, TestConsole, TestRandom, TestSystem }
 
 /**
  * _ZIO Test_ is a featherweight testing library for effectful programs.
@@ -43,8 +44,34 @@ import zio.stream.{ ZSink, ZStream }
  * }}}
  */
 package object test extends CompileVariants {
+
   type AssertResult = BoolAlgebraM[Any, Nothing, AssertionValue]
-  type TestResult   = BoolAlgebraM[Any, Nothing, FailureDetails]
+
+  /**
+   * A `PerTestAtLeastR[R]` is a `TestAspect.PerTest` that that requires at least an R in its environment
+   */
+  type PerTestAtLeastR[R] =
+    TestAspect.PerTest[Nothing, R, Nothing, Any, Nothing, Any]
+
+  /**
+   * A `PerTestPoly` is a `TestAspect.PerTest` that is completely polymorphic,
+   * having no requirements on error or environment.
+   */
+  type PerTestPoly = TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any]
+
+  /**
+   * A `TestAspectAtLeast[R]` is a `TestAspect` that requires at least an `R` in its environment.
+   */
+  type TestAspectAtLeastR[R] =
+    TestAspect[Nothing, R, Nothing, Any, Nothing, Any]
+
+  /**
+   * A `TestAspectPoly` is a `TestAspect` that is completely polymorphic,
+   * having no requirements on error or environment.
+   */
+  type TestAspectPoly = TestAspect[Nothing, Any, Nothing, Any, Nothing, Any]
+
+  type TestResult = BoolAlgebraM[Any, Nothing, FailureDetails]
 
   /**
    * A `TestReporter[E, L, S]` is capable of reporting test results annotated
@@ -68,10 +95,9 @@ package object test extends CompileVariants {
   type TestExecutor[+R, E, L, -T, +S] = (ZSpec[R, E, L, T], ExecutionStrategy) => UIO[ExecutedSpec[E, L, S]]
 
   /**
-   * A `TestAspectPoly` is a `TestAspect` that is completely polymorphic,
-   * having no requirements on error or environment.
+   * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable]] [[TestEnvironment]] objects
    */
-  type TestAspectPoly = TestAspect[Nothing, Any, Nothing, Any, Nothing, Any]
+  type ZRTestEnv = TestClock with TestConsole with TestRandom with TestSystem
 
   /**
    * A `ZTest[R, E, S]` is an effectfully produced test that requires an `R`


### PR DESCRIPTION
@adamgfraser, sorry to bug you with more nonFlaky stuff but you said something the other day that got me thinking:

> This isn't working without resetting the clock because the sleep calls never occur on the main fiber

This made me think if I changed `nonFlaky` so the tests weren't running on the main fiber, we'd have a `fiberTime` of 0 at the start of each iteration. I did some fiddling and (after more time than I'd care to admit) I think I've got it sorted. This should eliminate all the issues with keeping clock time and fiber time in sync - a simple `@@ after(setTime(0.hours))` should suffice!

Can you please check this is solid and won't break all the things?