### PR TITLE
ZStream.flatten, unwrap, unwrapManaged are safe to pull again

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -506,6 +506,29 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .use(nPulls(_, 5))
         } yield assert(pulls, equalTo(List(Right(1), Left(Some("Ouch")), Right(2), Left(None), Left(None))))
       }
+    ),
+    suite("Stream.unwrap")(
+      testM("is safe to pull again after success") {
+        Stream
+          .unwrap(UIO.succeed(Stream.fromEffect(UIO.succeed(5))))
+          .process
+          .use(nPulls(_, 3))
+          .map(assert(_, equalTo(List(Right(5), Left(None), Left(None)))))
+      },
+      testM("is safe to pull again after inner failure") {
+        Stream
+          .unwrap(UIO.succeed(Stream.fail("Ouch")))
+          .process
+          .use(nPulls(_, 3))
+          .map(assert(_, equalTo(List(Left(Some("Ouch")), Left(None), Left(None)))))
+      },
+      testM("is safe to pull again after outer failure") {
+        Stream
+          .unwrap(IO.fail("Ouch"))
+          .process
+          .use(nPulls(_, 3))
+          .map(assert(_, equalTo(List(Left(Some("Ouch")), Left(None), Left(None)))))
+      }
     )
   )
 }


### PR DESCRIPTION
Verifying more Stream constructors for pull safety.