### PR TITLE
Add new shorthands for running ZStream

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -970,16 +970,16 @@ object StreamSpec
             equalTo(List(List(1, 2), List(3, 4)))
           )
         ),
-        suite("Stream.head")(
+        suite("Stream.runHead")(
           testM("nonempty stream")(
             assertM(
-              Stream(1, 2, 3, 4).head,
+              Stream(1, 2, 3, 4).runHead,
               equalTo(Some(1))
             )
           ),
           testM("empty stream")(
             assertM(
-              Stream.empty.head,
+              Stream.empty.runHead,
               equalTo(None)
             )
           )
@@ -1030,16 +1030,16 @@ object StreamSpec
         testM("Stream.iterate")(
           assertM(Stream.iterate(1)(_ + 1).take(10).runCollect, equalTo((1 to 10).toList))
         ),
-        suite("Stream.last")(
+        suite("Stream.runLast")(
           testM("nonempty stream")(
             assertM(
-              Stream(1, 2, 3, 4).last,
+              Stream(1, 2, 3, 4).runLast,
               equalTo(Some(4))
             )
           ),
           testM("empty stream")(
             assertM(
-              Stream.empty.last,
+              Stream.empty.runLast,
               equalTo(None)
             )
           )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -970,6 +970,20 @@ object StreamSpec
             equalTo(List(List(1, 2), List(3, 4)))
           )
         ),
+        suite("Stream.head")(
+          testM("nonempty stream")(
+            assertM(
+              Stream(1, 2, 3, 4).head,
+              equalTo(Some(1))
+            )
+          ),
+          testM("empty stream")(
+            assertM(
+              Stream.empty.head,
+              equalTo(None)
+            )
+          )
+        ),
         suite("Stream interleaving")(
           testM("interleave") {
             val s1 = Stream(2, 3)
@@ -1015,6 +1029,20 @@ object StreamSpec
         ),
         testM("Stream.iterate")(
           assertM(Stream.iterate(1)(_ + 1).take(10).runCollect, equalTo((1 to 10).toList))
+        ),
+        suite("Stream.last")(
+          testM("nonempty stream")(
+            assertM(
+              Stream(1, 2, 3, 4).last,
+              equalTo(Some(4))
+            )
+          ),
+          testM("empty stream")(
+            assertM(
+              Stream.empty.last,
+              equalTo(None)
+            )
+          )
         ),
         testM("Stream.map")(checkM(pureStreamOfBytes, Gen.function(Gen.anyInt)) { (s, f) =>
           for {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1910,6 +1910,22 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
     }
 
   /**
+   * Returns the first element of the stream.
+   */
+  def head: ZIO[R, E, Option[A]] = take(1).runCollect.map(_.headOption)
+
+  /**
+   * Runs the stream returning the first element and discarding all elements thereafter.
+   */
+  def first: ZIO[R, E, Option[A]] =
+    run(ZSink.foldLeft[A, Option[A]](None) { case (s, a) => if (s.isDefined) s else Some(a) })
+
+  /**
+   * Runs the stream returning the last element and discarding all earlier elements.
+   */
+  def last: ZIO[R, E, Option[A]] = run(ZSink.foldLeft[A, Option[A]](None) { case (_, a) => Some(a) })
+
+  /**
    * Runs the stream and collects all of its elements in a list.
    *
    * Equivalent to `run(Sink.collectAll[A])`.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1915,12 +1915,6 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
   def head: ZIO[R, E, Option[A]] = take(1).runCollect.map(_.headOption)
 
   /**
-   * Runs the stream returning the first element and discarding all elements thereafter.
-   */
-  def first: ZIO[R, E, Option[A]] =
-    run(ZSink.foldLeft[A, Option[A]](None) { case (s, a) => if (s.isDefined) s else Some(a) })
-
-  /**
    * Runs the stream returning the last element and discarding all earlier elements.
    */
   def last: ZIO[R, E, Option[A]] = run(ZSink.foldLeft[A, Option[A]](None) { case (_, a) => Some(a) })

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1910,14 +1910,14 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
     }
 
   /**
-   * Returns the first element of the stream.
+   * Runs the stream returning the first element of the stream. Later elements will not be consumed / have effects run
    */
-  def head: ZIO[R, E, Option[A]] = take(1).runCollect.map(_.headOption)
+  def runHead: ZIO[R, E, Option[A]] = take(1).runCollect.map(_.headOption)
 
   /**
    * Runs the stream returning the last element and discarding all earlier elements.
    */
-  def last: ZIO[R, E, Option[A]] = run(ZSink.foldLeft[A, Option[A]](None) { case (_, a) => Some(a) })
+  def runLast: ZIO[R, E, Option[A]] = run(ZSink.foldLeft[A, Option[A]](None) { case (_, a) => Some(a) })
 
   /**
    * Runs the stream and collects all of its elements in a list.


### PR DESCRIPTION
Resolves #1491 

Since there was an "open" question on the behaviour of `head` two variants were added.

`head` which is equivalent to take(1) and is safe for infinite streams
`first` which consumes the entire stream (i.e. the inverse of last)