### PR TITLE
Modify fmt and check aliases to work off root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
-addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
+addCommandAlias("check", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile"


### PR DESCRIPTION
I changed the `fmt` and `check` SBT commands to work off the root so that when your active project is set to a different project the `fmt` alias can still pick everything up. The original behavior seemed confusing to some and was causing CI to run and fail unnecessarily due to missed formats.

Also, `scalafmtAll` seems to do both main and test in 1 command (not the SBT files though).
https://scalameta.org/scalafmt/docs/installation.html#sbt