### PR TITLE
ZIO Test: Implement Decorators for TestEnvironment

### DIFF
--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -25,7 +25,6 @@ case class TestEnvironment(
   console: TestConsole.Test,
   live: Live.Service[ZEnv],
   random: TestRandom.Test,
-  scheduler: TestClock.Test,
   sized: Sized.Service[Any],
   system: TestSystem.Test
 ) extends Live[ZEnv]
@@ -34,7 +33,56 @@ case class TestEnvironment(
     with TestRandom
     with TestSystem
     with Scheduler
-    with Sized
+    with Sized {
+
+  /**
+   * Maps all test implementations in the test environment individually.
+   */
+  final def mapAll(
+    mapTestClock: TestClock.Test => TestClock.Test = identity,
+    mapTestConsole: TestConsole.Test => TestConsole.Test = identity,
+    mapTestRandom: TestRandom.Test => TestRandom.Test = identity,
+    mapTestSystem: TestSystem.Test => TestSystem.Test = identity
+  ): TestEnvironment =
+    TestEnvironment(
+      mapTestClock(clock),
+      mapTestConsole(console),
+      live,
+      mapTestRandom(random),
+      sized,
+      mapTestSystem(system)
+    )
+
+  /**
+   * Maps the [[TestClock]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestClock(f: TestClock.Test => TestClock.Test): TestEnvironment =
+    mapAll(mapTestClock = f)
+
+  /**
+   * Maps the [[TestConsole]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestConsole(f: TestConsole.Test => TestConsole.Test): TestEnvironment =
+    mapAll(mapTestConsole = f)
+
+  /**
+   * Maps the [[TestRandom]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestRandom(f: TestRandom.Test => TestRandom.Test): TestEnvironment =
+    mapAll(mapTestRandom = f)
+
+  /**
+   * Maps the [[TestSystem]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestSystem(f: TestSystem.Test => TestSystem.Test): TestEnvironment =
+    mapAll(mapTestSystem = f)
+
+  val scheduler = clock
+}
 
 object TestEnvironment {
 
@@ -49,6 +97,6 @@ object TestEnvironment {
         _       <- random.setSeed(time)
         size    <- Sized.makeService(100)
         system  <- TestSystem.makeTest(TestSystem.DefaultData)
-      } yield new TestEnvironment(clock, console, live, random, clock, size, system)
+      } yield new TestEnvironment(clock, console, live, random, size, system)
     }
 }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -27,7 +27,6 @@ case class TestEnvironment(
   console: TestConsole.Test,
   live: Live.Service[ZEnv],
   random: TestRandom.Test,
-  scheduler: TestClock.Test,
   sized: Sized.Service[Any],
   system: TestSystem.Test
 ) extends Blocking
@@ -37,7 +36,57 @@ case class TestEnvironment(
     with TestRandom
     with TestSystem
     with Scheduler
-    with Sized
+    with Sized {
+
+  /**
+   * Maps all test implementations in the test environment individually.
+   */
+  final def mapAll(
+    mapTestClock: TestClock.Test => TestClock.Test = identity,
+    mapTestConsole: TestConsole.Test => TestConsole.Test = identity,
+    mapTestRandom: TestRandom.Test => TestRandom.Test = identity,
+    mapTestSystem: TestSystem.Test => TestSystem.Test = identity
+  ): TestEnvironment =
+    TestEnvironment(
+      blocking,
+      mapTestClock(clock),
+      mapTestConsole(console),
+      live,
+      mapTestRandom(random),
+      sized,
+      mapTestSystem(system)
+    )
+
+  /**
+   * Maps the [[TestClock]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestClock(f: TestClock.Test => TestClock.Test): TestEnvironment =
+    mapAll(mapTestClock = f)
+
+  /**
+   * Maps the [[TestConsole]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestConsole(f: TestConsole.Test => TestConsole.Test): TestEnvironment =
+    mapAll(mapTestConsole = f)
+
+  /**
+   * Maps the [[TestRandom]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestRandom(f: TestRandom.Test => TestRandom.Test): TestEnvironment =
+    mapAll(mapTestRandom = f)
+
+  /**
+   * Maps the [[TestSystem]] implementation in the test environment, leaving
+   * all other test implementations the same.
+   */
+  final def mapTestSystem(f: TestSystem.Test => TestSystem.Test): TestEnvironment =
+    mapAll(mapTestSystem = f)
+
+  val scheduler = clock
+}
 
 object TestEnvironment {
 
@@ -53,6 +102,6 @@ object TestEnvironment {
         size     <- Sized.makeService(100)
         system   <- TestSystem.makeTest(TestSystem.DefaultData)
         blocking = Blocking.Live.blocking
-      } yield new TestEnvironment(blocking, clock, console, live, random, clock, size, system)
+      } yield new TestEnvironment(blocking, clock, console, live, random, size, system)
     }
 }


### PR DESCRIPTION
Implements functions for mapping the test implementations of the standard ZIO environment types in the test environment. This can be useful for incrementally building test environments and in particular for providing a "fresh" copy of one or more of the test implementations for each test run when used with combinators such as `TestAspect#nonFlaky`.