### PR TITLE
Refactor Syntax Methods

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -341,26 +341,48 @@ object ZIOSpec extends ZIOBaseSpec {
           sequence2 <- IO.collectAll(ios)
         } yield assert(sequence1, equalTo(sequence2))
       },
-      testM("map2") {
+      testM("mapN with Tuple2") {
         checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
           def f(i: Int, s: String): String = i.toString + s
           val ios                          = (IO.succeed(int), IO.succeed(str))
-          assertM(ios.map2[String](f), equalTo(f(int, str)))
+          assertM(ios.mapN[String](f), equalTo(f(int, str)))
         }
       },
-      testM("map3") {
+      testM("mapN with Tuple3") {
         checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
           def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
           val ios                                       = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2))
-          assertM(ios.map3[String](f), equalTo(f(int, str1, str2)))
+          assertM(ios.mapN[String](f), equalTo(f(int, str1, str2)))
         }
       },
-      testM("map4") {
+      testM("mapN with Tuple4") {
         checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
           (int: Int, str1: String, str2: String, str3: String) =>
             def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
             val ios                                                   = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2), IO.succeed(str3))
-            assertM(ios.map4[String](f), equalTo(f(int, str1, str2, str3)))
+            assertM(ios.mapN[String](f), equalTo(f(int, str1, str2, str3)))
+        }
+      },
+      testM("mapParN with Tuple2") {
+        checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
+          def f(i: Int, s: String): String = i.toString + s
+          val ios                          = (IO.succeed(int), IO.succeed(str))
+          assertM(ios.mapParN[String](f), equalTo(f(int, str)))
+        }
+      },
+      testM("mapParN with Tuple3") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
+          def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
+          val ios                                       = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2))
+          assertM(ios.mapParN[String](f), equalTo(f(int, str1, str2)))
+        }
+      },
+      testM("mapParN with Tuple4") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
+          (int: Int, str1: String, str2: String, str3: String) =>
+            def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
+            val ios                                                   = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2), IO.succeed(str3))
+            assertM(ios.mapParN[String](f), equalTo(f(int, str1, str2, str3)))
         }
       }
     ),

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -304,86 +304,6 @@ object ZIOSpec extends ZIOBaseSpec {
             b <- IO.effect(str).refineOrDie(partial)
           } yield assert(a, equalTo(b))
         }
-      },
-      testM("mergeAll") {
-        val TestData                     = testString.toList
-        val ios                          = TestData.map(IO.succeed)
-        val zero                         = List.empty[Char]
-        def merger[A](as: List[A], a: A) = a :: as
-        for {
-          merged1 <- ios.mergeAll(zero)(merger)
-          merged2 <- IO.mergeAll(ios)(zero)(merger)
-        } yield assert(merged1, equalTo(merged2))
-      },
-      testM("parAll") {
-        val TestData = testString.toList
-        val ios      = TestData.map(IO.effectTotal(_))
-        for {
-          parAll1 <- ios.collectAllPar
-          parAll2 <- IO.collectAllPar(ios)
-        } yield assert(parAll1, equalTo(parAll2))
-      },
-      testM("forkAll") {
-        val TestData                        = testString.toList
-        val ios: Iterable[IO[String, Char]] = TestData.map(IO.effectTotal(_))
-        for {
-          f1       <- ios.forkAll
-          forkAll1 <- f1.join
-          f2       <- IO.forkAll(ios)
-          forkAll2 <- f2.join
-        } yield assert(forkAll1, equalTo(forkAll2))
-      },
-      testM("sequence") {
-        val TestData = testString.toList
-        val ios      = TestData.map(IO.effectTotal(_))
-        for {
-          sequence1 <- ios.collectAll
-          sequence2 <- IO.collectAll(ios)
-        } yield assert(sequence1, equalTo(sequence2))
-      },
-      testM("mapN with Tuple2") {
-        checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
-          def f(i: Int, s: String): String = i.toString + s
-          val ios                          = (IO.succeed(int), IO.succeed(str))
-          assertM(ios.mapN[String](f), equalTo(f(int, str)))
-        }
-      },
-      testM("mapN with Tuple3") {
-        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
-          def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
-          val ios                                       = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2))
-          assertM(ios.mapN[String](f), equalTo(f(int, str1, str2)))
-        }
-      },
-      testM("mapN with Tuple4") {
-        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
-          (int: Int, str1: String, str2: String, str3: String) =>
-            def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
-            val ios                                                   = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2), IO.succeed(str3))
-            assertM(ios.mapN[String](f), equalTo(f(int, str1, str2, str3)))
-        }
-      },
-      testM("mapParN with Tuple2") {
-        checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
-          def f(i: Int, s: String): String = i.toString + s
-          val ios                          = (IO.succeed(int), IO.succeed(str))
-          assertM(ios.mapParN[String](f), equalTo(f(int, str)))
-        }
-      },
-      testM("mapParN with Tuple3") {
-        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
-          def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
-          val ios                                       = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2))
-          assertM(ios.mapParN[String](f), equalTo(f(int, str1, str2)))
-        }
-      },
-      testM("mapParN with Tuple4") {
-        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
-          (int: Int, str1: String, str2: String, str3: String) =>
-            def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
-            val ios                                                   = (IO.succeed(int), IO.succeed(str1), IO.succeed(str2), IO.succeed(str3))
-            assertM(ios.mapParN[String](f), equalTo(f(int, str1, str2, str3)))
-        }
       }
     ),
     suite("filterOrElse")(
@@ -616,16 +536,6 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result, equalTo(Cause.die(boom)))
       } @@ flaky
     ),
