### PR TITLE
Add content to How To summary page

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -5,8 +5,8 @@ title: "Summary"
 
 Here are a few guides for common patterns with ZIO:
 
-- How to **[use the module pattern](use_module_pattern.md)**
-- How to **[test effects](test_effects.md)**
-- How to **[mock services](mock_services.md)**
-- How to **[handle errors](handle_errors.md)**
-- How to **[access system information](system.md)**
+- **[Use the module pattern](use_module_pattern.md)**: how to structure larger ZIO programs with the help of **ZIO environment**.
+- **[Test effects](test_effects.md)**: how to use **ZIO Test** to test effectual programs seamlessly.
+- **[Mock services](mock_services.md)**: how to test interactions between services with **mocks**.
+- **[Handle errors](handle_errors.md)**: how to deal with **errors** in ZIO (declared errors vs unforeseen defects).
+- **[Access system information](system.md)**: how to access **environment variables** and other **system properties** with ZIO.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,6 +1,12 @@
 ---
 id: howto_index
-title:  "Summary"
+title: "Summary"
 ---
 
-Coming soon
+Here are a few guides for common patterns with ZIO:
+
+- How to **[use the module pattern](use_module_pattern.md)**
+- How to **[test effects](test_effects.md)**
+- How to **[mock services](mock_services.md)**
+- How to **[handle errors](handle_errors.md)**
+- How to **[access system information](system.md)**


### PR DESCRIPTION
[This page](https://zio.dev/docs/howto/howto_index) is empty saying content is "coming soon" which is misleading because all the sub-items have content.