### PR TITLE
Fix subscribe button hover opacity when minimized

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -152,7 +152,7 @@ a {
 }
 
 .newsletter-button:hover{
-  opacity: 90%;
+  opacity: .9;
 }
 
 .input-group {


### PR DESCRIPTION
The docusaurus build/minification process seems to change all percentage opacity values to 1%

https://github.com/facebook/create-react-app/issues/7980