### PR TITLE
Align STM factory names

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -66,13 +66,13 @@ object STMSpec
         suite("Make a new `TRef` and")(
           testM("get its initial value") {
             (for {
-              intVar <- TRef(14)
+              intVar <- TRef.make(14)
               v      <- intVar.get
             } yield assert(v, equalTo(14))).commit
           },
           testM("set a new value") {
             (for {
-              intVar <- TRef(14)
+              intVar <- TRef.make(14)
               _      <- intVar.set(42)
               v      <- intVar.get
             } yield assert(v, equalTo(42))).commit
@@ -93,7 +93,7 @@ object STMSpec
             for {
               tVars <- STM
                         .atomically(
-                          TRef(10000) <*> TRef(0) <*> TRef(0)
+                          TRef.make(10000) <*> TRef.make(0) <*> TRef.make(0)
                         )
               tvar1 <*> tvar2 <*> tvar3 = tVars
               fiber                     <- ZIO.forkAll(List.fill(10)(compute3VarN(99, tvar1, tvar2, tvar3)))
@@ -302,7 +302,7 @@ object STMSpec
           "Using `collectAll` collect a list of transactional effects to a single transaction that produces a list of values"
         ) {
           for {
-            it    <- UIO((1 to 100).map(TRef(_)))
+            it    <- UIO((1 to 100).map(TRef.make(_)))
             tvars <- STM.collectAll(it).commit
             res   <- UIO.collectAllPar(tvars.map(_.get.commit))
           } yield assert(res, equalTo((1 to 100).toList))
@@ -373,7 +373,7 @@ object STMSpec
           },
           testM("local reset, not global") {
             for {
-              ref <- TRef(0).commit
+              ref <- TRef.make(0).commit
               result <- STM.atomically(for {
                          _       <- ref.set(2)
                          newVal1 <- ref.get

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -70,7 +70,7 @@ object TArraySpec
         suite("foreach")(
           testM("side-effect is transactional") {
             for {
-              ref    <- TRef(0).commit
+              ref    <- TRef.make(0).commit
               tArray <- makeTArray(n)(1).commit
               _      <- tArray.foreach(a => ref.update(_ + a).unit).commit.fork
               value  <- ref.get.commit

--- a/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
@@ -25,7 +25,7 @@ object TSetSpec
       suite("TSet")(
         suite("factories")(
           testM("apply") {
-            val tx = TSet(1, 2, 2, 3).flatMap(_.toList)
+            val tx = TSet.make(1, 2, 2, 3).flatMap(_.toList)
             assertM(tx.commit, hasSameElements(List(1, 2, 3)))
 
           },
@@ -40,19 +40,19 @@ object TSetSpec
         ),
         suite("lookups")(
           testM("contains existing element") {
-            val tx = TSet(1, 2, 3, 4).flatMap(_.contains(1))
+            val tx = TSet.make(1, 2, 3, 4).flatMap(_.contains(1))
             assertM(tx.commit, isTrue)
           },
           testM("contains non-existing element") {
-            val tx = TSet(1, 2, 3, 4).flatMap(_.contains(0))
+            val tx = TSet.make(1, 2, 3, 4).flatMap(_.contains(0))
             assertM(tx.commit, isFalse)
           },
           testM("collect all elements") {
-            val tx = TSet(1, 2, 3, 4).flatMap(_.toList)
+            val tx = TSet.make(1, 2, 3, 4).flatMap(_.toList)
             assertM(tx.commit, hasSameElements(List(1, 2, 3, 4)))
           },
           testM("cardinality") {
-            val tx = TSet(1, 2, 3, 4).flatMap(_.size)
+            val tx = TSet.make(1, 2, 3, 4).flatMap(_.size)
             assertM(tx.commit, equalTo(4))
           }
         ),
@@ -70,7 +70,7 @@ object TSetSpec
           testM("add duplicate element") {
             val tx =
               for {
-                tset <- TSet(1)
+                tset <- TSet.make(1)
                 _    <- tset.put(1)
                 res  <- tset.toList
               } yield res
@@ -80,7 +80,7 @@ object TSetSpec
           testM("remove existing element") {
             val tx =
               for {
-                tset <- TSet(1, 2)
+                tset <- TSet.make(1, 2)
                 _    <- tset.delete(1)
                 res  <- tset.toList
               } yield res
@@ -90,7 +90,7 @@ object TSetSpec
           testM("remove non-existing element") {
             val tx =
               for {
-                tset <- TSet(1, 2)
+                tset <- TSet.make(1, 2)
                 _    <- tset.delete(3)
                 res  <- tset.toList
               } yield res
@@ -102,7 +102,7 @@ object TSetSpec
           testM("retainIf") {
             val tx =
               for {
-                tset <- TSet("a", "aa", "aaa")
+                tset <- TSet.make("a", "aa", "aaa")
                 _    <- tset.retainIf(_ == "aa")
                 a    <- tset.contains("a")
                 aa   <- tset.contains("aa")
@@ -114,7 +114,7 @@ object TSetSpec
           testM("removeIf") {
             val tx =
               for {
-                tset <- TSet("a", "aa", "aaa")
+                tset <- TSet.make("a", "aa", "aaa")
                 _    <- tset.removeIf(_ == "aa")
                 a    <- tset.contains("a")
                 aa   <- tset.contains("aa")
@@ -126,7 +126,7 @@ object TSetSpec
           testM("transform") {
             val tx =
               for {
-                tset <- TSet(1, 2, 3)
+                tset <- TSet.make(1, 2, 3)
                 _    <- tset.transform(_ * 2)
                 res  <- tset.toList
               } yield res
@@ -136,7 +136,7 @@ object TSetSpec
           testM("transformM") {
             val tx =
               for {
-                tset <- TSet(1, 2, 3)
+                tset <- TSet.make(1, 2, 3)
                 _    <- tset.transformM(a => STM.succeed(a * 2))
                 res  <- tset.toList
               } yield res
@@ -148,7 +148,7 @@ object TSetSpec
           testM("fold on non-empty set") {
             val tx =
               for {
-                tset <- TSet(1, 2, 3)
+                tset <- TSet.make(1, 2, 3)
                 res  <- tset.fold(0)(_ + _)
               } yield res
 
@@ -166,7 +166,7 @@ object TSetSpec
           testM("foldM on non-empty set") {
             val tx =
               for {
-                tset <- TSet(1, 2, 3)
+                tset <- TSet.make(1, 2, 3)
                 res  <- tset.foldM(0)((acc, a) => STM.succeed(acc + a))
               } yield res
 
@@ -186,8 +186,8 @@ object TSetSpec
           testM("diff") {
             val tx =
               for {
-                tset1 <- TSet(1, 2, 3)
-                tset2 <- TSet(1, 4, 5)
+                tset1 <- TSet.make(1, 2, 3)
+                tset2 <- TSet.make(1, 4, 5)
                 _     <- tset1.diff(tset2)
                 res   <- tset1.toList
               } yield res
@@ -197,8 +197,8 @@ object TSetSpec
           testM("intersect") {
             val tx =
               for {
-                tset1 <- TSet(1, 2, 3)
-                tset2 <- TSet(1, 4, 5)
+                tset1 <- TSet.make(1, 2, 3)
+                tset2 <- TSet.make(1, 4, 5)
                 _     <- tset1.intersect(tset2)
                 res   <- tset1.toList
               } yield res
@@ -208,8 +208,8 @@ object TSetSpec
           testM("union") {
             val tx =
               for {
-                tset1 <- TSet(1, 2, 3)
-                tset2 <- TSet(1, 4, 5)
+                tset1 <- TSet.make(1, 2, 3)
+                tset2 <- TSet.make(1, 4, 5)
                 _     <- tset1.union(tset2)
                 res   <- tset1.toList
               } yield res

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -88,5 +88,5 @@ object TArray {
    * Makes a new `TArray` initialized with provided iterable.
    */
   final def fromIterable[A](data: Iterable[A]): STM[Nothing, TArray[A]] =
-    STM.foreach(data)(TRef(_)).map(list => new TArray(list.toArray))
+    STM.foreach(data)(TRef.make(_)).map(list => new TArray(list.toArray))
 }

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -77,7 +77,7 @@ object TArray {
   /**
    * Makes a new `TArray` that is initialized with specified values.
    */
-  final def apply[A](data: A*): STM[Nothing, TArray[A]] = fromIterable(data)
+  final def make[A](data: A*): STM[Nothing, TArray[A]] = fromIterable(data)
 
   /**
    * Makes an empty `TArray`.

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -238,9 +238,9 @@ object TMap {
 
     for {
       tChains   <- TArray.fromIterable(buckets)
-      tBuckets  <- TRef(tChains)
-      tCapacity <- TRef(capacity)
-      tSize     <- TRef(uniqueItems.size)
+      tBuckets  <- TRef.make(tChains)
+      tCapacity <- TRef.make(capacity)
+      tSize     <- TRef.make(uniqueItems.size)
     } yield new TMap(tBuckets, tCapacity, tSize)
   }
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -41,20 +41,18 @@ class TMap[K, V] private (
       if (toRemove.isEmpty) STM.succeed(toRetain) else tSize.update(_ - toRemove.size).as(toRetain)
     }
 
-    tBuckets.get.flatMap { buckets =>
-      indexOf(k).flatMap { idx =>
-        buckets.updateM(idx, removeMatching)
-      }
-    }.unit
+    for {
+      buckets <- tBuckets.get
+      idx     <- indexOf(k)
+      _       <- buckets.updateM(idx, removeMatching)
+    } yield ()
   }
 
   /**
    * Atomically folds using pure function.
    */
   final def fold[A](zero: A)(op: (A, (K, V)) => A): STM[Nothing, A] =
-    tBuckets.get.flatMap { buckets =>
-      buckets.fold(zero)((acc, bucket) => bucket.foldLeft(acc)(op))
-    }
+    tBuckets.get.flatMap(_.fold(zero)((acc, bucket) => bucket.foldLeft(acc)(op)))
 
   /**
    * Atomically folds using effectful function.
@@ -66,11 +64,7 @@ class TMap[K, V] private (
         case head :: tail => loopM(acc.flatMap(op(_, head)), tail)
       }
 
-    tBuckets.get.flatMap { buckets =>
-      buckets.foldM(zero) { (acc, bucket) =>
-        loopM(STM.succeed(acc), bucket)
-      }
-    }
+    tBuckets.get.flatMap(_.foldM(zero)((acc, bucket) => loopM(STM.succeed(acc), bucket)))
   }
 
   /**
@@ -83,11 +77,11 @@ class TMap[K, V] private (
    * Retrieves value associated with given key.
    */
   final def get(k: K): STM[Nothing, Option[V]] =
-    tBuckets.get.flatMap { buckets =>
-      indexOf(k).flatMap { idx =>
-        buckets(idx).map(_.find(_._1 == k).map(_._2))
-      }
-    }
+    for {
+      buckets <- tBuckets.get
+      idx     <- indexOf(k)
+      bucket  <- buckets(idx)
+    } yield bucket.find(_._1 == k).map(_._2)
 
   /**
    * Retrieves value associated with given key or default value, in case the
@@ -127,26 +121,23 @@ class TMap[K, V] private (
     }
 
     def resize(newCapacity: Int): STM[Nothing, Unit] =
-      toList.flatMap { data =>
-        TMap.allocate(newCapacity, data).flatMap { tmap =>
-          tmap.tBuckets.get.flatMap { newBuckets =>
-            tBuckets.set(newBuckets) *> tCapacity.set(newCapacity)
-          }
-        }
-      }
+      for {
+        data       <- toList
+        tmap       <- TMap.allocate(newCapacity, data)
+        newBuckets <- tmap.tBuckets.get
+        _          <- tBuckets.set(newBuckets)
+        _          <- tCapacity.set(newCapacity)
+      } yield ()
 
-    tBuckets.get.flatMap { buckets =>
-      indexOf(k).flatMap { idx =>
-        buckets.updateM(idx, upsert).zipRight {
-          tSize.get.flatMap { size =>
-            tCapacity.get.flatMap { capacity =>
-              val needsResize = capacity * TMap.LoadFactor < size
-              if (needsResize) resize(capacity * 2) else STM.unit
-            }
-          }
-        }
-      }
-    }
+    for {
+      buckets     <- tBuckets.get
+      idx         <- indexOf(k)
+      _           <- buckets.updateM(idx, upsert)
+      size        <- tSize.get
+      capacity    <- tCapacity.get
+      needsResize = capacity * TMap.LoadFactor < size
+      _           <- if (needsResize) resize(capacity * 2) else STM.unit
+    } yield ()
   }
 
   /**
@@ -189,9 +180,7 @@ class TMap[K, V] private (
    * Atomically updates all values using effectful function.
    */
   final def transformValuesM[E](f: V => STM[E, V]): STM[E, Unit] =
-    tBuckets.get.flatMap { buckets =>
-      buckets.transformM(bucket => STM.collectAll(bucket.map(kv => f(kv._2).map(kv._1 -> _))))
-    }
+    tBuckets.get.flatMap(_.transformM(bucket => STM.collectAll(bucket.map(kv => f(kv._2).map(kv._1 -> _)))))
 
   /**
    * Collects all values stored in map.
@@ -209,14 +198,13 @@ class TMap[K, V] private (
     tCapacity.get.map(c => k.hashCode() % c)
 
   private def overwriteWith(data: List[(K, V)]): STM[Nothing, Unit] =
-    tBuckets.get.flatMap { buckets =>
-      tCapacity.get.flatMap { capacity =>
-        buckets.transform(_ => Nil).zipRight {
-          val updates = data.map(kv => buckets.update(kv._1.hashCode() % capacity, kv :: _))
-          STM.collectAll(updates)
-        }
-      }
-    }.unit
+    for {
+      buckets  <- tBuckets.get
+      capacity <- tCapacity.get
+      _        <- buckets.transform(_ => Nil)
+      updates  = data.map(kv => buckets.update(kv._1.hashCode() % capacity, kv :: _))
+      _        <- STM.collectAll(updates)
+    } yield ()
 }
 
 object TMap {
@@ -248,15 +236,12 @@ object TMap {
       buckets(idx) = kv :: buckets(idx)
     }
 
-    TArray.fromIterable(buckets).flatMap { tChains =>
-      TRef(tChains).flatMap { tBuckets =>
-        TRef(capacity).flatMap { tCapacity =>
-          TRef(uniqueItems.size).map { tSize =>
-            new TMap(tBuckets, tCapacity, tSize)
-          }
-        }
-      }
-    }
+    for {
+      tChains   <- TArray.fromIterable(buckets)
+      tBuckets  <- TRef(tChains)
+      tCapacity <- TRef(capacity)
+      tSize     <- TRef(uniqueItems.size)
+    } yield new TMap(tBuckets, tCapacity, tSize)
   }
 
   private final val DefaultCapacity = 100

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -224,7 +224,7 @@ object TMap {
   /**
    * Makes a new `TMap` that is initialized with specified values.
    */
-  final def apply[K, V](data: (K, V)*): STM[Nothing, TMap[K, V]] = fromIterable(data)
+  final def make[K, V](data: (K, V)*): STM[Nothing, TMap[K, V]] = fromIterable(data)
 
   /**
    * Makes an empty `TMap`.

--- a/core/shared/src/main/scala/zio/stm/TPromise.scala
+++ b/core/shared/src/main/scala/zio/stm/TPromise.scala
@@ -43,6 +43,6 @@ class TPromise[E, A] private (val ref: TRef[Option[Either[E, A]]]) extends AnyVa
 }
 
 object TPromise {
-  final def apply[E, A]: STM[Nothing, TPromise[E, A]] =
+  final def make[E, A]: STM[Nothing, TPromise[E, A]] =
     TRef[Option[Either[E, A]]](None).map(ref => new TPromise(ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TPromise.scala
+++ b/core/shared/src/main/scala/zio/stm/TPromise.scala
@@ -44,5 +44,5 @@ class TPromise[E, A] private (val ref: TRef[Option[Either[E, A]]]) extends AnyVa
 
 object TPromise {
   final def make[E, A]: STM[Nothing, TPromise[E, A]] =
-    TRef[Option[Either[E, A]]](None).map(ref => new TPromise(ref))
+    TRef.make[Option[Either[E, A]]](None).map(ref => new TPromise(ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TPromise.scala
+++ b/core/shared/src/main/scala/zio/stm/TPromise.scala
@@ -25,8 +25,7 @@ class TPromise[E, A] private (val ref: TRef[Option[Either[E, A]]]) extends AnyVa
   final def done(v: Either[E, A]): STM[Nothing, Boolean] =
     ref.get.flatMap {
       case Some(_) => STM.succeed(false)
-      case None =>
-        ref.set(Some(v)) *> STM.succeed(true)
+      case None    => ref.set(Some(v)) *> STM.succeed(true)
     }
 
   final def fail(e: E): STM[Nothing, Boolean] =

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -55,5 +55,5 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 }
 object TQueue {
   final def make[A](capacity: Int): STM[Nothing, TQueue[A]] =
-    TRef(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
+    TRef.make(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -22,9 +22,11 @@ import scala.collection.immutable.{ Queue => ScalaQueue }
 
 class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
   final def offer(a: A): STM[Nothing, Unit] =
-    (ref.get
-      .flatMap(q => STM.check(q.length < capacity))
-      *> ref.update(_ enqueue a)).unit
+    for {
+      q <- ref.get
+      _ <- STM.check(q.length < capacity)
+      _ <- ref.update(_.enqueue(a))
+    } yield ()
 
   // TODO: Scala doesn't allow Iterable???
   @silent("enqueueAll")

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -54,6 +54,6 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       .map(_.toList)
 }
 object TQueue {
-  final def apply[A](capacity: Int): STM[Nothing, TQueue[A]] =
+  final def make[A](capacity: Int): STM[Nothing, TQueue[A]] =
     TRef(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -111,7 +111,7 @@ object TRef {
   /**
    * Makes a new `TRef` that is initialized to the specified value.
    */
-  final def apply[A](a: => A): STM[Nothing, TRef[A]] =
+  final def make[A](a: => A): STM[Nothing, TRef[A]] =
     new STM(journal => {
       val value     = a
       val versioned = new Versioned(value)
@@ -130,5 +130,5 @@ object TRef {
    * transaction to extract the value out.
    */
   final def makeCommit[A](a: => A): UIO[TRef[A]] =
-    STM.atomically(TRef(a))
+    STM.atomically(TRef.make(a))
 }

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -45,6 +45,6 @@ class TSemaphore private (val permits: TRef[Long]) extends AnyVal {
 }
 
 object TSemaphore {
-  final def apply(n: Long): STM[Nothing, TSemaphore] =
+  final def make(n: Long): STM[Nothing, TSemaphore] =
     TRef(n).map(v => new TSemaphore(v))
 }

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -45,5 +45,5 @@ class TSemaphore private (val permits: TRef[Long]) extends AnyVal {
 
 object TSemaphore {
   final def make(n: Long): STM[Nothing, TSemaphore] =
-    TRef(n).map(v => new TSemaphore(v))
+    TRef.make(n).map(v => new TSemaphore(v))
 }

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -20,13 +20,12 @@ class TSemaphore private (val permits: TRef[Long]) extends AnyVal {
   final def acquire: STM[Nothing, Unit] = acquireN(1L)
 
   final def acquireN(n: Long): STM[Nothing, Unit] =
-    assertNonNegative(n).flatMap { _ =>
-      permits.get.flatMap { value =>
-        STM.check(value >= n).flatMap { _ =>
-          permits.set(value - n)
-        }
-      }
-    }
+    for {
+      _     <- assertNonNegative(n)
+      value <- permits.get
+      _     <- STM.check(value >= n)
+      _     <- permits.set(value - n)
+    } yield ()
 
   final def available: STM[Nothing, Long] = permits.get
 

--- a/core/shared/src/main/scala/zio/stm/TSet.scala
+++ b/core/shared/src/main/scala/zio/stm/TSet.scala
@@ -38,9 +38,7 @@ class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * provided set.
    */
   final def diff(other: TSet[A]): STM[Nothing, Unit] =
-    other.toList
-      .map(_.toSet)
-      .flatMap(vals => removeIf(vals.contains))
+    other.toList.map(_.toSet).flatMap(vals => removeIf(vals.contains))
 
   /**
    * Atomically folds using pure function.
@@ -65,9 +63,7 @@ class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * provided set.
    */
   final def intersect(other: TSet[A]): STM[Nothing, Unit] =
-    other.toList
-      .map(_.toSet)
-      .flatMap(vals => retainIf(vals.contains))
+    other.toList.map(_.toSet).flatMap(vals => retainIf(vals.contains))
 
   /**
    * Stores new element in the set.
@@ -114,9 +110,7 @@ class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * set.
    */
   final def union(other: TSet[A]): STM[Nothing, Unit] =
-    other.toList
-      .flatMap(vals => STM.collectAll(vals.map(put)))
-      .unit
+    other.toList.flatMap(vals => STM.collectAll(vals.map(put))).unit
 }
 
 object TSet {
@@ -124,7 +118,7 @@ object TSet {
   /**
    * Makes a new `TSet` that is initialized with specified values.
    */
-  final def apply[A](data: A*): STM[Nothing, TSet[A]] = fromIterable(data)
+  final def make[A](data: A*): STM[Nothing, TSet[A]] = fromIterable(data)
 
   /**
    * Makes an empty `TSet`.


### PR DESCRIPTION
Ensure all factories returning STM are named `make` rather than `apply`.