### PR TITLE
Make ZStream.empty and ZStream.fail safe to pull again

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -12,6 +12,13 @@ object StreamPullSafetySpec
           Stream.empty.process
             .use(threePulls(_))
             .map(assert(_, equalTo(List(Left(None), Left(None), Left(None)))))
+        },
+        testM("Stream.fail is safe to pull again") {
+          Stream
+            .fail("Ouch")
+            .process
+            .use(threePulls(_))
+            .map(assert(_, equalTo(List(Left(Some("Ouch")), Left(None), Left(None)))))
         }
       )
     )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -1,0 +1,17 @@
+package zio.stream
+
+import zio._
+import zio.test._
+import zio.test.Assertion.equalTo
+import StreamUtils.threePulls
+
+object StreamPullSafetySpec
+    extends ZIOBaseSpec(
+      suite("StreamPullSafetySpec")(
+        testM("Stream.empty is safe to pull again") {
+          Stream.empty.process
+            .use(threePulls(_))
+            .map(assert(_, equalTo(List(Left(None), Left(None), Left(None)))))
+        }
+      )
+    )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -3,6 +3,7 @@ package zio.stream
 import zio.test.{ Gen, GenZIO, Sized }
 import zio.random.Random
 import zio._
+import ZStream.Pull
 import scala.concurrent.ExecutionContext
 
 trait StreamUtils extends ChunkUtils with GenZIO {
@@ -57,6 +58,13 @@ trait StreamUtils extends ChunkUtils with GenZIO {
 
   def takeUntil[A](as: List[A])(f: A => Boolean): List[A] =
     as.takeWhile(!f(_)) ++ as.dropWhile(!f(_)).take(1)
+
+  def threePulls[R, E, A](pull: Pull[R, E, A]): ZIO[R, Nothing, List[Either[Option[E], A]]] =
+    for {
+      e1 <- pull.either
+      e2 <- pull.either
+      e3 <- pull.either
+    } yield List(e1, e2, e3)
 }
 
 object StreamUtils extends StreamUtils with GenUtils {

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -345,6 +345,9 @@ private[stream] object StreamEffect extends Serializable {
   final def apply[R, E, A](pull: ZManaged[R, E, () => A]): StreamEffect[R, E, A] =
     new StreamEffect(pull)
 
+  final def fail[E](e: E): StreamEffect[Any, E, Nothing] =
+    StreamEffect(memoizeEnd(Managed.effectTotal(() => fail(e))))
+
   final def fromChunk[A](c: Chunk[A]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2789,7 +2789,7 @@ object ZStream {
    * The stream that always fails with `error`
    */
   final def fail[E](error: E): Stream[E, Nothing] =
-    halt(Cause.fail(error))
+    StreamEffect.fail[E](error)
 
   /**
    * Creates an empty stream that never fails and executes the finalizer when it ends.


### PR DESCRIPTION
Towards #1765.

@iravid 

I wanted to make `ZStream.fail`, which I consider to be a fairly simple constructor go through less ceremony and integrate better with _collections streams_ in `StreamEffect`. I think it might become more useful when we introduce element level error handling. I'm ok with reviewers deciding that we should revert that change.