### PR TITLE
ZIO Test: Fix Bug in TestAspect#flaky

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -168,7 +168,7 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
       ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
         lazy val untilSuccess: ZIO[R, Nothing, Either[TestFailure[Nothing], TestSuccess[S]]] =
-          test.foldM(_ => untilSuccess, _.fold(_ => untilSuccess, s => ZIO.succeed(Right(s))))
+          test.foldCauseM(_ => untilSuccess, _.fold(_ => untilSuccess, s => ZIO.succeed(Right(s))))
 
         untilSuccess
       }


### PR DESCRIPTION
We were using `foldM` in `TestAspect#flaky` so we were not retrying tests that died. In particular, this is relevant to using `flaky` in combination with `TestAspect#timeout`, since `timeout` causes a test to die if the timeout is exceeded. This PR fixes this by using `foldCauseM` and adds a test to prevent regression.