### PR TITLE
ZIO Test: Report Compilation Errors for assertCompiles

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -3,7 +3,8 @@ package zio.test
 import zio.Exit
 import zio.test.Assertion._
 import zio.test.AssertionSpecHelper._
-import zio.test.TestAspect.failure
+import zio.test.BoolAlgebra.Value
+import zio.test.TestAspect._
 
 object AssertionSpec
     extends ZIOBaseSpec(
@@ -256,7 +257,16 @@ object AssertionSpec
         },
         test("assertCompiles must fail when string is not valid Scala code") {
           assertCompiles("1 ++ 1")
-        } @@ failure
+        } @@ failure,
+        test("assertCompiles must report error messages on Scala 2") {
+          assert(
+            assertCompiles("1 ++ 1").failures match {
+              case Some(Value(failure)) => Some(failure.assertion.head.value)
+              case _                    => None
+            },
+            isSome(equalTo(Some("value ++ is not a member of Int")))
+          )
+        } @@ scala2Only
       )
     )
 

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -25,6 +25,19 @@ object TestAspectSpec
             assert(after, equalTo(-1))
           }
         },
+        testM("dotty applies test aspect only on Dotty") {
+          for {
+            ref    <- Ref.make(false)
+            spec   = test("test")(assert(true, isTrue)) @@ dotty(after(ref.set(true)))
+            _      <- execute(spec)
+            result <- ref.get
+          } yield if (TestVersion.isDotty) assert(result, isTrue) else assert(result, isFalse)
+        },
+        testM("dottyOnly runs tests only on Dotty") {
+          val spec   = test("Dotty-only")(assert(TestVersion.isDotty, isTrue)) @@ dottyOnly
+          val result = if (TestVersion.isDotty) succeeded(spec) else ignored(spec)
+          assertM(result, isTrue)
+        },
         testM("js applies test aspect only on ScalaJS") {
           for {
             ref    <- Ref.make(false)
@@ -127,6 +140,19 @@ object TestAspectSpec
         test("ifPropSet ignores a test if property is not set") {
           assert(true, isFalse)
         } @@ ifPropSet("qwerty") @@ jvmOnly,
+        testM("scala2 applies test aspect only on Scala 2") {
+          for {
+            ref    <- Ref.make(false)
+            spec   = test("test")(assert(true, isTrue)) @@ scala2(after(ref.set(true)))
+            _      <- execute(spec)
+            result <- ref.get
+          } yield if (TestVersion.isScala2) assert(result, isTrue) else assert(result, isFalse)
+        },
+        testM("scala2Only runs tests only on Scala 2") {
+          val spec   = test("Scala2-only")(assert(TestVersion.isScala2, isTrue)) @@ scala2Only
+          val result = if (TestVersion.isScala2) succeeded(spec) else ignored(spec)
+          assertM(result, isTrue)
+        },
         testM("timeout makes tests fail after given duration") {
           assertM(ZIO.never *> ZIO.unit, equalTo(()))
         } @@ timeout(1.nanos)

--- a/test/js/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/js/src/main/scala/zio/test/TestPlatform.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test
 
 /**

--- a/test/js/src/main/scala/zio/test/reflect/Reflect.scala
+++ b/test/js/src/main/scala/zio/test/reflect/Reflect.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test.reflect
 
 object Reflect {

--- a/test/jvm/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/jvm/src/main/scala/zio/test/TestPlatform.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test
 
 /**

--- a/test/jvm/src/main/scala/zio/test/reflect/Reflect.scala
+++ b/test/jvm/src/main/scala/zio/test/reflect/Reflect.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.test.reflect
 
 object Reflect {

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -24,9 +24,9 @@ private[test] object Macros {
     import c.universe._
     try {
       c.typecheck(c.parse(c.eval(c.Expr[String](c.untypecheck(code.tree)))))
-      c.Expr(q"assert(true, Assertion.isTrue)")
+      c.Expr(q"assert(None, Assertion.isNone)")
     } catch {
-      case _: Throwable => c.Expr(q"assert(false, Assertion.isTrue)")
+      case e: Throwable => c.Expr(q"assert(Some(${e.getMessage}), Assertion.isNone)")
     }
   }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/TestVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 John A. De Goes and the ZIO Contributors
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,19 @@
 
 package zio.test
 
-import scala.compiletime.testing.typeChecks
-
-trait AssertionVariants {
+/**
+ * `TestVersion` provides information about the Scala version tests are being
+ * run on to enable platform specific test configuration.
+ */
+object TestVersion {
 
   /**
-   * Makes a new assertion that requires the specified string to be valid Scala
-   * code.
+   * Returns whether the current Scala version is Dotty.
    */
-  inline final def assertCompiles(inline code: String): TestResult =
-    assert(
-      if (typeChecks(code)) None else Some(errorMessage),
-      Assertion.isNone
-    )
+  val isDotty: Boolean = false
 
-  private val errorMessage =
-    "Reporting of compilation error messages on Dotty is not currently supported due to instability of the underlying APIs."
+  /**
+   * Returns whether the current Scala version is Scala 2.
+   */
+  val isScala2: Boolean = true
 }

--- a/test/shared/src/main/scala-dotty/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/TestVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 John A. De Goes and the ZIO Contributors
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,15 @@
 
 package zio.test
 
-import scala.compiletime.testing.typeChecks
-
-trait AssertionVariants {
+object TestVersion {
+  
+  /**
+   * Returns whether the current Scala version is Dotty.
+   */
+  val isDotty: Boolean = false
 
   /**
-   * Makes a new assertion that requires the specified string to be valid Scala
-   * code.
+   * Returns whether the current Scala version is Scala 2.
    */
-  inline final def assertCompiles(inline code: String): TestResult =
-    assert(
-      if (typeChecks(code)) None else Some(errorMessage),
-      Assertion.isNone
-    )
-
-  private val errorMessage =
-    "Reporting of compilation error messages on Dotty is not currently supported due to instability of the underlying APIs."
+  val isScala2: Boolean = true
 }

--- a/test/shared/src/main/scala-dotty/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/TestVersion.scala
@@ -21,10 +21,10 @@ object TestVersion {
   /**
    * Returns whether the current Scala version is Dotty.
    */
-  val isDotty: Boolean = false
+  val isDotty: Boolean = true
 
   /**
    * Returns whether the current Scala version is Scala 2.
    */
-  val isScala2: Boolean = true
+  val isScala2: Boolean = false
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -171,6 +171,16 @@ package object test extends AssertionVariants with CheckVariants {
       }
     )
 
+  /**
+   * Passes version specific information to the specified function, which will
+   * use that information to create a test. If the version is neither Dotty nor
+   * Scala 2, an ignored test result will be returned.
+   */
+  final def versionSpecific[R, E, A, S](dotty: => A, scala2: => A)(f: A => ZTest[R, E, S]): ZTest[R, E, S] =
+    if (TestVersion.isDotty) f(dotty)
+    else if (TestVersion.isScala2) f(scala2)
+    else ignore
+
   val defaultTestRunner: TestRunner[TestEnvironment, String, Either[TestFailure[Nothing], TestSuccess[Any]], Any, Any] =
     TestRunner(TestExecutor.managed(zio.test.environment.testEnvironmentManaged))
 }


### PR DESCRIPTION
Adds functionality to `assertCompiles` to report the compilation error if code does not compile as expected. Also adds a new `TestVersion` concept analogous to the existing `TestPlatform` to allow the test framework to access information on the Scala version and uses this to to implement `dotty`, `dottyOnly`, `scala2`, and `scala2Only` test aspects similar to the platform specific versions.