### PR TITLE
Implement NeedsEnv

### DIFF
--- a/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
@@ -1,0 +1,33 @@
+package zio
+
+import zio.test.{ test => test0, _ }
+
+object NeedsEnvSpec
+    extends ZIOBaseSpec(
+      suite("NeedsEnvSpec")(
+        test0("useful combinators compile") {
+          assertCompiles {
+            """
+            import zio._
+            import zio.console._
+
+            val sayHello = console.putStrLn("Hello, World!")
+
+            sayHello.provide(Console.Live)
+            """
+          }
+        },
+        test0("useless combinators don't compile") {
+          !assertCompiles {
+            """
+            import zio._
+            import zio.console._
+
+            val uio = UIO.succeed("Hello, World!")
+
+            uio.provide(Clock.Live)
+            """
+          }
+        }
+      )
+    )

--- a/core/shared/src/main/scala-2.11/zio/NeedsEnv.scala
+++ b/core/shared/src/main/scala-2.11/zio/NeedsEnv.scala
@@ -19,17 +19,18 @@ package zio
 import scala.annotation.implicitNotFound
 
 /**
- * A value of type `CanFail[E]` provides implicit evidence that an effect with
- * error type `E` can fail, that is, that `E` is not equal to `Nothing`.
+ * A value of type `NeedsEnv[R]` provides implicit evidence that an effect with
+ * environment type `R` needs an environment, that is, that `R` is not equal to
+ * `Any`.
  */
-@implicitNotFound("This operation only makes sense for effects that can fail.")
-sealed trait CanFail[-E]
+@implicitNotFound("This operation only makes sense for effects that need an environment.")
+sealed trait NeedsEnv[+R]
 
