### PR TITLE
Fixes ZStream#fromPull and adds ZStream#repeatPull.

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -257,6 +257,12 @@ object Stream extends Serializable {
     ZStream.fromQueueWithShutdown(queue)
 
   /**
+   * See [[ZStream.repeatPull]]
+   */
+  final def repeatPull[E, A](pull: Pull[Any, E, A]): Stream[E, A] =
+    ZStream.repeatPull(pull)
+
+  /**
    * See [[ZStream.halt]]
    */
   final def halt[E](cause: Cause[E]): Stream[E, Nothing] = fromEffect(ZIO.halt(cause))

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -183,10 +183,10 @@ object Stream extends Serializable {
     ZStream.fromEffect(fa)
 
   /**
-   * See [[ZStream.fromPull]]
+   * See [[ZStream.fromEffectOption]]
    */
-  final def fromPull[E, A](pull: Pull[Any, E, A]): Stream[E, A] =
-    ZStream.fromPull(pull)
+  final def fromEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
+    ZStream.fromEffectOption(fa)
 
   /**
    * See [[ZStream.paginate]]
@@ -213,6 +213,12 @@ object Stream extends Serializable {
     fa: IO[E, A],
     schedule: Schedule[Any, Unit, Any]
   ): ZStream[Clock, E, A] = ZStream.repeatEffectWith(fa, schedule)
+
+  /**
+   * See [[ZStream.repeatEffectOption]]
+   */
+  final def repeatEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
+    ZStream.repeatEffectOption(fa)
 
   /**
    * See [[ZStream.fromIterable]]
@@ -255,12 +261,6 @@ object Stream extends Serializable {
    */
   final def fromQueueWithShutdown[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
     ZStream.fromQueueWithShutdown(queue)
-
-  /**
-   * See [[ZStream.repeatPull]]
-   */
-  final def repeatPull[E, A](pull: Pull[Any, E, A]): Stream[E, A] =
-    ZStream.repeatPull(pull)
 
   /**
    * See [[ZStream.halt]]


### PR DESCRIPTION
Fixes behaviour of ZStream#fromPull to be the same as fromEffect:
- It either produces one value or no value

Adds ZStream#repeatPull which was the old ZStream#fromPull which:
- Emits values until it fails with None

Adds tests to make sure the behaviour is correct

Closes #2481