### PR TITLE
ZIO Test: Improve Order of Parameters in CheckSome

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -298,7 +298,7 @@ object StreamChunkSpec
           val otherInts2 = pureStreamChunkGen(tinyChunks(Gen.int(-100, -1)))
           val fn1        = Gen.function[Random with Sized, Int, StreamChunk[Nothing, Int]](otherInts1)
           val fn2        = Gen.function[Random with Sized, Int, StreamChunk[Nothing, Int]](otherInts2)
-          checkSomeM(pureStreamChunkGen(tinyChunks(intGen)), fn1, fn2)(5) { (m, f, g) =>
+          checkSomeM(5)(pureStreamChunkGen(tinyChunks(intGen)), fn1, fn2) { (m, f, g) =>
             val leftStream: StreamChunk[Nothing, Int]  = m.flatMap(f).flatMap(g)
             val rightStream: StreamChunk[Nothing, Int] = m.flatMap(f(_).flatMap(g))
 

--- a/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/GenSpec.scala
@@ -428,7 +428,7 @@ object GenSpec extends AsyncBaseSpec {
         val p = (as ++ bs).reverse == (as.reverse ++ bs.reverse)
         if (p) assert((), Assertion.anything) else assert((as, bs), Assertion.nothing)
     }
-    val property = checkSome(gen)(100)(test).map { result =>
+    val property = checkSome(100)(gen)(test).map { result =>
       result.failures.fold(false) {
         case BoolAlgebra.Value(failureDetails) =>
           failureDetails.assertion.head.value.toString == "(List(0),List(1))" ||
@@ -444,7 +444,7 @@ object GenSpec extends AsyncBaseSpec {
   def testShrinkingNonEmptyList: Future[Boolean] = {
     val gen                            = Gen.int(1, 100).flatMap(Gen.listOfN(_)(Gen.anyInt))
     def test(a: List[Int]): TestResult = assert(a, Assertion.nothing)
-    val property = checkSome(gen)(100)(test).map { result =>
+    val property = checkSome(100)(gen)(test).map { result =>
       result.failures.fold(false) {
         case BoolAlgebra.Value(failureDetails) =>
           failureDetails.assertion.head.value.toString == "List(0)"
@@ -460,7 +460,7 @@ object GenSpec extends AsyncBaseSpec {
       val p = n % 2 == 0
       if (p) assert((), Assertion.anything) else assert(n, Assertion.nothing)
     }
-    val property = checkSome(gen)(100)(test).map { result =>
+    val property = checkSome(100)(gen)(test).map { result =>
       result.failures.fold(false) {
         case BoolAlgebra.Value(failureDetails) =>
           failureDetails.assertion.head.value.toString == "1"

--- a/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
@@ -67,7 +67,7 @@ object BoolAlgebraSpec
           assert(failure1 || failure2, isFailure)
         },
         testM("hashCode is consistent with equals") {
-          checkSome(equalBoolAlgebraOfSize(4))(n = 10) { pair =>
+          checkSome(10)(equalBoolAlgebraOfSize(4)) { pair =>
             val (a, b) = pair
             assert(a.hashCode, equalTo(b.hashCode))
           }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -368,7 +368,7 @@ package object test extends AssertionVariants {
               .either
         )
     }.dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
-      .take(1)                                         // Get the first failure
+      .take(1)                                          // Get the first failure
       .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks))
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken values
       .flatMap { shrinks =>


### PR DESCRIPTION
The current signature of `checkSome` is a bit irregular because it takes a generator, then a size, then the test. Normally in ZIO combinators like `foreachParN` would take the `n` parameter first. We originally had it this way but had to change it when we added the overloaded variants for multiple generators because it created ambiguity since the first parameter list was the same.

This PR uses the partial application to restore the order so the size parameter is first. I think this is a little nicer and more regular with the rest of ZIO though it does add a little complexity and make the methods a bit less discoverable.