### PR TITLE
Address Flaky Tests

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -7,7 +7,7 @@ import zio.clock.Clock
 import zio.duration._
 import zio.test._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ jvm, nonFlaky }
+import zio.test.TestAspect.{ flaky, jvm, nonFlaky }
 
 object RTSSpec
     extends ZIOBaseSpec(
@@ -59,7 +59,7 @@ object RTSSpec
             } yield result == 42
 
           assertM(io, isTrue)
-        } @@ jvm(nonFlaky(100)),
+        } @@ flaky,
         testM("interruption of unending bracket") {
           val io =
             for {

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import zio.blocking.BlockingSpecUtil._
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect._
+import zio.test.TestAspect.ignore
 import zio.test._
 import zio.{ UIO, ZIOBaseSpec }
 
@@ -21,7 +21,7 @@ object BlockingSpec
           },
           testM("effectBlocking can be interrupted") {
             assertM(effectBlocking(Thread.sleep(50000)).timeout(Duration.Zero), isNone)
-          } @@ timeout(10.millis) @@ flaky, //todo fix in #1882 - shouldn't be flaky or require timeout
+          } @@ ignore,
           testM("effectBlockingCancelable can be interrupted") {
             val release = new AtomicBoolean(false)
             val cancel  = UIO.effectTotal(release.set(true))

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -5,6 +5,7 @@ import zio._
 import zio.duration._
 import zio.test._
 import zio.test.Assertion._
+import zio.test.TestAspect._
 import STMSpecUtil._
 
 object STMSpec
@@ -399,7 +400,7 @@ object STMSpec
             } yield assert(sum, equalTo(0) || equalTo(2))
 
             repeat(race, 100000)
-          }
+          } @@ flaky
         }
       )
     )


### PR DESCRIPTION
Makes the following changes based on my review of recent build failures to make CI a reliable indicator for new PRs in advance of Berlin hackathon:

- Marks  "effectBlockingCanBeInterrupted" in `BlockingSpec` as `ignore`. It appears that `effectBlocking` can't always be interrupted, leading to a resource leak, which is hampering our ability to address by just marking it as `flaky`.
- Marks "read only STM shouldn't return partial state of concurrent read-write STM" in `STMSpec` as flaky. I have seen this fail several times on recent builds.
- Marks "cancellation is guaranteed" in `RTSSpec` as `flaky` and removes previous `nonFlaky` test aspect. The fact that it was still only failing sometimes even with `nonFlaky` indicates that this is an infrequent bug but still something going on here.

Obviously we should treat these as things we need to fix, maybe while we are in Berlin, but it will be a lot nicer for everyone if red means there is something wrong with your code instead of a spurious test failure.