### PR TITLE
Hand specialized Chunk for primitive value types

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -684,7 +684,7 @@ object Chunk {
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
     if (it.size <= 0) Empty
-    else if (it.size == 1) Singleton(it.head)
+    else if (it.size == 1) single(it.head)
     else {
       it match {
         case l: Vector[A] => VectorChunk(l)
@@ -700,12 +700,92 @@ object Chunk {
   /**
    * Returns a singleton chunk, eagerly evaluated.
    */
-  final def single[A](a: A): Chunk[A] = Singleton(a)
+  final def single[A](a: A): Chunk[A] = RefSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Boolean): Chunk[Boolean] = BooleanSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Byte): Chunk[Byte] = ByteSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Char): Chunk[Char] = CharSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Double): Chunk[Double] = DoubleSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Float): Chunk[Float] = FloatSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Int): Chunk[Int] = IntSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Long): Chunk[Long] = LongSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Short): Chunk[Short] = ShortSingleton(a)
 
   /**
    * Alias for [[Chunk.single]].
    */
   final def succeed[A](a: A): Chunk[A] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Boolean): Chunk[Boolean] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Byte): Chunk[Byte] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Char): Chunk[Char] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Double): Chunk[Double] = single(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def succeed(a: Float): Chunk[Float] = single(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def succeed(a: Int): Chunk[Int] = single(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def succeed(a: Long): Chunk[Long] = single(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def succeed(a: Short): Chunk[Short] = single(a)
 
   /**
    * Returns the `ClassTag` for the element type of the chunk.
@@ -975,19 +1055,91 @@ object Chunk {
     override def toArray[A1](implicit tag: ClassTag[A1]): Array[A1] = Array.empty
   }
 
-  private case class Singleton[A](a: A) extends Chunk[A] {
+  private sealed trait Singleton[A] extends Chunk[A] {
+    val a: A
+
     implicit val classTag: ClassTag[A] = Tags.fromValue(a)
 
-    override val length = 1
+    override val length: Int = 1
 
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
+      dest(n) = a
+  }
+
+  private object Singleton {
+    def unapply[A](singleton: Singleton[A]): Option[A] = Some(singleton.a)
+  }
+
+  private case class RefSingleton[A](override val a: A) extends Singleton[A] {
     override def apply(n: Int): A =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
 
     override def foreach(f: A => Unit): Unit = f(a)
+  }
 
-    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
-      dest(n) = a
+  private case class BooleanSingleton(override val a: Boolean) extends Singleton[Boolean] {
+    override def apply(n: Int): Boolean =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Boolean => Unit): Unit = f(a)
+  }
+
+  private case class ByteSingleton(override val a: Byte) extends Singleton[Byte] {
+    override def apply(n: Int): Byte =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Byte => Unit): Unit = f(a)
+  }
+
+  private case class CharSingleton(override val a: Char) extends Singleton[Char] {
+    override def apply(n: Int): Char =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Char => Unit): Unit = f(a)
+  }
+
+  private case class DoubleSingleton(override val a: Double) extends Singleton[Double] {
+    override def apply(n: Int): Double =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Double => Unit): Unit = f(a)
+  }
+
+  private case class FloatSingleton(override val a: Float) extends Singleton[Float] {
+    override def apply(n: Int): Float =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Float => Unit): Unit = f(a)
+  }
+
+  private case class IntSingleton(override val a: Int) extends Singleton[Int] {
+    override def apply(n: Int): Int =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Int => Unit): Unit = f(a)
+  }
+
+  private case class LongSingleton(override val a: Long) extends Singleton[Long] {
+    override def apply(n: Int): Long =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Long => Unit): Unit = f(a)
+  }
+
+  private case class ShortSingleton(override val a: Short) extends Singleton[Short] {
+    override def apply(n: Int): Short =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
+
+    override def foreach(f: Short => Unit): Unit = f(a)
   }
 
   private case class Slice[A](private val chunk: Chunk[A], offset: Int, l: Int) extends Chunk[A] {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -66,11 +66,11 @@ sealed trait Chunk[+A] { self =>
     else if (n >= len) Chunk.empty
     else
       self match {
-        case Chunk.Slice(c, o, l)        => Chunk.Slice(c, o + n, l - n)
-        case Chunk.Singleton(_) if n > 0 => Chunk.empty
-        case c @ Chunk.Singleton(_)      => c
-        case Chunk.Empty                 => Chunk.empty
-        case _                           => Chunk.Slice(self, n, len - n)
+        case Chunk.Slice(c, o, l)           => Chunk.Slice(c, o + n, l - n)
+        case _: Chunk.Singleton[_] if n > 0 => Chunk.empty
+        case c: Chunk.Singleton[_]          => c
+        case Chunk.Empty                    => Chunk.empty
+        case _                              => Chunk.Slice(self, n, len - n)
       }
   }
 
@@ -426,8 +426,8 @@ sealed trait Chunk[+A] { self =>
         case Chunk.Slice(c, o, l) =>
           if (n >= l) this
           else Chunk.Slice(c, o, n)
-        case c @ Chunk.Singleton(_) => c
-        case _                      => Chunk.Slice(self, 0, n)
+        case c: Chunk.Singleton[_] => c
+        case _                     => Chunk.Slice(self, 0, n)
       }
 
   /**
@@ -1131,10 +1131,6 @@ object Chunk {
 
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
       dest(n) = a
-  }
-
-  private object Singleton {
-    def unapply[A](singleton: Singleton[A]): Option[A] = Some(singleton.a)
   }
 
   private case class RefSingleton[A](override val a: A) extends Singleton[A] {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -797,9 +797,7 @@ object Chunk {
     case x: VectorChunk[A] => x.classTag
   }
 
-  private sealed trait Arr[A] extends Chunk[A] {
-    val array: Array[A]
-
+  private sealed abstract class Arr[A](val array: Array[A]) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = ClassTag(array.getClass.getComponentType)
 
     override def collect[B](p: PartialFunction[A, B]): Chunk[B] = {
@@ -1029,55 +1027,55 @@ object Chunk {
     }
   }
 
-  private case class RefArr[A](override val array: Array[A]) extends Arr[A] {
+  private case class RefArr[A](override val array: Array[A]) extends Arr[A](array) {
     override def apply(n: Int): A = array(n)
 
     override def foreach(f: A => Unit): Unit = array.foreach(f)
   }
 
-  private case class BooleanArr(override val array: Array[Boolean]) extends Arr[Boolean] {
+  private case class BooleanArr(override val array: Array[Boolean]) extends Arr[Boolean](array) {
     override def apply(n: Int): Boolean = array(n)
 
     override def foreach(f: Boolean => Unit): Unit = array.foreach(f)
   }
 
-  private case class ByteArr(override val array: Array[Byte]) extends Arr[Byte] {
+  private case class ByteArr(override val array: Array[Byte]) extends Arr[Byte](array) {
     override def apply(n: Int): Byte = array(n)
 
     override def foreach(f: Byte => Unit): Unit = array.foreach(f)
   }
 
-  private case class CharArr(override val array: Array[Char]) extends Arr[Char] {
+  private case class CharArr(override val array: Array[Char]) extends Arr[Char](array) {
     override def apply(n: Int): Char = array(n)
 
     override def foreach(f: Char => Unit): Unit = array.foreach(f)
   }
 
-  private case class DoubleArr(override val array: Array[Double]) extends Arr[Double] {
+  private case class DoubleArr(override val array: Array[Double]) extends Arr[Double](array) {
     override def apply(n: Int): Double = array(n)
 
     override def foreach(f: Double => Unit): Unit = array.foreach(f)
   }
 
-  private case class FloatArr(override val array: Array[Float]) extends Arr[Float] {
+  private case class FloatArr(override val array: Array[Float]) extends Arr[Float](array) {
     override def apply(n: Int): Float = array(n)
 
     override def foreach(f: Float => Unit): Unit = array.foreach(f)
   }
 
-  private case class IntArr(override val array: Array[Int]) extends Arr[Int] {
+  private case class IntArr(override val array: Array[Int]) extends Arr[Int](array) {
     override def apply(n: Int): Int = array(n)
 
     override def foreach(f: Int => Unit): Unit = array.foreach(f)
   }
 
-  private case class LongArr(override val array: Array[Long]) extends Arr[Long] {
+  private case class LongArr(override val array: Array[Long]) extends Arr[Long](array) {
     override def apply(n: Int): Long = array(n)
 
     override def foreach(f: Long => Unit): Unit = array.foreach(f)
   }
 
-  private case class ShortArr(override val array: Array[Short]) extends Arr[Short] {
+  private case class ShortArr(override val array: Array[Short]) extends Arr[Short](array) {
     override def apply(n: Int): Short = array(n)
 
     override def foreach(f: Short => Unit): Unit = array.foreach(f)
@@ -1122,9 +1120,7 @@ object Chunk {
     override def toArray[A1](implicit tag: ClassTag[A1]): Array[A1] = Array.empty
   }
 
-  private sealed trait Singleton[A] extends Chunk[A] {
-    val a: A
-
+  private sealed abstract class Singleton[A](a: A) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = Tags.fromValue(a)
 
     override val length: Int = 1
@@ -1133,7 +1129,7 @@ object Chunk {
       dest(n) = a
   }
 
-  private case class RefSingleton[A](override val a: A) extends Singleton[A] {
+  private case class RefSingleton[A](a: A) extends Singleton[A](a) {
     override def apply(n: Int): A =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1141,7 +1137,7 @@ object Chunk {
     override def foreach(f: A => Unit): Unit = f(a)
   }
 
-  private case class BooleanSingleton(override val a: Boolean) extends Singleton[Boolean] {
+  private case class BooleanSingleton(a: Boolean) extends Singleton[Boolean](a) {
     override def apply(n: Int): Boolean =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1149,7 +1145,7 @@ object Chunk {
     override def foreach(f: Boolean => Unit): Unit = f(a)
   }
 
-  private case class ByteSingleton(override val a: Byte) extends Singleton[Byte] {
+  private case class ByteSingleton(a: Byte) extends Singleton[Byte](a) {
     override def apply(n: Int): Byte =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1157,7 +1153,7 @@ object Chunk {
     override def foreach(f: Byte => Unit): Unit = f(a)
   }
 
-  private case class CharSingleton(override val a: Char) extends Singleton[Char] {
+  private case class CharSingleton(a: Char) extends Singleton[Char](a) {
     override def apply(n: Int): Char =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1165,7 +1161,7 @@ object Chunk {
     override def foreach(f: Char => Unit): Unit = f(a)
   }
 
-  private case class DoubleSingleton(override val a: Double) extends Singleton[Double] {
+  private case class DoubleSingleton(a: Double) extends Singleton[Double](a) {
     override def apply(n: Int): Double =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1173,7 +1169,7 @@ object Chunk {
     override def foreach(f: Double => Unit): Unit = f(a)
   }
 
-  private case class FloatSingleton(override val a: Float) extends Singleton[Float] {
+  private case class FloatSingleton(a: Float) extends Singleton[Float](a) {
     override def apply(n: Int): Float =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1181,7 +1177,7 @@ object Chunk {
     override def foreach(f: Float => Unit): Unit = f(a)
   }
 
-  private case class IntSingleton(override val a: Int) extends Singleton[Int] {
+  private case class IntSingleton(a: Int) extends Singleton[Int](a) {
     override def apply(n: Int): Int =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1189,7 +1185,7 @@ object Chunk {
     override def foreach(f: Int => Unit): Unit = f(a)
   }
 
-  private case class LongSingleton(override val a: Long) extends Singleton[Long] {
+  private case class LongSingleton(a: Long) extends Singleton[Long](a) {
     override def apply(n: Int): Long =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")
@@ -1197,7 +1193,7 @@ object Chunk {
     override def foreach(f: Long => Unit): Unit = f(a)
   }
 
-  private case class ShortSingleton(override val a: Short) extends Singleton[Short] {
+  private case class ShortSingleton(a: Short) extends Singleton[Short](a) {
     override def apply(n: Int): Short =
       if (n == 0) a
       else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to $n")

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -68,7 +68,7 @@ sealed trait Chunk[+A] { self =>
       self match {
         case Chunk.Slice(c, o, l)           => Chunk.Slice(c, o + n, l - n)
         case _: Chunk.Singleton[_] if n > 0 => Chunk.empty
-        case c: Chunk.Singleton[_]          => c
+        case c: Chunk.Singleton[_]          => c.asInstanceOf[Chunk[A]] // Dotty doesn't infer this properly
         case Chunk.Empty                    => Chunk.empty
         case _                              => Chunk.Slice(self, n, len - n)
       }
@@ -426,7 +426,7 @@ sealed trait Chunk[+A] { self =>
         case Chunk.Slice(c, o, l) =>
           if (n >= l) this
           else Chunk.Slice(c, o, n)
-        case c: Chunk.Singleton[_] => c
+        case c: Chunk.Singleton[_] => c.asInstanceOf[Chunk[A]] // Dotty doesn't infer this properly
         case _                     => Chunk.Slice(self, 0, n)
       }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -24,7 +24,7 @@ import scala.reflect.{ classTag, ClassTag }
  * to the underlying elements, and they become lazy on operations that would be
  * costly with arrays, such as repeated concatenation.
  */
-sealed trait Chunk[+A] { self =>
+sealed trait Chunk[+A] extends Serializable { self =>
 
   /**
    * The number of elements in the chunk.

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -129,7 +129,7 @@ sealed trait Chunk[+A] { self =>
     }
 
     if (j == 0) Chunk.Empty
-    else Chunk.Slice(Chunk.fromArray(dest), 0, j)
+    else Chunk.Slice(Chunk.Arr(dest), 0, j)
   }
 
   /**
@@ -162,7 +162,7 @@ sealed trait Chunk[+A] { self =>
     dest.map {
       case (array, arrLen) =>
         if (arrLen == 0) Chunk.empty
-        else Chunk.Slice(Chunk.fromArray(array), 0, arrLen)
+        else Chunk.Slice(Chunk.Arr(array), 0, arrLen)
     }
   }
 
@@ -213,7 +213,7 @@ sealed trait Chunk[+A] { self =>
         n += chunk.length
       }
 
-      Chunk.fromArray(dest)
+      Chunk.Arr(dest)
     }
   }
 
@@ -319,7 +319,7 @@ sealed trait Chunk[+A] { self =>
       i = i + 1
     }
 
-    if (dest != null) Chunk.fromArray(dest)
+    if (dest != null) Chunk.Arr(dest)
     else Chunk.Empty
   }
 
@@ -352,7 +352,7 @@ sealed trait Chunk[+A] { self =>
 
     s ->
       (if (dest == null) Chunk.empty
-       else Chunk.fromArray(dest))
+       else Chunk.Arr(dest))
   }
 
   /**
@@ -361,7 +361,7 @@ sealed trait Chunk[+A] { self =>
    */
   def materialize[A1 >: A]: Chunk[A1] = self.toArrayOption[A1] match {
     case None        => Chunk.Empty
-    case Some(array) => Chunk.fromArray(array)
+    case Some(array) => Chunk.Arr(array)
   }
 
   /**
@@ -510,7 +510,7 @@ sealed trait Chunk[+A] { self =>
     dest.map {
       case (state, array) =>
         if (array == null) (state, Chunk.empty)
-        else (state, Chunk.fromArray(array))
+        else (state, Chunk.Arr(array))
     }
   }
 
@@ -540,7 +540,7 @@ sealed trait Chunk[+A] { self =>
     array.map(
       array =>
         if (array == null) Chunk.empty
-        else Chunk.fromArray(array)
+        else Chunk.Arr(array)
     )
   }
 
@@ -597,7 +597,7 @@ sealed trait Chunk[+A] { self =>
         i = i + 1
       }
 
-      Chunk.fromArray(dest)
+      Chunk.Arr(dest)
     }
   }
 
@@ -626,8 +626,7 @@ sealed trait Chunk[+A] { self =>
 
       }
 
-      Chunk.fromArray(dest)
-
+      Chunk.Arr(dest)
     }
   }
 
@@ -652,7 +651,7 @@ sealed trait Chunk[+A] { self =>
       i += 1
     }
 
-    Chunk.fromArray(dest)
+    Chunk.Arr(dest)
   }
 
   protected[zio] def apply(n: Int): A
@@ -677,47 +676,7 @@ object Chunk {
   /**
    * Returns a chunk backed by an array.
    */
-  final def fromArray[A](array: Array[A]): Chunk[A] = RefArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Boolean]): Chunk[Boolean] = BooleanArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Byte]): Chunk[Byte] = ByteArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Char]): Chunk[Char] = CharArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Double]): Chunk[Double] = DoubleArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Float]): Chunk[Float] = FloatArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Int]): Chunk[Int] = IntArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Long]): Chunk[Long] = LongArr(array)
-
-  /**
-   * Returns a chunk backed by an array.
-   */
-  final def fromArray(array: Array[Short]): Chunk[Short] = ShortArr(array)
+  final def fromArray[A](array: Array[A]): Chunk[A] = Arr(array)
 
   /**
    * Returns a chunk backed by an iterable.
@@ -733,99 +692,19 @@ object Chunk {
 
           implicit val A: ClassTag[A] = Tags.fromValue(first)
 
-          fromArray(it.toArray)
+          Arr(it.toArray)
       }
     }
 
   /**
    * Returns a singleton chunk, eagerly evaluated.
    */
