### PR TITLE
Fix Bug in Assertion#forall

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -1,5 +1,7 @@
 package zio.test
 
+import scala.collection.immutable.SortedSet
+
 import zio.Exit
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -99,6 +101,9 @@ object AssertionSpec extends ZIOBaseSpec {
     } @@ failure,
     test("forall must succeed when an iterable is empty") {
       assert(Seq(), forall(hasField[String, Int]("length", _.length, isWithin(0, 3))))
+    },
+    test("forall must work with iterables that are not lists") {
+      assert(SortedSet(1, 2, 3), forall(isGreaterThan(0)))
     },
     test("hasAt must fail when an index is outside of a sequence range") {
       assert(Seq(1, 2, 3), hasAt(-1)(anything))

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -324,14 +324,7 @@ object Assertion {
    */
   final def forall[A](assertion: Assertion[A]): Assertion[Iterable[A]] =
     Assertion.assertionRec("forall")(param(assertion))(assertion)(
-      {
-        case head :: tail =>
-          Some(tail.foldLeft(head) {
-            case (result, next) if assertion.test(result) => next
-            case (acc, _)                                 => acc
-          })
-        case Nil => None
-      },
+      _.find(!assertion.test(_)),
       BoolAlgebra.success
     )
 


### PR DESCRIPTION
Resolves #2281. `Assertion.forall` was assuming that the `Iterable` was a list which was leading to a match error when the iterable was not a list. This PR fixes that by implementing `forall` in terms of methods defined on all iterables. I'm not sure why this wasn't generating a pattern match exhaustivity warning to be honest.