### PR TITLE
Fix Flaky TestAspect Spec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,10 +1,11 @@
 package zio.test
 
 import zio.duration._
+import zio.test.environment.{ Live, TestClock }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
-import zio.{ Cause, Promise, Ref, Schedule, ZIO }
+import zio.{ Cause, Managed, Promise, Ref, Schedule, ZIO }
 
 import scala.reflect.ClassTag
 
@@ -196,9 +197,17 @@ object TestAspectSpec extends ZIOBaseSpec {
     } @@ timeout(1.nanos)
       @@ failure(diesWithSubtypeOf[TestTimeoutException]),
     testM("timeout reports problem with interruption") {
-      assertM(ZIO.never.uninterruptible *> ZIO.unit, equalTo(()))
-    } @@ timeout(10.millis, 1.nano)
-      @@ failure(diesWith(equalTo(interruptionTimeoutFailure)))
+      for {
+        testClock <- ZIO.environment[TestClock]
+        liveClock <- Live.make(testClock)
+        spec = testM("uninterruptible test") {
+          for {
+            _ <- (testClock.clock.adjust(11.milliseconds) *> ZIO.never).uninterruptible
+          } yield assertCompletes
+        } @@ timeout(10.milliseconds, 1.nanosecond) @@ failure(diesWith(equalTo(interruptionTimeoutFailure)))
+        result <- isSuccess(spec.provideManaged(Managed.succeed(liveClock)))
+      } yield assert(result, isTrue)
+    }
   )
 
   def diesWithSubtypeOf[E](implicit ct: ClassTag[E]): Assertion[TestFailure[E]] =


### PR DESCRIPTION
Resolves #2252. The uninterruptible effect could be "pre-interrupted" before beginning execution, leading to flakiness. We use the `TestClock` to ensure that the `timeout` is executed after the effect has entered an uninterruptible region.