### PR TITLE
ZIO Test: Fix Naming Conflict with TestAspect#ignore

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -33,7 +33,7 @@ class QueueBackPressureBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](queueSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](queueSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(queueSize).commit)
+    zioTQ = unsafeRun(TQueue.make(queueSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](queueSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -33,7 +33,7 @@ class QueueParallelBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](totalSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -37,7 +37,7 @@ class QueueSequentialBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -30,7 +30,7 @@ class SemaphoreBenchmark {
   @Benchmark
   def tsemaphoreContention() =
     unsafeRun(for {
-      sem   <- TSemaphore(fibers / 2L).commit
+      sem   <- TSemaphore.make(fibers / 2L).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(STM.succeed(1)).commit)))
       _     <- fiber.join
     } yield ())

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -29,7 +29,7 @@ class SingleRefBenchmark {
   @Benchmark
   def trefContention() =
     unsafeRun(for {
-      tref  <- TRef(0).commit
+      tref  <- TRef.make(0).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))
       _     <- fiber.join
     } yield ())

--- a/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
@@ -53,7 +53,7 @@ object DefaultTestReporterSpec extends AsyncBaseSpec {
     )
   )
 
-  val test4 = Spec.test("Failing test", fail(Cause.fail("Fail")))
+  val test4 = Spec.test("Failing test", failed(Cause.fail("Fail")))
 
   val test4Expected = Vector(
     expectedFailure("Failing test"),

--- a/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
@@ -6,7 +6,7 @@ import zio.random.Random
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.GenUtils._
-import zio.test.TestUtils.{ label, succeeded }
+import zio.test.TestUtils.{ isSuccessful, label }
 import zio.ZIO
 
 object GenSpec extends AsyncBaseSpec {
@@ -374,7 +374,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(as.reverse.reverse, equalTo(as))
         }
       }
-      succeeded(reverseProp)
+      isSuccessful(reverseProp)
     }
 
   def uniformGeneratesValuesInRange: Future[Boolean] =
@@ -479,7 +479,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(as.takeWhile(f).forall(f), isTrue)
         }
       }
-      succeeded(takeWhileProp)
+      isSuccessful(takeWhileProp)
     }
   }
 
@@ -495,7 +495,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(f(a, b), equalTo(g(a, b)))
         }
       }
-      succeeded(swapProp)
+      isSuccessful(swapProp)
     }
   }
 }

--- a/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
@@ -6,7 +6,7 @@ import zio.random.Random
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.GenUtils._
-import zio.test.TestUtils.{ isSuccessful, label }
+import zio.test.TestUtils.{ isSuccess, label }
 import zio.ZIO
 
 object GenSpec extends AsyncBaseSpec {
@@ -374,7 +374,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(as.reverse.reverse, equalTo(as))
         }
       }
-      isSuccessful(reverseProp)
+      isSuccess(reverseProp)
     }
 
   def uniformGeneratesValuesInRange: Future[Boolean] =
@@ -479,7 +479,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(as.takeWhile(f).forall(f), isTrue)
         }
       }
-      isSuccessful(takeWhileProp)
+      isSuccess(takeWhileProp)
     }
   }
 
@@ -495,7 +495,7 @@ object GenSpec extends AsyncBaseSpec {
           assert(f(a, b), equalTo(g(a, b)))
         }
       }
-      isSuccessful(swapProp)
+      isSuccess(swapProp)
     }
   }
 }

--- a/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
@@ -47,7 +47,7 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
     )
   )
 
