### PR TITLE
ZIO Test: Fix Bug in Test Reporter

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
@@ -10,12 +10,14 @@ class MockLogger extends Logger {
     logged.getAndUpdate(_ :+ str)
     ()
   }
+  private def logWithPrefix(s: String)(prefix: String): Unit =
+    log(s.split("\n").map(prefix + _).mkString("\n"))
   def messages: Seq[String] = logged.get()
 
   override def ansiCodesSupported(): Boolean = false
-  override def error(msg: String): Unit      = log(s"error: $msg")
-  override def warn(msg: String): Unit       = log(s"warn: $msg")
-  override def info(msg: String): Unit       = log(s"info: $msg")
-  override def debug(msg: String): Unit      = log(s"debug: $msg")
-  override def trace(t: Throwable): Unit     = log(s"trace: $t")
+  override def error(msg: String): Unit      = logWithPrefix(msg)("error: ")
+  override def warn(msg: String): Unit       = logWithPrefix(msg)("warn: ")
+  override def info(msg: String): Unit       = logWithPrefix(msg)("info: ")
+  override def debug(msg: String): Unit      = logWithPrefix(msg)("debug: ")
+  override def trace(t: Throwable): Unit     = logWithPrefix(t.toString)("trace: ")
 }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -67,13 +67,13 @@ object ZTestFrameworkSpec {
       messages =>
         assertEquals(
           "logged messages",
-          messages.toList.dropRight(1),
+          messages.mkString.split("\n").dropRight(1).mkString("\n"),
           List(
             s"info: ${red("- some suite")}",
             s"info:   ${red("- failing test")}",
             s"info:     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
             s"info:   ${green("+")} passing test"
-          )
+          ).mkString("\n")
         )
       )
   }
@@ -87,11 +87,11 @@ object ZTestFrameworkSpec {
       messages =>
         assertEquals(
           "logged messages",
-          messages.toList.dropRight(1),
+          messages.mkString.split("\n").dropRight(1).mkString("\n"),
           List(
             s"info: ${green("+")} some suite",
             s"info:   ${green("+")} passing test"
-          )
+          ).mkString("\n")
         )
       )
   }

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -12,58 +12,55 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
     testM("correctly reports a successful test") {
       assertM(
         runLog(test1),
-        equalTo(Vector(test1Expected, reportStats(1, 0, 0)))
+        equalTo(test1Expected.mkString + reportStats(1, 0, 0))
       )
     },
     testM("correctly reports a failed test") {
       assertM(
         runLog(test3),
-        equalTo(test3Expected :+ reportStats(0, 0, 1))
+        equalTo(test3Expected.mkString + reportStats(0, 0, 1))
       )
     },
     testM("correctly reports an error in a test") {
       assertM(
         runLog(test4),
-        equalTo(test4Expected :+ reportStats(0, 0, 1))
+        equalTo(test4Expected.mkString + reportStats(0, 0, 1))
       )
     },
     testM("correctly reports successful test suite") {
       assertM(
         runLog(suite1),
-        equalTo(suite1Expected :+ reportStats(2, 0, 0))
+        equalTo(suite1Expected.mkString + reportStats(2, 0, 0))
       )
     },
     testM("correctly reports failed test suite") {
       assertM(
         runLog(suite2),
-        equalTo(suite2Expected :+ reportStats(2, 0, 1))
+        equalTo(suite2Expected.mkString + reportStats(2, 0, 1))
       )
     },
     testM("correctly reports multiple test suites") {
       assertM(
         runLog(suite3),
-        equalTo(
-          Vector(expectedFailure("Suite3")) ++ suite1Expected.map(withOffset(2)) ++ test3Expected
-            .map(withOffset(2)) :+ reportStats(2, 0, 1)
-        )
+        equalTo(suite3Expected.mkString + reportStats(2, 0, 1))
       )
     },
     testM("correctly reports failure of simple assertion") {
       assertM(
         runLog(test5),
-        equalTo(test5Expected :+ reportStats(0, 0, 1))
+        equalTo(test5Expected.mkString + reportStats(0, 0, 1))
       )
     },
     testM("correctly reports multiple nested failures") {
       assertM(
         runLog(test6),
-        equalTo(test6Expected :+ reportStats(0, 0, 1))
+        equalTo(test6Expected.mkString + reportStats(0, 0, 1))
       )
     },
     testM("correctly reports labeled failures") {
       assertM(
         runLog(test7),
-        equalTo(test7Expected :+ reportStats(0, 0, 1))
+        equalTo(test7Expected.mkString + reportStats(0, 0, 1))
       )
     }
   )
