### PR TITLE
Make Type Signature of ValidateM More Precise

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -640,7 +640,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.validateM]]
    */
-  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], List[B]] =
+  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
     ZIO.validateM(in)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2691,9 +2691,10 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def validateM[R, E, A, B](
     in: Iterable[A]
-  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, List[E], List[B]] =
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, ::[E], List[B]] =
     partitionM(in)(f).flatMap {
-      case (es, bs) => if (es.isEmpty) ZIO.succeed(bs) else ZIO.fail(es)
+      case (e :: es, _) => ZIO.fail(::(e, es))
+      case (_, bs)      => ZIO.succeed(bs)
     }
 
   /**


### PR DESCRIPTION
We know that if validateM failed there was at least one failure, so we can return a nonempty list to express this in the type signature.