### PR TITLE
Implement Ignored, Repeated, and Retried Test Annotations

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -71,11 +71,11 @@ object ZTestFrameworkSpec {
           messages.mkString.split("\n").dropRight(1).mkString("\n"),
           List(
             s"${reset("info:")} ${red("- some suite")}",
-            s"${reset("info:")} ${"ignored: 1"}",         
+            s"${reset("info:")} ${"ignored: 1"}",
             s"${reset("info:")}   ${red("- failing test")}",
             s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
             s"${reset("info:")}   ${green("+")} passing test",
-            s"${reset("info:")}   ${"ignored: 1"}",     
+            s"${reset("info:")}   ${"ignored: 1"}"
           ).mkString("\n")
         )
       )

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -70,12 +70,10 @@ object ZTestFrameworkSpec {
           "logged messages",
           messages.mkString.split("\n").dropRight(1).mkString("\n"),
           List(
-            s"${reset("info:")} ${red("- some suite")}",
-            s"${reset("info:")} ${"ignored: 1"}",
+            s"${reset("info:")} ${red("- some suite")} - ignored: 1",
             s"${reset("info:")}   ${red("- failing test")}",
             s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
-            s"${reset("info:")}   ${green("+")} passing test",
-            s"${reset("info:")}   ${"ignored: 1"}"
+            s"${reset("info:")}   ${green("+")} passing test"
           ).mkString("\n")
         )
       )

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -71,9 +71,11 @@ object ZTestFrameworkSpec {
           messages.mkString.split("\n").dropRight(1).mkString("\n"),
           List(
             s"${reset("info:")} ${red("- some suite")}",
+            s"${reset("info:")} ${"ignored: 1"}",         
             s"${reset("info:")}   ${red("- failing test")}",
             s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
-            s"${reset("info:")}   ${green("+")} passing test"
+            s"${reset("info:")}   ${green("+")} passing test",
+            s"${reset("info:")}   ${"ignored: 1"}",     
           ).mkString("\n")
         )
       )

