### PR TITLE
#2309 Introduced quite mode for fibers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -540,7 +540,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("calls provided function when task fails") {
         for {
           p <- Promise.make[Nothing, Unit]
-          _ <- ZIO.fail(()).forkWithErrorHandler(_ => p.succeed(()).unit)
+          _ <- ZIO.fail(()).forkWithErrorHandler(p.succeed(_).unit)
           _ <- p.await
         } yield assertCompletes
       }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -536,6 +536,15 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result, equalTo(Cause.die(boom)))
       } @@ flaky
     ),
+    suite("forkWithErrorHandler")(
+      testM("calls provided function when task fails") {
+        for {
+          p <- Promise.make[Nothing, Unit]
+          _ <- ZIO.fail(()).forkWithErrorHandler(_ => p.succeed(()).unit)
+          _ <- p.await
+        } yield assertCompletes
+      }
+    ),
     suite("head")(
       testM("on non empty list") {
         assertM(ZIO.succeed(List(1, 2, 3)).head.either, isRight(equalTo(1)))

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -40,7 +40,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly)
+        if (!cause.interruptedOnly && cause.died)
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -40,7 +40,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly && cause.died)
+        if (cause.died)
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -59,7 +59,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly && cause.died)
+        if (cause.died)
           System.err.println(cause.prettyPrint)
 
     }

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -59,7 +59,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly)
+        if (!cause.interruptedOnly && cause.died)
           System.err.println(cause.prettyPrint)
 
     }

--- a/core/native/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformLive.scala
@@ -40,7 +40,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly)
+        if (!cause.interruptedOnly && cause.died)
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)

--- a/core/native/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformLive.scala
@@ -40,7 +40,7 @@ object PlatformLive {
       }
 
       def reportFailure(cause: Cause[Any]): Unit =
-        if (!cause.interruptedOnly && cause.died)
+        if (cause.died)
           println(cause.prettyPrint)
 
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -519,6 +519,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def fork: URIO[R, Fiber[E, A]] = new ZIO.Fork(self)
 
   /**
+   * Like [[fork]] but handles an error with the provided handler.
+   */
+  final def forkWithErrorHandler(handler: E => UIO[Unit]): URIO[R, Fiber[E, A]] =
+    onError(new ZIO.FoldCauseMFailureFn(handler)).forkInternal
+
+  /**
    * Forks the effect into a new independent fiber, with the specified name.
    */
   final def forkAs(name: String): URIO[R, Fiber[E, A]] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -522,7 +522,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Like [[fork]] but handles an error with the provided handler.
    */
   final def forkWithErrorHandler(handler: E => UIO[Unit]): URIO[R, Fiber[E, A]] =
-    onError(new ZIO.FoldCauseMFailureFn(handler)).forkInternal
+    onError(new ZIO.FoldCauseMFailureFn(handler)).run.fork.map(_.mapM(IO.done))
 
   /**
    * Forks the effect into a new independent fiber, with the specified name.
@@ -1628,14 +1628,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    */
   final def <*>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
     self &&& that
-
-  /**
-   * Forks an effect that will be executed without unhandled failures being
-   * reported. This is useful for implementing combinators that handle failures
-   * themselves.
-   */
-  private[zio] final def forkInternal: URIO[R, Fiber[E, A]] =
-    run.fork.map(_.mapM(IO.done))
 }
 
 private[zio] trait ZIOFunctions extends Serializable {


### PR DESCRIPTION
As described in the issue #2309, forked fiber may print an error message if it fails. To avoid it I introduced quite mode for fiber races. I even considered using quite mode as a default mode for all fibers except the main one. Please suggest improvements. 