-    suite("merge")(
-      testM("on flipped result") {
-        val zio: IO[Int, Int] = ZIO.succeed(1)
-
-        for {
-          a <- zio.merge
-          b <- zio.flip.merge
-        } yield assert(a, equalTo(b))
-      }
-    ),
     suite("head")(
       testM("on non empty list") {
         assertM(ZIO.succeed(List(1, 2, 3)).head.either, isRight(equalTo(1)))
@@ -675,6 +585,60 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeed(Right(2)).leftOrFailException.run, fails(Assertion.anything))
       }
     ),
+    suite("mapN")(
+      testM("with Tuple2") {
+        checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
+          def f(i: Int, s: String): String = i.toString + s
+          val actual                       = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str))(f)
+          val expected                     = f(int, str)
+          assertM(actual, equalTo(expected))
+        }
+      },
+      testM("with Tuple3") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
+          def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
+          val actual                                    = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
+          val expected                                  = f(int, str1, str2)
+          assertM(actual, equalTo(expected))
+        }
+      },
+      testM("with Tuple4") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
+          (int: Int, str1: String, str2: String, str3: String) =>
+            def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
+            val actual                                                = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
+            val expected                                              = f(int, str1, str2, str3)
+            assertM(actual, equalTo(expected))
+        }
+      }
+    ),
+    suite("mapParN")(
+      testM("with Tuple2") {
+        checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
+          def f(i: Int, s: String): String = i.toString + s
+          val actual                       = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str))(f)
+          val expected                     = f(int, str)
+          assertM(actual, equalTo(expected))
+        }
+      },
+      testM("with Tuple3") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
+          def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
+          val actual                                    = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
+          val expected                                  = f(int, str1, str2)
+          assertM(actual, equalTo(expected))
+        }
+      },
+      testM("with Tuple4") {
+        checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString, Gen.alphaNumericString) {
+          (int: Int, str1: String, str2: String, str3: String) =>
+            def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
+            val actual                                                = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
+            val expected                                              = f(int, str1, str2, str3)
+            assertM(actual, equalTo(expected))
+        }
+      }
+    ),
     suite("memoize")(
       testM("non-memoized returns new instances on repeated calls") {
         val io = random.nextString(10)
@@ -686,6 +650,16 @@ object ZIOSpec extends ZIOBaseSpec {
         ioMemo
           .flatMap(io => io <*> io)
           .map(tuple => assert(tuple._1, equalTo(tuple._2)))
+      }
+    ),
+    suite("merge")(
+      testM("on flipped result") {
+        val zio: IO[Int, Int] = ZIO.succeed(1)
+
+        for {
+          a <- zio.merge
+          b <- zio.flip.merge
+        } yield assert(a, equalTo(b))
       }
     ),
     suite("none")(

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -399,6 +399,46 @@ object IO {
     ZIO.lock(executor)(io)
 
   /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
+    ZIO.mapN(io1, io2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
+    ZIO.mapN(io1, io2, io3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
+    f: (A, B, C, D) => F
+  ): IO[E, F] =
+    ZIO.mapN(io1, io2, io3, io4)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
+    ZIO.mapParN(io1, io2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
+    ZIO.mapParN(io1, io2, io3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
+    f: (A, B, C, D) => F
+  ): IO[E, F] =
+    ZIO.mapParN(io1, io2, io3, io4)(f)
+
+  /**
    * @see See [[zio.ZIO.mergeAll]]
    */
   final def mergeAll[E, A, B](in: Iterable[IO[E, A]])(zero: B)(f: (B, A) => B): IO[E, B] =

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -180,6 +180,60 @@ object Managed {
     ZManaged.makeInterruptible(acquire)(release)
 
   /**
+   *  @see [[zio.ZManaged.mapN]]
+   */
+  final def mapN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
+    ZManaged.mapN(managed1, managed2)(f)
+
+  /**
+   *  @see [[zio.ZManaged.mapN]]
+   */
+  final def mapN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
+    f: (A, B, C) => D
+  ): Managed[E, D] =
+    ZManaged.mapN(managed1, managed2, managed3)(f)
+
+  /**
+   *  @see [[zio.ZManaged.mapN]]
+   */
+  final def mapN[E, A, B, C, D, F](
+    managed1: Managed[E, A],
+    managed2: Managed[E, B],
+    managed3: Managed[E, C],
+    managed4: Managed[E, D]
+  )(
+    f: (A, B, C, D) => F
+  ): Managed[E, F] =
+    ZManaged.mapN(managed1, managed2, managed3, managed4)(f)
+
+  /**
+   *  @see [[zio.ZManaged.mapParN]]
+   */
+  final def mapParN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
+    ZManaged.mapParN(managed1, managed2)(f)
+
+  /**
+   *  @see [[zio.ZManaged.mapParN]]
+   */
+  final def mapParN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
+    f: (A, B, C) => D
+  ): Managed[E, D] =
+    ZManaged.mapParN(managed1, managed2, managed3)(f)
+
+  /**
+   *  @see [[zio.ZManaged.mapParN]]
+   */
+  final def mapParN[E, A, B, C, D, F](
+    managed1: Managed[E, A],
+    managed2: Managed[E, B],
+    managed3: Managed[E, C],
+    managed4: Managed[E, D]
+  )(
+    f: (A, B, C, D) => F
+  ): Managed[E, F] =
+    ZManaged.mapParN(managed1, managed2, managed3, managed4)(f)
+
+  /**
    * See [[zio.ZManaged.mergeAll]]
    */
   final def mergeAll[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -422,6 +422,48 @@ object RIO {
   final def left[R, A](a: A): RIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
+    ZIO.mapN(rio1, rio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(
+    f: (A, B, C) => D
+  ): RIO[R, D] =
+    ZIO.mapN(rio1, rio2, rio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
+    f: (A, B, C, D) => F
+  ): RIO[R, F] =
+    ZIO.mapN(rio1, rio2, rio3, rio4)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
+    ZIO.mapParN(rio1, rio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(f: (A, B, C) => D): RIO[R, D] =
+    ZIO.mapParN(rio1, rio2, rio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
+    f: (A, B, C, D) => F
+  ): RIO[R, F] =
+    ZIO.mapParN(rio1, rio2, rio3, rio4)(f)
+
+  /**
    * @see See [[zio.ZIO.mergeAll]]
    */
   final def mergeAll[R, A, B](in: Iterable[RIO[R, A]])(zero: B)(f: (B, A) => B): RIO[R, B] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -395,6 +395,46 @@ object Task {
     ZIO.lock(executor)(task)
 
   /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
+    ZIO.mapN(task1, task2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
+    ZIO.mapN(task1, task2, task3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
+    f: (A, B, C, D) => F
+  ): Task[F] =
+    ZIO.mapN(task1, task2, task3, task4)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
+    ZIO.mapParN(task1, task2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
+    ZIO.mapParN(task1, task2, task3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
+    f: (A, B, C, D) => F
+  ): Task[F] =
+    ZIO.mapParN(task1, task2, task3, task4)(f)
+
+  /**
    * @see See [[zio.ZIO.mergeAll]]
    */
   final def mergeAll[A, B](in: Iterable[Task[A]])(zero: B)(f: (B, A) => B): Task[B] =

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -346,6 +346,44 @@ object UIO {
     ZIO.lock(executor)(uio)
 
   /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
+    ZIO.mapN(uio1, uio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
+    ZIO.mapN(uio1, uio2, uio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(f: (A, B, C, D) => F): UIO[F] =
+    ZIO.mapN(uio1, uio2, uio3, uio4)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
+    ZIO.mapParN(uio1, uio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
+    ZIO.mapParN(uio1, uio2, uio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(
+    f: (A, B, C, D) => F
+  ): UIO[F] =
+    ZIO.mapParN(uio1, uio2, uio3, uio4)(f)
+
+  /**
    * @see See [[zio.ZIO.mergeAll]]
    */
   final def mergeAll[A, B](in: Iterable[UIO[A]])(zero: B)(f: (B, A) => B): UIO[B] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -374,6 +374,50 @@ object URIO {
   final def left[R, A](a: A): URIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
+    ZIO.mapN(urio1, urio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
+    f: (A, B, C) => D
+  ): URIO[R, D] =
+    ZIO.mapN(urio1, urio2, urio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapN]]
+   */
+  final def mapN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
+    f: (A, B, C, D) => F
+  ): URIO[R, F] =
+    ZIO.mapN(urio1, urio2, urio3, urio4)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
+    ZIO.mapParN(urio1, urio2)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
+    f: (A, B, C) => D
+  ): URIO[R, D] =
+    ZIO.mapParN(urio1, urio2, urio3)(f)
+
+  /**
+   *  @see [[zio.ZIO.mapParN]]
+   */
+  final def mapParN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
+    f: (A, B, C, D) => F
+  ): URIO[R, F] =
+    ZIO.mapParN(urio1, urio2, urio3, urio4)(f)
+
+  /**
    * @see [[zio.ZIO.mergeAll]]
    */
   final def mergeAll[R, A, B](in: Iterable[URIO[R, A]])(zero: B)(f: (B, A) => B): URIO[R, B] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2334,6 +2334,75 @@ private[zio] trait ZIOFunctions extends Serializable {
     new ZIO.Lock(executor, zio)
 
   /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C](zio1: ZIO[R, E, A], zio2: ZIO[R, E, B])(f: (A, B) => C): ZIO[R, E, C] =
+    zio1.zipWith(zio2)(f)
+
+  /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C, D](zio1: ZIO[R, E, A], zio2: ZIO[R, E, B], zio3: ZIO[R, E, C])(
+    f: (A, B, C) => D
+  ): ZIO[R, E, D] =
+    for {
+      a <- zio1
+      b <- zio2
+      c <- zio3
+    } yield f(a, b, c)
+
+  /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C, D, F](zio1: ZIO[R, E, A], zio2: ZIO[R, E, B], zio3: ZIO[R, E, C], zio4: ZIO[R, E, D])(
+    f: (A, B, C, D) => F
+  ): ZIO[R, E, F] =
+    for {
+      a <- zio1
+      b <- zio2
+      c <- zio3
+      d <- zio4
+    } yield f(a, b, c, d)
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C](zio1: ZIO[R, E, A], zio2: ZIO[R, E, B])(f: (A, B) => C): ZIO[R, E, C] =
+    zio1.zipWithPar(zio2)(f)
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C, D](zio1: ZIO[R, E, A], zio2: ZIO[R, E, B], zio3: ZIO[R, E, C])(
+    f: (A, B, C) => D
+  ): ZIO[R, E, D] =
+    (zio1 <&> zio2 <&> zio3).map {
+      case ((a, b), c) => f(a, b, c)
+    }
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C, D, F](
+    zio1: ZIO[R, E, A],
+    zio2: ZIO[R, E, B],
+    zio3: ZIO[R, E, C],
+    zio4: ZIO[R, E, D]
+  )(f: (A, B, C, D) => F): ZIO[R, E, F] =
+    (zio1 <&> zio2 <&> zio3 <&> zio4).map {
+      case (((a, b), c), d) => f(a, b, c, d)
+    }
+
+  /**
    * Merges an `Iterable[IO]` to a single IO, working sequentially.
    */
   final def mergeAll[R, E, A, B](

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1223,6 +1223,86 @@ object ZManaged {
     ZManaged.fromEffect(acquire).onExitFirst(_.foreach(release))
 
   /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
+    f: (A, B) => C
+  ): ZManaged[R, E, C] =
+    zManaged1.zipWith(zManaged2)(f)
+
+  /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C, D](
+    zManaged1: ZManaged[R, E, A],
+    zManaged2: ZManaged[R, E, B],
+    zManaged3: ZManaged[R, E, C]
+  )(f: (A, B, C) => D): ZManaged[R, E, D] =
+    for {
+      a <- zManaged1
+      b <- zManaged2
+      c <- zManaged3
+    } yield f(a, b, c)
+
+  /**
+   * Sequentially zips the specified effects using the specified combiner
+   * function.
+   */
+  final def mapN[R, E, A, B, C, D, F](
+    zManaged1: ZManaged[R, E, A],
+    zManaged2: ZManaged[R, E, B],
+    zManaged3: ZManaged[R, E, C],
+    zManaged4: ZManaged[R, E, D]
+  )(f: (A, B, C, D) => F): ZManaged[R, E, F] =
+    for {
+      a <- zManaged1
+      b <- zManaged2
+      c <- zManaged3
+      d <- zManaged4
+    } yield f(a, b, c, d)
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
+    f: (A, B) => C
+  ): ZManaged[R, E, C] =
+    zManaged1.zipWithPar(zManaged2)(f)
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C, D](
+    zManaged1: ZManaged[R, E, A],
+    zManaged2: ZManaged[R, E, B],
+    zManaged3: ZManaged[R, E, C]
+  )(f: (A, B, C) => D): ZManaged[R, E, D] =
+    (zManaged1 <&> zManaged2 <&> zManaged3).map {
+      case ((a, b), c) => f(a, b, c)
+    }
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  final def mapParN[R, E, A, B, C, D, F](
+    zManaged1: ZManaged[R, E, A],
+    zManaged2: ZManaged[R, E, B],
+    zManaged3: ZManaged[R, E, C],
+    zManaged4: ZManaged[R, E, D]
+  )(f: (A, B, C, D) => F): ZManaged[R, E, F] =
+    (zManaged1 <&> zManaged2 <&> zManaged3 <&> zManaged4).map {
+      case (((a, b), c), d) => f(a, b, c, d)
+    }
+
+  /**
    * Merges an `Iterable[IO]` to a single IO, working sequentially.
    */
   final def mergeAll[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =

--- a/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
+++ b/core/shared/src/main/scala/zio/syntax/ZIOSyntax.scala
@@ -38,27 +38,36 @@ object ZIOSyntax {
   }
 
   final class Tuple2Syntax[R, E, A, B](val ios2: (ZIO[R, E, A], ZIO[R, E, B])) extends AnyVal {
-    def map2[C](f: (A, B) => C): ZIO[R, E, C] = ios2._1.flatMap(a => ios2._2.map(f(a, _)))
+    def mapN[C](f: (A, B) => C): ZIO[R, E, C]    = ios2._1.flatMap(a => ios2._2.map(f(a, _)))
+    def mapParN[C](f: (A, B) => C): ZIO[R, E, C] = ios2._1.zipWithPar(ios2._2)(f)
   }
 
   final class Tuple3Syntax[R, E, A, B, C](val ios3: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C])) extends AnyVal {
-    def map3[D](f: (A, B, C) => D): ZIO[R, E, D] =
+    def mapN[D](f: (A, B, C) => D): ZIO[R, E, D] =
       for {
         a <- ios3._1
         b <- ios3._2
         c <- ios3._3
       } yield f(a, b, c)
+    def mapParN[D](f: (A, B, C) => D): ZIO[R, E, D] =
+      (ios3._1 <&> ios3._2 <&> ios3._3).map {
+        case ((a, b), c) => f(a, b, c)
+      }
   }
 
   final class Tuple4Syntax[R, E, A, B, C, D](
     val ios4: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C], ZIO[R, E, D])
   ) extends AnyVal {
-    def map4[F](f: (A, B, C, D) => F): ZIO[R, E, F] =
+    def mapN[F](f: (A, B, C, D) => F): ZIO[R, E, F] =
       for {
         a <- ios4._1
         b <- ios4._2
         c <- ios4._3
         d <- ios4._4
       } yield f(a, b, c, d)
+    def mapParN[F](f: (A, B, C, D) => F): ZIO[R, E, F] =
+      (ios4._1 <&> ios4._2 <&> ios4._3 <&> ios4._4).map {
+        case (((a, b), c), d) => f(a, b, c, d)
+      }
   }
 }

--- a/core/shared/src/main/scala/zio/syntax/package.scala
+++ b/core/shared/src/main/scala/zio/syntax/package.scala
@@ -23,17 +23,4 @@ package object syntax {
 
   implicit final def zioEagerCreationSyntax[A](a: A): EagerCreationSyntax[A]  = new EagerCreationSyntax[A](a)
   implicit final def zioLazyCreationSyntax[A](a: => A): LazyCreationSyntax[A] = new LazyCreationSyntax[A](() => a)
-  implicit final def zioIterableSyntax[R, E, A](zios: Iterable[ZIO[R, E, A]]): IterableSyntax[R, E, A] =
-    new IterableSyntax[R, E, A](zios)
-
-  implicit final def zioTuple2Syntax[R, E, A, B](zios: (ZIO[R, E, A], ZIO[R, E, B])): Tuple2Syntax[R, E, A, B] =
-    new Tuple2Syntax(zios)
-  implicit final def zioTuple3Syntax[R, E, A, B, C](
-    zios: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C])
-  ): Tuple3Syntax[R, E, A, B, C] =
-    new Tuple3Syntax(zios)
-  implicit final def zioTuple4Syntax[R, E, A, B, C, D](
-    zios: (ZIO[R, E, A], ZIO[R, E, B], ZIO[R, E, C], ZIO[R, E, D])
-  ): Tuple4Syntax[R, E, A, B, C, D] =
-    new Tuple4Syntax(zios)
 }

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -60,6 +60,33 @@ object Stream extends Serializable {
     ZStream.bracketExit(acquire)(release)
 
   /**
+   *  @see [[zio.ZStream.crossN]]
+   */
+  final def crossNN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
+    ZStream.crossN(stream1, stream2)(f)
+
+  /**
+   *  @see [[zio.ZStream.crossN]]
+   */
+  final def crossN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
+    f: (A, B, C) => D
+  ): Stream[E, D] =
+    ZStream.crossN(stream1, stream2, stream3)(f)
+
+  /**
+   *  @see [[zio.ZStream.crossN]]
+   */
+  final def crossN[E, A, B, C, D, F](
+    stream1: Stream[E, A],
+    stream2: Stream[E, B],
+    stream3: Stream[E, C],
+    stream4: Stream[E, D]
+  )(
+    f: (A, B, C, D) => F
+  ): Stream[E, F] =
+    ZStream.crossN(stream1, stream2, stream3, stream4)(f)
+
+  /**
    * See [[ZStream.die]]
    */
   final def die(ex: Throwable): Stream[Nothing, Nothing] =
