### PR TITLE
Add "run ci" trigger logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,19 @@ install_nodejs: &install_nodejs
         nvm use
         node -v
 
+check_should_run: &check_should_run
+  - run: |
+      if git log -1 --format=oneline $CIRCLE_SHA1 | grep --ignore-case '\[run ci\]'; then
+        echo 'CI set to run'
+      else
+        echo 'Early-exiting since CI is not set to run (no "[run ci]" in commit message). Use the "ci" SBT task.'
+        exit 1
+      fi
+
 lint: &lint
   steps:
     - checkout
+    - check_should_run
     - <<: *load_cache
     - run:
         name: Lint code
@@ -122,7 +132,7 @@ testJVM: &testJVM
     - <<: *install_jdk
     - run:
         name: Run tests
-        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVM
+        command: ./sbt ++${SCALA_VERSION}! testJVM
     - <<: *clean_cache
     - <<: *save_cache
     - store_test_results:
@@ -134,7 +144,7 @@ testJVMDotty: &testJVMDotty
     - <<: *load_cache
     - run:
         name: Run tests
-        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMDotty
+        command: ./sbt ++${SCALA_VERSION}! testJVMDotty
     - <<: *clean_cache
     - <<: *save_cache
 
@@ -146,7 +156,7 @@ testJS: &testJS
     - <<: *install_nodejs
     - run:
         name: Run tests
-        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJS
+        command: ./sbt ++${SCALA_VERSION}! testJS
     - <<: *clean_cache
     - <<: *save_cache
     - store_test_results:

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ ThisBuild / publishTo := sonatypePublishToBundle.value
 
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("check", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
+addCommandAlias("ci", "check; checkCanRunCI; git commit --only --allow-empty -m \"[run ci]\"")
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile"
@@ -54,6 +55,7 @@ lazy val root = project
     skip in publish := true,
     console := (console in Compile in coreJVM).value,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
+    checkCanRunCISetting,
     welcomeMessage
   )
   .aggregate(

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -151,6 +151,12 @@ If all the tests are passing, then you can format your code:
 fmt
 ```
 
+And then set CI to run with:
+
+```bash
+ci
+```
+
 If your changes altered an API, then you may need to rebuild the microsite to make sure none of the (compiled) documentation breaks:
 
 ```bash

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,4 @@ addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                 %
 addSbtPlugin("com.dwijnand"                      % "sbt-dynver"                % "4.0.0")
 addSbtPlugin("com.jsuereth"                      % "sbt-pgp"                   % "1.1.2")
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"              % "3.8")
+addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"                   % "1.0.0")


### PR DESCRIPTION
@jdegoes Feel free to close this if you don't like the idea, but I wanted to give it a test run to see how the idea fairs in practice.

This attempts to solve a few problems:
- Circle CI seems to have a usage-based pricing scheme now. Meaning minimizing unnecessary work is beneficial in terms of cost savings (but probably also wait time if many builds are queued up).
- We also have a lot of unnecessary CI runs due to things like WIP commits and forgetting to run `fmt` manually. Then there's also the the `-Xfatal-warnings` being off by default issue when working locally.

What this PR does is:
- CI does not run by default (well, except the prerequites like `checkout` and so on). `[run ci]` is needed to trigger it (basically the opposite of [Circle CI's built-in [skip ci]](https://circleci.com/docs/2.0/skip-build/)).
- Makes `-Xfatal-warnings` on by default (but can still be overridden if it's getting in the way of your productivity).
- Added an SBT task called `ci` that adds the `[run ci]` message. But before doing that, it does the scalafmt check, as well as ensuring you haven't overridden `-Xfatal-warnings`.

My concern was that running the `ci` command is an extra step, but it might not be that big of a deal considering `fmt` is also a manual step currently. I don't know... whether this is a deal-breaker is up to you all. I can see arguments for either side.