### PR TITLE
Add mapMPartitioned to ZStream

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1649,7 +1649,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    */
   final def mapMPartitioned[R1 <: R, E1 >: E, B, K](
     keyBy: A => K,
-    buffer: Int
+    buffer: Int = 16
   )(f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
     groupByKey(keyBy, buffer).apply { case (_, s) => s.mapM(f) }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1643,9 +1643,10 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
 
   /**
    * Maps over elements of the stream with the specified effectful function,
-   * partitioned by `p` executing invocations of `f` concurrently on up
-   * to `buffer` partitions. Transformed elements may be reordered but the order within
-   * a partition is maintained.
+   * partitioned by `p` executing invocations of `f` concurrently. The number
+   * of concurrent invocations of `f` is determined by the number of different
+   * outputs of type `K`. Up to `buffer` elements may be buffered per partition.
+   * Transformed elements may be reordered but the order within a partition is maintained.
    */
   final def mapMPartitioned[R1 <: R, E1 >: E, B, K](
     keyBy: A => K,

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1642,6 +1642,17 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
     self.flatMapPar[R1, E1, B](n)(a => ZStream.fromEffect(f(a)))
 
   /**
+   * Maps over elements of the stream with the specified effectful function,
+   * partitioned by `p` executing invocations of `f` concurrently on up
+   * to `n` partitions. Transformed elements may be reordered but the order within
+   * a partition is maintained.
+   */
+  final def mapMPartitioned[R1 <: R, E1 >: E, B, K](
+    n: Int
+  )(p: A => K, f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
+    groupByKey(p, n).apply { case (_, s) => s.mapM(f) }
+
+  /**
    * Merges this stream and the specified stream together.
    */
   final def merge[R1 <: R, E1 >: E, A1 >: A](that: ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1644,13 +1644,14 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
   /**
    * Maps over elements of the stream with the specified effectful function,
    * partitioned by `p` executing invocations of `f` concurrently on up
-   * to `n` partitions. Transformed elements may be reordered but the order within
+   * to `buffer` partitions. Transformed elements may be reordered but the order within
    * a partition is maintained.
    */
   final def mapMPartitioned[R1 <: R, E1 >: E, B, K](
-    n: Int
-  )(p: A => K, f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
-    groupByKey(p, n).apply { case (_, s) => s.mapM(f) }
+    keyBy: A => K,
+    buffer: Int
+  )(f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
+    groupByKey(keyBy, buffer).apply { case (_, s) => s.mapM(f) }
 
   /**
    * Merges this stream and the specified stream together.


### PR DESCRIPTION
When performing operations on a stream, it is quite a common use case to want to perform some operation concurrently on elements of the stream while maintaining the order of messages within some partition.

This is currently achievable using the `ZStream.GroupBy` but this is not immediately obvious to new users.

This PR proposes adding a `mapMPartitioned` method to the `ZStream` class to cover this.