@@ -269,4 +296,32 @@ object Stream extends Serializable {
    */
   final def unwrapManaged[E, A](fa: Managed[E, ZStream[Any, E, A]]): Stream[E, A] =
     ZStream.unwrapManaged(fa)
+
+  /**
+   *  @see [[zio.ZStream.zipN]]
+   */
+  final def zipN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
+    ZStream.zipN(stream1, stream2)(f)
+
+  /**
+   *  @see [[zio.ZStream.zipN]]
+   */
+  final def zipN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
+    f: (A, B, C) => D
+  ): Stream[E, D] =
+    ZStream.zipN(stream1, stream2, stream3)(f)
+
+  /**
+   *  @see [[zio.ZStream.zipN]]
+   */
+  final def zipN[E, A, B, C, D, F](
+    stream1: Stream[E, A],
+    stream2: Stream[E, B],
+    stream3: Stream[E, C],
+    stream4: Stream[E, D]
+  )(
+    f: (A, B, C, D) => F
+  ): Stream[E, F] =
+    ZStream.zipN(stream1, stream2, stream3, stream4)(f)
+
 }

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -62,7 +62,7 @@ object Stream extends Serializable {
   /**
    *  @see [[zio.ZStream.crossN]]
    */
-  final def crossNN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
+  final def crossN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
     ZStream.crossN(stream1, stream2)(f)
 
   /**

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -253,6 +253,38 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     fromEffectSample(ZIO.succeed(sample))
 
   /**
+   * Composes the specified generators to create a cartesian product of
+   * elements with the specified function.
+   */
+  final def crossN[R, A, B, C](gen1: Gen[R, A], gen2: Gen[R, B])(f: (A, B) => C): Gen[R, C] =
+    gen1.crossWith(gen2)(f)
+
+  /**
+   * Composes the specified generators to create a cartesian product of
+   * elements with the specified function.
+   */
+  final def crossN[R, A, B, C, D](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C])(f: (A, B, C) => D): Gen[R, D] =
+    for {
+      a <- gen1
+      b <- gen2
+      c <- gen3
+    } yield f(a, b, c)
+
+  /**
+   * Composes the specified generators to create a cartesian product of
+   * elements with the specified function.
+   */
+  final def crossN[R, A, B, C, D, F](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C], gen4: Gen[R, D])(
+    f: (A, B, C, D) => F
+  ): Gen[R, F] =
+    for {
+      a <- gen1
+      b <- gen2
+      c <- gen3
+      d <- gen4
+    } yield f(a, b, c, d)
+
+  /**
    * A generator of double values inside the specified range: [start, end].
    * The shrinker will shrink toward the lower end of the range ("smallest").
    */
