### PR TITLE
ZIO Stream: Improve ZStream#accessM signature

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1355,7 +1355,7 @@ object ZIOSpec extends ZIOBaseSpec {
           assert(unexpected, isEmpty) &&
           assert(result, isNone) // timeout happens
         }
-      },
+      } @@ flaky,
       testM("effectAsyncMaybe should not resume fiber twice after synchronous result") {
         for {
           step            <- Promise.make[Nothing, Unit]

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -44,6 +44,18 @@ object StreamSpec extends ZIOBaseSpec {
         } yield assert(result, fails(equalTo("fail")))
       }
     ),
+    suite("Stream.accessStream")(
+      testM("accessStream") {
+        for {
+          result <- ZStream.accessStream[String](ZStream.succeed).provide("test").runHead.get
+        } yield assert(result, equalTo("test"))
+      },
+      testM("accessStream fails") {
+        for {
+          result <- ZStream.accessStream[Int](_ => ZStream.fail("fail")).provide(0).runHead.run
+        } yield assert(result, fails(equalTo("fail")))
+      }
+    ),
     suite("Stream.aggregateAsync")(
       testM("aggregateAsync") {
         Stream(1, 1, 1, 1)
@@ -559,6 +571,11 @@ object StreamSpec extends ZIOBaseSpec {
             } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
         execution <- log.get
       } yield assert(execution, equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+    },
+    testM("Stream.environment") {
+      for {
+        result <- ZStream.environment[String].provide("test").runHead.get
+      } yield assert(result, equalTo("test"))
     },
     testM("Stream.filter")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
       for {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -27,6 +27,23 @@ import StreamUtils._
 object StreamSpec extends ZIOBaseSpec {
 
   def spec = suite("StreamSpec")(
+    testM("Stream.access") {
+      for {
+        result <- ZStream.access[String](identity).provide("test").runHead.get
+      } yield assert(result, equalTo("test"))
+    },
+    suite("Stream.accessM")(
+      testM("accessM") {
+        for {
+          result <- ZStream.accessM[String](ZIO.succeed).provide("test").runHead.get
+        } yield assert(result, equalTo("test"))
+      },
+      testM("accessM fails") {
+        for {
+          result <- ZStream.accessM[Int](_ => ZIO.fail("fail")).provide(0).runHead.run
+        } yield assert(result, fails(equalTo("fail")))
+      }
+    ),
     suite("Stream.aggregateAsync")(
       testM("aggregateAsync") {
         Stream(1, 1, 1, 1)
@@ -224,18 +241,6 @@ object StreamSpec extends ZIOBaseSpec {
                      )
                      .runCollect
         } yield assert(result, equalTo(List(List(1, 1, 1, 1), List(2))))
-      }
-    ),
-    suite("access/accessM")(
-      testM("ZStream.access") {
-        for {
-          result <- ZStream.access[String](identity).provide("test").runHead.get
-        } yield assert(result, equalTo("test"))
-      },
-      testM("ZStream.accessM") {
-        for {
-          result <- ZStream.accessM[String](ZStream.succeed).provide("test").runHead.get
-        } yield assert(result, equalTo("test"))
       }
     ),
     suite("Stream.bracket")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2695,16 +2695,22 @@ object ZStream extends Serializable {
     new ZStream[R, E, A](ZStream.Structure.Iterator(pull))
 
   /**
-   * Creates a stream from a value received from the accessed environment.
+   * Accesses the environment of the stream.
    */
   final def access[R]: AccessPartiallyApplied[R] =
     new AccessPartiallyApplied[R]
 
   /**
-   * Creates a stream from a value received from the effectfully accessed environment.
+   * Accesses the environment of the stream in the context of an effect.
    */
   final def accessM[R]: AccessMPartiallyApplied[R] =
     new AccessMPartiallyApplied[R]
+
+  /**
+   * Accesses the environment of the stream in the context of a stream.
+   */
+  final def accessStream[R]: AccessStreamPartiallyApplied[R] =
+    new AccessStreamPartiallyApplied[R]
 
   /**
    * Creates a stream from a single value that will get cleaned up after the
@@ -2890,6 +2896,12 @@ object ZStream extends Serializable {
                }
       } yield pull
     }
+
+  /**
+   * Accesses the whole environment of the stream.
+   */
+  final def environment[R]: ZStream[R, Nothing, R] =
+    ZStream.fromEffect(ZIO.environment[R])
 
   /**
    * The stream that always fails with `error`
@@ -3137,12 +3149,17 @@ object ZStream extends Serializable {
 
   final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: R => A): ZStream[R, Nothing, A] =
-      ZStream.fromEffect(ZIO.access(f))
+      ZStream.environment[R].map(f)
   }
 
   final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: R => ZIO[R, E, A]): ZStream[R, E, A] =
-      ZStream.fromEffect(ZIO.accessM(f))
+      ZStream.environment[R].mapM(f)
+  }
+
+  final class AccessStreamPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: R => ZStream[R, E, A]): ZStream[R, E, A] =
+      ZStream.environment[R].flatMap(f)
   }
 
   private[stream] final def exitToInputStreamRead(exit: Exit[Option[Throwable], Byte]): Int = exit match {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3141,8 +3141,8 @@ object ZStream extends Serializable {
   }
 
   final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](f: R => ZStream[R, Nothing, A]): ZStream[R, Nothing, A] =
-      ZStream.unwrap(ZIO.access(f))
+    def apply[E, A](f: R => ZIO[R, E, A]): ZStream[R, E, A] =
+      ZStream.fromEffect(ZIO.accessM(f))
   }
 
   private[stream] final def exitToInputStreamRead(exit: Exit[Option[Throwable], Byte]): Int = exit match {


### PR DESCRIPTION
Someone pointed out on Discord that the existing signature of `ZStream#accessM` is a bit too narrow in that it requires the `E` type to be `Nothing` instead of allowing it to be polymorphic.

When I was looking at that I realized the current signature is also inconsistent with other combinators in that right now it takes a `R => ZStream[R, E, A]` whereas all other `M` combinators take a function that returns a `ZIO`. I think this makes more sense and then if users want to create a different stream based on the value accessed they can just flatMap it.