### PR TITLE
Issue #2238 - adding access and accessM to ZStream

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -18,6 +18,7 @@ import zio.test.Assertion.{
   isTrue,
   isUnit
 }
+
 import scala.{ Stream => _ }
 import Exit.Success
 import StreamUtils._
@@ -222,6 +223,18 @@ object StreamSpec
                          )
                          .runCollect
             } yield assert(result, equalTo(List(List(1, 1, 1, 1), List(2))))
+          }
+        ),
+        suite("access/accessM")(
+          testM("ZStream.access") {
+            for {
+              result <- ZStream.access[String](identity).provide("test").runHead.get
+            } yield assert(result, equalTo("test"))
+          },
+          testM("ZStream.accessM") {
+            for {
+              result <- ZStream.accessM[String](ZStream.succeed).provide("test").runHead.get
+            } yield assert(result, equalTo("test"))
           }
         ),
         suite("Stream.bracket")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2647,6 +2647,18 @@ object ZStream extends Serializable {
     new ZStream[R, E, A](ZStream.Structure.Iterator(pull))
 
   /**
+   * Creates a stream from a value received from the accessed environment.
+   */
+  final def access[R](f: R => Any): ZStream[R, Nothing, Any] =
+    fromEffect(ZIO.access[R](f))
+
+  /**
+   * Creates a stream from a value received from the effectfully accessed environment.
+   */
+  final def accessM[R](f: R => ZIO[R, Nothing, Any]): ZStream[R, Nothing, Any] =
+    fromEffect(ZIO.accessM[R](f))
+
+  /**
    * Creates a stream from a single value that will get cleaned up after the
    * stream is consumed
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2649,13 +2649,13 @@ object ZStream extends Serializable {
   /**
    * Creates a stream from a value received from the accessed environment.
    */
-  final def access[R](f: R => Any): ZStream[R, Nothing, Any] =
+  final def access[R, A](f: R => A): ZStream[R, Nothing, A] =
     fromEffect(ZIO.access[R](f))
 
   /**
    * Creates a stream from a value received from the effectfully accessed environment.
    */
-  final def accessM[R](f: R => ZIO[R, Nothing, Any]): ZStream[R, Nothing, Any] =
+  final def accessM[R, A](f: R => ZIO[R, Nothing, A]): ZStream[R, Nothing, A] =
     fromEffect(ZIO.accessM[R](f))
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2658,16 +2658,6 @@ object ZStream extends Serializable {
   final def accessM[R]: AccessMPartiallyApplied[R] =
     new AccessMPartiallyApplied[R]
 
-  final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[A](f: R => A): ZStream[R, Nothing, A] =
-      ZStream.fromEffect(ZIO.access(f))
-  }
-
-  final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](f: R => ZStream[R, Nothing, A]): ZStream[R, Nothing, A] =
-      ZStream.unwrap(ZIO.access(f))
-  }
-
   /**
    * Creates a stream from a single value that will get cleaned up after the
    * stream is consumed
@@ -3100,6 +3090,16 @@ object ZStream extends Serializable {
    */
   final def unwrapManaged[R, E, A](fa: ZManaged[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
     ZStream[R, E, A](fa.flatMap(_.process))
+
+  final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[A](f: R => A): ZStream[R, Nothing, A] =
+      ZStream.fromEffect(ZIO.access(f))
+  }
+
+  final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: R => ZStream[R, Nothing, A]): ZStream[R, Nothing, A] =
+      ZStream.unwrap(ZIO.access(f))
+  }
 
   private[stream] final def exitToInputStreamRead(exit: Exit[Option[Throwable], Byte]): Int = exit match {
     case Exit.Success(value) => value.toInt

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2650,7 +2650,7 @@ object ZStream extends Serializable {
    * Creates a stream from a value received from the accessed environment.
    */
   final def access[R]: AccessPartiallyApplied[R] =
-   new AccessPartiallyApplied[R]
+    new AccessPartiallyApplied[R]
 
   /**
    * Creates a stream from a value received from the effectfully accessed environment.
@@ -2658,15 +2658,14 @@ object ZStream extends Serializable {
   final def accessM[R]: AccessMPartiallyApplied[R] =
    new AccessMPartiallyApplied[R]
 
-
   final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: R => A): ZStream[R, Nothing, A] =
-      managed(ZManaged.fromFunction(f))
+      ZStream.fromEffect(ZIO.access(f))
   }
 
   final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: R => ZStream[R, Nothing, A]): ZStream[R, Nothing, A] =
-      managed(ZManaged.fromFunction(f).flatten)
+      ZStream.unwrap(ZIO.access(f))
   }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -16,7 +16,7 @@
 
 package zio.stream
 
-import java.io.{IOException, InputStream}
+import java.io.{ IOException, InputStream }
 
 import com.github.ghik.silencer.silent
 import zio._
@@ -2656,7 +2656,7 @@ object ZStream extends Serializable {
    * Creates a stream from a value received from the effectfully accessed environment.
    */
   final def accessM[R]: AccessMPartiallyApplied[R] =
-   new AccessMPartiallyApplied[R]
+    new AccessMPartiallyApplied[R]
 
   final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: R => A): ZStream[R, Nothing, A] =


### PR DESCRIPTION
Resolves #2238 

I was also thinking of having something like

 `final def access[R, A](f: R => A): ZStream[R, Nothing, A]`

but I'm not sure if that would result in too much boilerplate for the user?
e.g. when accessing the environment I'd not know what the output type would be from `f`, so that also can be cumbersome when changing calls to something else, since I'd have to fix the types afterwards.
