### PR TITLE
ZIO Test: Fix Bug in Gen#int

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -170,6 +170,10 @@ object GenSpec extends ZIOBaseSpec {
       testM("int generates values in range") {
         checkSample(smallInt)(forall(isGreaterThanEqualTo(-10) && isLessThanEqualTo(10)))
       },
+      testM("int is safe for ranges greater than Int.MaxValue") {
+        val gen = Gen.int(0, Int.MaxValue)
+        checkSample(gen)(forall(isGreaterThanEqualTo(0) && isLessThanEqualTo(Int.MaxValue)))
+      },
       testM("large generates sizes in range") {
         val gen = Gen.large(Gen.listOfN(_)(Gen.int(-10, 10)))
         checkSample(gen)(forall(isLessThanEqualTo(100)), _.map(_.length))


### PR DESCRIPTION
Fixes #2444 

The issue was that `Gen.int` calls `Gen.integral`, which generates a random number in the specified range, but when the range is greater than `Int.MaxValue` can lead to overflow.

This PR fixes the issue with `Gen.int` and also removes `Gen.integral`. I think `Integral` ends up being a leaky abstraction because while it guarantees that we can convert a value to or from an `Int`, it doesn't give us a guarantee that the type is "small" enough for `nextInt`, or even `nextLong`, to generate all the values in that range. We could do something fancier to generate multiple random numbers and compose them if necessary but I don't this abstraction is buying us much relative to just having generators for concrete numeric types.