### PR TITLE
ZIO Test: Implement Overloaded Version of TestAspect#nonFlaky

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -79,7 +79,7 @@ object RTSSpec
             } yield (startValue + exitValue) == 42
 
           assertM(io, isTrue)
-        } @@ jvm(nonFlaky(100)),
+        } @@ jvm(nonFlaky),
         testM("deadlock regression 1") {
           import java.util.concurrent.Executors
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -165,7 +165,7 @@ object ZIOSpec
                 equalTo(List("error1")) ||
                 equalTo(List("error2"))
             )
-          } @@ nonFlaky(100)
+          } @@ nonFlaky
         ),
         suite("raceAll")(
           testM("returns first success") {
@@ -946,7 +946,7 @@ object ZIOSpec
           testM("par regression") {
             val io = IO.succeed[Int](1).zipPar(IO.succeed[Int](2)).flatMap(t => IO.succeed(t._1 + t._2)).map(_ == 3)
             assertM(io, isTrue)
-          } @@ jvm(nonFlaky(100)),
+          } @@ jvm(nonFlaky),
           testM("par of now values") {
             def countdown(n: Int): UIO[Int] =
               if (n == 0) IO.succeed(0)
@@ -1238,7 +1238,7 @@ object ZIOSpec
               } yield exit.interrupted == true || finished == true
 
             assertM(io, isTrue)
-          } @@ jvm(nonFlaky(100)),
+          } @@ jvm(nonFlaky),
           testM("bracket use inherits interrupt status") {
             val io =
               for {
@@ -1343,7 +1343,7 @@ object ZIOSpec
               } yield v.contains(exec)
 
             assertM(io, isTrue)
-          } @@ jvm(nonFlaky(100)),
+          } @@ jvm(nonFlaky),
           testM("supervision is heritable") {
             val io =
               for {

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -716,7 +716,7 @@ object ZQueueSpec
             _ <- q.shutdown
             _ <- f.await
           } yield assertCompletes
-        } @@ jvm(nonFlaky(100)),
+        } @@ jvm(nonFlaky),
         testM("shutdown race condition with take") {
           for {
             q <- Queue.bounded[Int](2)
@@ -726,7 +726,7 @@ object ZQueueSpec
             _ <- q.shutdown
             _ <- f.await
           } yield assertCompletes
-        } @@ jvm(nonFlaky(100))
+        } @@ jvm(nonFlaky)
       )
     )
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -23,7 +23,7 @@ object ClockSpec
             _     <- latch.await
           } yield assertCompletes
         } @@ after(setTime(0.hours))
-          @@ nonFlaky(100),
+          @@ nonFlaky,
         testM("sleep delays effect until time is adjusted") {
           for {
             ref    <- Ref.make(true)
@@ -32,7 +32,7 @@ object ClockSpec
             result <- ref.get
           } yield assert(result, isTrue)
         } @@ after(setTime(0.hours))
-          @@ nonFlaky(100),
+          @@ nonFlaky,
         testM("sleep correctly handles multiple sleeps") {
           for {
             latch1 <- Promise.make[Nothing, Unit]
@@ -47,7 +47,7 @@ object ClockSpec
             result <- ref.get
           } yield assert(result, equalTo("Hello, World!"))
         } @@ after(setTime(0.hours))
-          @@ nonFlaky(100),
+          @@ nonFlaky,
         testM("sleep correctly handles new set time") {
           for {
             latch <- Promise.make[Nothing, Unit]
@@ -56,14 +56,14 @@ object ClockSpec
             _     <- latch.await
           } yield assertCompletes
         } @@ after(setTime(0.hours))
-          @@ nonFlaky(100),
+          @@ nonFlaky,
         testM("sleep does sleep instantly when sleep duration less than or equal to clock time") {
           for {
             latch <- Promise.make[Nothing, Unit]
             _     <- (adjust(10.hours) *> latch.succeed(())).fork
             _     <- latch.await *> sleep(10.hours)
           } yield assertCompletes
-        } @@ nonFlaky(100),
+        } @@ nonFlaky,
         testM("adjust correctly advances nanotime") {
           for {
             time1 <- nanoTime
@@ -134,7 +134,7 @@ object ClockSpec
             result <- fiber.join
           } yield result == None
           assertM(example, isTrue)
-        } @@ nonFlaky(100),
+        } @@ nonFlaky,
         testM("recurrence example from TestClock documentation works correctly") {
           val example = for {
             q <- Queue.unbounded[Unit]
@@ -156,6 +156,6 @@ object ClockSpec
             result   <- fiberTime
             expected <- clock.currentTime(TimeUnit.MILLISECONDS)
           } yield assert(result.toMillis, equalTo(expected))
-        } @@ nonFlaky(100)
+        } @@ nonFlaky
       )
     )

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -340,6 +340,13 @@ object TestAspect extends TimeoutVariants {
     if (TestPlatform.isJVM) identity else ignore
 
   /**
+   * An aspect that repeats the test a default number of times, ensuring it is
+   * stable ("non-flaky"). Stops at the first failure.
+   */
+  val nonFlaky: TestAspectPoly =
+    nonFlaky(100)
+
+  /**
    * An aspect that repeats the test a specified number of times, ensuring it
    * is stable ("non-flaky"). Stops at the first failure.
    */


### PR DESCRIPTION
`nonFlaky` is a commonly used test aspect. Currently the user has to specify the number of times for the test to be repeated. This PR adds an overloaded version that repeats a test a default number of times determined by the test framework (currently set at 100). I think this makes it a little nicer. Users can still specify a number of repetitions if they want.