### PR TITLE
Make STM stack-safe

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -430,9 +430,11 @@ object STMSpec extends ZIOBaseSpec {
         assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))), equalTo(10000))
       },
       testM("long fold chains") {
+        import zio.CanFail.canFail
         assertM(chain(10000)(_.fold(_ => 0, _ + 1)), equalTo(10000))
       },
       testM("long foldM chains") {
+        import zio.CanFail.canFail
         assertM(chain(10000)(_.foldM(_ => STM.succeed(0), a => STM.succeed(a + 1))), equalTo(10000))
       },
       testM("long mapError chains") {

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -393,7 +393,15 @@ object STMSpec extends ZIOBaseSpec {
           sum      <- sumFiber.join
         } yield assert(sum, equalTo(0) || equalTo(2))
       } @@ nonFlaky(5000)
-    }
+    },
+    suite("STM stack safety")(
+      testM("long map chains") {
+        assertM(chain(10000)(_.map(_ + 1)), equalTo(10000))
+      },
+      testM("long flatMap chains") {
+        assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))), equalTo(10000))
+      }
+    )
   )
 
   def unpureSuspend(ms: Long) = STM.succeed {
@@ -456,4 +464,13 @@ object STMSpec extends ZIOBaseSpec {
       _ <- tvar1.set(b)
       _ <- tvar2.set(a)
     } yield ()
+
+  def chain(depth: Int)(next: STM[Nothing, Int] => STM[Nothing, Int]): UIO[Int] = {
+    @annotation.tailrec
+    def loop(n: Int, acc: STM[Nothing, Int]): UIO[Int] =
+      if (n <= 0) acc.commit else loop(n - 1, next(acc))
+
+    loop(depth, STM.succeed(0))
+  }
+
 }

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -407,6 +407,9 @@ object STMSpec extends ZIOBaseSpec {
       testM("long collect chains") {
         assertM(chain(10000)(_.collect { case a: Int => a + 1 }), equalTo(10000))
       },
+      testM("long collectM chains") {
+        assertM(chain(10000)(_.collectM { case a: Int => STM.succeed(a + 1) }), equalTo(10000))
+      },
       testM("long flatMap chains") {
         assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))), equalTo(10000))
       },

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -398,8 +398,43 @@ object STMSpec extends ZIOBaseSpec {
       testM("long map chains") {
         assertM(chain(10000)(_.map(_ + 1)), equalTo(10000))
       },
+      testM("long collect chains") {
+        assertM(chain(10000)(_.collect { case a: Int => a + 1 }), equalTo(10000))
+      },
       testM("long flatMap chains") {
         assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))), equalTo(10000))
+      },
+      testM("long fold chains") {
+        assertM(chain(10000)(_.fold(_ => 0, _ + 1)), equalTo(10000))
+      },
+      testM("long foldM chains") {
+        assertM(chain(10000)(_.foldM(_ => STM.succeed(0), a => STM.succeed(a + 1))), equalTo(10000))
+      },
+      testM("long mapError chains") {
+        def chain(depth: Int): ZIO[Any, Int, Nothing] = {
+          @annotation.tailrec
+          def loop(n: Int, acc: STM[Int, Nothing]): ZIO[Any, Int, Nothing] =
+            if (n <= 0) acc.commit else loop(n - 1, acc.mapError(_ + 1))
+
+          loop(depth, STM.fail(0))
+        }
+
+        assertM(chain(10000).run, fails(equalTo(10000)))
+      },
+      testM("long orElse chains") {
+        def chain(depth: Int): ZIO[Any, Int, Nothing] = {
+          @annotation.tailrec
+          def loop(n: Int, curr: Int, acc: STM[Int, Nothing]): ZIO[Any, Int, Nothing] =
+            if (n <= 0) acc.commit
+            else {
+              val inc = curr + 1
+              loop(n - 1, inc, acc.orElse(STM.fail(inc)))
+            }
+
+          loop(depth, 0, STM.fail(0))
+        }
+
+        assertM(chain(10000).run, fails(equalTo(10000)))
       }
     )
   )
@@ -472,5 +507,4 @@ object STMSpec extends ZIOBaseSpec {
 
     loop(depth, STM.succeed(0))
   }
