### PR TITLE
Reimplement RaceWith in the ZIO runloop

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -307,11 +307,11 @@ class StacktracesSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     uploadUsers(List(new User)) causeMust { cause =>
       (cause.traces.head.stackTrace must have size 2) and
         (cause.traces.head.stackTrace.head must mentionMethod("uploadUsers")) and
-        (cause.traces(1).stackTrace must have size 1) and
+        (cause.traces(1).stackTrace must have size 0) and
         (cause.traces(1).executionTrace must have size 1) and
         (cause.traces(1).executionTrace.head must mentionMethod("uploadTo")) and
         (cause.traces(1).parentTrace must not be empty) and
-        (cause.traces(1).parentTrace.get.stackTrace must mentionMethod("uploadUsers"))
+        (cause.traces(1).parentTrace.get.parentTrace.get.stackTrace must mentionMethod("uploadUsers"))
     }
   }
 

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -12,11 +12,11 @@ object StackBoolSpec
     extends ZIOBaseSpec(
       suite("StackBoolSpec")(
         testM("Size tracking") {
-          checkAll(gen)(list => assert(StackBool(list).size.toInt, equalTo(list.length)))
+          checkAll(gen)(list => assert(StackBool.fromIterable(list).size.toInt, equalTo(list.length)))
         },
         testM("From/to list identity") {
           checkAll(gen) { list =>
-            assert(StackBool(list).toList, equalTo(list))
+            assert(StackBool.fromIterable(list).toList, equalTo(list))
           }
         },
         testM("Push/pop example") {

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -12,11 +12,11 @@ object StackBoolSpec
     extends ZIOBaseSpec(
       suite("StackBoolSpec")(
         testM("Size tracking") {
-          checkAll(gen)(list => assert(StackBool(list: _*).size.toInt, equalTo(list.length)))
+          checkAll(gen)(list => assert(StackBool(list).size.toInt, equalTo(list.length)))
         },
         testM("From/to list identity") {
           checkAll(gen) { list =>
-            assert(StackBool(list: _*).toList, equalTo(list))
+            assert(StackBool(list).toList, equalTo(list))
           }
         },
         testM("Push/pop example") {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1502,12 +1502,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       }
 
     val g = (b: B, a: A) => f(a, b)
-    (self raceWith that)(coordinate(f, true), coordinate(g, false)).fork.flatMap { f =>
-      f.await.flatMap { exit =>
-        if (exit.succeeded) f.inheritFiberRefs *> ZIO.done(exit)
-        else ZIO.done(exit)
-      }
-    }
+    (self raceWith that)(coordinate(f, true), coordinate(g, false))
   }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -924,57 +924,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Returns an effect that races this effect with the specified effect, calling
    * the specified finisher as soon as one result or the other has been computed.
    */
-  final def raceWith[R1 <: R, E1, E2, B, C](
-    that: ZIO[R1, E1, B]
-  )(
+  final def raceWith[R1 <: R, E1, E2, B, C](that: ZIO[R1, E1, B])(
     leftDone: (Exit[E, A], Fiber[E1, B]) => ZIO[R1, E2, C],
     rightDone: (Exit[E1, B], Fiber[E, A]) => ZIO[R1, E2, C]
-  ): ZIO[R1, E2, C] = {
-    def arbiter[E0, E1, A, B](
-      f: (Exit[E0, A], Fiber[E1, B]) => ZIO[R1, E2, C],
-      winner: Fiber[E0, A],
-      loser: Fiber[E1, B],
-      leftWins: Boolean,
-      raceDone: Ref[Boolean],
-      inherit: Ref[Option[Boolean]],
-      done: Promise[E2, C]
-    )(res: Exit[E0, A]): URIO[R1, Any] = {
-
-      val handleRes =
-        winner.poll.flatMap {
-          case Some(Exit.Success(_)) => winner.inheritFiberRefs
-          case _                     => ZIO.unit
-        } *> (f(res, loser) <* inherit.set(Some(leftWins))).to(done)
-
-      ZIO.flatten(raceDone.modify(b => (if (b) ZIO.unit else handleRes) -> true))
-    }
-
-    for {
-      done     <- Promise.make[E2, C]
-      raceDone <- Ref.make[Boolean](false)
-      inherit  <- Ref.make(None: Option[Boolean])
-      c <- ZIO.uninterruptibleMask { restore =>
-            for {
-              left  <- ZIO.interruptible(self).forkInternal
-              right <- ZIO.interruptible(that).forkInternal
-              left2 <- left.await
-                        .flatMap(arbiter(leftDone, left, right, true, raceDone, inherit, done))
-                        .forkInternal
-              right2 <- right.await
-                         .flatMap(arbiter(rightDone, right, left, false, raceDone, inherit, done))
-                         .forkInternal
-
-              inheritFiberRefs = inherit.get.flatMap {
-                case None        => ZIO.unit
-                case Some(true)  => left2.inheritFiberRefs
-                case Some(false) => right2.inheritFiberRefs
-              }
-
-              c <- restore(done.await <* inheritFiberRefs).onInterrupt(left.interrupt *> right.interrupt)
-            } yield c
-          }
-    } yield c
-  }
+  ): ZIO[R1, E2, C] =
+    new ZIO.RaceWith[R1, E, E1, E2, A, B, C](
+      self,
+      that,
+      leftDone,
+      rightDone
+    )
 
   /**
    * Attach a wrapping trace pointing to this location in case of error.
@@ -1524,7 +1483,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * in parallel, combining their results with the specified `f` function. If
    * either side fails, then the other side will be interrupted.
    */
-  final def zipWithPar[R1 <: R, E1 >: E, B, C](that: ZIO[R1, E1, B])(f: (A, B) => C): ZIO[R1, E1, C] = {
+  final def zipWithPar[R1 <: R, E1 >: E, B, C](
+    that: ZIO[R1, E1, B]
+  )(f: (A, B) => C): ZIO[R1, E1, C] = {
     def coordinate[A, B](
       f: (A, B) => C,
       leftWinner: Boolean
@@ -1539,8 +1500,14 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               else ZIO.halt(loserCause && cause)
           }
       }
+
     val g = (b: B, a: A) => f(a, b)
-    (self raceWith that)(coordinate(f, true), coordinate(g, false))
+    (self raceWith that)(coordinate(f, true), coordinate(g, false)).fork.flatMap { f =>
+      f.await.flatMap { exit =>
+        if (exit.succeeded) f.inheritFiberRefs *> ZIO.done(exit)
+        else ZIO.done(exit)
+      }
+    }
   }
 
   /**
@@ -2796,6 +2763,7 @@ object ZIO extends ZIOFunctions {
     final val TracingStatus            = 20
     final val CheckTracing             = 21
     final val EffectSuspendTotalWith   = 22
+    final val RaceWith                 = 23
   }
   private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A])
       extends ZIO[R, E, A] {
@@ -2907,5 +2875,14 @@ object ZIO extends ZIOFunctions {
 
   private[zio] final class CheckTracing[R, E, A](val k: TracingS => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.CheckTracing
+  }
+
+  private[zio] final class RaceWith[R, EL, ER, E, A, B, C](
+    val left: ZIO[R, EL, A],
+    val right: ZIO[R, ER, B],
+    val leftWins: (Exit[EL, A], Fiber[ER, B]) => ZIO[R, E, C],
+    val rightWins: (Exit[ER, B], Fiber[EL, A]) => ZIO[R, E, C]
+  ) extends ZIO[R, E, C] {
+    override def tag: Int = Tags.RaceWith
   }
 }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -255,7 +255,7 @@ private[zio] final class FiberContext[E, A](
             complete(right, left, race.rightWins, rightRegister, raceIndicator, cb)
         }
       }
-      .onInterrupt(left.interrupt *> right.interrupt)
+      .onInterrupt(left.interrupt.flatMap(_ => right.interrupt))
   }
 
   /**

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,13 +16,13 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
 
 import com.github.ghik.silencer.silent
+import zio._
 import zio.internal.FiberContext.{ FiberRefLocals, SuperviseStatus }
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.tracing.ZIOFn
-import zio._
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
@@ -205,6 +205,58 @@ private[zio] final class FiberContext[E, A](
   }
 
   private[this] final def executor: Executor = executors.peekOrElse(platform.executor)
+
+  @inline private[this] final def raceWithImpl[R, EL, ER, E, A, B, C](
+    race: ZIO.RaceWith[R, EL, ER, E, A, B, C]
+  ): ZIO[R, E, C] = {
+    @inline def complete[E0, E1, A, B](
+      winner: Fiber[E0, A],
+      loser: Fiber[E1, B],
+      cont: (Exit[E0, A], Fiber[E1, B]) => ZIO[R, E, C],
+      winnerExit: Exit[E0, A],
+      ab: AtomicBoolean,
+      cb: ZIO[R, E, C] => Unit
+    ): Unit =
+      if (ab.compareAndSet(true, false)) {
+        winnerExit match {
+          case exit: Exit.Success[_] =>
+            cb(winner.inheritFiberRefs.flatMap(_ => cont(exit, loser)))
+          case exit: Exit.Failure[_] =>
+            cb(cont(exit, loser))
+        }
+      }
+
+    val raceIndicator = new AtomicBoolean(true)
+
+    val left  = fork[EL, A](race.left.interruptible.asInstanceOf[IO[EL, A]])
+    val right = fork[ER, B](race.right.interruptible.asInstanceOf[IO[ER, B]])
+
+    supervise(left)
+    supervise(right)
+
+    ZIO
+      .effectAsync[R, E, C] { cb =>
+        val leftRegister = left.register0 {
+          case exit0: Exit.Success[Exit[EL, A]] =>
+            complete[EL, ER, A, B](left, right, race.leftWins, exit0.value, raceIndicator, cb)
+          case exit: Exit.Failure[_] => complete(left, right, race.leftWins, exit, raceIndicator, cb)
+        }
+
+        if (leftRegister ne null)
+          complete(left, right, race.leftWins, leftRegister, raceIndicator, cb)
+        else {
+          val rightRegister = right.register0 {
+            case exit0: Exit.Success[Exit[_, _]] =>
+              complete(right, left, race.rightWins, exit0.value, raceIndicator, cb)
+            case exit: Exit.Failure[_] => complete(right, left, race.rightWins, exit, raceIndicator, cb)
+          }
+
+          if (rightRegister ne null)
+            complete(right, left, race.rightWins, rightRegister, raceIndicator, cb)
+        }
+      }
+      .onInterrupt(left.interrupt *> right.interrupt)
+  }
 
   /**
    * The main interpreter loop for `IO` actions. For purely synchronous actions,
@@ -522,6 +574,9 @@ private[zio] final class FiberContext[E, A](
 
                   curZio = nextInstr(result)
 
+                case ZIO.Tags.RaceWith =>
+                  val zio = curZio.asInstanceOf[ZIO.RaceWith[Any, Any, Any, Any, Any, Any, Any]]
+                  curZio = raceWithImpl(zio).asInstanceOf[IO[E, Any]]
               }
             }
           } else {
@@ -652,7 +707,7 @@ private[zio] final class FiberContext[E, A](
 
   }
 
-  private[this] final def supervise(child: FiberContext[Any, Any]): Unit =
+  private[this] final def supervise[E, A](child: FiberContext[E, A]): Unit =
     supervised.peek() match {
       case SuperviseStatus.Unsupervised    =>
       case SuperviseStatus.Supervised(set) => set.add(child); ()
@@ -777,7 +832,7 @@ private[zio] final class FiberContext[E, A](
     }
 
   @tailrec
-  private[this] final def register0(k: Callback[Nothing, Exit[E, A]]): Exit[E, A] = {
+  private final def register0(k: Callback[Nothing, Exit[E, A]]): Exit[E, A] = {
     val oldState = state.get
 
     oldState match {
@@ -811,6 +866,7 @@ private[zio] final class FiberContext[E, A](
           .submitOrThrow(() => k(result))
     )
   }
+
 }
 private[zio] object FiberContext {
   val fiberCounter = new AtomicLong(0)

--- a/core/shared/src/main/scala/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/zio/internal/Stack.scala
@@ -75,10 +75,11 @@ private[zio] final class Stack[A <: AnyRef]() {
 }
 
 private[zio] object Stack {
-  def apply[A <: AnyRef](as: A*): Stack[A] = {
+  def apply[A <: AnyRef](): Stack[A] = new Stack[A]
+  def apply[A <: AnyRef](a: A): Stack[A] = {
     val stack = new Stack[A]
 
-    as.foreach(stack.push)
+    stack.push(a)
 
     stack
   }

--- a/core/shared/src/main/scala/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/zio/internal/StackBool.scala
@@ -96,11 +96,17 @@ private[zio] final class StackBool private () {
 private[zio] object StackBool {
   def apply(): StackBool = new StackBool
 
-  def apply(bools: Boolean*): StackBool = {
+  def apply(bool: Boolean): StackBool = {
     val stack = StackBool()
 
-    bools.reverse.foreach(stack.push(_))
+    stack.push(bool)
 
+    stack
+  }
+
+  def apply(bools: List[Boolean]): StackBool = {
+    val stack = StackBool()
+    bools.reverse.foreach(stack.push)
     stack
   }
 

--- a/core/shared/src/main/scala/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/zio/internal/StackBool.scala
@@ -106,10 +106,9 @@ private[zio] object StackBool {
 
   def fromIterable(it: Iterable[Boolean]): StackBool = {
     val stack = StackBool()
-    it.foldRight(stack) {
-      (b, stack) =>
-        stack.push(b)
-        stack
+    it.foldRight(stack) { (b, stack) =>
+      stack.push(b)
+      stack
     }
   }
 

--- a/core/shared/src/main/scala/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/zio/internal/StackBool.scala
@@ -104,10 +104,13 @@ private[zio] object StackBool {
     stack
   }
 
-  def apply(bools: List[Boolean]): StackBool = {
+  def fromIterable(it: Iterable[Boolean]): StackBool = {
     val stack = StackBool()
-    bools.reverse.foreach(stack.push)
-    stack
+    it.foldRight(stack) {
+      (b, stack) =>
+        stack.push(b)
+        stack
+    }
   }
 
   private class Entry(val next: Entry) {


### PR DESCRIPTION
Resolves #1844 by lifting the RaceWith to the run loop.

Original benchmark by @neko-kai

```
info] Benchmark                                (size)   Mode  Cnt    Score     Error  Units
[info] IOEmptyRaceBenchmark.catsEmptyRace         1000  thrpt   10  315.196 ± 398.678  ops/s
[info] IOEmptyRaceBenchmark.monixEmptyRace        1000  thrpt   10  192.894 ±   7.672  ops/s
[info] IOEmptyRaceBenchmark.zioEmptyRace          1000  thrpt   10   33.152 ±   0.572  ops/s
[info] IOEmptyRaceBenchmark.zioTracedEmptyRace    1000  thrpt   10   25.166 ±   1.548  ops/s
```

After a code review with @jdegoes and further improvements, we've even improved more! (almost 5x)

```
[info] Benchmark                                (size)   Mode  Cnt    Score    Error  Units
[info] IOEmptyRaceBenchmark.catsEmptyRace         1000  thrpt   10  279.041 ± 10.432  ops/s
[info] IOEmptyRaceBenchmark.monixEmptyRace        1000  thrpt   10  290.857 ±  5.608  ops/s
[info] IOEmptyRaceBenchmark.zioEmptyRace          1000  thrpt   10  149.221 ±  1.637  ops/s
[info] IOEmptyRaceBenchmark.zioTracedEmptyRace    1000  thrpt   10   96.610 ±  0.357  ops/s
```