### PR TITLE
ZIO Test: Prevent Spurious TestClock Warnings

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/TestRuntime.scala
+++ b/core-tests/jvm/src/test/scala/zio/TestRuntime.scala
@@ -46,4 +46,7 @@ abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def unsafeRunWith[R, E, A](r: UIO[R])(zio: ZIO[R, E, A]): A =
     unsafeRun(r.flatMap[Any, E, A](zio.provide))
+
+  def unsafeRunWithManaged[R, E, A](r: UManaged[R])(zio: ZIO[R, E, A]): A =
+    unsafeRun(zio.provideManaged(r))
 }

--- a/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOSpecJvm.scala
@@ -332,7 +332,7 @@ class ZIOSpecJvm(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRu
     )
   }
 
-  def testCached = unsafeRunWith(TestClock.make(TestClock.DefaultData)) {
+  def testCached = unsafeRunWithManaged(TestClock.make(TestClock.DefaultData)) {
     def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.update(_ + 1)
     for {
       ref   <- Ref.make(0)

--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -17,23 +17,27 @@ The backbone of `zio-test` is the `Spec[L, T]` class. Every spec is labeled with
 
 The most common and easy way to create suites is to use `suite` function. For testing of pure functions there is `test` function and for effectful testing there is `testM`
 
-```scala
+```scala mdoc
 import zio.test._
 import zio.clock.nanoTime
 import Assertion.isGreaterThan
 
-val clockSuite = suite("clock") {
+val clockSuite = suite("clock") (
   testM("time is non-zero") {
-    assertM(nanoTime, isGreaterThan(0))
+    assertM(nanoTime, isGreaterThan(0L))
   }
-}
+)
 ```
 
 As you can see the whole suit was assigned to `clockSuite` val. As it was said suites can contain other suites so we can aggregate them as much as needed. Example, we can have multiple suites that test external HTTP apis and one big suite that will aggregate them all.
 
-```scala
-val paymentProviderABCSuite  = suite("ABC payment provider tests") {/* tests */}
-val paymentProviderXYZSuite  = suite("XYZ payment provider tests") {/* tests */}
+
+```scala mdoc
+import zio.test._
+import Assertion._
+
+val paymentProviderABCSuite  = suite("ABC payment provider tests") {test("Your test")(assert("Your value", Assertion.isNonEmptyString))}
+val paymentProviderXYZSuite  = suite("XYZ payment provider tests") {test("Your other test")(assert("Your other value", Assertion.isNonEmptyString))}
 val allPaymentProvidersTests = suite("All payment providers tests")(paymentProviderABCSuite, paymentProviderXYZSuite)
 ```
 
@@ -52,7 +56,7 @@ of useful assertions predefined like `equalTo`, `isFalse`, `isTrue`, `contains`,
 What is really useful in assertions is that they behave like boolean values and can be composed with operators
 known from operating on boolean values like and (`&&`), or (`||`), negation (`negate`).
 
-```scala
+```scala mdoc
 import zio.test.Assertion
 
 val assertionForString: Assertion[String] = Assertion.containsString("Foo") && Assertion.endsWith("Bar")
@@ -60,7 +64,7 @@ val assertionForString: Assertion[String] = Assertion.containsString("Foo") && A
 
 What's more, assertions also compose with each other allowing for doing rich diffs not only simple value to value comparison.
 
-```scala
+```scala mdoc
 import zio.test.Assertion.{isRight, isSome,equalTo, hasField}
 
 test("Check assertions") {
@@ -74,7 +78,7 @@ Here the expression `Right(Some(2))` is of type `Either[Any, Option[Int]]`and ou
 is of type `Assertion[Either[Any, Option[Int]]]`
 
 
-```scala
+```scala mdoc
 import zio.test.Assertion.{isRight, isSome,equalTo, isGreaterThanEqualTo, not, hasField}
 
 final case class Address(country:String, city:String)
@@ -100,7 +104,11 @@ on console will be a nice detailed text explaining what exactly went wrong:
 Having this all in mind probably the most common and also most readable way of structuring tests is to pass
 a for-comprehension to `testM` function and yield a call to `assert` function.
 
-```scala
+```scala mdoc
+import zio._
+import zio.test._
+import Assertion._
+
 testM("Semaphore should expose available number of permits") {
   for {
     s         <- Semaphore.make(1L)
@@ -113,19 +121,24 @@ testM("Semaphore should expose available number of permits") {
 
 When all of our tests are constructed, we need to have a way to actually execute them. Your first stop is the `zio.test.DefaultRunnableSpec` which accepts a single suite that will be executed. A single suite might seem to be limiting but as it was already said suites can hold any number of other suites. You may structure your tests like this:
 
-```scala
-val suite1 = suite("suite1") {
-  testM("s1.t1") {...},
-  testM("s1.t2") {...}
-}
-val suite2 = suite("suite2") {
-  testM("s2.t1") {...},
-  testM("s2.t2") {...},
-  testM("s2.t3") {...}
-}
-val suite3 = suite("suite3") {
-  testM("s3.t1") {...}
-}
+
+```scala mdoc
+import zio.test._
+import zio.clock.nanoTime
+import Assertion._
+
+val suite1 = suite("suite1") (
+  testM("s1.t1") {assertM(nanoTime, isGreaterThanEqualTo(0L))},
+  testM("s1.t2") {assertM(nanoTime, isGreaterThanEqualTo(0L))}
+)
+val suite2 = suite("suite2") (
+  testM("s2.t1") {assertM(nanoTime, isGreaterThanEqualTo(0L))},
+  testM("s2.t2") {assertM(nanoTime, isGreaterThanEqualTo(0L))},
+  testM("s2.t3") {assertM(nanoTime, isGreaterThanEqualTo(0L))}
+)
+val suite3 = suite("suite3") (
+  testM("s3.t1") {assertM(nanoTime, isGreaterThanEqualTo(0L))}
+)
 
 object AllSuites extends DefaultRunnableSpec(suite("All tests")(suite1, suite2, suite3))
 ```
@@ -137,7 +150,7 @@ Just like with `zio.App` where at the very end an instance of `ZIO[R,E,A]` is ex
 Here again the design of `zio-test` shines. Since our tests are ordinary values we can just transform them with a call to `mapTest`.
 It accepts a lambda of type `ZIO[R with TestSystem, TestFailure[Throwable], TestSuccess[Unit] ] => T1`. Without getting into too much details about types we can see that our lambda argument is a test instance (`ZIO`) that expects an environment of type `R with TestSystem`. This is no different from normal usage of ZIO in `zio.App`. We can use the same `provide`, `provideSome` methods to provide modules which `DefaultRunnableSpec` cannot provide itself as those are users modules. When all dependencies are provided we can run our tests in two ways. If we added `zio-test-sbt` to our dependencies and `zio.test.sbt.TestFramework` to SBT's `testFrameworks` our tests should be automatically picked up by SBT on invocation of `test`. However if we're not using SBT or have some other special needs `DefaultRunnableSpec` has a `main` method which can be invoked directly or with SBTs `test:run`.
 
-```scala
+```sbt
 libraryDependencies ++= Seq(
   "dev.zio" %% "zio-test"     % zioVersion % "test",
   "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
@@ -154,24 +167,38 @@ control and determinism. However there is another source of complexity that come
 
 It is easy to accidentally use different test instances at the same time.
 
-```scala
+```scala mdoc:fail
+import zio.test._
+import zio.test.environment.TestClock
+import scala.language.postfixOps
+import Assertion._
+import zio.duration.Duration
+import scala.concurrent.duration._
+
 testM("`acquire` doesn't leak permits upon cancellation") {
   for {
-    testClock <- TestClock.makeTest(TestClock.DefaultData)
-    s         <- Semaphore.make(1L)
-    sf        <- s.acquireN(2).timeout(1.milli).either.fork
-    _         <- testClock.adjust(1.second)
-    _         <- sf.join
-    _         <- s.release
-    permits   <- s.available
+      testClock <- TestClock.makeTest(TestClock.DefaultData)
+      s         <- Semaphore.make(1L)
+      sf        <- s.acquireN(2).timeout(Duration.fromScala(1 milli)).either.fork
+      _         <- testClock.adjust(Duration.fromScala(1 second))
+      _         <- sf.join
+      _         <- s.release
+      permits   <- s.available
   } yield assert(permits, equalTo(2L))
 }
 ```
 
 Above code doesn't work. We created a new `TestClock` instance and are correctly adjusting its time. What might be surprising is that call to `timeout` will use the `TestClock` provided by the `TestEnvironment` not our `testClock` instance. It easy to know why when you look at the signature of `timeout`:
 
-```scala
-final def timeout(d: Duration): ZIO[R with Clock, E, Option[A]]
+```scala mdoc
+import zio.duration.Duration
+import zio.clock.Clock
+
+sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
+    /* All other method declarations in this trait ignored to avoid clutter */
+
+    def timeout(d: Duration): ZIO[R with Clock, E, Option[A]]
+}
 ```
 
 The returned type is `ZIO[R with Clock, E, Option[A]]` where our environment is "some R plus a Clock".
@@ -185,7 +212,11 @@ When working with randomness testing might be hard because the inputs to the tes
 that deals with Randomness.
 `TestRandom` can operate in two modes based on needed use case. In first mode it is a purely functional pseudo-random number generator. During generation on random values like when calling `nextInt` no internal state is being mutated. It is expected to chain such operations with combinators like `flatMap`. To preserve the same values generated between invocation of tests `setSeed` method can be used. It is guaranteed to return the same sequence of values for any given seed.
 
-```scala
+```scala mdoc
+import zio.test.assert
+import zio.test.environment.TestRandom
+import zio.test.Assertion.equalTo
+
 testM("Use setSeed to generate stable values") {
   for {
     _  <- TestRandom.setSeed(27)
@@ -203,7 +234,7 @@ testM("Use setSeed to generate stable values") {
 
 In second mode `TestRandom` maintains an internal buffer of values that can be "fed" upfront with methods such as `feedInts`. When random values are being generated first values from that buffer are being used.
 
-```scala
+```scala mdoc
 import zio.test.environment.TestRandom
 testM("One can provide its own list of ints") {
   for {
@@ -235,14 +266,20 @@ Sometimes one need to be able to control the flow of time. In most cases you wan
 
 Thanks to call to `TestClock.adjust(1.minute)` we moved the time instantly 1 minute.
 
-```scala
+```scala mdoc
+import java.util.concurrent.TimeUnit
+import zio.clock.currentTime
+import zio.duration.Duration
+import zio.test.Assertion.isGreaterThanEqualTo
+import zio.test._
 import zio.test.environment.TestClock
-import zio.duration._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 testM("One can move time very fast") {
   for {
     startTime <- currentTime(TimeUnit.SECONDS)
-    _         <- TestClock.adjust(1.minute)
+    _         <- TestClock.adjust(Duration.fromScala(1 minute))
     endTime   <- currentTime(TimeUnit.SECONDS)
   } yield assert(endTime - startTime, isGreaterThanEqualTo(60L))
 }
@@ -252,12 +289,19 @@ testM("One can move time very fast") {
 
 `TestClock` affects also all code running asynchronously that is scheduled to run after certain time but with caveats to how runtime works.
 
-```scala
+```scala mdoc
+import zio.duration.Duration
+import zio.test.Assertion.equalTo
+import zio.test._
+import zio.test.environment.TestClock
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 testM("One can control time as he see fit") {
   for {
     promise <- Promise.make[Unit, Int]
-    _       <- (ZIO.sleep(10.seconds) *> promise.succeed(1)).fork
-    _       <- TestClock.adjust(10.seconds)
+    _       <- (ZIO.sleep(Duration.fromScala(10 seconds)) *> promise.succeed(1)).fork
+    _       <- TestClock.adjust(Duration.fromScala(10 seconds))
     readRef <- promise.await
   } yield assert(1, equalTo(readRef))
 }
@@ -274,7 +318,7 @@ Also it is worth mentioning that adjusting the time on `TestClock` doesn't make 
 Below code will be flaky because there is non-zero overhead when switching fibers thus reading of the value might happen before it is set and its change is 
 propagated.
 
-```scala
+```scala mdoc
 testM("THIS TEST WILL FAIL - Sleep and adjust can introduce races") {
   for {
     ref     <- Ref.make(0)
@@ -290,28 +334,36 @@ the queue and progress the clock multiple times and there is no need to create m
 Even if you have a non-trivial flow of data from multiple streams that can produce at different intervals and would like to test
 snapshots of data in particular point in time `Queue` can help with that.
 
-```scala
+```scala mdoc
+import zio.duration.Duration
+import zio.test.Assertion.equalTo
+import zio.test._
+import zio.test.environment.TestClock
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import zio.stream._
+
 testM("zipWithLatest") {
-  val s1 = Stream.iterate(0)(_ + 1).fixed(100.millis)
-  val s2 = Stream.iterate(0)(_ + 1).fixed(70.millis)
+  val s1 = Stream.iterate(0)(_ + 1).fixed(Duration.fromScala(100 millis))
+  val s2 = Stream.iterate(0)(_ + 1).fixed(Duration.fromScala(70 millis))
   val s3 = s1.zipWithLatest(s2)((_, _))
 
   for {
-    _ <- TestClock.setTime(0.millis)
+    _ <- TestClock.setTime(Duration.fromScala(0 millis))
     q <- Queue.unbounded[(Int, Int)]
     _ <- s3.foreach(q.offer).fork
     a <- q.take
-    _ <- TestClock.setTime(70.millis)
+    _ <- TestClock.setTime(Duration.fromScala(70 millis))
     b <- q.take
-    _ <- TestClock.setTime(100.millis)
+    _ <- TestClock.setTime(Duration.fromScala(100 millis))
     c <- q.take
-    _ <- TestClock.setTime(140.millis)
+    _ <- TestClock.setTime(Duration.fromScala(140 millis))
     d <- q.take
   } yield
     assert(a, equalTo(0 -> 0)) &&
-    assert(b, equalTo(0       -> 1)) &&
-    assert(c, equalTo(1       -> 1)) &&
-    assert(d, equalTo(1       -> 2))
+      assert(b, equalTo(0       -> 1)) &&
+      assert(c, equalTo(1       -> 1)) &&
+      assert(d, equalTo(1       -> 2))
 }
 ```
 
@@ -320,7 +372,7 @@ testM("zipWithLatest") {
 `TestConsole` allows testing of applications that interact with console by modeling working with standard input and output
 as writing and reading to and from internal buffers.
 
-```scala
+```scala mdoc
 import zio.test.environment.TestConsole
 import zio.console
 
@@ -357,7 +409,7 @@ of environment variables. It is important to test this logic just like other par
 exposes `TestSystem` module. Additionally to setting the environment variables it also allows for setting JVM system properties 
 like in the code below:
 
-```scala
+```scala mdoc
 import zio.system
 import zio.test.environment._
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1228,13 +1228,7 @@ object SinkSpec
                   res5  <- sink.extract(step5).map(_._1)
                 } yield assert(List(res1, res2, res3, res4, res5), equalTo(List(Some(1), Some(2), None, None, Some(5))))
 
-              for {
-                clock <- TestClock.make(TestClock.DefaultData)
-                test <- ZSink
-                         .throttleEnforce[Int](1, 10.milliseconds)(_ => 1)
-                         .use(sinkTest)
-                         .provide(clock)
-              } yield test
+              ZSink.throttleEnforce[Int](1, 10.milliseconds)(_ => 1).use(sinkTest)
             },
             testM("with burst") {
 
@@ -1262,13 +1256,7 @@ object SinkSpec
                   equalTo(List(Some(1), Some(2), Some(3), None, Some(5)))
                 )
 
-              for {
-                clock <- TestClock.make(TestClock.DefaultData)
-                test <- ZSink
-                         .throttleEnforce[Int](1, 10.milliseconds, 1)(_ => 1)
-                         .use(sinkTest)
-                         .provide(clock)
-              } yield test
+              ZSink.throttleEnforce[Int](1, 10.milliseconds, 1)(_ => 1).use(sinkTest)
             }
           ),
           suite("throttleShape")(
@@ -1289,13 +1277,11 @@ object SinkSpec
                 } yield assert(List(res1, res2, res3), equalTo(List(1, 2, 3)))
 
               for {
-                clock <- TestClock.make(TestClock.DefaultData)
                 fiber <- ZSink
                           .throttleShape[Int](1, 1.second)(_.toLong)
                           .use(sinkTest)
-                          .provide(clock)
                           .fork
-                _    <- clock.clock.adjust(8.seconds)
+                _    <- TestClock.adjust(8.seconds)
                 test <- fiber.join
               } yield test
             },
@@ -1312,13 +1298,7 @@ object SinkSpec
                   elapsed <- clock.currentTime(TimeUnit.SECONDS)
                 } yield assert(elapsed, equalTo(0L)) && assert(List(res1, res2), equalTo(List(1, 2)))
 
-              for {
-                clock <- TestClock.make(TestClock.DefaultData)
-                test <- ZSink
-                         .throttleShape[Int](1, 0.seconds)(_ => 100000L)
-                         .use(sinkTest)
-                         .provide(clock)
-              } yield test
+              ZSink.throttleShape[Int](1, 0.seconds)(_ => 100000L).use(sinkTest)
             },
             testM("with burst") {
 
@@ -1339,11 +1319,9 @@ object SinkSpec
                 } yield assert(List(res1, res2, res3), equalTo(List(1, 2, 3)))
 
               for {
-                clock <- TestClock.make(TestClock.DefaultData)
                 fiber <- ZSink
                           .throttleShape[Int](1, 1.second, 2)(_.toLong)
                           .use(sinkTest)
-                          .provide(clock)
                           .fork
                 test <- fiber.join
               } yield test

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1801,20 +1801,19 @@ object StreamSpec
             import zio.test.environment.TestClock
 
             for {
-              clock <- TestClock.make(TestClock.DefaultData)
-              s1    = Stream.iterate(0)(_ + 1).fixed(100.millis).provide(clock)
-              s2    = Stream.iterate(0)(_ + 1).fixed(70.millis).provide(clock)
-              s3    = s1.zipWithLatest(s2)((_, _))
-              q     <- Queue.unbounded[(Int, Int)]
-              _     <- s3.foreach(q.offer).fork
-              a     <- q.take
-              _     <- clock.clock.setTime(70.millis)
-              b     <- q.take
-              _     <- clock.clock.setTime(100.millis)
-              c     <- q.take
-              _     <- clock.clock.setTime(140.millis)
-              d     <- q.take
-              _     <- clock.clock.setTime(210.millis)
+              q  <- Queue.unbounded[(Int, Int)]
+              s1 = Stream.iterate(0)(_ + 1).fixed(100.millis)
+              s2 = Stream.iterate(0)(_ + 1).fixed(70.millis)
+              s3 = s1.zipWithLatest(s2)((_, _))
+              _  <- s3.foreach(q.offer).fork
+              a  <- q.take
+              _  <- TestClock.setTime(70.millis)
+              b  <- q.take
+              _  <- TestClock.setTime(100.millis)
+              c  <- q.take
+              _  <- TestClock.setTime(140.millis)
+              d  <- q.take
+              _  <- TestClock.setTime(210.millis)
             } yield assert(List(a, b, c, d), equalTo(List(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2)))
           }
         ),