-  final def single[A](a: A): Chunk[A] = RefSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Boolean): Chunk[Boolean] = BooleanSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Byte): Chunk[Byte] = ByteSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Char): Chunk[Char] = CharSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Double): Chunk[Double] = DoubleSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Float): Chunk[Float] = FloatSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Int): Chunk[Int] = IntSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Long): Chunk[Long] = LongSingleton(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def single(a: Short): Chunk[Short] = ShortSingleton(a)
+  final def single[A](a: A): Chunk[A] = Singleton(a)
 
   /**
    * Alias for [[Chunk.single]].
    */
   final def succeed[A](a: A): Chunk[A] = single(a)
-
-  /**
-   * Alias for [[Chunk.single]].
-   */
-  final def succeed(a: Boolean): Chunk[Boolean] = single(a)
-
-  /**
-   * Alias for [[Chunk.single]].
-   */
-  final def succeed(a: Byte): Chunk[Byte] = single(a)
-
-  /**
-   * Alias for [[Chunk.single]].
-   */
-  final def succeed(a: Char): Chunk[Char] = single(a)
-
-  /**
-   * Alias for [[Chunk.single]].
-   */
-  final def succeed(a: Double): Chunk[Double] = single(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def succeed(a: Float): Chunk[Float] = single(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def succeed(a: Int): Chunk[Int] = single(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def succeed(a: Long): Chunk[Long] = single(a)
-
-  /**
-   * Returns a singleton chunk, eagerly evaluated.
-   */
-  final def succeed(a: Short): Chunk[Short] = single(a)
 
   /**
    * Returns the `ClassTag` for the element type of the chunk.
@@ -868,7 +747,7 @@ object Chunk {
       }
 
       if (dest == null) Chunk.Empty
-      else Chunk.Slice(Chunk.fromArray(dest), 0, j)
+      else Chunk.Slice(Chunk.Arr(dest), 0, j)
     }
 
     override def collectWhile[B](p: PartialFunction[A, B]): Chunk[B] = {
@@ -898,7 +777,7 @@ object Chunk {
       }
 
       if (dest == null) Chunk.Empty
-      else Chunk.Slice(Chunk.fromArray(dest), 0, j)
+      else Chunk.Slice(Chunk.Arr(dest), 0, j)
     }
 
     override def dropWhile(f: A => Boolean): Chunk[A] = {
@@ -932,7 +811,7 @@ object Chunk {
       }
 
       if (dest == null) Chunk.Empty
-      else Chunk.Slice(Chunk.fromArray(dest), 0, j)
+      else Chunk.Slice(Chunk.Arr(dest), 0, j)
     }
 
     override def flatMap[B](f: A => Chunk[B]): Chunk[B] = {
@@ -973,7 +852,7 @@ object Chunk {
           n += chunk.length
         }
 
-        Chunk.fromArray(dest)
+        Chunk.Arr(dest)
       }
     }
 
@@ -1025,7 +904,7 @@ object Chunk {
         i = i + 1
       }
 
-      if (dest != null) Chunk.fromArray(dest)
+      if (dest != null) Chunk.Arr(dest)
       else Chunk.Empty
     }
 
@@ -1052,6 +931,23 @@ object Chunk {
 
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
       Array.copy(array, 0, dest, n, length)
+  }
+
+  private object Arr {
+    def apply[A](array: Array[A]): Arr[A] = {
+      val clss = array.getClass().getComponentType()
+      val res =
+        if (clss == java.lang.Boolean.TYPE) BooleanArr(array.asInstanceOf[Array[Boolean]])
+        else if (clss == java.lang.Byte.TYPE) ByteArr(array.asInstanceOf[Array[Byte]])
+        else if (clss == java.lang.Character.TYPE) CharArr(array.asInstanceOf[Array[Char]])
+        else if (clss == java.lang.Double.TYPE) DoubleArr(array.asInstanceOf[Array[Double]])
+        else if (clss == java.lang.Float.TYPE) FloatArr(array.asInstanceOf[Array[Float]])
+        else if (clss == java.lang.Integer.TYPE) IntArr(array.asInstanceOf[Array[Int]])
+        else if (clss == java.lang.Long.TYPE) LongArr(array.asInstanceOf[Array[Long]])
+        else if (clss == java.lang.Short.TYPE) ShortArr(array.asInstanceOf[Array[Short]])
+        else RefArr(array)
+      res.asInstanceOf[Arr[A]]
+    }
   }
 
   private case class RefArr[A](override val array: Array[A]) extends Arr[A] {
@@ -1159,6 +1055,35 @@ object Chunk {
   }
 
   private object Singleton {
+    def apply[A](a: A): Singleton[A] = {
+      val clss = a.getClass()
+      val res =
+        if (clss == java.lang.Boolean.TYPE) BooleanSingleton(a.asInstanceOf[Boolean])
+        else if (clss == java.lang.Byte.TYPE) ByteSingleton(a.asInstanceOf[Byte])
+        else if (clss == java.lang.Character.TYPE) CharSingleton(a.asInstanceOf[Char])
+        else if (clss == java.lang.Double.TYPE) DoubleSingleton(a.asInstanceOf[Double])
+        else if (clss == java.lang.Float.TYPE) FloatSingleton(a.asInstanceOf[Float])
+        else if (clss == java.lang.Integer.TYPE) IntSingleton(a.asInstanceOf[Int])
+        else if (clss == java.lang.Long.TYPE) LongSingleton(a.asInstanceOf[Long])
+        else if (clss == java.lang.Short.TYPE) ShortSingleton(a.asInstanceOf[Short])
+        else RefSingleton(a)
+      res.asInstanceOf[Singleton[A]]
+    }
+
+    def apply[A](array: Array[A]): Arr[A] = {
+      val clss = array.getClass().getComponentType()
+      val res =
+        if (clss == java.lang.Boolean.TYPE) BooleanArr(array.asInstanceOf[Array[Boolean]])
+        else if (clss == java.lang.Byte.TYPE) ByteArr(array.asInstanceOf[Array[Byte]])
+        else if (clss == java.lang.Character.TYPE) CharArr(array.asInstanceOf[Array[Char]])
+        else if (clss == java.lang.Double.TYPE) DoubleArr(array.asInstanceOf[Array[Double]])
+        else if (clss == java.lang.Float.TYPE) FloatArr(array.asInstanceOf[Array[Float]])
+        else if (clss == java.lang.Integer.TYPE) IntArr(array.asInstanceOf[Array[Int]])
+        else if (clss == java.lang.Long.TYPE) LongArr(array.asInstanceOf[Array[Long]])
+        else if (clss == java.lang.Short.TYPE) ShortArr(array.asInstanceOf[Array[Short]])
+      res.asInstanceOf[Arr[A]]
+    }
+
     def unapply[A](singleton: Singleton[A]): Option[A] = Some(singleton.a)
   }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -683,7 +683,6 @@ object Chunk {
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
     if (it.size <= 0) Empty
-    else if (it.size == 1) single(it.head)
     else {
       it match {
         case l: Vector[A] => VectorChunk(l)
@@ -699,12 +698,92 @@ object Chunk {
   /**
    * Returns a singleton chunk, eagerly evaluated.
    */
-  final def single[A](a: A): Chunk[A] = Singleton(a)
+  final def single[A](a: A): Chunk[A] = RefSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Boolean): Chunk[Boolean] = BooleanSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Byte): Chunk[Byte] = ByteSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Char): Chunk[Char] = CharSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Double): Chunk[Double] = DoubleSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Float): Chunk[Float] = FloatSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Int): Chunk[Int] = IntSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Long): Chunk[Long] = LongSingleton(a)
+
+  /**
+   * Returns a singleton chunk, eagerly evaluated.
+   */
+  final def single(a: Short): Chunk[Short] = ShortSingleton(a)
 
   /**
    * Alias for [[Chunk.single]].
    */
   final def succeed[A](a: A): Chunk[A] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Boolean): Chunk[Boolean] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Byte): Chunk[Byte] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Char): Chunk[Char] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Double): Chunk[Double] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Float): Chunk[Float] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Int): Chunk[Int] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Long): Chunk[Long] = single(a)
