### PR TITLE
Fix Issue on Master and Update CI To Prevent Regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,14 @@ testJVM: &testJVM
     - store_test_results:
         path: core-tests/jvm/target/test-reports
 
-  testJVM213: &testJVM213
+  testJVMScala213: &testJVMScala213
     steps:
       - checkout
       - <<: *load_cache
       - <<: *install_jdk
       - run:
           name: Run tests
-          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVM213
+          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMScala213
       - <<: *clean_cache
       - <<: *save_cache
       - store_test_results:
@@ -245,7 +245,7 @@ jobs:
       - <<: *jdk_8
 
   test_213_jdk8_jvm:
-    <<: *testJVM213
+    <<: *testJVMScala213
     <<: *machine_ubuntu
     <<: *machine_resource
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,19 @@ testJVM: &testJVM
     - store_test_results:
         path: core-tests/jvm/target/test-reports
 
+  testJVM213: &testJVM213
+    steps:
+      - checkout
+      - <<: *load_cache
+      - <<: *install_jdk
+      - run:
+          name: Run tests
+          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVM213
+      - <<: *clean_cache
+      - <<: *save_cache
+      - store_test_results:
+          path: core-tests/jvm/target/test-reports
+
 testJVMDotty: &testJVMDotty
   steps:
     - checkout
@@ -232,7 +245,7 @@ jobs:
       - <<: *jdk_8
 
   test_213_jdk8_jvm:
-    <<: *testJVM
+    <<: *testJVM213
     <<: *machine_ubuntu
     <<: *machine_resource
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,14 @@ testJVM: &testJVM
     - store_test_results:
         path: core-tests/jvm/target/test-reports
 
-  testJVMScala213: &testJVMScala213
+  testJVMNoBenchmarks: &testJVMNoBenchmarks
     steps:
       - checkout
       - <<: *load_cache
       - <<: *install_jdk
       - run:
           name: Run tests
-          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMScala213
+          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMNoBenchmarks
       - <<: *clean_cache
       - <<: *save_cache
       - store_test_results:
@@ -245,7 +245,7 @@ jobs:
       - <<: *jdk_8
 
   test_213_jdk8_jvm:
-    <<: *testJVMScala213
+    <<: *testJVMNoBenchmarks
     <<: *machine_ubuntu
     <<: *machine_resource
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,18 +128,18 @@ testJVM: &testJVM
     - store_test_results:
         path: core-tests/jvm/target/test-reports
 
-  testJVMNoBenchmarks: &testJVMNoBenchmarks
-    steps:
-      - checkout
-      - <<: *load_cache
-      - <<: *install_jdk
-      - run:
-          name: Run tests
-          command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMNoBenchmarks
-      - <<: *clean_cache
-      - <<: *save_cache
-      - store_test_results:
-          path: core-tests/jvm/target/test-reports
+testJVMNoBenchmarks: &testJVMNoBenchmarks
+  steps:
+    - checkout
+    - <<: *load_cache
+    - <<: *install_jdk
+    - run:
+        name: Run tests
+        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! testJVMNoBenchmarks
+    - <<: *clean_cache
+    - <<: *save_cache
+    - store_test_results:
+        path: core-tests/jvm/target/test-reports
 
 testJVMDotty: &testJVMDotty
   steps:

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -33,7 +33,7 @@ class QueueBackPressureBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](queueSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](queueSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(queueSize).commit)
+    zioTQ = unsafeRun(TQueue.make(queueSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](queueSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -33,7 +33,7 @@ class QueueParallelBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](totalSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -37,7 +37,7 @@ class QueueSequentialBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -30,7 +30,7 @@ class SemaphoreBenchmark {
   @Benchmark
   def tsemaphoreContention() =
     unsafeRun(for {
-      sem   <- TSemaphore(fibers / 2L).commit
+      sem   <- TSemaphore.make(fibers / 2L).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(STM.succeed(1)).commit)))
       _     <- fiber.join
     } yield ())

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -29,7 +29,7 @@ class SingleRefBenchmark {
   @Benchmark
   def trefContention() =
     unsafeRun(for {
-      tref  <- TRef(0).commit
+      tref  <- TRef.make(0).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))
       _     <- fiber.join
     } yield ())

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJVM",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks:compile"
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile"
 )
 addCommandAlias(
   "testJVMDotty",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ addCommandAlias(
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile"
 )
 addCommandAlias(
-  "testJVM213",
+  "testJVMScala213",
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
 )
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJVM",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks:compile"
 )
 addCommandAlias(
   "testJVMDotty",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ addCommandAlias(
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile"
 )
 addCommandAlias(
-  "testJVMScala213",
+  "testJVMNoBenchmarks",
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
 )
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,10 @@ addCommandAlias(
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile"
 )
 addCommandAlias(
+  "testJVM213",
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
+)
+addCommandAlias(
   "testJVMDotty",
   ";coreJVM/test:compile;stacktracerJVM/test:compile;streamsJVM/test:compile;testTestsJVM/run;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
 )


### PR DESCRIPTION
The benchmarks project is not currently compiling on master because of the recent change to the factory methods to the STM types. We're not currently compiling the benchmarks project in CI which creates the risk of regressions like this. Corrects the current issue and adds a task to CI to compile the benchmarks.