### PR TITLE
Fix ZSink#zipPar's continuing conditions

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -811,6 +811,21 @@ object SinkSpec extends ZIOBaseSpec {
           val sink1 = sinkWithLeftover(3, 1, -42)
           val sink2 = sinkWithLeftover(2, 4, -42)
           ZipParLaws.laws(zipParLawsStream, sink1, sink2)
+        },
+        testM("zipPar should continue only if both continue") {
+          val sink1          = ZSink.collectAllN[Int](3)
+          val sink2          = ZSink.collectAllN[Int](2)
+          val expectedResult = List(List(1, 2), List(3, 4), List(5, 6))
+
+          Stream(1, 2, 3, 4, 5, 6)
+            .aggregate(sink1 zipPar sink2)
+            .runCollect
+            .map { result =>
+              val (l, r) = result.unzip
+
+              assert(l, equalTo(expectedResult) ?? "Left sink result") &&
+              assert(r, equalTo(expectedResult) ?? "Right sink result")
+            }
         }
       ),
       suite("zipRight (*>)")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -2,7 +2,7 @@ package zio.stream
 
 import zio.{ Chunk, IO, UIO }
 import zio.test.{ assert, Gen, GenZIO, TestResult }
-import zio.test.Assertion.{ equalTo, isLeft, isRight, isTrue }
+import zio.test.Assertion.{ equalTo, isRight, isTrue }
 
 trait SinkUtils {
   def initErrorSink = new ZSink[Any, String, Int, Int, Int] {
@@ -59,22 +59,6 @@ trait SinkUtils {
     sink.initial >>= (sink.step(_, a)) >>= sink.extract
 
   object ZipParLaws {
-    def coherence[A, B, C](
-      s: Stream[String, A],
-      sink1: ZSink[Any, String, A, A, B],
-      sink2: ZSink[Any, String, A, A, C]
-    ) =
-      for {
-        zb  <- s.run(sink1).either
-        zc  <- s.run(sink2).either
-        zbc <- s.run(sink1.zipPar(sink2)).either
-      } yield {
-        zbc match {
-          case Left(e)       => assert(zb, isLeft(equalTo(e))) || assert(zc, isLeft(equalTo(e)))
-          case Right((b, c)) => assert(zb, isRight(equalTo(b))) && assert(zc, isRight(equalTo(c)))
-        }
-      }
-
     def swap[A, B, C](
       s: Stream[String, A],
       sink1: ZSink[Any, String, A, A, B],
@@ -113,8 +97,8 @@ trait SinkUtils {
       sink1: ZSink[Any, String, A, A, B],
       sink2: ZSink[Any, String, A, A, C]
     ) =
-      (coherence(s, sink1, sink2) <*> remainders(s, sink1, sink2) <*> swap(s, sink1, sink2)).map {
-        case ((x, y), z) => x && y && z
+      (remainders(s, sink1, sink2) <*> swap(s, sink1, sink2)).map {
+        case (x, y) => x && y
       }
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -680,10 +680,8 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
       def cont(state: State) =
         state match {
-          case (Left(s1), Left(s2)) => self.cont(s1) || that.cont(s2)
-          case (Left(s), Right(_))  => self.cont(s)
-          case (Right(_), Left(s))  => that.cont(s)
-          case (Right(_), Right(_)) => false
+          case (Left(s1), Left(s2)) => self.cont(s1) && that.cont(s2)
+          case _                    => false
         }
     }
 


### PR DESCRIPTION
Fixes one part of #2455.

In retrospect, the coherence law is incorrect, so I removed it; it was the only test that failed.

@vasilmkd 