### PR TITLE
Implement CanFail

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -264,7 +264,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         _ <- ZIO.unit
         _ <- ZIO.unit
       } yield t)
-        .foldCauseM(
+        .foldM(
           failure = _ => IO.fail(()),
           success = t =>
             IO.trace

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -264,9 +264,8 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         _ <- ZIO.unit
         _ <- ZIO.unit
       } yield t)
-        .foldM(
-          failure = _ => IO.fail(()),
-          success = t =>
+        .flatMap(
+          t =>
             IO.trace
               .map(tuple(t))
         )

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -264,7 +264,7 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         _ <- ZIO.unit
         _ <- ZIO.unit
       } yield t)
-        .foldM(
+        .foldCauseM(
           failure = _ => IO.fail(()),
           success = t =>
             IO.trace

--- a/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
@@ -378,6 +378,7 @@ class ZIOSpecJvm(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     val ex = new Exception("Died")
 
     unsafeRun {
+      import zio.CanFail.canFail
       for {
         plain <- (ZIO.die(ex) <> IO.unit).run
         both  <- (ZIO.halt(Cause.Both(interrupt, die(ex))) <> IO.unit).run

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -72,7 +72,7 @@ object SemaphoreSpec
             val n = 1L
             for {
               s           <- Semaphore.make(n)
-              acquireFork <- s.acquireN(2).timeout(1.milli).either.fork
+              acquireFork <- s.acquireN(2).timeout(1.milli).fork
               _           <- TestClock.adjust(1.milli) *> acquireFork.join
               permitsFork <- (s.release *> clock.sleep(10.millis) *> s.available).fork
               permits     <- TestClock.adjust(10.millis) *> permitsFork.join
@@ -85,7 +85,7 @@ object SemaphoreSpec
             val n = 0L
             for {
               s           <- Semaphore.make(n)
-              acquireFork <- s.withPermit(s.release).timeout(1.milli).either.fork
+              acquireFork <- s.withPermit(s.release).timeout(1.milli).fork
               _           <- TestClock.adjust(1.milli) *> acquireFork.join
               permitsFork <- (s.release *> clock.sleep(10.millis) *> s.available).fork
               permits     <- TestClock.adjust(10.millis) *> permitsFork.join
@@ -94,7 +94,7 @@ object SemaphoreSpec
           testM("`withPermitManaged` does not leak fibers or permits upon cancellation") {
             for {
               s           <- Semaphore.make(0)
-              acquireFork <- s.withPermitManaged.use(_ => s.release).timeout(1.millisecond).either.fork
+              acquireFork <- s.withPermitManaged.use(_ => s.release).timeout(1.millisecond).fork
               _           <- TestClock.adjust(1.milli) *> acquireFork.join
               permitsFork <- (s.release *> clock.sleep(10.milliseconds) *> s.available).fork
               permits     <- TestClock.adjust(10.millis) *> permitsFork.join

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1049,7 +1049,7 @@ object ZIOSpec
             for {
               cont <- Promise.make[Nothing, Unit]
               p1   <- Promise.make[Nothing, Boolean]
-              f1   <- (cont.succeed(()) *> IO.never).catchAllCause(IO.fail).ensuring(p1.succeed(true)).fork
+              f1   <- (cont.succeed(()) *> IO.never).ensuring(p1.succeed(true)).fork
               _    <- cont.await
               _    <- f1.interrupt
               res  <- p1.await

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -689,11 +689,11 @@ object ZManagedSpec
                            for {
                              fiber        <- canceler.fork
                              _            <- latch.await
-                             interruption <- withLive(fiber.interrupt)(_.timeout(5.seconds)).either
+                             interruption <- withLive(fiber.interrupt)(_.timeout(5.seconds))
                              _            <- ref.set(false)
                            } yield interruption
                        }
-            } yield assert(result, isRight(isNone))
+            } yield assert(result, isNone)
           },
           testM("If completed, the canceler should cause the regular finalizer to not run") {
             for {
@@ -830,8 +830,8 @@ object ZManagedSpecUtil {
       reachedAcquisition <- Promise.make[Nothing, Unit]
       managedFiber       <- managed(reachedAcquisition.succeed(()) *> never.await).use_(IO.unit).fork
       _                  <- reachedAcquisition.await
-      interruption       <- managedFiber.interrupt.timeout(5.seconds).provide(zio.clock.Clock.Live).either
-    } yield assert(interruption, isRight(equalTo(expected)))
+      interruption       <- managedFiber.interrupt.timeout(5.seconds).provide(zio.clock.Clock.Live)
+    } yield assert(interruption, equalTo(expected))
 
   def testFinalizersPar[R, E](
     n: Int,

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -191,6 +191,7 @@ object ZManagedSpec
             } yield assert(values, equalTo(List(1, 1)))
           },
           testM("Runs onSuccess on success") {
+            import zio.CanFail.canFail
             for {
               effects <- Ref.make[List[Int]](Nil)
               res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
@@ -207,6 +208,7 @@ object ZManagedSpec
             } yield assert(values, equalTo(List(1, 2, 2, 1)))
           },
           testM("Invokes cleanups on interrupt - 1") {
+            import zio.CanFail.canFail
             for {
               effects <- Ref.make[List[Int]](Nil)
               res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))

--- a/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
@@ -116,10 +116,10 @@ object ZScheduleSpec
         ),
         suite("Retry on failure according to a provided strategy")(
           testM("retry 0 time for `once` when first time succeeds") {
-            def update(ref: Ref[Int]): ZIO[Any, String, Int] = ref.update(_ + 1)
+            import zio.CanFail.canFail
             for {
               ref <- Ref.make(0)
-              _   <- update(ref).retry(Schedule.once)
+              _   <- ref.update(_ + 1).retry(Schedule.once)
               i   <- ref.get
             } yield assert(i, equalTo(1))
           },

--- a/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZScheduleSpec.scala
@@ -116,9 +116,10 @@ object ZScheduleSpec
         ),
         suite("Retry on failure according to a provided strategy")(
           testM("retry 0 time for `once` when first time succeeds") {
+            def update(ref: Ref[Int]): ZIO[Any, String, Int] = ref.update(_ + 1)
             for {
               ref <- Ref.make(0)
-              _   <- ref.update(_ + 1).retry(Schedule.once)
+              _   <- update(ref).retry(Schedule.once)
               i   <- ref.get
             } yield assert(i, equalTo(1))
           },

--- a/core/shared/src/main/scala-2.11/zio/=!=.scala
+++ b/core/shared/src/main/scala-2.11/zio/=!=.scala
@@ -28,9 +28,9 @@ import scala.annotation.implicitNotFound
 trait =!=[A, B] extends Serializable
 
 object =!= {
-  def unexpected : Nothing = sys.error("Unexpected invocation")
+  def unexpected: Nothing = sys.error("Unexpected invocation")
 
-  implicit def neq[A, B] : A =!= B = new =!=[A, B] {}
-  implicit def neqAmbig1[A] : A =!= A = unexpected
-  implicit def neqAmbig2[A] : A =!= A = unexpected
+  implicit def neq[A, B]: A =!= B    = new =!=[A, B] {}
+  implicit def neqAmbig1[A]: A =!= A = unexpected
+  implicit def neqAmbig2[A]: A =!= A = unexpected
 }

--- a/core/shared/src/main/scala-2.11/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.11/zio/CanFail.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.annotation.implicitNotFound
+
+/**
+ * A value of type `CanFail[E]` provides implicit evidence that an effect with
+ * error type `E` can fail, that is, that `E` is not equal to `Nothing`.
+ */
+@implicitNotFound("This operation only makes sense for effects that can fail.")
+sealed trait CanFail[-E]
+
+object CanFail {
+
+  implicit final def canFail[E]: CanFail[E] =
+    new CanFail[E] {}
+
+  implicit final val cannotFail: CanFail[Nothing] =
+    new CanFail[Nothing] {}
+}

--- a/core/shared/src/main/scala-2.11/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.11/zio/CanFail.scala
@@ -27,9 +27,8 @@ sealed trait CanFail[-E]
 
 object CanFail extends CanFail[Any] {
 
-  implicit final def canFail[E]: CanFail[E] =
-    CanFail
+  implicit final def canFail[A >: Nothing, E >: A]: CanFail[E] = CanFail
 
-  implicit final val cannotFail: CanFail[Nothing] =
-    CanFail
+  implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
+  implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail
 }

--- a/core/shared/src/main/scala-2.11/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.11/zio/CanFail.scala
@@ -27,7 +27,7 @@ sealed trait CanFail[-E]
 
 object CanFail extends CanFail[Any] {
 
-  implicit final def canFail[A >: Nothing, E >: A]: CanFail[E] = CanFail
+  implicit final def canFail[E]: CanFail[E] = CanFail
 
   implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
   implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail

--- a/core/shared/src/main/scala-2.11/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.11/zio/CanFail.scala
@@ -25,11 +25,11 @@ import scala.annotation.implicitNotFound
 @implicitNotFound("This operation only makes sense for effects that can fail.")
 sealed trait CanFail[-E]
 
-object CanFail {
+object CanFail extends CanFail[Any] {
 
   implicit final def canFail[E]: CanFail[E] =
-    new CanFail[E] {}
+    CanFail
 
   implicit final val cannotFail: CanFail[Nothing] =
-    new CanFail[Nothing] {}
+    CanFail
 }

--- a/core/shared/src/main/scala-2.12+/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.12+/zio/CanFail.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.annotation.implicitAmbiguous
+
+/**
+ * A value of type `CanFail[E]` provides implicit evidence that an effect with
+ * error type `E` can fail, that is, that `E` is not equal to `Nothing`.
+ */
+sealed trait CanFail[-E]
+
+object CanFail {
+
+  implicit final def canFail[E]: CanFail[E] =
+    new CanFail[E] {}
+
+  @implicitAmbiguous("This operation only makes sense for effects that can fail.")
+  implicit final val cannotFail: CanFail[Nothing] =
+    new CanFail[Nothing] {}
+}

--- a/core/shared/src/main/scala-2.12+/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.12+/zio/CanFail.scala
@@ -26,10 +26,9 @@ sealed trait CanFail[-E]
 
 object CanFail extends CanFail[Any] {
 
-  implicit final def canFail[E]: CanFail[E] =
-    CanFail
+  implicit final def canFail[E]: CanFail[E] = CanFail
 
   @implicitAmbiguous("This operation only makes sense for effects that can fail.")
-  implicit final val cannotFail: CanFail[Nothing] =
-    CanFail
+  implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
+  implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail
 }

--- a/core/shared/src/main/scala-2.12+/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.12+/zio/CanFail.scala
@@ -24,12 +24,12 @@ import scala.annotation.implicitAmbiguous
  */
 sealed trait CanFail[-E]
 
-object CanFail {
+object CanFail extends CanFail[Any] {
 
   implicit final def canFail[E]: CanFail[E] =
-    new CanFail[E] {}
+    CanFail
 
   @implicitAmbiguous("This operation only makes sense for effects that can fail.")
   implicit final val cannotFail: CanFail[Nothing] =
-    new CanFail[Nothing] {}
+    CanFail
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -423,7 +423,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZIO[R, Nothing, B] =
+  final def fold[B](failure: E => B, success: A => B): ZIO[R, Nothing, B] =
     foldM(new ZIO.MapFn(failure), new ZIO.MapFn(success))
 
   /**
@@ -449,9 +449,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * The error parameter of the returned `IO` may be chosen arbitrarily, since
    * it will depend on the `IO`s returned by the given continuations.
    */
-  final def foldM[R1 <: R, E2, B](failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B])(
-    implicit ev: CanFail[E]
-  ): ZIO[R1, E2, B] =
+  final def foldM[R1 <: R, E2, B](failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]): ZIO[R1, E2, B] =
     foldCauseM(new ZIO.FoldCauseMFailureFn(failure), success)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -27,8 +27,6 @@ import zio.internal.{ Executor, Platform }
 import zio.{ InterruptStatus => InterruptS }
 import zio.{ TracingStatus => TracingS }
 
-import com.github.ghik.silencer.silent
-
 /**
  * A `ZIO[R, E, A]` ("Zee-Oh of Are Eeh Aye") is an immutable data structure
  * that models an effectful program. The effect requires an environment `R`,
@@ -107,7 +105,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Maps the error value of this effect to the specified constant value.
    */
-  @silent("never used")
   final def asError[E1](e1: => E1)(implicit ev: CanFail[E]): ZIO[R, E1, A] =
     mapError(new ZIO.ConstFn(() => e1))
 
@@ -115,7 +112,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
-  @silent("never used")
   final def bimap[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZIO[R, E2, B] = mapError(f).map(g)
 
   /**
@@ -211,7 +207,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * openFile("config.json").catchAll(_ => IO.succeed(defaultConfig))
    * }}}
    */
-  @silent("never used")
   final def catchAll[R1 <: R, E2, A1 >: A](h: E => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
     self.foldM[R1, E2, A1](h, new ZIO.SucceedFn(h))
 
@@ -236,7 +231,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * }
    * }}}
    */
-  @silent("never used")
   final def catchSome[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[E, ZIO[R1, E1, A1]]
   )(implicit ev: CanFail[E]): ZIO[R1, E1, A1] = {
@@ -302,7 +296,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * The error parameter of the returned `ZIO` is `Nothing`, since it is
    * guaranteed the `ZIO` effect does not model failure.
    */
-  @silent("never used")
   final def either(implicit ev: CanFail[E]): ZIO[R, Nothing, Either[E, A]] =
     self.foldM(ZIO.succeedLeft, ZIO.succeedRight)
 
@@ -336,7 +329,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Returns an effect that ignores errors and runs repeatedly until it eventually succeeds.
    */
-  @silent("never used")
   final def eventually(implicit ev: CanFail[E]): ZIO[R, Nothing, A] =
     self orElse eventually
 
@@ -402,7 +394,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * val parsed = readFile("foo.txt").flatMapError(error => logErrorToFile(error))
    * }}}
    */
-  @silent("never used")
   final def flatMapError[R1 <: R, E2](f: E => ZIO[R1, Nothing, E2])(implicit ev: CanFail[E]): ZIO[R1, E2, A] =
     flipWith(_ flatMap f)
 
@@ -432,7 +423,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  @silent("never used")
   final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZIO[R, Nothing, B] =
     foldM(new ZIO.MapFn(failure), new ZIO.MapFn(success))
 
@@ -459,7 +449,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * The error parameter of the returned `IO` may be chosen arbitrarily, since
    * it will depend on the `IO`s returned by the given continuations.
    */
-  @silent("never used")
   final def foldM[R1 <: R, E2, B](failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B])(
     implicit ev: CanFail[E]
   ): ZIO[R1, E2, B] =
@@ -576,7 +565,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * function. This can be used to lift a "smaller" error into a "larger"
    * error.
    */
-  @silent("never used")
   final def mapError[E2](f: E => E2)(implicit ev: CanFail[E]): ZIO[R, E2, A] =
     self.foldCauseM(new ZIO.MapErrorFn(f), new ZIO.SucceedFn(f))
 
@@ -664,7 +652,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Executes this effect, skipping the error but returning optionally the success.
    */
-  @silent("never used")
   final def option(implicit ev: CanFail[E]): ZIO[R, Nothing, Option[A]] =
     self.foldM(_ => IO.succeed(None), a => IO.succeed(Some(a)))
 
@@ -678,7 +665,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Translates effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  @silent("never used")
   final def orDie[E1 >: E](implicit ev1: E1 <:< Throwable, ev2: CanFail[E]): ZIO[R, Nothing, A] =
     orDieWith(ev1)
 
@@ -686,7 +672,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Keeps none of the errors, and terminates the fiber with them, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  @silent("never used")
   final def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZIO[R, Nothing, A] =
     (self mapError f) catchAll (IO.die)
 
@@ -694,7 +679,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Executes this effect and returns its value, if it succeeds, but
    * otherwise executes the specified effect.
    */
-  @silent("never used")
   final def orElse[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
     tryOrElse(that, new ZIO.SucceedFn(() => that))
 
@@ -702,7 +686,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Returns an effect that will produce the value of this effect, unless it
    * fails, in which case, it will produce the value of the specified effect.
    */
-  @silent("never used")
   final def orElseEither[R1 <: R, E2, B](that: => ZIO[R1, E2, B])(implicit ev: CanFail[E]): ZIO[R1, E2, Either[A, B]] =
     tryOrElse(that.map(Right(_)), ZIO.succeedLeft)
 
@@ -1012,7 +995,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Keeps some of the errors, and terminates the fiber with the rest
    */
-  @silent("never used")
   final def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZIO[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
@@ -1020,14 +1002,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Keeps some of the errors, and terminates the fiber with the rest, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  @silent("never used")
   final def refineOrDieWith[E1](pf: PartialFunction[E, E1])(f: E => Throwable)(implicit ev: CanFail[E]): ZIO[R, E1, A] =
     self catchAll (err => (pf lift err).fold[ZIO[R, E1, A]](ZIO.die(f(err)))(ZIO.fail(_)))
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  @silent("never used")
   final def refineToOrDie[E1: ClassTag](implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZIO[R, E1, A] =
     refineOrDieWith { case e: E1 => e }(ev1)
 
@@ -1101,7 +1081,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  @silent("never used")
   final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S])(implicit ev: CanFail[E]): ZIO[R1, E, A] =
     retryOrElse(policy, (e: E, _: S) => ZIO.fail(e))
 
@@ -1110,7 +1089,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * value produced by the schedule together with the last error are passed to
    * the recovery function.
    */
-  @silent("never used")
   final def retryOrElse[R1 <: R, A2 >: A, E1 >: E, S, E2](
     policy: ZSchedule[R1, E1, S],
     orElse: (E, S) => ZIO[R1, E2, A2]
@@ -1122,7 +1100,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * value produced by the schedule together with the last error are passed to
    * the recovery function.
    */
-  @silent("never used")
   final def retryOrElseEither[R1 <: R, E1 >: E, S, E2, B](
     policy: ZSchedule[R1, E1, S],
     orElse: (E, S) => ZIO[R1, E2, B]
@@ -1289,7 +1266,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * readFile("data.json").tapBoth(logError(_), logData(_))
    * }}}
    */
-  @silent("never used")
   final def tapBoth[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any], g: A => ZIO[R1, E1, Any])(
     implicit ev: CanFail[E]
   ): ZIO[R1, E1, A] =
@@ -1301,7 +1277,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * readFile("data.json").tapError(logError(_))
    * }}}
    */
