### PR TITLE
Add Schedule.doWhile example to microsite

### DIFF
--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -102,3 +102,12 @@ Stops retrying after a specified amount of time has elapsed:
 ```scala mdoc:silent
 val expMaxElapsed = Schedule.exponential(10.milliseconds) && Schedule.elapsed.whileOutput(_ < 30.seconds)
 ```
+
+Retry only when a specific exception occurs:
+
+```scala mdoc:silent
+val whileTimeout = Schedule.exponential(10.milliseconds) && Schedule.doWhile[Throwable] {
+  case _: TimeoutException => true
+  case _ => false
+}
+```

--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -106,6 +106,8 @@ val expMaxElapsed = Schedule.exponential(10.milliseconds) && Schedule.elapsed.wh
 Retry only when a specific exception occurs:
 
 ```scala mdoc:silent
+import scala.concurrent.TimeoutException
+
 val whileTimeout = Schedule.exponential(10.milliseconds) && Schedule.doWhile[Throwable] {
   case _: TimeoutException => true
   case _ => false


### PR DESCRIPTION
Thought we should have at least 1 `doWhile` example since this question comes up a lot.