### PR TITLE
ZIO Test: Fix Type Inference Issue in `checkM` Variants

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -83,6 +83,13 @@ object CheckSpec
             val sorted   = assert(nss.zip(nss.tail).exists { case (a, b) => a > b }, isFalse)
             nonEmpty ==> sorted
           }
+        },
+        testM("checkM effect type is correctly inferred") {
+          CheckM(Gen.unit) { _ =>
+            for {
+              _ <- random.nextInt
+            } yield assertCompletes
+          }
         }
       )
     )

--- a/test/shared/src/main/scala/zio/test/CheckVariants.scala
+++ b/test/shared/src/main/scala/zio/test/CheckVariants.scala
@@ -54,31 +54,31 @@ trait CheckVariants {
    * Checks the effectual test passes for "sufficient" numbers of samples from
    * the given random variable.
    */
-  final def checkM[R, E, A](rv: Gen[R, A])(test: A => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  final def checkM[R, R1 <: R, E, A](rv: Gen[R, A])(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkSomeM(rv)(200)(test)
 
   /**
    * A version of `checkM` that accepts two random variables.
    */
-  final def checkM[R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (A, B) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkM[R, R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (A, B) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkM(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkM` that accepts three random variables.
    */
-  final def checkM[R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (A, B, C) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkM[R, R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (A, B, C) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `checkM` that accepts four random variables.
    */
-  final def checkM[R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (A, B, C, D) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkM[R, R1 <: R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (A, B, C, D) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
@@ -116,31 +116,31 @@ trait CheckVariants {
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
-  final def checkAllM[R, E, A](rv: Gen[R, A])(test: A => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  final def checkAllM[R, R1 <: R, E, A](rv: Gen[R, A])(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkStream(rv.sample)(test)
 
   /**
    * A version of `checkAllM` that accepts two random variables.
    */
-  final def checkAllM[R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (A, B) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkAllM[R, R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (A, B) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkAllM(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkAllM` that accepts three random variables.
    */
-  final def checkAllM[R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (A, B, C) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkAllM[R, R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (A, B, C) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkAllM(rv1 <*> rv2 <*> rv3)(reassociate(test))
 
   /**
    * A version of `checkAllM` that accepts four random variables.
    */
-  final def checkAllM[R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (A, B, C, D) => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  final def checkAllM[R, R1 <: R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (A, B, C, D) => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     checkAllM(rv1 <*> rv2 <*> rv3 <*> rv4)(reassociate(test))
 
   /**
@@ -178,36 +178,38 @@ trait CheckVariants {
    * Checks the effectual test passes for the specified number of samples from
    * the given random variable.
    */
-  final def checkSomeM[R, E, A](rv: Gen[R, A])(n: Int)(test: A => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  final def checkSomeM[R, R1 <: R, E, A](
+    rv: Gen[R, A]
+  )(n: Int)(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkStream(rv.sample.forever.take(n))(test)
 
   /**
    * A version of `checkSomeM` that accepts two random variables.
    */
-  final def checkSomeM[R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
+  final def checkSomeM[R, R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
-  )(test: (A, B) => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  )(test: (A, B) => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkSomeM(rv1 <*> rv2)(n)(test.tupled)
 
   /**
    * A version of `checkSomeM` that accepts three random variables.
    */
-  final def checkSomeM[R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+  final def checkSomeM[R, R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (A, B, C) => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  )(test: (A, B, C) => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkSomeM(rv1 <*> rv2 <*> rv3)(n)(reassociate(test))
 
   /**
    * A version of `checkSomeM` that accepts four random variables.
    */
-  final def checkSomeM[R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+  final def checkSomeM[R, R1 <: R, E, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (A, B, C, D) => ZIO[R, E, TestResult]): ZIO[R, E, TestResult] =
+  )(test: (A, B, C, D) => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
     checkSomeM(rv1 <*> rv2 <*> rv3 <*> rv4)(n)(reassociate(test))
 
-  private final def checkStream[R, E, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
-    test: A => ZIO[R, E, TestResult]
-  ): ZIO[R, E, TestResult] =
+  private final def checkStream[R, R1 <: R, E, A](stream: ZStream[R, Nothing, Sample[R, A]], maxShrinks: Int = 1000)(
+    test: A => ZIO[R1, E, TestResult]
+  ): ZIO[R1, E, TestResult] =
     stream.zipWithIndex.mapM {
       case (initial, index) =>
         initial.traverse(


### PR DESCRIPTION
The current signature of `checkM` is:

```scala
final def checkM[R, E, A](rv: Gen[R, A])(test: A => ZIO[R, E, TestResult]): ZIO[R, E, TestResult]
```

The curried syntax is quite nice for ergonomics and writing tests in a property based style, but there can be a type inference issue if the test requires an additional environment beyond what the generator does because the compiler determines the `R` type after looking at the first parameter without considering the second.

This PR resolves this by changing the signature to be:

```scala
final def checkM[R, R1 <: R, E, A](rv: Gen[R, A])(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult]
```