### PR TITLE
ZIO Test: Don't Render New Line for Empty Suites

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -45,6 +45,12 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
         equalTo(suite3Expected.mkString + reportStats(2, 0, 1))
       )
     },
+    testM("correctly reports empty test suite") {
+      assertM(
+        runLog(suite4),
+        equalTo(suite4Expected.mkString + reportStats(2, 0, 1))
+      )
+    },
     testM("correctly reports failure of simple assertion") {
       assertM(
         runLog(test5),
@@ -146,6 +152,11 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
 
   val suite3 = suite("Suite3")(suite1, test3)
   val suite3Expected = Vector(expectedFailure("Suite3")) ++
+    suite1Expected.map(withOffset(2)) ++
+    test3Expected.map(withOffset(2))
+
+  val suite4 = suite("Suite4")(suite1, suite("Empty")(), test3)
+  val suite4Expected = Vector(expectedFailure("Suite4")) ++
     suite1Expected.map(withOffset(2)) ++
     test3Expected.map(withOffset(2))
 

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -40,11 +40,11 @@ object DefaultTestReporter {
                        })
             hasFailures = failures.exists(identity)
             status      = if (hasFailures) Failed else Passed
-            renderedLabel = if (specs.isEmpty) ""
-            else if (hasFailures) renderFailureLabel(label, depth)
-            else renderSuccessLabel(label, depth)
+            renderedLabel = if (specs.isEmpty) Seq.empty
+            else if (hasFailures) Seq(renderFailureLabel(label, depth))
+            else Seq(renderSuccessLabel(label, depth))
             rest <- UIO.foreach(specs)(loop(_, depth + tabSize)).map(_.flatten)
-          } yield rendered(Suite, label, status, depth, renderedLabel) +: rest
+          } yield rendered(Suite, label, status, depth, renderedLabel: _*) +: rest
         case Spec.TestCase(label, result) =>
           result.flatMap {
             case Right(TestSuccess.Succeeded(_)) =>


### PR DESCRIPTION
Minor follow up to #2385 to prevent new lines from being rendered when a test suite is empty (e.g. because all the tests in the suite have been filtered out with `testOnly`).