### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test-output/
 .metals
 .idea
 coursier
+.DS_Store
 
 # if you are here to add your IDE's files please read this instead:
 # https://stackoverflow.com/questions/7335420/global-git-ignore#22885996


### PR DESCRIPTION
Sometimes I browse the file system with `Finder` and end up with a clutter of these `.DS_Store` files.