### PR TITLE
Improve Error Messages for CanFail and NeedsEnv

### DIFF
--- a/core/shared/src/main/scala-2.11/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.11/zio/CanFail.scala
@@ -22,7 +22,13 @@ import scala.annotation.implicitNotFound
  * A value of type `CanFail[E]` provides implicit evidence that an effect with
  * error type `E` can fail, that is, that `E` is not equal to `Nothing`.
  */
-@implicitNotFound("This operation only makes sense for effects that can fail.")
+@implicitNotFound(
+  "This error handling operation assumes your effect can fail. However, " +
+    "your effect has Nothing for the error type, which means it cannot " +
+    "fail, so there is no need to handle the failure. To find out which " +
+    "method you can use instead of this operation, please see the " +
+    "reference chart at: https://zio.dev/docs/canfail"
+)
 sealed trait CanFail[-E]
 
 object CanFail extends CanFail[Any] {

--- a/core/shared/src/main/scala-2.11/zio/NeedsEnv.scala
+++ b/core/shared/src/main/scala-2.11/zio/NeedsEnv.scala
@@ -23,7 +23,11 @@ import scala.annotation.implicitNotFound
  * environment type `R` needs an environment, that is, that `R` is not equal to
  * `Any`.
  */
-@implicitNotFound("This operation only makes sense for effects that need an environment.")
+@implicitNotFound(
+  "This operation assumes that your effect requires an environment. " +
+  "However, your effect has Any for the environment type, which means it " +
+  "has no requirement, so there is no need to provide the environment."
+)
 sealed trait NeedsEnv[+R]
 
 object NeedsEnv extends NeedsEnv[Nothing] {

--- a/core/shared/src/main/scala-2.12+/zio/CanFail.scala
+++ b/core/shared/src/main/scala-2.12+/zio/CanFail.scala
@@ -29,7 +29,13 @@ object CanFail extends CanFail[Any] {
   implicit final def canFail[E]: CanFail[E] = CanFail
 
   // Provide multiple ambiguous values so an implicit CanFail[Nothing] cannot be found.
-  @implicitAmbiguous("This operation only makes sense for effects that can fail.")
+  @implicitAmbiguous(
+    "This error handling operation assumes your effect can fail. However, " +
+      "your effect has Nothing for the error type, which means it cannot " +
+      "fail, so there is no need to handle the failure. To find out which " +
+      "method you can use instead of this operation, please see the " +
+      "reference chart at: https://zio.dev/docs/canfail"
+  )
   implicit final val canFailAmbiguous1: CanFail[Nothing] = CanFail
   implicit final val canFailAmbiguous2: CanFail[Nothing] = CanFail
 }

--- a/core/shared/src/main/scala-2.12+/zio/NeedsEnv.scala
+++ b/core/shared/src/main/scala-2.12+/zio/NeedsEnv.scala
@@ -30,7 +30,11 @@ object NeedsEnv extends NeedsEnv[Nothing] {
   implicit final def needsEnv[R]: NeedsEnv[R] = NeedsEnv
 
   // Provide multiple ambiguous values so an implicit NeedsEnv[Any] cannot be found.
-  @implicitAmbiguous("This operation only makes sense for effects that need an environment.")
+  @implicitAmbiguous(
+    "This operation assumes that your effect requires an environment. " +
+      "However, your effect has Any for the environment type, which means it " +
+      "has no requirement, so there is no need to provide the environment."
+  )
   implicit final val needsEnvAmbiguous1: NeedsEnv[Any] = NeedsEnv
   implicit final val needsEnvAmbiguous2: NeedsEnv[Any] = NeedsEnv
 }

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -1,0 +1,77 @@
+---
+id: can_fail
+title:  "Compile Time Errors for Handling Combinators"
+---
+
+ZIO provides a variety of combinators to handle errors such as `orElse`, `catchAll`, `catchSome`, `option`, `either`, and `retry`. However, these combinators only make sense for effects that can fail (i.e. where the error type is not `Nothing`). To help you identify code that doesn't make sense, error handling combinators require implicit evidence `CanFail[E]`, which is automatically avaiable for all types except `Nothing`. The table below includes a list of combinators that only make sense for effects that can fail along with value preserving rewrites.
+
+**ZIO**
+
+Code | Rewrite 
+--- | ---
+`uio <> zio` | `uio`
+`uio.asError(e)` | `uio`
+`uio.bimap(f, g)` |  `uio.map(g)`
+`uio.catchAll(f)` | `uio`
+`uio.catchSome(pf)` | `uio`
+`uio.either` | `uio`*
+`uio.eventually` | `uio`
+`uio.flatMapError(f)` | `uio`
+`uio.fold(f, g)` | `uio.map(g)`
+`uio.foldM(f, g)` | `uio.flatMap(g)`
+`uio.mapError(f)` | `uio`
+`uio.option` | `uio`*
+`uio.orDie` | `uio`
+`uio.orDieWith(f)` | `uio`
+`uio.orElse(zio)` | `uio`
+`uio.orElseEither(zio)` | `uio`*
+`uio.refineOrDie(pf)` | `uio`
+`uio.refineOrDieWith(pf)(f)` | `uio`
+`uio.refineToOrDie` | `uio`
+`uio.retry(s)` | `uio`
+`uio.retryOrElse(s, f)` | `uio`
+`uio.retryOrElseEither(s, f)` | `uio`*
+`uio.tapBoth(f, g)` | `uio.tap(g)`
+`uio.tapError(f)` | `uio`
+
+**ZManaged**
+
+Code | Rewrite 
+--- | ---
+`umanaged <> zmanaged` | `umanaged`
+`umanaged.bimap(f, g)` | `umanaged.map(g)`
+`umanaged.catchAll(f)` | `umanaged`
+`umanaged.catchSome(pf)` | `umanaged`
+`umanaged.either` | `umanaged`*
+`umanaged.flatMapError(f)` | `umanaged`
+`umanaged.fold(f, g)` | `umanaged.map(f)`
+`umanaged.foldM(f, g)` | `umanaged.flatMap(g)`
+`umanaged.mapError(f)` | `umanaged`
+`umanaged.option` | `umanaged`*
+`umanaged.orDie` | `umanaged`
+`umanaged.orDieWith(f)` | `umanaged`
+`umanaged.orElse(zmanaged)` | `umanaged`
+`umanaged.orElseEither(zmanaged)` | `umanaged`
+`umanaged.refineOrDie(pf)` | `umanaged`
+`umanaged.refineToOrDie` | `umanaged`
+`umanaged.refineToOrDieWith(pf)(f)` | `umanaged`
+`umanaged.retry(s)` | `umanaged`
+
+**ZStream**
+
+Code | Rewrite 
+--- | ---
+`ustream.bimap(f, g)` | `ustream.map(g)`
+`ustream.catchAll(f)` | `ustream`
+`ustream.either` | `ustream`*
+`ustream.mapError(f)` | `ustream`
+`ustream.orElse(zstream)` | `ustream`
+
+**ZStreamChunk**
+
+Code | Rewrite 
+--- | ---
+`ustream.either` | `ustream`
+`ustream.orElse(zstream)` | `ustream`
+
+* `either`, `option`, `orElseEither`, and `retryOrElseEither` wrap their results in `Some` or `Right` so after rewriting, code calling these methods can be simplified to accept an `A` rather than an `Option[A]` or `Either[E, A]`.

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -3,7 +3,7 @@ id: can_fail
 title:  "Compile Time Errors for Handling Combinators"
 ---
 
-ZIO provides a variety of combinators to handle errors such as `orElse`, `catchAll`, `catchSome`, `option`, `either`, and `retry`. However, these combinators only make sense for effects that can fail (i.e. where the error type is not `Nothing`). To help you identify code that doesn't make sense, error handling combinators require implicit evidence `CanFail[E]`, which is automatically avaiable for all types except `Nothing`. The table below includes a list of combinators that only make sense for effects that can fail along with value preserving rewrites.
+ZIO provides a variety of combinators to handle errors such as `orElse`, `catchAll`, `catchSome`, `option`, `either`, and `retry`. However, these combinators only make sense for effects that can fail (i.e. where the error type is not `Nothing`). To help you identify code that doesn't make sense, error handling combinators require implicit evidence `CanFail[E]`, which is automatically available for all types except `Nothing`. The table below includes a list of combinators that only make sense for effects that can fail along with value preserving rewrites.
 
 **ZIO**
 


### PR DESCRIPTION
Resolves #2285.

I wasn't able to find a way to just generate a warning instead of an error so I expanded the error message and included a link to a new page on the website with more detailed information on how to replace useless error handling combinators.