--- a/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/DefaultTestReporterSpec.scala
@@ -143,8 +143,8 @@ object DefaultTestReporterSpec extends AsyncBaseSpec {
       val zio = for {
         _ <- TestTestRunner(r)
               .run(spec)
-              .provideSomeM(for {
-                logSvc   <- TestLogger.fromConsoleM
+              .provideSomeManaged(for {
+                logSvc   <- TestLogger.fromConsoleM.toManaged_
                 clockSvc <- TestClock.make(TestClock.DefaultData)
               } yield new TestLogger with Clock {
                 override def testLogger: TestLogger.Service = logSvc.testLogger

--- a/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
@@ -103,8 +103,8 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
       val zio = for {
         results <- TestTestRunner(r)
                     .run(spec)
-                    .provideSomeM(for {
-                      logSvc   <- TestLogger.fromConsoleM
+                    .provideSomeManaged(for {
+                      logSvc   <- TestLogger.fromConsoleM.toManaged_
                       clockSvc <- TestClock.make(TestClock.DefaultData)
                     } yield new TestLogger with Clock {
                       override def testLogger: TestLogger.Service = logSvc.testLogger

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -67,14 +67,15 @@ object EnvironmentSpec
           } yield assert(lineSep, equalTo(","))
         },
         testM("mapTestClock maps the `TestClock` implementation in the test environment") {
-          for {
-            _               <- TestClock.setTime(1.millis)
-            testEnvironment <- ZIO.environment[TestEnvironment]
-            testClock       <- TestClock.makeTest(TestClock.DefaultData)
-            result <- clock
-                       .currentTime(TimeUnit.MILLISECONDS)
-                       .provide(testEnvironment.mapTestClock(_ => testClock))
-          } yield assert(result, equalTo(0L))
+          TestClock.makeTest(TestClock.DefaultData).use { testClock =>
+            for {
+              _               <- TestClock.setTime(1.millis)
+              testEnvironment <- ZIO.environment[TestEnvironment]
+              result <- clock
+                         .currentTime(TimeUnit.MILLISECONDS)
+                         .provide(testEnvironment.mapTestClock(_ => testClock))
+            } yield assert(result, equalTo(0L))
+          }
         },
         testM("mapTestConsole maps the `TestConsole` implementation in the test environment") {
           for {

--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -87,16 +87,14 @@ case class TestEnvironment(
 object TestEnvironment extends Serializable {
 
   val Value: Managed[Nothing, TestEnvironment] =
-    Managed.fromEffect {
-      for {
-        live    <- Live.makeService(new DefaultRuntime {}.Environment)
-        clock   <- TestClock.makeTest(TestClock.DefaultData, Some(live))
-        console <- TestConsole.makeTest(TestConsole.DefaultData)
-        random  <- TestRandom.makeTest(TestRandom.DefaultData)
-        size    <- Sized.makeService(100)
-        system  <- TestSystem.makeTest(TestSystem.DefaultData)
-        time    <- live.provide(zio.clock.nanoTime)
-        _       <- random.setSeed(time)
-      } yield new TestEnvironment(clock, console, live, random, size, system)
-    }
+    for {
+      live    <- Live.makeService(new DefaultRuntime {}.Environment).toManaged_
+      clock   <- TestClock.makeTest(TestClock.DefaultData, Some(live))
+      console <- TestConsole.makeTest(TestConsole.DefaultData).toManaged_
+      random  <- TestRandom.makeTest(TestRandom.DefaultData).toManaged_
+      size    <- Sized.makeService(100).toManaged_
+      system  <- TestSystem.makeTest(TestSystem.DefaultData).toManaged_
+      time    <- live.provide(zio.clock.nanoTime).toManaged_
+      _       <- random.setSeed(time).toManaged_
+    } yield new TestEnvironment(clock, console, live, random, size, system)
 }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -91,17 +91,15 @@ case class TestEnvironment(
 object TestEnvironment extends Serializable {
 
   val Value: Managed[Nothing, TestEnvironment] =
-    Managed.fromEffect {
-      for {
-        live     <- Live.makeService(new DefaultRuntime {}.Environment)
-        clock    <- TestClock.makeTest(TestClock.DefaultData, Some(live))
-        console  <- TestConsole.makeTest(TestConsole.DefaultData)
-        random   <- TestRandom.makeTest(TestRandom.DefaultData)
-        size     <- Sized.makeService(100)
-        system   <- TestSystem.makeTest(TestSystem.DefaultData)
-        blocking = Blocking.Live.blocking
-        time     <- live.provide(zio.clock.nanoTime)
-        _        <- random.setSeed(time)
-      } yield new TestEnvironment(blocking, clock, console, live, random, size, system)
-    }
+    for {
+      live     <- Live.makeService(new DefaultRuntime {}.Environment).toManaged_
+      clock    <- TestClock.makeTest(TestClock.DefaultData, Some(live))
+      console  <- TestConsole.makeTest(TestConsole.DefaultData).toManaged_
+      random   <- TestRandom.makeTest(TestRandom.DefaultData).toManaged_
+      size     <- Sized.makeService(100).toManaged_
+      system   <- TestSystem.makeTest(TestSystem.DefaultData).toManaged_
+      blocking = Blocking.Live.blocking
+      time     <- live.provide(zio.clock.nanoTime).toManaged_
+      _        <- random.setSeed(time).toManaged_
+    } yield new TestEnvironment(blocking, clock, console, live, random, size, system)
 }

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -308,7 +308,7 @@ object TestClock extends Serializable {
       warningState.updateSome {
         case WarningData.Start =>
           for {
-            fiber <- live.provide(console.putStrLn(warning).delay(5.seconds)).fork
+            fiber <- live.provide(console.putStrLn(warning).delay(5.seconds)).interruptible.fork
           } yield WarningData.pending(fiber)
       }.unit
 

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -296,7 +296,7 @@ object TestClock extends Serializable {
     private def run(wakes: List[(Duration, Promise[Nothing, Unit])]): UIO[Unit] =
       UIO.forkAll_(wakes.sortBy(_._1).map(_._2.succeed(()))).fork.unit
 
-    private val warningDone: UIO[Unit] =
+    private[TestClock] val warningDone: UIO[Unit] =
       warningState
         .updateSome[Any, Nothing] {
           case WarningData.Start          => ZIO.succeed(WarningData.done)
@@ -334,7 +334,7 @@ object TestClock extends Serializable {
    * be useful for providing the required environment to an effect that
    * requires a `Clock`, such as with [[ZIO!.provide]].
    */
-  def make(data: Data, live: Option[Live.Service[Clock with Console]] = None): UIO[TestClock] =
+  def make(data: Data, live: Option[Live.Service[Clock with Console]] = None): UManaged[TestClock] =
     makeTest(data, live).map { test =>
       new TestClock {
         val clock     = test
@@ -346,13 +346,15 @@ object TestClock extends Serializable {
    * Constructs a new `Test` object that implements the `TestClock` interface.
    * This can be useful for mixing in with implementations of other interfaces.
    */
-  def makeTest(data: Data, live: Option[Live.Service[Clock with Console]] = None): UIO[Test] =
-    for {
-      ref      <- Ref.make(data)
-      fiberRef <- FiberRef.make(FiberData(data.nanoTime), FiberData.combine)
-      live     <- live.fold(Live.makeService[Clock with Console](new DefaultRuntime {}.Environment))(ZIO.succeed)
-      refM     <- RefM.make(WarningData.start)
-    } yield Test(ref, fiberRef, live, refM)
+  def makeTest(data: Data, live: Option[Live.Service[Clock with Console]] = None): UManaged[Test] =
+    Managed.make {
+      for {
+        ref      <- Ref.make(data)
+        fiberRef <- FiberRef.make(FiberData(data.nanoTime), FiberData.combine)
+        live     <- live.fold(Live.makeService[Clock with Console](new DefaultRuntime {}.Environment))(ZIO.succeed)
+        refM     <- RefM.make(WarningData.start)
+      } yield Test(ref, fiberRef, live, refM)
+    }(_.warningDone)
 
   /**
    * Accesses a `TestClock` instance in the environment and sets the clock time


### PR DESCRIPTION
Since we added warnings to the test clock I have been seeing some spurious warnings in our internal tests. It appears this is related to tests that that use the `TestClock` to do sleeping but complete without adjusting it (e.g. delaying an effect, forking it, then checking that it can be interrupted). To prevent this, this PR has making a `TestClock` return a `Managed` where the release action is canceling the warning.