### PR TITLE
Fix ZIO#withFilter

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2175,18 +2175,6 @@ object ZIOSpec extends ZIOBaseSpec {
           } yield n
         assertM(task.run, fails(isSubtype[NoSuchElementException](anything)))
       },
-      testM("withFilter doesn't compile with UIO") {
-        val result = typeCheck {
-          """
-            import zio._
-
-            for {
-              n <- UIO(3) if n > 0
-            } yield n
-                """
-        }
-        assertM(result, isLeft(anything))
-      },
       testM("withFilter doesn't compile with IO that fails with type other than Throwable") {
         val result = typeCheck {
           """
@@ -2199,7 +2187,6 @@ object ZIOSpec extends ZIOBaseSpec {
         }
         val expected = "Cannot prove that NoSuchElementException <:< String."
         if (TestVersion.isScala2) assertM(result, isLeft(equalTo(expected)))
-        else if (TestVersion.isDotty) assertM(result, isRight(equalTo(())))
         else assertM(result, isLeft(anything))
       }
     ),

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2686,8 +2686,7 @@ object ZIO extends ZIOFunctions {
       self.refineOrDie { case e: E1 => e }
   }
 
-  implicit final class ZIOWithFilterOps[R, E, A](private val self: ZIO[R, E, A])
-      extends AnyVal {
+  implicit final class ZIOWithFilterOps[R, E, A](private val self: ZIO[R, E, A]) extends AnyVal {
 
     /**
      * Enables to check conditions in the value produced by ZIO


### PR DESCRIPTION
Resolves #2413.  `withFilter` is now available in any situation where the `E` type is related to `NoSuchElementException` so it will work with `UIO[A]` as well as `Task[A]` but not `IO[String, A]`. We could potentially generalize further to allow it to always be available but the `E` type would be widened to `Any` in that case.