### PR TITLE
Add ZIO.merge

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -594,6 +594,16 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result, equalTo(Cause.die(boom)))
       } @@ flaky
     ),
+    suite("merge")(
+      testM("on flipped result") {
+        val zio: IO[Int, Int] = ZIO.succeed(1)
+
+        for {
+          a <- zio.merge
+          b <- zio.flip.merge
+        } yield assert(a, equalTo(b))
+      }
+    ),
     suite("head")(
       testM("on non empty list") {
         assertM(ZIO.succeed(List(1, 2, 3)).head.either, isRight(equalTo(1)))
@@ -1034,7 +1044,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io, isSome(equalTo(Cause.die(ExampleError))))
       },
       testM("catch sandbox terminate") {
-        val io = IO.effectTotal(throw ExampleError).sandbox.fold(identity, identity)
+        val io = IO.effectTotal(throw ExampleError).sandbox.merge
         assertM(io, equalTo(Cause.die(ExampleError)))
       },
       testM("uncaught fail") {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -975,6 +975,16 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield res1 && res2 && res3
       }
     ),
+    suite("merge")(
+      testM("on flipped result") {
+        val managed: Managed[Int, Int] = ZManaged.succeed(1)
+
+        for {
+          a <- managed.merge.use(ZIO.succeed)
+          b <- managed.flip.merge.use(ZIO.succeed)
+        } yield assert(a, equalTo(b))
+      }
+    ),
     suite("catch")(
       testM("catchAllCause") {
         val zm: ZManaged[Any, String, String] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -637,8 +637,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Returns a new effect where the error channel has been merged into the
    * success channel to their common combined type.
    */
-  final def merge[A1 >: A](implicit ev: E <:< A1): URIO[R, A1] =
-    self.foldM(e => ZIO.succeed(ev(e)), ZIO.succeed)
+  final def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): URIO[R, A1] =
+    self.foldM(e => ZIO.succeed(ev1(e)), ZIO.succeed)
 
   /**
    * Turns off daemon mode for this region, which means that any fibers forked

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -634,6 +634,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     } yield l.succeed(()) *> p.await
 
   /**
+   * Returns a new effect where the error channel has been merged into the
+   * success channel to their common combined type.
+   */
+  final def merge[A1 >: A](implicit ev: E <:< A1): URIO[R, A1] =
+    self.foldM(e => ZIO.succeed(ev(e)), ZIO.succeed)
+
+  /**
    * Turns off daemon mode for this region, which means that any fibers forked
    * in this region will not be daemon fibers, so they will be visible as
    * children of their parent fiber, and interrupted when their parent fiber is

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -463,6 +463,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     ZManaged(reserve.mapErrorCause(f).map(r => Reservation(r.acquire.mapErrorCause(f), r.release)))
 
   /**
+   * Returns a new effect where the error channel has been merged into the
+   * success channel to their common combined type.
+   */
+  final def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): ZManaged[R, Nothing, A1] =
+    self.foldM(e => ZManaged.succeed(ev1(e)), ZManaged.succeed)
+
+  /**
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */


### PR DESCRIPTION
I was looking for `merge` on ZIO but couldn't find it. I've been doing `zio.fold(identity, identity)` up until now, but I figured this is a common enough method that might be worth adding since you find across many libraries (stdlib, Scalaz, Cats) with the same name: `Either.merge`, `EitherT.merge`, `\/.merge`, etc.

What do you think? Do you think it's worth it? If so, we might also want to consider if there's value in adding this to any other applicable data types. I only had `ZIO` in mind when I started this.