### PR TITLE
ZIO Test: Support Labeled Assertions

### DIFF
--- a/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
@@ -104,7 +104,7 @@ object DefaultTestReporterSpec extends AsyncBaseSpec {
     expectedFailure("labeled failures"),
     withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
     withOffset(2)(
-      s"${blue("Some(0)")} did not satisfy ${cyan("(isSome(" + yellowThenCyan("equalTo(1)") + ") @@ \"third\")")}\n"
+      s"${blue("Some(0)")} did not satisfy ${cyan("(isSome(" + yellowThenCyan("equalTo(1)") + ") ?? \"third\")")}\n"
     )
   )
 

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -39,6 +39,12 @@ class Assertion[-A] private (val render: Render, val run: (=> A) => AssertResult
     })
 
   /**
+   * A symbolic alias for `label`.
+   */
+  final def ??(string: String): Assertion[A] =
+    label(string)
+
+  /**
    * Returns a new assertion that succeeds if either assertion succeeds.
    */
   final def ||[A1 <: A](that: => Assertion[A1]): Assertion[A1] =
@@ -63,7 +69,7 @@ class Assertion[-A] private (val render: Render, val run: (=> A) => AssertResult
    * Labels this assertion with the specified string.
    */
   final def label(string: String): Assertion[A] =
-    new Assertion(infix(param(self), "@@", param(quoted(string))), run)
+    new Assertion(infix(param(self), "??", param(quoted(string))), run)
 
   /**
    * Returns the negation of this assertion.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -60,6 +60,12 @@ class Assertion[-A] private (val render: Render, val run: (=> A) => AssertResult
     toString.hashCode
 
   /**
+   * Labels this assertion with the specified string.
+   */
+  final def label(string: String): Assertion[A] =
+    new Assertion(infix(param(self), "@@", param(quoted(string))), run)
+
+  /**
    * Returns the negation of this assertion.
    */
   final def negate: Assertion[A] =


### PR DESCRIPTION
In some cases it can be useful to label assertions to provide additional information for test reporting. For example, consider the following test:

```scala
testM("test") {
  for {
    a <- ZIO.effectTotal(Some(1))
    b <- ZIO.effectTotal(Some(1))
    c <- ZIO.effectTotal(Some(0))
    d <- ZIO.effectTotal(Some(1))
  } yield assert(a, isSome(equalTo(1)) &&
    assert(b, isSome(equalTo(1)) &&
    assert(c, isSome(equalTo(1)) &&
    assert(d, isSome(equalTo(1))
}
```

This test will fail with an error message that "0 did not satisfy equalTo(1)",  but that is not particularly helpful here because we don't know which of the four composed assertions failed. This PR adds a method `label` to Assertion that labels an assertion with an arbitrary string. Using this, the test could be rewritten as:

```scala
testM("test") {
  for {
    a <- ZIO.effectTotal(Some(1))
    b <- ZIO.effectTotal(Some(1))
    c <- ZIO.effectTotal(Some(0))
    d <- ZIO.effectTotal(Some(1))
  } yield assert(a, isSome(equalTo(1)).label("first")) &&
    assert(b, isSome(equalTo(1)).label("second")) &&
    assert(c, isSome(equalTo(1)).label("third")) &&
    assert(d, isSome(equalTo(1)).label("fourth"))
}
```

The error message would now get reported like so:

![image](https://user-images.githubusercontent.com/20825463/68537751-79d04b80-0337-11ea-954d-061f1fa193f7.png)
