### PR TITLE
Benchmark STM flatMap chains

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/FlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/FlatMapBenchmark.scala
@@ -1,0 +1,26 @@
+package zio.stm
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class FlatMapBenchmark {
+  @Param(Array("20"))
+  var depth: Int = _
+
+  @Benchmark
+  def deepFlatMap(runtime: Runtime[Any]): BigInt = {
+    def fib(n: Int): STM[Nothing, BigInt] =
+      if (n <= 1) STM.succeed[BigInt](n)
+      else
+        fib(n - 1).flatMap { a =>
+          fib(n - 2).flatMap(b => STM.succeed(a + b))
+        }
+
+    runtime.unsafeRun(fib(depth).commit)
+  }
+}

--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -8,12 +8,12 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-class FlatMapBenchmark {
+class STMFlatMapBenchmark {
   @Param(Array("20"))
   var depth: Int = _
 
   @Benchmark
-  def deepFlatMap(runtime: Runtime[Any]): BigInt = {
+  def deepFlatMap(): BigInt = {
     def fib(n: Int): STM[Nothing, BigInt] =
       if (n <= 1) STM.succeed[BigInt](n)
       else
@@ -21,6 +21,6 @@ class FlatMapBenchmark {
           fib(n - 2).flatMap(b => STM.succeed(a + b))
         }
 
-    runtime.unsafeRun(fib(depth).commit)
+    IOBenchmarks.unsafeRun(fib(depth).commit)
   }
 }


### PR DESCRIPTION
Pre-requisite for #2450 

STM is benchmarked using the following command:

```
jmh:run -i 15 -wi 15 -f1 -t1 .*SingleRefBenchmark.*
```

Running it on the current implementation produces:

```
Result "zio.stm.STMFlatMapBenchmark.deepFlatMap":
   1679.665 ±(99.9%) 2.441 ops/s [Average]
   (min, avg, max) = (1675.412, 1679.665, 1683.691), stdev = 2.283
   CI (99.9%): [1677.224, 1682.106] (assumes normal distribution)

Benchmark                        (depth)   Mode  Cnt     Score   Error  Units
STMFlatMapBenchmark.deepFlatMap       20  thrpt   15  1679.665 ± 2.441  ops/s
```