+
+  /**
+   * Alias for [[Chunk.single]].
+   */
+  final def succeed(a: Short): Chunk[Short] = single(a)
 
   /**
    * Returns the `ClassTag` for the element type of the chunk.
@@ -1055,35 +1134,6 @@ object Chunk {
   }
 
   private object Singleton {
-    def apply[A](a: A): Singleton[A] = {
-      val clss = a.getClass()
-      val res =
-        if (clss == java.lang.Boolean.TYPE) BooleanSingleton(a.asInstanceOf[Boolean])
-        else if (clss == java.lang.Byte.TYPE) ByteSingleton(a.asInstanceOf[Byte])
-        else if (clss == java.lang.Character.TYPE) CharSingleton(a.asInstanceOf[Char])
-        else if (clss == java.lang.Double.TYPE) DoubleSingleton(a.asInstanceOf[Double])
-        else if (clss == java.lang.Float.TYPE) FloatSingleton(a.asInstanceOf[Float])
-        else if (clss == java.lang.Integer.TYPE) IntSingleton(a.asInstanceOf[Int])
-        else if (clss == java.lang.Long.TYPE) LongSingleton(a.asInstanceOf[Long])
-        else if (clss == java.lang.Short.TYPE) ShortSingleton(a.asInstanceOf[Short])
-        else RefSingleton(a)
-      res.asInstanceOf[Singleton[A]]
-    }
-
-    def apply[A](array: Array[A]): Arr[A] = {
-      val clss = array.getClass().getComponentType()
-      val res =
-        if (clss == java.lang.Boolean.TYPE) BooleanArr(array.asInstanceOf[Array[Boolean]])
-        else if (clss == java.lang.Byte.TYPE) ByteArr(array.asInstanceOf[Array[Byte]])
-        else if (clss == java.lang.Character.TYPE) CharArr(array.asInstanceOf[Array[Char]])
-        else if (clss == java.lang.Double.TYPE) DoubleArr(array.asInstanceOf[Array[Double]])
-        else if (clss == java.lang.Float.TYPE) FloatArr(array.asInstanceOf[Array[Float]])
-        else if (clss == java.lang.Integer.TYPE) IntArr(array.asInstanceOf[Array[Int]])
-        else if (clss == java.lang.Long.TYPE) LongArr(array.asInstanceOf[Array[Long]])
-        else if (clss == java.lang.Short.TYPE) ShortArr(array.asInstanceOf[Array[Short]])
-      res.asInstanceOf[Arr[A]]
-    }
-
     def unapply[A](singleton: Singleton[A]): Option[A] = Some(singleton.a)
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
@@ -17,11 +17,11 @@ trait ChunkUtils {
   def chunkGen[R <: Random, A: ClassTag](a: Gen[R, A], max: Int): Gen[R with Sized, Chunk[A]] =
     max match {
       case 0 => Gen.const(Chunk.empty)
-      case 1 => Gen.oneOf(Gen.const(Chunk.empty), a.map(Chunk.succeed(_)))
+      case 1 => Gen.oneOf(Gen.const(Chunk.empty), a.map(Chunk.succeed))
       case _ =>
         Gen.oneOf(
           Gen.const(Chunk.empty),
-          a.map(Chunk.succeed(_)),
+          a.map(Chunk.succeed),
           chunkWithIndex(a).map(_._1),
           Gen.suspend(for {
             arr  <- chunkGen(a, max)

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
@@ -17,11 +17,11 @@ trait ChunkUtils {
   def chunkGen[R <: Random, A: ClassTag](a: Gen[R, A], max: Int): Gen[R with Sized, Chunk[A]] =
     max match {
       case 0 => Gen.const(Chunk.empty)
-      case 1 => Gen.oneOf(Gen.const(Chunk.empty), a.map(Chunk.succeed))
+      case 1 => Gen.oneOf(Gen.const(Chunk.empty), a.map(Chunk.succeed(_)))
       case _ =>
         Gen.oneOf(
           Gen.const(Chunk.empty),
-          a.map(Chunk.succeed),
+          a.map(Chunk.succeed(_)),
           chunkWithIndex(a).map(_._1),
           Gen.suspend(for {
             arr  <- chunkGen(a, max)

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1694,7 +1694,7 @@ object ZSink extends ZSinkPlatformSpecific with Serializable {
    * `\r\n` and `\n`.
    */
   final val splitLinesChunk: ZSink[Any, Nothing, Chunk[String], Chunk[String], Chunk[String]] =