--- a/test-tests/shared/src/test/scala/zio/test/TestAnnotationMapSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAnnotationMapSpec.scala
@@ -1,0 +1,14 @@
+package zio.test
+
+import zio.test.Assertion._
+
+object TestAnnotationMapSpec extends DefaultRunnableSpec {
+
+  def spec = suite("TestAnnotationMapSpec")(
+    test("get retrieves the annotation of the specified type") {
+      val annotations = TestAnnotationMap.empty.annotate(TestAnnotation.ignored, 1)
+      assert(annotations.get(TestAnnotation.ignored), equalTo(1)) &&
+      assert(annotations.get(TestAnnotation.retried), equalTo(0))
+    }
+  )
+}

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -30,10 +30,11 @@ final class TestAnnotation[V] private (
   private val classTag: ClassTag[V]
 ) {
   override final def equals(that: Any): Boolean = that match {
-    case that: TestAnnotation[_] => (identifier, classTag) == ((identifier, that.classTag))
+    case that: TestAnnotation[_] => (identifier, classTag) == ((that.identifier, that.classTag))
   }
 
-  override final lazy val hashCode = (identifier, classTag).hashCode
+  override final lazy val hashCode =
+    (identifier, classTag).hashCode
 }
 object TestAnnotation {
 
@@ -45,12 +46,18 @@ object TestAnnotation {
   /**
    * An annotation which counts ignored tests.
    */
-  val ignored: TestAnnotation[Int] =
+  final val ignored: TestAnnotation[Int] =
     TestAnnotation("ignored", 0, _ + _)
+
+  /**
+   * An annotation which counts retried tests.
+   */
+  final val retried: TestAnnotation[Int] =
+    TestAnnotation("retried", 0, _ + _)
 
   /**
    * An annotation for timing.
    */
-  val timing: TestAnnotation[Duration] =
+  final val timing: TestAnnotation[Duration] =
     TestAnnotation("timing", Duration.Zero, _ + _)
 }

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -50,6 +50,12 @@ object TestAnnotation {
     TestAnnotation("ignored", 0, _ + _)
 
   /**
+   * An annotation which counts repeated tests.
+   */
+  final val repeated: TestAnnotation[Int] =
+    TestAnnotation("repeated", 0, _ + _)
+
+  /**
    * An annotation which counts retried tests.
    */
   final val retried: TestAnnotation[Int] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -43,6 +43,12 @@ object TestAnnotation {
     new TestAnnotation(identifier, initial, combine, classTag)
 
   /**
+   * An annotation which counts ignored tests.
+   */
+  val ignored: TestAnnotation[Int] =
+    TestAnnotation("ignored", 0, _ + _)
+
+  /**
    * An annotation for timing.
    */
   val timing: TestAnnotation[Duration] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -16,10 +16,13 @@
 
 package zio.test
 
+import scala.collection.immutable.Map
+
 /**
  * An annotation map keeps track of annotations of different types.
  */
 class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRef]) { self =>
+
   final def ++(that: TestAnnotationMap): TestAnnotationMap =
     new TestAnnotationMap((self.map.toVector ++ that.map.toVector).foldLeft[Map[TestAnnotation[Any], AnyRef]](Map()) {
       case (acc, (key, value)) =>
@@ -30,7 +33,7 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
    * Appends the specified annotation to the annotation map.
    */
   final def annotate[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
-    update[V](key, key.combine(_, value))
+    update(key, key.combine(_, value))
 
   /**
    * Retrieves the annotation of the specified type, or its default value if there is none.
@@ -41,12 +44,15 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
   private final def overwrite[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
     new TestAnnotationMap(map + (key.asInstanceOf[TestAnnotation[Any]] -> value.asInstanceOf[AnyRef]))
 
-  private final def update[V](key: TestAnnotation[V], f: V => V): TestAnnotationMap = overwrite(key, f(get(key)))
+  private final def update[V](key: TestAnnotation[V], f: V => V): TestAnnotationMap =
+    overwrite(key, f(get(key)))
 }
+
 object TestAnnotationMap {
 
   /**
    * An empty annotation map.
    */
-  val empty = new TestAnnotationMap(Map())
+  val empty: TestAnnotationMap =
+    new TestAnnotationMap(Map())
 }

--- a/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationMap.scala
@@ -33,7 +33,7 @@ class TestAnnotationMap private (private val map: Map[TestAnnotation[Any], AnyRe
    * Appends the specified annotation to the annotation map.
    */
   final def annotate[V](key: TestAnnotation[V], value: V): TestAnnotationMap =
-    update(key, key.combine(_, value))
+    update[V](key, key.combine(_, value))
 
   /**
    * Retrieves the annotation of the specified type, or its default value if there is none.

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,17 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   final lazy val default: TestAnnotationRenderer =
-    timed
+    CompositeRenderer(Vector(ignored, timed))
+
+  /**
+   * A test annotation renderer that renders the number of ignored tests.
+   */
+  final val ignored: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.ignored) {
+      case (child :: _) =>
+        if (child == 0) None
+        else Some(s"ignored: $child")
+    }
 
   /**
    * A test annotation renderer that does not render any test annotations.

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,7 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   final lazy val default: TestAnnotationRenderer =
-    CompositeRenderer(Vector(ignored, timed))
+    CompositeRenderer(Vector(ignored, retried, timed))
 
   /**
    * A test annotation renderer that renders the number of ignored tests.
@@ -82,6 +82,17 @@ object TestAnnotationRenderer {
       case (child :: _) =>
         if (child == 0) None
         else Some(s"ignored: $child")
+    }
+
+  /**
+   * A test annotation renderer that renders how many times a test had to be
+   * retried before it succeeded.
+   */
+  final val retried: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.retried) {
+      case (child :: _) =>
+        if (child == 0) None
+        else Some(s"retried: $child")
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,7 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   final lazy val default: TestAnnotationRenderer =
-    CompositeRenderer(Vector(ignored, retried, timed))
+    CompositeRenderer(Vector(ignored, repeated, retried, timed))
 
   /**
    * A test annotation renderer that renders the number of ignored tests.
@@ -82,6 +82,17 @@ object TestAnnotationRenderer {
       case (child :: _) =>
         if (child == 0) None
         else Some(s"ignored: $child")
+    }
+
+  /**
+   * A test annotation renderer that renders how many times a test was
+   * repeated.
+   */
+  final val repeated: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.repeated) {
+      case (child :: _) =>
+        if (child == 0) None
+        else Some(s"repeated: $child")
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -105,9 +105,9 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that marks tests as ignored.
    */
-  val ignore: TestAspectPoly =
-    new TestAspectPoly {
-      def some[R, E, S, L](predicate: L => Boolean, spec: ZSpec[R, E, L, S]): ZSpec[R, E, L, S] =
+  val ignore: TestAspectAtLeastR[Annotations] =
+    new TestAspectAtLeastR[Annotations] {
+      def some[R <: Annotations, E, S, L](predicate: L => Boolean, spec: ZSpec[R, E, L, S]): ZSpec[R, E, L, S] =
         spec.when(false)
     }
 
@@ -193,7 +193,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that only runs tests on Dotty.
    */
-  val dottyOnly: TestAspectPoly =
+  val dottyOnly: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isDotty) identity else ignore
 
   /**
@@ -212,25 +212,25 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that runs tests on all versions except Dotty.
    */
-  val exceptDotty: TestAspectPoly =
+  val exceptDotty: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isDotty) ignore else identity
 
   /**
    * An aspect that runs tests on all platforms except ScalaJS.
    */
-  val exceptJS: TestAspectPoly =
+  val exceptJS: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJS) ignore else identity
 
   /**
    * An aspect that runs tests on all platforms except the JVM.
    */
-  val exceptJVM: TestAspectPoly =
+  val exceptJVM: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJVM) ignore else identity
 
   /**
    * An aspect that runs tests on all versions except Scala2.
    */
-  val exceptScala2: TestAspectPoly =
+  val exceptScala2: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isScala2) ignore else identity
 
   /**
@@ -297,9 +297,12 @@ object TestAspect extends TimeoutVariants {
    * An aspect that only runs a test if the specified environment variable
    * satisfies the specified assertion.
    */
-  def ifEnv(env: String, assertion: Assertion[String]): TestAspectAtLeastR[Live[System]] =
-    new TestAspectAtLeastR[Live[System]] {
-      def some[R <: Live[System], E, S, L](predicate: L => Boolean, spec: ZSpec[R, E, L, S]): ZSpec[R, E, L, S] =
+  def ifEnv(env: String, assertion: Assertion[String]): TestAspectAtLeastR[Live[System] with Annotations] =
+    new TestAspectAtLeastR[Live[System] with Annotations] {
+      def some[R <: Live[System] with Annotations, E, S, L](
+        predicate: L => Boolean,
+        spec: ZSpec[R, E, L, S]
+      ): ZSpec[R, E, L, S] =
         spec.whenM(Live.live(system.env(env)).orDie.flatMap(_.fold(ZIO.succeed(false))(assertion.test)))
     }
 
@@ -307,7 +310,7 @@ object TestAspect extends TimeoutVariants {
    * As aspect that only runs a test if the specified environment variable is
    * set.
    */
-  def ifEnvSet(env: String): TestAspectAtLeastR[Live[System]] =
+  def ifEnvSet(env: String): TestAspectAtLeastR[Live[System] with Annotations] =
     ifEnv(env, Assertion.anything)
 
   /**
@@ -317,16 +320,19 @@ object TestAspect extends TimeoutVariants {
   def ifProp(
     prop: String,
     assertion: Assertion[String]
-  ): TestAspectAtLeastR[Live[System]] =
-    new TestAspectAtLeastR[Live[System]] {
-      def some[R <: Live[System], E, S, L](predicate: L => Boolean, spec: ZSpec[R, E, L, S]): ZSpec[R, E, L, S] =
+  ): TestAspectAtLeastR[Live[System] with Annotations] =
+    new TestAspectAtLeastR[Live[System] with Annotations] {
+      def some[R <: Live[System] with Annotations, E, S, L](
+        predicate: L => Boolean,
+        spec: ZSpec[R, E, L, S]
+      ): ZSpec[R, E, L, S] =
         spec.whenM(Live.live(system.property(prop)).orDie.flatMap(_.fold(ZIO.succeed(false))(assertion.test)))
     }
 
   /**
    * As aspect that only runs a test if the specified Java property is set.
    */
-  def ifPropSet(prop: String): TestAspectAtLeastR[Live[System]] =
+  def ifPropSet(prop: String): TestAspectAtLeastR[Live[System] with Annotations] =
     ifProp(prop, Assertion.anything)
 
   /**
@@ -340,7 +346,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that only runs tests on ScalaJS.
    */
-  val jsOnly: TestAspectPoly =
+  val jsOnly: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJS) identity else ignore
 
   /**
@@ -354,7 +360,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that only runs tests on the JVM.
    */
-  val jvmOnly: TestAspectPoly =
+  val jvmOnly: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJVM) identity else ignore
 
   /**
@@ -466,7 +472,7 @@ object TestAspect extends TimeoutVariants {
   /**
    * An aspect that only runs tests on Scala 2.
    */
-  val scala2Only: TestAspectPoly =
+  val scala2Only: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isScala2) identity else ignore
 
   /**


### PR DESCRIPTION
Resolves #2498.

A couple of things for us to think about:

1. Right now we are rendering the number of ignored tests but we aren't rendering the labels for the ignored tests. To do that we would need to modify the `DefaultTestRenderer` to render labels for ignored tests with something analogous to the green plus or red minus for passed or failed tests. Not sure if this is a good or a bad thing. On the one hand you might want to know which tests were ignored. On the other hand it makes it very clear where tests were ignored.
2. This works very naturally when we ignore individual tests and then the suite level number of ignored tests is just a natural buildup from that. But if we ignore a whole suite the number of ignored tests in that suite is going to be zero because we are never executing the effect of creating the specs in the suite. I think this is a natural implication of effectual specs but something we should be aware of.

```
[info] + TestAspectSpec
[info] ignored: 8
[info]   + around evaluates tests inside context of Managed
[info]   + dotty applies test aspect only on Dotty
[info]   + dottyOnly runs tests only on Dotty
[info]   + exceptDotty runs tests on all versions except Dotty
[info]   + exceptJS runs tests on all platforms except ScalaJS
[info]   ignored: 1
[info]   ignored: 1
[info]   + failure makes a test pass if the result was a failure
[info]   + failure makes a test pass if it died with a specified failure
[info]   + failure does not make a test pass if it failed with an unexpected exception
[info]   + failure does not make a test pass if the specified failure does not match
[info]   + failure makes tests pass on any assertion failure
[info]   + failure makes tests pass on an expected assertion failure
[info]   + flaky retries a test that fails
[info]   + flaky retries a test that dies
[info]   + flaky retries a test with a limit
[info]   + ifEnv runs a test if environment variable satisfies assertion
[info]   ignored: 1
[info]   ignored: 1
[info]   + ifEnvSet runs a test if environment variable is set
[info]   ignored: 1
[info]   + ifProp runs a test if property satisfies assertion
[info]   ignored: 1
[info]   ignored: 1
[info]   + ifPropSet runs a test if property is set
[info]   ignored: 1
[info]   + js applies test aspect only on ScalaJS
[info]   + jsOnly runs tests only on ScalaJS
[info]   + jvm applies test aspect only on jvm
[info]   + jvmOnly runs tests only on the JVM
[info]   + retry retries failed tests according to a schedule
[info]   + scala2 applies test aspect only on Scala 2
[info]   + scala2Only runs tests only on Scala 2
[info]   + timeout makes tests fail after given duration
[info]   + timeout reports problem with interruption
```