### PR TITLE
ZSink.collectAllToMap/N now are able to merge values

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -974,12 +974,22 @@ object SinkSpec extends ZIOBaseSpec {
             equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))
           )
         ),
-        testM("collectAllToMapN")(
-          assertM(
-            Stream
-              .range(0, 10)
-              .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _)),
-            equalTo(Map[Int, Int](0 -> 18, 1 -> 12))
+        suite("collectAllToMapN")(
+          testM("stop collecting when map size exceeds limit")(
+            assertM(
+              Stream
+                .range(0, 10)
+                .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _)),
+              equalTo(Map[Int, Int](0 -> 0, 1 -> 1))
+            )
+          ),
+          testM("keep collecting as long as map size does not exceed the limit")(
+            assertM(
+              Stream
+                .range(0, 10)
+                .run(Sink.collectAllToMapN[Int, Int](3)(value => value % 3)(_ + _)),
+              equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))
+            )
           )
         ),
         testM("collectAllWhile")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -945,41 +945,43 @@ object SinkSpec extends ZIOBaseSpec {
         }
       ),
       suite("collectAll")(
-        testM("collectAllN") {
+        testM("collectAllN")(
           assertM(
             Stream[Int](1, 2, 3)
               .run(Sink.collectAllN[Int](2)),
             equalTo(List(1, 2))
           )
-        },
-        testM("collectAllToSet") {
+        ),
+        testM("collectAllToSet")(
           assertM(
             Stream[Int](1, 2, 3, 3, 4)
               .run(Sink.collectAllToSet[Int]),
             equalTo(Set(1, 2, 3, 4))
           )
-        },
-        testM("collectAllToSetN") {
+        ),
+        testM("collectAllToSetN")(
           assertM(
             Stream[Int](1, 2, 1, 2, 3, 3, 4)
               .run(Sink.collectAllToSetN[Int](3)),
             equalTo(Set(1, 2, 3))
           )
-        },
-        testM("collectAllToMap") {
+        ),
+        testM("collectAllToMap")(
           assertM(
-            Stream[Int](1, 2, 3)
-              .run(Sink.collectAllToMap[Int, Int](value => value)),
-            equalTo(Map[Int, Int](1 -> 1, 2 -> 2, 3 -> 3))
+            Stream
+              .range(0, 10)
+              .run(Sink.collectAllToMap[Int, Int](value => value % 3)(_ + _)),
+            equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))
           )
-        },
-        testM("collectAllToMapN") {
+        ),
+        testM("collectAllToMapN")(
           assertM(
-            Stream[Int](1, 2, 3, 4, 5, 6)
-              .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 2)),
-            equalTo(Map[Int, Int](1 -> 1, 0 -> 2))
+            Stream
+              .range(0, 10)
+              .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _)),
+            equalTo(Map[Int, Int](0 -> 18, 1 -> 12))
           )
