### PR TITLE
java.nio.Buffer backed Chunks

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -28,6 +28,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
       },
+      testM("byte array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = ByteBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toByte)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromByteBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
+        }
+      },
       testM("direct byte buffer copying") {
         UIO.effectTotal {
           val buffer = ByteBuffer.allocateDirect(10)
@@ -61,6 +75,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.position(5)
           buffer.limit(8)
           assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("char array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = CharBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toChar)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromCharBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
         }
       },
       testM("direct char buffer copying") {
@@ -105,6 +133,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
       },
+      testM("double array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = DoubleBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toDouble)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromDoubleBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
+        }
+      },
       testM("direct double buffer copying") {
         UIO.effectTotal {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Double.BYTES * 10)
@@ -145,6 +187,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.position(5)
           buffer.limit(8)
           assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("float array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = FloatBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toFloat)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromFloatBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
         }
       },
       testM("direct float buffer copying") {
@@ -189,6 +245,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
       },
+      testM("int array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = IntBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromIntBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
+        }
+      },
       testM("direct int buffer copying") {
         UIO.effectTotal {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Integer.BYTES * 10)
@@ -231,6 +301,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromLongBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
       },
+      testM("long array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = LongBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toLong)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromLongBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
+        }
+      },
       testM("direct long buffer copying") {
         UIO.effectTotal {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Long.BYTES * 10)
@@ -271,6 +355,20 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.position(5)
           buffer.limit(8)
           assert(Chunk.fromShortBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("short array buffer slice copying") {
+        UIO.effectTotal {
+          val buffer = ShortBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toShort)
+            i += 1
+          }
+          buffer.position(3)
+          buffer.limit(7)
+          val newBuffer = buffer.slice()
+          assert(Chunk.fromShortBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
         }
       },
       testM("direct short buffer copying") {

--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -1,6 +1,5 @@
-package zio.stream
+package zio
 
-import zio.{ Chunk, UIO, ZIOBaseSpec }
 import zio.test._
 import zio.test.Assertion.equalTo
 import java.nio._

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1178,108 +1178,59 @@ object Chunk {
       }
 
     final def manualByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Byte](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Byte](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualCharBuffer(buffer: CharBuffer): Chunk[Char] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Char](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Char](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Double](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Double](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Float](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Float](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualIntBuffer(buffer: IntBuffer): Chunk[Int] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Int](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Int](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualLongBuffer(buffer: LongBuffer): Chunk[Long] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Long](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Long](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
 
     final def manualShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
-      val pos = buffer.position()
-      val lim = buffer.limit()
-      val len = lim - pos
-      val dst = Array.ofDim[Short](len)
-      var i   = pos
-      var j   = 0
-      while (i < lim) {
-        dst(j) = buffer.get(i)
-        i += 1
-        j += 1
-      }
-      Chunk.fromArray(dst)
+      val dest = Array.ofDim[Short](buffer.remaining())
+      val pos  = buffer.position()
+      buffer.get(dest)
+      buffer.position(pos)
+      Chunk.fromArray(dest)
     }
   }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1166,22 +1166,15 @@ object Chunk {
       else {
         val pos = buffer.position()
         val lim = buffer.limit()
-        val cap = buffer.capacity()
         val arr = buffer.array().asInstanceOf[Array[A]]
         val off = buffer.arrayOffset()
 
-        val chunk = if (off == 0 && pos == 0 && cap == arr.length && lim == cap) {
-          // best case, reuse the underlying array
-          fromArray(arr)
-        } else {
-          implicit val classTag: ClassTag[A] = ClassTag(arr.getClass.getComponentType)
-          val len                            = lim - pos
-          val dest                           = Array.ofDim[A](len)
-          Array.copy(arr, off + pos, dest, 0, len)
-          fromArray(dest)
-        }
+        implicit val classTag: ClassTag[A] = ClassTag(arr.getClass.getComponentType)
 
-        Some(chunk.asInstanceOf[Chunk[A]])
+        val len  = lim - pos
+        val dest = Array.ofDim[A](len)
+        Array.copy(arr, off + pos, dest, 0, len)
+        Some(fromArray(dest))
       }
 
     final def manualByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -726,6 +726,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualLongBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.ShortBuffer]].
