### PR TITLE
readd ZSchedule#foldM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -68,19 +68,19 @@ object ScheduleSpec extends ZIOBaseSpec {
     suite("Collect all inputs into a list")(
       testM("as long as the condition f holds") {
         def cond: Int => Boolean = _ < 10
-        checkRepeat(Schedule.collectWhile(cond), expected = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        checkRepeat(Schedule.collectWhile(cond), expected = List(1, 2, 3, 4, 5, 6, 7, 8, 9))
       },
       testM("as long as the effectful condition f holds") {
         def cond = (x: Int) => IO.succeed(x > 10)
-        checkRepeat(Schedule.collectWhileM(cond), expected = List(1))
+        checkRepeat(Schedule.collectWhileM(cond), expected = Nil)
       },
       testM("until the effectful condition f fails") {
-        def cond = (_: Int) < 10
+        def cond = (i: Int) => i < 10 && i > 1
         checkRepeat(Schedule.collectUntil(cond), expected = List(1))
       },
       testM("until the effectful condition f fails") {
         def cond = (x: Int) => IO.succeed(x > 10)
-        checkRepeat(Schedule.collectUntilM(cond), expected = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+        checkRepeat(Schedule.collectUntilM(cond), expected = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
       }
     ),
     testM("Repeat on failure does not actually repeat") {

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -371,15 +371,21 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
    * Returns a new schedule that folds over the outputs of this one.
    */
   final def fold[Z](z: Z)(f: (Z, B) => Z): Schedule[R, A, Z] =
-    new Schedule[R, A, Z] {
+    foldM(z)((z, b) => ZIO.succeed(f(z, b)))
+
+  /**
+   * Returns a new schedule that effectfully folds over the outputs of this one.
+   */
+  final def foldM[R1 <: R, Z](z: Z)(f: (Z, B) => ZIO[R1, Nothing, Z]): Schedule[R1, A, Z] =
+    new Schedule[R1, A, Z] {
       type State = (self.State, Z)
       val initial = self.initial.map((_, z))
-      val extract = (a: A, s: (self.State, Z)) => f(s._2, self.extract(a, s._1))
-
+      val extract = (_: A, s: (self.State, Z)) => s._2
       val update = (a: A, s: (self.State, Z)) =>
-        self
-          .update(a, s._1)
-          .map(s1 => (s1, f(s._2, self.extract(a, s._1))))
+        for {
+          s1 <- self.update(a, s._1)
+          z1 <- f(s._2, self.extract(a, s._1))
+        } yield (s1, z1)
     }
 
   /**


### PR DESCRIPTION
Seems we missed a few things in the larger schedule pr.

Also changes the behavior of both fold and foldM to until consider values if the schedule intends to continue.