### PR TITLE
ZIO Test: Improvements to provideManagedShared

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -1,0 +1,22 @@
+package zio.test
+
+import zio.test.Assertion._
+import zio.test.TestUtils.execute
+import zio.ZManaged
+
+object SpecSpec
+    extends ZIOBaseSpec(
+      suite("SpecSpec")(
+        testM("provideManagedShared gracefully handles fiber death") {
+          import zio.NeedsEnv.needsEnv
+          val spec = suite("Suite1")(
+            test("Test1") {
+              assert(true, isTrue)
+            }
+          ).provideManagedShared(ZManaged.dieMessage("everybody dies"))
+          for {
+            _ <- execute(spec)
+          } yield assertCompletes
+        }
+      )
+    )

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -227,13 +227,13 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
     }
 
   /**
-   * Uses the specified `Managed` to provide each test in this spec with its
+   * Uses the specified `ZManaged` to provide each test in this spec with its
    * required environment.
    */
-  final def provideManaged[E1 >: E](managed: Managed[E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, L, T] =
-    transform[Any, E1, L, T] {
-      case SuiteCase(label, specs, exec) => SuiteCase(label, specs.provideManaged(managed), exec)
-      case TestCase(label, test)         => TestCase(label, test.provideManaged(managed))
+  final def provideManaged[R0, E1 >: E](managed: ZManaged[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, L, T] =
+    transform[R0, E1, L, T] {
+      case SuiteCase(label, specs, exec) => SuiteCase(label, specs.provideSomeManaged(managed), exec)
+      case TestCase(label, test)         => TestCase(label, test.provideSomeManaged(managed))
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -280,16 +280,6 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
       case t @ TestCase(_, _)            => Spec(f(t))
     }
 
-  final def mapTests[R1, E1, L1 >: L, T1](
-    suiteCase: ZIO[R, E, Vector[Spec[R1, E1, L1, T1]]] => ZIO[R1, E1, Vector[Spec[R1, E1, L1, T1]]],
-    testCase: ZIO[R, E, T] => ZIO[R1, E1, T1]
-  ): Spec[R1, E1, L1, T1] =
-    caseValue match {
-      case SuiteCase(label, specs, exec) =>
-        Spec.suite(label, suiteCase(specs.map(_.map(_.mapTests(suiteCase, testCase)))), exec)
-      case TestCase(label, test) => Spec.test(label, testCase(test))
-    }
-
   /**
    * Transforms the spec statefully, one layer at a time.
    */

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -245,12 +245,12 @@ final case class Spec[-R, +E, +L, +T](caseValue: SpecCase[R, E, L, T, Spec[R, E,
   final def provideManagedShared[R0, E1 >: E](
     managed: ZManaged[R0, E1, R]
   )(implicit ev: NeedsEnv[R]): Spec[R0, E1, L, T] = {
-    def loop(r: R)(spec: Spec[R, E, L, T]): ZIO[R, E, Spec[R0, E, L, T]] =
+    def loop(r: R)(spec: Spec[R, E, L, T]): ZIO[R, E, Spec[Any, E, L, T]] =
       spec.caseValue match {
         case SuiteCase(label, specs, exec) =>
           specs.flatMap(ZIO.foreach(_)(loop(r))).map(z => Spec.suite(label, ZIO.succeed(z.toVector), exec))
         case TestCase(label, test) =>
-          test.map(t => Spec.test(label, ZIO.succeed(t))).provide(r)
+          test.map(t => Spec.test(label, ZIO.succeed(t)))
       }
     caseValue match {
       case SuiteCase(label, specs, exec) =>


### PR DESCRIPTION
Makes two improvement to `provideManagedShared`. First, fixes a bug where an unchecked exception in the managed resource could cause the test framework to die instead of being caught and reported. Second, makes `provideManagedShared` more polymorphic by accepting a `ZManaged[R0, E1, R]`, allowing for partial provision of the environment and in particular accessing the `TestEnvironment` to help construct a managed resource. Technically I think this should be `provideManagedSomeShared` but that is a mouthful. Also since all tests require the `TestEnvironment` I think the value of demonstrating full elimination of environment requirements is less. But happy to change.

Also removes an unused method that I added at some point when we were making suites effectual but I don't think we need to be exposing at this point.