@@ -500,6 +532,36 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     }
     uniform.flatMap(n => map.rangeImpl(Some(n), None).head._2)
   }
+
+  /**
+   * Zips the specified generators together pairwise. The new generator will
+   * generate elements as long as any generator is generating elements, running
+   * the other generator multiple times if necessary.
+   */
+  final def zipN[R, A, B, C](gen1: Gen[R, A], gen2: Gen[R, B])(f: (A, B) => C): Gen[R, C] =
+    gen1.zipWith(gen2)(f)
+
+  /**
+   * Zips the specified generators together pairwise. The new generator will
+   * generate elements as long as any generator is generating elements, running
+   * the other generator multiple times if necessary.
+   */
+  final def zipN[R, A, B, C, D](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C])(f: (A, B, C) => D): Gen[R, D] =
+    (gen1 <&> gen2 <&> gen3).map {
+      case ((a, b), c) => f(a, b, c)
+    }
+
+  /**
+   * Zips the specified generators together pairwise. The new generator will
+   * generate elements as long as any generator is generating elements, running
+   * the other generator multiple times if necessary.
+   */
+  final def zipN[R, A, B, C, D, F](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C], gen4: Gen[R, D])(
+    f: (A, B, C, D) => F
+  ): Gen[R, F] =
+    (gen1 <&> gen2 <&> gen3 <&> gen4).map {
+      case (((a, b), c), d) => f(a, b, c, d)
+    }
 
   /**
    * Restricts an integer to the specified range.


### PR DESCRIPTION
Resolves #2356. Resolves #2357.

@jdegoes What do you think about moving these methods to the companion object instead so they are always available and the user doesn't have to rely on importing the implicit syntax?

Whatever we decide to do we should probably do it for other ZIO data types as well. I am thinking `ZIO`, `ZManaged`, `ZStream`, and `Gen`.