### PR TITLE
change welcome message

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -240,7 +240,9 @@ object BuildHelper {
         |${item("~compileJVM")} - Compiles all JVM modules (file-watch enabled)
         |${item("testJVM")} - Runs all JVM tests
         |${item("testJS")} - Runs all ScalaJS tests
-        |${item("coreTestsJVM/testOnly *.ZIOSpec -- -t \"happy-path\"")} - Only runs tests with matching term
+        |${item("testOnly *.YourSpec -- -t \"YourLabel\"")} - Only runs tests with matching term e.g. ${item(
+         "coreTestsJVM/testOnly *.ZIOSpec -- -t \"happy-path\""
+       )}
         |${item("docs/docusaurusCreateSite")} - Generates the ZIO microsite
       """.stripMargin
   }


### PR DESCRIPTION
Follow on from a discussion with @reibitto regarding the welcome message, I'm proposing we include a bit more on `testOnly` to make usage clearer. I and at least several others have asked on discord how to use this (super helpful) command.

This option provides both a version to explain usage and a version that can be copied and pasted directly.
```
[info] testOnly *.YourSpec -- -t "YourLabel" - Only runs tests with matching term e.g. coreTestsJVM/testOnly *.ZIOSpec -- -t "happy-path"
```