### PR TITLE
refactor RandomSpec to use Gen

### DIFF
--- a/core/jvm/project/build.properties
+++ b/core/jvm/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.8

--- a/core/jvm/project/build.properties
+++ b/core/jvm/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -1,32 +1,79 @@
 package zio.test.environment
 
+import zio._
+import zio.random.Random
 import zio.test.Assertion._
 import zio.test.environment.RandomSpecUtil._
-import zio.test.environment.TestRandom.DefaultData
-import zio.test.{ assert, suite, testM, TestResult, ZIOBaseSpec }
-import zio._
+import zio.test.environment.TestRandom.{ DefaultData, Test }
+import zio.test._
+
+import scala.util.{ Random => SRandom }
 
 object RandomSpec
     extends ZIOBaseSpec(
       suite("RandomSpec")(
-        testM("check clearBooleans")(checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(_.nextBoolean)),
-        testM("check clearBytes")(checkClear(nextBytes(1))(_.feedBytes(_: _*))(_.clearBytes)(_.nextBytes(1))),
-        testM("check clearChars")(
-          checkClear(_.nextPrintableChar)(_.feedChars(_: _*))(_.clearChars)(_.nextPrintableChar)
+        testM("check clearBooleans")(
+          checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(
+            _.nextBoolean
+          )
         ),
-        testM("check clearDoubles")(checkClear(_.nextDouble)(_.feedDoubles(_: _*))(_.clearDoubles)(_.nextDouble)),
-        testM("check clearFloats")(checkClear(_.nextFloat)(_.feedFloats(_: _*))(_.clearFloats)(_.nextFloat)),
-        testM("check clearInts")(checkClear(_.nextInt)(_.feedInts(_: _*))(_.clearInts)(_.nextInt)),
-        testM("check clearLongs")(checkClear(_.nextLong)(_.feedLongs(_: _*))(_.clearLongs)(_.nextLong)),
-        testM("check clearStrings")(checkClear(_.nextString(1))(_.feedStrings(_: _*))(_.clearStrings)(_.nextString(1))),
-        testM("check feedBooleans")(checkFeed(_.nextBoolean)(_.feedBooleans(_: _*))(_.nextBoolean)),
-        testM("check feedBytes")(checkFeed(nextBytes(1))(_.feedBytes(_: _*))(_.nextBytes(1))),
-        testM("check feedChars")(checkFeed(_.nextPrintableChar)(_.feedChars(_: _*))(_.nextPrintableChar)),
-        testM("check feedDoubles")(checkFeed(_.nextDouble)(_.feedDoubles(_: _*))(_.nextDouble)),
-        testM("check feedFloats")(checkFeed(_.nextFloat)(_.feedFloats(_: _*))(_.nextFloat)),
-        testM("check feedInts")(checkFeed(_.nextInt)(_.feedInts(_: _*))(_.nextInt)),
-        testM("check feedLongs")(checkFeed(_.nextLong)(_.feedLongs(_: _*))(_.nextLong)),
-        testM("check feedStrings")(checkFeed(_.nextString(1))(_.feedStrings(_: _*))(_.nextString(1))),
+        testM("check clearBytes")(
+          checkClear(nextBytes(1))(_.feedBytes(_: _*))(_.clearBytes)(
+            _.nextBytes(1)
+          )
+        ),
+        testM("check clearChars")(
+          checkClear(_.nextPrintableChar)(_.feedChars(_: _*))(_.clearChars)(
+            _.nextPrintableChar
+          )
+        ),
+        testM("check clearDoubles")(
+          checkClear(_.nextDouble)(_.feedDoubles(_: _*))(_.clearDoubles)(
+            _.nextDouble
+          )
+        ),
+        testM("check clearFloats")(
+          checkClear(_.nextFloat)(_.feedFloats(_: _*))(_.clearFloats)(
+            _.nextFloat
+          )
+        ),
+        testM("check clearInts")(
+          checkClear(_.nextInt)(_.feedInts(_: _*))(_.clearInts)(_.nextInt)
+        ),
+        testM("check clearLongs")(
+          checkClear(_.nextLong)(_.feedLongs(_: _*))(_.clearLongs)(_.nextLong)
+        ),
+        testM("check clearStrings")(
+          checkClear(_.nextString(1))(_.feedStrings(_: _*))(_.clearStrings)(
+            _.nextString(1)
+          )
+        ),
+        testM("check feedBooleans")(
+          checkFeed(_.nextBoolean)(_.feedBooleans(_: _*))(_.nextBoolean)
+        ),
+        testM("check feedBytes")(
+          checkFeed(nextBytes(1))(_.feedBytes(_: _*))(_.nextBytes(1))
+        ),
+        testM("check feedChars")(
+          checkFeed(_.nextPrintableChar)(_.feedChars(_: _*))(
+            _.nextPrintableChar
+          )
+        ),
+        testM("check feedDoubles")(
+          checkFeed(_.nextDouble)(_.feedDoubles(_: _*))(_.nextDouble)
+        ),
+        testM("check feedFloats")(
+          checkFeed(_.nextFloat)(_.feedFloats(_: _*))(_.nextFloat)
+        ),
+        testM("check feedInts")(
+          checkFeed(_.nextInt)(_.feedInts(_: _*))(_.nextInt)
+        ),
+        testM("check feedLongs")(
+          checkFeed(_.nextLong)(_.feedLongs(_: _*))(_.nextLong)
+        ),
+        testM("check feedStrings")(
+          checkFeed(_.nextString(1))(_.feedStrings(_: _*))(_.nextString(1))
+        ),
         testM("check nextBoolean")(forAllEqual(_.nextBoolean)(_.nextBoolean())),
         testM("check nextBytes")(forAllEqualBytes),
         testM("check nextDouble")(forAllEqual(_.nextDouble)(_.nextDouble())),
@@ -34,11 +81,19 @@ object RandomSpec
         testM("check nextGaussian")(forAllEqualGaussian),
         testM("check nextInt")(forAllEqual(_.nextInt)(_.nextInt())),
         testM("check nextLong")(forAllEqual(_.nextLong)(_.nextLong())),
-        testM("check nextPrintableChar")(forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())),
-        testM("check nextString")(forAllEqualN(_.nextString(_))(_.nextString(_))),
+        testM("check nextPrintableChar")(
+          forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())
+        ),
+        testM("check nextString")(
+          forAllEqualN(_.nextString(_))(_.nextString(_))
+        ),
         testM("bounded nextInt")(forAllEqualN(_.nextInt(_))(_.nextInt(_))),
-        testM("bounded nextInt generates values within the bounds")(forAllBounded(_.nextInt)(_.nextInt(_))),
-        testM("bounded nextLong generates values within the bounds")(forAllBounded(_.nextLong)(_.nextLong(_))),
+        testM("bounded nextInt generates values within the bounds")(
+          forAllBounded(Gen.anyInt)(_.nextInt(_))
+        ),
+        testM("bounded nextLong generates values within the bounds")(
+          forAllBounded(Gen.anyLong)(_.nextLong(_))
+        ),
         testM("shuffle")(forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))),
         testM("referential transparency") {
           val test = TestRandom.makeTest(DefaultData)
@@ -55,12 +110,9 @@ object RandomSpec
 
 object RandomSpecUtil {
 
-  import scala.util.{ Random => SRandom }
-  import zio.test.environment.TestRandom.Test
-
-  def checkClear[A](generate: SRandom => A)(
-    feed: (Test, List[A]) => UIO[Unit]
-  )(clear: Test => UIO[Unit])(extract: Test => UIO[A]): ZIO[TestRandom, Nothing, TestResult] = {
+  def checkClear[A](generate: SRandom => A)(feed: (Test, List[A]) => UIO[Unit])(
+    clear: Test => UIO[Unit]
+  )(extract: Test => UIO[A]): ZIO[TestRandom, Nothing, TestResult] = {
     val seed    = SRandom.nextLong()
     val sRandom = new SRandom(seed)
     for {
@@ -72,9 +124,10 @@ object RandomSpecUtil {
       random     <- extract(testRandom)
     } yield assert(random, equalTo(generate(new SRandom(seed))))
   }
-  def checkFeed[A](
-    generate: SRandom => A
-  )(feed: (Test, List[A]) => UIO[Unit])(extract: Test => UIO[A]): ZIO[TestRandom, Nothing, TestResult] = {
+
+  def checkFeed[A](generate: SRandom => A)(
+    feed: (Test, List[A]) => UIO[Unit]
+  )(extract: Test => UIO[A]): ZIO[TestRandom, Nothing, TestResult] = {
     val seed    = SRandom.nextLong()
     val sRandom = new SRandom(seed)
     for {
@@ -96,7 +149,9 @@ object RandomSpecUtil {
     Chunk.fromArray(arr)
   }
 
-  def forAllEqual[A](f: Test => UIO[A])(g: SRandom => A): ZIO[Any, Nothing, TestResult] = {
+  def forAllEqual[A](
+    f: Test => UIO[A]
+  )(g: SRandom => A): ZIO[Any, Nothing, TestResult] = {
     val seed    = SRandom.nextLong()
     val sRandom = new SRandom(seed)
     for {
@@ -129,10 +184,14 @@ object RandomSpecUtil {
       _          <- testRandom.setSeed(seed)
       actual     <- UIO.foreach(List.fill(100)(()))(_ => testRandom.nextGaussian)
       expected   = List.fill(100)(sRandom.nextGaussian)
-    } yield assert(actual.zip(expected).forall { case (x, y) => math.abs(x - y) < 0.01 }, equalTo(true))
+    } yield assert(actual.zip(expected).forall {
+      case (x, y) => math.abs(x - y) < 0.01
+    }, equalTo(true))
   }
 
-  def forAllEqualN[A](f: (Test, Int) => UIO[A])(g: (SRandom, Int) => A): ZIO[Any, Nothing, TestResult] = {
+  def forAllEqualN[A](
+    f: (Test, Int) => UIO[A]
+  )(g: (SRandom, Int) => A): ZIO[Any, Nothing, TestResult] = {
     val seed    = SRandom.nextLong()
     val sRandom = new SRandom(seed)
     for {
@@ -151,21 +210,23 @@ object RandomSpecUtil {
     for {
       testRandom <- TestRandom.makeTest(DefaultData)
       _          <- testRandom.setSeed(seed)
-      actual     <- UIO.foreach(List.range(0, 100).map(List.range(0, _)))(f(testRandom, _))
-      expected   = List.range(0, 100).map(List.range(0, _)).map(g(sRandom, _))
+      actual <- UIO.foreach(List.range(0, 100).map(List.range(0, _)))(
+                 f(testRandom, _)
+               )
+      expected = List.range(0, 100).map(List.range(0, _)).map(g(sRandom, _))
     } yield assert(actual, equalTo(expected))
   }
 
-  def forAllBounded[A: Numeric](bound: SRandom => A)(f: (Test, A) => UIO[A]): ZIO[Any, Nothing, TestResult] = {
+  def forAllBounded[A: Numeric](
+    gen: Gen[Random, A]
+  )(next: (Random.Service[Any], A) => UIO[A]): ZIO[Random, Nothing, TestResult] = {
     val num = implicitly[Numeric[A]]
     import num._
-    val seed    = SRandom.nextLong()
-    val sRandom = new SRandom(seed)
-    for {
-      testRandom <- TestRandom.makeTest(DefaultData)
-      _          <- testRandom.setSeed(seed)
-      bounds     = List.fill(100)(num.abs(bound(sRandom)) max one)
-      actual     <- UIO.foreach(bounds)(f(testRandom, _))
-    } yield assert(actual.zip(bounds).forall { case (a, n) => zero <= a && a < n }, equalTo(true))
+    checkM(gen.map(num.abs(_))) { upper =>
+      for {
+        testRandom <- ZIO.environment[Random].map(_.random)
+        nextRandom <- next(testRandom, upper)
+      } yield assert(nextRandom, isWithin(zero, upper))
+    }
   }
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -1,7 +1,6 @@
 package zio.test.environment
 
 import zio._
-import zio.ZIO._
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.environment.RandomSpecUtil._
@@ -13,108 +12,41 @@ import scala.util.{ Random => SRandom }
 object RandomSpec
     extends ZIOBaseSpec(
       suite("RandomSpec")(
-        testM("check clearBooleans") {
-          checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(_.nextBoolean)
-        },
-        testM("check clearBytes") {
-          checkClear(nextBytes(1))(_.feedBytes(_: _*))(_.clearBytes)(
-            _.nextBytes(1)
-          )
-        },
-        testM("check clearChars") {
-          checkClear(_.nextPrintableChar)(_.feedChars(_: _*))(_.clearChars)(
-            _.nextPrintableChar
-          )
-        },
-        testM("check clearDoubles") {
-          checkClear(_.nextDouble)(_.feedDoubles(_: _*))(_.clearDoubles)(
-            _.nextDouble
-          )
-        },
-        testM("check clearFloats") {
-          checkClear(_.nextFloat)(_.feedFloats(_: _*))(_.clearFloats)(
-            _.nextFloat
-          )
-        },
-        testM("check clearInts") {
-          checkClear(_.nextInt)(_.feedInts(_: _*))(_.clearInts)(_.nextInt)
-        },
-        testM("check clearLongs") {
-          checkClear(_.nextLong)(_.feedLongs(_: _*))(_.clearLongs)(_.nextLong)
-        },
-        testM("check clearStrings") {
-          checkClear(_.nextString(1))(_.feedStrings(_: _*))(_.clearStrings)(
-            _.nextString(1)
-          )
-        },
-        testM("check feedBooleans") {
-          checkFeed(_.nextBoolean)(_.feedBooleans(_: _*))(_.nextBoolean)
-        },
-        testM("check feedBytes") {
-          checkFeed(nextBytes(1))(_.feedBytes(_: _*))(_.nextBytes(1))
-        },
-        testM("check feedChars")(
-          checkFeed(_.nextPrintableChar)(_.feedChars(_: _*))(
-            _.nextPrintableChar
-          )
+        testM("check clearBooleans")(checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(_.nextBoolean)),
+        testM("check clearBytes")(checkClear(nextBytes(1))(_.feedBytes(_: _*))(_.clearBytes)(_.nextBytes(1))),
+        testM("check clearChars")(
+          checkClear(_.nextPrintableChar)(_.feedChars(_: _*))(_.clearChars)(_.nextPrintableChar)
         ),
-        testM("check feedDoubles") {
-          checkFeed(_.nextDouble)(_.feedDoubles(_: _*))(_.nextDouble)
-        },
-        testM("check feedFloats") {
-          checkFeed(_.nextFloat)(_.feedFloats(_: _*))(_.nextFloat)
-        },
-        testM("check feedInts") {
-          checkFeed(_.nextInt)(_.feedInts(_: _*))(_.nextInt)
-        },
-        testM("check feedLongs") {
-          checkFeed(_.nextLong)(_.feedLongs(_: _*))(_.nextLong)
-        },
-        testM("check feedStrings") {
-          checkFeed(_.nextString(1))(_.feedStrings(_: _*))(_.nextString(1))
-        },
-        testM("check nextBoolean") {
-          forAllEqual(_.nextBoolean)(_.nextBoolean())
-        },
-        testM("check nextBytes") {
-          forAllEqualBytes
-        },
-        testM("check nextDouble") {
-          forAllEqual(_.nextDouble)(_.nextDouble())
-        },
-        testM("check nextFloat") {
-          forAllEqual(_.nextFloat)(_.nextFloat())
-        },
-        testM("check nextGaussian") {
-          forAllEqualGaussian
-        },
-        testM("check nextInt") {
-          forAllEqual(_.nextInt)(_.nextInt())
-        },
-        testM("check nextLong") {
-          forAllEqual(_.nextLong)(_.nextLong())
-        },
-        testM("check nextPrintableChar") {
-          forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())
-        },
-        testM("check nextString") {
-          forAllEqualN(_.nextString(_))(_.nextString(_))
-        },
-        testM("bounded nextInt") {
-          forAllEqualN(_.nextInt(_))(_.nextInt(_))
-        },
-        testM("bounded nextInt generates values within the bounds") {
-          forAllBounded(Gen.anyInt)(_.nextInt(_))
-        },
-        testM("bounded nextLong generates values within the bounds") {
-          forAllBounded(Gen.anyLong)(_.nextLong(_))
-        },
-        testM("shuffle") {
-          forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))
-        },
+        testM("check clearDoubles")(checkClear(_.nextDouble)(_.feedDoubles(_: _*))(_.clearDoubles)(_.nextDouble)),
+        testM("check clearFloats")(checkClear(_.nextFloat)(_.feedFloats(_: _*))(_.clearFloats)(_.nextFloat)),
+        testM("check clearInts")(checkClear(_.nextInt)(_.feedInts(_: _*))(_.clearInts)(_.nextInt)),
+        testM("check clearLongs")(checkClear(_.nextLong)(_.feedLongs(_: _*))(_.clearLongs)(_.nextLong)),
+        testM("check clearStrings")(checkClear(_.nextString(1))(_.feedStrings(_: _*))(_.clearStrings)(_.nextString(1))),
+        testM("check feedBooleans")(checkFeed(_.nextBoolean)(_.feedBooleans(_: _*))(_.nextBoolean)),
+        testM("check feedBytes")(checkFeed(nextBytes(1))(_.feedBytes(_: _*))(_.nextBytes(1))),
+        testM("check feedChars")(checkFeed(_.nextPrintableChar)(_.feedChars(_: _*))(_.nextPrintableChar)),
+        testM("check feedDoubles")(checkFeed(_.nextDouble)(_.feedDoubles(_: _*))(_.nextDouble)),
+        testM("check feedFloats")(checkFeed(_.nextFloat)(_.feedFloats(_: _*))(_.nextFloat)),
+        testM("check feedInts")(checkFeed(_.nextInt)(_.feedInts(_: _*))(_.nextInt)),
+        testM("check feedLongs")(checkFeed(_.nextLong)(_.feedLongs(_: _*))(_.nextLong)),
+        testM("check feedStrings")(checkFeed(_.nextString(1))(_.feedStrings(_: _*))(_.nextString(1))),
+        testM("check nextBoolean")(forAllEqual(_.nextBoolean)(_.nextBoolean())),
+        testM("check nextBytes")(forAllEqualBytes),
+        testM("check nextDouble")(forAllEqual(_.nextDouble)(_.nextDouble())),
+        testM("check nextFloat")(forAllEqual(_.nextFloat)(_.nextFloat())),
+        testM("check nextGaussian")(forAllEqualGaussian),
+        testM("check nextInt")(forAllEqual(_.nextInt)(_.nextInt())),
+        testM("check nextLong")(forAllEqual(_.nextLong)(_.nextLong())),
+        testM("check nextPrintableChar")(forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())),
+        testM("check nextString")(forAllEqualN(_.nextString(_))(_.nextString(_))),
+        testM("bounded nextInt")(forAllEqualN(_.nextInt(_))(_.nextInt(_))),
+        testM("bounded nextInt generates values within the bounds")(forAllBounded(Gen.anyInt)(_.nextInt(_))),
+        testM("bounded nextLong generates values within the bounds")(forAllBounded(Gen.anyLong)(_.nextLong(_))),
+        testM("shuffle")(forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))),
         testM("referential transparency") {
           val test = TestRandom.makeTest(DefaultData)
-          runtime[Any]
+          ZIO
+            .runtime[Any]
             .map(rt => {
               val x = rt.unsafeRun(test.flatMap[Any, Nothing, Int](_.nextInt))
               val y = rt.unsafeRun(test.flatMap[Any, Nothing, Int](_.nextInt))
@@ -131,14 +63,15 @@ object RandomSpecUtil {
   )(extract: Test => UIO[A]): ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
-        value      <- effectTotal(generate(sRandom))
+        value      <- ZIO.effectTotal(generate(sRandom))
         _          <- feed(testRandom, List(value))
         _          <- clear(testRandom)
         random     <- extract(testRandom)
-      } yield assert(random, equalTo(generate(new SRandom(seed))))
+        expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
+      } yield assert(random, equalTo(expected))
     }
 
   def checkFeed[A, B >: Random](generate: SRandom => A)(
@@ -146,16 +79,17 @@ object RandomSpecUtil {
   )(extract: Test => UIO[A]): ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
-        values     <- effectTotal(List.fill(100)(generate(sRandom)))
+        values     <- ZIO.effectTotal(List.fill(100)(generate(sRandom)))
         _          <- feed(testRandom, values)
         results    <- UIO.foreach(List.range(0, 100))(_ => extract(testRandom))
         random     <- extract(testRandom)
+        expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
       } yield {
         assert(results, equalTo(values)) &&
-        assert(random, equalTo(generate(new SRandom(seed))))
+        assert(random, equalTo(expected))
       }
     }
 
@@ -170,22 +104,22 @@ object RandomSpecUtil {
   )(g: SRandom => A): ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- UIO.foreach(List.fill(100)(()))(_ => f(testRandom))
-        expected   <- effectTotal(List.fill(100)(g(sRandom)))
+        expected   <- ZIO.effectTotal(List.fill(100)(g(sRandom)))
       } yield assert(actual, equalTo(expected))
     }
 
   def forAllEqualBytes: ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- UIO.foreach(0 to 100)(testRandom.nextBytes(_))
-        expected <- effectTotal((0 to 100).map(new Array[Byte](_)).map { arr =>
+        expected <- ZIO.effectTotal((0 to 100).map(new Array[Byte](_)).map { arr =>
                      sRandom.nextBytes(arr)
                      Chunk.fromArray(arr)
                    })
@@ -195,11 +129,11 @@ object RandomSpecUtil {
   def forAllEqualGaussian: ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- testRandom.nextGaussian
-        expected   <- effectTotal(sRandom.nextGaussian)
+        expected   <- ZIO.effectTotal(sRandom.nextGaussian)
       } yield assert(math.abs(actual - expected), isLessThan(0.01))
     }
 
@@ -208,11 +142,11 @@ object RandomSpecUtil {
   )(g: (SRandom, Int) => A): ZIO[Random, Nothing, TestResult] =
     checkM(Gen.anyLong, Gen.int(1, 100)) { (seed, size) =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, size)
-        expected   <- effectTotal(g(sRandom, size))
+        expected   <- ZIO.effectTotal(g(sRandom, size))
       } yield assert(actual, equalTo(expected))
     }
 
@@ -221,11 +155,11 @@ object RandomSpecUtil {
   )(g: (SRandom, List[Int]) => List[Int]): ZIO[Random with Sized, Nothing, TestResult] =
     checkM(Gen.anyLong, Gen.listOf(Gen.anyInt)) { (seed, testList) =>
       for {
-        sRandom    <- effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.effectTotal(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, testList)
-        expected   <- effectTotal(g(sRandom, testList))
+        expected   <- ZIO.effectTotal(g(sRandom, testList))
       } yield assert(actual, equalTo(expected))
     }
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -134,7 +134,7 @@ object RandomSpecUtil {
         _          <- testRandom.setSeed(seed)
         actual     <- testRandom.nextGaussian
         expected   <- ZIO.effectTotal(sRandom.nextGaussian)
-      } yield assert(math.abs(actual - expected), isLessThan(0.01))
+      } yield assert(actual, approximatelyEquals(expected, 0.01))
     }
 
   def forAllEqualN[A](

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -12,89 +12,105 @@ import scala.util.{ Random => SRandom }
 object RandomSpec
     extends ZIOBaseSpec(
       suite("RandomSpec")(
-        testM("check clearBooleans")(
-          checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(
-            _.nextBoolean
-          )
-        ),
-        testM("check clearBytes")(
+        testM("check clearBooleans") {
+          checkClear(_.nextBoolean)(_.feedBooleans(_: _*))(_.clearBooleans)(_.nextBoolean)
+        },
+        testM("check clearBytes") {
           checkClear(nextBytes(1))(_.feedBytes(_: _*))(_.clearBytes)(
             _.nextBytes(1)
           )
-        ),
-        testM("check clearChars")(
+        },
+        testM("check clearChars") {
           checkClear(_.nextPrintableChar)(_.feedChars(_: _*))(_.clearChars)(
             _.nextPrintableChar
           )
-        ),
-        testM("check clearDoubles")(
+        },
+        testM("check clearDoubles") {
           checkClear(_.nextDouble)(_.feedDoubles(_: _*))(_.clearDoubles)(
             _.nextDouble
           )
-        ),
-        testM("check clearFloats")(
+        },
+        testM("check clearFloats") {
           checkClear(_.nextFloat)(_.feedFloats(_: _*))(_.clearFloats)(
             _.nextFloat
           )
-        ),
-        testM("check clearInts")(
+        },
+        testM("check clearInts") {
           checkClear(_.nextInt)(_.feedInts(_: _*))(_.clearInts)(_.nextInt)
-        ),
-        testM("check clearLongs")(
+        },
+        testM("check clearLongs") {
           checkClear(_.nextLong)(_.feedLongs(_: _*))(_.clearLongs)(_.nextLong)
-        ),
-        testM("check clearStrings")(
+        },
+        testM("check clearStrings") {
           checkClear(_.nextString(1))(_.feedStrings(_: _*))(_.clearStrings)(
             _.nextString(1)
           )
-        ),
-        testM("check feedBooleans")(
+        },
+        testM("check feedBooleans") {
           checkFeed(_.nextBoolean)(_.feedBooleans(_: _*))(_.nextBoolean)
-        ),
-        testM("check feedBytes")(
+        },
+        testM("check feedBytes") {
           checkFeed(nextBytes(1))(_.feedBytes(_: _*))(_.nextBytes(1))
-        ),
+        },
         testM("check feedChars")(
           checkFeed(_.nextPrintableChar)(_.feedChars(_: _*))(
             _.nextPrintableChar
           )
         ),
-        testM("check feedDoubles")(
+        testM("check feedDoubles") {
           checkFeed(_.nextDouble)(_.feedDoubles(_: _*))(_.nextDouble)
-        ),
-        testM("check feedFloats")(
+        },
+        testM("check feedFloats") {
           checkFeed(_.nextFloat)(_.feedFloats(_: _*))(_.nextFloat)
-        ),
-        testM("check feedInts")(
+        },
+        testM("check feedInts") {
           checkFeed(_.nextInt)(_.feedInts(_: _*))(_.nextInt)
-        ),
-        testM("check feedLongs")(
+        },
+        testM("check feedLongs") {
           checkFeed(_.nextLong)(_.feedLongs(_: _*))(_.nextLong)
-        ),
-        testM("check feedStrings")(
+        },
+        testM("check feedStrings") {
           checkFeed(_.nextString(1))(_.feedStrings(_: _*))(_.nextString(1))
-        ),
-        testM("check nextBoolean")(forAllEqual(_.nextBoolean)(_.nextBoolean())),
-        testM("check nextBytes")(forAllEqualBytes),
-        testM("check nextDouble")(forAllEqual(_.nextDouble)(_.nextDouble())),
-        testM("check nextFloat")(forAllEqual(_.nextFloat)(_.nextFloat())),
-        testM("check nextGaussian")(forAllEqualGaussian),
-        testM("check nextInt")(forAllEqual(_.nextInt)(_.nextInt())),
-        testM("check nextLong")(forAllEqual(_.nextLong)(_.nextLong())),
-        testM("check nextPrintableChar")(
+        },
+        testM("check nextBoolean") {
+          forAllEqual(_.nextBoolean)(_.nextBoolean())
+        },
+        testM("check nextBytes") {
+          forAllEqualBytes
+        },
+        testM("check nextDouble") {
+          forAllEqual(_.nextDouble)(_.nextDouble())
+        },
+        testM("check nextFloat") {
+          forAllEqual(_.nextFloat)(_.nextFloat())
+        },
+        testM("check nextGaussian") {
+          forAllEqualGaussian
+        },
+        testM("check nextInt") {
+          forAllEqual(_.nextInt)(_.nextInt())
+        },
+        testM("check nextLong") {
+          forAllEqual(_.nextLong)(_.nextLong())
+        },
+        testM("check nextPrintableChar") {
           forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())
-        ),
-        testM("check nextString")(
+        },
+        testM("check nextString") {
           forAllEqualN(_.nextString(_))(_.nextString(_))
-        ),
-        testM("bounded nextInt")(forAllEqualN(_.nextInt(_))(_.nextInt(_))),
-        testM("bounded nextInt generates values within the bounds")(
+        },
+        testM("bounded nextInt") {
+          forAllEqualN(_.nextInt(_))(_.nextInt(_))
+        },
+        testM("bounded nextInt generates values within the bounds") {
           forAllBounded(Gen.anyInt)(_.nextInt(_))
-        ),
-        testM("bounded nextLong generates values within the bounds")(
+        },
+        testM("bounded nextLong generates values within the bounds") {
           forAllBounded(Gen.anyLong)(_.nextLong(_))
-        ),
-        testM("shuffle")(forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))),
+        },
+        testM("shuffle") {
+          forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))
+        },
         testM("referential transparency") {
           val test = TestRandom.makeTest(DefaultData)
           ZIO
@@ -191,7 +207,7 @@ object RandomSpecUtil {
 
   def forAllEqualN[A](
     f: (Test, Int) => UIO[A]
-  )(g: (SRandom, Int) => A): ZIO[Any, Nothing, TestResult] = {
+  )(g: (SRandom, Int) => A) = {
     val seed    = SRandom.nextLong()
     val sRandom = new SRandom(seed)
     for {
@@ -203,23 +219,24 @@ object RandomSpecUtil {
   }
 
   def forAllEqualShuffle(
-    f: (Test, List[Int]) => UIO[List[Int]]
-  )(g: (SRandom, List[Int]) => List[Int]): ZIO[Any, Nothing, TestResult] = {
-    val seed    = SRandom.nextLong()
-    val sRandom = new SRandom(seed)
-    for {
-      testRandom <- TestRandom.makeTest(DefaultData)
-      _          <- testRandom.setSeed(seed)
-      actual <- UIO.foreach(List.range(0, 100).map(List.range(0, _)))(
-                 f(testRandom, _)
-               )
-      expected = List.range(0, 100).map(List.range(0, _)).map(g(sRandom, _))
-    } yield assert(actual, equalTo(expected))
-  }
+    f: (TestRandom.Test, List[Int]) => UIO[List[Int]]
+  )(g: (SRandom, List[Int]) => List[Int]): ZIO[Random, Nothing, TestResult] =
+    checkSomeM(Gen.int(0, 100))(100) { size =>
+      checkSomeM(Gen.listOfN(size)(Gen.anyInt))(1) { testList =>
+        val seed    = SRandom.nextLong()
+        val sRandom = new SRandom(seed)
+        for {
+          testRandom <- TestRandom.makeTest(DefaultData)
+          _          <- testRandom.setSeed(seed)
+          actual     <- f(testRandom, testList)
+          expected   = g(sRandom, testList)
+        } yield assert(actual, equalTo(expected))
+      }
+    }
 
-  def forAllBounded[A: Numeric](
-    gen: Gen[Random, A]
-  )(next: (Random.Service[Any], A) => UIO[A]): ZIO[Random, Nothing, TestResult] = {
+  def forAllBounded[A: Numeric](gen: Gen[Random, A])(
+    next: (Random.Service[Any], A) => UIO[A]
+  ): ZIO[Random, Nothing, TestResult] = {
     val num = implicitly[Numeric[A]]
     import num._
     checkM(gen.map(num.abs(_))) { upper =>


### PR DESCRIPTION
RandomSpec round 1 had some messy assertions which would be improved by using property based testing
#1898, #2037 

@adamgfraser I think I've cracked `forAllBounded` - before I tackle the others, can you please review to confirm this is what you're after? Some things I'm concerned about that you may be able to assist with:

1. is the state of testRandom ever going to update during this test? I tried to debug to find out but my breakpoints were being ignored for some reason.
2. `next` is asking for a `(Random.Service[Any], A) => UIO[A]` mainly because that's how I'm getting my `Random`. my gut feel is this should really be `TestRandom.Test` instead of `Random.Service[Any]`, because we're operating in the test environment but I couldn't get this to work. I guess I'm not using any features of Test that aren't part of the standard interface so perhaps this doesn't matter.
3. looks like `fmt` went to town with the new lines - is this intentional?