-        },
+        ),
         testM("collectAllWhile")(
           checkM(Gen.small(pureStreamGen(Gen.anyString, _)), Gen.function(Gen.boolean)) { (s, f) =>
             for {
@@ -990,7 +992,7 @@ object SinkSpec extends ZIOBaseSpec {
         )
       ),
       suite("foldWeighted/foldUntil")(
-        testM("foldWeighted") {
+        testM("foldWeighted")(
           assertM(
             Stream[Long](1, 5, 2, 3)
               .aggregate(
@@ -999,8 +1001,8 @@ object SinkSpec extends ZIOBaseSpec {
               .runCollect,
             equalTo(List(List(1L, 5L), List(2L, 3L)))
           )
-        },
-        testM("foldWeightedDecompose") {
+        ),
+        testM("foldWeightedDecompose")(
           assertM(
             Stream(1, 5, 1)
               .aggregate(
@@ -1014,8 +1016,8 @@ object SinkSpec extends ZIOBaseSpec {
               .runCollect,
             equalTo(List(List(1), List(4), List(1, 1)))
           )
-        },
-        testM("foldWeightedM") {
+        ),
+        testM("foldWeightedM")(
           assertM(
             Stream[Long](1, 5, 2, 3)
               .aggregate(
@@ -1028,8 +1030,8 @@ object SinkSpec extends ZIOBaseSpec {
               .runCollect,
             equalTo(List(List(1L, 5L), List(2L, 3L)))
           )
-        },
-        testM("foldWeightedDecomposeM") {
+        ),
+        testM("foldWeightedDecomposeM")(
           assertM(
             Stream(1, 5, 1)
               .aggregate(
@@ -1046,39 +1048,39 @@ object SinkSpec extends ZIOBaseSpec {
               .runCollect,
             equalTo(List(List(1), List(4), List(1, 1)))
           )
-        },
-        testM("foldUntil") {
+        ),
+        testM("foldUntil")(
           assertM(
             Stream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(Sink.foldUntil(0L, 3)(_ + (_: Long)))
               .runCollect,
             equalTo(List(3L, 3L))
           )
-        },
-        testM("foldUntilM") {
+        ),
+        testM("foldUntilM")(
           assertM(
             Stream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(Sink.foldUntilM(0L, 3)((s, a: Long) => UIO.succeed(s + a)))
               .runCollect,
             equalTo(List(3L, 3L))
           )
-        },
-        testM("fromFunction") {
+        ),
+        testM("fromFunction")(
           assertM(
             Stream(1, 2, 3, 4, 5)
               .aggregate(Sink.fromFunction[Int, String](_.toString))
               .runCollect,
             equalTo(List("1", "2", "3", "4", "5"))
           )
-        },
-        testM("fromFunctionM") {
+        ),
+        testM("fromFunctionM")(
           assertM(
             Stream("1", "2", "3", "4", "5")
               .transduce(Sink.fromFunctionM[Throwable, String, Int](s => Task(s.toInt)))
               .runCollect,
             equalTo(List(1, 2, 3, 4, 5))
           )
-        }
+        )
       ),
       testM("fromOutputStream") {
         import java.io.ByteArrayOutputStream

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -55,14 +55,14 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.collectAllToMap]]
    */
-  final def collectAllToMap[K, A](key: A => K): ZSink[Any, Nothing, Nothing, A, Map[K, A]] =
-    ZSink.collectAllToMap(key)
+  final def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, Nothing, A, Map[K, A]] =
+    ZSink.collectAllToMap(key)(f)
 
   /**
    * see [[ZSink.collectAllToMapN]]
    */
-  final def collectAllToMapN[K, A](n: Long)(key: A => K): ZSink[Any, Nothing, A, A, Map[K, A]] =
-    ZSink.collectAllToMapN(n)(key)
+  final def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, A, A, Map[K, A]] =
+    ZSink.collectAllToMapN(n)(key)(f)
 
   /**
    * see [[ZSink.collectAllWhile]]

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1236,23 +1236,34 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink accumulating incoming values into a map.
    * Key of each element is determined by supplied function.
+   * Combines elements with same key with supplied function f.
+   *
    */
-  final def collectAllToMap[K, A](key: A => K): ZSink[Any, Nothing, Nothing, A, Map[K, A]] =
-    foldLeft[A, Map[K, A]](Map.empty[K, A])((map, element) => map + (key(element) -> element))
+  final def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): Sink[Nothing, Nothing, A, Map[K, A]] =
+    foldLeft[A, Map[K, A]](Map.empty)((curMap, a) => {
+      val k = key(a)
+      curMap.get(k).fold(curMap.updated(k, a))(v => curMap.updated(k, f(v, a)))
+    })
 
   /**
    * Creates a sink accumulating incoming values into a map of maximum size `n`.
    * Key of each element is determined by supplied function.
+   *
+   * Combines elements with same key with supplied function f.
    */
-  final def collectAllToMapN[K, A](n: Long)(key: A => K): Sink[Nothing, A, A, Map[K, A]] = {
-    type State = (Map[K, A], Boolean)
-    def f(state: State, a: A): (State, Chunk[A]) = {
-      val newMap = state._1 + (key(a) -> a)
-      if (newMap.size > n) ((state._1, false), Chunk.single(a))
-      else if (newMap.size == n) ((newMap, false), Chunk.empty)
-      else ((newMap, true), Chunk.empty)
+  final def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): Sink[Nothing, A, A, Map[K, A]] = {
+
+    def inner(curMap: Map[K, A], a: A): (Map[K, A], Chunk[A]) = {
+      val k = key(a)
+      curMap
+        .get(k)
+        .fold(
+          if (curMap.size >= n) (curMap, Chunk.single(a))
+          else (curMap.updated(k, a), Chunk.empty)
+        )(v => (curMap.updated(k, f(v, a)), Chunk.empty))
+
     }
-    fold[A, A, State]((Map.empty, true))(_._2)(f).map(_._1)
+    fold[A, A, Map[K, A]](Map.empty)(_ => true)(inner)
   }
 
   /**


### PR DESCRIPTION
Unlike before, collectAllToMap now receives a merging function. This means that now collectAllToMapN keeps consuming elements discarding those who would see its map grow over the size limit.

In this context I changed max size constraint on Stream#range in order to make it behave similarly to standard library Range.

closes #2454
