### PR TITLE
Add ZIO#partitionM, validateFirstM, validateM, foldRight

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -779,7 +779,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collect only successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionM(in)(a => UIO.succeed(a))
+          res <- ZIO.partitionM(in)(a => ZIO.effect(a))
         } yield assert(res._1, isEmpty) && assert(res._2, equalTo(in))
       },
       testM("collect only failures") {
@@ -2165,28 +2165,28 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
         val res = ZIO.validateM[Any, Int, Int, Int](in)(a => ZIO.fail(a)).flip
-        assertM(res, hasSize(equalTo(in.length)))
+        assertM(res, equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         val in  = List.range(0, 10)
-        val res = ZIO.validateM(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
-        assertM(res.flip, hasSize(equalTo(in.length / 2)))
+        val res = ZIO.validateM(in)(a => if (a % 2 == 0) ZIO.effect(a) else ZIO.fail(a))
+        assertM(res.flip, equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
         val in  = List.range(0, 10)
-        val res = IO.validateM(in)(a => ZIO.succeed(a))
-        assertM(res, hasSize(equalTo(in.length)))
+        val res = IO.validateM(in)(a => ZIO.effect(a))
+        assertM(res, equalTo(in))
       }
     ),
     suite("validateFirstM")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
         val res = ZIO.validateFirstM[Any, Int, Int, Int](in)(a => ZIO.fail(a)).flip
-        assertM(res, hasSize(equalTo(in.length)))
+        assertM(res, equalTo(in))
       },
       testM("short circuits on first success validation") {
         val in = List.range(1, 10)
-        val f  = (a: Int) => if (a == 5) ZIO.succeed(a) else ZIO.fail(a)
+        val f  = (a: Int) => if (a == 5) ZIO.effect(a) else ZIO.fail(a)
 
         for {
           counter    <- Ref.make(0)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -765,10 +765,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("partitionM")(
       testM("collect only successes") {
-        val in = List.fill(10)(0)
+        val in = List.range(0, 10)
         for {
           res <- ZIO.partitionM(in)(a => UIO.succeed(a))
-        } yield assert(res._1, isEmpty) && assert(res._2, hasSize(equalTo(in.length)))
+        } yield assert(res._1, isEmpty) && assert(res._2, equalTo(List.range(0, 10)))
       },
       testM("collect only failures") {
         val in = List.fill(10)(0)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -320,6 +320,20 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       }
     ),
+    suite("foldRight")(
+      testM("with a successful step function sums the list properly") {
+        checkM(Gen.listOf(Gen.anyInt)) { l =>
+          val res = IO.foldRight(l)(0)((el, acc) => IO.succeed(acc + el))
+          assertM(res, equalTo(l.sum))
+        }
+      },
+      testM("`with a failing step function returns a failed IO") {
+        checkM(Gen.listOf1(Gen.anyInt)) { l =>
+          val res = IO.foldRight(l)(0)((_, _) => IO.fail("fail"))
+          assertM(res.run, fails(equalTo("fail")))
+        }
+      }
+    ),
     suite("foreach")(
       testM("returns the list of results") {
         checkAllM(functionIOGen, listGen) { (f, list) =>

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -252,6 +252,12 @@ object IO {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
+   * @see See [[zio.ZIO.foldRight]]
+   */
+  final def foldRight[E, S, A](in: Iterable[A])(zero: S)(f: (A, S) => IO[E, S]): IO[E, S] =
+    ZIO.foldRight(in)(zero)(f)
+
+  /**
    * @see See [[zio.ZIO.foreach]]
    */
   final def foreach[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[E, List[B]] =

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -480,6 +480,12 @@ object IO {
   final val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
+   * @see See [[zio.ZIO.partitionM]]
+   */
+  final def partitionM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[Nothing, (List[E], List[B])] =
+    ZIO.partitionM(in)(f)
+
+  /**
    * @see See [[zio.ZIO.raceAll]]
    */
   final def raceAll[E, A](io: IO[E, A], ios: Iterable[IO[E, A]]): IO[E, A] = ZIO.raceAll(io, ios)
@@ -628,6 +634,16 @@ object IO {
    * @see See [[zio.ZIO.untraced]]
    */
   final def untraced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.untraced(zio)
+
+  /**
+   * @see See [[zio.ZIO.validateM]]
+   */
+  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[List[E], List[B]] = ZIO.validateM(in)(f)
+
+  /**
+   * @see See [[zio.ZIO.validateFirstM]]
+   */
+  final def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[List[E], B] = ZIO.validateFirstM(in)(f)
 
   /**
    * @see See [[zio.ZIO.when]]

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -482,7 +482,9 @@ object IO {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[Nothing, (List[E], List[B])] =
+  final def partitionM[E, A, B](
+    in: Iterable[A]
+  )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
     ZIO.partitionM(in)(f)
 
   /**
@@ -638,12 +640,14 @@ object IO {
   /**
    * @see See [[zio.ZIO.validateM]]
    */
-  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[List[E], List[B]] = ZIO.validateM(in)(f)
+  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], List[B]] =
+    ZIO.validateM(in)(f)
 
   /**
    * @see See [[zio.ZIO.validateFirstM]]
    */
-  final def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[List[E], B] = ZIO.validateFirstM(in)(f)
+  final def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
+    ZIO.validateFirstM(in)(f)
 
   /**
    * @see See [[zio.ZIO.when]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -505,6 +505,12 @@ object RIO {
   final val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
+   * @see See [[zio.ZIO.partitionM]]
+   */
+  final def partitionM[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+    ZIO.partitionM(in)(f)
+
+  /**
    * @see See [[zio.ZIO.provide]]
    */
   final def provide[R, A](r: R): RIO[R, A] => Task[A] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -507,7 +507,9 @@ object RIO {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+  final def partitionM[R, A, B](
+    in: Iterable[A]
+  )(f: A => RIO[R, B])(implicit ev: CanFail[Throwable]): RIO[Nothing, (List[Throwable], List[B])] =
     ZIO.partitionM(in)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -276,6 +276,12 @@ object RIO {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
+   * @see See [[zio.ZIO.foldRight]]
+   */
+  final def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => RIO[R, S]): RIO[R, S] =
+    ZIO.foldRight(in)(zero)(f)
+
+  /**
    * @see See [[zio.ZIO.foreach]]
    */
   final def foreach[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -252,6 +252,12 @@ object Task {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
+   * @see See [[zio.ZIO.foldRight]]
+   */
+  final def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => Task[S]): Task[S] =
+    ZIO.foldRight(in)(zero)(f)
+
+  /**
    * @see See [[zio.ZIO.foreach]]
    */
   final def foreach[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -475,6 +475,12 @@ object Task {
   final val none: Task[Option[Nothing]] = ZIO.none
 
   /**
+   * @see See [[zio.ZIO.partitionM]]
+   */
+  final def partitionM[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+    ZIO.partitionM(in)(f)
+
+  /**
    * @see See [[zio.ZIO.raceAll]]
    */
   final def raceAll[A](task: Task[A], ios: Iterable[Task[A]]): Task[A] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -477,7 +477,9 @@ object Task {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+  final def partitionM[A, B](
+    in: Iterable[A]
+  )(f: A => Task[B])(implicit ev: CanFail[Throwable]): Task[(List[Throwable], List[B])] =
     ZIO.partitionM(in)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -222,6 +222,12 @@ object UIO {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
+   * @see See [[zio.ZIO.foldRight]]
+   */
+  final def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => UIO[S]): UIO[S] =
+    ZIO.foldRight(in)(zero)(f)
+
+  /**
    * @see See [[zio.ZIO.forkAll]]
    */
   final def forkAll[A](as: Iterable[UIO[A]]): UIO[Fiber[Nothing, List[A]]] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -453,12 +453,6 @@ object URIO {
   final val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
-   * @see [[zio.ZIO.partitionM]]
-   */
-  final def partitionM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): URIO[R, (List[E], List[B])] =
-    ZIO.partitionM(in)(f)
-
-  /**
    * @see [[zio.ZIO.provide]]
    */
   final def provide[R, A](r: R): URIO[R, A] => UIO[A] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -248,6 +248,12 @@ object URIO {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
+   * @see [[zio.ZIO.foldRight]
+   */
+  final def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => URIO[R, S]): URIO[R, S] =
+    ZIO.foldRight(in)(zero)(f)
+
+  /**
    * @see [[zio.ZIO.foreach]]
    */
   final def foreach[R, A, B](in: Iterable[A])(f: A => URIO[R, B]): URIO[R, List[B]] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -447,6 +447,12 @@ object URIO {
   final val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
+   * @see [[zio.ZIO.partitionM]]
+   */
+  final def partitionM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): URIO[R, (List[E], List[B])] =
+    ZIO.partitionM(in)(f)
+
+  /**
    * @see [[zio.ZIO.provide]]
    */
   final def provide[R, A](r: R): URIO[R, A] => UIO[A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2041,6 +2041,8 @@ private[zio] trait ZIOFunctions extends Serializable {
 
   /**
    * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.
+   *
+   * FoldLeft folds an Iterable from Left to Right.
    */
   final def foldLeft[R, E, S, A](
     in: Iterable[A]
@@ -2051,6 +2053,8 @@ private[zio] trait ZIOFunctions extends Serializable {
 
   /**
    * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.
+   *
+   * FoldRight folds an Iterable from Right to Left.
    */
   final def foldRight[R, E, S, A](
     in: Iterable[A]
@@ -2451,14 +2455,13 @@ private[zio] trait ZIOFunctions extends Serializable {
    * Collects all successes and failures in a tupled fashion.
    */
   final def partitionM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, Nothing, (List[E], List[B])] =
-    ZIO
-      .foldRight(in)(List.empty[E] -> List.empty[B])(
-        (x, acc) =>
-          f(x).fold(
-            e => (e :: acc._1, acc._2),
-            a => (acc._1, a :: acc._2)
-          )
-      )
+    ZIO.foldRight(in)(List.empty[E] -> List.empty[B]) {
+      case (a, (es, bs)) =>
+        f(a).fold(
+          e => (e :: es, bs),
+          b => (es, b :: bs)
+        )
+    }
 
   /**
    * Given an environment `R`, returns a function that can supply the

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2040,9 +2040,7 @@ private[zio] trait ZIOFunctions extends Serializable {
     zio.flatMap(ZIO.identityFn)
 
   /**
-   * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.
-   *
-   * FoldLeft folds an Iterable from Left to Right.
+   * Folds an Iterable[A] using an effectual function f, working sequentially from left to right.
    */
   final def foldLeft[R, E, S, A](
     in: Iterable[A]
@@ -2052,9 +2050,7 @@ private[zio] trait ZIOFunctions extends Serializable {
     }
 
   /**
-   * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.
-   *
-   * FoldRight folds an Iterable from Right to Left.
+   * Folds an Iterable[A] using an effectual function f, working sequentially from right to left.
    */
   final def foldRight[R, E, S, A](
     in: Iterable[A]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2450,7 +2450,9 @@ private[zio] trait ZIOFunctions extends Serializable {
    *
    * Collects all successes and failures in a tupled fashion.
    */
-  final def partitionM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, Nothing, (List[E], List[B])] =
+  final def partitionM[R, E, A, B](
+    in: Iterable[A]
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, Nothing, (List[E], List[B])] =
     ZIO.foldRight(in)(List.empty[E] -> List.empty[B]) {
       case (a, (es, bs)) =>
         f(a).fold(
@@ -2680,7 +2682,9 @@ private[zio] trait ZIOFunctions extends Serializable {
    * This combinator is lossy meaning that if there are errors all successes will be lost.
    * To retain all information please use ZIO#partitionM
    */
-  final def validateM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, List[E], List[B]] =
+  final def validateM[R, E, A, B](
+    in: Iterable[A]
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, List[E], List[B]] =
     partitionM(in)(f).flatMap {
       case (es, bs) => if (es.isEmpty) ZIO.succeed(bs) else ZIO.fail(es)
     }
@@ -2688,7 +2692,9 @@ private[zio] trait ZIOFunctions extends Serializable {
   /**
    * Feeds elements of type A to f until it succeeds. Returns first success or the accumulation of all errors.
    */
-  final def validateFirstM[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, List[E], B] =
+  final def validateFirstM[R, E, A, B](
+    in: Iterable[A]
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, List[E], B] =
     ZIO
       .foldLeft(in)(List.empty[E]) {
         case (es, a) =>

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -33,6 +33,9 @@ Code | Rewrite
 `uio.retryOrElseEither(s, f)` | `uio`*
 `uio.tapBoth(f, g)` | `uio.tap(g)`
 `uio.tapError(f)` | `uio`
+`ZIO.partitionM(in)(f)` | `ZIO.foreach(in)(f)`*
+`ZIO.validateM(in)(f)` | `ZIO.foreach(in)(f)`*
+`ZIO.validateFirstM(in)(f)` | `ZIO.foreach(in)(f)`*
 
 **ZManaged**
 

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -77,4 +77,8 @@ Code | Rewrite
 `ustream.either` | `ustream`
 `ustream.orElse(zstream)` | `ustream`
 
-* `either`, `option`, `orElseEither`, and `retryOrElseEither` wrap their results in `Some` or `Right` so after rewriting, code calling these methods can be simplified to accept an `A` rather than an `Option[A]` or `Either[E, A]`.
+(*) Notes:
+
+- `either`, `option`, `orElseEither`, and `retryOrElseEither` wrap their results in `Some` or `Right` so after rewriting, code calling these methods can be simplified to accept an `A` rather than an `Option[A]` or `Either[E, A]`. 
+
+- `partitionM`, `validateM` and `validateFirstM` have error accumulating semantics on either error channel or success channel. After rewrite the error type can be simplified to `E` rather than `List[E]` or the success type `List[B]` instead of `(List[E], List[B])`.


### PR DESCRIPTION
Partially closes #2432 parallel counterparts of this combinator to be tackled on next PR