### PR TITLE
Fix chunk tests

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -771,15 +771,18 @@ object Chunk {
     }
 
     override def collectM[R, E, B](pf: PartialFunction[A, ZIO[R, E, B]]): ZIO[R, E, Chunk[B]] = {
-      val self                      = array
-      val len                       = self.length
+      val len                       = array.length
       val orElse                    = (_: A) => UIO.succeed(null.asInstanceOf[B])
       var dest: ZIO[R, E, Array[B]] = UIO.succeed(null.asInstanceOf[Array[B]])
 
       var i = 0
       var j = 0
       while (i < len) {
-        dest = dest.zipWith(pf.applyOrElse(self(i), orElse)) { (array, b) =>
+        // `zipWith` is lazy in the RHS, so we need to capture to evaluate the
+        // `pf.applyOrElse` strictly to make sure we use the right value of `i`.
+        val rhs = pf.applyOrElse(array(i), orElse)
+
+        dest = dest.zipWith(rhs) { (array, b) =>
           var tmp = array
           if (b != null) {
             if (tmp == null) {
@@ -846,7 +849,10 @@ object Chunk {
       }
 
       while (!done && i < len) {
-        dest = dest.zipWith(pf.applyOrElse(self(i), orElse)) { (array, b) =>
+        // `zipWith` is lazy in the RHS, and we rely on the side-effects of `orElse` here.
+        val rhs = pf.applyOrElse(self(i), orElse)
+        
+        dest = dest.zipWith(rhs) { (array, b) =>
           var tmp = array
           if (b != null) {
             if (tmp == null) {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -851,7 +851,7 @@ object Chunk {
       while (!done && i < len) {
         // `zipWith` is lazy in the RHS, and we rely on the side-effects of `orElse` here.
         val rhs = pf.applyOrElse(self(i), orElse)
-        
+
         dest = dest.zipWith(rhs) { (array, b) =>
           var tmp = array
           if (b != null) {

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -4,7 +4,6 @@ import zio.{ Chunk, IO, UIO, ZIOBaseSpec }
 import zio.random.Random
 import zio.test._
 import zio.test.Assertion.{ equalTo, isLeft }
-import zio.test.TestAspect.ignore
 import ChunkUtils._
 
 case class Value(i: Int) extends AnyVal
@@ -161,10 +160,10 @@ object ChunkSpec
                 expected <- UIO.sequence(c.toList.collect(pf))
               } yield assert(result, equalTo(expected))
             }
-          } @@ ignore,
+          },
           testM("collectM chunk that fails") {
             Chunk(1, 2).collectM { case 2 => IO.fail("Ouch") }.either.map(assert(_, isLeft(equalTo("Ouch"))))
-          } @@ ignore
+          }
         ),
         suite("collectWhile")(
           test("collectWhile empty Chunk") {
@@ -189,10 +188,10 @@ object ChunkSpec
                 expected <- UIO.sequence(c.toList.takeWhile(pf.isDefinedAt).map(pf.apply))
               } yield assert(result, equalTo(expected))
             }
-          } @@ ignore,
+          },
           testM("collectWhileM chunk that fails") {
             Chunk(1, 2).collectWhileM { case _ => IO.fail("Ouch") }.either.map(assert(_, isLeft(equalTo("Ouch"))))
-          } @@ ignore
+          }
         ),
         testM("foreach") {
           check(mediumChunks(intGen)) { c =>


### PR DESCRIPTION
ZIO#zipWith became lazy in the RHS in the Autosupervision branch, and the implementations in Chunk were relying on side-effects.

cc @saraiva132 