+   */
+  final def fromShortBuffer(buffer: ShortBuffer): Chunk[Short] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualShortBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1258,6 +1264,21 @@ object Chunk {
       val lim = buffer.limit()
       val len = lim - pos
       val dst = Array.ofDim[Long](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
+    }
+
+    final def manualShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Short](len)
       var i   = pos
       var j   = 0
       while (i < lim) {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -714,6 +714,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualFloatBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.IntBuffer]].
+   */
+  final def fromIntBuffer(buffer: IntBuffer): Chunk[Int] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualIntBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1216,6 +1222,21 @@ object Chunk {
       val lim = buffer.limit()
       val len = lim - pos
       val dst = Array.ofDim[Float](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
+    }
+
+    final def manualIntBuffer(buffer: IntBuffer): Chunk[Int] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Int](len)
       var i   = pos
       var j   = 0
       while (i < lim) {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -720,6 +720,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualIntBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.LongBuffer]].
+   */
+  final def fromLongBuffer(buffer: LongBuffer): Chunk[Long] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualLongBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1237,6 +1243,21 @@ object Chunk {
       val lim = buffer.limit()
       val len = lim - pos
       val dst = Array.ofDim[Int](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
+    }
+
+    final def manualLongBuffer(buffer: LongBuffer): Chunk[Long] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Long](len)
       var i   = pos
       var j   = 0
       while (i < lim) {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -692,44 +692,79 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.ByteBuffer]].
    */
-  final def fromByteBuffer(buffer: ByteBuffer): Chunk[Byte] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualByteBuffer(buffer))
+  final def fromByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
+    val dest = Array.ofDim[Byte](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.CharBuffer]].
    */
-  final def fromCharBuffer(buffer: CharBuffer): Chunk[Char] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualCharBuffer(buffer))
+  final def fromCharBuffer(buffer: CharBuffer): Chunk[Char] = {
+    val dest = Array.ofDim[Char](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.DoubleBuffer]].
    */
-  final def fromDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualDoubleBuffer(buffer))
+  final def fromDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
+    val dest = Array.ofDim[Double](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.FloatBuffer]].
    */
-  final def fromFloatBuffer(buffer: FloatBuffer): Chunk[Float] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualFloatBuffer(buffer))
+  final def fromFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
+    val dest = Array.ofDim[Float](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.IntBuffer]].
    */
-  final def fromIntBuffer(buffer: IntBuffer): Chunk[Int] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualIntBuffer(buffer))
+  final def fromIntBuffer(buffer: IntBuffer): Chunk[Int] = {
+    val dest = Array.ofDim[Int](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.LongBuffer]].
    */
-  final def fromLongBuffer(buffer: LongBuffer): Chunk[Long] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualLongBuffer(buffer))
+  final def fromLongBuffer(buffer: LongBuffer): Chunk[Long] = {
+    val dest = Array.ofDim[Long](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by a [[java.nio.ShortBuffer]].
    */
-  final def fromShortBuffer(buffer: ShortBuffer): Chunk[Short] =
-    Buff.arrayBacked(buffer).getOrElse(Buff.manualShortBuffer(buffer))
+  final def fromShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
+    val dest = Array.ofDim[Short](buffer.remaining())
+    val pos  = buffer.position()
+    buffer.get(dest)
+    buffer.position(pos)
+    Chunk.fromArray(dest)
+  }
 
   /**
    * Returns a chunk backed by an iterable.
@@ -1158,80 +1193,6 @@ object Chunk {
     override def foreach(f: A => Unit): Unit = vector.foreach(f)
 
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = { val _ = vector.copyToArray(dest, n, length) }
-  }
-
-  private[zio] object Buff {
-    final def arrayBacked[A](buffer: Buffer): Option[Chunk[A]] =
-      if (!buffer.hasArray()) None
-      else {
-        val pos = buffer.position()
-        val lim = buffer.limit()
-        val arr = buffer.array().asInstanceOf[Array[A]]
-        val off = buffer.arrayOffset()
-
-        implicit val classTag: ClassTag[A] = ClassTag(arr.getClass.getComponentType)
-
-        val len  = lim - pos
-        val dest = Array.ofDim[A](len)
-        Array.copy(arr, off + pos, dest, 0, len)
-        Some(fromArray(dest))
-      }
-
-    final def manualByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
-      val dest = Array.ofDim[Byte](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualCharBuffer(buffer: CharBuffer): Chunk[Char] = {
-      val dest = Array.ofDim[Char](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
-      val dest = Array.ofDim[Double](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
-      val dest = Array.ofDim[Float](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualIntBuffer(buffer: IntBuffer): Chunk[Int] = {
-      val dest = Array.ofDim[Int](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualLongBuffer(buffer: LongBuffer): Chunk[Long] = {
-      val dest = Array.ofDim[Long](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
-
-    final def manualShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
-      val dest = Array.ofDim[Short](buffer.remaining())
-      val pos  = buffer.position()
-      buffer.get(dest)
-      buffer.position(pos)
-      Chunk.fromArray(dest)
-    }
   }
 
   private[zio] object Tags {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1177,7 +1177,7 @@ object Chunk {
           implicit val classTag: ClassTag[A] = ClassTag(arr.getClass.getComponentType)
           val len                            = lim - pos
           val dest                           = Array.ofDim[A](len)
-          Array.copy(arr, pos, dest, 0, len)
+          Array.copy(arr, off + pos, dest, 0, len)
           fromArray(dest)
         }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -708,6 +708,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualDoubleBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.FloatBuffer]].
+   */
+  final def fromFloatBuffer(buffer: FloatBuffer): Chunk[Float] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualFloatBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1195,6 +1201,21 @@ object Chunk {
       val lim = buffer.limit()
       val len = lim - pos
       val dst = Array.ofDim[Double](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
+    }
+
+    final def manualFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Float](len)
       var i   = pos
       var j   = 0
       while (i < lim) {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -696,6 +696,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualByteBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.CharBuffer]].