-object CanFail extends CanFail[Any] {
+object NeedsEnv extends NeedsEnv[Nothing] {
 
-  implicit final def canFail[E]: CanFail[E] = CanFail
+  implicit final def needsEnv[R]: NeedsEnv[R] = NeedsEnv
 
-  // Provide multiple ambiguous values so an implicit CanFail[Nothing] cannot be found.
-  implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
-  implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail
+  // Provide multiple ambiguous values so an implicit NeedsEnv[Any] cannot be found.
+  implicit final val needsEnvAmbiguous1: NeedsEnv[Any] = NeedsEnv
+  implicit final val needsEnvAmbiguous2: NeedsEnv[Any] = NeedsEnv
 }

--- a/core/shared/src/main/scala-2.12+/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.12+/zio/CanFail.scala
@@ -28,6 +28,7 @@ object CanFail extends CanFail[Any] {
 
   implicit final def canFail[E]: CanFail[E] = CanFail
 
+  // Provide multiple ambiguous values so an implicit CanFail[Nothing] cannot be found.
   @implicitAmbiguous("This operation only makes sense for effects that can fail.")
   implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
   implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail

--- a/core/shared/src/main/scala-2.12+/zio/NeedsEnv.scala
+++ b/core/shared/src/main/scala-2.12+/zio/NeedsEnv.scala
@@ -16,20 +16,21 @@
 
 package zio
 
-import scala.annotation.implicitNotFound
+import scala.annotation.implicitAmbiguous
 
 /**
- * A value of type `CanFail[E]` provides implicit evidence that an effect with
- * error type `E` can fail, that is, that `E` is not equal to `Nothing`.
+ * A value of type `NeedsEnv[R]` provides implicit evidence that an effect with
+ * environment type `R` needs an environment, that is, that `R` is not equal to
+ * `Any`.
  */
-@implicitNotFound("This operation only makes sense for effects that can fail.")
-sealed trait CanFail[-E]
+sealed trait NeedsEnv[+R]
 
-object CanFail extends CanFail[Any] {
+object NeedsEnv extends NeedsEnv[Nothing] {
 
-  implicit final def canFail[E]: CanFail[E] = CanFail
+  implicit final def needsEnv[R]: NeedsEnv[R] = NeedsEnv
 
-  // Provide multiple ambiguous values so an implicit CanFail[Nothing] cannot be found.
-  implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
-  implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail
+  // Provide multiple ambiguous values so an implicit NeedsEnv[Any] cannot be found.
+  @implicitAmbiguous("This operation only makes sense for effects that need an environment.")
+  implicit final val needsEnvAmbiguous1: NeedsEnv[Any] = NeedsEnv
+  implicit final val needsEnvAmbiguous2: NeedsEnv[Any] = NeedsEnv
 }

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -474,14 +474,14 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
    * Provides the `ZManaged` effect with its required environment, which eliminates
    * its dependency on `R`.
    */
-  final def provide(r: R): ZManaged[Any, E, A] =
+  final def provide(r: R)(implicit ev: NeedsEnv[R]): ZManaged[Any, E, A] =
     provideSome(_ => r)
 
   /**
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  final def provideSome[R0](f: R0 => R): ZManaged[R0, E, A] =
+  final def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): ZManaged[R0, E, A] =
     ZManaged(reserve.provideSome(f).map(r => Reservation(r.acquire.provideSome(f), e => r.release(e).provideSome(f))))
 
   /**

--- a/core/shared/src/main/scala/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/zio/ZSchedule.scala
@@ -502,13 +502,13 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
   /**
    * Provide all requirements to the schedule.
    */
-  final def provide(r: R): ZSchedule[Any, A, B] =
+  final def provide(r: R)(implicit ev: NeedsEnv[R]): ZSchedule[Any, A, B] =
     provideSome(_ => r)
 
   /**
    * Provide some of the requirements to the schedule.
    */
-  final def provideSome[R1](f: R1 => R): ZSchedule[R1, A, B] =
+  final def provideSome[R1](f: R1 => R)(implicit ev: NeedsEnv[R]): ZSchedule[R1, A, B] =
     new ZSchedule[R1, A, B] {
       type State = self.State
       val initial = self.initial.provideSome(f)

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -231,7 +231,7 @@ import zio.test._
 import zio.test.Assertion._
 
 val event = new AccountEvent {}
-val app = AccountObserver.>.processEvent(event)
+val app: ZIO[AccountObserver, Nothing, Unit] = AccountObserver.>.processEvent(event)
 val mockEnv: Managed[Nothing, MockConsole] = (
   MockSpec.expectIn(MockConsole.Service.putStrLn)(equalTo(s"Got $event")) *>
   MockSpec.expectOut(MockConsole.Service.getStrLn)("42") *>

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -417,7 +417,7 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
   /**
    * Narrows the environment by partially building it with `f`
    */
-  final def provideSome[R1](f: R1 => R): ZSink[R1, E, A0, A, B] =
+  final def provideSome[R1](f: R1 => R)(implicit ev: NeedsEnv[R]): ZSink[R1, E, A0, A, B] =
     new ZSink[R1, E, A0, A, B] {
       type State = self.State
       val initial                  = self.initial.provideSome(f)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1772,21 +1772,21 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Provides the stream with its required environment, which eliminates
    * its dependency on `R`.
    */
-  final def provide(r: R): Stream[E, A] =
+  final def provide(r: R)(implicit ev: NeedsEnv[R]): Stream[E, A] =
     ZStream(self.process.provide(r).map(_.provide(r)))
 
   /**
    * An effectual version of `provide`, useful when the act of provision
    * requires an effect.
    */
-  final def provideM[E1 >: E](r: ZIO[Any, E1, R]): Stream[E1, A] =
+  final def provideM[E1 >: E](r: ZIO[Any, E1, R])(implicit ev: NeedsEnv[R]): Stream[E1, A] =
     provideSomeM(r)
 
   /**
    * Uses the given [[Managed]] to provide the environment required to run this stream,
    * leaving no outstanding environments.
    */
-  final def provideManaged[E1 >: E](m: Managed[E1, R]): Stream[E1, A] =
+  final def provideManaged[E1 >: E](m: Managed[E1, R])(implicit ev: NeedsEnv[R]): Stream[E1, A] =
     ZStream {
       for {
         r  <- m
@@ -1798,7 +1798,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  final def provideSome[R0](env: R0 => R): ZStream[R0, E, A] =
+  final def provideSome[R0](env: R0 => R)(implicit ev: NeedsEnv[R]): ZStream[R0, E, A] =
     ZStream {
       for {
         r0 <- ZManaged.environment[R0]
@@ -1810,7 +1810,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R]): ZStream[R0, E1, A] =
+  final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStream[R0, E1, A] =
     ZStream {
       for {
         r  <- env.toManaged_
@@ -1822,7 +1822,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Uses the given [[ZManaged]] to provide some of the environment required to run
    * this stream, leaving the remainder `R0`.
    */
-  final def provideSomeManaged[R0, E1 >: E](env: ZManaged[R0, E1, R]): ZStream[R0, E1, A] =
+  final def provideSomeManaged[R0, E1 >: E](env: ZManaged[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStream[R0, E1, A] =
     ZStream {
       for {
         r  <- env

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -437,42 +437,44 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) { self =>
    * Provides the stream with its required environment, which eliminates
    * its dependency on `R`.
    */
-  final def provide(r: R): StreamChunk[E, A] =
+  final def provide(r: R)(implicit ev: NeedsEnv[R]): StreamChunk[E, A] =
     provideSome(_ => r)
 
   /**
    * An effectful version of `provide`, useful when the act of provision
    * requires an effect.
    */
-  final def provideM[E1 >: E](r: IO[E1, R]): StreamChunk[E1, A] =
+  final def provideM[E1 >: E](r: IO[E1, R])(implicit ev: NeedsEnv[R]): StreamChunk[E1, A] =
     provideSomeM(r)
 
   /**
    * Uses the given [[Managed]] to provide the environment required to run this stream,
    * leaving no outstanding environments.
    */
-  final def provideManaged[E1 >: E](m: Managed[E1, R]): StreamChunk[E1, A] =
+  final def provideManaged[E1 >: E](m: Managed[E1, R])(implicit ev: NeedsEnv[R]): StreamChunk[E1, A] =
     provideSomeManaged(m)
 
   /**
    * Provides some of the environment reuqired to run this effect,
    * leaving the remainder `R0`.
    */
-  final def provideSome[R0](env: R0 => R): ZStreamChunk[R0, E, A] =
+  final def provideSome[R0](env: R0 => R)(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E, A] =
     ZStreamChunk(chunks.provideSome(env))
 
   /**
    * Effectfully provides some of the environment required to run this effect
    * leaving the remainder `R0`.
    */
-  final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R]): ZStreamChunk[R0, E1, A] =
+  final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E1, A] =
     ZStreamChunk(chunks.provideSomeM(env))
 
   /**
    * Uses the given [[Managed]] to provide some of the environment required to run
    * this stream, leaving the remainder `R0`.
    */
-  final def provideSomeManaged[R0, E1 >: E](env: ZManaged[R0, E1, R]): ZStreamChunk[R0, E1, A] =
+  final def provideSomeManaged[R0, E1 >: E](
+    env: ZManaged[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E1, A] =
     ZStreamChunk(chunks.provideSomeManaged(env))
 
   /**

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ Cause, Managed, ZIO }
+import zio.{ Cause, Managed, NeedsEnv, ZIO }
 
 import Spec._
 
@@ -212,7 +212,7 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
    * Uses the specified `Managed` to provide each test in this spec with its
    * required environment.
    */
-  final def provideManaged[E1 >: E](managed: Managed[E1, R]): Spec[Any, E1, L, T] =
+  final def provideManaged[E1 >: E](managed: Managed[E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, L, T] =
     transform[Any, E1, L, T] {
       case SuiteCase(label, specs, exec) => SuiteCase(label, specs.provideManaged(managed), exec)
       case TestCase(label, test)         => TestCase(label, test.provideManaged(managed))
@@ -224,7 +224,7 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
    * act of creating the environment is expensive and should only be performed
    * once.
    */
-  final def provideManagedShared[E1 >: E](managed: Managed[E1, R]): Spec[Any, E1, L, T] = {
+  final def provideManagedShared[E1 >: E](managed: Managed[E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, L, T] = {
     def loop(r: R)(spec: Spec[R, E, L, T]): ZIO[Any, E, Spec[Any, E, L, T]] =
       spec.caseValue match {
         case SuiteCase(label, specs, exec) =>

--- a/test/shared/src/main/scala/zio/test/environment/Live.scala
+++ b/test/shared/src/main/scala/zio/test/environment/Live.scala
@@ -16,7 +16,7 @@
 
 package zio.test.environment
 
-import zio.{ IO, UIO, ZIO }
+import zio.{ IO, NeedsEnv, UIO, ZIO }
 
 /**
  * The `Live` trait provides access to the "live" environment from within the
@@ -51,7 +51,7 @@ object Live {
   /**
    * Provides an effect with the "live" environment.
    */
-  def live[R, E, A](zio: ZIO[R, E, A]): ZIO[Live[R], E, A] =
+  def live[R, E, A](zio: ZIO[R, E, A])(implicit ev: NeedsEnv[R]): ZIO[Live[R], E, A] =
     ZIO.accessM[Live[R]](_.live.provide(zio))
 
   /**
@@ -88,6 +88,8 @@ object Live {
    * while ensuring that the effect itself is provided with the test
    * environment.
    */
-  def withLive[R, R1, E, E1, A, B](zio: ZIO[R, E, A])(f: IO[E, A] => ZIO[R1, E1, B]): ZIO[R with Live[R1], E1, B] =
+  def withLive[R, R1, E, E1, A, B](
+    zio: ZIO[R, E, A]
+  )(f: IO[E, A] => ZIO[R1, E1, B])(implicit ev: NeedsEnv[R1]): ZIO[R with Live[R1], E1, B] =
     ZIO.environment[R].flatMap(r => live(f(zio.provide(r))))
 }

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ IO, ZIO }
+import zio.{ IO, NeedsEnv, ZIO }
 
 import zio.Managed
 
@@ -77,7 +77,7 @@ package object environment {
    * environment. This is useful for performing effects such as timing out
    * tests, accessing the real time, or printing to the real console.
    */
-  def live[R, E, A](zio: ZIO[R, E, A]): ZIO[Live[R], E, A] =
+  def live[R, E, A](zio: ZIO[R, E, A])(implicit ev: NeedsEnv[R]): ZIO[Live[R], E, A] =
     Live.live(zio)
 
   /**
@@ -91,7 +91,9 @@ package object environment {
    *  withLive(test)(_.timeout(duration))
    * }}}
    */
-  def withLive[R, R1, E, E1, A, B](zio: ZIO[R, E, A])(f: IO[E, A] => ZIO[R1, E1, B]): ZIO[R with Live[R1], E1, B] =
+  def withLive[R, R1, E, E1, A, B](
+    zio: ZIO[R, E, A]
+  )(f: IO[E, A] => ZIO[R1, E1, B])(implicit ev: NeedsEnv[R1]): ZIO[R with Live[R1], E1, B] =
     Live.withLive(zio)(f)
 
   /**


### PR DESCRIPTION
Implements `NeedsEnv` so that useless combinators involving effects that don't require an environment don't compile.