@@ -148,6 +145,9 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
   ) ++ test3Expected.map(withOffset(2)(_))
 
   val suite3 = suite("Suite3")(suite1, test3)
+  val suite3Expected = Vector(expectedFailure("Suite3")) ++
+    suite1Expected.map(withOffset(2)) ++
+    test3Expected.map(withOffset(2))
 
   def reportStats(success: Int, ignore: Int, failure: Int) = {
     val total = success + ignore + failure
@@ -156,8 +156,8 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
     ) + "\n"
   }
 
-  def runLog[E](spec: ZSpec[TestEnvironment, String, String, Unit]) = {
-    val zio = for {
+  def runLog[E](spec: ZSpec[TestEnvironment, String, String, Unit]) =
+    for {
       _ <- TestTestRunner(testEnvironmentManaged)
             .run(spec)
             .provideSomeManaged(for {
@@ -169,9 +169,7 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
               override val clock: Clock.Service[Any] = clockSvc.clock
             })
       output <- TestConsole.output
-    } yield output
-    zio
-  }
+    } yield output.mkString
 
   private[this] def TestTestRunner(testEnvironment: Managed[Nothing, TestEnvironment]) =
     TestRunner[TestEnvironment, String, String, Unit, Unit](

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -24,7 +24,7 @@ import zio.test.mock.MockException.{ InvalidArgumentsException, InvalidMethodExc
 import zio.test.RenderedResult.CaseType._
 import zio.test.RenderedResult.Status._
 import zio.test.RenderedResult.{ CaseType, Status }
-import zio.{ Cause, UIO, URIO, ZIO }
+import zio.{ Cause, UIO, URIO }
 
 object DefaultTestReporter {
 
@@ -82,13 +82,13 @@ object DefaultTestReporter {
 
   def apply[E, S](): TestReporter[E, String, S] = { (duration: Duration, executedSpec: ExecutedSpec[E, String, S]) =>
     for {
-      res <- render(executedSpec.mapLabel(_.toString))
-      _   <- ZIO.foreach(res.flatMap(_.rendered))(TestLogger.logLine)
-      _   <- logStats(duration, executedSpec)
+      rendered <- render(executedSpec.mapLabel(_.toString)).map(_.flatMap(_.rendered))
+      stats    <- logStats(duration, executedSpec)
+      _        <- TestLogger.logLine((rendered ++ Seq(stats)).mkString("\n"))
     } yield ()
   }
 
-  private def logStats[E, L, S](duration: Duration, executedSpec: ExecutedSpec[E, L, S]): URIO[TestLogger, Unit] = {
+  private def logStats[E, L, S](duration: Duration, executedSpec: ExecutedSpec[E, L, S]): URIO[TestLogger, String] = {
     def loop(executedSpec: ExecutedSpec[E, String, S]): UIO[(Int, Int, Int)] =
       executedSpec.caseValue match {
         case Spec.SuiteCase(_, executedSpecs, _) =>
@@ -109,12 +109,9 @@ object DefaultTestReporter {
       stats                      <- loop(executedSpec.mapLabel(_.toString))
       (success, ignore, failure) = stats
       total                      = success + ignore + failure
-      _ <- TestLogger.logLine(
-            cyan(
-              s"Ran $total test${if (total == 1) "" else "s"} in ${duration.render}: $success succeeded, $ignore ignored, $failure failed"
-            )
-          )
-    } yield ()
+    } yield cyan(
+      s"Ran $total test${if (total == 1) "" else "s"} in ${duration.render}: $success succeeded, $ignore ignored, $failure failed"
+    )
   }
 
   private def renderSuccessLabel(label: String, offset: Int) =


### PR DESCRIPTION
When multiple specs were executed by the SBT test runner there was the possibility for test results from different specs to be interleaved because the specs were being executed in parallel by the ZIO Test Runner. This was occurring because the rendering of test results were composed of multiple `Console` effects so it was possible for one effect from one spec to be interleaved with another effect from a different spec. This PR fixes this by having the `DefaultTestReport` create one string containing all results for a spec and then rendering that string as a single action.

Thanks to @softinio for reporting.

@softinio and @reibitto Would you mind testing this branch and confirming it resolves your issue?