+   */
+  final def fromCharBuffer(buffer: CharBuffer): Chunk[Char] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualCharBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1149,18 +1155,33 @@ object Chunk {
       }
 
     final def manualByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
-      val pos  = buffer.position()
-      val lim  = buffer.limit()
-      val len  = lim - pos
-      val dest = Array.ofDim[Byte](len)
-      var i    = pos
-      var j    = 0
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Byte](len)
+      var i   = pos
+      var j   = 0
       while (i < lim) {
-        dest(j) = buffer.get(i)
+        dst(j) = buffer.get(i)
         i += 1
         j += 1
       }
-      Chunk.fromArray(dest)
+      Chunk.fromArray(dst)
+    }
+
+    final def manualCharBuffer(buffer: CharBuffer): Chunk[Char] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Char](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
     }
   }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -702,6 +702,12 @@ object Chunk {
     Buff.arrayBacked(buffer).getOrElse(Buff.manualCharBuffer(buffer))
 
   /**
+   * Returns a chunk backed by a [[java.nio.DoubleBuffer]].
+   */
+  final def fromDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] =
+    Buff.arrayBacked(buffer).getOrElse(Buff.manualDoubleBuffer(buffer))
+
+  /**
    * Returns a chunk backed by an iterable.
    */
   final def fromIterable[A](it: Iterable[A]): Chunk[A] =
@@ -1174,6 +1180,21 @@ object Chunk {
       val lim = buffer.limit()
       val len = lim - pos
       val dst = Array.ofDim[Char](len)
+      var i   = pos
+      var j   = 0
+      while (i < lim) {
+        dst(j) = buffer.get(i)
+        i += 1
+        j += 1
+      }
+      Chunk.fromArray(dst)
+    }
+
+    final def manualDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
+      val pos = buffer.position()
+      val lim = buffer.limit()
+      val len = lim - pos
+      val dst = Array.ofDim[Double](len)
       var i   = pos
       var j   = 0
       while (i < lim) {

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -126,6 +126,48 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk.fromArray(array)))
         }
       }
