### PR TITLE
Chunk#apply considered harmful

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -5,6 +5,7 @@ import zio.random.Random
 import zio.test._
 import zio.test.Assertion.{ equalTo, isLeft }
 import ChunkUtils._
+import java.nio._
 
 case class Value(i: Int) extends AnyVal
 
@@ -15,6 +16,41 @@ object ChunkSpec extends ZIOBaseSpec {
       check(chunkWithIndex(Gen.unit)) {
         case (chunk, i) =>
           assert(chunk.apply(i), equalTo(chunk.toSeq.apply(i)))
+      }
+    },
+    testM("byte buffer") {
+      check(Gen.vectorOf(Gen.anyByte).map(_.toArray)) { arr =>
+        assert(Chunk.fromByteBuffer(ByteBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("char buffer") {
+      check(Gen.vectorOf(Gen.anyChar).map(_.toArray)) { arr =>
+        assert(Chunk.fromCharBuffer(CharBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("double buffer") {
+      check(Gen.vectorOf(Gen.double(Double.MinValue, Double.MaxValue)).map(_.toArray)) { arr =>
+        assert(Chunk.fromDoubleBuffer(DoubleBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("float buffer") {
+      check(Gen.vectorOf(Gen.anyFloat).map(_.toArray)) { arr =>
+        assert(Chunk.fromFloatBuffer(FloatBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("int buffer") {
+      check(Gen.vectorOf(Gen.anyInt).map(_.toArray)) { arr =>
+        assert(Chunk.fromIntBuffer(IntBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("long buffer") {
+      check(Gen.vectorOf(Gen.anyLong).map(_.toArray)) { arr =>
+        assert(Chunk.fromLongBuffer(LongBuffer.wrap(arr)).toArray, equalTo(arr))
+      }
+    },
+    testM("short buffer") {
+      check(Gen.vectorOf(Gen.anyShort).map(_.toArray)) { arr =>
+        assert(Chunk.fromShortBuffer(ShortBuffer.wrap(arr)).toArray, equalTo(arr))
       }
     },
     testM("length") {


### PR DESCRIPTION
Alternative implementation that I would like to see benchmarked as part of #2269, if anyone is actively working on that.

Let me try to explain my reasoning.

All of the Chunk combinators were implemented by accessing each element of the chunk that we are reading from using `def apply(n: Int): A`, which is a polymorphic method on the JVM that _must_ return a reference type, and therefore incur boxing overhead for primitives.

Now, after extensive debates with @iravid (many thanks), we came to the conclusion that most of the higher order functions in the combinators will force boxing for some of the primitive types, and if we are lucky, no boxing for `Int, Long, Float, Double`. If you are interested, check the specialization of [`Function1`](https://github.com/scala/scala/blob/v2.13.1/src/library/scala/Function1.scala#L65).

But, examining the specialization of `Function1` gave me an idea. Namely, `Function1`s that return `Boolean` (predicates) and `Unit` (Java void functions) are specialized and don't incur boxing overhead for some of the primitive input types. I also noticed that we had an implementation of `foreach` for Chunk that was lying around unused.

This PR removes the old `apply` method (there is one transient implementation that is used in `ZStream` code for now, to avoid changing the code) and defines all Chunk interactions through bulk traversal methods like `loopWhile`, `loop`, `foreach`, `foreachWhile`. These methods accept a predicate and a void function, whose side effects are used for propagating change and building new Chunks internally. This allows the implementation of these methods (the actual Chunk type, like Arr, Concat, Slice and in the future `java.nio.Buffer`) to use the internal magic of the backing type (array, vector, buffer, other chunk) to avoid boxing as much as possible. Of course, in the event of an unspecialized type like `Byte` (which is very sad to me), this would still incur boxing, but is unavoidable due to how Scala `Function1` works.

The good news is that we already did special overrides for Array backed chunks which didn't go through `def apply` and this PR does not change any of them. The PR aims to improve the performance of Slice and Concat Chunks, by allowing the underlying chunks to sort out the boxing requirements, instead of forcing a boxing through `apply`.

The code is very dirty, and I took some shortcuts in places (`def equals`) in order to pass the tests so there is still room for improvements, but the combinators are working reliably. I wanted to gather some feedback first.

I'm interested to hear some thoughts on this.

@iravid @jdegoes @Vilkina 

Edit: Added `java.nio.Buffer` backed Chunks.