### PR TITLE
Enable fatal warnings for all compile tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ testJVM: &testJVM
     - <<: *install_jdk
     - run:
         name: Run tests
-        command: ./sbt ++${SCALA_VERSION}! testJVM
+        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVM
     - <<: *clean_cache
     - <<: *save_cache
     - store_test_results:
@@ -146,7 +146,7 @@ testJS: &testJS
     - <<: *install_nodejs
     - run:
         name: Run tests
-        command: ./sbt ++${SCALA_VERSION}! testJS
+        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJS
     - <<: *clean_cache
     - <<: *save_cache
     - store_test_results:


### PR DESCRIPTION
`fatal.warnings` is currently only set for Dotty for some reason. This PR enables it for all of them.

We could also flip the logic so the default is true to prevent issues like this creeping up in the future. Slightly more work for the person who wants to turn it off locally, but safer against refactorings. Though if we do that, I think I would prefer an env var fallback (easier to enable in your exports).

There was also John's concern here:
https://github.com/zio/zio/pull/1924#issuecomment-539113881