### PR TITLE
ZIO Test: Implement Warnings for Test Clock

### DIFF
--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -89,14 +89,14 @@ object TestEnvironment extends Serializable {
   val Value: Managed[Nothing, TestEnvironment] =
     Managed.fromEffect {
       for {
-        clock   <- TestClock.makeTest(TestClock.DefaultData)
-        console <- TestConsole.makeTest(TestConsole.DefaultData)
         live    <- Live.makeService(new DefaultRuntime {}.Environment)
+        clock   <- TestClock.makeTest(TestClock.DefaultData, Some(live))
+        console <- TestConsole.makeTest(TestConsole.DefaultData)
         random  <- TestRandom.makeTest(TestRandom.DefaultData)
-        time    <- live.provide(zio.clock.nanoTime)
-        _       <- random.setSeed(time)
         size    <- Sized.makeService(100)
         system  <- TestSystem.makeTest(TestSystem.DefaultData)
+        time    <- live.provide(clock.nanoTime)
+        _       <- random.setSeed(time)
       } yield new TestEnvironment(clock, console, live, random, size, system)
     }
 }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -93,15 +93,15 @@ object TestEnvironment extends Serializable {
   val Value: Managed[Nothing, TestEnvironment] =
     Managed.fromEffect {
       for {
-        clock    <- TestClock.makeTest(TestClock.DefaultData)
-        console  <- TestConsole.makeTest(TestConsole.DefaultData)
         live     <- Live.makeService(new DefaultRuntime {}.Environment)
+        clock    <- TestClock.makeTest(TestClock.DefaultData, Some(live))
+        console  <- TestConsole.makeTest(TestConsole.DefaultData)
         random   <- TestRandom.makeTest(TestRandom.DefaultData)
-        time     <- live.provide(zio.clock.nanoTime)
-        _        <- random.setSeed(time)
         size     <- Sized.makeService(100)
         system   <- TestSystem.makeTest(TestSystem.DefaultData)
         blocking = Blocking.Live.blocking
+        time     <- live.provide(clock.nanoTime)
+        _        <- random.setSeed(time)
       } yield new TestEnvironment(blocking, clock, console, live, random, size, system)
     }
 }


### PR DESCRIPTION
If at least one effect has been put to sleep with the test clock and no adjustments to the time have been made within 5 seconds a warning message will be displayed.