### PR TITLE
Fixed #2216 - Chunk.size always returns 0

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -1,0 +1,40 @@
+package zio
+
+import zio.test.{ assert, suite }
+import zio.test.Assertion.equalTo
+
+object ChunkSpec
+    extends ZIOBaseSpec(
+      suite("ChunkSpec")(
+        suite("concatenated")(
+          zio.test.test("size must match length") {
+            val chunk = Chunk.empty ++ Chunk.fromArray(Array(1, 2)) ++ Chunk(3, 4, 5) ++ Chunk.single(6)
+            assert(chunk.size, equalTo(chunk.length))
+          }
+        ),
+        suite("empty")(
+          zio.test.test("size must match length") {
+            val chunk = Chunk.empty
+            assert(chunk.size, equalTo(chunk.length))
+          }
+        ),
+        suite("fromArray")(
+          zio.test.test("size must match length") {
+            val chunk = Chunk.fromArray(Array(1, 2, 3))
+            assert(chunk.size, equalTo(chunk.length))
+          }
+        ),
+        suite("fromIterable")(
+          zio.test.test("size must match length") {
+            val chunk = Chunk.fromIterable(List("1", "2", "3"))
+            assert(chunk.size, equalTo(chunk.length))
+          }
+        ),
+        suite("single")(
+          zio.test.test("size must match length") {
+            val chunk = Chunk.single(true)
+            assert(chunk.size, equalTo(chunk.length))
+          }
+        )
+      )
+    )

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -413,7 +413,7 @@ sealed trait Chunk[+A] { self =>
   /**
    * The number of elements in the chunk.
    */
-  final val size: Int = length
+  final def size: Int = length
 
   /**
    * Returns two splits of this chunk at the specified index.


### PR DESCRIPTION
Changed `Chunk.size` from `val` to `def`.