+    ),
+    suite("FloatBuffer")(
+      testM("float array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3).map(_.toFloat)
+          val buffer = FloatBuffer.wrap(array)
+          assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+        }
+      },
+      testM("float array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = FloatBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toFloat)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("direct float buffer copying") {
+        UIO.effectTotal {
+          val byteBuffer = ByteBuffer.allocateDirect(40)
+          var i          = 0
+          while (i < 40) {
+            byteBuffer.put(i, i.toByte)
+            i += 1
+          }
+          val buffer = byteBuffer.asFloatBuffer()
+          val array  = Array.ofDim[Float](3)
+          i = 5
+          while (i < 8) {
+            array(i - 5) = buffer.get(i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk.fromArray(array)))
+        }
+      }
     )
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -1,0 +1,45 @@
+package zio.stream
+
+import zio.{ Chunk, UIO, ZIOBaseSpec }
+import zio.test._
+import zio.test.Assertion.equalTo
+import java.nio._
+
+object ChunkBufferSpec extends ZIOBaseSpec {
+
+  def spec = suite("ChunkBufferSpec")(
+    testM("byte array buffer no copying") {
+      UIO.effectTotal {
+        val array = Array(1, 2, 3).map(_.toByte)
+        val buffer = ByteBuffer.wrap(array)
+        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+      }
+    },
+    testM("byte array buffer partial copying") {
+      UIO.effectTotal {
+        val buffer = ByteBuffer.allocate(10)
+        var i = 0
+        while (i < 10) {
+          buffer.put(i, i.toByte)
+          i += 1
+        }
+        buffer.position(5)
+        buffer.limit(8)
+        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+      }
+    },
+    testM("direct byte buffer copying") {
+      UIO.effectTotal {
+        val buffer = ByteBuffer.allocateDirect(10)
+        var i = 0
+        while (i < 10) {
+          buffer.put(i, i.toByte)
+          i += 1
+        }
+        buffer.position(2)
+        buffer.limit(5)
+        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(2, 3, 4)))
+      }
+    }
+  )
+}

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -252,6 +252,48 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromLongBuffer(buffer), equalTo(Chunk.fromArray(array)))
         }
       }
+    ),
+    suite("ShortBuffer")(
+      testM("short array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3).map(_.toShort)
+          val buffer = ShortBuffer.wrap(array)
+          assert(Chunk.fromShortBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+        }
+      },
+      testM("short array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = ShortBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toShort)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromShortBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("direct short buffer copying") {
+        UIO.effectTotal {
+          val byteBuffer = ByteBuffer.allocateDirect(20)
+          var i          = 0
+          while (i < 20) {
+            byteBuffer.put(i, i.toByte)
+            i += 1
+          }
+          val buffer = byteBuffer.asShortBuffer()
+          val array  = Array.ofDim[Short](3)
+          i = 5
+          while (i < 8) {
+            array(i - 5) = buffer.get(i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromShortBuffer(buffer), equalTo(Chunk.fromArray(array)))
+        }
+      }
     )
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -64,6 +64,28 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
       }
+    ),
+    suite("DoubleBuffer")(
+      testM("double array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3).map(_.toDouble)
+          val buffer = DoubleBuffer.wrap(array)
+          assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+        }
+      },
+      testM("double array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = DoubleBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toDouble)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      }
     )
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -63,6 +63,26 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.limit(8)
           assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
+      },
+      testM("direct char buffer copying") {
+        UIO.effectTotal {
+          val byteBuffer = ByteBuffer.allocateDirect(20)
+          var i          = 0
+          while (i < 20) {
+            byteBuffer.put(i, i.toByte)
+            i += 1
+          }
+          val buffer = byteBuffer.asCharBuffer()
+          val array  = Array.ofDim[Char](3)
+          i = 5
+          while (i < 8) {
+            array(i - 5) = buffer.get(i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk.fromArray(array)))
+        }
       }
     ),
     suite("DoubleBuffer")(
@@ -84,6 +104,26 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.position(5)
           buffer.limit(8)
           assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("direct double buffer copying") {
+        UIO.effectTotal {
+          val byteBuffer = ByteBuffer.allocateDirect(80)
+          var i          = 0
+          while (i < 80) {
+            byteBuffer.put(i, i.toByte)
+            i += 1
+          }
+          val buffer = byteBuffer.asDoubleBuffer()
+          val array  = Array.ofDim[Double](3)
+          i = 5
+          while (i < 8) {
+            array(i - 5) = buffer.get(i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk.fromArray(array)))
         }
       }
     )

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -66,9 +66,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct char buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(20)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Character.BYTES * 10)
           var i          = 0
-          while (i < 20) {
+          while (i < java.lang.Character.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }
@@ -108,9 +108,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct double buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(80)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Double.BYTES * 10)
           var i          = 0
-          while (i < 80) {
+          while (i < java.lang.Double.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }
@@ -150,9 +150,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct float buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(40)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Float.BYTES * 10)
           var i          = 0
-          while (i < 40) {
+          while (i < java.lang.Float.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }
@@ -192,9 +192,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct int buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(40)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Integer.BYTES * 10)
           var i          = 0
-          while (i < 40) {
+          while (i < java.lang.Integer.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }
@@ -234,9 +234,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct long buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(80)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Long.BYTES * 10)
           var i          = 0