-  @silent("never used")
   final def tapError[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any])(implicit ev: CanFail[E]): ZIO[R1, E1, A] =
     self.foldCauseM(new ZIO.TapErrorRefailFn(f), ZIO.succeed)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -25,7 +25,7 @@ import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
 import zio.internal.{ Executor, Platform }
 import zio.{ InterruptStatus => InterruptS }
-import zio.{ TracingStatus => TrasingS }
+import zio.{ TracingStatus => TracingS }
 
 import com.github.ghik.silencer.silent
 
@@ -2901,11 +2901,11 @@ object ZIO extends ZIOFunctions {
     override def tag = Tags.Trace
   }
 
-  private[zio] final class TracingStatus[R, E, A](val zio: ZIO[R, E, A], val flag: TrasingS) extends ZIO[R, E, A] {
+  private[zio] final class TracingStatus[R, E, A](val zio: ZIO[R, E, A], val flag: TracingS) extends ZIO[R, E, A] {
     override def tag = Tags.TracingStatus
   }
 
-  private[zio] final class CheckTracing[R, E, A](val k: TrasingS => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class CheckTracing[R, E, A](val k: TracingS => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.CheckTracing
   }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1561,7 +1561,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Operator alias for `orElse`.
    */
-  final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1]): ZIO[R1, E2, A1] =
+  final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
     orElse(that)
 
   final def <<<[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -423,7 +423,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  final def fold[B](failure: E => B, success: A => B): ZIO[R, Nothing, B] =
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZIO[R, Nothing, B] =
     foldM(new ZIO.MapFn(failure), new ZIO.MapFn(success))
 
   /**
@@ -449,7 +449,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * The error parameter of the returned `IO` may be chosen arbitrarily, since
    * it will depend on the `IO`s returned by the given continuations.
    */
-  final def foldM[R1 <: R, E2, B](failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]): ZIO[R1, E2, B] =
+  final def foldM[R1 <: R, E2, B](failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B])(
+    implicit ev: CanFail[E]
+  ): ZIO[R1, E2, B] =
     foldCauseM(new ZIO.FoldCauseMFailureFn(failure), success)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -92,7 +92,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Operator alias for `orElse`.
    */
