### PR TITLE
ZIO Test: Suspend Effects in testM

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -4,6 +4,7 @@ import zio.ZIO
 import zio.clock._
 import zio.test.Assertion._
 import zio.test.TestAspect.failure
+import zio.test.TestUtils.execute
 
 object TestSpec
     extends ZIOBaseSpec(
@@ -22,6 +23,22 @@ object TestSpec
             _      <- ZIO.effect(())
             result <- ZIO.succeed("succeed")
           } yield assert(result, equalTo("succeed"))
+        },
+        testM("testM suspends effects") {
+          var n = 0
+          val spec = suite("suite")(
+            testM("test1") {
+              n += 1
+              ZIO.succeed(assertCompletes)
+            },
+            testM("test2") {
+              n += 1
+              ZIO.succeed(assertCompletes)
+            }
+          ).filterLabels(_ == "test2").get
+          for {
+            _ <- execute(spec)
+          } yield assert(n, equalTo(1))
         }
       )
     )


### PR DESCRIPTION
Currently `testM` accepts a `assertion: ZIO[R, E, TestResult]`. This works fine when the assertion really is an effect but can result in unintended behavior when the assertion contains side effects that are not properly suspended. For example, consider:

```scala
testM("test) {
  val x = 1
  println("x = " + x)
  ZIO.succeed(assert(x, equalTo(1))
}
```

This will only print "x = 1" once when run using a `main` method but twice when run with the SBT test runner. A similar issue can also come up when filtering tests, where the side effect can get executed even for tests that are supposed to be filtered out. You could argue that it is a contract violation to be creating effects that are not properly suspended like this but I think it is pretty common to want to do a debug statement in testing and users may not always properly suspend them so with this PR we suspend the entire assertion.

@jdegoes Is this the issue you identified in #1802?