### PR TITLE
ZIO Test: Fix Type Inference Issue With TestAspect#retry

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,11 +1,11 @@
 package zio.test
 
+import zio._
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestAspectSpecUtil._
 import zio.test.TestUtils._
-import zio.{ Cause, Promise, Ref, ZIO }
 
 import scala.reflect.ClassTag
 
@@ -169,6 +169,15 @@ object TestAspectSpec
             _ <- execute(spec)
             n <- ref.get
           } yield assert(n, equalTo(100))
+        },
+        testM("retry retries failed tests according to a schedule") {
+          for {
+            ref <- Ref.make(0)
+            spec = testM("retry") {
+              assertM(ref.update(_ + 1), equalTo(2))
+            } @@ retry(ZSchedule.recurs(1))
+            result <- isSuccess(spec)
+          } yield assert(result, isTrue)
         },
         testM("scala2 applies test aspect only on Scala 2") {
           for {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,11 +1,11 @@
 package zio.test
 
-import zio._
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestAspectSpecUtil._
 import zio.test.TestUtils._
+import zio.{ Cause, Promise, Ref, ZIO, ZSchedule }
 
 import scala.reflect.ClassTag
 

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -424,9 +424,9 @@ object TestAspect extends TimeoutVariants {
    */
   def retry[R0, E0, S0](
     schedule: ZSchedule[R0, TestFailure[E0], S0]
-  ): TestAspect[Nothing, R0, Nothing, E0, Nothing, S0] =
-    new TestAspect.PerTest[Nothing, R0, Nothing, E0, Nothing, S0] {
-      def perTest[R >: Nothing <: R0, E >: Nothing <: E0, S >: Nothing <: S0](
+  ): TestAspect[Nothing, R0, Nothing, E0, Nothing, Any] =
+    new TestAspect.PerTest[Nothing, R0, Nothing, E0, Nothing, Any] {
+      def perTest[R >: Nothing <: R0, E >: Nothing <: E0, S >: Nothing <: Any](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         test.retry(schedule)


### PR DESCRIPTION
We were unnecessarily narrowing the result type based on the result type of the schedule, but the result type of the schedule is independent of the result type of the effect in retry.