### PR TITLE
ZIO Test: Implement Provide Variants for Spec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -5,7 +5,7 @@ import zio.test.environment.{ Live, TestClock }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
-import zio.{ Cause, Managed, Promise, Ref, Schedule, ZIO }
+import zio.{ Cause, Promise, Ref, Schedule, ZIO }
 
 import scala.reflect.ClassTag
 
@@ -205,7 +205,7 @@ object TestAspectSpec extends ZIOBaseSpec {
             _ <- (testClock.clock.adjust(11.milliseconds) *> ZIO.never).uninterruptible
           } yield assertCompletes
         } @@ timeout(10.milliseconds, 1.nanosecond) @@ failure(diesWith(equalTo(interruptionTimeoutFailure)))
-        result <- isSuccess(spec.provideManaged(Managed.succeed(liveClock)))
+        result <- isSuccess(spec.provide(liveClock))
       } yield assert(result, isTrue)
     }
   )


### PR DESCRIPTION
I found myself wanting to provide an environment that wasn't in a `Managed` to a `Spec` so I added the same `provide` variants that exist on `ZIO` and `ZStream`. There are regular and shared versions of all combinators except `provide`, where since the environment is just a value that already exists there isn't a difference.