-  final def <>[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1]): ZManaged[R1, E2, A1] =
+  final def <>[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     orElse(that)
 
   /**
@@ -147,19 +147,23 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
-  final def bimap[E1, A1](f: E => E1, g: A => A1): ZManaged[R, E1, A1] =
+  final def bimap[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZManaged[R, E1, A1] =
     mapError(f).map(g)
 
   /**
    * Recovers from all errors.
    */
-  final def catchAll[R1 <: R, E2, A1 >: A](h: E => ZManaged[R1, E2, A1]): ZManaged[R1, E2, A1] =
+  final def catchAll[R1 <: R, E2, A1 >: A](
+    h: E => ZManaged[R1, E2, A1]
+  )(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     foldM(h, ZManaged.succeed)
 
   /**
    * Recovers from some or all of the error cases.
    */
-  final def catchSome[R1 <: R, E1 >: E, A1 >: A](pf: PartialFunction[E, ZManaged[R1, E1, A1]]): ZManaged[R1, E1, A1] =
+  final def catchSome[R1 <: R, E1 >: E, A1 >: A](
+    pf: PartialFunction[E, ZManaged[R1, E1, A1]]
+  )(implicit ev: CanFail[E]): ZManaged[R1, E1, A1] =
     foldM(pf.applyOrElse[E, ZManaged[R1, E1, A1]](_, ZManaged.fail), ZManaged.succeed)
 
   /**
@@ -183,7 +187,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Returns an effect whose failure and success have been lifted into an
    * `Either`.The resulting effect cannot fail
    */
-  final def either: ZManaged[R, Nothing, Either[E, A]] =
+  final def either(implicit ev: CanFail[E]): ZManaged[R, Nothing, Either[E, A]] =
     fold(Left[E, A], Right[E, A])
 
   /**
@@ -245,7 +249,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Effectfully map the error channel
    */
-  final def flatMapError[R1 <: R, E2](f: E => ZManaged[R1, Nothing, E2]): ZManaged[R1, E2, A] =
+  final def flatMapError[R1 <: R, E2](f: E => ZManaged[R1, Nothing, E2])(implicit ev: CanFail[E]): ZManaged[R1, E2, A] =
     flipWith(_.flatMap(f))
 
   /**
@@ -274,7 +278,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  final def fold[B](failure: E => B, success: A => B): ZManaged[R, Nothing, B] =
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZManaged[R, Nothing, B] =
     foldM(failure.andThen(ZManaged.succeed), success.andThen(ZManaged.succeed))
 
   /**
@@ -293,7 +297,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   final def foldM[R1 <: R, E2, B](
     failure: E => ZManaged[R1, E2, B],
     success: A => ZManaged[R1, E2, B]
-  ): ZManaged[R1, E2, B] =
+  )(implicit ev: CanFail[E]): ZManaged[R1, E2, B] =
     ZManaged[R1, E2, B] {
       Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
@@ -389,7 +393,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Returns an effect whose failure is mapped by the specified `f` function.
    */
-  final def mapError[E1](f: E => E1): ZManaged[R, E1, A] =
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
     ZManaged(reserve.mapError(f).map(r => Reservation(r.acquire.mapError(f), r.release)))
 
   /**
@@ -433,35 +437,37 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Executes this effect, skipping the error but returning optionally the success.
    */
-  final def option: ZManaged[R, Nothing, Option[A]] =
+  final def option(implicit ev: CanFail[E]): ZManaged[R, Nothing, Option[A]] =
     fold(_ => None, Some(_))
 
   /**
    * Translates effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  final def orDie(implicit ev: E <:< Throwable): ZManaged[R, Nothing, A] =
-    orDieWith(ev)
+  final def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, Nothing, A] =
+    orDieWith(ev1)
 
   /**
    * Keeps none of the errors, and terminates the fiber with them, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  final def orDieWith(f: E => Throwable): ZManaged[R, Nothing, A] =
+  final def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
     mapError(f).catchAll(ZManaged.die)
 
   /**
    * Executes this effect and returns its value, if it succeeds, but
    * otherwise executes the specified effect.
    */
-  final def orElse[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1]): ZManaged[R1, E2, A1] =
+  final def orElse[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     foldM(_ => that, ZManaged.succeed)
 
   /**
    * Returns an effect that will produce the value of this effect, unless it
    * fails, in which case, it will produce the value of the specified effect.
    */
-  final def orElseEither[R1 <: R, E2, B](that: => ZManaged[R1, E2, B]): ZManaged[R1, E2, Either[A, B]] =
+  final def orElseEither[R1 <: R, E2, B](
+    that: => ZManaged[R1, E2, B]
+  )(implicit ev: CanFail[E]): ZManaged[R1, E2, Either[A, B]] =
     foldM(_ => that.map(Right[A, B]), a => ZManaged.succeed(Left[A, B](a)))
 
   /**
@@ -481,20 +487,24 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  final def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev: E <:< Throwable): ZManaged[R, E1, A] =
-    refineOrDieWith(pf)(ev)
+  final def refineOrDie[E1](
+    pf: PartialFunction[E, E1]
+  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
+    refineOrDieWith(pf)(ev1)
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  final def refineToOrDie[E1: ClassTag](implicit ev: E <:< Throwable): ZManaged[R, E1, A] =
-    refineOrDieWith { case e: E1 => e }(ev)
+  final def refineToOrDie[E1: ClassTag](implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
+    refineOrDieWith { case e: E1 => e }(ev1)
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  final def refineOrDieWith[E1](pf: PartialFunction[E, E1])(f: E => Throwable): ZManaged[R, E1, A] =
+  final def refineOrDieWith[E1](
+    pf: PartialFunction[E, E1]
+  )(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
     catchAll { e =>
       pf.lift(e).fold[ZManaged[R, E1, A]](ZManaged.die(f(e)))(ZManaged.fail)
     }
@@ -505,7 +515,7 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S]): ZManaged[R1, E1, A] = {
+  final def retry[R1 <: R, E1 >: E, S](policy: ZSchedule[R1, E1, S])(implicit ev: CanFail[E]): ZManaged[R1, E1, A] = {
     def loop[B](zio: ZIO[R, E1, B], state: policy.State): ZIO[R1, E1, (policy.State, B)] =
       zio.foldM(
         err =>

--- a/docs/datatypes/ref.md
+++ b/docs/datatypes/ref.md
@@ -90,7 +90,7 @@ object S {
               case false => IO.fail(())
               case true  => IO.unit
             }
-        } <> P).either.unit
+        } <> P).unit
       }
     }
 }

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -121,7 +121,9 @@ object BuildHelper {
           "-Xignore-scala2-macros"
         )
       case Some((2, 13)) =>
-        std2xOptions ++ optimizerOptions(optimize)
+        Seq(
+          "-Ywarn-unused:params,-implicits"
+        ) ++ std2xOptions ++ optimizerOptions(optimize)
       case Some((2, 12)) =>
         Seq(
           "-opt-warnings",
@@ -134,6 +136,7 @@ object BuildHelper {
           "-Ywarn-infer-any",
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit",
+          "-Ywarn-unused:params,-implicits",
           "-Xfuture",
           "-Xsource:2.13",
           "-Xmax-classfile-name",

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1178,7 +1178,7 @@ object StreamSpec
 
             for {
               merge <- s1.mergeEither(s2).runCollect
-            } yield assert(merge, hasSameElements(List(Left(1), Left(2), Right(1), Right(2))))
+            } yield assert[List[Either[Int, Int]]](merge, hasSameElements(List(Left(1), Left(2), Right(1), Right(2))))
           },
           testM("mergeWith") {
             val s1 = Stream(1, 2)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -505,7 +505,7 @@ object StreamSpec
             val stream   = fib(20)
             val expected = 6765
 
-            assertM(stream.runCollect.either, isRight(equalTo(List(expected))))
+            assertM(stream.runCollect, equalTo(List(expected)))
           },
           testM("left identity")(checkM(Gen.anyInt, Gen.function(pureStreamOfInts)) { (x, f) =>
             for {
@@ -1085,8 +1085,8 @@ object StreamSpec
             val s = Stream.fromIterable(data)
 
             for {
-              l <- s.mapM(f).runCollect.either
-              r <- IO.foreach(data)(f).either
+              l <- s.mapM(f).runCollect
+              r <- IO.foreach(data)(f)
             } yield assert(l, equalTo(r))
           }
         },
@@ -1169,18 +1169,16 @@ object StreamSpec
             val s2 = Stream(1, 2)
 
             for {
-              merge <- s1.mergeEither(s2).runCollect.either
-              list  = merge.fold[List[Either[Int, Int]]](_ => Nil, identity)
-            } yield assert(list, hasSameElements[Either[Int, Int]](List(Left(1), Left(2), Right(1), Right(2))))
+              merge <- s1.mergeEither(s2).runCollect
+            } yield assert(merge, hasSameElements(List(Left(1), Left(2), Right(1), Right(2))))
           },
           testM("mergeWith") {
             val s1 = Stream(1, 2)
             val s2 = Stream(1, 2)
 
             for {
-              merge <- s1.mergeWith(s2)(_.toString, _.toString).runCollect.either
-              list  = merge.fold[List[String]](_ => Nil, identity)
-            } yield assert(list, hasSameElements(List("1", "2", "1", "2")))
+              merge <- s1.mergeWith(s2)(_.toString, _.toString).runCollect
+            } yield assert(merge, hasSameElements(List("1", "2", "1", "2")))
           },
           testM("mergeWith short circuit") {
             val s1 = Stream(1, 2)


### PR DESCRIPTION
Resolves #2047.

Adds a new implicit instance `CanFail[E]` which provides implicit evidence that an effect with an error type `E` can fail, that is that `E` is not equal to `Nothing`. Requires such evidence to exist for ZIO combinators such as `orElse` that only make sense if an effect can fail.

Not implemented yet is adding annotations so that the implicit type does not appear in the Scaladoc. It looks like this has to be done through the `@useCase` annotation, but one watch out there is it requires you to specify the "simplified" type signature as a text string, so there is some risk that the documentation gets out of sync with the actual type signature since it is not tied to the code.

Also not implemented is applying this technique to other effect types such as `ZManaged` and `ZStream`.