### PR TITLE
Implement ZIO#fallback

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -253,6 +253,15 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(test, equalTo(10))
       }
     ),
+    suite("fallback")(
+      testM("executes an effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        assertM(ZIO.succeed(1).fallback(2), equalTo(1))
+      },
+      testM("returns the specified value if the effect fails") {
+        assertM(ZIO.fail("fail").fallback(1), equalTo(1))
+      }
+    ),
     suite("filterOrElse")(
       testM("returns checked failure from held value") {
         val goodCase =

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -238,6 +238,15 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(result, equalTo(List("Ensured")))
       }
     ),
+    suite("fallback")(
+      testM("executes an effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        assertM(ZManaged.succeed(1).fallback(2).use(ZIO.succeed), equalTo(1))
+      },
+      testM("returns the specified value if the effect fails") {
+        assertM(ZManaged.fail("fail").fallback(1).use(ZIO.succeed), equalTo(1))
+      }
+    ),
     testM("eventually") {
       def acquire(ref: Ref[Int]) =
         for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -373,6 +373,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self orElse eventually
 
   /**
+   * Executes this effect and returns its value, if it succeeds, but otherwise
+   * returns the specified value.
+   */
+  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): ZIO[R, Nothing, A1] =
+    fold(_ => a, identity)
+
+  /**
    * Dies with specified `Throwable` if the predicate fails.
    */
   final def filterOrDie(p: A => Boolean)(t: => Throwable): ZIO[R, E, A] =

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -283,6 +283,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     }
 
   /**
+   * Executes this effect and returns its value, if it succeeds, but otherwise
+   * returns the specified value.
+   */
+  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A1] =
+    fold(_ => a, identity)
+
+  /**
    * Zips this effect with its environment
    */
   final def first[R1 <: R, A1 >: A]: ZManaged[R1, E, (A1, R1)] = self &&& ZManaged.identity

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -157,7 +157,7 @@ final class STM[+E, +A] private[stm] (
    * Tries this effect first, and if it fails, succeeds with the specified
    * value.
    */
-  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): STM[E, A1] =
+  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): STM[Nothing, A1] =
     fold(_ => a, identity)
 
   /**


### PR DESCRIPTION
Resolves #2448.

I also added `fallback` to `ZManaged` and `STM`. I noticed that the error handling methods in `STM` weren't using `CanFail` so I added that as well.