-          while (i < 80) {
+          while (i < java.lang.Long.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }
@@ -276,9 +276,9 @@ object ChunkBufferSpec extends ZIOBaseSpec {
       },
       testM("direct short buffer copying") {
         UIO.effectTotal {
-          val byteBuffer = ByteBuffer.allocateDirect(20)
+          val byteBuffer = ByteBuffer.allocateDirect(java.lang.Short.BYTES * 10)
           var i          = 0
-          while (i < 20) {
+          while (i < java.lang.Short.BYTES * 10) {
             byteBuffer.put(i, i.toByte)
             i += 1
           }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -168,6 +168,48 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk.fromArray(array)))
         }
       }
+    ),
+    suite("IntBuffer")(
+      testM("int array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3)
+          val buffer = IntBuffer.wrap(array)
+          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+        }
+      },
+      testM("int array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = IntBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      },
+      testM("direct int buffer copying") {
+        UIO.effectTotal {
+          val byteBuffer = ByteBuffer.allocateDirect(40)
+          var i          = 0
+          while (i < 40) {
+            byteBuffer.put(i, i.toByte)
+            i += 1
+          }
+          val buffer = byteBuffer.asIntBuffer()
+          val array  = Array.ofDim[Int](3)
+          i = 5
+          while (i < 8) {
+            array(i - 5) = buffer.get(i)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk.fromArray(array)))
+        }
+      }
     )
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkBufferSpec.scala
@@ -8,38 +8,62 @@ import java.nio._
 object ChunkBufferSpec extends ZIOBaseSpec {
 
   def spec = suite("ChunkBufferSpec")(
-    testM("byte array buffer no copying") {
-      UIO.effectTotal {
-        val array = Array(1, 2, 3).map(_.toByte)
-        val buffer = ByteBuffer.wrap(array)
-        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(1, 2, 3)))
-      }
-    },
-    testM("byte array buffer partial copying") {
-      UIO.effectTotal {
-        val buffer = ByteBuffer.allocate(10)
-        var i = 0
-        while (i < 10) {
-          buffer.put(i, i.toByte)
-          i += 1
+    suite("ByteBuffer")(
+      testM("byte array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3).map(_.toByte)
+          val buffer = ByteBuffer.wrap(array)
+          assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(1, 2, 3)))
         }
-        buffer.position(5)
-        buffer.limit(8)
-        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(5, 6, 7)))
-      }
-    },
-    testM("direct byte buffer copying") {
-      UIO.effectTotal {
-        val buffer = ByteBuffer.allocateDirect(10)
-        var i = 0
-        while (i < 10) {
-          buffer.put(i, i.toByte)
-          i += 1
+      },
+      testM("byte array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = ByteBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toByte)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(5, 6, 7)))
         }
-        buffer.position(2)
-        buffer.limit(5)
-        assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(2, 3, 4)))
+      },
+      testM("direct byte buffer copying") {
+        UIO.effectTotal {
+          val buffer = ByteBuffer.allocateDirect(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toByte)
+            i += 1
+          }
+          buffer.position(2)
+          buffer.limit(5)
+          assert(Chunk.fromByteBuffer(buffer), equalTo(Chunk(2, 3, 4)))
+        }
       }
-    }
+    ),
+    suite("CharBuffer")(
+      testM("char array buffer no copying") {
+        UIO.effectTotal {
+          val array  = Array(1, 2, 3).map(_.toChar)
+          val buffer = CharBuffer.wrap(array)
+          assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+        }
+      },
+      testM("char array buffer partial copying") {
+        UIO.effectTotal {
+          val buffer = CharBuffer.allocate(10)
+          var i      = 0
+          while (i < 10) {
+            buffer.put(i, i.toChar)
+            i += 1
+          }
+          buffer.position(5)
+          buffer.limit(8)
+          assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+        }
+      }
+    )
   )
 }


### PR DESCRIPTION
Resolves #1479.

I tried to minimize code duplication as much as possible.

The implementation copies the buffer into an array backed Chunk.

I implemented it this way for two reasons. First, if we read from the buffer directly, each read will incur boxing overhead if we are going through the `Chunk` polymorphic methods like `def apply(n: Int): A`. Second, the chunk combinators are hand optimized on array backed chunks, so further boxing will be avoided as much as possible.

The tests are running on both JVM and JS.

Hopefully, this is a nice addition for `zio-nio`.

@iravid @mijicd 