### PR TITLE
ZIO Test: Refactor ZSpec to Move All Test Failures to Error Channel

### DIFF
--- a/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
@@ -159,7 +159,7 @@ object DefaultTestReporterSpec extends AsyncBaseSpec {
     unsafeRunToFuture(r.use[Any, E, A](f))
 
   def TestTestRunner(testEnvironment: TestEnvironment) =
-    TestRunner[TestEnvironment, String, Either[TestFailure[Nothing], TestSuccess[Unit]], String, Unit](
+    TestRunner[TestEnvironment, String, Unit, String, Unit](
       executor = TestExecutor.managed[TestEnvironment, String, String, Unit](Managed.succeed(testEnvironment)),
       reporter = DefaultTestReporter()
     )

--- a/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
@@ -21,7 +21,7 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
   )
 
   def makeTest[L](label: L)(assertion: => TestResult): ZSpec[Any, Nothing, L, Unit] =
-    zio.test.test(label)(assertion).mapTest(_.map(_ => TestSuccess.Succeeded(BoolAlgebra.unit)))
+    zio.test.test(label)(assertion)
 
   val test1 = makeTest("Addition works fine") {
     assert(1 + 1, equalTo(2))
@@ -120,7 +120,7 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
     unsafeRunToFuture(r.use[Any, E, A](f))
 
   def TestTestRunner(testEnvironment: TestEnvironment) =
-    TestRunner[TestEnvironment, String, Either[TestFailure[Nothing], TestSuccess[Unit]], String, Unit](
+    TestRunner[TestEnvironment, String, Unit, String, Unit](
       executor = TestExecutor.managed[TestEnvironment, String, String, Unit](Managed.succeed(testEnvironment)),
       reporter = DefaultTestReporter()
     )

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -30,7 +30,7 @@ abstract class AbstractRunnableSpec {
   type Success
 
   def runner: TestRunner[Environment, Label, Test, Failure, Success]
-  def spec: Spec[Environment, Failure, Label, Test]
+  def spec: ZSpec[Environment, Failure, Label, Test]
 
   /**
    * Returns an effect that executes the spec, producing the results of the execution.

--- a/test/shared/src/main/scala/zio/test/DefaultTestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestRunner.scala
@@ -22,6 +22,6 @@ import zio.test.environment._
  * A `Runner` that provides a default testable environment.
  */
 object DefaultTestRunner
-    extends TestRunner[TestEnvironment, String, Either[TestFailure[Nothing], TestSuccess[Any]], Any, Any](
+    extends TestRunner[TestEnvironment, String, Any, Any, Any](
       TestExecutor.managed(testEnvironmentManaged)
     ) {}

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -23,7 +23,7 @@ import zio.{ UIO, URIO }
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
  */
-abstract class RunnableSpec[R, L, T, E, S](runner0: TestRunner[R, L, T, E, S])(spec0: => Spec[R, E, L, T])
+abstract class RunnableSpec[R, L, T, E, S](runner0: TestRunner[R, L, T, E, S])(spec0: => ZSpec[R, E, L, T])
     extends AbstractRunnableSpec {
   override type Environment = R
   override type Label       = L

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -37,7 +37,7 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
   final def @@[R0 <: R1, R1 <: R, E0, E1, E2 >: E0 <: E1, S0, S1, S >: S0 <: S1](
     aspect: TestAspect[R0, R1, E0, E1, S0, S1]
   )(implicit ev1: E <:< TestFailure[E2], ev2: T <:< TestSuccess[S]): ZSpec[R1, E2, L, S] =
-    aspect(self.bimap(ev1, ev2))
+    aspect(self.asInstanceOf[ZSpec[R1, E2, L, S]])
 
   /**
    * Returns a new spec with remapped errors and tests.

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ Cause, Managed, NeedsEnv, ZIO }
+import zio._
 
 import Spec._
 
@@ -34,10 +34,19 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
    * test("foo") { assert(42, equalTo(42)) } @@ ignore
    * }}}
    */
-  final def @@[R0 <: R1, R1 <: R, E0 >: E, E1 >: E0, S0 <: S, S, S1 >: S](aspect: TestAspect[R0, R1, E0, E1, S0, S1])(
-    implicit ev: T <:< Either[TestFailure[Nothing], TestSuccess[S]]
-  ): Spec[R1, E0, L, Either[TestFailure[Nothing], TestSuccess[S]]] =
-    aspect(mapTest(ev))
+  final def @@[R0 <: R1, R1 <: R, E0, E1, E2 >: E0 <: E1, S0, S1, S >: S0 <: S1](
+    aspect: TestAspect[R0, R1, E0, E1, S0, S1]
+  )(implicit ev1: E <:< TestFailure[E2], ev2: T <:< TestSuccess[S]): ZSpec[R1, E2, L, S] =
+    aspect(self.bimap(ev1, ev2))
+
+  /**
+   * Returns a new spec with remapped errors and tests.
+   */
+  final def bimap[E1, T1](f: E => E1, g: T => T1)(implicit ev: CanFail[E]): Spec[R, E1, L, T1] =
+    transform[R, E1, L, T1] {
+      case SuiteCase(label, specs, exec) => SuiteCase(label, specs.mapError(f), exec)
+      case TestCase(label, test)         => TestCase(label, test.bimap(f, g))
+    }
 
   /**
    * Returns a new spec with the suite labels distinguished by `Left`, and the
@@ -189,6 +198,15 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
     n: Int
   )(failure: Cause[E] => ZIO[R1, E1, A], success: T => ZIO[R1, E1, A]): ZIO[R1, Nothing, Spec[R1, E1, L, A]] =
     foreachExec(ExecutionStrategy.ParallelN(n))(failure, success)
+
+  /**
+   * Returns a new spec with remapped errors.
+   */
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): Spec[R, E1, L, T] =
+    transform[R, E1, L, T] {
+      case SuiteCase(label, specs, exec) => SuiteCase(label, specs.mapError(f), exec)
+      case TestCase(label, test)         => TestCase(label, test.mapError(f))
+    }
 
   /**
    * Returns a new spec with remapped labels.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -198,12 +198,9 @@ object TestAspect extends TimeoutVariants {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
-        lazy val untilSuccess: ZIO[R, Nothing, TestSuccess[S]] =
-          test.foldM(_ => untilSuccess, ZIO.succeed(_))
-
-        untilSuccess
-      }
+        test.eventually
     }
+  }
 
   /**
    * An aspect that sets suites to the specified execution strategy, but only

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -108,9 +108,9 @@ object TestAspect extends TimeoutVariants {
   val ignore: TestAspectPoly =
     new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
-        ZIO.succeed(Right(TestSuccess.Ignored))
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        ZIO.succeed(TestSuccess.Ignored)
     }
 
   /**
@@ -119,9 +119,9 @@ object TestAspect extends TimeoutVariants {
   def after[R0, E0](effect: ZIO[R0, E0, Any]): TestAspect[Nothing, R0, E0, Any, Nothing, Any] =
     new TestAspect.PerTest[Nothing, R0, E0, Any, Nothing, Any] {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
-        test <* effect
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        test <* effect.catchAllCause(cause => ZIO.fail(TestFailure.Runtime(cause)))
     }
 
   /**
@@ -130,25 +130,24 @@ object TestAspect extends TimeoutVariants {
   def around[R0, E0](before: ZIO[R0, E0, Any], after: ZIO[R0, Nothing, Any]) =
     new TestAspect.PerTest[Nothing, R0, E0, Any, Nothing, Any] {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
-        ZManaged.make(before)(_ => after).use(_ => test)
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        ZManaged
+          .make(before)(_ => after)
+          .catchAllCause(c => ZManaged.fail(TestFailure.Runtime(c)))
+          .use(_ => test)
     }
 
   /**
    * Constructs an aspect that evaluates every test inside the context of the managed function.
    */
   def aroundTest[R0, E0, S0](
-    managed: ZManaged[
-      R0,
-      E0,
-      Either[TestFailure[Nothing], TestSuccess[S0]] => ZIO[R0, E0, Either[TestFailure[Nothing], TestSuccess[S0]]]
-    ]
+    managed: ZManaged[R0, TestFailure[E0], TestSuccess[S0] => ZIO[R0, TestFailure[E0], TestSuccess[S0]]]
   ) =
     new TestAspect.PerTest[Nothing, R0, E0, Any, S0, S0] {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S >: S0 <: S0](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         managed.use(f => test.flatMap(f))
     }
 
@@ -157,16 +156,12 @@ object TestAspect extends TimeoutVariants {
    * environment and error type.
    */
   def aspect[R0, E0, S0](
-    f: ZIO[R0, E0, Either[TestFailure[Nothing], TestSuccess[S0]]] => ZIO[
-      R0,
-      E0,
-      Either[TestFailure[Nothing], TestSuccess[S0]]
-    ]
+    f: ZIO[R0, TestFailure[E0], TestSuccess[S0]] => ZIO[R0, TestFailure[E0], TestSuccess[S0]]
   ): TestAspect[R0, R0, E0, E0, S0, S0] =
     new TestAspect.PerTest[R0, R0, E0, E0, S0, S0] {
       def perTest[R >: R0 <: R0, E >: E0 <: E0, S >: S0 <: S0](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         f(test)
     }
 
@@ -176,8 +171,8 @@ object TestAspect extends TimeoutVariants {
   def before[R0, E0, S0](effect: ZIO[R0, Nothing, Any]): TestAspect[Nothing, R0, E0, Any, S0, Any] =
     new TestAspect.PerTest[Nothing, R0, E0, Any, S0, Any] {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S >: S0 <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         effect *> test
     }
 
@@ -201,10 +196,10 @@ object TestAspect extends TimeoutVariants {
   val eventually: TestAspectPoly =
     new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
-        lazy val untilSuccess: ZIO[R, Nothing, Either[TestFailure[Nothing], TestSuccess[S]]] =
-          test.foldCauseM(_ => untilSuccess, _.fold(_ => untilSuccess, s => ZIO.succeed(Right(s))))
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
+        lazy val untilSuccess: ZIO[R, Nothing, TestSuccess[S]] =
+          test.foldM(_ => untilSuccess, ZIO.succeed(_))
 
         untilSuccess
       }
@@ -219,7 +214,7 @@ object TestAspect extends TimeoutVariants {
       def some[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any, L](
         predicate: L => Boolean,
         spec: ZSpec[R, E, L, S]
-      ): ZSpec[R, E, L, S] = spec.transform[R, E, L, Either[TestFailure[Nothing], TestSuccess[S]]] {
+      ): ZSpec[R, E, L, S] = spec.transform[R, TestFailure[E], L, TestSuccess[S]] {
         case Spec.SuiteCase(label, specs, None) if (predicate(label)) => Spec.SuiteCase(label, specs, Some(exec))
         case c                                                        => c
       }
@@ -238,17 +233,18 @@ object TestAspect extends TimeoutVariants {
   def failure[E0](p: Assertion[TestFailure[E0]]): PerTest[Nothing, Any, Nothing, E0, Unit, Unit] =
     new TestAspect.PerTest[Nothing, Any, Nothing, E0, Unit, Unit] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: E0, S >: Unit <: Unit](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
-        lazy val succeed = Right(TestSuccess.Succeeded(BoolAlgebra.unit))
-        test.foldCause(
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
+        lazy val succeed = ZIO.succeed(TestSuccess.Succeeded(BoolAlgebra.unit))
+        test.foldM(
           {
-            case c if p.run(TestFailure.Runtime(c)).isSuccess => succeed
-            case other                                        => Left(TestFailure.Assertion(assert(TestFailure.Runtime(other), p)))
-          }, {
-            case Left(e) => if (p.run(e).isSuccess) succeed else Left(TestFailure.Assertion(assert(e, p)))
-            case _       => Left(TestFailure.Runtime(Cause.die(new RuntimeException("did not fail as expected"))))
-          }
+            case testFailure if p.run(testFailure).isSuccess => succeed
+            case other =>
+              ZIO.fail(
+                TestFailure.Assertion(assert(other, p))
+              )
+          },
+          _ => ZIO.fail(TestFailure.Runtime(zio.Cause.die(new RuntimeException("did not fail as expected"))))
         )
       }
     }
@@ -266,12 +262,12 @@ object TestAspect extends TimeoutVariants {
   def ifEnv(env: String, assertion: Assertion[String]): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
     new TestAspect.PerTest[Nothing, Live[System], Nothing, Any, Nothing, Any] {
       def perTest[R <: Live[System], E, S](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         Live.live(system.env(env)).orDie.flatMap { value =>
           value
             .filter(assertion.test)
-            .fold[ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]](ZIO.succeed(Right(TestSuccess.Ignored)))(
+            .fold[ZIO[R, TestFailure[E], TestSuccess[S]]](ZIO.succeed(TestSuccess.Ignored))(
               _ => test
             )
         }
@@ -294,12 +290,12 @@ object TestAspect extends TimeoutVariants {
   ): TestAspect[Nothing, Live[System], Nothing, Any, Nothing, Any] =
     new TestAspect.PerTest[Nothing, Live[System], Nothing, Any, Nothing, Any] {
       def perTest[R <: Live[System], E, S](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         Live.live(system.property(prop)).orDie.flatMap { value =>
           value
             .filter(assertion.test)
-            .fold[ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]](ZIO.succeed(Right(TestSuccess.Ignored)))(
+            .fold[ZIO[R, TestFailure[E], TestSuccess[S]]](ZIO.succeed(TestSuccess.Ignored))(
               _ => test
             )
         }
@@ -346,11 +342,11 @@ object TestAspect extends TimeoutVariants {
   def nonFlaky(n0: Int): TestAspectPoly =
     new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
-        def repeat(n: Int): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
+        def repeat(n: Int): ZIO[R, TestFailure[E], TestSuccess[S]] =
           if (n <= 1) test
-          else test.flatMap(_.fold(e => ZIO.succeed(Left(e)), _ => repeat(n - 1)))
+          else test.flatMap(_ => repeat(n - 1))
 
         repeat(n0)
       }
@@ -372,33 +368,12 @@ object TestAspect extends TimeoutVariants {
    */
   def retry[R0, E0, S0](
     schedule: ZSchedule[R0, TestFailure[E0], S0]
-  ): TestAspect[Nothing, Live[R0], Nothing, E0, Nothing, S0] =
-    new TestAspect.PerTest[Nothing, Live[R0], Nothing, E0, Nothing, S0] {
-      def perTest[R >: Nothing <: Live[R0], E >: Nothing <: E0, S >: Nothing <: S0](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
-        def loop(state: schedule.State): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
-          test.foldCauseM(
-            err =>
-              Live
-                .live(schedule.update(TestFailure.Runtime(err), state))
-                .foldM(
-                  _ => ZIO.halt(err),
-                  loop
-                ), {
-              case Left(e) =>
-                Live
-                  .live(schedule.update(e, state))
-                  .foldM(
-                    _ => ZIO.succeed(Left(e)),
-                    loop
-                  )
-              case Right(s) => ZIO.succeed(Right(s))
-            }
-          )
-
-        Live.live(schedule.initial).flatMap(loop)
-      }
+  ): TestAspect[Nothing, R0, Nothing, E0, Nothing, S0] =
+    new TestAspect.PerTest[Nothing, R0, Nothing, E0, Nothing, S0] {
+      def perTest[R >: Nothing <: R0, E >: Nothing <: E0, S >: Nothing <: S0](
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        test.retry(schedule)
     }
 
   /**
@@ -426,12 +401,12 @@ object TestAspect extends TimeoutVariants {
   val success: TestAspectPoly =
     new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] =
-        test.map {
-          case Right(TestSuccess.Ignored) =>
-            Left(TestFailure.Runtime(Cause.die(new RuntimeException("Test was ignored."))))
-          case x => x
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
+        test.flatMap {
+          case TestSuccess.Ignored =>
+            ZIO.fail(TestFailure.Runtime(Cause.die(new RuntimeException("Test was ignored."))))
+          case x => ZIO.succeed(x)
         }
     }
 
@@ -446,8 +421,8 @@ object TestAspect extends TimeoutVariants {
   ): TestAspect[Nothing, Live[Clock], Nothing, Any, Nothing, Any] =
     new TestAspect.PerTest[Nothing, Live[Clock], Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Live[Clock], E >: Nothing <: Any, S >: Nothing <: Any](
-        test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-      ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]] = {
+        test: ZIO[R, TestFailure[E], TestSuccess[S]]
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
         def timeoutFailure =
           TestTimeoutException(s"Timeout of ${duration.render} exceeded.")
         def interruptionTimeoutFailure = {
@@ -459,8 +434,8 @@ object TestAspect extends TimeoutVariants {
           .withLive(test)(_.either.timeoutFork(duration).flatMap {
             case Left(fiber) =>
               fiber.join.raceWith(ZIO.sleep(interruptDuration))(
-                (_, fiber) => fiber.interrupt *> ZIO.die(timeoutFailure),
-                (_, _) => ZIO.die(interruptionTimeoutFailure)
+                (_, fiber) => fiber.interrupt *> ZIO.fail(TestFailure.Runtime(Cause.die(timeoutFailure))),
+                (_, _) => ZIO.fail(TestFailure.Runtime(Cause.die(interruptionTimeoutFailure)))
               )
             case Right(result) => result.fold(ZIO.fail, ZIO.succeed)
           })
@@ -470,14 +445,14 @@ object TestAspect extends TimeoutVariants {
   trait PerTest[+LowerR, -UpperR, +LowerE, -UpperE, +LowerS, -UpperS]
       extends TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS] {
     def perTest[R >: LowerR <: UpperR, E >: LowerE <: UpperE, S >: LowerS <: UpperS](
-      test: ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
-    ): ZIO[R, E, Either[TestFailure[Nothing], TestSuccess[S]]]
+      test: ZIO[R, TestFailure[E], TestSuccess[S]]
+    ): ZIO[R, TestFailure[E], TestSuccess[S]]
 
     final def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE, S >: LowerS <: UpperS, L](
       predicate: L => Boolean,
       spec: ZSpec[R, E, L, S]
     ): ZSpec[R, E, L, S] =
-      spec.transform[R, E, L, Either[TestFailure[Nothing], TestSuccess[S]]] {
+      spec.transform[R, TestFailure[E], L, TestSuccess[S]] {
         case c @ Spec.SuiteCase(_, _, _) => c
         case Spec.TestCase(label, test) =>
           Spec.TestCase(label, if (predicate(label)) perTest(test) else test)

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -197,10 +197,9 @@ object TestAspect extends TimeoutVariants {
     new TestAspect.PerTest[Nothing, Any, Nothing, Any, Nothing, Any] {
       def perTest[R >: Nothing <: Any, E >: Nothing <: Any, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
-      ): ZIO[R, TestFailure[E], TestSuccess[S]] = {
+      ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         test.eventually
     }
-  }
 
   /**
    * An aspect that sets suites to the specified execution strategy, but only

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -21,13 +21,17 @@ import zio.{ Managed, ZIO }
 object TestExecutor {
   def managed[R, E, L, S](
     environment: Managed[Nothing, R]
-  ): TestExecutor[R, L, Either[TestFailure[Nothing], TestSuccess[S]], E, S] =
+  ): TestExecutor[R, L, S, E, S] =
     (spec: ZSpec[R, E, L, S], defExec: ExecutionStrategy) => {
       spec
         .provideManaged(environment)
         .foreachExec(defExec)(
-          e => ZIO.succeed(Left(TestFailure.Runtime(e))),
-          ZIO.succeed
+          e =>
+            e.failureOrCause.fold(
+              failure => ZIO.succeed(Left(failure)),
+              cause => ZIO.succeed(Left(TestFailure.Runtime(cause)))
+            ),
+          s => ZIO.succeed(Right(s))
         )
 
     }

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -38,7 +38,7 @@ case class TestRunner[R, L, -T, E, S](
   /**
    * Runs the spec, producing the execution results.
    */
-  final def run(spec: Spec[R, E, L, T]): URIO[TestLogger with Clock, ExecutedSpec[L, E, S]] =
+  final def run(spec: ZSpec[R, E, L, T]): URIO[TestLogger with Clock, ExecutedSpec[L, E, S]] =
     executor(spec, ExecutionStrategy.ParallelN(4)).timed.flatMap {
       case (duration, results) => reporter(duration, results).as(results)
     }
@@ -47,7 +47,7 @@ case class TestRunner[R, L, -T, E, S](
    * An unsafe, synchronous run of the specified spec.
    */
   final def unsafeRun(
-    spec: Spec[R, E, L, T],
+    spec: ZSpec[R, E, L, T],
     testLogger: TestLogger = defaultTestLogger,
     clock: Clock = Clock.Live
   ): ExecutedSpec[L, E, S] =
@@ -57,7 +57,7 @@ case class TestRunner[R, L, -T, E, S](
    * An unsafe, asynchronous run of the specified spec.
    */
   final def unsafeRunAsync(
-    spec: Spec[R, E, L, T],
+    spec: ZSpec[R, E, L, T],
     testLogger: TestLogger = defaultTestLogger,
     clock: Clock = Clock.Live
   )(
@@ -72,7 +72,7 @@ case class TestRunner[R, L, -T, E, S](
    * An unsafe, synchronous run of the specified spec.
    */
   final def unsafeRunSync(
-    spec: Spec[R, E, L, T],
+    spec: ZSpec[R, E, L, T],
     testLogger: TestLogger = defaultTestLogger,
     clock: Clock = Clock.Live
   ): Exit[Nothing, ExecutedSpec[L, E, S]] =


### PR DESCRIPTION
When we refactored suites to be effectual we moved to an encoding where assertion failures were represented by a `Left` value whereas runtime failures were represented captured in the error channel. While I thought it was necessary at the time it has created some issues with bugs in properly keeping track of the different failure modes and I think at this point it is hindering our ability to add other useful test aspects because the encoding of all test failures in the error channel lends itself very naturally to many ZIO combinators.

This PR refactors ZSpec to move all test failures back to the error channel. I was able to do it in a relatively minimalistic way. The only thing we are really giving up is that a `TestExecutor` now takes a `ZSpec` rather than a `Spec` because we need `ZSpec` to have the structure where `TestFailure` is in the error channel and we also need to know that `ExecutedSpec` has the same structure for reporting and interface with the SBT test runner. I think this is a pretty minor cost considering that to my knowledge no one has implemented any other `TestExecutor` instance and doing one that didn't use `ZSpec` would also mean losing out on test aspects and a lot of other ZIO Test functionality.