-
 }

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -128,7 +128,7 @@ final class STM[+E, +A] private[stm] (
       (journal, fiberId, stackSize) =>
         continueWith(journal, fiberId, stackSize) {
           case t @ TRez.Fail(_) => t
-          case TRez.Succeed(a)  => if (pf.isDefinedAt(a)) pf(a).exec(journal, fiberId) else TRez.Retry
+          case TRez.Succeed(a)  => if (pf.isDefinedAt(a)) pf(a).exec(journal, fiberId, stackSize) else TRez.Retry
           case TRez.Retry       => TRez.Retry
         }
     )

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -242,8 +242,8 @@ final class STM[+E, +A] private[stm] (
       }
 
       if (framesCount > STM.MaxFrames) {
-        val ks = new ArrayList[TRez[E, A] => STM[E, A]]()
-        ks.add(STM.done)
+        val ks = new ArrayList[TRez[E, A] => STM[E1, A1]]()
+        ks.add(continueM)
         throw new STM.Resumable(self, ks)
       } else {
         try {
@@ -305,8 +305,8 @@ final class STM[+E, +A] private[stm] (
         val framesCount = stackSize.incrementAndGet()
 
         if (framesCount > STM.MaxFrames) {
-          val ks = new ArrayList[TRez[E, A] => STM[E, A]]()
-          ks.add(STM.done)
+          val ks = new ArrayList[TRez[E, A] => STM[E1, B]]()
+          ks.add(continueM)
           throw new STM.Resumable(self, ks)
         } else {
           try {

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -20,7 +20,7 @@ import java.util.{ HashMap => MutableMap }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 
 import com.github.ghik.silencer.silent
-import zio.{ Fiber, IO, UIO }
+import zio.{ CanFail, Fiber, IO, UIO }
 import zio.internal.{ Platform, Stack, Sync }
 
 import scala.util.{ Failure, Success, Try }

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -298,7 +298,7 @@ final class STM[+E, +A] private[stm] (
   private def continueWith[E1, B](journal: STM.internal.Journal, fiberId: Fiber.Id, stackSize: AtomicLong)(
     continue: TRez[E, A] => TRez[E1, B]
   ): TRez[E1, B] = {
-    val framesCount = stackSize.getAndIncrement()
+    val framesCount = stackSize.incrementAndGet()
 
     if (framesCount > STM.MaxFrames)
       throw new STM.Resumable(self, continue)

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -168,7 +168,7 @@ final class STM[+E, +A] private[stm] (
   final def flatMap[E1 >: E, B](f: A => STM[E1, B]): STM[E1, B] =
     new STM(
       (journal, fiberId, stackSize) => {
-        val count = stackSize.getAndIncrement()
+        val framesCount = stackSize.getAndIncrement()
 
         val continue: TRez[E, A] => TRez[E1, B] = {
           case TRez.Succeed(a)  => f(a).exec(journal, fiberId, stackSize)
@@ -176,7 +176,7 @@ final class STM[+E, +A] private[stm] (
           case TRez.Retry       => TRez.Retry
         }
 
-        if (count > STM.MaxFrames)
+        if (framesCount > STM.MaxFrames)
           throw new STM.Resumable(self, continue)
         else
           continue(self.exec(journal, fiberId, stackSize))
@@ -228,7 +228,7 @@ final class STM[+E, +A] private[stm] (
   final def map[B](f: A => B): STM[E, B] =
     new STM(
       (journal, fiberId, stackSize) => {
-        val count = stackSize.getAndIncrement()
+        val framesCount = stackSize.getAndIncrement()
 
         val continue: TRez[E, A] => TRez[E, B] = {
           case TRez.Succeed(a)  => TRez.Succeed(f(a))
@@ -236,7 +236,7 @@ final class STM[+E, +A] private[stm] (
           case TRez.Retry       => TRez.Retry
         }
 
-        if (count > STM.MaxFrames)
+        if (framesCount > STM.MaxFrames)
           throw new STM.Resumable(self, continue)
         else
           continue(self.exec(journal, fiberId, stackSize))
@@ -249,7 +249,7 @@ final class STM[+E, +A] private[stm] (
   final def mapError[E1](f: E => E1): STM[E1, A] =
     new STM(
       (journal, fiberId, stackSize) => {
-        val count = stackSize.getAndIncrement()
+        val framesCount = stackSize.getAndIncrement()
 
         val continue: TRez[E, A] => TRez[E1, A] = {
           case t @ TRez.Succeed(_) => t
@@ -257,7 +257,7 @@ final class STM[+E, +A] private[stm] (
           case TRez.Retry          => TRez.Retry
         }
 
-        if (count > STM.MaxFrames)
+        if (framesCount > STM.MaxFrames)
           throw new STM.Resumable(self, continue)
         else
           continue(self.exec(journal, fiberId, stackSize))

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -638,8 +638,6 @@ object STM {
       }
     }
 
-    final val succeedUnit: TExit[Nothing, Unit] = TExit.Succeed(())
-
     final def makeTxnId(): Long = txnCounter.incrementAndGet()
 
     private[this] val txnCounter: AtomicLong = new AtomicLong()

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -306,7 +306,7 @@ final class STM[+E, +A] private[stm] (
       continue(self.exec(journal, fiberId, stackSize))
   }
 
-  private def run(journal: STM.internal.Journal, fiberId: Fiber.Id): STM.internal.TRez[E, A] = {
+  private def run(journal: STM.internal.Journal, fiberId: Fiber.Id): TRez[E, A] = {
     type Cont = Any => TRez[Any, Any]
 
     val stackSize = new AtomicLong()

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -72,7 +72,7 @@ import scala.annotation.tailrec
  *
  */
 final class STM[+E, +A] private[stm] (
-  val exec: (STM.internal.Journal, Fiber.Id, AtomicLong) => STM.internal.TRez[E, A]
+  private val exec: (STM.internal.Journal, Fiber.Id, AtomicLong) => STM.internal.TRez[E, A]
 ) extends AnyVal { self =>
   import STM.internal.{ prepareResetJournal, TRez }
 

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -37,7 +37,7 @@ class TRef[A] private (
     new STM((journal, _, _) => {
       val entry = getOrMakeEntry(journal)
 
-      TRez.Succeed(entry.unsafeGet[A])
+      TExit.Succeed(entry.unsafeGet[A])
     })
 
   /**
@@ -66,7 +66,7 @@ class TRef[A] private (
 
       entry.unsafeSet(newValue)
 
-      TRez.Succeed(newValue)
+      TExit.Succeed(newValue)
     })
 
   /**
@@ -87,7 +87,7 @@ class TRef[A] private (
 
       entry.unsafeSet(newValue)
 
-      TRez.Succeed(retValue)
+      TExit.Succeed(retValue)
     })
 
   /**
@@ -122,7 +122,7 @@ object TRef {
 
       journal.put(tref, Entry(tref, true))
 
-      TRez.Succeed(tref)
+      TExit.Succeed(tref)
     })
 
   /**

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -49,7 +49,7 @@ class TRef[A] private (
 
       entry.unsafeSet(newValue)
 
-      succeedUnit
+      TExit.Succeed(())
     })
 
   override final def toString =

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -34,7 +34,7 @@ class TRef[A] private (
    * Retrieves the value of the `TRef`.
    */
   final val get: STM[Nothing, A] =
-    new STM((journal, _) => {
+    new STM((journal, _, _) => {
       val entry = getOrMakeEntry(journal)
 
       TRez.Succeed(entry.unsafeGet[A])
@@ -44,7 +44,7 @@ class TRef[A] private (
    * Sets the value of the `TRef`.
    */
   final def set(newValue: A): STM[Nothing, Unit] =
-    new STM((journal, _) => {
+    new STM((journal, _, _) => {
       val entry = getOrMakeEntry(journal)
 
       entry.unsafeSet(newValue)
@@ -59,7 +59,7 @@ class TRef[A] private (
    * Updates the value of the variable.
    */
   final def update(f: A => A): STM[Nothing, A] =
-    new STM((journal, _) => {
+    new STM((journal, _, _) => {
       val entry = getOrMakeEntry(journal)
 
       val newValue = f(entry.unsafeGet[A])
@@ -80,7 +80,7 @@ class TRef[A] private (
    * value.
    */
   final def modify[B](f: A => (B, A)): STM[Nothing, B] =
-    new STM((journal, _) => {
+    new STM((journal, _, _) => {
       val entry = getOrMakeEntry(journal)
 
       val (retValue, newValue) = f(entry.unsafeGet[A])
@@ -112,7 +112,7 @@ object TRef {
    * Makes a new `TRef` that is initialized to the specified value.
    */
   final def make[A](a: => A): STM[Nothing, TRef[A]] =
-    new STM((journal, _) => {
+    new STM((journal, _, _) => {
       val value     = a
       val versioned = new Versioned(value)
 


### PR DESCRIPTION
The current implementation of STM suffers from stack safety issues. STM stack safety suite was able to verify these on the depth of 10000. 

This PR introduces resumable exceptions as a way to mitigate these problems. 

### Summary

- Operations use stack up to predefined number of frames, after which they're continued via `Resumable`.
- Renamed `TRez` to `TExit`.
- Introduced `STM.done`.