-    splitLines.contramap[Chunk[String]](_.mkString).mapRemainder(Chunk.single)
+    splitLines.contramap[Chunk[String]](_.mkString).mapRemainder(Chunk.single(_))
 
   /**
    * Splits strings on a delimiter.

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1694,7 +1694,7 @@ object ZSink extends ZSinkPlatformSpecific with Serializable {
    * `\r\n` and `\n`.
    */
   final val splitLinesChunk: ZSink[Any, Nothing, Chunk[String], Chunk[String], Chunk[String]] =
-    splitLines.contramap[Chunk[String]](_.mkString).mapRemainder(Chunk.single(_))
+    splitLines.contramap[Chunk[String]](_.mkString).mapRemainder(Chunk.single)
 
   /**
    * Splits strings on a delimiter.


### PR DESCRIPTION
I'm sorry that I'm polluting the Chunk companion object namespace, but unfortunately I fell victim to the https://github.com/scala/bug/issues/2034 bug.

Here is a proof that this works.
https://imgur.com/a/iUDc9t2

The singletons need some more work. Currently most of the operations such as `map, flatMap, filter` on chunks allocate an array, so they turn 1 element arrays into `Arr` instances, instead of `Singletons`, rendering `Singletons` not as useful IMO. I also had to remove `Singleton` creation from `Chunk.apply(as: A*)` because it would always box to `RefSingleton`.

@jdegoes 