-  val test4 = Spec.test("Failing test", fail(Cause.fail("Fail")))
+  val test4 = Spec.test("Failing test", failed(Cause.fail("Fail")))
 
   val test4Expected = Vector(
     expectedFailure("Failing test"),

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -18,7 +18,7 @@ object TestAspectSpec
             spec = testM("test") {
               assertM(ref.get, equalTo(1))
             } @@ around(ref.set(1), ref.set(-1))
-            result <- isSuccessful(spec)
+            result <- isSuccess(spec)
             after  <- ref.get
           } yield {
             assert(result, isTrue) &&
@@ -35,7 +35,7 @@ object TestAspectSpec
         },
         testM("dottyOnly runs tests only on Dotty") {
           val spec   = test("Dotty-only")(assert(TestVersion.isDotty, isTrue)) @@ dottyOnly
-          val result = if (TestVersion.isDotty) isSuccessful(spec) else isIgnored(spec)
+          val result = if (TestVersion.isDotty) isSuccess(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         test("exceptDotty runs tests on all versions except Dotty") {
@@ -82,7 +82,7 @@ object TestAspectSpec
             spec = testM("flaky test") {
               assertM(ref.update(_ + 1), equalTo(100))
             } @@ flaky
-            result <- isSuccessful(spec)
+            result <- isSuccess(spec)
             n      <- ref.get
           } yield assert(result, isTrue) && assert(n, equalTo(100))
         },
@@ -92,7 +92,7 @@ object TestAspectSpec
             spec = testM("flaky test that dies") {
               assertM(ref.update(_ + 1).filterOrDieMessage(_ >= 100)("die"), equalTo(100))
             } @@ flaky
-            result <- isSuccessful(spec)
+            result <- isSuccess(spec)
             n      <- ref.get
           } yield assert(result, isTrue) && assert(n, equalTo(100))
         },
