### PR TITLE
ZIO Test: Provide Combinators to Use Live Environment by Default

### DIFF
--- a/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/js/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -16,8 +16,14 @@
 
 package zio.test.environment
 
-import zio.{ Managed, ZEnv }
-import zio.scheduler.Scheduler
+import java.io.IOException
+import java.time.{ OffsetDateTime, ZoneId }
+import java.util.concurrent.TimeUnit
+
+import zio._
+import zio.duration._
+import zio.internal.{ Scheduler => IScheduler }
+import zio.scheduler.{ Scheduler, SchedulerLive }
 import zio.test.Sized
 
 case class TestEnvironment(
@@ -80,6 +86,106 @@ case class TestEnvironment(
    */
   final def mapTestSystem(f: TestSystem.Service[Any] => TestSystem.Service[Any]): TestEnvironment =
     mapAll(mapTestSystem = f)
+
+  /**
+   * Maps the [[TestClock]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveClock: TestEnvironment =
+    mapTestClock { _ =>
+      new TestClock.Service[Any] {
+        def adjust(duration: Duration): UIO[Unit]            = UIO.unit
+        val currentDateTime: UIO[OffsetDateTime]             = live.provide(zio.clock.currentDateTime)
+        def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
+        val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
+        val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
+        def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
+        def setTime(duration: Duration): UIO[Unit]           = UIO.unit
+        def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
+        val scheduler: UIO[IScheduler]                       = SchedulerLive.scheduler.scheduler
+        def sleep(duration: Duration): UIO[Unit]             = live.provide(zio.clock.sleep(duration))
+        val sleeps: UIO[List[Duration]]                      = UIO.succeed(List.empty)
+        val timeZone: UIO[ZoneId]                            = UIO.succeed(ZoneId.of("UTC"))
+      }
+    }
+
+  /**
+   * Maps the [[TestConsole]] implementation in the test environment to one
+   * that uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveConsole: TestEnvironment =
+    mapTestConsole { _ =>
+      new TestConsole.Service[Any] {
+        val clearInput: UIO[Unit]                = UIO.unit
+        val clearOutput: UIO[Unit]               = UIO.unit
+        def feedLines(lines: String*): UIO[Unit] = UIO.unit
+        val getStrLn: IO[IOException, String]    = live.provide(zio.console.getStrLn)
+        val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
+        def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
+        def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
+      }
+    }
+
+  /**
+   * Maps the [[TestRandom]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveRandom: TestEnvironment =
+    mapTestRandom { _ =>
+      new TestRandom.Service[Any] {
+        val clearBooleans: UIO[Unit]                    = UIO.unit
+        val clearBytes: UIO[Unit]                       = UIO.unit
+        val clearChars: UIO[Unit]                       = UIO.unit
+        val clearDoubles: UIO[Unit]                     = UIO.unit
+        val clearFloats: UIO[Unit]                      = UIO.unit
+        val clearInts: UIO[Unit]                        = UIO.unit
+        val clearLongs: UIO[Unit]                       = UIO.unit
+        val clearStrings: UIO[Unit]                     = UIO.unit
+        def feedBooleans(booleans: Boolean*): UIO[Unit] = UIO.unit
+        def feedBytes(bytes: Chunk[Byte]*): UIO[Unit]   = UIO.unit
+        def feedChars(chars: Char*): UIO[Unit]          = UIO.unit
+        def feedDoubles(doubles: Double*): UIO[Unit]    = UIO.unit
+        def feedFloats(floats: Float*): UIO[Unit]       = UIO.unit
+        def feedInts(ints: Int*): UIO[Unit]             = UIO.unit
+        def feedLongs(longs: Long*): UIO[Unit]          = UIO.unit
+        def feedStrings(strings: String*): UIO[Unit]    = UIO.unit
+        val nextBoolean: UIO[Boolean]                   = live.provide(zio.random.nextBoolean)
+        def nextBytes(length: Int): UIO[Chunk[Byte]]    = live.provide(zio.random.nextBytes(length))
+        val nextDouble: UIO[Double]                     = live.provide(zio.random.nextDouble)
+        val nextFloat: UIO[Float]                       = live.provide(zio.random.nextFloat)
+        val nextGaussian: UIO[Double]                   = live.provide(zio.random.nextGaussian)
+        def nextInt(n: Int): UIO[Int]                   = live.provide(zio.random.nextInt(n))
+        val nextInt: UIO[Int]                           = live.provide(zio.random.nextInt)
+        val nextLong: UIO[Long]                         = live.provide(zio.random.nextLong)
+        def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
+        val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
+        def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
+        def setSeed(seed: Long): UIO[Unit]              = UIO.unit
+        def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
+      }
+    }
+
+  /**
+   * Maps the [[TestSystem]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveSystem: TestEnvironment =
+    mapTestSystem { _ =>
+      new TestSystem.Service[Any] {
+        def clearEnv(variable: String): UIO[Unit]                        = UIO.unit
+        def clearProperty(prop: String): UIO[Unit]                       = UIO.unit
+        def env(variable: String): IO[SecurityException, Option[String]] = live.provide(zio.system.env(variable))
+        val lineSeparator: UIO[String]                                   = live.provide(zio.system.lineSeparator)
+        def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
+        def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
+        def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
+        def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
+      }
+    }
 
   val scheduler = clock
 }

--- a/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/TestEnvironment.scala
@@ -16,9 +16,15 @@
 
 package zio.test.environment
 
-import zio.{ Managed, ZEnv }
+import java.io.IOException
+import java.time.{ OffsetDateTime, ZoneId }
+import java.util.concurrent.TimeUnit
+
+import zio._
 import zio.blocking.Blocking
-import zio.scheduler.Scheduler
+import zio.duration._
+import zio.internal.{ Scheduler => IScheduler }
+import zio.scheduler.{ Scheduler, SchedulerLive }
 import zio.test.Sized
 
 case class TestEnvironment(
@@ -84,6 +90,106 @@ case class TestEnvironment(
    */
   final def mapTestSystem(f: TestSystem.Service[Any] => TestSystem.Service[Any]): TestEnvironment =
     mapAll(mapTestSystem = f)
+
+  /**
+   * Maps the [[TestClock]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveClock: TestEnvironment =
+    mapTestClock { _ =>
+      new TestClock.Service[Any] {
+        def adjust(duration: Duration): UIO[Unit]            = UIO.unit
+        val currentDateTime: UIO[OffsetDateTime]             = live.provide(zio.clock.currentDateTime)
+        def currentTime(unit: TimeUnit): UIO[Long]           = live.provide(zio.clock.currentTime(unit))
+        val fiberTime: UIO[Duration]                         = UIO.succeed(Duration.Zero)
+        val nanoTime: UIO[Long]                              = live.provide(zio.clock.nanoTime)
+        def setDateTime(dateTime: OffsetDateTime): UIO[Unit] = UIO.unit
+        def setTime(duration: Duration): UIO[Unit]           = UIO.unit
+        def setTimeZone(zone: ZoneId): UIO[Unit]             = UIO.unit
+        val scheduler: UIO[IScheduler]                       = SchedulerLive.scheduler.scheduler
+        def sleep(duration: Duration): UIO[Unit]             = live.provide(zio.clock.sleep(duration))
+        val sleeps: UIO[List[Duration]]                      = UIO.succeed(List.empty)
+        val timeZone: UIO[ZoneId]                            = UIO.succeed(ZoneId.of("UTC"))
+      }
+    }
+
+  /**
+   * Maps the [[TestConsole]] implementation in the test environment to one
+   * that uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveConsole: TestEnvironment =
+    mapTestConsole { _ =>
+      new TestConsole.Service[Any] {
+        val clearInput: UIO[Unit]                = UIO.unit
+        val clearOutput: UIO[Unit]               = UIO.unit
+        def feedLines(lines: String*): UIO[Unit] = UIO.unit
+        val getStrLn: IO[IOException, String]    = live.provide(zio.console.getStrLn)
+        val output: UIO[Vector[String]]          = UIO.succeed(Vector.empty)
+        def putStr(line: String): UIO[Unit]      = live.provide(zio.console.putStr(line))
+        def putStrLn(line: String): UIO[Unit]    = live.provide(zio.console.putStrLn(line))
+      }
+    }
+
+  /**
+   * Maps the [[TestRandom]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveRandom: TestEnvironment =
+    mapTestRandom { _ =>
+      new TestRandom.Service[Any] {
+        val clearBooleans: UIO[Unit]                    = UIO.unit
+        val clearBytes: UIO[Unit]                       = UIO.unit
+        val clearChars: UIO[Unit]                       = UIO.unit
+        val clearDoubles: UIO[Unit]                     = UIO.unit
+        val clearFloats: UIO[Unit]                      = UIO.unit
+        val clearInts: UIO[Unit]                        = UIO.unit
+        val clearLongs: UIO[Unit]                       = UIO.unit
+        val clearStrings: UIO[Unit]                     = UIO.unit
+        def feedBooleans(booleans: Boolean*): UIO[Unit] = UIO.unit
+        def feedBytes(bytes: Chunk[Byte]*): UIO[Unit]   = UIO.unit
+        def feedChars(chars: Char*): UIO[Unit]          = UIO.unit
+        def feedDoubles(doubles: Double*): UIO[Unit]    = UIO.unit
+        def feedFloats(floats: Float*): UIO[Unit]       = UIO.unit
+        def feedInts(ints: Int*): UIO[Unit]             = UIO.unit
+        def feedLongs(longs: Long*): UIO[Unit]          = UIO.unit
+        def feedStrings(strings: String*): UIO[Unit]    = UIO.unit
+        val nextBoolean: UIO[Boolean]                   = live.provide(zio.random.nextBoolean)
+        def nextBytes(length: Int): UIO[Chunk[Byte]]    = live.provide(zio.random.nextBytes(length))
+        val nextDouble: UIO[Double]                     = live.provide(zio.random.nextDouble)
+        val nextFloat: UIO[Float]                       = live.provide(zio.random.nextFloat)
+        val nextGaussian: UIO[Double]                   = live.provide(zio.random.nextGaussian)
+        def nextInt(n: Int): UIO[Int]                   = live.provide(zio.random.nextInt(n))
+        val nextInt: UIO[Int]                           = live.provide(zio.random.nextInt)
+        val nextLong: UIO[Long]                         = live.provide(zio.random.nextLong)
+        def nextLong(n: Long): UIO[Long]                = live.provide(zio.random.nextLong(n))
+        val nextPrintableChar: UIO[Char]                = live.provide(zio.random.nextPrintableChar)
+        def nextString(length: Int): UIO[String]        = live.provide(zio.random.nextString(length))
+        def setSeed(seed: Long): UIO[Unit]              = UIO.unit
+        def shuffle[A](list: List[A]): UIO[List[A]]     = UIO.succeed(list)
+      }
+    }
+
+  /**
+   * Maps the [[TestSystem]] implementation in the test environment to one that
+   * uses the live environment, leaving all other test implementations the
+   * same.
+   */
+  final def withLiveSystem: TestEnvironment =
+    mapTestSystem { _ =>
+      new TestSystem.Service[Any] {
+        def clearEnv(variable: String): UIO[Unit]                        = UIO.unit
+        def clearProperty(prop: String): UIO[Unit]                       = UIO.unit
+        def env(variable: String): IO[SecurityException, Option[String]] = live.provide(zio.system.env(variable))
+        val lineSeparator: UIO[String]                                   = live.provide(zio.system.lineSeparator)
+        def property(prop: String): Task[Option[String]]                 = live.provide(zio.system.property(prop))
+        def putEnv(name: String, value: String): UIO[Unit]               = UIO.unit
+        def putProperty(name: String, value: String): UIO[Unit]          = UIO.unit
+        def setLineSeparator(lineSep: String): UIO[Unit]                 = UIO.unit
+      }
+    }
 
   val scheduler = clock
 }


### PR DESCRIPTION
One of the pain points that I hear about regarding ZIO Test is people who want to use live implementations of the environment types by default.

I think this shows up in two ways.

One is that the `TestClock` in particular can make for a more difficult migration from existing test frameworks. We generally have a version of everything that exists in other testing frameworks so most of migration is just relatively mechanically replacing code with the ZIO Test version of things. But writing tests involving time with the `TestClock` is significantly different and while ultimately more powerful can require some thinking, before which your tests are going to be failing which is not very fun.

The second is there is a subset of users that just don't want one or more of the test implementations (e.g. you don't have any `Console` effects you want to test but you use a lot of them to print debug or information messages that are now no longer showing up, or you interact with a lot of third party services that need live clock effects and think that is a better default for you).

This PR addresses this by providing a set of combinators on `TestEnvironment` that replace one of the test implementations with a version of the live one that just ignores any "test" effects. For example, you can call `testEnvironment.withLiveClock` and get a `TestEnvironment` that does live sleeps.

I have somewhat mixed feelings about this because I think the `TestEnvironment` and the test implementations are great and want to make them even better, but I think if we can offer a relatively easy "escape hatch" like this we can both ease migration and provide a better for users who like everything else about ZIO Test but want to do something different here.

Other opinions very much appreciated.