### PR TITLE
Adapt `ZIO.someOrFailException` to improve interop with error types

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -246,6 +246,26 @@ object ZIOSpec
             assertM(ZIO.succeed(Left(2)).rightOrFailException.run, fails(Assertion.anything))
           }
         ),
+        suite("someOrFailException")(
+          suite("without another error type")(
+            testM("succeed something") {
+              assertM(ZIO.succeed(Option(3)).someOrFailException, equalTo(3))
+            },
+            testM("succeed nothing") {
+              assertM(ZIO.succeed(None: Option[Int]).someOrFailException.run, fails(Assertion.anything))
+            }
+          ),
+          suite("with throwable as base error type")(
+            testM("return something") {
+              assertM(Task(Option(3)).someOrFailException, equalTo(3))
+            }
+          ),
+          suite("with exception as base error type")(
+            testM("return something") {
+              assertM((ZIO.succeed(Option(3)): IO[Exception, Option[Int]]).someOrFailException, equalTo(3))
+            }
+          )
+        ),
         suite("RTS synchronous correctness")(
           testM("widen Nothing") {
             val op1 = IO.effectTotal[String]("1")

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1151,10 +1151,10 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Extracts the optional value, or fails with a [[java.util.NoSuchElementException]]
    */
-  def someOrFailException[B, E1 >: NoSuchElementException](implicit ev: A <:< Option[B], ev2: E <:< E1): ZIO[R, E1, B] =
-    self.foldM(e => ZIO.fail(ev2(e)), ev(_) match {
+  def someOrFailException[B, E1 >: E](implicit ev: A <:< Option[B], ev2: NoSuchElementException <:< E1): ZIO[R, E1, B] =
+    self.foldM(e => ZIO.fail(e), ev(_) match {
       case Some(value) => ZIO.succeed(value)
-      case None        => ZIO.fail(new NoSuchElementException("None.get"))
+      case None        => ZIO.fail(ev2(new NoSuchElementException("None.get")))
     })
 
   /**


### PR DESCRIPTION
This PR adapts the signature of `ZIO.someOrFailException` to better work with commonly used error types like `Throwable`. For example, without this PR,
```scala
Task(Option(3)).someOrFailException
```
does not compile, but with this PR, it does.

Something that does not yet compile is `(io: IO[E, Option[A]]).someOrFailException` if `E` is not a supertype of `NoSuchElementException`, like `(io: IO[IllegalArgumentException, Option[A]]).someOrFailException`. Ideally, this should work, with the error type of the result being the most specific common supertype of `E` and `NoSuchElementException`, but I didn't yet find a way to achieve this.

In any way, this PR is an improvement over the existing state of affairs.