@@ -139,7 +139,7 @@ object TestAspectSpec
         },
         testM("jsOnly runs tests only on ScalaJS") {
           val spec   = test("Javascript-only")(assert(TestPlatform.isJS, isTrue)) @@ jsOnly
-          val result = if (TestPlatform.isJS) isSuccessful(spec) else isIgnored(spec)
+          val result = if (TestPlatform.isJS) isSuccess(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("jvm applies test aspect only on jvm") {
@@ -152,7 +152,7 @@ object TestAspectSpec
         },
         testM("jvmOnly runs tests only on the JVM") {
           val spec   = test("JVM-only")(assert(TestPlatform.isJVM, isTrue)) @@ jvmOnly
-          val result = if (TestPlatform.isJVM) isSuccessful(spec) else isIgnored(spec)
+          val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("nonFlakyPar runs a test a specified number of times in parallel") {
@@ -180,7 +180,7 @@ object TestAspectSpec
         },
         testM("scala2Only runs tests only on Scala 2") {
           val spec   = test("Scala2-only")(assert(TestVersion.isScala2, isTrue)) @@ scala2Only
-          val result = if (TestVersion.isScala2) isSuccessful(spec) else isIgnored(spec)
+          val result = if (TestVersion.isScala2) isSuccess(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("timeout makes tests fail after given duration") {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -18,7 +18,7 @@ object TestAspectSpec
             spec = testM("test") {
               assertM(ref.get, equalTo(1))
             } @@ around(ref.set(1), ref.set(-1))
-            result <- succeeded(spec)
+            result <- isSuccessful(spec)
             after  <- ref.get
           } yield {
             assert(result, isTrue) &&
@@ -35,7 +35,7 @@ object TestAspectSpec
         },
         testM("dottyOnly runs tests only on Dotty") {
           val spec   = test("Dotty-only")(assert(TestVersion.isDotty, isTrue)) @@ dottyOnly
-          val result = if (TestVersion.isDotty) succeeded(spec) else ignored(spec)
+          val result = if (TestVersion.isDotty) isSuccessful(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         test("exceptDotty runs tests on all versions except Dotty") {
@@ -82,7 +82,7 @@ object TestAspectSpec
             spec = testM("flaky test") {
               assertM(ref.update(_ + 1), equalTo(100))
             } @@ flaky
-            result <- succeeded(spec)
+            result <- isSuccessful(spec)
             n      <- ref.get
           } yield assert(result, isTrue) && assert(n, equalTo(100))
         },
@@ -92,7 +92,7 @@ object TestAspectSpec
             spec = testM("flaky test that dies") {
               assertM(ref.update(_ + 1).filterOrDieMessage(_ >= 100)("die"), equalTo(100))
             } @@ flaky
-            result <- succeeded(spec)
+            result <- isSuccessful(spec)
             n      <- ref.get
           } yield assert(result, isTrue) && assert(n, equalTo(100))
         },
@@ -139,7 +139,7 @@ object TestAspectSpec
         },
         testM("jsOnly runs tests only on ScalaJS") {
           val spec   = test("Javascript-only")(assert(TestPlatform.isJS, isTrue)) @@ jsOnly
-          val result = if (TestPlatform.isJS) succeeded(spec) else ignored(spec)
+          val result = if (TestPlatform.isJS) isSuccessful(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("jvm applies test aspect only on jvm") {
@@ -152,7 +152,7 @@ object TestAspectSpec
         },
         testM("jvmOnly runs tests only on the JVM") {
           val spec   = test("JVM-only")(assert(TestPlatform.isJVM, isTrue)) @@ jvmOnly
-          val result = if (TestPlatform.isJVM) succeeded(spec) else ignored(spec)
+          val result = if (TestPlatform.isJVM) isSuccessful(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("nonFlakyPar runs a test a specified number of times in parallel") {
@@ -180,7 +180,7 @@ object TestAspectSpec
         },
         testM("scala2Only runs tests only on Scala 2") {
           val spec   = test("Scala2-only")(assert(TestVersion.isScala2, isTrue)) @@ scala2Only
-          val result = if (TestVersion.isScala2) succeeded(spec) else ignored(spec)
+          val result = if (TestVersion.isScala2) isSuccessful(spec) else isIgnored(spec)
           assertM(result, isTrue)
         },
         testM("timeout makes tests fail after given duration") {

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -132,7 +132,7 @@ package object test extends AssertionVariants with CheckVariants {
   /**
    * Creates an ignored test result.
    */
-  final val ignore: ZTest[Any, Nothing, Nothing] =
+  final val ignored: ZTest[Any, Nothing, Nothing] =
     ZIO.succeed(TestSuccess.Ignored)
 
   /**
@@ -143,7 +143,7 @@ package object test extends AssertionVariants with CheckVariants {
   final def platformSpecific[R, E, A, S](js: => A, jvm: => A)(f: A => ZTest[R, E, S]): ZTest[R, E, S] =
     if (TestPlatform.isJS) f(js)
     else if (TestPlatform.isJVM) f(jvm)
-    else ignore
+    else ignored
 
   /**
    * Builds a suite containing a number of other specs.
@@ -181,7 +181,7 @@ package object test extends AssertionVariants with CheckVariants {
   final def versionSpecific[R, E, A, S](dotty: => A, scala2: => A)(f: A => ZTest[R, E, S]): ZTest[R, E, S] =
     if (TestVersion.isDotty) f(dotty)
     else if (TestVersion.isScala2) f(scala2)
-    else ignore
+    else ignored
 
   val defaultTestRunner: TestRunner[TestEnvironment, String, Any, Any, Any] =
     TestRunner(TestExecutor.managed(zio.test.environment.testEnvironmentManaged))

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -126,7 +126,7 @@ package object test extends AssertionVariants with CheckVariants {
   /**
    * Creates a failed test result with the specified runtime cause.
    */
-  final def fail[E](cause: Cause[E]): ZTest[Any, E, Nothing] =
+  final def failed[E](cause: Cause[E]): ZTest[Any, E, Nothing] =
     ZIO.fail(TestFailure.Runtime(cause))
 
   /**


### PR DESCRIPTION
Currently we have `ignore` in the ZIO Test package object that creates an ignored test result and `TestAspect#ignore`. If you do some common wildcard imports like below this creates a naming conflict so you can't use `TestAspect#ignore` without hiding things / aliasing things / using a qualified name, which is not very nice. In my experience `TestAspect#ignore` is relatively commonly used versus `ignore` in the package object is quite uncommonly used. This PR changes the `ignore` in the package object to `ignored` to avoid the conflict.

```scala
import zio.test._
import zio.test.TestAspect._
```