### PR TITLE
ZIO Test: Remove Creation of New Runtimes

### DIFF
--- a/test/js/src/main/scala/zio/test/environment/LiveEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/LiveEnvironment.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.environment
+
+import zio.clock.Clock
+import zio.console.Console
+import zio.random.Random
+import zio.system.System
+
+private object LiveEnvironment extends Clock.Live with Console.Live with Random.Live with System.Live

--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -16,7 +16,7 @@
 
 package zio.test.environment
 
-import zio.{ DefaultRuntime, Managed, ZEnv }
+import zio.{ Managed, ZEnv }
 import zio.scheduler.Scheduler
 import zio.test.Sized
 
@@ -88,7 +88,7 @@ object TestEnvironment extends Serializable {
 
   val Value: Managed[Nothing, TestEnvironment] =
     for {
-      live    <- Live.makeService(new DefaultRuntime {}.Environment).toManaged_
+      live    <- Live.makeService(LiveEnvironment).toManaged_
       clock   <- TestClock.makeTest(TestClock.DefaultData, Some(live))
       console <- TestConsole.makeTest(TestConsole.DefaultData).toManaged_
       random  <- TestRandom.makeTest(TestRandom.DefaultData).toManaged_

--- a/test/jvm/src/main/scala/zio/test/environment/LiveEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/LiveEnvironment.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2019 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.environment
+
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.console.Console
+import zio.random.Random
+import zio.system.System
+
+private object LiveEnvironment extends Blocking.Live with Clock.Live with Console.Live with Random.Live with System.Live

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -16,7 +16,7 @@
 
 package zio.test.environment
 
-import zio.{ DefaultRuntime, Managed, ZEnv }
+import zio.{ Managed, ZEnv }
 import zio.blocking.Blocking
 import zio.scheduler.Scheduler
 import zio.test.Sized
@@ -92,7 +92,7 @@ object TestEnvironment extends Serializable {
 
   val Value: Managed[Nothing, TestEnvironment] =
     for {
-      live     <- Live.makeService(new DefaultRuntime {}.Environment).toManaged_
+      live     <- Live.makeService(LiveEnvironment).toManaged_
       clock    <- TestClock.makeTest(TestClock.DefaultData, Some(live))
       console  <- TestConsole.makeTest(TestConsole.DefaultData).toManaged_
       random   <- TestRandom.makeTest(TestRandom.DefaultData).toManaged_

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -351,7 +351,7 @@ object TestClock extends Serializable {
       for {
         ref      <- Ref.make(data)
         fiberRef <- FiberRef.make(FiberData(data.nanoTime), FiberData.combine)
-        live     <- live.fold(Live.makeService[Clock with Console](new DefaultRuntime {}.Environment))(ZIO.succeed)
+        live     <- live.fold(Live.makeService[Clock with Console](LiveEnvironment))(ZIO.succeed)
         refM     <- RefM.make(WarningData.start)
       } yield Test(ref, fiberRef, live, refM)
     }(_.warningDone)


### PR DESCRIPTION
Resolves #2212. We were actually only creating the runtimes to get access to the live environment, the actual runtime that runs the tests is provided by the platform specified to the test runner. So we can refer to the live environment directly and remove the creation of new runtimes altogether.