### PR TITLE
Added interruption in App main

### DIFF
--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -60,6 +60,7 @@ trait App extends DefaultRuntime {
                 }
               }))
           result <- fiber.join
+          _      <- fiber.interrupt
         } yield result
       )
     )


### PR DESCRIPTION
Regards #2436 

@jdegoes @adamgfraser  Hi!
I've started working on #2436. The first idea (and the simplest) that came to my head is just interrupting fiber after `.join`, instead of introducing new method. Thanks to this we can be sure that after running App.main we interrupt fibers.  

Such modification fixes example in the issue, but I don't know whether it's correct solution.
Also I'm not sure whether this shutdown hook is needed then.

What do you think about it?