### PR TITLE
fix: Normalize final functions.

### DIFF
--- a/core/js/src/main/scala/zio/internal/OneShot.scala
+++ b/core/js/src/main/scala/zio/internal/OneShot.scala
@@ -20,13 +20,13 @@ package zio.internal
  * A variable that can be set a single time. The synchronous,
  * effectful equivalent of `Promise`.
  */
-private[zio] class OneShot[A] private (var value: A) {
+private[zio] final class OneShot[A] private (var value: A) {
 
   /**
    * Sets the variable to the value. The behavior of this function
    * is undefined if the variable has already been set.
    */
-  final def set(v: A): Unit = {
+  def set(v: A): Unit = {
     if (v == null) throw new Error("Defect: OneShot variable cannot be set to null value")
     if (value != null) throw new Error("Defect: OneShot variable being set twice")
     value = v
@@ -35,12 +35,12 @@ private[zio] class OneShot[A] private (var value: A) {
   /**
    * Determines if the variable has been set.
    */
-  final def isSet: Boolean = value != null
+  def isSet: Boolean = value != null
 
   /**
    * Retrieves the value of the variable, blocking if necessary.
    */
-  final def get(): A = {
+  def get(): A = {
     if (value == null) throw new Error("Cannot block for result to be set in JavaScript")
     value
   }
@@ -51,5 +51,5 @@ object OneShot {
   /**
    * Makes a new (unset) variable.
    */
-  final def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
+  def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
 }

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -26,9 +26,9 @@ object PlatformLive {
   lazy val Default = Global
   lazy val Global  = fromExecutionContext(ExecutionContext.global)
 
-  final def makeDefault(): Platform = fromExecutionContext(global)
+  def makeDefault(): Platform = fromExecutionContext(global)
 
-  final def fromExecutor(executor0: Executor): Platform =
+  def fromExecutor(executor0: Executor): Platform =
     new Platform {
       val executor = executor0
 
@@ -46,6 +46,6 @@ object PlatformLive {
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)
     }
 
-  final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
+  def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ec))
 }

--- a/core/js/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
+++ b/core/js/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference 
 
 import zio.internal.MutableConcurrentQueue
 
-class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+final class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   private[this] final val ref = new AtomicReference[AnyRef]()
 
   private[this] final val headCounter   = new AtomicLong(0L)
@@ -33,13 +33,13 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
 
   override final val capacity: Int = 1
 
-  override final def dequeuedCount(): Long = headCounter.get()
-  override final def enqueuedCount(): Long = tailCounter.get()
+  override def dequeuedCount(): Long = headCounter.get()
+  override def enqueuedCount(): Long = tailCounter.get()
 
-  override final def isEmpty(): Boolean = ref.get() == null
-  override final def isFull(): Boolean  = !isEmpty()
+  override def isEmpty(): Boolean = ref.get() == null
+  override def isFull(): Boolean  = !isEmpty()
 
-  override final def offer(a: A): Boolean = {
+  override def offer(a: A): Boolean = {
     assert(a != null)
 
     var res     = false
@@ -65,7 +65,7 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     res
   }
 
-  override final def poll(default: A): A = {
+  override def poll(default: A): A = {
     var res     = default
     var looping = true
 
@@ -91,5 +91,5 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     res
   }
 
-  override final def size(): Int = if (isEmpty()) 0 else 1
+  override def size(): Int = if (isEmpty()) 0 else 1
 }

--- a/core/js/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/js/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -68,7 +68,7 @@ private[scheduler] object internal {
 }
 
 trait SchedulerLive extends Scheduler {
-  val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
+  final val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
     val scheduler = ZIO.succeed(internal.GlobalScheduler)
   }
 }

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -31,37 +31,37 @@ object ZEnv {
    *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+  final def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
     mapAll(mapClock = f)
 
   /**
    * Map the [[console.Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+  final def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     mapAll(mapConsole = f)
 
   /**
    * Map the [[system.System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+  final def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     mapAll(mapSystem = f)
 
   /**
    * Map the [[random.Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+  final def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     mapAll(mapRandom = f)
 
   /**
    * Map the [[blocking.Blocking.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapBlocking(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
+  final def mapBlocking(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
     mapAll(mapBlocking = f)
 
   /**
    * Map all components of a ZEnv individually.
    */
-  def mapAll(
+  final def mapAll(
     mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
     mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
     mapSystem: System.Service[Any] => System.Service[Any] = identity,

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -31,37 +31,37 @@ object ZEnv {
    *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  final def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+  def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
     mapAll(mapClock = f)
 
   /**
    * Map the [[console.Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+  def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     mapAll(mapConsole = f)
 
   /**
    * Map the [[system.System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+  def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     mapAll(mapSystem = f)
 
   /**
    * Map the [[random.Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+  def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     mapAll(mapRandom = f)
 
   /**
    * Map the [[blocking.Blocking.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapBlocking(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
+  def mapBlocking(f: Blocking.Service[Any] => Blocking.Service[Any]): ZEnv => ZEnv =
     mapAll(mapBlocking = f)
 
   /**
    * Map all components of a ZEnv individually.
    */
-  final def mapAll(
+  def mapAll(
     mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
     mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
     mapSystem: System.Service[Any] => System.Service[Any] = identity,

--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -23,7 +23,7 @@ import zio.internal.{ Executor, NamedThreadFactory }
 import zio.{ IO, UIO, ZIO }
 
 private[blocking] object internal {
-  private[blocking] val blockingExecutor0 =
+  private[blocking] final val blockingExecutor0 =
     Executor.fromThreadPoolExecutor(_ => Int.MaxValue) {
       val corePoolSize  = 0
       val maxPoolSize   = Int.MaxValue
@@ -65,7 +65,7 @@ object Blocking extends Serializable {
     /**
      * Locks the specified effect to the blocking thread pool.
      */
-    def blocking[R1 <: R, E, A](zio: ZIO[R1, E, A]): ZIO[R1, E, A] =
+    final def blocking[R1 <: R, E, A](zio: ZIO[R1, E, A]): ZIO[R1, E, A] =
       blockingExecutor.flatMap(exec => zio.lock(exec))
 
     /**
@@ -74,7 +74,7 @@ object Blocking extends Serializable {
      * If the returned `ZIO` is interrupted, the blocked thread running the synchronous effect
      * will be interrupted via `Thread.interrupt`.
      */
-    def effectBlocking[A](effect: => A): ZIO[R, Throwable, A] =
+    final def effectBlocking[A](effect: => A): ZIO[R, Throwable, A] =
       // Reference user's lambda for the tracer
       ZIOFn.recordTrace(() => effect) {
         ZIO.effectSuspendTotal {
@@ -146,12 +146,12 @@ object Blocking extends Serializable {
      * If the returned `ZIO` is interrupted, the blocked thread running the synchronous effect
      * will be interrupted via the cancel effect.
      */
-    def effectBlockingCancelable[A](effect: => A)(cancel: UIO[Unit]): ZIO[R, Throwable, A] =
+    final def effectBlockingCancelable[A](effect: => A)(cancel: UIO[Unit]): ZIO[R, Throwable, A] =
       blocking(ZIO.effect(effect)).fork.flatMap(_.join).onInterrupt(cancel)
   }
 
   trait Live extends Blocking {
-    val blocking: Service[Any] = new Service[Any] {
+    final val blocking: Service[Any] = new Service[Any] {
       val blockingExecutor: UIO[Executor] = ZIO.succeed(internal.blockingExecutor0)
     }
   }

--- a/core/jvm/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm/src/main/scala/zio/internal/OneShot.scala
@@ -20,7 +20,7 @@ package zio.internal
  * A variable that can be set a single time. The synchronous,
  * effectful equivalent of `Promise`.
  */
-private[zio] class OneShot[A] private (@volatile var value: A) {
+private[zio] final class OneShot[A] private (@volatile var value: A) {
 
   import OneShot._
 
@@ -28,7 +28,7 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
    * Sets the variable to the value. The behavior of this function
    * is undefined if the variable has already been set.
    */
-  final def set(v: A): Unit = {
+  def set(v: A): Unit = {
     if (v == null) throw new Error("Defect: OneShot variable cannot be set to null value")
 
     this.synchronized {
@@ -43,7 +43,7 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
   /**
    * Determines if the variable has been set.
    */
-  final def isSet: Boolean = value != null
+  def isSet: Boolean = value != null
 
   /**
    * Retrieves the value of the variable, blocking if necessary.
@@ -51,7 +51,7 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
    * @param timeout The maximum amount of time the thread will be blocked, in milliseconds.
    * @throws Error if the timeout is reached without the value being set.
    */
-  final def get(timeout: Long): A = {
+  def get(timeout: Long): A = {
     var remainingNano = math.min(timeout, Long.MaxValue / nanosPerMilli) * nanosPerMilli
     while (value == null && remainingNano > 0L) {
       val waitMilli = remainingNano / nanosPerMilli
@@ -73,7 +73,7 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
    *
    * This will block until the value is set or the thread is interrupted.
    */
-  final def get(): A = {
+  def get(): A = {
     while (value == null) {
       this.synchronized {
         if (value == null) this.wait()
@@ -86,10 +86,10 @@ private[zio] class OneShot[A] private (@volatile var value: A) {
 
 object OneShot {
 
-  private val nanosPerMilli = 1000000L
+  private final val nanosPerMilli = 1000000L
 
   /**
    * Makes a new (unset) variable.
    */
-  final def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
+  def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
 }

--- a/core/jvm/src/main/scala/zio/internal/Sync.scala
+++ b/core/jvm/src/main/scala/zio/internal/Sync.scala
@@ -1,5 +1,5 @@
 package zio.internal
 
 private[zio] object Sync {
-  def apply[A](anyRef: AnyRef)(f: => A): A = anyRef.synchronized { f }
+  final def apply[A](anyRef: AnyRef)(f: => A): A = anyRef.synchronized { f }
 }

--- a/core/jvm/src/main/scala/zio/internal/Tracing.scala
+++ b/core/jvm/src/main/scala/zio/internal/Tracing.scala
@@ -23,11 +23,11 @@ import zio.internal.tracing.TracingConfig
 final case class Tracing(tracer: Tracer, tracingConfig: TracingConfig)
 
 object Tracing {
-  def enabled =
+  final def enabled =
     Tracing(Tracer.globallyCached(new AkkaLineNumbersTracer), TracingConfig.enabled)
 
-  def enabledWith(tracingConfig: TracingConfig) =
+  final def enabledWith(tracingConfig: TracingConfig) =
     Tracing(Tracer.globallyCached(new AkkaLineNumbersTracer), tracingConfig)
 
-  def disabled = Tracing(Tracer.Empty, TracingConfig.disabled)
+  final def disabled = Tracing(Tracer.Empty, TracingConfig.disabled)
 }

--- a/core/jvm/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
+++ b/core/jvm/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
@@ -43,20 +43,20 @@ import zio.internal.MutableConcurrentQueue
  * Instance size: 24 bytes
  * Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
  */
-class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+final class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   private[this] final val ref      = new AtomicReference[AnyRef]()
   private[this] final val deqAdder = new LongAdder()
 
   override final val capacity: Int = 1
 
-  override final def dequeuedCount(): Long = deqAdder.sum()
-  override final def enqueuedCount(): Long =
+  override def dequeuedCount(): Long = deqAdder.sum()
+  override def enqueuedCount(): Long =
     if (isEmpty()) dequeuedCount() else dequeuedCount() + 1
 
-  override final def isEmpty(): Boolean = ref.get() == null
-  override final def isFull(): Boolean  = !isEmpty()
+  override def isEmpty(): Boolean = ref.get() == null
+  override def isFull(): Boolean  = !isEmpty()
 
-  override final def offer(a: A): Boolean = {
+  override def offer(a: A): Boolean = {
     assert(a != null)
 
     val aRef    = ref
@@ -76,7 +76,7 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     ret
   }
 
-  override final def poll(default: A): A = {
+  override def poll(default: A): A = {
     var ret     = default
     var looping = true
     val aRef    = ref
@@ -97,5 +97,5 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     ret
   }
 
-  override final def size(): Int = if (isEmpty()) 0 else 1
+  override def size(): Int = if (isEmpty()) 0 else 1
 }

--- a/core/jvm/src/main/scala/zio/internal/impls/RingBufferPow2.scala
+++ b/core/jvm/src/main/scala/zio/internal/impls/RingBufferPow2.scala
@@ -22,7 +22,7 @@ class RingBufferPow2[A](val requestedCapacity: Int) extends RingBuffer[A](RingBu
 }
 
 object RingBufferPow2 {
-  final def apply[A](requestedCapacity: Int): RingBufferPow2[A] = {
+  def apply[A](requestedCapacity: Int): RingBufferPow2[A] = {
     assert(requestedCapacity > 0)
 
     new RingBufferPow2(requestedCapacity)

--- a/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -24,7 +24,7 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
 private[scheduler] object internal {
-  private[scheduler] val GlobalScheduler = new IScheduler {
+  private[scheduler] final val GlobalScheduler = new IScheduler {
     import IScheduler.CancelToken
 
     private[this] val service = Executors.newScheduledThreadPool(1, new NamedThreadFactory("zio-timer", true))
@@ -66,7 +66,7 @@ private[scheduler] object internal {
 }
 
 trait SchedulerLive extends Scheduler {
-  val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
+  final val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
     val scheduler = ZIO.succeed(internal.GlobalScheduler)
   }
 }

--- a/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -33,7 +33,7 @@ private[scheduler] object internal {
 
     private[this] val _size = new AtomicInteger()
 
-    override def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
+    override final def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
       case Duration.Infinity => ConstFalse
       case Duration.Zero =>
         task.run()

--- a/core/native/src/main/scala/zio/ZEnv.scala
+++ b/core/native/src/main/scala/zio/ZEnv.scala
@@ -30,31 +30,31 @@ object ZEnv {
    *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  final def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+  def  mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
     mapAll(mapClock = f)
 
   /**
    * Map the [[console.Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+  def  mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     mapAll(mapConsole = f)
 
   /**
    * Map the [[system.System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+  def  mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     mapAll(mapSystem = f)
 
   /**
    * Map the [[random.Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  final def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+  def  mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     mapAll(mapRandom = f)
 
   /**
    * Map all components of a ZEnv individually.
    */
-  final def mapAll(
+  def  mapAll(
     mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
     mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
     mapSystem: System.Service[Any] => System.Service[Any] = identity,

--- a/core/native/src/main/scala/zio/ZEnv.scala
+++ b/core/native/src/main/scala/zio/ZEnv.scala
@@ -30,31 +30,31 @@ object ZEnv {
    *   clock.sleep(1.second).provideSome(ZEnv.mapClock(oldClock => ???))
    * }}}
    */
-  def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
+  final def mapClock(f: Clock.Service[Any] => Clock.Service[Any]): ZEnv => ZEnv =
     mapAll(mapClock = f)
 
   /**
    * Map the [[console.Console.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
+  final def mapConsole(f: Console.Service[Any] => Console.Service[Any]): ZEnv => ZEnv =
     mapAll(mapConsole = f)
 
   /**
    * Map the [[system.System.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
+  final def mapSystem(f: System.Service[Any] => System.Service[Any]): ZEnv => ZEnv =
     mapAll(mapSystem = f)
 
   /**
    * Map the [[random.Random.Service]] component of a ZEnv, keeping all other services the same.
    */
-  def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
+  final def mapRandom(f: Random.Service[Any] => Random.Service[Any]): ZEnv => ZEnv =
     mapAll(mapRandom = f)
 
   /**
    * Map all components of a ZEnv individually.
    */
-  def mapAll(
+  final def mapAll(
     mapClock: Clock.Service[Any] => Clock.Service[Any] = identity,
     mapConsole: Console.Service[Any] => Console.Service[Any] = identity,
     mapSystem: System.Service[Any] => System.Service[Any] = identity,

--- a/core/native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/native/src/main/scala/zio/internal/OneShot.scala
@@ -20,13 +20,13 @@ package zio.internal
  * A variable that can be set a single time. The synchronous,
  * effectful equivalent of `Promise`.
  */
-private[zio] class OneShot[A] private (var value: A) {
+private[zio] final class OneShot[A] private (var value: A) {
 
   /**
    * Sets the variable to the value. The behavior of this function
    * is undefined if the variable has already been set.
    */
-  final def set(v: A): Unit = {
+   def set(v: A): Unit = {
     if (v == null) throw new Error("Defect: OneShot variable cannot be set to null value")
     if (value != null) throw new Error("Defect: OneShot variable being set twice")
     value = v
@@ -35,12 +35,12 @@ private[zio] class OneShot[A] private (var value: A) {
   /**
    * Determines if the variable has been set.
    */
-  final def isSet: Boolean = value != null
+   def isSet: Boolean = value != null
 
   /**
    * Retrieves the value of the variable, blocking if necessary.
    */
-  final def get(): A = {
+   def get(): A = {
     if (value == null) throw new Error("Cannot block for result to be set in Scala Native")
     value
   }
@@ -51,5 +51,5 @@ object OneShot {
   /**
    * Makes a new (unset) variable.
    */
-  final def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
+   def make[A]: OneShot[A] = new OneShot(null.asInstanceOf[A])
 }

--- a/core/native/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformLive.scala
@@ -23,12 +23,12 @@ import zio.internal.tracing.TracingConfig
 import scala.scalanative.loop.EventLoop
 
 object PlatformLive {
-  lazy val Default = Global
-  lazy val Global  = fromExecutionContext(EventLoop)
+  lazy final val Default = Global
+  lazy final val Global  = fromExecutionContext(EventLoop)
 
-  final def makeDefault(): Platform = fromExecutionContext(EventLoop)
+  def makeDefault(): Platform = fromExecutionContext(EventLoop)
 
-  final def fromExecutor(executor0: Executor): Platform =
+  def fromExecutor(executor0: Executor): Platform =
     new Platform {
       val executor = executor0
 
@@ -46,6 +46,6 @@ object PlatformLive {
       val tracing = Tracing(Tracer.Empty, TracingConfig.disabled)
     }
 
-  final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
+  def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ec))
 }

--- a/core/native/src/main/scala/zio/internal/Sync.scala
+++ b/core/native/src/main/scala/zio/internal/Sync.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 private[zio] object Sync {
-  final def apply[A](anyRef: AnyRef)(f: => A): A = {
+   def apply[A](anyRef: AnyRef)(f: => A): A = {
     val _ = anyRef
     f
   }

--- a/core/native/src/main/scala/zio/internal/Sync.scala
+++ b/core/native/src/main/scala/zio/internal/Sync.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 private[zio] object Sync {
-  def apply[A](anyRef: AnyRef)(f: => A): A = {
+  final def apply[A](anyRef: AnyRef)(f: => A): A = {
     val _ = anyRef
     f
   }

--- a/core/native/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
+++ b/core/native/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference 
 
 import zio.internal.MutableConcurrentQueue
 
-class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+final class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   private[this] final val ref = new AtomicReference[AnyRef]()
 
   private[this] final val headCounter   = new AtomicLong(0L)
@@ -33,13 +33,13 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
 
   override final val capacity: Int = 1
 
-  override final def dequeuedCount(): Long = headCounter.get()
-  override final def enqueuedCount(): Long = tailCounter.get()
+  override def dequeuedCount(): Long = headCounter.get()
+  override def enqueuedCount(): Long = tailCounter.get()
 
-  override final def isEmpty(): Boolean = ref.get() == null
-  override final def isFull(): Boolean  = !isEmpty()
+  override def isEmpty(): Boolean = ref.get() == null
+  override def isFull(): Boolean  = !isEmpty()
 
-  override final def offer(a: A): Boolean = {
+  override def offer(a: A): Boolean = {
     assert(a != null)
 
     var res     = false
@@ -65,7 +65,7 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     res
   }
 
-  override final def poll(default: A): A = {
+  override def poll(default: A): A = {
     var res     = default
     var looping = true
 
@@ -91,5 +91,5 @@ class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serial
     res
   }
 
-  override final def size(): Int = if (isEmpty()) 0 else 1
+  override def size(): Int = if (isEmpty()) 0 else 1
 }

--- a/core/native/src/main/scala/zio/internal/impls/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/impls/RingBuffer.scala
@@ -23,7 +23,7 @@ object RingBuffer {
   /**
    * @note minimum supported capacity is 2
    */
-  final def apply[A](capacity: Int): MutableConcurrentQueue[A] = {
+   def apply[A](capacity: Int): MutableConcurrentQueue[A] = {
     assert(capacity >= 2)
 
     new RingBuffer(Math.max(capacity, 2))

--- a/core/native/src/main/scala/zio/internal/impls/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/impls/RingBuffer.scala
@@ -23,7 +23,7 @@ object RingBuffer {
   /**
    * @note minimum supported capacity is 2
    */
-  def apply[A](capacity: Int): MutableConcurrentQueue[A] = {
+  final def apply[A](capacity: Int): MutableConcurrentQueue[A] = {
     assert(capacity >= 2)
 
     new RingBuffer(Math.max(capacity, 2))

--- a/core/native/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/native/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -68,7 +68,7 @@ private[scheduler] object internal {
 }
 
 trait SchedulerLive extends Scheduler {
-  val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
+  final val scheduler: Scheduler.Service[Any] = new Scheduler.Service[Any] {
     val scheduler = ZIO.succeed(internal.GlobalScheduler)
   }
 }

--- a/core/native/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/native/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -30,7 +30,7 @@ private[scheduler] object internal {
 
     private[this] var _size = 0
 
-    override def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
+    override final def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
       case Duration.Infinity => ConstFalse
       case Duration.Zero =>
         task.run()

--- a/core/shared/src/main/scala-2.11/zio/clock.scala
+++ b/core/shared/src/main/scala-2.11/zio/clock.scala
@@ -29,7 +29,7 @@ package object clock {
   /**
    * Returns the current time, relative to the Unix epoch.
    */
-  final def currentTime(unit: TimeUnit): ZIO[Clock, Nothing, Long] =
+   def currentTime(unit: TimeUnit): ZIO[Clock, Nothing, Long] =
     ZIO.accessM(_.clock currentTime unit)
 
   /**
@@ -47,6 +47,6 @@ package object clock {
   /**
    * Sleeps for the specified duration. This is always asynchronous.
    */
-  final def sleep(duration: Duration): ZIO[Clock, Nothing, Unit] =
+   def sleep(duration: Duration): ZIO[Clock, Nothing, Unit] =
     ZIO.accessM(_.clock sleep duration)
 }

--- a/core/shared/src/main/scala-2.11/zio/console.scala
+++ b/core/shared/src/main/scala-2.11/zio/console.scala
@@ -26,13 +26,13 @@ package object console {
   /**
    * Prints text to the console.
    */
-  final def putStr(line: String): ZIO[Console, Nothing, Unit] =
+   def putStr(line: String): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStr line)
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  final def putStrLn(line: String): ZIO[Console, Nothing, Unit] =
+   def putStrLn(line: String): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStrLn line)
 
   /**

--- a/core/shared/src/main/scala-2.11/zio/random.scala
+++ b/core/shared/src/main/scala-2.11/zio/random.scala
@@ -21,16 +21,16 @@ package object random {
   final val randomService: ZIO[Random, Nothing, Random.Service[Any]] =
     ZIO.access(_.random)
 
-  val nextBoolean: ZIO[Random, Nothing, Boolean]                = ZIO.accessM(_.random.nextBoolean)
+  final val nextBoolean: ZIO[Random, Nothing, Boolean]                = ZIO.accessM(_.random.nextBoolean)
   def nextBytes(length: Int): ZIO[Random, Nothing, Chunk[Byte]] = ZIO.accessM(_.random.nextBytes(length))
-  val nextDouble: ZIO[Random, Nothing, Double]                  = ZIO.accessM(_.random.nextDouble)
-  val nextFloat: ZIO[Random, Nothing, Float]                    = ZIO.accessM(_.random.nextFloat)
-  val nextGaussian: ZIO[Random, Nothing, Double]                = ZIO.accessM(_.random.nextGaussian)
+  final val nextDouble: ZIO[Random, Nothing, Double]                  = ZIO.accessM(_.random.nextDouble)
+  final val nextFloat: ZIO[Random, Nothing, Float]                    = ZIO.accessM(_.random.nextFloat)
+  final val nextGaussian: ZIO[Random, Nothing, Double]                = ZIO.accessM(_.random.nextGaussian)
   def nextInt(n: Int): ZIO[Random, Nothing, Int]                = ZIO.accessM(_.random.nextInt(n))
-  val nextInt: ZIO[Random, Nothing, Int]                        = ZIO.accessM(_.random.nextInt)
-  val nextLong: ZIO[Random, Nothing, Long]                      = ZIO.accessM(_.random.nextLong)
+  final val nextInt: ZIO[Random, Nothing, Int]                        = ZIO.accessM(_.random.nextInt)
+  final val nextLong: ZIO[Random, Nothing, Long]                      = ZIO.accessM(_.random.nextLong)
   def nextLong(n: Long): ZIO[Random, Nothing, Long]             = ZIO.accessM(_.random.nextLong(n))
-  val nextPrintableChar: ZIO[Random, Nothing, Char]             = ZIO.accessM(_.random.nextPrintableChar)
+  final val nextPrintableChar: ZIO[Random, Nothing, Char]             = ZIO.accessM(_.random.nextPrintableChar)
   def nextString(length: Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.random.nextString(length))
   def shuffle[A](list: List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.random.shuffle(list))
 }

--- a/core/shared/src/main/scala-2.11/zio/system.scala
+++ b/core/shared/src/main/scala-2.11/zio/system.scala
@@ -30,6 +30,6 @@ package object system {
     ZIO.accessM(_.system property prop)
 
   /** System-specific line separator **/
-  val lineSeparator: ZIO[System, Nothing, String] =
+  final val lineSeparator: ZIO[System, Nothing, String] =
     ZIO.accessM(_.system.lineSeparator)
 }

--- a/core/shared/src/main/scala-2.12+/zio/FutureTransformCompat.scala
+++ b/core/shared/src/main/scala-2.12+/zio/FutureTransformCompat.scala
@@ -20,9 +20,9 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
 private[zio] trait FutureTransformCompat[+A] { this: CancelableFuture[Any, A] =>
-  def transform[S](f: Try[A] => Try[S])(implicit executor: ExecutionContext): Future[S] =
+  final def transform[S](f: Try[A] => Try[S])(implicit executor: ExecutionContext): Future[S] =
     future.transform(f)(executor)
 
-  def transformWith[S](f: Try[A] => Future[S])(implicit executor: ExecutionContext): Future[S] =
+  final def transformWith[S](f: Try[A] => Future[S])(implicit executor: ExecutionContext): Future[S] =
     future.transformWith(f)(executor)
 }

--- a/core/shared/src/main/scala-2.12+/zio/clock.scala
+++ b/core/shared/src/main/scala-2.12+/zio/clock.scala
@@ -28,7 +28,7 @@ package object clock extends Clock.Service[Clock] {
   /**
    * Returns the current time, relative to the Unix epoch.
    */
-  final def currentTime(unit: TimeUnit): ZIO[Clock, Nothing, Long] =
+  def currentTime(unit: TimeUnit): ZIO[Clock, Nothing, Long] =
     ZIO.accessM(_.clock currentTime unit)
 
   /**
@@ -46,7 +46,7 @@ package object clock extends Clock.Service[Clock] {
   /**
    * Sleeps for the specified duration. This is always asynchronous.
    */
-  final def sleep(duration: Duration): ZIO[Clock, Nothing, Unit] =
+  def sleep(duration: Duration): ZIO[Clock, Nothing, Unit] =
     ZIO.accessM(_.clock sleep duration)
 
 }

--- a/core/shared/src/main/scala-2.12+/zio/console.scala
+++ b/core/shared/src/main/scala-2.12+/zio/console.scala
@@ -25,13 +25,13 @@ package object console extends Console.Service[Console] {
   /**
    * Prints text to the console.
    */
-  final def putStr(line: String): ZIO[Console, Nothing, Unit] =
+  def putStr(line: String): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStr line)
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  final def putStrLn(line: String): ZIO[Console, Nothing, Unit] =
+  def putStrLn(line: String): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStrLn line)
 
   /**

--- a/core/shared/src/main/scala-2.12+/zio/random.scala
+++ b/core/shared/src/main/scala-2.12+/zio/random.scala
@@ -20,16 +20,16 @@ package object random extends Random.Service[Random] {
   final val randomService: ZIO[Random, Nothing, Random.Service[Any]] =
     ZIO.access(_.random)
 
-  val nextBoolean: ZIO[Random, Nothing, Boolean]                = ZIO.accessM(_.random.nextBoolean)
+  final val nextBoolean: ZIO[Random, Nothing, Boolean]          = ZIO.accessM(_.random.nextBoolean)
   def nextBytes(length: Int): ZIO[Random, Nothing, Chunk[Byte]] = ZIO.accessM(_.random.nextBytes(length))
-  val nextDouble: ZIO[Random, Nothing, Double]                  = ZIO.accessM(_.random.nextDouble)
-  val nextFloat: ZIO[Random, Nothing, Float]                    = ZIO.accessM(_.random.nextFloat)
-  val nextGaussian: ZIO[Random, Nothing, Double]                = ZIO.accessM(_.random.nextGaussian)
+  final val nextDouble: ZIO[Random, Nothing, Double]            = ZIO.accessM(_.random.nextDouble)
+  final val nextFloat: ZIO[Random, Nothing, Float]              = ZIO.accessM(_.random.nextFloat)
+  final val nextGaussian: ZIO[Random, Nothing, Double]          = ZIO.accessM(_.random.nextGaussian)
   def nextInt(n: Int): ZIO[Random, Nothing, Int]                = ZIO.accessM(_.random.nextInt(n))
-  val nextInt: ZIO[Random, Nothing, Int]                        = ZIO.accessM(_.random.nextInt)
-  val nextLong: ZIO[Random, Nothing, Long]                      = ZIO.accessM(_.random.nextLong)
+  final val nextInt: ZIO[Random, Nothing, Int]                  = ZIO.accessM(_.random.nextInt)
+  final val nextLong: ZIO[Random, Nothing, Long]                = ZIO.accessM(_.random.nextLong)
   def nextLong(n: Long): ZIO[Random, Nothing, Long]             = ZIO.accessM(_.random.nextLong(n))
-  val nextPrintableChar: ZIO[Random, Nothing, Char]             = ZIO.accessM(_.random.nextPrintableChar)
+  final val nextPrintableChar: ZIO[Random, Nothing, Char]       = ZIO.accessM(_.random.nextPrintableChar)
   def nextString(length: Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.random.nextString(length))
   def shuffle[A](list: List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.random.shuffle(list))
 }

--- a/core/shared/src/main/scala/zio/CancelableFuture.scala
+++ b/core/shared/src/main/scala/zio/CancelableFuture.scala
@@ -27,20 +27,20 @@ abstract class CancelableFuture[+E, +A](val future: Future[A]) extends Future[A]
    */
   def cancel: Future[Exit[E, A]]
 
-  def onComplete[U](f: Try[A] => U)(implicit executor: ExecutionContext): Unit =
+  final def onComplete[U](f: Try[A] => U)(implicit executor: ExecutionContext): Unit =
     future.onComplete(f)(executor)
 
-  def isCompleted: Boolean =
+  final def isCompleted: Boolean =
     future.isCompleted
 
-  def value: Option[Try[A]] =
+  final def value: Option[Try[A]] =
     future.value
 
-  def ready(atMost: Duration)(implicit permit: CanAwait): this.type = {
+  final def ready(atMost: Duration)(implicit permit: CanAwait): this.type = {
     future.ready(atMost)(permit)
     this
   }
 
-  def result(atMost: Duration)(implicit permit: CanAwait): A =
+  final def result(atMost: Duration)(implicit permit: CanAwait): A =
     future.result(atMost)
 }

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -197,8 +197,8 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
    * Returns a `String` with the cause pretty-printed.
    */
   final def prettyPrint: String = {
-    sealed trait Segment
-    sealed trait Step extends Segment
+    sealed trait Segment extends Serializable with Product
+    sealed trait Step    extends Segment
 
     final case class Sequential(all: List[Step])     extends Segment
     final case class Parallel(all: List[Sequential]) extends Step
@@ -425,19 +425,19 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
 }
 
 object Cause extends Serializable {
-  final val empty: Cause[Nothing]                               = Internal.Empty
-  final def die(defect: Throwable): Cause[Nothing]              = Internal.Die(defect)
-  final def fail[E](error: E): Cause[E]                         = Internal.Fail(error)
-  final def interrupt(fiberId: Fiber.Id): Cause[Nothing]        = Internal.Interrupt(fiberId)
-  final def stack[E](cause: Cause[E]): Cause[E]                 = Internal.Meta(cause, Internal.Data(false))
-  final def stackless[E](cause: Cause[E]): Cause[E]             = Internal.Meta(cause, Internal.Data(true))
-  final def traced[E](cause: Cause[E], trace: ZTrace): Cause[E] = Internal.Traced(cause, trace)
+  final val empty: Cause[Nothing]                         = Internal.Empty
+  def die(defect: Throwable): Cause[Nothing]              = Internal.Die(defect)
+  def fail[E](error: E): Cause[E]                         = Internal.Fail(error)
+  def interrupt(fiberId: Fiber.Id): Cause[Nothing]        = Internal.Interrupt(fiberId)
+  def stack[E](cause: Cause[E]): Cause[E]                 = Internal.Meta(cause, Internal.Data(false))
+  def stackless[E](cause: Cause[E]): Cause[E]             = Internal.Meta(cause, Internal.Data(true))
+  def traced[E](cause: Cause[E], trace: ZTrace): Cause[E] = Internal.Traced(cause, trace)
 
   /**
    * Converts the specified `Cause[Option[E]]` to an `Option[Cause[E]]` by
    * recursively stripping out any failures with the error `None`.
    */
-  final def sequenceCauseOption[E](c: Cause[Option[E]]): Option[Cause[E]] =
+  def sequenceCauseOption[E](c: Cause[Option[E]]): Option[Cause[E]] =
     c match {
       case Internal.Empty                => Some(Internal.Empty)
       case Internal.Traced(cause, trace) => sequenceCauseOption(cause).map(Internal.Traced(_, trace))
@@ -492,7 +492,7 @@ object Cause extends Serializable {
   }
 
   object Die {
-    final def apply(value: Throwable): Cause[Nothing] =
+    def apply(value: Throwable): Cause[Nothing] =
       new Internal.Die(value)
     def unapply[E](cause: Cause[E]): Option[Throwable] =
       cause.find {
@@ -569,7 +569,7 @@ object Cause extends Serializable {
   private object Internal {
 
     case object Empty extends Cause[Nothing] {
-      override final def equals(that: Any): Boolean = that match {
+      override def equals(that: Any): Boolean = that match {
         case _: Empty.type     => true
         case Then(left, right) => this == left && this == right
         case Both(left, right) => this == left && this == right
@@ -580,7 +580,7 @@ object Cause extends Serializable {
     }
 
     final case class Fail[E](value: E) extends Cause[E] {
-      override final def equals(that: Any): Boolean = that match {
+      override def equals(that: Any): Boolean = that match {
         case fail: Fail[_]     => value == fail.value
         case c @ Then(_, _)    => sym(empty)(this, c)
         case c @ Both(_, _)    => sym(empty)(this, c)
@@ -591,7 +591,7 @@ object Cause extends Serializable {
     }
 
     final case class Die(value: Throwable) extends Cause[Nothing] {
-      override final def equals(that: Any): Boolean = that match {
+      override def equals(that: Any): Boolean = that match {
         case die: Die          => value == die.value
         case c @ Then(_, _)    => sym(empty)(this, c)
         case c @ Both(_, _)    => sym(empty)(this, c)
@@ -602,7 +602,7 @@ object Cause extends Serializable {
     }
 
     final case class Interrupt(fiberId: Fiber.Id) extends Cause[Nothing] {
-      override final def equals(that: Any): Boolean =
+      override def equals(that: Any): Boolean =
         (this eq that.asInstanceOf[AnyRef]) || (that match {
           case interrupt: Interrupt => fiberId == interrupt.fiberId
           case c @ Then(_, _)       => sym(empty)(this, c)
@@ -615,8 +615,8 @@ object Cause extends Serializable {
 
     // Traced is excluded completely from equals & hashCode
     final case class Traced[E](cause: Cause[E], trace: ZTrace) extends Cause[E] {
-      override final def hashCode: Int = cause.hashCode()
-      override final def equals(obj: Any): Boolean = obj match {
+      override def hashCode: Int = cause.hashCode()
+      override def equals(obj: Any): Boolean = obj match {
         case traced: Traced[_] => cause == traced.cause
         case meta: Meta[_]     => cause == meta.cause
         case _                 => cause == obj
@@ -625,8 +625,8 @@ object Cause extends Serializable {
 
     // Meta is excluded completely from equals & hashCode
     final case class Meta[E](cause: Cause[E], data: Data) extends Cause[E] {
-      override final def hashCode: Int = cause.hashCode
-      override final def equals(obj: Any): Boolean = obj match {
+      override def hashCode: Int = cause.hashCode
+      override def equals(obj: Any): Boolean = obj match {
         case traced: Traced[_] => cause == traced.cause
         case meta: Meta[_]     => cause == meta.cause
         case _                 => cause == obj
@@ -634,14 +634,14 @@ object Cause extends Serializable {
     }
 
     final case class Then[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      override final def equals(that: Any): Boolean = that match {
+      override def equals(that: Any): Boolean = that match {
         case traced: Traced[_] => self.equals(traced.cause)
         case meta: Meta[_]     => self.equals(meta.cause)
         case other: Cause[_] =>
           eq(other) || sym(assoc)(other, self) || sym(dist)(self, other) || sym(empty)(self, other)
         case _ => false
       }
-      override final def hashCode: Int = Internal.hashCode(self)
+      override def hashCode: Int = Internal.hashCode(self)
 
       private def eq(that: Cause[Any]): Boolean = (self, that) match {
         case (tl: Then[_], tr: Then[_]) => tl.left == tr.left && tl.right == tr.right
@@ -665,14 +665,14 @@ object Cause extends Serializable {
     }
 
     final case class Both[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      override final def equals(that: Any): Boolean = that match {
+      override def equals(that: Any): Boolean = that match {
         case traced: Traced[_] => self.equals(traced.cause)
         case meta: Meta[_]     => self.equals(meta.cause)
         case other: Cause[_] =>
           eq(other) || sym(assoc)(self, other) || sym(dist)(self, other) || comm(other) || sym(empty)(self, other)
         case _ => false
       }
-      override final def hashCode: Int = Internal.hashCode(self)
+      override def hashCode: Int = Internal.hashCode(self)
 
       private def eq(that: Cause[Any]) = (self, that) match {
         case (bl: Both[_], br: Both[_]) => bl.left == br.left && bl.right == br.right

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -67,7 +67,7 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
    * Returns the `E` associated with the first `Fail` in this `Cause` if one
    * exists.
    */
-  def failureOption: Option[E] =
+  final def failureOption: Option[E] =
     find { case Fail(e) => e }
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -682,17 +682,17 @@ object Chunk {
   /**
    * Returns a chunk from a number of values.
    */
-  final def apply[A](as: A*): Chunk[A] = fromIterable(as)
+  def apply[A](as: A*): Chunk[A] = fromIterable(as)
 
   /**
    * Returns a chunk backed by an array.
    */
-  final def fromArray[A](array: Array[A]): Chunk[A] = Arr(array)
+  def fromArray[A](array: Array[A]): Chunk[A] = Arr(array)
 
   /**
    * Returns a chunk backed by a [[java.nio.ByteBuffer]].
    */
-  final def fromByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
+  def fromByteBuffer(buffer: ByteBuffer): Chunk[Byte] = {
     val dest = Array.ofDim[Byte](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -703,7 +703,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.CharBuffer]].
    */
-  final def fromCharBuffer(buffer: CharBuffer): Chunk[Char] = {
+  def fromCharBuffer(buffer: CharBuffer): Chunk[Char] = {
     val dest = Array.ofDim[Char](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -714,7 +714,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.DoubleBuffer]].
    */
-  final def fromDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
+  def fromDoubleBuffer(buffer: DoubleBuffer): Chunk[Double] = {
     val dest = Array.ofDim[Double](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -725,7 +725,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.FloatBuffer]].
    */
-  final def fromFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
+  def fromFloatBuffer(buffer: FloatBuffer): Chunk[Float] = {
     val dest = Array.ofDim[Float](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -736,7 +736,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.IntBuffer]].
    */
-  final def fromIntBuffer(buffer: IntBuffer): Chunk[Int] = {
+  def fromIntBuffer(buffer: IntBuffer): Chunk[Int] = {
     val dest = Array.ofDim[Int](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -747,7 +747,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.LongBuffer]].
    */
-  final def fromLongBuffer(buffer: LongBuffer): Chunk[Long] = {
+  def fromLongBuffer(buffer: LongBuffer): Chunk[Long] = {
     val dest = Array.ofDim[Long](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -758,7 +758,7 @@ object Chunk {
   /**
    * Returns a chunk backed by a [[java.nio.ShortBuffer]].
    */
-  final def fromShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
+  def fromShortBuffer(buffer: ShortBuffer): Chunk[Short] = {
     val dest = Array.ofDim[Short](buffer.remaining())
     val pos  = buffer.position()
     buffer.get(dest)
@@ -769,7 +769,7 @@ object Chunk {
   /**
    * Returns a chunk backed by an iterable.
    */
-  final def fromIterable[A](it: Iterable[A]): Chunk[A] =
+  def fromIterable[A](it: Iterable[A]): Chunk[A] =
     if (it.size <= 0) Empty
     else if (it.size == 1) Singleton(it.head)
     else {
@@ -787,17 +787,17 @@ object Chunk {
   /**
    * Returns a singleton chunk, eagerly evaluated.
    */
-  final def single[A](a: A): Chunk[A] = Singleton(a)
+  def single[A](a: A): Chunk[A] = Singleton(a)
 
   /**
    * Alias for [[Chunk.single]].
    */
-  final def succeed[A](a: A): Chunk[A] = single(a)
+  def succeed[A](a: A): Chunk[A] = single(a)
 
   /**
    * Returns the `ClassTag` for the element type of the chunk.
    */
-  private final def classTagOf[A](chunk: Chunk[A]): ClassTag[A] = chunk match {
+  private def classTagOf[A](chunk: Chunk[A]): ClassTag[A] = chunk match {
     case x: Arr[A]         => x.classTag
     case x: Concat[A]      => x.classTag
     case Empty             => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
@@ -806,7 +806,7 @@ object Chunk {
     case x: VectorChunk[A] => x.classTag
   }
 
-  private case class Arr[A](private val array: Array[A]) extends Chunk[A] {
+  private final case class Arr[A](private val array: Array[A]) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = ClassTag(array.getClass.getComponentType)
 
     override def collect[B](pf: PartialFunction[A, B]): Chunk[B] = {
@@ -1140,7 +1140,7 @@ object Chunk {
     override def toArray[A1](implicit tag: ClassTag[A1]): Array[A1] = Array.empty
   }
 
-  private case class Singleton[A](a: A) extends Chunk[A] {
+  private final case class Singleton[A](a: A) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = Tags.fromValue(a)
 
     override val length = 1
@@ -1155,7 +1155,7 @@ object Chunk {
       dest(n) = a
   }
 
-  private case class Slice[A](private val chunk: Chunk[A], offset: Int, l: Int) extends Chunk[A] {
+  private final case class Slice[A](private val chunk: Chunk[A], offset: Int, l: Int) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = classTagOf(chunk)
 
     override def apply(n: Int): A = chunk.apply(offset + n)
@@ -1183,7 +1183,7 @@ object Chunk {
     }
   }
 
-  private case class VectorChunk[A](private val vector: Vector[A]) extends Chunk[A] {
+  private final case class VectorChunk[A](private val vector: Vector[A]) extends Chunk[A] {
     implicit val classTag: ClassTag[A] = Tags.fromValue(vector(0))
 
     override val length: Int = vector.length
@@ -1196,10 +1196,10 @@ object Chunk {
   }
 
   private[zio] object Tags {
-    final def fromValue[A](a: A): ClassTag[A] =
+    def fromValue[A](a: A): ClassTag[A] =
       unbox(ClassTag(a.getClass))
 
-    private final def unbox[A](c: ClassTag[A]): ClassTag[A] =
+    private def unbox[A](c: ClassTag[A]): ClassTag[A] =
       if (isBoolean(c)) BooleanClass.asInstanceOf[ClassTag[A]]
       else if (isByte(c)) ByteClass.asInstanceOf[ClassTag[A]]
       else if (isShort(c)) ShortClass.asInstanceOf[ClassTag[A]]
@@ -1210,21 +1210,21 @@ object Chunk {
       else if (isChar(c)) CharClass.asInstanceOf[ClassTag[A]]
       else classTag[AnyRef].asInstanceOf[ClassTag[A]] // TODO: Find a better way
 
-    private final def isBoolean(c: ClassTag[_]): Boolean =
+    private def isBoolean(c: ClassTag[_]): Boolean =
       c == BooleanClass || c == BooleanClassBox
-    private final def isByte(c: ClassTag[_]): Boolean =
+    private def isByte(c: ClassTag[_]): Boolean =
       c == ByteClass || c == ByteClassBox
-    private final def isShort(c: ClassTag[_]): Boolean =
+    private def isShort(c: ClassTag[_]): Boolean =
       c == ShortClass || c == ShortClassBox
-    private final def isInt(c: ClassTag[_]): Boolean =
+    private def isInt(c: ClassTag[_]): Boolean =
       c == IntClass || c == IntClassBox
-    private final def isLong(c: ClassTag[_]): Boolean =
+    private def isLong(c: ClassTag[_]): Boolean =
       c == LongClass || c == LongClassBox
-    private final def isFloat(c: ClassTag[_]): Boolean =
+    private def isFloat(c: ClassTag[_]): Boolean =
       c == FloatClass || c == FloatClassBox
-    private final def isDouble(c: ClassTag[_]): Boolean =
+    private def isDouble(c: ClassTag[_]): Boolean =
       c == DoubleClass || c == DoubleClassBox
-    private final def isChar(c: ClassTag[_]): Boolean =
+    private def isChar(c: ClassTag[_]): Boolean =
       c == CharClass || c == CharClassBox
 
     private val BooleanClass    = classTag[Boolean]

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -98,7 +98,7 @@ sealed trait Chunk[+A] { self =>
     drop(i)
   }
 
-  override def equals(that: Any): Boolean = that match {
+  override final def equals(that: Any): Boolean = that match {
     case that: Chunk[_] =>
       if (self.length != that.length) false
       else {
@@ -179,7 +179,7 @@ sealed trait Chunk[+A] { self =>
   /**
    * Flattens a chunk of chunks into a single chunk by concatenating all chunks.
    */
-  def flatten[B](implicit ev: A <:< Chunk[B]): Chunk[B] =
+  final def flatten[B](implicit ev: A <:< Chunk[B]): Chunk[B] =
     flatMap(ev(_))
 
   /**
@@ -244,7 +244,7 @@ sealed trait Chunk[+A] { self =>
   /**
    * Effectfully folds over the elements in this chunk from the left.
    */
-  final def foldM[R, E, S](s: S)(f: (S, A) => ZIO[R, E, S]): ZIO[R, E, S] =
+  def foldM[R, E, S](s: S)(f: (S, A) => ZIO[R, E, S]): ZIO[R, E, S] =
     fold[ZIO[R, E, S]](IO.succeed(s)) { (s, a) =>
       s.flatMap(f(_, a))
     }
@@ -483,17 +483,17 @@ sealed trait Chunk[+A] { self =>
     builder.result()
   }
 
-  def toSeq: Seq[A] = {
+  final def toSeq: Seq[A] = {
     val seqBuilder = Seq.newBuilder[A]
     fromBuilder(seqBuilder)
   }
 
-  def toList: List[A] = {
+  final def toList: List[A] = {
     val listBuilder = List.newBuilder[A]
     fromBuilder(listBuilder)
   }
 
-  def toVector: Vector[A] = {
+  final def toVector: Vector[A] = {
     val vectorBuilder = Vector.newBuilder[A]
     fromBuilder(vectorBuilder)
   }
@@ -611,7 +611,7 @@ sealed trait Chunk[+A] { self =>
     }
   }
 
-  def zipAllWith[B, C](
+  final def zipAllWith[B, C](
     that: Chunk[B]
   )(left: A => C, right: B => C)(both: (A, B) => C): Chunk[C] = {
 

--- a/core/shared/src/main/scala/zio/DaemonStatus.scala
+++ b/core/shared/src/main/scala/zio/DaemonStatus.scala
@@ -27,8 +27,8 @@ sealed abstract class DaemonStatus extends Serializable with Product {
   private[zio] final def toBoolean: Boolean = isDaemon
 }
 object DaemonStatus {
-  final def daemon: DaemonStatus    = Daemon
-  final def nonDaemon: DaemonStatus = NonDaemon
+  def daemon: DaemonStatus    = Daemon
+  def nonDaemon: DaemonStatus = NonDaemon
 
   /**
    * Indicates forked children of the fiber will be marked as daemons.

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -237,9 +237,9 @@ object Exit extends Serializable {
   final case class Success[A](value: A)                   extends Exit[Nothing, A]
   final case class Failure[E](cause: _root_.zio.Cause[E]) extends Exit[E, Nothing]
 
-  final def interrupt(id: Fiber.Id): Exit[Nothing, Nothing] = halt(_root_.zio.Cause.interrupt(id))
+  def interrupt(id: Fiber.Id): Exit[Nothing, Nothing] = halt(_root_.zio.Cause.interrupt(id))
 
-  final def collectAll[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+  def collectAll[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     exits.headOption.map { head =>
       exits
         .drop(1)
@@ -250,10 +250,10 @@ object Exit extends Serializable {
   /**
    *  Alias for [[Exit.collectAll]]
    */
-  final def sequence[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+  def sequence[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     collectAll[E, A](exits)
 
-  final def collectAllPar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+  def collectAllPar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     exits.headOption.map { head =>
       exits
         .drop(1)
@@ -264,31 +264,31 @@ object Exit extends Serializable {
   /**
    *  Alias for [[Exit.collectAllPar]]
    */
-  final def sequencePar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
+  def sequencePar[E, A](exits: Iterable[Exit[E, A]]): Option[Exit[E, List[A]]] =
     collectAllPar[E, A](exits)
 
-  final def die(t: Throwable): Exit[Nothing, Nothing] = halt(_root_.zio.Cause.die(t))
+  def die(t: Throwable): Exit[Nothing, Nothing] = halt(_root_.zio.Cause.die(t))
 
-  final def fail[E](error: E): Exit[E, Nothing] = halt(_root_.zio.Cause.fail(error))
+  def fail[E](error: E): Exit[E, Nothing] = halt(_root_.zio.Cause.fail(error))
 
-  final def flatten[E, A](exit: Exit[E, Exit[E, A]]): Exit[E, A] =
+  def flatten[E, A](exit: Exit[E, Exit[E, A]]): Exit[E, A] =
     exit.flatMap(identity)
 
-  final def fromEither[E, A](e: Either[E, A]): Exit[E, A] =
+  def fromEither[E, A](e: Either[E, A]): Exit[E, A] =
     e.fold(fail, succeed)
 
-  final def fromOption[A](o: Option[A]): Exit[Unit, A] =
+  def fromOption[A](o: Option[A]): Exit[Unit, A] =
     o.fold[Exit[Unit, A]](fail(()))(succeed)
 
-  final def fromTry[A](t: scala.util.Try[A]): Exit[Throwable, A] =
+  def fromTry[A](t: scala.util.Try[A]): Exit[Throwable, A] =
     t match {
       case scala.util.Success(a) => succeed(a)
       case scala.util.Failure(t) => fail(t)
     }
 
-  final def halt[E](cause: _root_.zio.Cause[E]): Exit[E, Nothing] = Failure(cause)
+  def halt[E](cause: _root_.zio.Cause[E]): Exit[E, Nothing] = Failure(cause)
 
-  final def succeed[A](a: A): Exit[Nothing, A] = Success(a)
+  def succeed[A](a: A): Exit[Nothing, A] = Success(a)
 
-  final def unit: Exit[Nothing, Unit] = succeed(())
+  def unit: Exit[Nothing, Unit] = succeed(())
 }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -216,7 +216,7 @@ trait Fiber[+E, +A] { self =>
    * @tparam A1 type of the other fiber
    * @return `Fiber[E1, A1]`
    */
-  def orElse[E1 >: E, A1 >: A](that: => Fiber[E1, A1]): Fiber[E1, A1] =
+  final def orElse[E1 >: E, A1 >: A](that: => Fiber[E1, A1]): Fiber[E1, A1] =
     new Fiber[E1, A1] {
       final def await: UIO[Exit[E1, A1]] =
         self.await.zipWith(that.await) {
@@ -258,7 +258,7 @@ trait Fiber[+E, +A] { self =>
    * @tparam B type of the other fiber
    * @return `Fiber[E1, B]`
    */
-  def orElseEither[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, Either[A, B]] =
+  final def orElseEither[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, Either[A, B]] =
     (self map (Left(_))) orElse (that map (Right(_)))
 
   /**

--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -25,5 +25,5 @@ package zio
  * to better integrate with Scala exception handling.
  */
 final case class FiberFailure(cause: Cause[Any]) extends Throwable(null, null, true, false) {
-  override final def getMessage: String = cause.prettyPrint
+  override def getMessage: String = cause.prettyPrint
 }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -59,7 +59,7 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
    *
    * Guarantees that fiber data is properly restored via `bracket`.
    */
-  final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
+  def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
     for {
       oldValue <- get
       b        <- set(value).bracket_(set(oldValue))(use)
@@ -70,7 +70,7 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
    * a return value for the modification. This is a more powerful version of
    * `update`.
    */
-  final def modify[B](f: A => (B, A)): UIO[B] = new ZIO.FiberRefModify(this, f)
+  def modify[B](f: A => (B, A)): UIO[B] = new ZIO.FiberRefModify(this, f)
 
   /**
    * Atomically modifies the `FiberRef` with the specified partial function, which computes
@@ -78,19 +78,19 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
    * otherwise it returns a default value.
    * This is a more powerful version of `updateSome`.
    */
-  final def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): UIO[B] = modify { v =>
+  def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): UIO[B] = modify { v =>
     pf.applyOrElse[A, (B, A)](v, _ => (default, v))
   }
 
   /**
    * Sets the value associated with the current fiber.
    */
-  final def set(value: A): UIO[Unit] = modify(_ => ((), value))
+  def set(value: A): UIO[Unit] = modify(_ => ((), value))
 
   /**
    * Atomically modifies the `FiberRef` with the specified function.
    */
-  final def update(f: A => A): UIO[A] = modify { v =>
+  def update(f: A => A): UIO[A] = modify { v =>
     val result = f(v)
     (result, result)
   }
@@ -99,7 +99,7 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
    * Atomically modifies the `FiberRef` with the specified partial function.
    * if the function is undefined in the current value it returns the old value without changing it.
    */
-  final def updateSome(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
+  def updateSome(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
     val result = pf.applyOrElse[A, A](v, identity)
     (result, result)
   }
@@ -111,7 +111,7 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
    * like MDC contexts and the like. The returned `ThreadLocal` will be backed by this `FiberRef` on all threads that are
    * currently managed by ZIO, and behave like an ordinary `ThreadLocal` on all other threads.
    */
-  final def unsafeAsThreadLocal: UIO[ThreadLocal[A]] =
+  def unsafeAsThreadLocal: UIO[ThreadLocal[A]] =
     ZIO.effectTotal {
       new ThreadLocal[A] {
         override def get(): A = {
@@ -154,6 +154,6 @@ object FiberRef extends Serializable {
   /**
    * Creates a new `FiberRef` with given initial value.
    */
-  final def make[A](initialValue: A, combine: (A, A) => A = (_: A, last: A) => last): UIO[FiberRef[A]] =
+  def make[A](initialValue: A, combine: (A, A) => A = (_: A, last: A) => last): UIO[FiberRef[A]] =
     new ZIO.FiberRefNew(initialValue, combine)
 }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -154,6 +154,6 @@ object FiberRef extends Serializable {
   /**
    * Creates a new `FiberRef` with given initial value.
    */
-  def make[A](initialValue: A, combine: (A, A) => A = (_: A, last: A) => last): UIO[FiberRef[A]] =
+  final def make[A](initialValue: A, combine: (A, A) => A = (_: A, last: A) => last): UIO[FiberRef[A]] =
     new ZIO.FiberRefNew(initialValue, combine)
 }

--- a/core/shared/src/main/scala/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/zio/FunctionIO.scala
@@ -202,8 +202,8 @@ sealed trait FunctionIO[+E, -A, +B] extends Serializable { self =>
 }
 
 object FunctionIO extends Serializable {
-  private class FunctionIOError[E](error: E) extends Throwable {
-    final def unsafeCoerce[E2] = error.asInstanceOf[E2]
+  private final class FunctionIOError[E](error: E) extends Throwable {
+    def unsafeCoerce[E2] = error.asInstanceOf[E2]
   }
 
   private[zio] final class Pure[E, A, B](val run: A => IO[E, B]) extends FunctionIO[E, A, B] {}
@@ -220,41 +220,41 @@ object FunctionIO extends Serializable {
   /**
    * Lifts a value into the monad formed by `FunctionIO`.
    */
-  final def succeed[B](b: B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
+  def succeed[B](b: B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
 
   /**
    * Returns a `FunctionIO` representing a failure with the specified `E`.
    */
-  final def fail[E](e: E): FunctionIO[E, Any, Nothing] =
+  def fail[E](e: E): FunctionIO[E, Any, Nothing] =
     new Impure(_ => throw new FunctionIOError[E](e))
 
   /**
    * Returns the identity effectful function, which performs no effects and
    * merely returns its input unmodified.
    */
-  final def identity[A]: FunctionIO[Nothing, A, A] = fromFunction(a => a)
+  def identity[A]: FunctionIO[Nothing, A, A] = fromFunction(a => a)
 
   /**
    * Lifts a pure `A => IO[E, B]` into `FunctionIO`.
    */
-  final def fromFunctionM[E, A, B](f: A => IO[E, B]): FunctionIO[E, A, B] = new Pure(f)
+  def fromFunctionM[E, A, B](f: A => IO[E, B]): FunctionIO[E, A, B] = new Pure(f)
 
   /**
    * Lifts a pure `A => B` into `FunctionIO`.
    */
-  final def fromFunction[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
+  def fromFunction[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
 
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  final def swap[E, A, B]: FunctionIO[E, (A, B), (B, A)] =
+  def swap[E, A, B]: FunctionIO[E, (A, B), (B, A)] =
     FunctionIO.fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Lifts an impure function into `FunctionIO`, converting throwables into the
    * specified error type `E`.
    */
-  final def effect[E, A, B](catcher: PartialFunction[Throwable, E])(f: A => B): FunctionIO[E, A, B] =
+  def effect[E, A, B](catcher: PartialFunction[Throwable, E])(f: A => B): FunctionIO[E, A, B] =
     new Impure(
       (a: A) =>
         try f(a)
@@ -268,14 +268,14 @@ object FunctionIO extends Serializable {
    * Lifts an impure function into `FunctionIO`, assuming any throwables are
    * non-recoverable and do not need to be converted into errors.
    */
-  final def effectTotal[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
+  def effectTotal[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
 
   /**
    * Returns a new effectful function that passes an `A` to the condition, and
    * if the condition returns true, returns `Left(a)`, but if the condition
    * returns false, returns `Right(a)`.
    */
-  final def test[E, A](k: FunctionIO[E, A, Boolean]): FunctionIO[E, A, Either[A, A]] =
+  def test[E, A](k: FunctionIO[E, A, Boolean]): FunctionIO[E, A, Either[A, A]] =
     (k &&& FunctionIO.identity[A]) >>>
       FunctionIO.fromFunction((t: (Boolean, A)) => if (t._1) Left(t._2) else Right(t._2))
 
@@ -284,7 +284,7 @@ object FunctionIO extends Serializable {
    * if the condition returns true, passes the `A` to the `then0` function,
    * but if the condition returns false, passes the `A` to the `else0` function.
    */
-  final def ifThenElse[E, A, B](
+  def ifThenElse[E, A, B](
     cond: FunctionIO[E, A, Boolean]
   )(then0: FunctionIO[E, A, B])(else0: FunctionIO[E, A, B]): FunctionIO[E, A, B] =
     (cond, then0, else0) match {
@@ -298,7 +298,7 @@ object FunctionIO extends Serializable {
    * if the condition returns true, passes the `A` to the `then0` function, but
    * otherwise returns the original `A` unmodified.
    */
-  final def ifThen[E, A](cond: FunctionIO[E, A, Boolean])(then0: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
+  def ifThen[E, A](cond: FunctionIO[E, A, Boolean])(then0: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
     (cond, then0) match {
       case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
         new Impure[E, A, A](a => if (cond.apply0(a)) then0.apply0(a) else a)
@@ -310,7 +310,7 @@ object FunctionIO extends Serializable {
    * if the condition returns false, passes the `A` to the `then0` function, but
    * otherwise returns the original `A` unmodified.
    */
-  final def ifNotThen[E, A](cond: FunctionIO[E, A, Boolean])(then0: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
+  def ifNotThen[E, A](cond: FunctionIO[E, A, Boolean])(then0: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
     (cond, then0) match {
       case (cond: Impure[_, _, _], then0: Impure[_, _, _]) =>
         new Impure[E, A, A](a => if (cond.apply0(a)) a else then0.apply0(a))
@@ -323,7 +323,7 @@ object FunctionIO extends Serializable {
    * new `A`, which repeats until the condition returns false. This is the
    * `FunctionIO` equivalent of a `while(cond) { body }` loop.
    */
-  final def whileDo[E, A](check: FunctionIO[E, A, Boolean])(body: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
+  def whileDo[E, A](check: FunctionIO[E, A, Boolean])(body: FunctionIO[E, A, A]): FunctionIO[E, A, A] =
     (check, body) match {
       case (check: Impure[_, _, _], body: Impure[_, _, _]) =>
         new Impure[E, A, A]({ (a0: A) =>
@@ -352,24 +352,24 @@ object FunctionIO extends Serializable {
    * Returns an effectful function that extracts out the first element of a
    * tuple.
    */
-  final def _1[E, A, B]: FunctionIO[E, (A, B), A] = fromFunction[(A, B), A](_._1)
+  def _1[E, A, B]: FunctionIO[E, (A, B), A] = fromFunction[(A, B), A](_._1)
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  final def _2[E, A, B]: FunctionIO[E, (A, B), B] = fromFunction[(A, B), B](_._2)
+  def _2[E, A, B]: FunctionIO[E, (A, B), B] = fromFunction[(A, B), B](_._2)
 
   /**
    * See @FunctionIO.flatMap
    */
-  final def flatMap[E, A, B, C](fa: FunctionIO[E, A, B], f: B => FunctionIO[E, A, C]): FunctionIO[E, A, C] =
+  def flatMap[E, A, B, C](fa: FunctionIO[E, A, B], f: B => FunctionIO[E, A, C]): FunctionIO[E, A, C] =
     new Pure((a: A) => fa.run(a).flatMap(b => f(b).run(a)))
 
   /**
    * See FunctionIO.compose
    */
-  final def compose[E, A, B, C](second: FunctionIO[E, B, C], first: FunctionIO[E, A, B]): FunctionIO[E, A, C] =
+  def compose[E, A, B, C](second: FunctionIO[E, B, C], first: FunctionIO[E, A, B]): FunctionIO[E, A, C] =
     (second, first) match {
       case (second: Impure[_, _, _], first: Impure[_, _, _]) =>
         new Impure(second.apply0.compose(first.apply0))
@@ -381,7 +381,7 @@ object FunctionIO extends Serializable {
   /**
    * See FunctionIO.zipWith
    */
-  final def zipWith[E, A, B, C, D](l: FunctionIO[E, A, B], r: FunctionIO[E, A, C])(
+  def zipWith[E, A, B, C, D](l: FunctionIO[E, A, B], r: FunctionIO[E, A, C])(
     f: (B, C) => D
   ): FunctionIO[E, A, D] =
     (l, r) match {
@@ -406,7 +406,7 @@ object FunctionIO extends Serializable {
   /**
    * See FunctionIO.left
    */
-  final def left[E, A, B, C](k: FunctionIO[E, A, B]): FunctionIO[E, Either[A, C], Either[B, C]] =
+  def left[E, A, B, C](k: FunctionIO[E, A, B]): FunctionIO[E, Either[A, C], Either[B, C]] =
     k match {
       case k: Impure[E, A, B] =>
         new Impure[E, Either[A, C], Either[B, C]]({
@@ -423,7 +423,7 @@ object FunctionIO extends Serializable {
   /**
    * See FunctionIO.left
    */
-  final def right[E, A, B, C](k: FunctionIO[E, A, B]): FunctionIO[E, Either[C, A], Either[C, B]] =
+  def right[E, A, B, C](k: FunctionIO[E, A, B]): FunctionIO[E, Either[C, A], Either[C, B]] =
     k match {
       case k: Impure[E, A, B] =>
         new Impure[E, Either[C, A], Either[C, B]]({
@@ -440,7 +440,7 @@ object FunctionIO extends Serializable {
   /**
    * See FunctionIO.|||
    */
-  final def join[E, A, B, C](l: FunctionIO[E, A, B], r: FunctionIO[E, C, B]): FunctionIO[E, Either[A, C], B] =
+  def join[E, A, B, C](l: FunctionIO[E, A, B], r: FunctionIO[E, C, B]): FunctionIO[E, Either[A, C], B] =
     (l, r) match {
       case (l: Impure[_, _, _], r: Impure[_, _, _]) =>
         new Impure[E, Either[A, C], B]({

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -563,7 +563,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  def replicate[E, A](n: Int)(effect: IO[E, A]): Iterable[IO[E, A]] =
+  final def replicate[E, A](n: Int)(effect: IO[E, A]): Iterable[IO[E, A]] =
     ZIO.replicate(n)(effect)
 
   /**
@@ -581,7 +581,7 @@ object IO {
   /**
    *  @see [[zio.ZIO.right]]
    */
-  def right[E, B](b: B): IO[E, Either[Nothing, B]] = ZIO.right(b)
+  final def right[E, B](b: B): IO[E, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
@@ -609,7 +609,7 @@ object IO {
   /**
    *  @see [[zio.ZIO.some]]
    */
-  def some[E, A](a: A): IO[E, Option[A]] = ZIO.some(a)
+  final def some[E, A](a: A): IO[E, Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -9,42 +9,42 @@ object IO {
   /**
    * @see See [[zio.ZIO.absolve]]
    */
-  final def absolve[E, A](v: IO[E, Either[E, A]]): IO[E, A] =
+  def absolve[E, A](v: IO[E, Either[E, A]]): IO[E, A] =
     ZIO.absolve(v)
 
   /**
    * @see See [[zio.ZIO.allowInterrupt]]
    */
-  final def allowInterrupt: UIO[Unit] =
+  def allowInterrupt: UIO[Unit] =
     ZIO.allowInterrupt
 
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[E, A](acquire: IO[E, A]): BracketAcquire[E, A] =
+  def bracket[E, A](acquire: IO[E, A]): BracketAcquire[E, A] =
     new BracketAcquire(acquire)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[E, A, B](acquire: IO[E, A], release: A => UIO[Any], use: A => IO[E, B]): IO[E, B] =
+  def bracket[E, A, B](acquire: IO[E, A], release: A => UIO[Any], use: A => IO[E, B]): IO[E, B] =
     ZIO.bracket(acquire, release, use)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[E, A](acquire: IO[E, A]): ZIO.BracketExitAcquire[Any, E, A] =
+  def bracketExit[E, A](acquire: IO[E, A]): ZIO.BracketExitAcquire[Any, E, A] =
     ZIO.bracketExit(acquire)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[E, A, B](
+  def bracketExit[E, A, B](
     acquire: IO[E, A],
     release: (A, Exit[E, B]) => UIO[Any],
     use: A => IO[E, B]
@@ -54,25 +54,25 @@ object IO {
   /**
    * @see See bracketFork [[zio.ZIO]]
    */
-  final def bracketFork[E, A](acquire: IO[E, A]): BracketForkAcquire[E, A] =
+  def bracketFork[E, A](acquire: IO[E, A]): BracketForkAcquire[E, A] =
     new BracketForkAcquire(acquire)
 
   /**
    * @see See bracketFork [[zio.ZIO]]
    */
-  final def bracketFork[E, A, B](acquire: IO[E, A], release: A => UIO[Any], use: A => IO[E, B]): IO[E, B] =
+  def bracketFork[E, A, B](acquire: IO[E, A], release: A => UIO[Any], use: A => IO[E, B]): IO[E, B] =
     ZIO.bracketFork(acquire, release, use)
 
   /**
    * @see See bracketForkExit [[zio.ZIO]]
    */
-  final def bracketForkExit[E, A](acquire: IO[E, A]): ZIO.BracketForkExitAcquire[Any, E, A] =
+  def bracketForkExit[E, A](acquire: IO[E, A]): ZIO.BracketForkExitAcquire[Any, E, A] =
     ZIO.bracketForkExit(acquire)
 
   /**
    * @see See bracketForkExit [[zio.ZIO]]
    */
-  final def bracketForkExit[E, A, B](
+  def bracketForkExit[E, A, B](
     acquire: IO[E, A],
     release: (A, Exit[E, B]) => UIO[Any],
     use: A => IO[E, B]
@@ -82,127 +82,127 @@ object IO {
   /**
    * @see See [[zio.ZIO.checkDaemon]]
    */
-  final def checkDaemon[E, A](f: DaemonStatus => IO[E, A]): IO[E, A] =
+  def checkDaemon[E, A](f: DaemonStatus => IO[E, A]): IO[E, A] =
     ZIO.checkDaemon(f)
 
   /**
    * @see See [[zio.ZIO.checkInterruptible]]
    */
-  final def checkInterruptible[E, A](f: InterruptStatus => IO[E, A]): IO[E, A] =
+  def checkInterruptible[E, A](f: InterruptStatus => IO[E, A]): IO[E, A] =
     ZIO.checkInterruptible(f)
 
   /**
    * @see See [[zio.ZIO.checkTraced]]
    */
-  final def checkTraced[E, A](f: TracingStatus => IO[E, A]): IO[E, A] =
+  def checkTraced[E, A](f: TracingStatus => IO[E, A]): IO[E, A] =
     ZIO.checkTraced(f)
 
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
+  def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
    */
-  final def collectAll[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAll[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAll(in)
 
   /**
    * @see See [[zio.ZIO.collectAllPar]]
    */
-  final def collectAllPar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAllPar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAllPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
-  final def collectAllParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAllParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAllParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccesses]]
    */
-  final def collectAllSuccesses[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAllSuccesses[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAllSuccesses(in)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesPar]]
    */
-  final def collectAllSuccessesPar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAllSuccessesPar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAllSuccessesPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
-  final def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.collectAllSuccessesParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllWith]]
    */
-  final def collectAllWith[E, A, B](in: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
+  def collectAllWith[E, A, B](in: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
     ZIO.collectAllWith(in)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithPar]]
    */
-  final def collectAllWithPar[E, A, B](as: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
+  def collectAllWithPar[E, A, B](as: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
     ZIO.collectAllWithPar(as)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
-  final def collectAllWithParN[E, A, B](n: Int)(as: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
+  def collectAllWithParN[E, A, B](n: Int)(as: Iterable[IO[E, A]])(f: PartialFunction[A, B]): IO[E, List[B]] =
     ZIO.collectAllWithParN(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.daemonMask]]
    */
-  final def daemonMask[E, A](k: ZIO.DaemonStatusRestore => IO[E, A]): IO[E, A] =
+  def daemonMask[E, A](k: ZIO.DaemonStatusRestore => IO[E, A]): IO[E, A] =
     ZIO.daemonMask(k)
 
   /**
    * @see See [[zio.ZIO.descriptor]]
    */
-  final def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
+  def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
 
   /**
    * @see See [[zio.ZIO.descriptorWith]]
    */
-  final def descriptorWith[E, A](f: Fiber.Descriptor => IO[E, A]): IO[E, A] =
+  def descriptorWith[E, A](f: Fiber.Descriptor => IO[E, A]): IO[E, A] =
     ZIO.descriptorWith(f)
 
   /**
    * @see See [[zio.ZIO.die]]
    */
-  final def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
+  def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
 
   /**
    * @see See [[zio.ZIO.dieMessage]]
    */
-  final def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
+  def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
 
   /**
    * @see See [[zio.ZIO.done]]
    */
-  final def done[E, A](r: Exit[E, A]): IO[E, A] = ZIO.done(r)
+  def done[E, A](r: Exit[E, A]): IO[E, A] = ZIO.done(r)
 
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  final def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
    */
-  final def effectAsync[E, A](register: (IO[E, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): IO[E, A] =
+  def effectAsync[E, A](register: (IO[E, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): IO[E, A] =
     ZIO.effectAsync(register, blockingOn)
 
   /**
    * @see See [[zio.ZIO.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[E, A](
+  def effectAsyncInterrupt[E, A](
     register: (IO[E, A] => Unit) => Either[Canceler[Any], IO[E, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): IO[E, A] =
@@ -211,13 +211,13 @@ object IO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[E, A](register: (IO[E, A] => Unit) => IO[E, Any]): IO[E, A] =
+  def effectAsyncM[E, A](register: (IO[E, A] => Unit) => IO[E, Any]): IO[E, A] =
     ZIO.effectAsyncM(register)
 
   /**
    * @see See [[zio.ZIO.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[E, A](
+  def effectAsyncMaybe[E, A](
     register: (IO[E, A] => Unit) => Option[IO[E, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): IO[E, A] =
@@ -226,33 +226,33 @@ object IO {
   /**
    * @see [[zio.ZIO.effectSuspend]]
    */
-  final def effectSuspend[A](io: => IO[Throwable, A]): IO[Throwable, A] = ZIO.effectSuspend(io)
+  def effectSuspend[A](io: => IO[Throwable, A]): IO[Throwable, A] = ZIO.effectSuspend(io)
 
   /**
    * @see [[zio.ZIO.effectSuspendWith]]
    */
-  final def effectSuspendWith[A](p: (Platform, Fiber.Id) => IO[Throwable, A]): IO[Throwable, A] =
+  def effectSuspendWith[A](p: (Platform, Fiber.Id) => IO[Throwable, A]): IO[Throwable, A] =
     ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  final def effectSuspendTotal[E, A](io: => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotal(io)
+  def effectSuspendTotal[E, A](io: => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotal(io)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  final def effectSuspendTotalWith[E, A](p: (Platform, Fiber.Id) => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotalWith(p)
+  def effectSuspendTotalWith[E, A](p: (Platform, Fiber.Id) => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.fail]]
    */
-  final def fail[E](error: E): IO[E, Nothing] = ZIO.fail(error)
+  def fail[E](error: E): IO[E, Nothing] = ZIO.fail(error)
 
   /**
    * @see [[zio.ZIO.fiberId]]
@@ -262,7 +262,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.firstSuccessOf]]
    */
-  final def firstSuccessOf[E, A](
+  def firstSuccessOf[E, A](
     io: IO[E, A],
     rest: Iterable[IO[E, A]]
   ): IO[E, A] = ZIO.firstSuccessOf(io, rest)
@@ -270,141 +270,141 @@ object IO {
   /**
    * @see See [[zio.ZIO.flatten]]
    */
-  final def flatten[E, A](io: IO[E, IO[E, A]]): IO[E, A] =
+  def flatten[E, A](io: IO[E, IO[E, A]]): IO[E, A] =
     ZIO.flatten(io)
 
   /**
    * @see See [[zio.ZIO.foldLeft]]
    */
-  final def foldLeft[E, S, A](in: Iterable[A])(zero: S)(f: (S, A) => IO[E, S]): IO[E, S] =
+  def foldLeft[E, S, A](in: Iterable[A])(zero: S)(f: (S, A) => IO[E, S]): IO[E, S] =
     ZIO.foldLeft(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foldRight]]
    */
-  final def foldRight[E, S, A](in: Iterable[A])(zero: S)(f: (A, S) => IO[E, S]): IO[E, S] =
+  def foldRight[E, S, A](in: Iterable[A])(zero: S)(f: (A, S) => IO[E, S]): IO[E, S] =
     ZIO.foldRight(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foreach]]
    */
-  final def foreach[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[E, List[B]] =
+  def foreach[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[E, List[B]] =
     ZIO.foreach(in)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar]]
    */
-  final def foreachPar[E, A, B](as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
+  def foreachPar[E, A, B](as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
     ZIO.foreachPar(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
-  final def foreachParN[E, A, B](n: Int)(as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
+  def foreachParN[E, A, B](n: Int)(as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
     ZIO.foreachParN(n)(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
+  def foreach_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[E, A, B](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
+  def foreachPar_[E, A, B](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[E, A, B](n: Int)(as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
+  def foreachParN_[E, A, B](n: Int)(as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  final def forkAll[E, A](as: Iterable[IO[E, A]]): UIO[Fiber[E, List[A]]] =
+  def forkAll[E, A](as: Iterable[IO[E, A]]): UIO[Fiber[E, List[A]]] =
     ZIO.forkAll(as)
 
   /**
    * @see See [[zio.ZIO.forkAll_]]
    */
-  final def forkAll_[E, A](as: Iterable[IO[E, A]]): UIO[Unit] =
+  def forkAll_[E, A](as: Iterable[IO[E, A]]): UIO[Unit] =
     ZIO.forkAll_(as)
 
   /**
    * @see See [[zio.ZIO.fromEither]]
    */
-  final def fromEither[E, A](v: => Either[E, A]): IO[E, A] =
+  def fromEither[E, A](v: => Either[E, A]): IO[E, A] =
     ZIO.fromEither(v)
 
   /**
    * @see See [[zio.ZIO.fromFiber]]
    */
-  final def fromFiber[E, A](fiber: => Fiber[E, A]): IO[E, A] =
+  def fromFiber[E, A](fiber: => Fiber[E, A]): IO[E, A] =
     ZIO.fromFiber(fiber)
 
   /**
    * @see See [[zio.ZIO.fromFiberM]]
    */
-  final def fromFiberM[E, A](fiber: IO[E, Fiber[E, A]]): IO[E, A] =
+  def fromFiberM[E, A](fiber: IO[E, Fiber[E, A]]): IO[E, A] =
     ZIO.fromFiberM(fiber)
 
   /**
    * @see [[zio.ZIO.fromFunction]]
    */
-  final def fromFunction[A](f: Any => A): IO[Nothing, A] = ZIO.fromFunction(f)
+  def fromFunction[A](f: Any => A): IO[Nothing, A] = ZIO.fromFunction(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionFuture]]
    */
-  final def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
+  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFunctionFuture(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  final def fromFunctionM[E, A](f: Any => IO[E, A]): IO[E, A] = ZIO.fromFunctionM(f)
+  def fromFunctionM[E, A](f: Any => IO[E, A]): IO[E, A] = ZIO.fromFunctionM(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
    */
-  final def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFuture(make)
 
   /**
    * @see See [[zio.ZIO.fromFutureInterrupt]]
    */
-  final def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFutureInterrupt(make)
 
   /**
    * @see See [[zio.ZIO.fromOption]]
    */
-  final def fromOption[A](v: => Option[A]): IO[Unit, A] = ZIO.fromOption(v)
+  def fromOption[A](v: => Option[A]): IO[Unit, A] = ZIO.fromOption(v)
 
   /**
    * @see See [[zio.ZIO.fromTry]]
    */
-  final def fromTry[A](value: => scala.util.Try[A]): Task[A] =
+  def fromTry[A](value: => scala.util.Try[A]): Task[A] =
     ZIO.fromTry(value)
 
   /**
    * @see See [[zio.ZIO.halt]]
    */
-  final def halt[E](cause: Cause[E]): IO[E, Nothing] = ZIO.halt(cause)
+  def halt[E](cause: Cause[E]): IO[E, Nothing] = ZIO.halt(cause)
 
   /**
    * @see See [[zio.ZIO.haltWith]]
    */
-  final def haltWith[E](function: (() => ZTrace) => Cause[E]): IO[E, Nothing] =
+  def haltWith[E](function: (() => ZTrace) => Cause[E]): IO[E, Nothing] =
     ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.identity]]
    */
-  final def identity: IO[Nothing, Any] = ZIO.identity
+  def identity: IO[Nothing, Any] = ZIO.identity
 
   /**
    * @see See See [[zio.ZIO.interrupt]]
@@ -414,59 +414,59 @@ object IO {
   /**
    * @see See [[zio.ZIO.interruptAs]]
    */
-  final def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
 
   /**
    * @see See [[zio.ZIO.interruptible]]
    */
-  final def interruptible[E, A](io: IO[E, A]): IO[E, A] =
+  def interruptible[E, A](io: IO[E, A]): IO[E, A] =
     ZIO.interruptible(io)
 
   /**
    * @see See [[zio.ZIO.interruptibleFork]]
    */
-  final def interruptibleFork[E, A](io: IO[E, A]): IO[E, A] =
+  def interruptibleFork[E, A](io: IO[E, A]): IO[E, A] =
     ZIO.interruptibleFork(io)
 
   /**
    * @see See [[zio.ZIO.interruptibleForkMask]]
    */
-  final def interruptibleForkMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
+  def interruptibleForkMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
     ZIO.interruptibleForkMask(k)
 
   /**
    * @see See [[zio.ZIO.interruptibleMask]]
    */
-  final def interruptibleMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
+  def interruptibleMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
     ZIO.interruptibleMask(k)
 
   /**
    *  @see See [[zio.ZIO.left]]
    */
-  final def left[E, A](a: A): IO[E, Either[A, Nothing]] = ZIO.left(a)
+  def left[E, A](a: A): IO[E, Either[A, Nothing]] = ZIO.left(a)
 
   /**
    * @see See [[zio.ZIO.lock]]
    */
-  final def lock[E, A](executor: Executor)(io: IO[E, A]): IO[E, A] =
+  def lock[E, A](executor: Executor)(io: IO[E, A]): IO[E, A] =
     ZIO.lock(executor)(io)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
+  def mapN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapN(io1, io2)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
+  def mapN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapN(io1, io2, io3)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
+  def mapN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F
   ): IO[E, F] =
     ZIO.mapN(io1, io2, io3, io4)(f)
@@ -474,19 +474,19 @@ object IO {
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
+  def mapParN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapParN(io1, io2)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
+  def mapParN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapParN(io1, io2, io3)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
+  def mapParN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F
   ): IO[E, F] =
     ZIO.mapParN(io1, io2, io3, io4)(f)
@@ -494,13 +494,13 @@ object IO {
   /**
    * @see See [[zio.ZIO.mergeAll]]
    */
-  final def mergeAll[E, A, B](in: Iterable[IO[E, A]])(zero: B)(f: (B, A) => B): IO[E, B] =
+  def mergeAll[E, A, B](in: Iterable[IO[E, A]])(zero: B)(f: (B, A) => B): IO[E, B] =
     ZIO.mergeAll(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.mergeAllPar]]
    */
-  final def mergeAllPar[E, A, B](in: Iterable[IO[E, A]])(zero: B)(f: (B, A) => B): IO[E, B] =
+  def mergeAllPar[E, A, B](in: Iterable[IO[E, A]])(zero: B)(f: (B, A) => B): IO[E, B] =
     ZIO.mergeAllPar(in)(zero)(f)
 
   /**
@@ -511,7 +511,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.nonDaemonMask]]
    */
-  final def nonDaemonMask[E, A](k: ZIO.DaemonStatusRestore => IO[E, A]): IO[E, A] =
+  def nonDaemonMask[E, A](k: ZIO.DaemonStatusRestore => IO[E, A]): IO[E, A] =
     ZIO.nonDaemonMask(k)
 
   /**
@@ -522,7 +522,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[E, A, B](
+  def partitionM[E, A, B](
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
     ZIO.partitionM(in)(f)
@@ -530,7 +530,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.partitionMPar]]
    */
-  final def partitionMPar[E, A, B](
+  def partitionMPar[E, A, B](
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
     ZIO.partitionMPar(in)(f)
@@ -538,7 +538,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.partitionMParN]]
    */
-  final def partitionMParN[E, A, B](n: Int)(
+  def partitionMParN[E, A, B](n: Int)(
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
     ZIO.partitionMParN(n)(in)(f)
@@ -546,102 +546,102 @@ object IO {
   /**
    * @see See [[zio.ZIO.raceAll]]
    */
-  final def raceAll[E, A](io: IO[E, A], ios: Iterable[IO[E, A]]): IO[E, A] = ZIO.raceAll(io, ios)
+  def raceAll[E, A](io: IO[E, A], ios: Iterable[IO[E, A]]): IO[E, A] = ZIO.raceAll(io, ios)
 
   /**
    * @see See [[zio.ZIO.reduceAll]]
    */
-  final def reduceAll[E, A](a: IO[E, A], as: Iterable[IO[E, A]])(f: (A, A) => A): IO[E, A] =
+  def reduceAll[E, A](a: IO[E, A], as: Iterable[IO[E, A]])(f: (A, A) => A): IO[E, A] =
     ZIO.reduceAll(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.reduceAllPar]]
    */
-  final def reduceAllPar[E, A](a: IO[E, A], as: Iterable[IO[E, A]])(f: (A, A) => A): IO[E, A] =
+  def reduceAllPar[E, A](a: IO[E, A], as: Iterable[IO[E, A]])(f: (A, A) => A): IO[E, A] =
     ZIO.reduceAllPar(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  final def replicate[E, A](n: Int)(effect: IO[E, A]): Iterable[IO[E, A]] =
+  def replicate[E, A](n: Int)(effect: IO[E, A]): Iterable[IO[E, A]] =
     ZIO.replicate(n)(effect)
 
   /**
    * @see See [[zio.ZIO.require]]
    */
-  final def require[E, A](error: E): IO[E, Option[A]] => IO[E, A] =
+  def require[E, A](error: E): IO[E, Option[A]] => IO[E, A] =
     ZIO.require[Any, E, A](error)
 
   /**
    * @see See [[zio.ZIO.reserve]]
    */
-  final def reserve[E, A, B](reservation: IO[E, Reservation[Any, E, A]])(use: A => IO[E, B]): IO[E, B] =
+  def reserve[E, A, B](reservation: IO[E, Reservation[Any, E, A]])(use: A => IO[E, B]): IO[E, B] =
     ZIO.reserve(reservation)(use)
 
   /**
    *  @see [[zio.ZIO.right]]
    */
-  final def right[E, B](b: B): IO[E, Either[Nothing, B]] = ZIO.right(b)
+  def right[E, B](b: B): IO[E, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
    */
-  final def runtime: UIO[Runtime[Any]] = ZIO.runtime
+  def runtime: UIO[Runtime[Any]] = ZIO.runtime
 
   /**
    *  See [[zio.ZIO.sequence]]
    */
-  final def sequence[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def sequence[E, A](in: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.sequence(in)
 
   /**
    *  See [[zio.ZIO.sequencePar]]
    */
-  final def sequencePar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def sequencePar[E, A](as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.sequencePar(as)
 
   /**
    *  See [[zio.ZIO.sequenceParN]]
    */
-  final def sequenceParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
+  def sequenceParN[E, A](n: Int)(as: Iterable[IO[E, A]]): IO[E, List[A]] =
     ZIO.sequenceParN(n)(as)
 
   /**
    *  @see [[zio.ZIO.some]]
    */
-  final def some[E, A](a: A): IO[E, Option[A]] = ZIO.some(a)
+  def some[E, A](a: A): IO[E, Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]
    */
-  final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
   /**
    * @see See [[zio.ZIO.trace]]
    * */
-  final def trace: UIO[ZTrace] = ZIO.trace
+  def trace: UIO[ZTrace] = ZIO.trace
 
   /**
    * @see See [[zio.ZIO.traced]]
    */
-  final def traced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.traced(zio)
+  def traced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.traced(zio)
 
   /**
    * @see See [[zio.ZIO.traverse]]
    */
-  final def traverse[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[E, List[B]] =
+  def traverse[E, A, B](in: Iterable[A])(f: A => IO[E, B]): IO[E, List[B]] =
     ZIO.traverse(in)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar]]
    */
-  final def traversePar[E, A, B](as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
+  def traversePar[E, A, B](as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
     ZIO.traversePar(as)(fn)
 
   /**
    * Alias for [[ZIO.foreachParN]]
    */
-  final def traverseParN[E, A, B](
+  def traverseParN[E, A, B](
     n: Int
   )(as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =
     ZIO.traverseParN(n)(as)(fn)
@@ -649,19 +649,19 @@ object IO {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
+  def traverse_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
+  def traversePar_[E, A](as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[E, A](
+  def traverseParN_[E, A](
     n: Int
   )(as: Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.traverseParN_(n)(as)(f)
@@ -674,59 +674,59 @@ object IO {
   /**
    * @see See [[zio.ZIO.uninterruptible]]
    */
-  final def uninterruptible[E, A](io: IO[E, A]): IO[E, A] =
+  def uninterruptible[E, A](io: IO[E, A]): IO[E, A] =
     ZIO.uninterruptible(io)
 
   /**
    * @see See [[zio.ZIO.uninterruptibleMask]]
    */
-  final def uninterruptibleMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
+  def uninterruptibleMask[E, A](k: ZIO.InterruptStatusRestore => IO[E, A]): IO[E, A] =
     ZIO.uninterruptibleMask(k)
 
   /**
    * @see See [[zio.ZIO.unsandbox]]
    */
-  final def unsandbox[E, A](v: IO[Cause[E], A]): IO[E, A] = ZIO.unsandbox(v)
+  def unsandbox[E, A](v: IO[Cause[E], A]): IO[E, A] = ZIO.unsandbox(v)
 
   /**
    * @see See [[zio.ZIO.untraced]]
    */
-  final def untraced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.untraced(zio)
+  def untraced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.untraced(zio)
 
   /**
    * @see See [[zio.ZIO.validateM]]
    */
-  final def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
+  def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
     ZIO.validateM(in)(f)
 
   /**
    * @see See [[zio.ZIO.validateFirstM]]
    */
-  final def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
+  def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
     ZIO.validateFirstM(in)(f)
 
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when[E](b: Boolean)(io: IO[E, Any]): IO[E, Unit] =
+  def when[E](b: Boolean)(io: IO[E, Any]): IO[E, Unit] =
     ZIO.when(b)(io)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM[E](b: IO[E, Boolean])(io: IO[E, Any]): IO[E, Unit] =
+  def whenM[E](b: IO[E, Boolean])(io: IO[E, Any]): IO[E, Unit] =
     ZIO.whenM(b)(io)
 
   /**

--- a/core/shared/src/main/scala/zio/InterruptStatus.scala
+++ b/core/shared/src/main/scala/zio/InterruptStatus.scala
@@ -26,8 +26,8 @@ sealed abstract class InterruptStatus(val isInterruptible: Boolean) extends Seri
   private[zio] final def toBoolean: Boolean = isInterruptible
 }
 object InterruptStatus {
-  final def interruptible: InterruptStatus   = Interruptible
-  final def uninterruptible: InterruptStatus = Uninterruptible
+  def interruptible: InterruptStatus   = Interruptible
+  def uninterruptible: InterruptStatus = Uninterruptible
 
   /**
    * Indicates the fiber can be interrupted right now.

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -21,133 +21,133 @@ object Managed {
   /**
    * See [[zio.ZManaged.absolve]]
    */
-  final def absolve[E, A](v: Managed[E, Either[E, A]]): Managed[E, A] =
+  def absolve[E, A](v: Managed[E, Either[E, A]]): Managed[E, A] =
     ZManaged.absolve(v)
 
   /**
    * See [[zio.ZManaged]]
    */
-  final def apply[E, A](reserve: IO[E, Reservation[Any, E, A]]): Managed[E, A] =
+  def apply[E, A](reserve: IO[E, Reservation[Any, E, A]]): Managed[E, A] =
     ZManaged.apply(reserve)
 
   /**
    * See [[zio.ZManaged.collectAll]]
    */
-  final def collectAll[E, A1, A2](ms: Iterable[Managed[E, A2]]): Managed[E, List[A2]] =
+  def collectAll[E, A1, A2](ms: Iterable[Managed[E, A2]]): Managed[E, List[A2]] =
     ZManaged.collectAll(ms)
 
   /**
    * See [[zio.ZManaged.collectAllPar]]
    */
-  final def collectAllPar[E, A](as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
+  def collectAllPar[E, A](as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
     ZManaged.collectAllPar(as)
 
   /**
    * See [[zio.ZManaged.collectAllParN]]
    */
-  final def collectAllParN[E, A](n: Int)(as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
+  def collectAllParN[E, A](n: Int)(as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
     ZManaged.collectAllParN(n)(as)
 
   /**
    * See [[zio.ZManaged.die]]
    */
-  final def die(t: Throwable): Managed[Nothing, Nothing] =
+  def die(t: Throwable): Managed[Nothing, Nothing] =
     ZManaged.die(t)
 
   /**
    * See [[zio.ZManaged.dieMessage]]
    */
-  final def dieMessage(message: String): Managed[Throwable, Nothing] =
+  def dieMessage(message: String): Managed[Throwable, Nothing] =
     ZManaged.dieMessage(message)
 
   /**
    * See [[zio.ZManaged.done]]
    */
-  final def done[E, A](r: Exit[E, A]): Managed[E, A] =
+  def done[E, A](r: Exit[E, A]): Managed[E, A] =
     ZManaged.done(r)
 
   /**
    * See [[zio.ZManaged.effectTotal]]
    */
-  final def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
+  def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
     ZManaged.effectTotal(r)
 
   /**
    * See [[zio.ZManaged.fail]]
    */
-  final def fail[E](error: E): Managed[E, Nothing] =
+  def fail[E](error: E): Managed[E, Nothing] =
     ZManaged.fail(error)
 
   /**
    * See [[zio.ZManaged.finalizer]]
    */
-  final def finalizer(f: IO[Nothing, Any]): Managed[Nothing, Unit] =
+  def finalizer(f: IO[Nothing, Any]): Managed[Nothing, Unit] =
     ZManaged.finalizer(f)
 
   /**
    * See [[zio.ZManaged.flatten]]
    */
-  final def flatten[E, A](m: Managed[E, Managed[E, A]]): Managed[E, A] =
+  def flatten[E, A](m: Managed[E, Managed[E, A]]): Managed[E, A] =
     ZManaged.flatten(m)
 
   /**
    * See [[zio.ZManaged.foreach]]
    */
-  final def foreach[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def foreach[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.foreach(as)(f)
 
   /**
    * See [[zio.ZManaged.foreach_]]
    */
-  final def foreach_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def foreach_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.foreach_(as)(f)
 
   /**
    * See [[zio.ZManaged.foreachPar]]
    */
-  final def foreachPar[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def foreachPar[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.foreachPar(as)(f)
 
   /**
    * See [[zio.ZManaged.foreachPar_]]
    */
-  final def foreachPar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def foreachPar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.foreachPar_(as)(f)
 
   /**
    * See [[zio.ZManaged.foreachParN]]
    */
-  final def foreachParN[E, A1, A2](n: Int)(as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def foreachParN[E, A1, A2](n: Int)(as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.foreachParN(n)(as)(f)
 
   /**
    * See [[zio.ZManaged.foreachParN_]]
    */
-  final def foreachParN_[E, A](n: Int)(as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def foreachParN_[E, A](n: Int)(as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.foreachParN_(n)(as)(f)
 
   /**
    * See [[zio.ZManaged.fromAutoCloseable]]
    */
-  final def fromAutoCloseable[E, A <: AutoCloseable](fa: IO[E, A]): Managed[E, A] =
+  def fromAutoCloseable[E, A <: AutoCloseable](fa: IO[E, A]): Managed[E, A] =
     ZManaged.fromAutoCloseable(fa)
 
   /**
    * See [[zio.ZManaged.fromEffect]]
    */
-  final def fromEffect[E, A](fa: IO[E, A]): Managed[E, A] =
+  def fromEffect[E, A](fa: IO[E, A]): Managed[E, A] =
     ZManaged.fromEffect(fa)
 
   /**
    * See [[zio.ZManaged.fromEither]]
    */
-  final def fromEither[E, A](v: => Either[E, A]): Managed[E, A] =
+  def fromEither[E, A](v: => Either[E, A]): Managed[E, A] =
     ZManaged.fromEither(v)
 
   /**
    * See [[zio.ZManaged.halt]]
    */
-  final def halt[E](cause: Cause[E]): Managed[E, Nothing] =
+  def halt[E](cause: Cause[E]): Managed[E, Nothing] =
     ZManaged.halt(cause)
 
   /**
@@ -158,37 +158,37 @@ object Managed {
   /**
    * See [[zio.ZManaged.make]]
    */
-  final def make[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Managed[E, A] =
+  def make[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Managed[E, A] =
     ZManaged.make(acquire)(release)
 
   /**
    * See [[zio.ZManaged.makeEffect]]
    */
-  final def makeEffect[A](acquire: => A)(release: A => Any): Managed[Throwable, A] =
+  def makeEffect[A](acquire: => A)(release: A => Any): Managed[Throwable, A] =
     ZManaged.makeEffect(acquire)(release)
 
   /**
    * See [[zio.ZManaged.makeExit]]
    */
-  final def makeExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Managed[E, A] =
+  def makeExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Managed[E, A] =
     ZManaged.makeExit(acquire)(release)
 
   /**
    * See [[zio.ZManaged.makeInterruptible]]
    */
-  final def makeInterruptible[R, E, A](acquire: IO[E, A])(release: A => UIO[Any]): Managed[E, A] =
+  def makeInterruptible[R, E, A](acquire: IO[E, A])(release: A => UIO[Any]): Managed[E, A] =
     ZManaged.makeInterruptible(acquire)(release)
 
   /**
    *  @see [[zio.ZManaged.mapN]]
    */
-  final def mapN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
+  def mapN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
     ZManaged.mapN(managed1, managed2)(f)
 
   /**
    *  @see [[zio.ZManaged.mapN]]
    */
-  final def mapN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
+  def mapN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
     f: (A, B, C) => D
   ): Managed[E, D] =
     ZManaged.mapN(managed1, managed2, managed3)(f)
@@ -196,7 +196,7 @@ object Managed {
   /**
    *  @see [[zio.ZManaged.mapN]]
    */
-  final def mapN[E, A, B, C, D, F](
+  def mapN[E, A, B, C, D, F](
     managed1: Managed[E, A],
     managed2: Managed[E, B],
     managed3: Managed[E, C],
@@ -209,13 +209,13 @@ object Managed {
   /**
    *  @see [[zio.ZManaged.mapParN]]
    */
-  final def mapParN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
+  def mapParN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
     ZManaged.mapParN(managed1, managed2)(f)
 
   /**
    *  @see [[zio.ZManaged.mapParN]]
    */
-  final def mapParN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
+  def mapParN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
     f: (A, B, C) => D
   ): Managed[E, D] =
     ZManaged.mapParN(managed1, managed2, managed3)(f)
@@ -223,7 +223,7 @@ object Managed {
   /**
    *  @see [[zio.ZManaged.mapParN]]
    */
-  final def mapParN[E, A, B, C, D, F](
+  def mapParN[E, A, B, C, D, F](
     managed1: Managed[E, A],
     managed2: Managed[E, B],
     managed3: Managed[E, C],
@@ -236,19 +236,19 @@ object Managed {
   /**
    * See [[zio.ZManaged.mergeAll]]
    */
-  final def mergeAll[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
+  def mergeAll[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
     ZManaged.mergeAll(in)(zero)(f)
 
   /**
    * See [[zio.ZManaged.mergeAllPar]]
    */
-  final def mergeAllPar[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
+  def mergeAllPar[E, A, B](in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
     ZManaged.mergeAllPar(in)(zero)(f)
 
   /**
    * See [[zio.ZManaged.mergeAllParN]]
    */
-  final def mergeAllParN[E, A, B](n: Int)(in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
+  def mergeAllParN[E, A, B](n: Int)(in: Iterable[Managed[E, A]])(zero: B)(f: (B, A) => B): Managed[E, B] =
     ZManaged.mergeAllParN(n)(in)(zero)(f)
 
   /**
@@ -259,19 +259,19 @@ object Managed {
   /**
    * See [[zio.ZManaged.reduceAll]]
    */
-  final def reduceAll[E, A](a: Managed[E, A], as: Iterable[Managed[E, A]])(f: (A, A) => A): Managed[E, A] =
+  def reduceAll[E, A](a: Managed[E, A], as: Iterable[Managed[E, A]])(f: (A, A) => A): Managed[E, A] =
     ZManaged.reduceAll(a, as)(f)
 
   /**
    * See [[zio.ZManaged.reduceAllPar]]
    */
-  final def reduceAllPar[E, A](a: Managed[E, A], as: Iterable[Managed[E, A]])(f: (A, A) => A): Managed[E, A] =
+  def reduceAllPar[E, A](a: Managed[E, A], as: Iterable[Managed[E, A]])(f: (A, A) => A): Managed[E, A] =
     ZManaged.reduceAllPar(a, as)(f)
 
   /**
    * See [[zio.ZManaged.reduceAllParN]]
    */
-  final def reduceAllParN[E, A](
+  def reduceAllParN[E, A](
     n: Long
   )(a1: Managed[E, A], as: Iterable[Managed[E, A]])(f: (A, A) => A): Managed[E, A] =
     ZManaged.reduceAllParN(n)(a1, as)(f)
@@ -279,85 +279,85 @@ object Managed {
   /**
    * See [[zio.ZManaged.require]]
    */
-  final def require[E, A](error: E): Managed[E, Option[A]] => Managed[E, A] =
+  def require[E, A](error: E): Managed[E, Option[A]] => Managed[E, A] =
     ZManaged.require[Any, E, A](error)
 
   /**
    * See [[zio.ZManaged.reserve]]
    */
-  final def reserve[E, A](reservation: Reservation[Any, E, A]): Managed[E, A] =
+  def reserve[E, A](reservation: Reservation[Any, E, A]): Managed[E, A] =
     ZManaged.reserve(reservation)
 
   /**
    * See [[zio.ZManaged.sandbox]]
    */
-  final def sandbox[E, A](v: Managed[E, A]): Managed[Cause[E], A] =
+  def sandbox[E, A](v: Managed[E, A]): Managed[Cause[E], A] =
     ZManaged.sandbox(v)
 
   /**
    * See [[zio.ZManaged.sequence]]
    */
-  final def sequence[E, A1, A2](ms: Iterable[Managed[E, A2]]): Managed[E, List[A2]] =
+  def sequence[E, A1, A2](ms: Iterable[Managed[E, A2]]): Managed[E, List[A2]] =
     ZManaged.sequence(ms)
 
   /**
    * See [[zio.ZManaged.sequencePar]]
    */
-  final def sequencePar[E, A](as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
+  def sequencePar[E, A](as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
     ZManaged.sequencePar(as)
 
   /**
    * See [[zio.ZManaged.sequenceParN]]
    */
-  final def sequenceParN[E, A](n: Int)(as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
+  def sequenceParN[E, A](n: Int)(as: Iterable[Managed[E, A]]): Managed[E, List[A]] =
     ZManaged.sequenceParN(n)(as)
 
   /**
    * See [[zio.ZManaged.succeed]]
    */
-  final def succeed[A](r: A): Managed[Nothing, A] =
+  def succeed[A](r: A): Managed[Nothing, A] =
     ZManaged.succeed(r)
 
   /**
    * See [[zio.ZManaged.suspend]]
    */
-  final def suspend[E, A](managed: => Managed[E, A]): Managed[E, A] =
+  def suspend[E, A](managed: => Managed[E, A]): Managed[E, A] =
     ZManaged.suspend(managed)
 
   /**
    * See [[zio.ZManaged.traverse]]
    */
-  final def traverse[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def traverse[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.traverse(as)(f)
 
   /**
    * See [[zio.ZManaged.traverse_]]
    */
-  final def traverse_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def traverse_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traverse_(as)(f)
 
   /**
    * See [[zio.ZManaged.traversePar]]
    */
-  final def traversePar[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def traversePar[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.traversePar(as)(f)
 
   /**
    * See [[zio.ZManaged.traversePar_]]
    */
-  final def traversePar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def traversePar_[E, A](as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traversePar_(as)(f)
 
   /**
    * See [[zio.ZManaged.traverseParN]]
    */
-  final def traverseParN[E, A1, A2](n: Int)(as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
+  def traverseParN[E, A1, A2](n: Int)(as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =
     ZManaged.traverseParN(n)(as)(f)
 
   /**
    * See [[zio.ZManaged.traverseParN_]]
    */
-  final def traverseParN_[E, A](n: Int)(as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
+  def traverseParN_[E, A](n: Int)(as: Iterable[A])(f: A => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.traverseParN_(n)(as)(f)
 
   /**
@@ -368,31 +368,31 @@ object Managed {
   /**
    * See [[zio.ZManaged.unsandbox]]
    */
-  final def unsandbox[E, A](v: Managed[Cause[E], A]): Managed[E, A] =
+  def unsandbox[E, A](v: Managed[Cause[E], A]): Managed[E, A] =
     ZManaged.unsandbox(v)
 
   /**
    * See [[zio.ZManaged.unwrap]]
    */
-  final def unwrap[E, A](fa: IO[E, Managed[E, A]]): Managed[E, A] =
+  def unwrap[E, A](fa: IO[E, Managed[E, A]]): Managed[E, A] =
     ZManaged.unwrap(fa)
 
   /**
    * See [[zio.ZManaged.when]]
    */
-  final def when[E](b: Boolean)(managed: Managed[E, Any]): Managed[E, Unit] =
+  def when[E](b: Boolean)(managed: Managed[E, Any]): Managed[E, Unit] =
     ZManaged.when(b)(managed)
 
   /**
    * See [[zio.ZManaged.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     ZManaged.whenCase(a)(pf)
 
   /**
    * See [[zio.ZManaged.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](
+  def whenCaseM[R, E, A](
     a: ZManaged[R, E, A]
   )(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     ZManaged.whenCaseM(a)(pf)
@@ -400,7 +400,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.whenM]]
    */
-  final def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, Any]): Managed[E, Unit] =
+  def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, Any]): Managed[E, Unit] =
     ZManaged.whenM(b)(managed)
 
 }

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -181,7 +181,7 @@ class Promise[E, A] private (private val state: AtomicReference[State[E, A]], bl
    */
   final def succeed(a: A): UIO[Boolean] = completeWith(IO.succeed(a))
 
-  private def interruptJoiner(joiner: IO[E, A] => Unit): Canceler[Any] = IO.effectTotal {
+  private final def interruptJoiner(joiner: IO[E, A] => Unit): Canceler[Any] = IO.effectTotal {
     var retry = true
 
     while (retry) {
@@ -232,12 +232,12 @@ object Promise {
   /**
    * Makes a new promise to be completed by the fiber creating the promise.
    */
-  final def make[E, A]: UIO[Promise[E, A]] = ZIO.fiberId.flatMap(makeAs(_))
+  def make[E, A]: UIO[Promise[E, A]] = ZIO.fiberId.flatMap(makeAs(_))
 
   /**
    * Makes a new promise to be completed by the fiber with the specified id.
    */
-  final def makeAs[E, A](fiberId: Fiber.Id): UIO[Promise[E, A]] =
+  def makeAs[E, A](fiberId: Fiber.Id): UIO[Promise[E, A]] =
     ZIO.effectTotal(
       new Promise[E, A](new AtomicReference[State[E, A]](new internal.Pending[E, A](Nil)), fiberId :: Nil)
     )

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -21,21 +21,21 @@ object Queue {
   /**
    * @see See [[zio.ZQueue.bounded]]
    */
-  final def bounded[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.bounded(requestedCapacity)
+  def bounded[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.bounded(requestedCapacity)
 
   /**
    * @see See [[zio.ZQueue.dropping]]
    */
-  final def dropping[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.dropping(requestedCapacity)
+  def dropping[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.dropping(requestedCapacity)
 
   /**
    * @see See [[zio.ZQueue.sliding]]
    */
-  final def sliding[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.sliding(requestedCapacity)
+  def sliding[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.sliding(requestedCapacity)
 
   /**
    * @see See [[zio.ZQueue.unbounded]]
    */
-  final def unbounded[A]: UIO[Queue[A]] = ZQueue.unbounded
+  def unbounded[A]: UIO[Queue[A]] = ZQueue.unbounded
 
 }

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -551,7 +551,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  def replicate[R, A](n: Int)(effect: RIO[R, A]): Iterable[RIO[R, A]] =
+  final def replicate[R, A](n: Int)(effect: RIO[R, A]): Iterable[RIO[R, A]] =
     ZIO.replicate(n)(effect)
 
   /**
@@ -569,7 +569,7 @@ object RIO {
   /**
    *  @see [[zio.ZIO.right]]
    */
-  def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
+  final def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
@@ -585,7 +585,7 @@ object RIO {
   /**
    *  @see [[zio.ZIO.some]]
    */
-  def some[R, A](a: A): RIO[R, Option[A]] = ZIO.some(a)
+  final def some[R, A](a: A): RIO[R, Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -11,42 +11,42 @@ object RIO {
   /**
    * @see See [[zio.ZIO.absolve]]
    */
-  final def absolve[R, A](v: RIO[R, Either[Throwable, A]]): RIO[R, A] =
+  def absolve[R, A](v: RIO[R, Either[Throwable, A]]): RIO[R, A] =
     ZIO.absolve(v)
 
   /**
    * @see See [[zio.ZIO.allowInterrupt]]
    */
-  final def allowInterrupt: UIO[Unit] =
+  def allowInterrupt: UIO[Unit] =
     ZIO.allowInterrupt
 
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See [[zio.ZIO.access]]
    */
-  final def access[R]: ZIO.AccessPartiallyApplied[R] =
+  def access[R]: ZIO.AccessPartiallyApplied[R] =
     ZIO.access
 
   /**
    * @see See [[zio.ZIO.accessM]]
    */
-  final def accessM[R]: ZIO.AccessMPartiallyApplied[R] =
+  def accessM[R]: ZIO.AccessMPartiallyApplied[R] =
     ZIO.accessM
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[R, A](acquire: RIO[R, A]): ZIO.BracketAcquire[R, Throwable, A] =
+  def bracket[R, A](acquire: RIO[R, A]): ZIO.BracketAcquire[R, Throwable, A] =
     ZIO.bracket(acquire)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[R, A, B](
+  def bracket[R, A, B](
     acquire: RIO[R, A],
     release: A => ZIO[R, Nothing, Any],
     use: A => RIO[R, B]
@@ -55,13 +55,13 @@ object RIO {
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[R, A](acquire: RIO[R, A]): ZIO.BracketExitAcquire[R, Throwable, A] =
+  def bracketExit[R, A](acquire: RIO[R, A]): ZIO.BracketExitAcquire[R, Throwable, A] =
     ZIO.bracketExit(acquire)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[R, A, B](
+  def bracketExit[R, A, B](
     acquire: RIO[R, A],
     release: (A, Exit[Throwable, B]) => ZIO[R, Nothing, Any],
     use: A => RIO[R, B]
@@ -71,127 +71,127 @@ object RIO {
   /**
    * @see See [[zio.ZIO.checkDaemon]]
    */
-  final def checkDaemon[R, A](f: DaemonStatus => RIO[R, A]): RIO[R, A] =
+  def checkDaemon[R, A](f: DaemonStatus => RIO[R, A]): RIO[R, A] =
     ZIO.checkDaemon(f)
 
   /**
    * @see See [[zio.ZIO.checkInterruptible]]
    */
-  final def checkInterruptible[R, A](f: InterruptStatus => RIO[R, A]): RIO[R, A] =
+  def checkInterruptible[R, A](f: InterruptStatus => RIO[R, A]): RIO[R, A] =
     ZIO.checkInterruptible(f)
 
   /**
    * @see See [[zio.ZIO.checkTraced]]
    */
-  final def checkTraced[R, A](f: TracingStatus => RIO[R, A]): RIO[R, A] =
+  def checkTraced[R, A](f: TracingStatus => RIO[R, A]): RIO[R, A] =
     ZIO.checkTraced(f)
 
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
+  def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
    */
-  final def collectAll[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def collectAll[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.collectAll(in)
 
   /**
    * @see See [[zio.ZIO.collectAllPar]]
    */
-  final def collectAllPar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def collectAllPar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.collectAllPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
-  final def collectAllParN[R, A](n: Int)(as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def collectAllParN[R, A](n: Int)(as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.collectAllParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccesses]]
    */
-  final def collectAllSuccesses[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def collectAllSuccesses[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.collectAllSuccesses(in)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesPar]]
    */
-  final def collectAllSuccessesPar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def collectAllSuccessesPar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.collectAllSuccessesPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
-  final def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[RIO[E, A]]): RIO[E, List[A]] =
+  def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[RIO[E, A]]): RIO[E, List[A]] =
     ZIO.collectAllSuccessesParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllWith]]
    */
-  final def collectAllWith[R, A, B](in: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
+  def collectAllWith[R, A, B](in: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
     ZIO.collectAllWith(in)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithPar]]
    */
-  final def collectAllWithPar[R, A, B](as: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
+  def collectAllWithPar[R, A, B](as: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
     ZIO.collectAllWithPar(as)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
-  final def collectAllWithParN[R, A, B](n: Int)(as: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
+  def collectAllWithParN[R, A, B](n: Int)(as: Iterable[RIO[R, A]])(f: PartialFunction[A, B]): RIO[R, List[B]] =
     ZIO.collectAllWithParN(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.daemonMask]]
    */
-  final def daemonMask[R, A](k: ZIO.DaemonStatusRestore => RIO[R, A]): RIO[R, A] =
+  def daemonMask[R, A](k: ZIO.DaemonStatusRestore => RIO[R, A]): RIO[R, A] =
     ZIO.daemonMask(k)
 
   /**
    * @see See [[zio.ZIO.descriptor]]
    */
-  final def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
+  def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
 
   /**
    * @see See [[zio.ZIO.descriptorWith]]
    */
-  final def descriptorWith[R, A](f: Fiber.Descriptor => RIO[R, A]): RIO[R, A] =
+  def descriptorWith[R, A](f: Fiber.Descriptor => RIO[R, A]): RIO[R, A] =
     ZIO.descriptorWith(f)
 
   /**
    * @see See [[zio.ZIO.die]]
    */
-  final def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
+  def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
 
   /**
    * @see See [[zio.ZIO.dieMessage]]
    */
-  final def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
+  def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
 
   /**
    * @see See [[zio.ZIO.done]]
    */
-  final def done[A](r: Exit[Throwable, A]): Task[A] = ZIO.done(r)
+  def done[A](r: Exit[Throwable, A]): Task[A] = ZIO.done(r)
 
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  final def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
    */
-  final def effectAsync[R, A](register: (RIO[R, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): RIO[R, A] =
+  def effectAsync[R, A](register: (RIO[R, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): RIO[R, A] =
     ZIO.effectAsync(register, blockingOn)
 
   /**
    * @see See [[zio.ZIO.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[R, A](
+  def effectAsyncMaybe[R, A](
     register: (RIO[R, A] => Unit) => Option[RIO[R, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): RIO[R, A] =
@@ -200,13 +200,13 @@ object RIO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[R, A](register: (RIO[R, A] => Unit) => RIO[R, Any]): RIO[R, A] =
+  def effectAsyncM[R, A](register: (RIO[R, A] => Unit) => RIO[R, Any]): RIO[R, A] =
     ZIO.effectAsyncM(register)
 
   /**
    * @see See [[zio.ZIO.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[R, A](
+  def effectAsyncInterrupt[R, A](
     register: (RIO[R, A] => Unit) => Either[Canceler[R], RIO[R, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): RIO[R, A] =
@@ -216,39 +216,39 @@ object RIO {
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */
-  final def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspend(rio)
+  def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspend(rio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  final def effectSuspendTotal[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendTotal(rio)
+  def effectSuspendTotal[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendTotal(rio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  final def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
+  def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
     ZIO.effectSuspendTotalWith(p)
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */
-  final def effectSuspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendWith(p)
+  def effectSuspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.environment]]
    */
-  final def environment[R]: ZIO[R, Nothing, R] = ZIO.environment
+  def environment[R]: ZIO[R, Nothing, R] = ZIO.environment
 
   /**
    * @see See [[zio.ZIO.fail]]
    */
-  final def fail(error: Throwable): Task[Nothing] = ZIO.fail(error)
+  def fail(error: Throwable): Task[Nothing] = ZIO.fail(error)
 
   /**
    * @see [[zio.ZIO.fiberId]]
@@ -258,7 +258,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.firstSuccessOf]]
    */
-  final def firstSuccessOf[R, A](
+  def firstSuccessOf[R, A](
     rio: RIO[R, A],
     rest: Iterable[RIO[R, A]]
   ): RIO[R, A] = ZIO.firstSuccessOf(rio, rest)
@@ -266,140 +266,140 @@ object RIO {
   /**
    * @see See [[zio.ZIO.flatten]]
    */
-  final def flatten[R, A](taskr: RIO[R, RIO[R, A]]): RIO[R, A] =
+  def flatten[R, A](taskr: RIO[R, RIO[R, A]]): RIO[R, A] =
     ZIO.flatten(taskr)
 
   /**
    * @see See [[zio.ZIO.foldLeft]]
    */
-  final def foldLeft[R, S, A](in: Iterable[A])(zero: S)(f: (S, A) => RIO[R, S]): RIO[R, S] =
+  def foldLeft[R, S, A](in: Iterable[A])(zero: S)(f: (S, A) => RIO[R, S]): RIO[R, S] =
     ZIO.foldLeft(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foldRight]]
    */
-  final def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => RIO[R, S]): RIO[R, S] =
+  def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => RIO[R, S]): RIO[R, S] =
     ZIO.foldRight(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foreach]]
    */
-  final def foreach[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
+  def foreach[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.foreach(in)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar]]
    */
-  final def foreachPar[R, A, B](as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
+  def foreachPar[R, A, B](as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.foreachPar(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
-  final def foreachParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
+  def foreachParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.foreachParN(n)(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+  def foreach_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+  def foreachPar_[R, A, B](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+  def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  final def forkAll[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Fiber[Throwable, List[A]]] =
+  def forkAll[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Fiber[Throwable, List[A]]] =
     ZIO.forkAll(as)
 
   /**
    * @see See [[zio.ZIO.forkAll_]]
    */
-  final def forkAll_[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Unit] =
+  def forkAll_[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Unit] =
     ZIO.forkAll_(as)
 
   /**
    * @see See [[zio.ZIO.fromEither]]
    */
-  final def fromEither[A](v: => Either[Throwable, A]): Task[A] =
+  def fromEither[A](v: => Either[Throwable, A]): Task[A] =
     ZIO.fromEither(v)
 
   /**
    * @see See [[zio.ZIO.fromFiber]]
    */
-  final def fromFiber[A](fiber: => Fiber[Throwable, A]): Task[A] =
+  def fromFiber[A](fiber: => Fiber[Throwable, A]): Task[A] =
     ZIO.fromFiber(fiber)
 
   /**
    * @see See [[zio.ZIO.fromFiberM]]
    */
-  final def fromFiberM[A](fiber: Task[Fiber[Throwable, A]]): Task[A] =
+  def fromFiberM[A](fiber: Task[Fiber[Throwable, A]]): Task[A] =
     ZIO.fromFiberM(fiber)
 
   /**
    * @see See [[zio.ZIO.fromFunction]]
    */
-  final def fromFunction[R, A](f: R => A): URIO[R, A] =
+  def fromFunction[R, A](f: R => A): URIO[R, A] =
     ZIO.fromFunction(f)
 
   /**
    * @see See [[zio.ZIO.fromFunctionFuture]]
    */
-  final def fromFunctionFuture[R, A](f: R => scala.concurrent.Future[A]): RIO[R, A] =
+  def fromFunctionFuture[R, A](f: R => scala.concurrent.Future[A]): RIO[R, A] =
     ZIO.fromFunctionFuture(f)
 
   /**
    * @see See [[zio.ZIO.fromFunctionM]]
    */
-  final def fromFunctionM[R, A](f: R => Task[A]): RIO[R, A] =
+  def fromFunctionM[R, A](f: R => Task[A]): RIO[R, A] =
     ZIO.fromFunctionM(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
    */
-  final def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFuture(make)
 
   /**
    * @see See [[zio.ZIO.fromFutureInterrupt]]
    */
-  final def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFutureInterrupt(make)
 
-  final def fromOption[A](v: => Option[A]): IO[Unit, A] = ZIO.fromOption(v)
+  def fromOption[A](v: => Option[A]): IO[Unit, A] = ZIO.fromOption(v)
 
   /**
    * @see See [[zio.ZIO.fromTry]]
    */
-  final def fromTry[A](value: => scala.util.Try[A]): Task[A] =
+  def fromTry[A](value: => scala.util.Try[A]): Task[A] =
     ZIO.fromTry(value)
 
   /**
    * @see See [[zio.ZIO.halt]]
    */
-  final def halt(cause: Cause[Throwable]): Task[Nothing] = ZIO.halt(cause)
+  def halt(cause: Cause[Throwable]): Task[Nothing] = ZIO.halt(cause)
 
   /**
    * @see See [[zio.ZIO.haltWith]]
    */
-  final def haltWith[R](function: (() => ZTrace) => Cause[Throwable]): RIO[R, Nothing] =
+  def haltWith[R](function: (() => ZTrace) => Cause[Throwable]): RIO[R, Nothing] =
     ZIO.haltWith(function)
 
   /**
    * @see See [[zio.ZIO.identity]]
    */
-  final def identity[R]: RIO[Nothing, R] = ZIO.identity
+  def identity[R]: RIO[Nothing, R] = ZIO.identity
 
   /**
    * @see See [[zio.ZIO.interrupt]]
@@ -409,41 +409,41 @@ object RIO {
   /**
    * @see See [[zio.ZIO.interruptAs]]
    */
-  final def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
 
   /**
    * @see See [[zio.ZIO.interruptible]]
    */
-  final def interruptible[R, A](taskr: RIO[R, A]): RIO[R, A] =
+  def interruptible[R, A](taskr: RIO[R, A]): RIO[R, A] =
     ZIO.interruptible(taskr)
 
   /**
    * @see See [[zio.ZIO.interruptibleMask]]
    */
-  final def interruptibleMask[R, A](k: ZIO.InterruptStatusRestore => RIO[R, A]): RIO[R, A] =
+  def interruptibleMask[R, A](k: ZIO.InterruptStatusRestore => RIO[R, A]): RIO[R, A] =
     ZIO.interruptibleMask(k)
 
   /**
    * @see See [[zio.ZIO.lock]]
    */
-  final def lock[R, A](executor: Executor)(taskr: RIO[R, A]): RIO[R, A] =
+  def lock[R, A](executor: Executor)(taskr: RIO[R, A]): RIO[R, A] =
     ZIO.lock(executor)(taskr)
 
   /**
    *  @see See [[zio.ZIO.left]]
    */
-  final def left[R, A](a: A): RIO[R, Either[A, Nothing]] = ZIO.left(a)
+  def left[R, A](a: A): RIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
+  def mapN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapN(rio1, rio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(
+  def mapN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(
     f: (A, B, C) => D
   ): RIO[R, D] =
     ZIO.mapN(rio1, rio2, rio3)(f)
@@ -451,7 +451,7 @@ object RIO {
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
+  def mapN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F
   ): RIO[R, F] =
     ZIO.mapN(rio1, rio2, rio3, rio4)(f)
@@ -459,19 +459,19 @@ object RIO {
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
+  def mapParN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapParN(rio1, rio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(f: (A, B, C) => D): RIO[R, D] =
+  def mapParN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(f: (A, B, C) => D): RIO[R, D] =
     ZIO.mapParN(rio1, rio2, rio3)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
+  def mapParN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F
   ): RIO[R, F] =
     ZIO.mapParN(rio1, rio2, rio3, rio4)(f)
@@ -479,13 +479,13 @@ object RIO {
   /**
    * @see See [[zio.ZIO.mergeAll]]
    */
-  final def mergeAll[R, A, B](in: Iterable[RIO[R, A]])(zero: B)(f: (B, A) => B): RIO[R, B] =
+  def mergeAll[R, A, B](in: Iterable[RIO[R, A]])(zero: B)(f: (B, A) => B): RIO[R, B] =
     ZIO.mergeAll(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.mergeAllPar]]
    */
-  final def mergeAllPar[R, A, B](in: Iterable[RIO[R, A]])(zero: B)(f: (B, A) => B): RIO[R, B] =
+  def mergeAllPar[R, A, B](in: Iterable[RIO[R, A]])(zero: B)(f: (B, A) => B): RIO[R, B] =
     ZIO.mergeAllPar(in)(zero)(f)
 
   /**
@@ -496,7 +496,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.nonDaemonMask]]
    */
-  final def nonDaemonMask[R, A](k: ZIO.DaemonStatusRestore => RIO[R, A]): RIO[R, A] =
+  def nonDaemonMask[R, A](k: ZIO.DaemonStatusRestore => RIO[R, A]): RIO[R, A] =
     ZIO.nonDaemonMask(k)
 
   /**
@@ -507,19 +507,19 @@ object RIO {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+  def partitionM[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
     ZIO.partitionM(in)(f)
 
   /**
    * @see See [[zio.ZIO.partitionMPar]]
    */
-  final def partitionMPar[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+  def partitionMPar[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
     ZIO.partitionMPar(in)(f)
 
   /**
    * @see See [[zio.ZIO.partitionMParN]]
    */
-  final def partitionMParN[R, A, B](n: Int)(
+  def partitionMParN[R, A, B](n: Int)(
     in: Iterable[A]
   )(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
     ZIO.partitionMParN(n)(in)(f)
@@ -527,121 +527,121 @@ object RIO {
   /**
    * @see See [[zio.ZIO.provide]]
    */
-  final def provide[R, A](r: R): RIO[R, A] => Task[A] =
+  def provide[R, A](r: R): RIO[R, A] => Task[A] =
     ZIO.provide(r)
 
   /**
    * @see See [[zio.ZIO.raceAll]]
    */
-  final def raceAll[R, R1 <: R, A](taskr: RIO[R, A], taskrs: Iterable[RIO[R1, A]]): RIO[R1, A] =
+  def raceAll[R, R1 <: R, A](taskr: RIO[R, A], taskrs: Iterable[RIO[R1, A]]): RIO[R1, A] =
     ZIO.raceAll(taskr, taskrs)
 
   /**
    * @see See [[zio.ZIO.reduceAll]]
    */
-  final def reduceAll[R, R1 <: R, A](a: RIO[R, A], as: Iterable[RIO[R1, A]])(f: (A, A) => A): RIO[R1, A] =
+  def reduceAll[R, R1 <: R, A](a: RIO[R, A], as: Iterable[RIO[R1, A]])(f: (A, A) => A): RIO[R1, A] =
     ZIO.reduceAll(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.reduceAllPar]]
    */
-  final def reduceAllPar[R, R1 <: R, A](a: RIO[R, A], as: Iterable[RIO[R1, A]])(f: (A, A) => A): RIO[R1, A] =
+  def reduceAllPar[R, R1 <: R, A](a: RIO[R, A], as: Iterable[RIO[R1, A]])(f: (A, A) => A): RIO[R1, A] =
     ZIO.reduceAllPar(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  final def replicate[R, A](n: Int)(effect: RIO[R, A]): Iterable[RIO[R, A]] =
+  def replicate[R, A](n: Int)(effect: RIO[R, A]): Iterable[RIO[R, A]] =
     ZIO.replicate(n)(effect)
 
   /**
    * @see See [[zio.ZIO.require]]
    */
-  final def require[A](error: Throwable): IO[Throwable, Option[A]] => IO[Throwable, A] =
+  def require[A](error: Throwable): IO[Throwable, Option[A]] => IO[Throwable, A] =
     ZIO.require[Any, Throwable, A](error)
 
   /**
    * @see See [[zio.ZIO.reserve]]
    */
-  final def reserve[R, A, B](reservation: RIO[R, Reservation[R, Throwable, A]])(use: A => RIO[R, B]): RIO[R, B] =
+  def reserve[R, A, B](reservation: RIO[R, Reservation[R, Throwable, A]])(use: A => RIO[R, B]): RIO[R, B] =
     ZIO.reserve(reservation)(use)
 
   /**
    *  @see [[zio.ZIO.right]]
    */
-  final def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
+  def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
    */
-  final def runtime[R]: ZIO[R, Nothing, Runtime[R]] = ZIO.runtime
+  def runtime[R]: ZIO[R, Nothing, Runtime[R]] = ZIO.runtime
 
   /**
    * @see See [[zio.ZIO.sleep]]
    */
-  final def sleep(duration: Duration): RIO[Clock, Unit] =
+  def sleep(duration: Duration): RIO[Clock, Unit] =
     ZIO.sleep(duration)
 
   /**
    *  @see [[zio.ZIO.some]]
    */
-  final def some[R, A](a: A): RIO[R, Option[A]] = ZIO.some(a)
+  def some[R, A](a: A): RIO[R, Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]
    */
-  final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
   /**
    *  See [[zio.ZIO.sequence]]
    */
-  final def sequence[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def sequence[R, A](in: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.sequence(in)
 
   /**
    *  See [[zio.ZIO.sequencePar]]
    */
-  final def sequencePar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def sequencePar[R, A](as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.sequencePar(as)
 
   /**
    *  See [[zio.ZIO.sequenceParN]]
    */
-  final def sequenceParN[R, A](n: Int)(as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+  def sequenceParN[R, A](n: Int)(as: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     ZIO.sequenceParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.swap]]
    */
-  final def swap[R, A, B](implicit ev: R <:< (A, B)): RIO[R, (B, A)] =
+  def swap[R, A, B](implicit ev: R <:< (A, B)): RIO[R, (B, A)] =
     ZIO.swap
 
   /**
    * @see See [[zio.ZIO.trace]]
    * */
-  final def trace: UIO[ZTrace] = ZIO.trace
+  def trace: UIO[ZTrace] = ZIO.trace
 
   /**
    * @see See [[zio.ZIO.traced]]
    */
-  final def traced[R, A](zio: RIO[R, A]): RIO[R, A] = ZIO.traced(zio)
+  def traced[R, A](zio: RIO[R, A]): RIO[R, A] = ZIO.traced(zio)
 
   /**
    * @see See [[zio.ZIO.traverse]]
    */
-  final def traverse[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
+  def traverse[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.traverse(in)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar]]
    */
-  final def traversePar[R, A, B](as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
+  def traversePar[R, A, B](as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.traversePar(as)(fn)
 
   /**
    * Alias for [[ZIO.foreachParN]]
    */
-  final def traverseParN[R, A, B](
+  def traverseParN[R, A, B](
     n: Int
   )(as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.traverseParN(n)(as)(fn)
@@ -649,19 +649,19 @@ object RIO {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+  def traverse_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+  def traversePar_[R, A](as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[R, A](
+  def traverseParN_[R, A](
     n: Int
   )(as: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.traverseParN_(n)(as)(f)
@@ -674,47 +674,47 @@ object RIO {
   /**
    * @see See [[zio.ZIO.uninterruptible]]
    */
-  final def uninterruptible[R, A](taskr: RIO[R, A]): RIO[R, A] =
+  def uninterruptible[R, A](taskr: RIO[R, A]): RIO[R, A] =
     ZIO.uninterruptible(taskr)
 
   /**
    * @see See [[zio.ZIO.uninterruptibleMask]]
    */
-  final def uninterruptibleMask[R, A](k: ZIO.InterruptStatusRestore => RIO[R, A]): RIO[R, A] =
+  def uninterruptibleMask[R, A](k: ZIO.InterruptStatusRestore => RIO[R, A]): RIO[R, A] =
     ZIO.uninterruptibleMask(k)
 
   /**
    * @see See [[zio.ZIO.unsandbox]]
    */
-  final def unsandbox[R, A](v: IO[Cause[Throwable], A]): RIO[R, A] = ZIO.unsandbox(v)
+  def unsandbox[R, A](v: IO[Cause[Throwable], A]): RIO[R, A] = ZIO.unsandbox(v)
 
   /**
    * @see See [[zio.ZIO.untraced]]
    */
-  final def untraced[R, A](zio: RIO[R, A]): RIO[R, A] = ZIO.untraced(zio)
+  def untraced[R, A](zio: RIO[R, A]): RIO[R, A] = ZIO.untraced(zio)
 
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when[R](b: Boolean)(rio: RIO[R, Any]): RIO[R, Unit] =
+  def when[R](b: Boolean)(rio: RIO[R, Any]): RIO[R, Unit] =
     ZIO.when(b)(rio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM[R](b: RIO[R, Boolean])(rio: RIO[R, Any]): RIO[R, Unit] =
+  def whenM[R](b: RIO[R, Boolean])(rio: RIO[R, Any]): RIO[R, Unit] =
     ZIO.whenM(b)(rio)
 
   /**
@@ -725,11 +725,11 @@ object RIO {
   /**
    * @see See [[zio.ZIO._1]]
    */
-  final def _1[R, A, B](implicit ev: R <:< (A, B)): RIO[R, A] = ZIO._1
+  def _1[R, A, B](implicit ev: R <:< (A, B)): RIO[R, A] = ZIO._1
 
   /**
    * @see See [[zio.ZIO._2]]
    */
-  final def _2[R, A, B](implicit ev: R <:< (A, B)): RIO[R, B] = ZIO._2
+  def _2[R, A, B](implicit ev: R <:< (A, B)): RIO[R, B] = ZIO._2
 
 }

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -38,7 +38,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    *
    * @return `UIO[A]` value from the `Ref`
    */
-  final def get: UIO[A] = IO.effectTotal(value.get)
+  def get: UIO[A] = IO.effectTotal(value.get)
 
   /**
    * Atomically modifies the `Ref` with the specified function, which computes
@@ -49,7 +49,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @tparam B type of the value of the `Ref` to be modified
    * @return `UIO[B]` modified value the `Ref`
    */
-  final def modify[B](f: A => (B, A)): UIO[B] = IO.effectTotal {
+  def modify[B](f: A => (B, A)): UIO[B] = IO.effectTotal {
     var loop = true
     var b: B = null.asInstanceOf[B]
 
@@ -77,7 +77,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @tparam B type of the value of the `Ref` to be modified
    * @return `UIO[B]` modified value of the `Ref`
    */
-  final def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): UIO[B] = IO.effectTotal {
+  def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): UIO[B] = IO.effectTotal {
     var loop = true
     var b: B = null.asInstanceOf[B]
 
@@ -101,7 +101,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @param a value to be written to the `Ref`
    * @return `UIO[Unit]`
    */
-  final def set(a: A): UIO[Unit] = IO.effectTotal(value.set(a))
+  def set(a: A): UIO[Unit] = IO.effectTotal(value.set(a))
 
   /**
    * Writes a new value to the `Ref` without providing a guarantee of
@@ -110,7 +110,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @param a value to be written to the `Ref`
    * @return `UIO[Unit]`
    */
-  final def setAsync(a: A): UIO[Unit] = IO.effectTotal(value.lazySet(a))
+  def setAsync(a: A): UIO[Unit] = IO.effectTotal(value.lazySet(a))
 
   /**
    * Atomically modifies the `Ref` with the specified function. This is not
@@ -119,7 +119,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @param f function to atomically modify the `Ref`
    * @return `UIO[A]` modified value of the `Ref`
    */
-  final def update(f: A => A): UIO[A] = IO.effectTotal {
+  def update(f: A => A): UIO[A] = IO.effectTotal {
     var loop    = true
     var next: A = null.asInstanceOf[A]
 
@@ -141,7 +141,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
    * @param pf partial function to atomically modify the `Ref`
    * @return `UIO[A]` modified value of the `Ref`
    */
-  final def updateSome(pf: PartialFunction[A, A]): UIO[A] = IO.effectTotal {
+  def updateSome(pf: PartialFunction[A, A]): UIO[A] = IO.effectTotal {
     var loop    = true
     var next: A = null.asInstanceOf[A]
 
@@ -166,5 +166,5 @@ object Ref extends Serializable {
    * @tparam A type of the value
    * @return `UIO[Ref[A]]`
    */
-  final def make[A](a: A): UIO[Ref[A]] = IO.effectTotal(new Ref[A](new AtomicReference(a)))
+  def make[A](a: A): UIO[Ref[A]] = IO.effectTotal(new Ref[A](new AtomicReference(a)))
 }

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -39,7 +39,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    *
    * @return `UIO[A]` value from the `Ref`
    */
-  final def get: UIO[A] = value.get
+  def get: UIO[A] = value.get
 
   /**
    * Atomically modifies the `RefM` with the specified function, which computes
@@ -52,7 +52,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @tparam B type of the `RefM`
    * @return `ZIO[R, E, B]` modified value of the `RefM`
    */
-  final def modify[R, E, B](f: A => ZIO[R, E, (B, A)]): ZIO[R, E, B] =
+  def modify[R, E, B](f: A => ZIO[R, E, (B, A)]): ZIO[R, E, B] =
     for {
       promise <- Promise.make[E, B]
       ref     <- Ref.make[Option[Cause[Nothing]]](None)
@@ -77,7 +77,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @tparam B type of the `RefM`
    * @return `ZIO[R, E, B]` modified value of the `RefM`
    */
-  final def modifySome[R, E, B](default: B)(pf: PartialFunction[A, ZIO[R, E, (B, A)]]): ZIO[R, E, B] =
+  def modifySome[R, E, B](default: B)(pf: PartialFunction[A, ZIO[R, E, (B, A)]]): ZIO[R, E, B] =
     for {
       promise <- Promise.make[E, B]
       ref     <- Ref.make[Option[Cause[Nothing]]](None)
@@ -100,7 +100,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @param a value to be written to the `RefM`
    * @return `UIO[Unit]`
    */
-  final def set(a: A): UIO[Unit] = value.set(a)
+  def set(a: A): UIO[Unit] = value.set(a)
 
   /**
    * Writes a new value to the `Ref` without providing a guarantee of
@@ -109,7 +109,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @param a value to be written to the `RefM`
    * @return `UIO[Unit]`
    */
-  final def setAsync(a: A): UIO[Unit] = value.setAsync(a)
+  def setAsync(a: A): UIO[Unit] = value.setAsync(a)
 
   /**
    * Atomically modifies the `RefM` with the specified function, returning the
@@ -120,7 +120,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @tparam E error type
    * @return `ZIO[R, E, A]` modified value of the `RefM`
    */
-  final def update[R, E](f: A => ZIO[R, E, A]): ZIO[R, E, A] =
+  def update[R, E](f: A => ZIO[R, E, A]): ZIO[R, E, A] =
     modify(a => f(a).map(a => (a, a)))
 
   /**
@@ -132,7 +132,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    * @tparam E error type
    * @return `ZIO[R, E, A]` modified value of the `RefM`
    */
-  final def updateSome[R, E](pf: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, A] =
+  def updateSome[R, E](pf: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, A] =
     modify(a => pf.applyOrElse(a, (_: A) => IO.succeed(a)).map(a => (a, a)))
 }
 
@@ -142,7 +142,7 @@ object RefM extends Serializable {
     update: A => IO[E, (B, A)],
     promise: Promise[E, B]
   ) {
-    final def run(a: A, ref: Ref[A], onDefect: Cause[E] => UIO[Unit]): UIO[Unit] =
+    def run(a: A, ref: Ref[A], onDefect: Cause[E] => UIO[Unit]): UIO[Unit] =
       interrupted.get.flatMap {
         case Some(cause) => onDefect(cause)
         case None =>
@@ -161,7 +161,7 @@ object RefM extends Serializable {
    * @tparam A type of the value
    * @return `UIO[RefM[A]]`
    */
-  final def make[A](
+  def make[A](
     a: A,
     n: Int = 1000,
     onDefect: Cause[Any] => UIO[Unit] = _ => IO.unit

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -157,7 +157,7 @@ object Runtime {
   /**
    * Builds a new runtime given an environment `R` and a [[zio.internal.Platform]].
    */
-  final def apply[R](r: R, platform0: Platform): Runtime[R] = new Runtime[R] {
+  def apply[R](r: R, platform0: Platform): Runtime[R] = new Runtime[R] {
     val environment = r
     val platform    = platform0
   }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -681,7 +681,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
 
 object Schedule {
 
-  final def apply[R, S, A, B](
+  def apply[R, S, A, B](
     initial0: ZIO[R, Nothing, S],
     update0: (A, S) => ZIO[R, Nothing, S],
     extract0: (A, S) => B
@@ -696,80 +696,80 @@ object Schedule {
   /**
    * A schedule that recurs forever, collecting all inputs into a list.
    */
-  final def collectAll[A]: Schedule[Any, A, List[A]] =
+  def collectAll[A]: Schedule[Any, A, List[A]] =
     identity[A].collectAll
 
   /**
    * A schedule that recurs as long as the condition f holds, collecting all inputs into a list.
    */
-  final def collectWhile[A](f: A => Boolean): Schedule[Any, A, List[A]] =
+  def collectWhile[A](f: A => Boolean): Schedule[Any, A, List[A]] =
     this.doWhile(f).collectAll
 
   /**
    * A schedule that recurs as long as the effectful condition holds, collecting all inputs into a list.
    */
-  final def collectWhileM[A](f: A => UIO[Boolean]): Schedule[Any, A, List[A]] =
+  def collectWhileM[A](f: A => UIO[Boolean]): Schedule[Any, A, List[A]] =
     this.doWhileM(f).collectAll
 
   /**
    * A schedule that recurs until the condition f fails, collecting all inputs into a list.
    */
-  final def collectUntil[A](f: A => Boolean): Schedule[Any, A, List[A]] =
+  def collectUntil[A](f: A => Boolean): Schedule[Any, A, List[A]] =
     this.doUntil(f).collectAll
 
   /**
    * A schedule that recurs until the effectful condition f fails, collecting all inputs into a list.
    */
-  final def collectUntilM[A](f: A => UIO[Boolean]): Schedule[Any, A, List[A]] =
+  def collectUntilM[A](f: A => UIO[Boolean]): Schedule[Any, A, List[A]] =
     this.doUntilM(f).collectAll
 
   /**
    * A new schedule derived from the specified schedule which transforms the delays into effectful sleeps.
    */
-  final def delayed[R <: Clock, A](s: Schedule[R, A, Duration]): Schedule[R, A, Duration] =
+  def delayed[R <: Clock, A](s: Schedule[R, A, Duration]): Schedule[R, A, Duration] =
     s.addDelay(x => x)
 
   /**
    * A schedule that recurs for as long as the predicate evaluates to true.
    */
-  final def doWhile[A](f: A => Boolean): Schedule[Any, A, A] =
+  def doWhile[A](f: A => Boolean): Schedule[Any, A, A] =
     doWhileM(a => ZIO.succeed(f(a)))
 
   /**
    * A schedule that recurs for as long as the effectful predicate evaluates to true.
    */
-  final def doWhileM[A](f: A => UIO[Boolean]): Schedule[Any, A, A] =
+  def doWhileM[A](f: A => UIO[Boolean]): Schedule[Any, A, A] =
     identity[A].whileInputM(f)
 
   /**
    * A schedule that recurs for as long as the predicate is equal.
    */
-  final def doWhileEquals[A](a: A): Schedule[Any, A, A] =
+  def doWhileEquals[A](a: A): Schedule[Any, A, A] =
     identity[A].whileInput(_ == a)
 
   /**
    * A schedule that recurs for until the predicate evaluates to true.
    */
-  final def doUntil[A](f: A => Boolean): Schedule[Any, A, A] =
+  def doUntil[A](f: A => Boolean): Schedule[Any, A, A] =
     doUntilM(a => ZIO.succeed(f(a)))
 
   /**
    * A schedule that recurs for until the predicate evaluates to true.
    */
-  final def doUntilM[A](f: A => UIO[Boolean]): Schedule[Any, A, A] =
+  def doUntilM[A](f: A => UIO[Boolean]): Schedule[Any, A, A] =
     identity[A].untilInputM(f)
 
   /**
    * A schedule that recurs for until the predicate is equal.
    */
-  final def doUntilEquals[A](a: A): Schedule[Any, A, A] =
+  def doUntilEquals[A](a: A): Schedule[Any, A, A] =
     identity[A].untilInput(_ == a)
 
   /**
    * A schedule that recurs for until the input value becomes applicable to partial function
    * and then map that value with given function.
    * */
-  final def doUntil[A, B](pf: PartialFunction[A, B]): Schedule[Any, A, Option[B]] =
+  def doUntil[A, B](pf: PartialFunction[A, B]): Schedule[Any, A, Option[B]] =
     new Schedule[Any, A, Option[B]] {
       type State = Unit
       val initial = ZIO.unit
@@ -781,7 +781,7 @@ object Schedule {
    * A schedule that will recur until the specified duration elapses. Returns
    * the total elapsed time.
    */
-  final def duration(duration: Duration): Schedule[Clock, Any, Duration] =
+  def duration(duration: Duration): Schedule[Clock, Any, Duration] =
     elapsed.untilOutput(_ >= duration)
 
   /**
@@ -800,7 +800,7 @@ object Schedule {
    * repetitions, given by `base * factor.pow(n)`, where `n` is the number of
    * repetitions so far. Returns the current duration between recurrences.
    */
-  final def exponential(base: Duration, factor: Double = 2.0): Schedule[Clock, Any, Duration] =
+  def exponential(base: Duration, factor: Double = 2.0): Schedule[Clock, Any, Duration] =
     delayed(forever.map(i => base * math.pow(factor, (i + 1).doubleValue)))
 
   /**
@@ -808,7 +808,7 @@ object Schedule {
    * preceding two delays (similar to the fibonacci sequence). Returns the
    * current duration between recurrences.
    */
-  final def fibonacci(one: Duration): Schedule[Clock, Any, Duration] =
+  def fibonacci(one: Duration): Schedule[Clock, Any, Duration] =
     delayed {
       unfold[(Duration, Duration)]((one, one)) {
         case (a1, a2) => (a2, a1 + a2)
@@ -827,7 +827,7 @@ object Schedule {
    * |action|                   |action|
    * </pre>
    */
-  final def fixed(interval: Duration): Schedule[Clock, Any, Int] = interval match {
+  def fixed(interval: Duration): Schedule[Clock, Any, Int] = interval match {
     case Duration.Infinity                    => once >>> never.as(1)
     case Duration.Finite(nanos) if nanos == 0 => forever
     case Duration.Finite(nanos) =>
@@ -857,12 +857,12 @@ object Schedule {
    * A schedule that recurs forever, mapping input values through the
    * specified function.
    */
-  final def fromFunction[A, B](f: A => B): Schedule[Any, A, B] = identity[A].map(f)
+  def fromFunction[A, B](f: A => B): Schedule[Any, A, B] = identity[A].map(f)
 
   /**
    * A schedule that recurs forever, returning each input as the output.
    */
-  final def identity[A]: Schedule[Any, A, A] =
+  def identity[A]: Schedule[Any, A, A] =
     Schedule[Any, Unit, A, A](ZIO.succeed(()), (_, _) => ZIO.succeed(()), (a, _) => a)
 
   /**
@@ -870,7 +870,7 @@ object Schedule {
    * interval, given by `base * n` where `n` is the number of
    * repetitions so far. Returns the current duration between recurrences.
    */
-  final def linear(base: Duration): Schedule[Clock, Any, Duration] =
+  def linear(base: Duration): Schedule[Clock, Any, Duration] =
     delayed(forever.map(i => base * (i + 1).doubleValue()))
 
   /**
@@ -888,7 +888,7 @@ object Schedule {
    * A schedule that sleeps for random duration that is uniformly distributed in the given range.
    * The schedules output is the duration it has slept on the last update, or 0 if it hasn't updated yet.
    */
-  final def randomDelay(min: Duration, max: Duration): Schedule[Random with Clock, Any, Duration] = {
+  def randomDelay(min: Duration, max: Duration): Schedule[Random with Clock, Any, Duration] = {
     val minNanos = min.toNanos
     val maxNanos = max.toNanos
     Schedule[Clock with Random, Duration, Any, Duration](
@@ -907,7 +907,7 @@ object Schedule {
    * A schedule that sleeps for random duration that is normally distributed.
    * The schedules output is the duration it has slept on the last update, or 0 if it hasn't updated yet.
    */
-  final def randomDelayNormal(mean: Duration, std: Duration): Schedule[Random with Clock, Any, Duration] =
+  def randomDelayNormal(mean: Duration, std: Duration): Schedule[Random with Clock, Any, Duration] =
     Schedule[Clock with Random, Duration, Any, Duration](
       ZIO.succeed(Duration.Zero), {
         case _ =>
@@ -926,7 +926,7 @@ object Schedule {
    * If 0 or negative numbers are given, the operation is not done at all so
    * that in `(op: IO[E, A]).repeat(Schedule.recurs(0)) `, op is not done at all.
    */
-  final def recurs(n: Int): Schedule[Any, Any, Int] =
+  def recurs(n: Int): Schedule[Any, Any, Int] =
     forever.whileOutput(_ < n)
 
   /**
@@ -937,7 +937,7 @@ object Schedule {
    * |action|-----interval-----|action|-----interval-----|action|
    * </pre>
    */
-  final def spaced(interval: Duration): Schedule[Clock, Any, Int] =
+  def spaced(interval: Duration): Schedule[Clock, Any, Int] =
     forever.addDelay(_ => interval)
 
   /**
@@ -949,34 +949,34 @@ object Schedule {
   /**
    * A schedule that recurs forever, returning the constant for every output.
    */
-  final def succeed[A](a: A): Schedule[Any, Any, A] =
+  def succeed[A](a: A): Schedule[Any, Any, A] =
     forever.as(a)
 
   /**
    * A schedule that recurs forever, dumping input values to the specified
    * sink, and returning those same values unmodified.
    */
-  final def tapInput[R, A](f: A => ZIO[R, Nothing, Unit]): Schedule[R, A, A] =
+  def tapInput[R, A](f: A => ZIO[R, Nothing, Unit]): Schedule[R, A, A] =
     identity[A].tapInput(f)
 
   /**
    * A schedule that recurs forever, dumping output values to the specified
    * sink, and returning those same values unmodified.
    */
-  final def tapOutput[R, A](f: A => ZIO[R, Nothing, Unit]): Schedule[R, A, A] =
+  def tapOutput[R, A](f: A => ZIO[R, Nothing, Unit]): Schedule[R, A, A] =
     identity[A].tapOutput(f)
 
   /**
    * A schedule that always recurs without delay, and computes the output
    * through recured application of a function to a base value.
    */
-  final def unfold[A](a: => A)(f: A => A): Schedule[Any, Any, A] =
+  def unfold[A](a: => A)(f: A => A): Schedule[Any, Any, A] =
     unfoldM(IO.succeed(a))(f.andThen(IO.succeed[A](_)))
 
   /**
    * A schedule that always recurs without delay, and computes the output
    * through recured application of a function to a base value.
    */
-  final def unfoldM[R, A](a: ZIO[R, Nothing, A])(f: A => ZIO[R, Nothing, A]): Schedule[R, Any, A] =
+  def unfoldM[R, A](a: ZIO[R, Nothing, A])(f: A => ZIO[R, Nothing, A]): Schedule[R, Any, A] =
     Schedule[R, A, Any, A](a, (_, a) => f(a), (_, a) => a)
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -37,7 +37,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   /**
    * The number of permits currently available.
    */
-  final def available: UIO[Long] = state.get.map {
+  def available: UIO[Long] = state.get.map {
     case Left(_)  => 0
     case Right(n) => n
   }
@@ -45,19 +45,19 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   /**
    * Acquires a permit, executes the action and releases the permit right after.
    */
-  final def withPermit[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] =
+  def withPermit[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] =
     withPermits(1)(task)
 
   /**
    * Acquires a permit in a [[zio.ZManaged]] and releases the permit in the finalizer.
    */
-  final def withPermitManaged[R, E]: ZManaged[R, E, Unit] =
+  def withPermitManaged[R, E]: ZManaged[R, E, Unit] =
     withPermitsManaged(1)
 
   /**
    * Acquires `n` permits, executes the action and releases the permits right after.
    */
-  final def withPermits[R, E, A](n: Long)(task: ZIO[R, E, A]): ZIO[R, E, A] =
+  def withPermits[R, E, A](n: Long)(task: ZIO[R, E, A]): ZIO[R, E, A] =
     prepare(n).bracket(
       e => e.release
     )(r => r.awaitAcquire *> task)
@@ -65,13 +65,13 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   /**
    * Acquires `n` permits in a [[zio.ZManaged]] and releases the permits in the finalizer.
    */
-  final def withPermitsManaged[R, E](n: Long): ZManaged[R, E, Unit] =
+  def withPermitsManaged[R, E](n: Long): ZManaged[R, E, Unit] =
     ZManaged(prepare(n).map(a => Reservation(a.awaitAcquire, _ => a.release)))
 
   /**
    * Ported from @mpilquist work in Cats Effect (https://github.com/typelevel/cats-effect/pull/403)
    */
-  final private def prepare(n: Long): UIO[Acquisition] = {
+  private def prepare(n: Long): UIO[Acquisition] = {
     def restore(p: Promise[Nothing, Unit], n: Long): UIO[Unit] =
       IO.flatten(state.modify {
         case Left(q) =>
@@ -98,7 +98,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
    * they will be woken up (in FIFO order) if this action releases enough
    * of them.
    */
-  final private def releaseN0(toRelease: Long): UIO[Unit] = {
+  private def releaseN0(toRelease: Long): UIO[Unit] = {
 
     @tailrec def loop(n: Long, state: State, acc: UIO[Unit]): (UIO[Unit], State) = state match {
       case Right(m) => acc -> Right(n + m)
@@ -126,7 +126,7 @@ object Semaphore extends Serializable {
   /**
    * Creates a new `Sempahore` with the specified number of permits.
    */
-  final def make(permits: Long): UIO[Semaphore] = Ref.make[State](Right(permits)).map(new Semaphore(_))
+  def make(permits: Long): UIO[Semaphore] = Ref.make[State](Right(permits)).map(new Semaphore(_))
 }
 
 private object internals {
@@ -142,5 +142,5 @@ private object internals {
       IO.die(new NegativeArgument(s"Unexpected negative value `$n` passed to acquireN or releaseN."))
     else IO.unit
 
-  class NegativeArgument(message: String) extends IllegalArgumentException(message)
+  final class NegativeArgument(message: String) extends IllegalArgumentException(message)
 }

--- a/core/shared/src/main/scala/zio/SuperviseStatus.scala
+++ b/core/shared/src/main/scala/zio/SuperviseStatus.scala
@@ -18,8 +18,8 @@ package zio
 
 sealed abstract class SuperviseStatus extends Serializable with Product
 object SuperviseStatus {
-  def supervised: SuperviseStatus   = Supervised
-  def unsupervised: SuperviseStatus = Unsupervised
+  final def supervised: SuperviseStatus   = Supervised
+  final def unsupervised: SuperviseStatus = Unsupervised
 
   case object Supervised   extends SuperviseStatus
   case object Unsupervised extends SuperviseStatus

--- a/core/shared/src/main/scala/zio/SuperviseStatus.scala
+++ b/core/shared/src/main/scala/zio/SuperviseStatus.scala
@@ -18,8 +18,8 @@ package zio
 
 sealed abstract class SuperviseStatus extends Serializable with Product
 object SuperviseStatus {
-  final def supervised: SuperviseStatus   = Supervised
-  final def unsupervised: SuperviseStatus = Unsupervised
+  def supervised: SuperviseStatus   = Supervised
+  def unsupervised: SuperviseStatus = Unsupervised
 
   case object Supervised   extends SuperviseStatus
   case object Unsupervised extends SuperviseStatus

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -9,42 +9,42 @@ object Task {
   /**
    * @see See [[zio.ZIO.absolve]]
    */
-  final def absolve[A](v: Task[Either[Throwable, A]]): Task[A] =
+  def absolve[A](v: Task[Either[Throwable, A]]): Task[A] =
     ZIO.absolve(v)
 
   /**
    * @see See [[zio.ZIO.allowInterrupt]]
    */
-  final def allowInterrupt: UIO[Unit] =
+  def allowInterrupt: UIO[Unit] =
     ZIO.allowInterrupt
 
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  final def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A](acquire: Task[A]): ZIO.BracketAcquire[Any, Throwable, A] =
+  def bracket[A](acquire: Task[A]): ZIO.BracketAcquire[Any, Throwable, A] =
     ZIO.bracket(acquire)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A, B](acquire: Task[A], release: A => UIO[Any], use: A => Task[B]): Task[B] =
+  def bracket[A, B](acquire: Task[A], release: A => UIO[Any], use: A => Task[B]): Task[B] =
     ZIO.bracket(acquire, release, use)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[A](acquire: Task[A]): ZIO.BracketExitAcquire[Any, Throwable, A] =
+  def bracketExit[A](acquire: Task[A]): ZIO.BracketExitAcquire[Any, Throwable, A] =
     ZIO.bracketExit(acquire)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[A, B](
+  def bracketExit[A, B](
     acquire: Task[A],
     release: (A, Exit[Throwable, B]) => UIO[Any],
     use: A => Task[B]
@@ -54,25 +54,25 @@ object Task {
   /**
    * @see See bracketFork [[zio.ZIO]]
    */
-  final def bracketFork[A](acquire: Task[A]): ZIO.BracketForkAcquire[Any, Throwable, A] =
+  def bracketFork[A](acquire: Task[A]): ZIO.BracketForkAcquire[Any, Throwable, A] =
     ZIO.bracketFork(acquire)
 
   /**
    * @see See bracketFork [[zio.ZIO]]
    */
-  final def bracketFork[A, B](acquire: Task[A], release: A => UIO[Any], use: A => Task[B]): Task[B] =
+  def bracketFork[A, B](acquire: Task[A], release: A => UIO[Any], use: A => Task[B]): Task[B] =
     ZIO.bracketFork(acquire, release, use)
 
   /**
    * @see See bracketForkExit [[zio.ZIO]]
    */
-  final def bracketForkExit[A](acquire: Task[A]): ZIO.BracketForkExitAcquire[Any, Throwable, A] =
+  def bracketForkExit[A](acquire: Task[A]): ZIO.BracketForkExitAcquire[Any, Throwable, A] =
     ZIO.bracketForkExit(acquire)
 
   /**
    * @see See bracketForkExit [[zio.ZIO]]
    */
-  final def bracketForkExit[A, B](
+  def bracketForkExit[A, B](
     acquire: Task[A],
     release: (A, Exit[Throwable, B]) => UIO[Any],
     use: A => Task[B]
@@ -82,127 +82,127 @@ object Task {
   /**
    * @see See [[zio.ZIO.checkDaemon]]
    */
-  final def checkDaemon[A](f: DaemonStatus => Task[A]): Task[A] =
+  def checkDaemon[A](f: DaemonStatus => Task[A]): Task[A] =
     ZIO.checkDaemon(f)
 
   /**
    * @see See [[zio.ZIO.checkInterruptible]]
    */
-  final def checkInterruptible[A](f: InterruptStatus => Task[A]): Task[A] =
+  def checkInterruptible[A](f: InterruptStatus => Task[A]): Task[A] =
     ZIO.checkInterruptible(f)
 
   /**
    * @see See [[zio.ZIO.checkTraced]]
    */
-  final def checkTraced[A](f: TracingStatus => Task[A]): Task[A] =
+  def checkTraced[A](f: TracingStatus => Task[A]): Task[A] =
     ZIO.checkTraced(f)
 
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
+  def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
    */
-  final def collectAll[A](in: Iterable[Task[A]]): Task[List[A]] =
+  def collectAll[A](in: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAll(in)
 
   /**
    * @see See [[zio.ZIO.collectAllPar]]
    */
-  final def collectAllPar[A](as: Iterable[Task[A]]): Task[List[A]] =
+  def collectAllPar[A](as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAllPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
-  final def collectAllParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
+  def collectAllParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAllParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccesses]]
    */
-  final def collectAllSuccesses[A](in: Iterable[Task[A]]): Task[List[A]] =
+  def collectAllSuccesses[A](in: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAllSuccesses(in)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesPar]]
    */
-  final def collectAllSuccessesPar[A](as: Iterable[Task[A]]): Task[List[A]] =
+  def collectAllSuccessesPar[A](as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAllSuccessesPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
-  final def collectAllSuccessesParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
+  def collectAllSuccessesParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.collectAllSuccessesParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllWith]]
    */
-  final def collectAllWith[A, B](in: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
+  def collectAllWith[A, B](in: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
     ZIO.collectAllWith(in)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithPar]]
    */
-  final def collectAllWithPar[A, B](as: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
+  def collectAllWithPar[A, B](as: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
     ZIO.collectAllWithPar(as)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
-  final def collectAllWithParN[A, B](n: Int)(as: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
+  def collectAllWithParN[A, B](n: Int)(as: Iterable[Task[A]])(f: PartialFunction[A, B]): Task[List[B]] =
     ZIO.collectAllWithParN(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.daemonMask]]
    */
-  final def daemonMask[A](k: ZIO.DaemonStatusRestore => Task[A]): Task[A] =
+  def daemonMask[A](k: ZIO.DaemonStatusRestore => Task[A]): Task[A] =
     ZIO.daemonMask(k)
 
   /**
    * @see See [[zio.ZIO.die]]
    */
-  final def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
+  def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
 
   /**
    * @see See [[zio.ZIO.dieMessage]]
    */
-  final def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
+  def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
 
   /**
    * @see See [[zio.ZIO.done]]
    */
-  final def done[A](r: Exit[Throwable, A]): Task[A] = ZIO.done(r)
+  def done[A](r: Exit[Throwable, A]): Task[A] = ZIO.done(r)
 
   /**
    * @see See [[zio.ZIO.descriptor]]
    */
-  final def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
+  def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
 
   /**
    * @see See [[zio.ZIO.descriptorWith]]
    */
-  final def descriptorWith[A](f: Fiber.Descriptor => Task[A]): Task[A] =
+  def descriptorWith[A](f: Fiber.Descriptor => Task[A]): Task[A] =
     ZIO.descriptorWith(f)
 
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  final def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
    */
-  final def effectAsync[A](register: (Task[A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): Task[A] =
+  def effectAsync[A](register: (Task[A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): Task[A] =
     ZIO.effectAsync(register, blockingOn)
 
   /**
    * @see See [[zio.ZIO.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[A](
+  def effectAsyncMaybe[A](
     register: (Task[A] => Unit) => Option[Task[A]],
     blockingOn: List[Fiber.Id] = Nil
   ): Task[A] =
@@ -211,13 +211,13 @@ object Task {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[A](register: (Task[A] => Unit) => Task[Any]): Task[A] =
+  def effectAsyncM[A](register: (Task[A] => Unit) => Task[Any]): Task[A] =
     ZIO.effectAsyncM(register)
 
   /**
    * @see See [[zio.ZIO.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[A](
+  def effectAsyncInterrupt[A](
     register: (Task[A] => Unit) => Either[Canceler[Any], Task[A]],
     blockingOn: List[Fiber.Id] = Nil
   ): Task[A] =
@@ -226,32 +226,32 @@ object Task {
   /**
    * @see See [[zio.RIO.effectSuspend]]
    */
-  final def effectSuspend[A](task: => Task[A]): Task[A] = ZIO.effectSuspend(task)
+  def effectSuspend[A](task: => Task[A]): Task[A] = ZIO.effectSuspend(task)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  final def effectSuspendTotal[A](task: => Task[A]): Task[A] = ZIO.effectSuspendTotal(task)
+  def effectSuspendTotal[A](task: => Task[A]): Task[A] = ZIO.effectSuspendTotal(task)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  final def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendTotalWith(p)
+  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see See [[zio.RIO.effectSuspendWith]]
    */
-  final def effectSuspendWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendWith(p)
+  def effectSuspendWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.fail]]
    */
-  final def fail(error: Throwable): Task[Nothing] = ZIO.fail(error)
+  def fail(error: Throwable): Task[Nothing] = ZIO.fail(error)
 
   /**
    * @see [[zio.ZIO.fiberId]]
@@ -261,7 +261,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.firstSuccessOf]]
    */
-  final def firstSuccessOf[A](
+  def firstSuccessOf[A](
     task: Task[A],
     rest: Iterable[Task[A]]
   ): Task[A] =
@@ -270,136 +270,136 @@ object Task {
   /**
    * @see See [[zio.ZIO.flatten]]
    */
-  final def flatten[A](task: Task[Task[A]]): Task[A] =
+  def flatten[A](task: Task[Task[A]]): Task[A] =
     ZIO.flatten(task)
 
   /**
    * @see See [[zio.ZIO.foldLeft]]
    */
-  final def foldLeft[S, A](in: Iterable[A])(zero: S)(f: (S, A) => Task[S]): Task[S] =
+  def foldLeft[S, A](in: Iterable[A])(zero: S)(f: (S, A) => Task[S]): Task[S] =
     ZIO.foldLeft(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foldRight]]
    */
-  final def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => Task[S]): Task[S] =
+  def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => Task[S]): Task[S] =
     ZIO.foldRight(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foreach]]
    */
-  final def foreach[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
+  def foreach[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
     ZIO.foreach(in)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar]]
    */
-  final def foreachPar[A, B](as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
+  def foreachPar[A, B](as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
     ZIO.foreachPar(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
-  final def foreachParN[A, B](n: Int)(as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
+  def foreachParN[A, B](n: Int)(as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
     ZIO.foreachParN(n)(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
+  def foreach_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[A, B](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
+  def foreachPar_[A, B](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[A, B](n: Int)(as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
+  def foreachParN_[A, B](n: Int)(as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  final def forkAll[A](as: Iterable[Task[A]]): UIO[Fiber[Throwable, List[A]]] =
+  def forkAll[A](as: Iterable[Task[A]]): UIO[Fiber[Throwable, List[A]]] =
     ZIO.forkAll(as)
 
   /**
    * @see See [[zio.ZIO.forkAll_]]
    */
-  final def forkAll_[A](as: Iterable[Task[A]]): UIO[Unit] =
+  def forkAll_[A](as: Iterable[Task[A]]): UIO[Unit] =
     ZIO.forkAll_(as)
 
   /**
    * @see See [[zio.ZIO.fromEither]]
    */
-  final def fromEither[A](v: => Either[Throwable, A]): Task[A] =
+  def fromEither[A](v: => Either[Throwable, A]): Task[A] =
     ZIO.fromEither(v)
 
   /**
    * @see See [[zio.ZIO.fromFiber]]
    */
-  final def fromFiber[A](fiber: => Fiber[Throwable, A]): Task[A] =
+  def fromFiber[A](fiber: => Fiber[Throwable, A]): Task[A] =
     ZIO.fromFiber(fiber)
 
   /**
    * @see See [[zio.ZIO.fromFiberM]]
    */
-  final def fromFiberM[A](fiber: Task[Fiber[Throwable, A]]): Task[A] =
+  def fromFiberM[A](fiber: Task[Fiber[Throwable, A]]): Task[A] =
     ZIO.fromFiberM(fiber)
 
   /**
    * @see [[zio.ZIO.fromFunction]]
    */
-  final def fromFunction[A](f: Any => A): Task[A] = ZIO.fromFunction(f)
+  def fromFunction[A](f: Any => A): Task[A] = ZIO.fromFunction(f)
 
   /**
    * @see See [[zio.ZIO.fromFutureInterrupt]]
    */
-  final def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFutureInterrupt(make)
 
   /**
    * @see [[zio.ZIO.fromFunctionFuture]]
    */
-  final def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
+  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFunctionFuture(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  final def fromFunctionM[A](f: Any => Task[A]): Task[A] = ZIO.fromFunctionM(f)
+  def fromFunctionM[A](f: Any => Task[A]): Task[A] = ZIO.fromFunctionM(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
    */
-  final def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFuture(make)
 
   /**
    * @see See [[zio.ZIO.fromTry]]
    */
-  final def fromTry[A](value: => scala.util.Try[A]): Task[A] =
+  def fromTry[A](value: => scala.util.Try[A]): Task[A] =
     ZIO.fromTry(value)
 
   /**
    * @see See [[zio.ZIO.halt]]
    */
-  final def halt(cause: Cause[Throwable]): Task[Nothing] = ZIO.halt(cause)
+  def halt(cause: Cause[Throwable]): Task[Nothing] = ZIO.halt(cause)
 
   /**
    * @see See [[zio.ZIO.haltWith]]
    */
-  final def haltWith[E <: Throwable](function: (() => ZTrace) => Cause[E]): Task[Nothing] =
+  def haltWith[E <: Throwable](function: (() => ZTrace) => Cause[E]): Task[Nothing] =
     ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.identity]]
    */
-  final def identity: Task[Any] = ZIO.identity
+  def identity: Task[Any] = ZIO.identity
 
   /**
    * @see See [[zio.ZIO.interrupt]]
@@ -409,59 +409,59 @@ object Task {
   /**
    * @see See [[zio.ZIO.interruptAs]]
    */
-  final def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
 
   /**
    * @see See [[zio.ZIO.interruptible]]
    */
-  final def interruptible[A](task: Task[A]): Task[A] =
+  def interruptible[A](task: Task[A]): Task[A] =
     ZIO.interruptible(task)
 
   /**
    * @see See [[zio.ZIO.interruptibleFork]]
    */
-  final def interruptibleFork[A](task: Task[A]): Task[A] =
+  def interruptibleFork[A](task: Task[A]): Task[A] =
     ZIO.interruptibleFork(task)
 
   /**
    * @see See [[zio.ZIO.interruptibleForkMask]]
    */
-  final def interruptibleForkMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
+  def interruptibleForkMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
     ZIO.interruptibleForkMask(k)
 
   /**
    * @see See [[zio.ZIO.interruptibleMask]]
    */
-  final def interruptibleMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
+  def interruptibleMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
     ZIO.interruptibleMask(k)
 
   /**
    *  @see See [[zio.ZIO.left]]
    */
-  final def left[A](a: A): Task[Either[A, Nothing]] = ZIO.left(a)
+  def left[A](a: A): Task[Either[A, Nothing]] = ZIO.left(a)
 
   /**
    * @see See [[zio.ZIO.lock]]
    */
-  final def lock[A](executor: Executor)(task: Task[A]): Task[A] =
+  def lock[A](executor: Executor)(task: Task[A]): Task[A] =
     ZIO.lock(executor)(task)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
+  def mapN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapN(task1, task2)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
+  def mapN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapN(task1, task2, task3)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
+  def mapN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F
   ): Task[F] =
     ZIO.mapN(task1, task2, task3, task4)(f)
@@ -469,19 +469,19 @@ object Task {
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
+  def mapParN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapParN(task1, task2)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
+  def mapParN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapParN(task1, task2, task3)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
+  def mapParN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F
   ): Task[F] =
     ZIO.mapParN(task1, task2, task3, task4)(f)
@@ -489,13 +489,13 @@ object Task {
   /**
    * @see See [[zio.ZIO.mergeAll]]
    */
-  final def mergeAll[A, B](in: Iterable[Task[A]])(zero: B)(f: (B, A) => B): Task[B] =
+  def mergeAll[A, B](in: Iterable[Task[A]])(zero: B)(f: (B, A) => B): Task[B] =
     ZIO.mergeAll(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.mergeAllPar]]
    */
-  final def mergeAllPar[A, B](in: Iterable[Task[A]])(zero: B)(f: (B, A) => B): Task[B] =
+  def mergeAllPar[A, B](in: Iterable[Task[A]])(zero: B)(f: (B, A) => B): Task[B] =
     ZIO.mergeAllPar(in)(zero)(f)
 
   /**
@@ -506,7 +506,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.nonDaemonMask]]
    */
-  final def nonDaemonMask[A](k: ZIO.DaemonStatusRestore => Task[A]): Task[A] =
+  def nonDaemonMask[A](k: ZIO.DaemonStatusRestore => Task[A]): Task[A] =
     ZIO.nonDaemonMask(k)
 
   /**
@@ -517,121 +517,121 @@ object Task {
   /**
    * @see See [[zio.ZIO.partitionM]]
    */
-  final def partitionM[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+  def partitionM[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
     ZIO.partitionM(in)(f)
 
   /**
    * @see See [[zio.ZIO.partitionMPar]]
    */
-  final def partitionMPar[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+  def partitionMPar[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
     ZIO.partitionMPar(in)(f)
 
   /**
    * @see See [[zio.ZIO.partitionMParN]]
    */
-  final def partitionMParN[A, B](n: Int)(in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+  def partitionMParN[A, B](n: Int)(in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
     ZIO.partitionMParN(n)(in)(f)
 
   /**
    * @see See [[zio.ZIO.raceAll]]
    */
-  final def raceAll[A](task: Task[A], ios: Iterable[Task[A]]): Task[A] =
+  def raceAll[A](task: Task[A], ios: Iterable[Task[A]]): Task[A] =
     ZIO.raceAll(task, ios)
 
   /**
    * @see See [[zio.ZIO.reduceAll]]
    */
-  final def reduceAll[A](a: Task[A], as: Iterable[Task[A]])(f: (A, A) => A): Task[A] =
+  def reduceAll[A](a: Task[A], as: Iterable[Task[A]])(f: (A, A) => A): Task[A] =
     ZIO.reduceAll(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.reduceAllPar]]
    */
-  final def reduceAllPar[A](a: Task[A], as: Iterable[Task[A]])(f: (A, A) => A): Task[A] =
+  def reduceAllPar[A](a: Task[A], as: Iterable[Task[A]])(f: (A, A) => A): Task[A] =
     ZIO.reduceAllPar(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  final def replicate[A](n: Int)(effect: Task[A]): Iterable[Task[A]] =
+  def replicate[A](n: Int)(effect: Task[A]): Iterable[Task[A]] =
     ZIO.replicate(n)(effect)
 
   /**
    * @see See [[zio.ZIO.require]]
    */
-  final def require[A](error: Throwable): Task[Option[A]] => Task[A] =
+  def require[A](error: Throwable): Task[Option[A]] => Task[A] =
     ZIO.require[Any, Throwable, A](error)
 
   /**
    * @see See [[zio.ZIO.reserve]]
    */
-  final def reserve[A, B](reservation: Task[Reservation[Any, Throwable, A]])(use: A => Task[B]): Task[B] =
+  def reserve[A, B](reservation: Task[Reservation[Any, Throwable, A]])(use: A => Task[B]): Task[B] =
     ZIO.reserve(reservation)(use)
 
   /**
    *  @see [[zio.ZIO.right]]
    */
-  final def right[B](b: B): Task[Either[Nothing, B]] = ZIO.right(b)
+  def right[B](b: B): Task[Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
    */
-  final def runtime: UIO[Runtime[Any]] = ZIO.runtime
+  def runtime: UIO[Runtime[Any]] = ZIO.runtime
 
   /**
    * @see See [[zio.ZIO.succeed]]
    */
-  final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
   /**
    *  See [[zio.ZIO.sequence]]
    */
-  final def sequence[A](in: Iterable[Task[A]]): Task[List[A]] =
+  def sequence[A](in: Iterable[Task[A]]): Task[List[A]] =
     ZIO.sequence(in)
 
   /**
    *  See [[zio.ZIO.sequencePar]]
    */
-  final def sequencePar[A](as: Iterable[Task[A]]): Task[List[A]] =
+  def sequencePar[A](as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.sequencePar(as)
 
   /**
    *  See [[zio.ZIO.sequenceParN]]
    */
-  final def sequenceParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
+  def sequenceParN[A](n: Int)(as: Iterable[Task[A]]): Task[List[A]] =
     ZIO.sequenceParN(n)(as)
 
   /**
    *  @see [[zio.ZIO.some]]
    */
-  final def some[A](a: A): Task[Option[A]] = ZIO.some(a)
+  def some[A](a: A): Task[Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.trace]]
    * */
-  final def trace: UIO[ZTrace] = ZIO.trace
+  def trace: UIO[ZTrace] = ZIO.trace
 
   /**
    * @see See [[zio.ZIO.traced]]
    */
-  final def traced[A](task: Task[A]): Task[A] = ZIO.traced(task)
+  def traced[A](task: Task[A]): Task[A] = ZIO.traced(task)
 
   /**
    * @see See [[zio.ZIO.traverse]]
    */
-  final def traverse[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
+  def traverse[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
     ZIO.traverse(in)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar]]
    */
-  final def traversePar[A, B](as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
+  def traversePar[A, B](as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
     ZIO.traversePar(as)(fn)
 
   /**
    * Alias for [[ZIO.foreachParN]]
    */
-  final def traverseParN[A, B](
+  def traverseParN[A, B](
     n: Int
   )(as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =
     ZIO.traverseParN(n)(as)(fn)
@@ -639,19 +639,19 @@ object Task {
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
+  def traverse_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
+  def traversePar_[A](as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[A](
+  def traverseParN_[A](
     n: Int
   )(as: Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.traverseParN_(n)(as)(f)
@@ -664,47 +664,47 @@ object Task {
   /**
    * @see See [[zio.ZIO.uninterruptible]]
    */
-  final def uninterruptible[A](task: Task[A]): Task[A] =
+  def uninterruptible[A](task: Task[A]): Task[A] =
     ZIO.uninterruptible(task)
 
   /**
    * @see See [[zio.ZIO.uninterruptibleMask]]
    */
-  final def uninterruptibleMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
+  def uninterruptibleMask[A](k: ZIO.InterruptStatusRestore => Task[A]): Task[A] =
     ZIO.uninterruptibleMask(k)
 
   /**
    * @see [[zio.ZIO.unsandbox]]
    */
-  final def unsandbox[A](v: IO[Cause[Throwable], A]): Task[A] = ZIO.unsandbox(v)
+  def unsandbox[A](v: IO[Cause[Throwable], A]): Task[A] = ZIO.unsandbox(v)
 
   /**
    * @see See [[zio.ZIO.untraced]]
    */
-  final def untraced[A](task: Task[A]): Task[A] = ZIO.untraced(task)
+  def untraced[A](task: Task[A]): Task[A] = ZIO.untraced(task)
 
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when(b: Boolean)(task: Task[Any]): Task[Unit] =
+  def when(b: Boolean)(task: Task[Any]): Task[Unit] =
     ZIO.when(b)(task)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM(b: Task[Boolean])(task: Task[Any]): Task[Unit] =
+  def whenM(b: Task[Boolean])(task: Task[Any]): Task[Unit] =
     ZIO.whenM(b)(task)
 
   /**

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -553,7 +553,7 @@ object Task {
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  def replicate[A](n: Int)(effect: Task[A]): Iterable[Task[A]] =
+  final def replicate[A](n: Int)(effect: Task[A]): Iterable[Task[A]] =
     ZIO.replicate(n)(effect)
 
   /**
@@ -571,7 +571,7 @@ object Task {
   /**
    *  @see [[zio.ZIO.right]]
    */
-  def right[B](b: B): Task[Either[Nothing, B]] = ZIO.right(b)
+  final def right[B](b: B): Task[Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
@@ -604,7 +604,7 @@ object Task {
   /**
    *  @see [[zio.ZIO.some]]
    */
-  def some[A](a: A): Task[Option[A]] = ZIO.some(a)
+  final def some[A](a: A): Task[Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/TracingStatus.scala
+++ b/core/shared/src/main/scala/zio/TracingStatus.scala
@@ -10,8 +10,8 @@ sealed abstract class TracingStatus extends Serializable with Product {
   private[zio] final def toBoolean: Boolean = isTraced
 }
 object TracingStatus {
-  final def traced: TracingStatus   = Traced
-  final def untraced: TracingStatus = Untraced
+  def traced: TracingStatus   = Traced
+  def untraced: TracingStatus = Untraced
 
   case object Traced   extends TracingStatus
   case object Untraced extends TracingStatus

--- a/core/shared/src/main/scala/zio/TracingStatus.scala
+++ b/core/shared/src/main/scala/zio/TracingStatus.scala
@@ -10,8 +10,8 @@ sealed abstract class TracingStatus extends Serializable with Product {
   private[zio] final def toBoolean: Boolean = isTraced
 }
 object TracingStatus {
-  def traced: TracingStatus   = Traced
-  def untraced: TracingStatus = Untraced
+  final def traced: TracingStatus   = Traced
+  final def untraced: TracingStatus = Untraced
 
   case object Traced   extends TracingStatus
   case object Untraced extends TracingStatus

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -7,168 +7,168 @@ object UIO {
   /**
    * @see See [[zio.ZIO.absolve]]
    */
-  final def absolve[A](v: UIO[Either[Nothing, A]]): UIO[A] =
+  def absolve[A](v: UIO[Either[Nothing, A]]): UIO[A] =
     ZIO.absolve(v)
 
   /**
    * @see See [[zio.ZIO.allowInterrupt]]
    */
-  final def allowInterrupt: UIO[Unit] =
+  def allowInterrupt: UIO[Unit] =
     ZIO.allowInterrupt
 
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  final def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
+  def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A](acquire: UIO[A]): ZIO.BracketAcquire[Any, Nothing, A] =
+  def bracket[A](acquire: UIO[A]): ZIO.BracketAcquire[Any, Nothing, A] =
     ZIO.bracket(acquire)
 
   /**
    * @see See bracket [[zio.ZIO]]
    */
-  final def bracket[A, B](acquire: UIO[A], release: A => UIO[Any], use: A => UIO[B]): UIO[B] =
+  def bracket[A, B](acquire: UIO[A], release: A => UIO[Any], use: A => UIO[B]): UIO[B] =
     ZIO.bracket(acquire, release, use)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[A](acquire: UIO[A]): ZIO.BracketExitAcquire[Any, Nothing, A] =
+  def bracketExit[A](acquire: UIO[A]): ZIO.BracketExitAcquire[Any, Nothing, A] =
     ZIO.bracketExit(acquire)
 
   /**
    * @see See bracketExit [[zio.ZIO]]
    */
-  final def bracketExit[A, B](acquire: UIO[A], release: (A, Exit[Nothing, B]) => UIO[Any], use: A => UIO[B]): UIO[B] =
+  def bracketExit[A, B](acquire: UIO[A], release: (A, Exit[Nothing, B]) => UIO[Any], use: A => UIO[B]): UIO[B] =
     ZIO.bracketExit(acquire, release, use)
 
   /**
    * @see See [[zio.ZIO.checkDaemon]]
    */
-  final def checkDaemon[A](f: DaemonStatus => UIO[A]): UIO[A] =
+  def checkDaemon[A](f: DaemonStatus => UIO[A]): UIO[A] =
     ZIO.checkDaemon(f)
 
   /**
    * @see See [[zio.ZIO.checkInterruptible]]
    */
-  final def checkInterruptible[A](f: InterruptStatus => UIO[A]): UIO[A] =
+  def checkInterruptible[A](f: InterruptStatus => UIO[A]): UIO[A] =
     ZIO.checkInterruptible(f)
 
   /**
    * @see See [[zio.ZIO.checkTraced]]
    */
-  final def checkTraced[A](f: TracingStatus => UIO[A]): UIO[A] =
+  def checkTraced[A](f: TracingStatus => UIO[A]): UIO[A] =
     ZIO.checkTraced(f)
 
   /**
    * @see See [[zio.ZIO.children]]
    */
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
+  def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see See [[zio.ZIO.collectAll]]
    */
-  final def collectAll[A](in: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAll[A](in: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAll(in)
 
   /**
    * @see See [[zio.ZIO.collectAllPar]]
    */
-  final def collectAllPar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAllPar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAllPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
-  final def collectAllParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAllParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAllParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccesses]]
    */
-  final def collectAllSuccesses[A](in: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAllSuccesses[A](in: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAllSuccesses(in)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesPar]]
    */
-  final def collectAllSuccessesPar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAllSuccessesPar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAllSuccessesPar(as)
 
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
-  final def collectAllSuccessesParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
+  def collectAllSuccessesParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.collectAllSuccessesParN(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllWith]]
    */
-  final def collectAllWith[A, B](in: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
+  def collectAllWith[A, B](in: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
     ZIO.collectAllWith(in)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithPar]]
    */
-  final def collectAllWithPar[A, B](as: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
+  def collectAllWithPar[A, B](as: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
     ZIO.collectAllWithPar(as)(f)
 
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
-  final def collectAllWithParN[A, B](n: Int)(as: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
+  def collectAllWithParN[A, B](n: Int)(as: Iterable[UIO[A]])(f: PartialFunction[A, B]): UIO[List[B]] =
     ZIO.collectAllWithParN(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.daemonMask]]
    */
-  final def daemonMask[A](k: ZIO.DaemonStatusRestore => UIO[A]): UIO[A] =
+  def daemonMask[A](k: ZIO.DaemonStatusRestore => UIO[A]): UIO[A] =
     ZIO.daemonMask(k)
 
   /**
    * @see See [[zio.ZIO.descriptor]]
    */
-  final def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
+  def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
 
   /**
    * @see See [[zio.ZIO.descriptorWith]]
    */
-  final def descriptorWith[A](f: Fiber.Descriptor => UIO[A]): UIO[A] =
+  def descriptorWith[A](f: Fiber.Descriptor => UIO[A]): UIO[A] =
     ZIO.descriptorWith(f)
 
   /**
    * @see See [[zio.ZIO.die]]
    */
-  final def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
+  def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
 
   /**
    * @see See [[zio.ZIO.dieMessage]]
    */
-  final def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
+  def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
 
   /**
    * @see See [[zio.ZIO.done]]
    */
-  final def done[A](r: Exit[Nothing, A]): UIO[A] = ZIO.done(r)
+  def done[A](r: Exit[Nothing, A]): UIO[A] = ZIO.done(r)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
    */
-  final def effectAsync[A](register: (UIO[A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): UIO[A] =
+  def effectAsync[A](register: (UIO[A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): UIO[A] =
     ZIO.effectAsync(register, blockingOn)
 
   /**
    * @see See [[zio.ZIO.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[A](
+  def effectAsyncMaybe[A](
     register: (UIO[A] => Unit) => Option[UIO[A]],
     blockingOn: List[Fiber.Id] = Nil
   ): UIO[A] =
@@ -177,13 +177,13 @@ object UIO {
   /**
    * @see See [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[A](register: (UIO[A] => Unit) => UIO[Any]): UIO[A] =
+  def effectAsyncM[A](register: (UIO[A] => Unit) => UIO[Any]): UIO[A] =
     ZIO.effectAsyncM(register)
 
   /**
    * @see See [[zio.ZIO.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[A](
+  def effectAsyncInterrupt[A](
     register: (UIO[A] => Unit) => Either[Canceler[Any], UIO[A]],
     blockingOn: List[Fiber.Id] = Nil
   ): UIO[A] =
@@ -192,12 +192,12 @@ object UIO {
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  final def effectSuspendTotal[A](uio: => UIO[A]): UIO[A] = ZIO.effectSuspendTotal(uio)
+  def effectSuspendTotal[A](uio: => UIO[A]): UIO[A] = ZIO.effectSuspendTotal(uio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  final def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => UIO[A]): UIO[A] = ZIO.effectSuspendTotalWith(p)
+  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => UIO[A]): UIO[A] = ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see [[zio.ZIO.fiberId]]
@@ -207,116 +207,116 @@ object UIO {
   /**
    * @see [[zio.ZIO.firstSuccessOf]]
    */
-  final def firstSuccessOf[A](uio: UIO[A], rest: Iterable[UIO[A]]): UIO[A] = ZIO.firstSuccessOf(uio, rest)
+  def firstSuccessOf[A](uio: UIO[A], rest: Iterable[UIO[A]]): UIO[A] = ZIO.firstSuccessOf(uio, rest)
 
   /**
    * @see See [[zio.ZIO.flatten]]
    */
-  final def flatten[A](uio: UIO[UIO[A]]): UIO[A] =
+  def flatten[A](uio: UIO[UIO[A]]): UIO[A] =
     ZIO.flatten(uio)
 
   /**
    * @see See [[zio.ZIO.foldLeft]]
    */
-  final def foldLeft[S, A](in: Iterable[A])(zero: S)(f: (S, A) => UIO[S]): UIO[S] =
+  def foldLeft[S, A](in: Iterable[A])(zero: S)(f: (S, A) => UIO[S]): UIO[S] =
     ZIO.foldLeft(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.foldRight]]
    */
-  final def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => UIO[S]): UIO[S] =
+  def foldRight[S, A](in: Iterable[A])(zero: S)(f: (A, S) => UIO[S]): UIO[S] =
     ZIO.foldRight(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  final def forkAll[A](as: Iterable[UIO[A]]): UIO[Fiber[Nothing, List[A]]] =
+  def forkAll[A](as: Iterable[UIO[A]]): UIO[Fiber[Nothing, List[A]]] =
     ZIO.forkAll(as)
 
   /**
    * @see See [[zio.ZIO.forkAll_]]
    */
-  final def forkAll_[A](as: Iterable[UIO[A]]): UIO[Unit] =
+  def forkAll_[A](as: Iterable[UIO[A]]): UIO[Unit] =
     ZIO.forkAll_(as)
 
   /**
    * @see See [[zio.ZIO.foreach]]
    */
-  final def foreach[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
+  def foreach[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
     ZIO.foreach(in)(f)
 
   /**
    * @see See [[zio.ZIO.foreach_]]
    */
-  final def foreach_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
+  def foreach_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachPar]]
    */
-  final def foreachPar[A, B](as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =
+  def foreachPar[A, B](as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =
     ZIO.foreachPar(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
+  def foreachPar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
-  final def foreachParN[A, B](n: Int)(as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =
+  def foreachParN[A, B](n: Int)(as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =
     ZIO.foreachParN(n)(as)(fn)
 
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[A](n: Int)(as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
+  def foreachParN_[A](n: Int)(as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.fromEither]]
    */
-  final def fromEither[A](v: => Either[Nothing, A]): UIO[A] =
+  def fromEither[A](v: => Either[Nothing, A]): UIO[A] =
     ZIO.fromEither(v)
 
   /**
    * @see See [[zio.ZIO.fromFiber]]
    */
-  final def fromFiber[A](fiber: => Fiber[Nothing, A]): UIO[A] =
+  def fromFiber[A](fiber: => Fiber[Nothing, A]): UIO[A] =
     ZIO.fromFiber(fiber)
 
   /**
    * @see See [[zio.ZIO.fromFiberM]]
    */
-  final def fromFiberM[A](fiber: UIO[Fiber[Nothing, A]]): UIO[A] =
+  def fromFiberM[A](fiber: UIO[Fiber[Nothing, A]]): UIO[A] =
     ZIO.fromFiberM(fiber)
 
   /**
    * @see [[zio.ZIO.fromFunction]]
    */
-  final def fromFunction[A](f: Any => A): UIO[A] = ZIO.fromFunction(f)
+  def fromFunction[A](f: Any => A): UIO[A] = ZIO.fromFunction(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  final def fromFunctionM[A](f: Any => UIO[A]): UIO[A] = ZIO.fromFunctionM(f)
+  def fromFunctionM[A](f: Any => UIO[A]): UIO[A] = ZIO.fromFunctionM(f)
 
   /**
    * @see See [[zio.ZIO.halt]]
    */
-  final def halt(cause: Cause[Nothing]): UIO[Nothing] = ZIO.halt(cause)
+  def halt(cause: Cause[Nothing]): UIO[Nothing] = ZIO.halt(cause)
 
   /**
    * @see [[zio.ZIO.haltWith]]
    */
-  final def haltWith(function: (() => ZTrace) => Cause[Nothing]): UIO[Nothing] = ZIO.haltWith(function)
+  def haltWith(function: (() => ZTrace) => Cause[Nothing]): UIO[Nothing] = ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.identity]]
    */
-  final def identity: UIO[Any] = ZIO.identity
+  def identity: UIO[Any] = ZIO.identity
 
   /**
    * @see See [[zio.ZIO.interrupt]]
@@ -326,65 +326,65 @@ object UIO {
   /**
    * @see See [[zio.ZIO.interruptAs]]
    */
-  final def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
 
   /**
    * @see See [[zio.ZIO.interruptible]]
    */
-  final def interruptible[A](uio: UIO[A]): UIO[A] =
+  def interruptible[A](uio: UIO[A]): UIO[A] =
     ZIO.interruptible(uio)
 
   /**
    * @see See [[zio.ZIO.interruptibleMask]]
    */
-  final def interruptibleMask[A](k: ZIO.InterruptStatusRestore => UIO[A]): UIO[A] =
+  def interruptibleMask[A](k: ZIO.InterruptStatusRestore => UIO[A]): UIO[A] =
     ZIO.interruptibleMask(k)
 
   /**
    *  @see See [[zio.ZIO.left]]
    */
-  final def left[A](a: A): UIO[Either[A, Nothing]] = ZIO.left(a)
+  def left[A](a: A): UIO[Either[A, Nothing]] = ZIO.left(a)
 
   /**
    * @see See [[zio.ZIO.lock]]
    */
-  final def lock[A](executor: Executor)(uio: UIO[A]): UIO[A] =
+  def lock[A](executor: Executor)(uio: UIO[A]): UIO[A] =
     ZIO.lock(executor)(uio)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
+  def mapN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapN(uio1, uio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
+  def mapN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapN(uio1, uio2, uio3)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(f: (A, B, C, D) => F): UIO[F] =
+  def mapN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(f: (A, B, C, D) => F): UIO[F] =
     ZIO.mapN(uio1, uio2, uio3, uio4)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
+  def mapParN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapParN(uio1, uio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
+  def mapParN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapParN(uio1, uio2, uio3)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(
+  def mapParN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(
     f: (A, B, C, D) => F
   ): UIO[F] =
     ZIO.mapParN(uio1, uio2, uio3, uio4)(f)
@@ -392,13 +392,13 @@ object UIO {
   /**
    * @see See [[zio.ZIO.mergeAll]]
    */
-  final def mergeAll[A, B](in: Iterable[UIO[A]])(zero: B)(f: (B, A) => B): UIO[B] =
+  def mergeAll[A, B](in: Iterable[UIO[A]])(zero: B)(f: (B, A) => B): UIO[B] =
     ZIO.mergeAll(in)(zero)(f)
 
   /**
    * @see See [[zio.ZIO.mergeAllPar]]
    */
-  final def mergeAllPar[A, B](in: Iterable[UIO[A]])(zero: B)(f: (B, A) => B): UIO[B] =
+  def mergeAllPar[A, B](in: Iterable[UIO[A]])(zero: B)(f: (B, A) => B): UIO[B] =
     ZIO.mergeAllPar(in)(zero)(f)
 
   /**
@@ -409,7 +409,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.nonDaemonMask]]
    */
-  final def nonDaemonMask[A](k: ZIO.DaemonStatusRestore => UIO[A]): UIO[A] =
+  def nonDaemonMask[A](k: ZIO.DaemonStatusRestore => UIO[A]): UIO[A] =
     ZIO.nonDaemonMask(k)
 
   /**
@@ -420,109 +420,109 @@ object UIO {
   /**
    * @see See [[zio.ZIO.raceAll]]
    */
-  final def raceAll[A](uio: UIO[A], uios: Iterable[UIO[A]]): UIO[A] =
+  def raceAll[A](uio: UIO[A], uios: Iterable[UIO[A]]): UIO[A] =
     ZIO.raceAll(uio, uios)
 
   /**
    * @see See [[zio.ZIO.reduceAll]]
    */
-  final def reduceAll[A](a: UIO[A], as: Iterable[UIO[A]])(f: (A, A) => A): UIO[A] =
+  def reduceAll[A](a: UIO[A], as: Iterable[UIO[A]])(f: (A, A) => A): UIO[A] =
     ZIO.reduceAll(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.reduceAllPar]]
    */
-  final def reduceAllPar[A](a: UIO[A], as: Iterable[UIO[A]])(f: (A, A) => A): UIO[A] =
+  def reduceAllPar[A](a: UIO[A], as: Iterable[UIO[A]])(f: (A, A) => A): UIO[A] =
     ZIO.reduceAllPar(a, as)(f)
 
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  final def replicate[A](n: Int)(effect: UIO[A]): Iterable[UIO[A]] =
+  def replicate[A](n: Int)(effect: UIO[A]): Iterable[UIO[A]] =
     ZIO.replicate(n)(effect)
 
   /**
    * @see See [[zio.ZIO.reserve]]
    */
-  final def reserve[A, B](reservation: UIO[Reservation[Any, Nothing, A]])(use: A => UIO[B]): UIO[B] =
+  def reserve[A, B](reservation: UIO[Reservation[Any, Nothing, A]])(use: A => UIO[B]): UIO[B] =
     ZIO.reserve(reservation)(use)
 
   /**
    *  @see [[zio.ZIO.right]]
    */
-  final def right[B](b: B): UIO[Either[Nothing, B]] = ZIO.right(b)
+  def right[B](b: B): UIO[Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
    */
-  final def runtime: UIO[Runtime[Any]] = ZIO.runtime
+  def runtime: UIO[Runtime[Any]] = ZIO.runtime
 
   /**
    *  See [[zio.ZIO.sequence]]
    */
-  final def sequence[A](in: Iterable[UIO[A]]): UIO[List[A]] =
+  def sequence[A](in: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.sequence(in)
 
   /**
    * @see See [[zio.ZIO.sequencePar]]
    */
-  final def sequencePar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
+  def sequencePar[A](as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.sequencePar(as)
 
   /**
    *  See [[zio.ZIO.sequenceParN]]
    */
-  final def sequenceParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
+  def sequenceParN[A](n: Int)(as: Iterable[UIO[A]]): UIO[List[A]] =
     ZIO.sequenceParN(n)(as)
 
   /**
    *  @see [[zio.ZIO.some]]
    */
-  final def some[A](a: A): UIO[Option[A]] = ZIO.some(a)
+  def some[A](a: A): UIO[Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]
    */
-  final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
   /**
    * @see See [[zio.ZIO.trace]]
    * */
-  final def trace: UIO[ZTrace] = ZIO.trace
+  def trace: UIO[ZTrace] = ZIO.trace
 
   /**
    * @see See [[zio.ZIO.traced]]
    */
-  final def traced[A](uio: UIO[A]): UIO[A] = ZIO.traced(uio)
+  def traced[A](uio: UIO[A]): UIO[A] = ZIO.traced(uio)
 
   /**
    * @see See [[zio.ZIO.traverse]]
    */
-  final def traverse[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
+  def traverse[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
     ZIO.traverse(in)(f)
 
   /**
    * @see See [[zio.ZIO.traverse_]]
    */
-  final def traverse_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
+  def traverse_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traverse_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar]]
    */
-  final def traversePar[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
+  def traversePar[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
     ZIO.traversePar(in)(f)
 
   /**
    * @see See [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
+  def traversePar_[A](as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traversePar_(as)(f)
 
   /**
    * @see See [[zio.ZIO.traverseParN]]
    */
-  final def traverseParN[A, B](
+  def traverseParN[A, B](
     n: Int
   )(as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =
     ZIO.traverseParN(n)(as)(fn)
@@ -530,7 +530,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[A](
+  def traverseParN_[A](
     n: Int
   )(as: Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.traverseParN_(n)(as)(f)
@@ -543,47 +543,47 @@ object UIO {
   /**
    * @see See [[zio.ZIO.interruptibleMask]]
    */
-  final def uninterruptible[A](uio: UIO[A]): UIO[A] =
+  def uninterruptible[A](uio: UIO[A]): UIO[A] =
     ZIO.uninterruptible(uio)
 
   /**
    * @see See [[zio.ZIO.uninterruptibleMask]]
    */
-  final def uninterruptibleMask[A](k: ZIO.InterruptStatusRestore => UIO[A]): UIO[A] =
+  def uninterruptibleMask[A](k: ZIO.InterruptStatusRestore => UIO[A]): UIO[A] =
     ZIO.uninterruptibleMask(k)
 
   /**
    * @see [[zio.ZIO.unsandbox]]
    */
-  final def unsandbox[A](v: IO[Cause[Nothing], A]): UIO[A] = ZIO.unsandbox(v)
+  def unsandbox[A](v: IO[Cause[Nothing], A]): UIO[A] = ZIO.unsandbox(v)
 
   /**
    * @see See [[zio.ZIO.untraced]]
    */
-  final def untraced[A](uio: UIO[A]): UIO[A] = ZIO.untraced(uio)
+  def untraced[A](uio: UIO[A]): UIO[A] = ZIO.untraced(uio)
 
   /**
    * @see See [[zio.ZIO.when]]
    */
-  final def when(b: Boolean)(uio: UIO[Any]): UIO[Unit] =
+  def when(b: Boolean)(uio: UIO[Any]): UIO[Unit] =
     ZIO.when(b)(uio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
+  def whenCaseM[R, E, A](a: ZIO[R, E, A])(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  final def whenM(b: UIO[Boolean])(uio: UIO[Any]): UIO[Unit] =
+  def whenM(b: UIO[Boolean])(uio: UIO[Any]): UIO[Unit] =
     ZIO.whenM(b)(uio)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -438,7 +438,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.replicate]]
    */
-  def replicate[A](n: Int)(effect: UIO[A]): Iterable[UIO[A]] =
+  final def replicate[A](n: Int)(effect: UIO[A]): Iterable[UIO[A]] =
     ZIO.replicate(n)(effect)
 
   /**
@@ -450,7 +450,7 @@ object UIO {
   /**
    *  @see [[zio.ZIO.right]]
    */
-  def right[B](b: B): UIO[Either[Nothing, B]] = ZIO.right(b)
+  final def right[B](b: B): UIO[Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see See [[zio.ZIO.runtime]]
@@ -478,7 +478,7 @@ object UIO {
   /**
    *  @see [[zio.ZIO.some]]
    */
-  def some[A](a: A): UIO[Option[A]] = ZIO.some(a)
+  final def some[A](a: A): UIO[Option[A]] = ZIO.some(a)
 
   /**
    * @see See [[zio.ZIO.succeed]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -9,39 +9,39 @@ object URIO {
   /**
    * @see [[zio.ZIO.absolve]]
    */
-  final def absolve[R, A](v: URIO[R, Either[Nothing, A]]): URIO[R, A] =
+  def absolve[R, A](v: URIO[R, Either[Nothing, A]]): URIO[R, A] =
     ZIO.absolve(v)
 
   /**
    * @see [[zio.ZIO.access]]
    */
-  final def access[R]: ZIO.AccessPartiallyApplied[R] = ZIO.access[R]
+  def access[R]: ZIO.AccessPartiallyApplied[R] = ZIO.access[R]
 
   /**
    * @see [[zio.ZIO.accessM]]
    */
-  final def accessM[R]: ZIO.AccessMPartiallyApplied[R] = ZIO.accessM[R]
+  def accessM[R]: ZIO.AccessMPartiallyApplied[R] = ZIO.accessM[R]
 
   /**
    * @see [[zio.ZIO.allowInterrupt]]
    */
-  final def allowInterrupt: UIO[Unit] = ZIO.allowInterrupt
+  def allowInterrupt: UIO[Unit] = ZIO.allowInterrupt
 
   /**
    * @see [[zio.ZIO.apply]]
    */
-  final def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
+  def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
 
   /**
    * @see bracket in [[zio.ZIO]]
    */
-  final def bracket[R, A](acquire: URIO[R, A]): ZIO.BracketAcquire[R, Nothing, A] =
+  def bracket[R, A](acquire: URIO[R, A]): ZIO.BracketAcquire[R, Nothing, A] =
     ZIO.bracket(acquire)
 
   /**
    * @see bracket in [[zio.ZIO]]
    **/
-  final def bracket[R, A, B](
+  def bracket[R, A, B](
     acquire: URIO[R, A],
     release: A => URIO[R, Any],
     use: A => URIO[R, B]
@@ -50,13 +50,13 @@ object URIO {
   /**
    * @see bracketExit in [[zio.ZIO]]
    */
-  final def bracketExit[R, A](acquire: URIO[R, A]): ZIO.BracketExitAcquire[R, Nothing, A] =
+  def bracketExit[R, A](acquire: URIO[R, A]): ZIO.BracketExitAcquire[R, Nothing, A] =
     ZIO.bracketExit(acquire)
 
   /**
    * @see bracketExit in [[zio.ZIO]]
    */
-  final def bracketExit[R, A, B](
+  def bracketExit[R, A, B](
     acquire: URIO[R, A],
     release: (A, Exit[Nothing, B]) => URIO[R, Any],
     use: A => URIO[R, B]
@@ -65,122 +65,122 @@ object URIO {
   /**
    * @see [[zio.ZIO.checkDaemon]]
    */
-  final def checkDaemon[R, A](f: DaemonStatus => URIO[R, A]): URIO[R, A] =
+  def checkDaemon[R, A](f: DaemonStatus => URIO[R, A]): URIO[R, A] =
     ZIO.checkDaemon(f)
 
   /**
    * @see [[zio.ZIO.checkInterruptible]]
    */
-  final def checkInterruptible[R, A](f: InterruptStatus => URIO[R, A]): URIO[R, A] =
+  def checkInterruptible[R, A](f: InterruptStatus => URIO[R, A]): URIO[R, A] =
     ZIO.checkInterruptible(f)
 
   /**
    * @see [[zio.ZIO.checkTraced]]
    */
-  final def checkTraced[R, A](f: TracingStatus => URIO[R, A]): URIO[R, A] =
+  def checkTraced[R, A](f: TracingStatus => URIO[R, A]): URIO[R, A] =
     ZIO.checkTraced(f)
 
   /**
    * @see [[zio.ZIO.children]]
    */
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
+  def children: UIO[Iterable[Fiber[Any, Any]]] = ZIO.children
 
   /**
    * @see [[zio.ZIO.collectAll]]
    */
-  final def collectAll[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] =
+  def collectAll[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] =
     ZIO.collectAll(in)
 
   /**
    * @see [[zio.ZIO.collectAllPar]]
    */
-  final def collectAllPar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
+  def collectAllPar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
     ZIO.collectAllPar(as)
 
   /**
    * @see [[zio.ZIO.collectAllParN]]
    */
-  final def collectAllParN[R, A](n: Int)(as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
+  def collectAllParN[R, A](n: Int)(as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
     ZIO.collectAllParN(n)(as)
 
   /**
    * @see [[zio.ZIO.collectAllSuccesses]]
    */
-  final def collectAllSuccesses[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] =
+  def collectAllSuccesses[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] =
     ZIO.collectAllSuccesses(in)
 
   /**
    * @see [[zio.ZIO.collectAllSuccessesPar]]
    */
-  final def collectAllSuccessesPar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
+  def collectAllSuccessesPar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] =
     ZIO.collectAllSuccessesPar(as)
 
   /**
    * @see [[zio.ZIO.collectAllSuccessesParN]]
    */
-  final def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[URIO[E, A]]): URIO[E, List[A]] =
+  def collectAllSuccessesParN[E, A](n: Int)(as: Iterable[URIO[E, A]]): URIO[E, List[A]] =
     ZIO.collectAllSuccessesParN(n)(as)
 
   /**
    * @see [[zio.ZIO.collectAllWith]]
    */
-  final def collectAllWith[R, A, B](in: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
+  def collectAllWith[R, A, B](in: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
     ZIO.collectAllWith(in)(f)
 
   /**
    * @see [[zio.ZIO.collectAllWithPar]]
    */
-  final def collectAllWithPar[R, A, B](as: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
+  def collectAllWithPar[R, A, B](as: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
     ZIO.collectAllWithPar(as)(f)
 
   /**
    * @see [[zio.ZIO.collectAllWithParN]]
    */
-  final def collectAllWithParN[R, A, B](n: Int)(as: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
+  def collectAllWithParN[R, A, B](n: Int)(as: Iterable[URIO[R, A]])(f: PartialFunction[A, B]): URIO[R, List[B]] =
     ZIO.collectAllWithParN(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.daemonMask]]
    */
-  final def daemonMask[R, A](k: ZIO.DaemonStatusRestore => URIO[R, A]): URIO[R, A] =
+  def daemonMask[R, A](k: ZIO.DaemonStatusRestore => URIO[R, A]): URIO[R, A] =
     ZIO.daemonMask(k)
 
   /**
    * @see [[zio.ZIO.descriptor]]
    */
-  final def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
+  def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor
 
   /**
    * @see [[zio.ZIO.descriptorWith]]
    */
-  final def descriptorWith[R, A](f: Fiber.Descriptor => URIO[R, A]): URIO[R, A] =
+  def descriptorWith[R, A](f: Fiber.Descriptor => URIO[R, A]): URIO[R, A] =
     ZIO.descriptorWith(f)
 
   /**
    * @see [[zio.ZIO.die]]
    */
-  final def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
+  def die(t: Throwable): UIO[Nothing] = ZIO.die(t)
 
   /**
    * @see [[zio.ZIO.dieMessage]]
    */
-  final def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
+  def dieMessage(message: String): UIO[Nothing] = ZIO.dieMessage(message)
 
   /**
    * @see [[zio.ZIO.done]]
    */
-  final def done[A](r: Exit[Nothing, A]): UIO[A] = ZIO.done(r)
+  def done[A](r: Exit[Nothing, A]): UIO[A] = ZIO.done(r)
 
   /**
    * @see [[zio.ZIO.effectAsync]]
    */
-  final def effectAsync[R, A](register: (URIO[R, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): URIO[R, A] =
+  def effectAsync[R, A](register: (URIO[R, A] => Unit) => Unit, blockingOn: List[Fiber.Id] = Nil): URIO[R, A] =
     ZIO.effectAsync(register, blockingOn)
 
   /**
    * @see [[zio.ZIO.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[R, A](
+  def effectAsyncMaybe[R, A](
     register: (URIO[R, A] => Unit) => Option[URIO[R, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): URIO[R, A] =
@@ -189,13 +189,13 @@ object URIO {
   /**
    * @see [[zio.ZIO.effectAsyncM]]
    */
-  final def effectAsyncM[R, A](register: (URIO[R, A] => Unit) => URIO[R, Any]): URIO[R, A] =
+  def effectAsyncM[R, A](register: (URIO[R, A] => Unit) => URIO[R, Any]): URIO[R, A] =
     ZIO.effectAsyncM(register)
 
   /**
    * @see [[zio.ZIO.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[R, A](
+  def effectAsyncInterrupt[R, A](
     register: (URIO[R, A] => Unit) => Either[Canceler[R], URIO[R, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): URIO[R, A] =
@@ -204,23 +204,23 @@ object URIO {
   /**
    * @see [[zio.ZIO.effectSuspendTotal]]
    */
-  final def effectSuspendTotal[R, A](rio: => URIO[R, A]): URIO[R, A] = ZIO.effectSuspendTotal(rio)
+  def effectSuspendTotal[R, A](rio: => URIO[R, A]): URIO[R, A] = ZIO.effectSuspendTotal(rio)
 
   /**
    * @see [[zio.ZIO.effectSuspendTotalWith]]
    */
-  final def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => URIO[R, A]): URIO[R, A] =
+  def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => URIO[R, A]): URIO[R, A] =
     ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see [[zio.ZIO.effectTotal]]
    */
-  final def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
 
   /**
    * @see [[zio.ZIO.environment]]
    */
-  final def environment[R]: ZIO[R, Nothing, R] = ZIO.environment
+  def environment[R]: ZIO[R, Nothing, R] = ZIO.environment
 
   /**
    * @see [[zio.ZIO.fiberId]]
@@ -230,7 +230,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.firstSuccessOf]]
    */
-  final def firstSuccessOf[R, A](
+  def firstSuccessOf[R, A](
     rio: URIO[R, A],
     rest: Iterable[URIO[R, A]]
   ): URIO[R, A] = ZIO.firstSuccessOf(rio, rest)
@@ -238,114 +238,114 @@ object URIO {
   /**
    * @see [[zio.ZIO.flatten]]
    */
-  final def flatten[R, A](taskr: URIO[R, URIO[R, A]]): URIO[R, A] =
+  def flatten[R, A](taskr: URIO[R, URIO[R, A]]): URIO[R, A] =
     ZIO.flatten(taskr)
 
   /**
    * @see [[zio.ZIO.foldLeft]]
    */
-  final def foldLeft[R, S, A](in: Iterable[A])(zero: S)(f: (S, A) => URIO[R, S]): URIO[R, S] =
+  def foldLeft[R, S, A](in: Iterable[A])(zero: S)(f: (S, A) => URIO[R, S]): URIO[R, S] =
     ZIO.foldLeft(in)(zero)(f)
 
   /**
    * @see [[zio.ZIO.foldRight]
    */
-  final def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => URIO[R, S]): URIO[R, S] =
+  def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => URIO[R, S]): URIO[R, S] =
     ZIO.foldRight(in)(zero)(f)
 
   /**
    * @see [[zio.ZIO.foreach]]
    */
-  final def foreach[R, A, B](in: Iterable[A])(f: A => URIO[R, B]): URIO[R, List[B]] =
+  def foreach[R, A, B](in: Iterable[A])(f: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.foreach(in)(f)
 
   /**
    * @see [[zio.ZIO.foreachPar]]
    */
-  final def foreachPar[R, A, B](as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
+  def foreachPar[R, A, B](as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.foreachPar(as)(fn)
 
   /**
    * @see [[zio.ZIO.foreachParN]]
    */
-  final def foreachParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
+  def foreachParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.foreachParN(n)(as)(fn)
 
   /**
    * @see [[zio.ZIO.foreach_]]
    */
-  final def foreach_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
+  def foreach_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
    * @see [[zio.ZIO.foreachPar_]]
    */
-  final def foreachPar_[R, A, B](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
+  def foreachPar_[R, A, B](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachPar_(as)(f)
 
   /**
    * @see [[zio.ZIO.foreachParN_]]
    */
-  final def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
+  def foreachParN_[R, A, B](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see [[zio.ZIO.forkAll]]
    */
-  final def forkAll[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Fiber[Nothing, List[A]]] =
+  def forkAll[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Fiber[Nothing, List[A]]] =
     ZIO.forkAll(as)
 
   /**
    * @see [[zio.ZIO.forkAll_]]
    */
-  final def forkAll_[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Unit] =
+  def forkAll_[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Unit] =
     ZIO.forkAll_(as)
 
   /**
    * @see [[zio.ZIO.fromEither]]
    */
-  final def fromEither[A](v: => Either[Nothing, A]): UIO[A] =
+  def fromEither[A](v: => Either[Nothing, A]): UIO[A] =
     ZIO.fromEither(v)
 
   /**
    * @see [[zio.ZIO.fromFiber]]
    */
-  final def fromFiber[A](fiber: => Fiber[Nothing, A]): UIO[A] =
+  def fromFiber[A](fiber: => Fiber[Nothing, A]): UIO[A] =
     ZIO.fromFiber(fiber)
 
   /**
    * @see [[zio.ZIO.fromFiberM]]
    */
-  final def fromFiberM[A](fiber: UIO[Fiber[Nothing, A]]): UIO[A] =
+  def fromFiberM[A](fiber: UIO[Fiber[Nothing, A]]): UIO[A] =
     ZIO.fromFiberM(fiber)
 
   /**
    * @see [[zio.ZIO.fromFunction]]
    */
-  final def fromFunction[R, A](f: R => A): URIO[R, A] =
+  def fromFunction[R, A](f: R => A): URIO[R, A] =
     ZIO.fromFunction(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  final def fromFunctionM[R, A](f: R => UIO[A]): URIO[R, A] =
+  def fromFunctionM[R, A](f: R => UIO[A]): URIO[R, A] =
     ZIO.fromFunctionM(f)
 
   /**
    * @see [[zio.ZIO.halt]]
    */
-  final def halt(cause: Cause[Nothing]): UIO[Nothing] = ZIO.halt(cause)
+  def halt(cause: Cause[Nothing]): UIO[Nothing] = ZIO.halt(cause)
 
   /**
    * @see [[zio.ZIO.haltWith]]
    */
-  final def haltWith[R](function: (() => ZTrace) => Cause[Nothing]): URIO[R, Nothing] =
+  def haltWith[R](function: (() => ZTrace) => Cause[Nothing]): URIO[R, Nothing] =
     ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.identity]]
    */
-  final def identity[R]: URIO[R, R] = ZIO.identity
+  def identity[R]: URIO[R, R] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.interrupt]]
@@ -355,41 +355,41 @@ object URIO {
   /**
    * @see See [[zio.ZIO.interruptAs]]
    */
-  final def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Nothing] = ZIO.interruptAs(fiberId)
 
   /**
    * @see [[zio.ZIO.interruptible]]
    */
-  final def interruptible[R, A](taskr: URIO[R, A]): URIO[R, A] =
+  def interruptible[R, A](taskr: URIO[R, A]): URIO[R, A] =
     ZIO.interruptible(taskr)
 
   /**
    * @see [[zio.ZIO.interruptibleMask]]
    */
-  final def interruptibleMask[R, A](k: ZIO.InterruptStatusRestore => URIO[R, A]): URIO[R, A] =
+  def interruptibleMask[R, A](k: ZIO.InterruptStatusRestore => URIO[R, A]): URIO[R, A] =
     ZIO.interruptibleMask(k)
 
   /**
    * @see [[zio.ZIO.lock]]
    */
-  final def lock[R, A](executor: Executor)(taskr: URIO[R, A]): URIO[R, A] =
+  def lock[R, A](executor: Executor)(taskr: URIO[R, A]): URIO[R, A] =
     ZIO.lock(executor)(taskr)
 
   /**
    *  @see [[zio.ZIO.left]]
    */
-  final def left[R, A](a: A): URIO[R, Either[A, Nothing]] = ZIO.left(a)
+  def left[R, A](a: A): URIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
+  def mapN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapN(urio1, urio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
+  def mapN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
   ): URIO[R, D] =
     ZIO.mapN(urio1, urio2, urio3)(f)
@@ -397,7 +397,7 @@ object URIO {
   /**
    *  @see [[zio.ZIO.mapN]]
    */
-  final def mapN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
+  def mapN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F
   ): URIO[R, F] =
     ZIO.mapN(urio1, urio2, urio3, urio4)(f)
@@ -405,13 +405,13 @@ object URIO {
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
+  def mapParN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapParN(urio1, urio2)(f)
 
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
+  def mapParN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
   ): URIO[R, D] =
     ZIO.mapParN(urio1, urio2, urio3)(f)
@@ -419,7 +419,7 @@ object URIO {
   /**
    *  @see [[zio.ZIO.mapParN]]
    */
-  final def mapParN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
+  def mapParN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F
   ): URIO[R, F] =
     ZIO.mapParN(urio1, urio2, urio3, urio4)(f)
@@ -427,13 +427,13 @@ object URIO {
   /**
    * @see [[zio.ZIO.mergeAll]]
    */
-  final def mergeAll[R, A, B](in: Iterable[URIO[R, A]])(zero: B)(f: (B, A) => B): URIO[R, B] =
+  def mergeAll[R, A, B](in: Iterable[URIO[R, A]])(zero: B)(f: (B, A) => B): URIO[R, B] =
     ZIO.mergeAll(in)(zero)(f)
 
   /**
    * @see [[zio.ZIO.mergeAllPar]]
    */
-  final def mergeAllPar[R, A, B](in: Iterable[URIO[R, A]])(zero: B)(f: (B, A) => B): URIO[R, B] =
+  def mergeAllPar[R, A, B](in: Iterable[URIO[R, A]])(zero: B)(f: (B, A) => B): URIO[R, B] =
     ZIO.mergeAllPar(in)(zero)(f)
 
   /**
@@ -444,7 +444,7 @@ object URIO {
   /**
    * @see See [[zio.ZIO.nonDaemonMask]]
    */
-  final def nonDaemonMask[R, A](k: ZIO.DaemonStatusRestore => URIO[R, A]): URIO[R, A] =
+  def nonDaemonMask[R, A](k: ZIO.DaemonStatusRestore => URIO[R, A]): URIO[R, A] =
     ZIO.nonDaemonMask(k)
 
   /**
@@ -455,124 +455,124 @@ object URIO {
   /**
    * @see [[zio.ZIO.provide]]
    */
-  final def provide[R, A](r: R): URIO[R, A] => UIO[A] =
+  def provide[R, A](r: R): URIO[R, A] => UIO[A] =
     ZIO.provide(r)
 
   /**
    * @see [[zio.ZIO.raceAll]]
    */
-  final def raceAll[R, R1 <: R, A](taskr: URIO[R, A], taskrs: Iterable[URIO[R1, A]]): URIO[R1, A] =
+  def raceAll[R, R1 <: R, A](taskr: URIO[R, A], taskrs: Iterable[URIO[R1, A]]): URIO[R1, A] =
     ZIO.raceAll(taskr, taskrs)
 
   /**
    * @see [[zio.ZIO.reduceAll]]
    */
-  final def reduceAll[R, R1 <: R, A](a: URIO[R, A], as: Iterable[URIO[R1, A]])(f: (A, A) => A): URIO[R1, A] =
+  def reduceAll[R, R1 <: R, A](a: URIO[R, A], as: Iterable[URIO[R1, A]])(f: (A, A) => A): URIO[R1, A] =
     ZIO.reduceAll(a, as)(f)
 
   /**
    * @see [[zio.ZIO.reduceAllPar]]
    */
-  final def reduceAllPar[R, R1 <: R, A](a: URIO[R, A], as: Iterable[URIO[R1, A]])(f: (A, A) => A): URIO[R1, A] =
+  def reduceAllPar[R, R1 <: R, A](a: URIO[R, A], as: Iterable[URIO[R1, A]])(f: (A, A) => A): URIO[R1, A] =
     ZIO.reduceAllPar(a, as)(f)
 
   /**
    * @see [[zio.ZIO.replicate]]
    */
-  final def replicate[R, A](n: Int)(effect: URIO[R, A]): Iterable[URIO[R, A]] =
+  def replicate[R, A](n: Int)(effect: URIO[R, A]): Iterable[URIO[R, A]] =
     ZIO.replicate(n)(effect)
 
   /**
    * @see [[zio.ZIO.reserve]]
    */
-  final def reserve[R, A, B](reservation: URIO[R, Reservation[R, Nothing, A]])(use: A => URIO[R, B]): URIO[R, B] =
+  def reserve[R, A, B](reservation: URIO[R, Reservation[R, Nothing, A]])(use: A => URIO[R, B]): URIO[R, B] =
     ZIO.reserve(reservation)(use)
 
   /**
    *  @see [[zio.ZIO.right]]
    */
-  final def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
+  def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see [[zio.ZIO.runtime]]
    */
-  final def runtime[R]: URIO[R, Runtime[R]] = ZIO.runtime
+  def runtime[R]: URIO[R, Runtime[R]] = ZIO.runtime
 
   /**
    * @see [[zio.ZIO.sleep]]
    */
-  final def sleep(duration: Duration): URIO[Clock, Unit] = ZIO.sleep(duration)
+  def sleep(duration: Duration): URIO[Clock, Unit] = ZIO.sleep(duration)
 
   /**
    *  @see [[zio.ZIO.some]]
    */
-  final def some[R, A](a: A): URIO[R, Option[A]] = ZIO.some(a)
+  def some[R, A](a: A): URIO[R, Option[A]] = ZIO.some(a)
 
   /**
    * @see [[zio.ZIO.succeed]]
    */
-  final def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](a: A): UIO[A] = ZIO.succeed(a)
 
   /**
    *  [[zio.ZIO.sequence]]
    */
-  final def sequence[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequence(in)
+  def sequence[R, A](in: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequence(in)
 
   /**
    *  [[zio.ZIO.sequencePar]]
    */
-  final def sequencePar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequencePar(as)
+  def sequencePar[R, A](as: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequencePar(as)
 
   /**
    *  [[zio.ZIO.sequenceParN]]
    */
-  final def sequenceParN[R, A](n: Int)(as: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequenceParN(n)(as)
+  def sequenceParN[R, A](n: Int)(as: Iterable[URIO[R, A]]): URIO[R, List[A]] = ZIO.sequenceParN(n)(as)
 
   /**
    * @see [[zio.ZIO.swap]]
    */
-  final def swap[R, A, B](implicit ev: R <:< (A, B)): URIO[R, (B, A)] = ZIO.swap
+  def swap[R, A, B](implicit ev: R <:< (A, B)): URIO[R, (B, A)] = ZIO.swap
 
   /**
    * @see [[zio.ZIO.trace]]
    * */
-  final def trace: UIO[ZTrace] = ZIO.trace
+  def trace: UIO[ZTrace] = ZIO.trace
 
   /**
    * @see [[zio.ZIO.traced]]
    */
-  final def traced[R, A](zio: URIO[R, A]): URIO[R, A] = ZIO.traced(zio)
+  def traced[R, A](zio: URIO[R, A]): URIO[R, A] = ZIO.traced(zio)
 
   /**
    * @see [[zio.ZIO.traverse]]
    */
-  final def traverse[R, A, B](in: Iterable[A])(f: A => URIO[R, B]): URIO[R, List[B]] = ZIO.traverse(in)(f)
+  def traverse[R, A, B](in: Iterable[A])(f: A => URIO[R, B]): URIO[R, List[B]] = ZIO.traverse(in)(f)
 
   /**
    * @see [[zio.ZIO.traversePar]]
    */
-  final def traversePar[R, A, B](as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] = ZIO.traversePar(as)(fn)
+  def traversePar[R, A, B](as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] = ZIO.traversePar(as)(fn)
 
   /**
    * Alias for [[ZIO.foreachParN]]
    */
-  final def traverseParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
+  def traverseParN[R, A, B](n: Int)(as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.traverseParN(n)(as)(fn)
 
   /**
    * @see [[zio.ZIO.traverse_]]
    */
-  final def traverse_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traverse_(as)(f)
+  def traverse_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traverse_(as)(f)
 
   /**
    * @see [[zio.ZIO.traversePar_]]
    */
-  final def traversePar_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traversePar_(as)(f)
+  def traversePar_[R, A](as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] = ZIO.traversePar_(as)(f)
 
   /**
    * @see [[zio.ZIO.traverseParN_]]
    */
-  final def traverseParN_[R, A](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
+  def traverseParN_[R, A](n: Int)(as: Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.traverseParN_(n)(as)(f)
 
   /**
@@ -583,44 +583,44 @@ object URIO {
   /**
    * @see [[zio.ZIO.uninterruptible]]
    */
-  final def uninterruptible[R, A](taskr: URIO[R, A]): URIO[R, A] = ZIO.uninterruptible(taskr)
+  def uninterruptible[R, A](taskr: URIO[R, A]): URIO[R, A] = ZIO.uninterruptible(taskr)
 
   /**
    * @see [[zio.ZIO.uninterruptibleMask]]
    */
-  final def uninterruptibleMask[R, A](k: ZIO.InterruptStatusRestore => URIO[R, A]): URIO[R, A] =
+  def uninterruptibleMask[R, A](k: ZIO.InterruptStatusRestore => URIO[R, A]): URIO[R, A] =
     ZIO.uninterruptibleMask(k)
 
   /**
    * @see [[zio.ZIO.unsandbox]]
    */
-  final def unsandbox[R, A](v: IO[Cause[Nothing], A]): URIO[R, A] = ZIO.unsandbox(v)
+  def unsandbox[R, A](v: IO[Cause[Nothing], A]): URIO[R, A] = ZIO.unsandbox(v)
 
   /**
    * @see [[zio.ZIO.untraced]]
    */
-  final def untraced[R, A](zio: URIO[R, A]): URIO[R, A] = ZIO.untraced(zio)
+  def untraced[R, A](zio: URIO[R, A]): URIO[R, A] = ZIO.untraced(zio)
 
   /**
    * @see [[zio.ZIO.when]]
    */
-  final def when[R](b: Boolean)(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.when(b)(rio)
+  def when[R](b: Boolean)(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.when(b)(rio)
 
   /**
    * @see [[zio.ZIO.whenCase]]
    */
-  final def whenCase[R, A](a: A)(pf: PartialFunction[A, ZIO[R, Nothing, Any]]): URIO[R, Unit] = ZIO.whenCase(a)(pf)
+  def whenCase[R, A](a: A)(pf: PartialFunction[A, ZIO[R, Nothing, Any]]): URIO[R, Unit] = ZIO.whenCase(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenCaseM]]
    */
-  final def whenCaseM[R, A](a: URIO[R, A])(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
+  def whenCaseM[R, A](a: URIO[R, A])(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenM]]
    */
-  final def whenM[R](b: URIO[R, Boolean])(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.whenM(b)(rio)
+  def whenM[R](b: URIO[R, Boolean])(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.whenM(b)(rio)
 
   /**
    * @see [[zio.ZIO.yieldNow]]
@@ -630,11 +630,11 @@ object URIO {
   /**
    * @see [[zio.ZIO._1]]
    */
-  final def _1[R, A, B](implicit ev: R <:< (A, B)): URIO[R, A] = ZIO._1
+  def _1[R, A, B](implicit ev: R <:< (A, B)): URIO[R, A] = ZIO._1
 
   /**
    * @see [[zio.ZIO._2]]
    */
-  final def _2[R, A, B](implicit ev: R <:< (A, B)): URIO[R, B] = ZIO._2
+  def _2[R, A, B](implicit ev: R <:< (A, B)): URIO[R, B] = ZIO._2
 
 }

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -479,7 +479,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.replicate]]
    */
-  def replicate[R, A](n: Int)(effect: URIO[R, A]): Iterable[URIO[R, A]] =
+  final def replicate[R, A](n: Int)(effect: URIO[R, A]): Iterable[URIO[R, A]] =
     ZIO.replicate(n)(effect)
 
   /**
@@ -491,7 +491,7 @@ object URIO {
   /**
    *  @see [[zio.ZIO.right]]
    */
-  def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
+  final def right[R, B](b: B): RIO[R, Either[Nothing, B]] = ZIO.right(b)
 
   /**
    * @see [[zio.ZIO.runtime]]
@@ -506,7 +506,7 @@ object URIO {
   /**
    *  @see [[zio.ZIO.some]]
    */
-  def some[R, A](a: A): URIO[R, Option[A]] = ZIO.some(a)
+  final def some[R, A](a: A): URIO[R, Option[A]] = ZIO.some(a)
 
   /**
    * @see [[zio.ZIO.succeed]]

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -44,19 +44,19 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Symbolic alias for zip.
    */
-  final def &&&[R1 <: R, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R1, E1, (A, B)] =
+  def &&&[R1 <: R, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R1, E1, (A, B)] =
     zipWith(that)((a, b) => (a, b))
 
   /**
    * Symbolic alias for zipParRight
    */
-  final def &>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
+  def &>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
     zipPar(that).map(_._2)
 
   /**
    * Symbolic alias for join
    */
-  final def |||[R1, E1 >: E, A1 >: A](that: ZManaged[R1, E1, A1]): ZManaged[Either[R, R1], E1, A1] =
+  def |||[R1, E1 >: E, A1 >: A](that: ZManaged[R1, E1, A1]): ZManaged[Either[R, R1], E1, A1] =
     for {
       either <- ZManaged.environment[Either[R, R1]]
       a1     <- either.fold(provide, that.provide)
@@ -65,13 +65,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Symbolic alias for flatMap
    */
-  final def >>=[R1 <: R, E1 >: E, B](k: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
+  def >>=[R1 <: R, E1 >: E, B](k: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
     flatMap(k)
 
   /**
    * Symbolic alias for andThen
    */
-  final def >>>[R1 >: A, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R, E1, B] =
+  def >>>[R1 >: A, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R, E1, B] =
     for {
       r  <- ZManaged.environment[R]
       r1 <- provide(r)
@@ -81,24 +81,24 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Symbolic alias for zipParLeft
    */
-  final def <&[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] = zipPar(that).map(_._1)
+  def <&[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] = zipPar(that).map(_._1)
 
   /**
    * Symbolic alias for zipPar
    */
-  final def <&>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
+  def <&>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
     zipWithPar(that)((_, _))
 
   /**
    * Operator alias for `orElse`.
    */
-  final def <>[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
+  def <>[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     orElse(that)
 
   /**
    * Symbolic alias for compose
    */
-  final def <<<[R1, E1 >: E](that: ZManaged[R1, E1, R]): ZManaged[R1, E1, A] =
+  def <<<[R1, E1 >: E](that: ZManaged[R1, E1, R]): ZManaged[R1, E1, A] =
     for {
       r1 <- ZManaged.environment[R1]
       r  <- that.provide(r1)
@@ -108,16 +108,16 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Symbolic alias for zipLeft.
    */
-  final def <*[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
+  def <*[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
     flatMap(r => that.map(_ => r))
 
   /**
    * Symbolic alias for zip.
    */
-  final def <*>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
+  def <*>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
     zipWith(that)((_, _))
 
-  final def +++[R1, B, E1 >: E](that: ZManaged[R1, E1, B]): ZManaged[Either[R, R1], E1, Either[A, B]] =
+  def +++[R1, B, E1 >: E](that: ZManaged[R1, E1, B]): ZManaged[Either[R, R1], E1, Either[A, B]] =
     for {
       e <- ZManaged.environment[Either[R, R1]]
       r <- e.fold(map(Left(_)).provide(_), that.map(Right(_)).provide(_))
@@ -126,14 +126,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Symbolic alias for zipRight
    */
-  final def *>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
+  def *>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
     flatMap(_ => that)
 
   /**
    * Submerges the error case of an `Either` into the `ZManaged`. The inverse
    * operation of `ZManaged.either`.
    */
-  final def absolve[R1 <: R, E1, B](
+  def absolve[R1 <: R, E1, B](
     implicit ev: ZManaged[R, E, A] <:< ZManaged[R1, E1, Either[E1, B]]
   ): ZManaged[R1, E1, B] =
     ZManaged.absolve(ev(self))
@@ -142,14 +142,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Attempts to convert defects into a failure, throwing away all information
    * about the cause of the failure.
    */
-  final def absorb(implicit ev: E <:< Throwable): ZManaged[R, Throwable, A] =
+  def absorb(implicit ev: E <:< Throwable): ZManaged[R, Throwable, A] =
     absorbWith(ev)
 
   /**
    * Attempts to convert defects into a failure, throwing away all information
    * about the cause of the failure.
    */
-  final def absorbWith(f: E => Throwable): ZManaged[R, Throwable, A] =
+  def absorbWith(f: E => Throwable): ZManaged[R, Throwable, A] =
     self.sandbox
       .foldM(
         cause => ZManaged.fail(cause.squashWith(f)),
@@ -159,24 +159,24 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Replaces the error value (if any) by the value provided.
    */
-  final def asError[E1](e1: => E1): ZManaged[R, E1, A] = mapError(_ => e1)
+  def asError[E1](e1: => E1): ZManaged[R, E1, A] = mapError(_ => e1)
 
   /**
    * Executes the this effect and then provides its output as an environment to the second effect
    */
-  final def andThen[R1 >: A, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R, E1, B] = self >>> that
+  def andThen[R1 >: A, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[R, E1, B] = self >>> that
 
   /**
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
-  final def bimap[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZManaged[R, E1, A1] =
+  def bimap[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZManaged[R, E1, A1] =
     mapError(f).map(g)
 
   /**
    * Recovers from all errors.
    */
-  final def catchAll[R1 <: R, E2, A1 >: A](
+  def catchAll[R1 <: R, E2, A1 >: A](
     h: E => ZManaged[R1, E2, A1]
   )(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     foldM(h, ZManaged.succeed)
@@ -190,13 +190,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * @see [[absorb]], [[sandbox]], [[mapErrorCause]] - other functions that can recover from defects
    */
-  final def catchAllCause[R1 <: R, E2, A1 >: A](h: Cause[E] => ZManaged[R1, E2, A1]): ZManaged[R1, E2, A1] =
+  def catchAllCause[R1 <: R, E2, A1 >: A](h: Cause[E] => ZManaged[R1, E2, A1]): ZManaged[R1, E2, A1] =
     self.foldCauseM[R1, E2, A1](h, ZManaged.succeed)
 
   /**
    * Recovers from some or all of the error cases.
    */
-  final def catchSome[R1 <: R, E1 >: E, A1 >: A](
+  def catchSome[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[E, ZManaged[R1, E1, A1]]
   )(implicit ev: CanFail[E]): ZManaged[R1, E1, A1] =
     foldM(pf.applyOrElse[E, ZManaged[R1, E1, A1]](_, ZManaged.fail), ZManaged.succeed)
@@ -204,7 +204,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Recovers from some or all of the error Causes.
    */
-  final def catchSomeCause[R1 <: R, E1 >: E, A1 >: A](
+  def catchSomeCause[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[Cause[E], ZManaged[R1, E1, A1]]
   ): ZManaged[R1, E1, A1] =
     foldCauseM(pf.applyOrElse[Cause[E], ZManaged[R1, E1, A1]](_, ZManaged.halt), ZManaged.succeed)
@@ -213,14 +213,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Fail with `e` if the supplied `PartialFunction` does not match, otherwise
    * succeed with the returned value.
    */
-  final def collect[E1 >: E, B](e: => E1)(pf: PartialFunction[A, B]): ZManaged[R, E1, B] =
+  def collect[E1 >: E, B](e: => E1)(pf: PartialFunction[A, B]): ZManaged[R, E1, B] =
     collectM(e)(pf.andThen(ZManaged.succeed(_)))
 
   /**
    * Fail with `e` if the supplied `PartialFunction` does not match, otherwise
    * continue with the returned value.
    */
-  final def collectM[R1 <: R, E1 >: E, B](e: => E1)(pf: PartialFunction[A, ZManaged[R1, E1, B]]): ZManaged[R1, E1, B] =
+  def collectM[R1 <: R, E1 >: E, B](e: => E1)(pf: PartialFunction[A, ZManaged[R1, E1, B]]): ZManaged[R1, E1, B] =
     self.flatMap { v =>
       pf.applyOrElse[A, ZManaged[R1, E1, B]](v, _ => ZManaged.fail(e))
     }
@@ -228,21 +228,21 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Executes the second effect and then provides its output as an environment to this effect
    */
-  final def compose[R1, E1 >: E](that: ZManaged[R1, E1, R]): ZManaged[R1, E1, A] =
+  def compose[R1, E1 >: E](that: ZManaged[R1, E1, R]): ZManaged[R1, E1, A] =
     self <<< that
 
   /**
    * Maps this effect to the specified constant while preserving the
    * effects of this effect.
    */
-  final def as[B](b: => B): ZManaged[R, E, B] =
+  def as[B](b: => B): ZManaged[R, E, B] =
     map(_ => b)
 
   /**
    * Returns an effect whose failure and success have been lifted into an
    * `Either`.The resulting effect cannot fail
    */
-  final def either(implicit ev: CanFail[E]): ZManaged[R, Nothing, Either[E, A]] =
+  def either(implicit ev: CanFail[E]): ZManaged[R, Nothing, Either[E, A]] =
     fold(Left[E, A], Right[E, A])
 
   /**
@@ -251,7 +251,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#onExit]].
    */
-  final def ensuring[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuring[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
         r.copy(release = e => r.release(e).ensuring(f))
@@ -264,7 +264,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#onExitFirst]].
    */
-  final def ensuringFirst[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuringFirst[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map { r =>
         r.copy(release = e => f.ensuring(r.release(e)))
@@ -275,7 +275,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Returns a ZManaged that ignores errors raised by the acquire effect and
    * runs it repeatedly until it eventually succeeds.
    */
-  final def eventually(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
+  def eventually(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
     ZManaged {
       reserve.eventually.map { r =>
         Reservation(r.acquire.eventually, r.release)
@@ -286,20 +286,20 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Executes this effect and returns its value, if it succeeds, but otherwise
    * returns the specified value.
    */
-  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A1] =
+  def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A1] =
     fold(_ => a, identity)
 
   /**
    * Zips this effect with its environment
    */
-  final def first[R1 <: R, A1 >: A]: ZManaged[R1, E, (A1, R1)] = self &&& ZManaged.identity
+  def first[R1 <: R, A1 >: A]: ZManaged[R1, E, (A1, R1)] = self &&& ZManaged.identity
 
   /**
    * Returns an effect that models the execution of this effect, followed by
    * the passing of its value to the specified continuation function `k`,
    * followed by the effect that it returns.
    */
-  final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
+  def flatMap[R1 <: R, E1 >: E, B](f0: A => ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
     ZManaged[R1, E1, B] {
       Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
@@ -322,7 +322,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Effectfully map the error channel
    */
-  final def flatMapError[R1 <: R, E2](f: E => ZManaged[R1, Nothing, E2])(implicit ev: CanFail[E]): ZManaged[R1, E2, A] =
+  def flatMapError[R1 <: R, E2](f: E => ZManaged[R1, Nothing, E2])(implicit ev: CanFail[E]): ZManaged[R1, E2, A] =
     flipWith(_.flatMap(f))
 
   /**
@@ -331,19 +331,19 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * This method can be used to "flatten" nested effects.
     **/
-  final def flatten[R1 <: R, E1 >: E, B](implicit ev: A <:< ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
+  def flatten[R1 <: R, E1 >: E, B](implicit ev: A <:< ZManaged[R1, E1, B]): ZManaged[R1, E1, B] =
     flatMap(ev)
 
   /**
    * Flip the error and result
     **/
-  final def flip: ZManaged[R, A, E] =
+  def flip: ZManaged[R, A, E] =
     foldM(ZManaged.succeed, ZManaged.fail)
 
   /**
    * Flip the error and result, then apply an effectful function to the effect
     **/
-  final def flipWith[R1, A1, E1](f: ZManaged[R, A, E] => ZManaged[R1, A1, E1]): ZManaged[R1, E1, A1] =
+  def flipWith[R1, A1, E1](f: ZManaged[R, A, E] => ZManaged[R1, A1, E1]): ZManaged[R1, E1, A1] =
     f(flip).flip
 
   /**
@@ -351,13 +351,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * does not fail, but succeeds with the value returned by the left or right
    * function passed to `fold`.
    */
-  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZManaged[R, Nothing, B] =
+  def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZManaged[R, Nothing, B] =
     foldM(failure.andThen(ZManaged.succeed), success.andThen(ZManaged.succeed))
 
   /**
    * A more powerful version of `foldM` that allows recovering from any kind of failure except interruptions.
    */
-  final def foldCauseM[R1 <: R, E1, A1](
+  def foldCauseM[R1 <: R, E1, A1](
     failure: Cause[E] => ZManaged[R1, E1, A1],
     success: A => ZManaged[R1, E1, A1]
   ): ZManaged[R1, E1, A1] =
@@ -367,7 +367,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Recovers from errors by accepting one effect to execute for the case of an
    * error, and one effect to execute for the case of success.
    */
-  final def foldM[R1 <: R, E2, B](
+  def foldM[R1 <: R, E2, B](
     failure: E => ZManaged[R1, E2, B],
     success: A => ZManaged[R1, E2, B]
   )(implicit ev: CanFail[E]): ZManaged[R1, E2, B] =
@@ -410,7 +410,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * and provides that fiber. The finalizer for this value will interrupt the fiber
    * and run the original finalizer.
    */
-  final def fork: ZManaged[R, Nothing, Fiber[E, A]] =
+  def fork: ZManaged[R, Nothing, Fiber[E, A]] =
     ZManaged {
       for {
         finalizer <- Ref.make[Exit[Any, Any] => ZIO[R, Nothing, Any]](_ => UIO.unit)
@@ -429,20 +429,20 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Unwraps the optional success of this effect, but can fail with unit value.
    */
-  final def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): ZManaged[R, Unit, B] =
+  def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): ZManaged[R, Unit, B] =
     ZManaged.absolve(mapError(ev1).map(ev2(_).toRight(())))
 
   /**
    * Depending on the environment execute this or the other effect
    */
-  final def join[R1, E1 >: E, A1 >: A](that: ZManaged[R1, E1, A1]): ZManaged[Either[R, R1], E1, A1] = self ||| that
+  def join[R1, E1 >: E, A1 >: A](that: ZManaged[R1, E1, A1]): ZManaged[Either[R, R1], E1, A1] = self ||| that
 
-  final def left[R1 <: R, C]: ZManaged[Either[R1, C], E, Either[A, C]] = self +++ ZManaged.identity
+  def left[R1 <: R, C]: ZManaged[Either[R1, C], E, Either[A, C]] = self +++ ZManaged.identity
 
   /**
    * Returns an effect whose success is mapped by the specified `f` function.
    */
-  final def map[B](f0: A => B): ZManaged[R, E, B] =
+  def map[B](f0: A => B): ZManaged[R, E, B] =
     ZManaged[R, E, B] {
       reserve.map(token => token.copy(acquire = token.acquire.map(f0)))
     }
@@ -450,7 +450,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Effectfully maps the resource acquired by this value.
    */
-  final def mapM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZManaged[R1, E1, B] =
+  def mapM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZManaged[R1, E1, B] =
     ZManaged[R1, E1, B] {
       reserve.map { token =>
         token.copy(acquire = token.acquire.flatMap(f))
@@ -460,16 +460,16 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Returns an effect whose failure is mapped by the specified `f` function.
    */
-  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
+  def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
     ZManaged(reserve.mapError(f).map(r => Reservation(r.acquire.mapError(f), r.release)))
 
   /**
    * Returns an effect whose full failure is mapped by the specified `f` function.
    */
-  final def mapErrorCause[E1](f: Cause[E] => Cause[E1]): ZManaged[R, E1, A] =
+  def mapErrorCause[E1](f: Cause[E] => Cause[E1]): ZManaged[R, E1, A] =
     ZManaged(reserve.mapErrorCause(f).map(r => Reservation(r.acquire.mapErrorCause(f), r.release)))
 
-  final def memoize: ZManaged[R, E, ZManaged[R, E, A]] =
+  def memoize: ZManaged[R, E, ZManaged[R, E, A]] =
     ZManaged {
       RefM.make[Option[(Reservation[R, E, A], Exit[E, A])]](None).map { ref =>
         val acquire1: ZIO[R, E, A] =
@@ -499,14 +499,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Returns a new effect where the error channel has been merged into the
    * success channel to their common combined type.
    */
-  final def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): ZManaged[R, Nothing, A1] =
+  def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): ZManaged[R, Nothing, A1] =
     self.foldM(e => ZManaged.succeed(ev1(e)), ZManaged.succeed)
 
   /**
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */
-  final def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
@@ -522,7 +522,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that a cleanup function runs when this ZManaged is finalized, before
    * the existing finalizers.
    */
-  final def onExitFirst[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def onExitFirst[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(
@@ -537,35 +537,35 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Executes this effect, skipping the error but returning optionally the success.
    */
-  final def option(implicit ev: CanFail[E]): ZManaged[R, Nothing, Option[A]] =
+  def option(implicit ev: CanFail[E]): ZManaged[R, Nothing, Option[A]] =
     fold(_ => None, Some(_))
 
   /**
    * Translates effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  final def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, Nothing, A] =
+  def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, Nothing, A] =
     orDieWith(ev1)
 
   /**
    * Keeps none of the errors, and terminates the fiber with them, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  final def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
+  def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
     mapError(f).catchAll(ZManaged.die)
 
   /**
    * Executes this effect and returns its value, if it succeeds, but
    * otherwise executes the specified effect.
    */
-  final def orElse[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
+  def orElse[R1 <: R, E2, A1 >: A](that: => ZManaged[R1, E2, A1])(implicit ev: CanFail[E]): ZManaged[R1, E2, A1] =
     foldM(_ => that, ZManaged.succeed)
 
   /**
    * Returns an effect that will produce the value of this effect, unless it
    * fails, in which case, it will produce the value of the specified effect.
    */
-  final def orElseEither[R1 <: R, E2, B](
+  def orElseEither[R1 <: R, E2, B](
     that: => ZManaged[R1, E2, B]
   )(implicit ev: CanFail[E]): ZManaged[R1, E2, Either[A, B]] =
     foldM(_ => that.map(Right[A, B]), a => ZManaged.succeed(Left[A, B](a)))
@@ -575,7 +575,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * You should take care that you are not interrupted between running preallocate and actually acquiring the resource
    * as you might leak otherwise.
    */
-  final def preallocate: ZIO[R, E, Managed[Nothing, A]] =
+  def preallocate: ZIO[R, E, Managed[Nothing, A]] =
     ZIO.uninterruptibleMask { restore =>
       for {
         env      <- ZIO.environment[R]
@@ -587,7 +587,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Preallocates the managed resource inside an outer managed, resulting in a ZManaged that reserves and acquires immediately and cannot fail.
    */
-  final def preallocateManaged: ZManaged[R, E, Managed[Nothing, A]] =
+  def preallocateManaged: ZManaged[R, E, Managed[Nothing, A]] =
     ZManaged.finalizerRef[R](_ => ZIO.unit).mapM { finalizer =>
       ZIO.uninterruptibleMask { restore =>
         for {
@@ -605,25 +605,25 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Provides the `ZManaged` effect with its required environment, which eliminates
    * its dependency on `R`.
    */
-  final def provide(r: R)(implicit ev: NeedsEnv[R]): ZManaged[Any, E, A] =
+  def provide(r: R)(implicit ev: NeedsEnv[R]): ZManaged[Any, E, A] =
     provideSome(_ => r)
 
   /**
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  final def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): ZManaged[R0, E, A] =
+  def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): ZManaged[R0, E, A] =
     ZManaged(reserve.provideSome(f).map(r => Reservation(r.acquire.provideSome(f), e => r.release(e).provideSome(f))))
 
   /**
    * Gives access to wrapped [[Reservation]].
    */
-  final def reserve: ZIO[R, E, Reservation[R, E, A]] = reservation
+  def reserve: ZIO[R, E, Reservation[R, E, A]] = reservation
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  final def refineOrDie[E1](
+  def refineOrDie[E1](
     pf: PartialFunction[E, E1]
   )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
     refineOrDieWith(pf)(ev1)
@@ -631,14 +631,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  final def refineToOrDie[E1: ClassTag](implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
+  def refineToOrDie[E1: ClassTag](implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
     refineOrDieWith { case e: E1 => e }(ev1)
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest, using
    * the specified function to convert the `E` into a `Throwable`.
    */
-  final def refineOrDieWith[E1](
+  def refineOrDieWith[E1](
     pf: PartialFunction[E, E1]
   )(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
     catchAll { e =>
@@ -651,7 +651,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
    * "execute `io` and in case of failure, try again once".
    */
-  final def retry[R1 <: R, E1 >: E, S](policy: Schedule[R1, E1, S])(implicit ev: CanFail[E]): ZManaged[R1, E1, A] = {
+  def retry[R1 <: R, E1 >: E, S](policy: Schedule[R1, E1, S])(implicit ev: CanFail[E]): ZManaged[R1, E1, A] = {
     def loop[B](zio: ZIO[R, E1, B], state: policy.State): ZIO[R1, E1, (policy.State, B)] =
       zio.foldM(
         err =>
@@ -671,13 +671,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     }
   }
 
-  final def right[R1 <: R, C]: ZManaged[Either[C, R1], E, Either[C, A]] = ZManaged.identity +++ self
+  def right[R1 <: R, C]: ZManaged[Either[C, R1], E, Either[C, A]] = ZManaged.identity +++ self
 
   /**
    * Returns an effect that semantically runs the effect on a fiber,
    * producing an [[zio.Exit]] for the completion value of the fiber.
    */
-  final def run: ZManaged[R, Nothing, Exit[E, A]] =
+  def run: ZManaged[R, Nothing, Exit[E, A]] =
     foldCauseM(
       cause => ZManaged.succeed(Exit.halt(cause)),
       succ => ZManaged.succeed(Exit.succeed(succ))
@@ -686,7 +686,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Exposes the full cause of failure of this effect.
    */
-  final def sandbox: ZManaged[R, Cause[E], A] =
+  def sandbox: ZManaged[R, Cause[E], A] =
     ZManaged {
       reserve.sandbox.map {
         case Reservation(acquire, release) =>
@@ -698,7 +698,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Companion helper to `sandbox`. Allows recovery, and partial recovery, from
    * errors and defects alike.
    */
-  final def sandboxWith[R1 <: R, E2, B](
+  def sandboxWith[R1 <: R, E2, B](
     f: ZManaged[R1, Cause[E], A] => ZManaged[R1, Cause[E2], B]
   ): ZManaged[R1, E2, B] =
     ZManaged.unsandbox(f(self.sandbox))
@@ -706,25 +706,25 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Zips this effect with its environment
    */
-  final def second[R1 <: R, A1 >: A]: ZManaged[R1, E, (R1, A1)] = ZManaged.identity[R1] &&& self
+  def second[R1 <: R, A1 >: A]: ZManaged[R1, E, (R1, A1)] = ZManaged.identity[R1] &&& self
 
   /**
    * Returns an effect that effectfully peeks at the acquired resource.
    */
-  final def tap[R1 <: R, E1 >: E](f: A => ZManaged[R1, E1, Any]): ZManaged[R1, E1, A] =
+  def tap[R1 <: R, E1 >: E](f: A => ZManaged[R1, E1, Any]): ZManaged[R1, E1, A] =
     flatMap(a => f(a).as(a))
 
   /**
    * Like [[ZManaged#tap]], but uses a function that returns a ZIO value rather than a
    * ZManaged value.
    */
-  final def tapM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZManaged[R1, E1, A] =
+  def tapM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZManaged[R1, E1, A] =
     mapM(a => f(a).as(a))
 
   /**
    * Returns a new effect that executes this one and times the acquisition of the resource.
    */
-  final def timed: ZManaged[R with Clock, E, (Duration, A)] =
+  def timed: ZManaged[R with Clock, E, (Duration, A)] =
     ZManaged {
       clock.nanoTime.flatMap { start =>
         reserve.map {
@@ -740,7 +740,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * If the reservation completes successfully (even after the timeout) the release action will be run on a new fiber.
    * `Some` will be returned if acquisition and reservation complete in time
    */
-  final def timeout(d: Duration): ZManaged[R with Clock, E, Option[A]] = {
+  def timeout(d: Duration): ZManaged[R with Clock, E, Option[A]] = {
     def timeoutReservation[B](
       zio: ZIO[R, E, Reservation[R, E, A]],
       d: Duration
@@ -793,20 +793,20 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * The inverse operation `ZManaged.sandboxed`
    */
-  final def unsandbox[E1](implicit ev: E <:< Cause[E1]): ZManaged[R, E1, A] =
+  def unsandbox[E1](implicit ev: E <:< Cause[E1]): ZManaged[R, E1, A] =
     ZManaged.unsandbox(mapError(ev))
 
   /**
    * Run an effect while acquiring the resource before and releasing it after
    */
-  final def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
+  def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     reserve.bracketExit((r, e: Exit[Any, Any]) => r.release(e), _.acquire.flatMap(f))
 
   /**
    *  Run an effect while acquiring the resource before and releasing it after.
    *  This does not provide the resource to the function
    */
-  final def use_[R1 <: R, E1 >: E, B](f: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
+  def use_[R1 <: R, E1 >: E, B](f: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     use(_ => f)
 
   /**
@@ -818,13 +818,13 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * The moral equivalent of `if (p) exp`
    */
-  final def when(b: Boolean): ZManaged[R, E, Unit] =
+  def when(b: Boolean): ZManaged[R, E, Unit] =
     ZManaged.when(b)(self)
 
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  final def whenM[R1 <: R, E1 >: E](b: ZManaged[R1, E1, Boolean]): ZManaged[R1, E1, Unit] =
+  def whenM[R1 <: R, E1 >: E](b: ZManaged[R1, E1, Boolean]): ZManaged[R1, E1, Unit] =
     ZManaged.whenM(b)(self)
 
   /**
@@ -833,14 +833,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * uninterruptibly with an exit value indicating that the effect was
    * interrupted, and if completed will cause the regular finalizer to not run.
    */
-  final def withEarlyRelease: ZManaged[R, E, (URIO[R, Any], A)] =
+  def withEarlyRelease: ZManaged[R, E, (URIO[R, Any], A)] =
     ZManaged.fiberId.flatMap(fiberId => withEarlyReleaseExit(Exit.interrupt(fiberId)))
 
   /**
    * A more powerful version of `withEarlyRelease` that allows specifying an
    * exit value in the event of early release.
    */
-  final def withEarlyReleaseExit(exit: Exit[Any, Any]): ZManaged[R, E, (URIO[R, Any], A)] =
+  def withEarlyReleaseExit(exit: Exit[Any, Any]): ZManaged[R, E, (URIO[R, Any], A)] =
     ZManaged[R, E, (URIO[R, Any], A)] {
       reserve.flatMap {
         case Reservation(acquire, release) =>
@@ -855,44 +855,44 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Named alias for `<*>`.
    */
-  final def zip[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
+  def zip[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
     self <*> that
 
   /**
    * Named alias for `<*`.
    */
-  final def zipLeft[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
+  def zipLeft[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
     self <* that
 
   /**
    * Named alias for `<&>`.
    */
-  final def zipPar[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
+  def zipPar[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, (A, A1)] =
     self <&> that
 
   /**
    * Named alias for `<&`.
    */
-  final def zipParLeft[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
+  def zipParLeft[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A] =
     self <& that
 
   /**
    * Named alias for `&>`.
    */
-  final def zipParRight[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
+  def zipParRight[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
     self &> that
 
   /**
    * Named alias for `*>`.
    */
-  final def zipRight[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
+  def zipRight[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
     self *> that
 
   /**
    * Returns an effect that executes both this effect and the specified effect,
    * in sequence, combining their results with the specified `f` function.
    */
-  final def zipWith[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f: (A, A1) => A2): ZManaged[R1, E1, A2] =
+  def zipWith[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f: (A, A1) => A2): ZManaged[R1, E1, A2] =
     flatMap(r => that.map(r1 => f(r, r1)))
 
   /**
@@ -900,7 +900,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * in parallel, combining their results with the specified `f` function. If
    * either side fails, then the other side will be interrupted.
    */
-  final def zipWithPar[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f0: (A, A1) => A2): ZManaged[R1, E1, A2] =
+  def zipWithPar[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f0: (A, A1) => A2): ZManaged[R1, E1, A2] =
     ZManaged[R1, E1, A2] {
       Ref.make[List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]](Nil).map { finalizers =>
         Reservation(
@@ -953,57 +953,57 @@ object ZManaged {
    * Returns an effectful function that extracts out the first element of a
    * tuple.
    */
-  final def _1[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, A] = fromFunction(_._1)
+  def _1[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, A] = fromFunction(_._1)
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  final def _2[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, B] = fromFunction(_._2)
+  def _2[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, B] = fromFunction(_._2)
 
   /**
    * Submerges the error case of an `Either` into the `ZManaged`. The inverse
    * operation of `ZManaged.either`.
    */
-  final def absolve[R, E, A](v: ZManaged[R, E, Either[E, A]]): ZManaged[R, E, A] =
+  def absolve[R, E, A](v: ZManaged[R, E, Either[E, A]]): ZManaged[R, E, A] =
     v.flatMap(fromEither(_))
 
   /**
    * Create a managed that accesses the environment.
    */
-  final def access[R]: AccessPartiallyApplied[R] =
+  def access[R]: AccessPartiallyApplied[R] =
     new AccessPartiallyApplied
 
   /**
    * Create a managed that accesses the environment.
    */
-  final def accessM[R]: AccessMPartiallyApplied[R] =
+  def accessM[R]: AccessMPartiallyApplied[R] =
     new AccessMPartiallyApplied
 
   /**
    * Create a managed that accesses the environment.
    */
-  final def accessManaged[R]: AccessManagedPartiallyApplied[R] =
+  def accessManaged[R]: AccessManagedPartiallyApplied[R] =
     new AccessManagedPartiallyApplied
 
   /**
    * Creates new [[ZManaged]] from wrapped [[Reservation]].
    */
-  final def apply[R, E, A](reservation: ZIO[R, E, Reservation[R, E, A]]): ZManaged[R, E, A] =
+  def apply[R, E, A](reservation: ZIO[R, E, Reservation[R, E, A]]): ZManaged[R, E, A] =
     new ZManaged(reservation)
 
   /**
    * Evaluate each effect in the structure from left to right, and collect
    * the results. For a parallel version, see `collectAllPar`.
    */
-  final def collectAll[R, E, A1, A2](ms: Iterable[ZManaged[R, E, A2]]): ZManaged[R, E, List[A2]] =
+  def collectAll[R, E, A1, A2](ms: Iterable[ZManaged[R, E, A2]]): ZManaged[R, E, List[A2]] =
     foreach(ms)(scala.Predef.identity)
 
   /**
    * Evaluate each effect in the structure in parallel, and collect
    * the results. For a sequential version, see `collectAll`.
    */
-  final def collectAllPar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+  def collectAllPar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     foreachPar(as)(scala.Predef.identity)
 
   /**
@@ -1012,7 +1012,7 @@ object ZManaged {
    *
    * Unlike `CollectAllPar`, this method will use at most `n` fibers.
    */
-  final def collectAllParN[R, E, A](n: Int)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+  def collectAllParN[R, E, A](n: Int)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     foreachParN(n)(as)(scala.Predef.identity)
 
   /**
@@ -1020,38 +1020,38 @@ object ZManaged {
    * This method can be used for terminating a fiber because a defect has been
    * detected in the code.
    */
-  final def die(t: Throwable): ZManaged[Any, Nothing, Nothing] = halt(Cause.die(t))
+  def die(t: Throwable): ZManaged[Any, Nothing, Nothing] = halt(Cause.die(t))
 
   /**
    * Returns an effect that dies with a [[java.lang.RuntimeException]] having the
    * specified text message. This method can be used for terminating a fiber
    * because a defect has been detected in the code.
    */
-  final def dieMessage(message: String): ZManaged[Any, Nothing, Nothing] = die(new RuntimeException(message))
+  def dieMessage(message: String): ZManaged[Any, Nothing, Nothing] = die(new RuntimeException(message))
 
   /**
    * Returns an effect from a [[zio.Exit]] value.
    */
-  final def done[E, A](r: Exit[E, A]): ZManaged[Any, E, A] =
+  def done[E, A](r: Exit[E, A]): ZManaged[Any, E, A] =
     ZManaged.fromEffect(ZIO.done(r))
 
   /**
    * Lifts a by-name, pure value into a Managed.
    */
-  final def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
+  def effectTotal[R, A](r: => A): ZManaged[R, Nothing, A] =
     ZManaged.fromEffect(ZIO.effectTotal(r))
 
   /**
    * Accesses the whole environment of the effect.
    */
-  final def environment[R]: ZManaged[R, Nothing, R] =
+  def environment[R]: ZManaged[R, Nothing, R] =
     ZManaged.fromEffect(ZIO.environment)
 
   /**
    * Returns an effect that models failure with the specified error.
    * The moral equivalent of `throw` for pure code.
    */
-  final def fail[E](error: E): ZManaged[Any, E, Nothing] =
+  def fail[E](error: E): ZManaged[Any, E, Nothing] =
     halt(Cause.fail(error))
 
   /**
@@ -1063,14 +1063,14 @@ object ZManaged {
    * Creates an effect that only executes the provided finalizer as its
    * release action.
    */
-  final def finalizer[R](f: ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
+  def finalizer[R](f: ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
     finalizerExit(_ => f)
 
   /**
    * Creates an effect that only executes the provided function as its
    * release action.
    */
-  final def finalizerExit[R](f: Exit[Any, Any] => ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
+  def finalizerExit[R](f: Exit[Any, Any] => ZIO[R, Nothing, Any]): ZManaged[R, Nothing, Unit] =
     ZManaged.reserve(Reservation(ZIO.unit, f))
 
   /**
@@ -1078,7 +1078,7 @@ object ZManaged {
    * is yielded as the result of the effect, allowing for control flows that require
    * mutating finalizers.
    */
-  final def finalizerRef[R](
+  def finalizerRef[R](
     initial: Exit[Any, Any] => ZIO[R, Nothing, Any]
   ): ZManaged[R, Nothing, Ref[Exit[Any, Any] => ZIO[R, Nothing, Any]]] =
     ZManaged {
@@ -1097,7 +1097,7 @@ object ZManaged {
    *
    * This method can be used to "flatten" nested effects.
     **/
-  final def flatten[R, E, A](zManaged: ZManaged[R, E, ZManaged[R, E, A]]): ZManaged[R, E, A] =
+  def flatten[R, E, A](zManaged: ZManaged[R, E, ZManaged[R, E, A]]): ZManaged[R, E, A] =
     zManaged.flatMap(scala.Predef.identity)
 
   /**
@@ -1106,7 +1106,7 @@ object ZManaged {
    *
    * For a parallel version of this method, see `foreachPar`.
    */
-  final def foreach[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
+  def foreach[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
     as.foldRight[ZManaged[R, E, List[A2]]](succeed(Nil)) { (a, m) =>
       f(a).zipWith(m)(_ :: _)
     }
@@ -1117,7 +1117,7 @@ object ZManaged {
    *
    * For a sequential version of this method, see `foreach`.
    */
-  final def foreachPar[R, E, A1, A2](
+  def foreachPar[R, E, A1, A2](
     as: Iterable[A1]
   )(
     f: A1 => ZManaged[R, E, A2]
@@ -1134,7 +1134,7 @@ object ZManaged {
    * Unlike `foreachPar`, this method will use at most up to `n` fibers.
    *
    */
-  final def foreachParN[R, E, A1, A2](
+  def foreachParN[R, E, A1, A2](
     n: Int
   )(
     as: Iterable[A1]
@@ -1150,7 +1150,7 @@ object ZManaged {
    * Equivalent to `foreach(as)(f).unit`, but without the cost of building
    * the list of results.
    */
-  final def foreach_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def foreach_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next) *> loop
@@ -1164,7 +1164,7 @@ object ZManaged {
    *
    * For a sequential version of this method, see `foreach_`.
    */
-  final def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     ZManaged.succeed(as.iterator).flatMap { i =>
       def loop: ZManaged[R, E, Unit] =
         if (i.hasNext) f(i.next).zipWithPar(loop)((_, _) => ())
@@ -1178,7 +1178,7 @@ object ZManaged {
    *
    * Unlike `foreachPar_`, this method will use at most up to `n` fibers.
    */
-  final def foreachParN_[R, E, A](
+  def foreachParN_[R, E, A](
     n: Int
   )(
     as: Iterable[A]
@@ -1193,14 +1193,14 @@ object ZManaged {
    * Creates a [[ZManaged]] from an `AutoCloseable` resource. The resource's `close`
    * method will be used as the release action.
    */
-  final def fromAutoCloseable[R, E, A <: AutoCloseable](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
+  def fromAutoCloseable[R, E, A <: AutoCloseable](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
     ZManaged.make(fa)(a => UIO(a.close()))
 
   /**
    * Lifts a ZIO[R, E, A] into ZManaged[R, E, A] with no release action. The
    * effect will be performed interruptibly.
    */
-  final def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
+  def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
     ZManaged(IO.succeed(Reservation(fa, _ => IO.unit)))
 
   /**
@@ -1208,36 +1208,36 @@ object ZManaged {
    * effect will be performed uninterruptibly. You usually want the [[ZManaged.fromEffect]]
    * variant.
    */
-  final def fromEffectUninterruptible[R, E, A](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
+  def fromEffectUninterruptible[R, E, A](fa: ZIO[R, E, A]): ZManaged[R, E, A] =
     ZManaged(fa.map(a => Reservation(UIO.succeed(a), _ => UIO.unit)))
 
   /**
    * Lifts an `Either` into a `ZManaged` value.
    */
-  final def fromEither[E, A](v: => Either[E, A]): ZManaged[Any, E, A] =
+  def fromEither[E, A](v: => Either[E, A]): ZManaged[Any, E, A] =
     effectTotal(v).flatMap(_.fold(fail, succeed))
 
   /**
    * Lifts a function `R => A` into a `ZManaged[R, Nothing, A]`.
    */
-  final def fromFunction[R, A](f: R => A): ZManaged[R, Nothing, A] = ZManaged.fromEffect(ZIO.environment[R]).map(f)
+  def fromFunction[R, A](f: R => A): ZManaged[R, Nothing, A] = ZManaged.fromEffect(ZIO.environment[R]).map(f)
 
   /**
    * Lifts an effectful function whose effect requires no environment into
    * an effect that requires the input to the function.
    */
-  final def fromFunctionM[R, E, A](f: R => ZManaged[Any, E, A]): ZManaged[R, E, A] = flatten(fromFunction(f))
+  def fromFunctionM[R, E, A](f: R => ZManaged[Any, E, A]): ZManaged[R, E, A] = flatten(fromFunction(f))
 
   /**
    * Returns an effect that models failure with the specified `Cause`.
    */
-  final def halt[E](cause: Cause[E]): ZManaged[Any, E, Nothing] =
+  def halt[E](cause: Cause[E]): ZManaged[Any, E, Nothing] =
     ZManaged.fromEffect(ZIO.halt(cause))
 
   /**
    * Returns the identity effectful function, which performs no effects
    */
-  final def identity[R]: ZManaged[R, Nothing, R] = fromFunction(scala.Predef.identity)
+  def identity[R]: ZManaged[R, Nothing, R] = fromFunction(scala.Predef.identity)
 
   /**
    * Returns an effect that is interrupted as if by the fiber calling this
@@ -1249,28 +1249,28 @@ object ZManaged {
   /**
    * Returns an effect that is interrupted as if by the specified fiber.
    */
-  final def interruptAs(fiberId: Fiber.Id): ZManaged[Any, Nothing, Nothing] =
+  def interruptAs(fiberId: Fiber.Id): ZManaged[Any, Nothing, Nothing] =
     halt(Cause.interrupt(fiberId))
 
   /**
    * Lifts a `ZIO[R, E, A]` into `ZManaged[R, E, A]` with a release action.
    * The acquire and release actions will be performed uninterruptibly.
    */
-  final def make[R, R1 <: R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def make[R, R1 <: R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged(acquire.map(r => Reservation(IO.succeed(r), _ => release(r))))
 
   /**
    * Lifts a synchronous effect into `ZManaged[R, Throwable, A]` with a release action.
    * The acquire and release actions will be performed uninterruptibly.
    */
-  final def makeEffect[R, A](acquire: => A)(release: A => Any): ZManaged[R, Throwable, A] =
+  def makeEffect[R, A](acquire: => A)(release: A => Any): ZManaged[R, Throwable, A] =
     make(Task(acquire))(a => Task(release(a)).orDie)
 
   /**
    * Lifts a `ZIO[R, E, A]` into `ZManaged[R, E, A]` with a release action that handles `Exit`.
    * The acquire and release actions will be performed uninterruptibly.
    */
-  final def makeExit[R, E, A](
+  def makeExit[R, E, A](
     acquire: ZIO[R, E, A]
   )(release: (A, Exit[Any, Any]) => ZIO[R, Nothing, Any]): ZManaged[R, E, A] =
     ZManaged(acquire.map(r => Reservation(IO.succeed(r), e => release(r, e))))
@@ -1280,7 +1280,7 @@ object ZManaged {
    * The acquire action will be performed interruptibly, while release
    * will be performed uninterruptibly.
    */
-  final def makeInterruptible[R, E, A](
+  def makeInterruptible[R, E, A](
     acquire: ZIO[R, E, A]
   )(release: A => ZIO[R, Nothing, Any]): ZManaged[R, E, A] =
     ZManaged.fromEffect(acquire).onExitFirst(_.foreach(release))
@@ -1289,7 +1289,7 @@ object ZManaged {
    * Sequentially zips the specified effects using the specified combiner
    * function.
    */
-  final def mapN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
+  def mapN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
     f: (A, B) => C
   ): ZManaged[R, E, C] =
     zManaged1.zipWith(zManaged2)(f)
@@ -1298,7 +1298,7 @@ object ZManaged {
    * Sequentially zips the specified effects using the specified combiner
    * function.
    */
-  final def mapN[R, E, A, B, C, D](
+  def mapN[R, E, A, B, C, D](
     zManaged1: ZManaged[R, E, A],
     zManaged2: ZManaged[R, E, B],
     zManaged3: ZManaged[R, E, C]
@@ -1313,7 +1313,7 @@ object ZManaged {
    * Sequentially zips the specified effects using the specified combiner
    * function.
    */
-  final def mapN[R, E, A, B, C, D, F](
+  def mapN[R, E, A, B, C, D, F](
     zManaged1: ZManaged[R, E, A],
     zManaged2: ZManaged[R, E, B],
     zManaged3: ZManaged[R, E, C],
@@ -1331,7 +1331,7 @@ object ZManaged {
    * combining their results with the specified `f` function. If any effect
    * fails, then the other effects will be interrupted.
    */
-  final def mapParN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
+  def mapParN[R, E, A, B, C](zManaged1: ZManaged[R, E, A], zManaged2: ZManaged[R, E, B])(
     f: (A, B) => C
   ): ZManaged[R, E, C] =
     zManaged1.zipWithPar(zManaged2)(f)
@@ -1341,7 +1341,7 @@ object ZManaged {
    * combining their results with the specified `f` function. If any effect
    * fails, then the other effects will be interrupted.
    */
-  final def mapParN[R, E, A, B, C, D](
+  def mapParN[R, E, A, B, C, D](
     zManaged1: ZManaged[R, E, A],
     zManaged2: ZManaged[R, E, B],
     zManaged3: ZManaged[R, E, C]
@@ -1355,7 +1355,7 @@ object ZManaged {
    * combining their results with the specified `f` function. If any effect
    * fails, then the other effects will be interrupted.
    */
-  final def mapParN[R, E, A, B, C, D, F](
+  def mapParN[R, E, A, B, C, D, F](
     zManaged1: ZManaged[R, E, A],
     zManaged2: ZManaged[R, E, B],
     zManaged3: ZManaged[R, E, C],
@@ -1368,13 +1368,13 @@ object ZManaged {
   /**
    * Merges an `Iterable[IO]` to a single IO, working sequentially.
    */
-  final def mergeAll[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
+  def mergeAll[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
     in.foldLeft[ZManaged[R, E, B]](ZManaged.succeed(zero))((acc, a) => acc.zip(a).map(f.tupled))
 
   /**
    * Merges an `Iterable[IO]` to a single IO, working in parallel.
    */
-  final def mergeAllPar[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
+  def mergeAllPar[R, E, A, B](in: Iterable[ZManaged[R, E, A]])(zero: B)(f: (B, A) => B): ZManaged[R, E, B] =
     in.foldLeft[ZManaged[R, E, B]](ZManaged.succeed(zero))((acc, a) => acc.zipPar(a).map(f.tupled))
 
   /**
@@ -1384,7 +1384,7 @@ object ZManaged {
    *
    * This is not implemented in terms of ZIO.foreach / ZManaged.zipWithPar as otherwise all reservation phases would always run, causing unnecessary work
    */
-  final def mergeAllParN[R, E, A, B](
+  def mergeAllParN[R, E, A, B](
     n: Int
   )(
     in: Iterable[ZManaged[R, E, A]]
@@ -1439,7 +1439,7 @@ object ZManaged {
   /**
    * Creates a scope in which resources can be safely preallocated.
    */
-  final def scope[R]: ZManaged[R, Nothing, Scope] =
+  def scope[R]: ZManaged[R, Nothing, Scope] =
     ZManaged {
       // we abuse the fact that Function1 will use reference equality
       Ref.make(Set.empty[Exit[Any, Any] => ZIO[R, Nothing, Any]]).map { finalizers =>
@@ -1474,7 +1474,7 @@ object ZManaged {
   /**
    * Reduces an `Iterable[IO]` to a single `IO`, working sequentially.
    */
-  final def reduceAll[R, E, A](a: ZManaged[R, E, A], as: Iterable[ZManaged[R, E, A]])(
+  def reduceAll[R, E, A](a: ZManaged[R, E, A], as: Iterable[ZManaged[R, E, A]])(
     f: (A, A) => A
   ): ZManaged[R, E, A] =
     as.foldLeft[ZManaged[R, E, A]](a) { (l, r) =>
@@ -1484,7 +1484,7 @@ object ZManaged {
   /**
    * Reduces an `Iterable[IO]` to a single `IO`, working in parallel.
    */
-  final def reduceAllPar[R, E, A](a: ZManaged[R, E, A], as: Iterable[ZManaged[R, E, A]])(
+  def reduceAllPar[R, E, A](a: ZManaged[R, E, A], as: Iterable[ZManaged[R, E, A]])(
     f: (A, A) => A
   ): ZManaged[R, E, A] =
     as.foldLeft[ZManaged[R, E, A]](a) { (l, r) =>
@@ -1498,7 +1498,7 @@ object ZManaged {
    *
    * This is not implemented in terms of ZIO.foreach / ZManaged.zipWithPar as otherwise all reservation phases would always run, causing unnecessary work
    */
-  final def reduceAllParN[R, E, A](
+  def reduceAllParN[R, E, A](
     n: Long
   )(
     a1: ZManaged[R, E, A],
@@ -1554,52 +1554,52 @@ object ZManaged {
    * Requires that the given `ZManaged[E, Option[A]]` contain a value. If there is no
    * value, then the specified error will be raised.
    */
-  final def require[R, E, A](error: E): ZManaged[R, E, Option[A]] => ZManaged[R, E, A] =
+  def require[R, E, A](error: E): ZManaged[R, E, Option[A]] => ZManaged[R, E, A] =
     (zManaged: ZManaged[R, E, Option[A]]) => zManaged.flatMap(_.fold[ZManaged[R, E, A]](fail(error))(succeed))
 
   /**
    * Lifts a pure `Reservation[R, E, A]` into `ZManaged[R, E, A]`
    */
-  final def reserve[R, E, A](reservation: Reservation[R, E, A]): ZManaged[R, E, A] =
+  def reserve[R, E, A](reservation: Reservation[R, E, A]): ZManaged[R, E, A] =
     ZManaged(ZIO.succeed(reservation))
 
-  final def sandbox[R, E, A](v: ZManaged[R, E, A]): ZManaged[R, Cause[E], A] =
+  def sandbox[R, E, A](v: ZManaged[R, E, A]): ZManaged[R, Cause[E], A] =
     v.sandbox
 
   /**
    *  Alias for [[ZManaged.collectAll]]
    */
-  final def sequence[R, E, A1, A2](ms: Iterable[ZManaged[R, E, A2]]): ZManaged[R, E, List[A2]] =
+  def sequence[R, E, A1, A2](ms: Iterable[ZManaged[R, E, A2]]): ZManaged[R, E, List[A2]] =
     collectAll[R, E, A1, A2](ms)
 
   /**
    *  Alias for [[ZManaged.collectAllPar]]
    */
-  final def sequencePar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+  def sequencePar[R, E, A](as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     collectAllPar[R, E, A](as)
 
   /**
    *  Alias for [[ZManaged.collectAllParN]]
    */
-  final def sequenceParN[R, E, A](n: Int)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
+  def sequenceParN[R, E, A](n: Int)(as: Iterable[ZManaged[R, E, A]]): ZManaged[R, E, List[A]] =
     collectAllParN[R, E, A](n)(as)
 
   /**
    * Lifts a strict, pure value into a Managed.
    */
-  final def succeed[R, A](r: A): ZManaged[R, Nothing, A] =
+  def succeed[R, A](r: A): ZManaged[R, Nothing, A] =
     ZManaged(IO.succeed(Reservation(IO.succeed(r), _ => IO.unit)))
 
   /**
    * Returns a lazily constructed Managed.
    */
-  final def suspend[R, E, A](zManaged: => ZManaged[R, E, A]): ZManaged[R, E, A] =
+  def suspend[R, E, A](zManaged: => ZManaged[R, E, A]): ZManaged[R, E, A] =
     flatten(effectTotal(zManaged))
 
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  final def swap[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, (B, A)] = fromFunction(_.swap)
+  def swap[R, E, A, B](implicit ev: R <:< (A, B)): ZManaged[R, E, (B, A)] = fromFunction(_.swap)
 
   /**
    * Returns a ZManaged value that represents a managed resource that can be safely
@@ -1632,7 +1632,7 @@ object ZManaged {
    *   }
    * }}}
    */
-  final def switchable[R, E, A]: ZManaged[R, Nothing, ZManaged[R, E, A] => ZIO[R, E, A]] =
+  def switchable[R, E, A]: ZManaged[R, Nothing, ZManaged[R, E, A] => ZIO[R, E, A]] =
     for {
       fiberId      <- ZManaged.fiberId
       finalizerRef <- ZManaged.finalizerRef[R](_ => UIO.unit)
@@ -1653,19 +1653,19 @@ object ZManaged {
   /**
    * Alias for [[ZManaged.foreach]]
    */
-  final def traverse[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
+  def traverse[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
     foreach[R, E, A1, A2](as)(f)
 
   /**
    * Alias for [[ZManaged.foreach_]]
    */
-  final def traverse_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def traverse_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     foreach_[R, E, A](as)(f)
 
   /**
    * Alias for [[ZManaged.foreachPar]]
    */
-  final def traversePar[R, E, A1, A2](
+  def traversePar[R, E, A1, A2](
     as: Iterable[A1]
   )(
     f: A1 => ZManaged[R, E, A2]
@@ -1675,13 +1675,13 @@ object ZManaged {
   /**
    * Alias for [[ZManaged.foreachPar_]]
    */
-  final def traversePar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def traversePar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     foreachPar_[R, E, A](as)(f)
 
   /**
    * Alias for [[ZManaged.foreachParN]]
    */
-  final def traverseParN[R, E, A1, A2](
+  def traverseParN[R, E, A1, A2](
     n: Int
   )(
     as: Iterable[A1]
@@ -1693,7 +1693,7 @@ object ZManaged {
   /**
    * Alias for [[ZManaged.foreachParN_]]
    */
-  final def traverseParN_[R, E, A](
+  def traverseParN_[R, E, A](
     n: Int
   )(
     as: Iterable[A]
@@ -1711,31 +1711,31 @@ object ZManaged {
   /**
    * The inverse operation to `sandbox`. Submerges the full cause of failure.
    */
-  final def unsandbox[R, E, A](v: ZManaged[R, Cause[E], A]): ZManaged[R, E, A] =
+  def unsandbox[R, E, A](v: ZManaged[R, Cause[E], A]): ZManaged[R, E, A] =
     v.mapErrorCause(_.flatten)
 
   /**
    * Unwraps a `ZManaged` that is inside a `ZIO`.
    */
-  final def unwrap[R, E, A](fa: ZIO[R, E, ZManaged[R, E, A]]): ZManaged[R, E, A] =
+  def unwrap[R, E, A](fa: ZIO[R, E, ZManaged[R, E, A]]): ZManaged[R, E, A] =
     ZManaged.fromEffect(fa).flatten
 
   /**
    * The moral equivalent of `if (p) exp`
    */
-  final def when[R, E](b: Boolean)(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def when[R, E](b: Boolean)(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     if (b) zManaged.unit else unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given value, otherwise does nothing.
    */
-  final def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
+  def whenCase[R, E, A](a: A)(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     pf.applyOrElse(a, (_: A) => unit).unit
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given effectful value, otherwise does nothing.
    */
-  final def whenCaseM[R, E, A](
+  def whenCaseM[R, E, A](
     a: ZManaged[R, E, A]
   )(pf: PartialFunction[A, ZManaged[R, E, Any]]): ZManaged[R, E, Unit] =
     a.flatMap(whenCase(_)(pf))
@@ -1743,7 +1743,7 @@ object ZManaged {
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  final def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     b.flatMap(b => if (b) zManaged.unit else unit)
 
 }

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -103,7 +103,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Alias for `both`.
    */
-  def &&[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
+  final def &&[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
     that: ZQueue[RA1, EA1, RB1, EB1, A1, C]
   ): ZQueue[RA1, EA1, RB1, EB1, A1, (B, C)] =
     both(that)
@@ -111,7 +111,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Like `bothWith`, but tuples the elements instead of applying a function.
    */
-  def both[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
+  final def both[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
     that: ZQueue[RA1, EA1, RB1, EB1, A1, C]
   ): ZQueue[RA1, EA1, RB1, EB1, A1, (B, C)] =
     bothWith(that)((_, _))
@@ -119,7 +119,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Like `bothWithM`, but uses a pure function.
    */
-  def bothWith[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
+  final def bothWith[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, D](
     that: ZQueue[RA1, EA1, RB1, EB1, A1, C]
   )(f: (B, C) => D): ZQueue[RA1, EA1, RB1, EB1, A1, D] =
     bothWithM(that)((a, b) => IO.succeed(f(a, b)))
@@ -133,7 +133,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
    * For example, a dropping queue and a bounded queue composed together may apply `f`
    * to different elements.
    */
-  def bothWithM[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, R3 <: RB1, E3 >: EB1, D](
+  final def bothWithM[RA1 <: RA, EA1 >: EA, A1 <: A, RB1 <: RB, EB1 >: EB, C, R3 <: RB1, E3 >: EB1, D](
     that: ZQueue[RA1, EA1, RB1, EB1, A1, C]
   )(f: (B, C) => ZIO[R3, E3, D]): ZQueue[RA1, EA1, R3, E3, A1, D] =
     new ZQueue[RA1, EA1, R3, E3, A1, D] {
@@ -170,7 +170,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Transforms elements enqueued into this queue with a pure function.
    */
-  def contramap[C](f: C => A): ZQueue[RA, EA, RB, EB, C, B] =
+  final def contramap[C](f: C => A): ZQueue[RA, EA, RB, EB, C, B] =
     new ZQueue[RA, EA, RB, EB, C, B] {
       def capacity: Int = self.capacity
 
@@ -191,7 +191,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Transforms elements enqueued into this queue with an effectful function.
    */
-  def contramapM[RA2 <: RA, EA2 >: EA, C](f: C => ZIO[RA2, EA2, A]): ZQueue[RA2, EA2, RB, EB, C, B] =
+  final def contramapM[RA2 <: RA, EA2 >: EA, C](f: C => ZIO[RA2, EA2, A]): ZQueue[RA2, EA2, RB, EB, C, B] =
     new ZQueue[RA2, EA2, RB, EB, C, B] {
       def capacity: Int = self.capacity
 
@@ -214,7 +214,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
    * Applies a filter to elements enqueued into this queue. Elements that do not
    * pass the filter will be immediately dropped.
    */
-  def filterInput[A1 <: A](f: A1 => Boolean): ZQueue[RA, EA, RB, EB, A1, B] =
+  final def filterInput[A1 <: A](f: A1 => Boolean): ZQueue[RA, EA, RB, EB, A1, B] =
     new ZQueue[RA, EA, RB, EB, A1, B] {
       def capacity: Int = self.capacity
 
@@ -241,7 +241,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Like `filterInput`, but uses an effectful function to filter the elements.
    */
-  def filterInputM[R2 <: RA, E2 >: EA, A1 <: A](f: A1 => ZIO[R2, E2, Boolean]): ZQueue[R2, E2, RB, EB, A1, B] =
+  final def filterInputM[R2 <: RA, E2 >: EA, A1 <: A](f: A1 => ZIO[R2, E2, Boolean]): ZQueue[R2, E2, RB, EB, A1, B] =
     new ZQueue[R2, E2, RB, EB, A1, B] {
       def capacity: Int = self.capacity
 
@@ -270,7 +270,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /*
    * Transforms elements dequeued from this queue with a function.
    */
-  def map[C](f: B => C): ZQueue[RA, EA, RB, EB, A, C] =
+  final def map[C](f: B => C): ZQueue[RA, EA, RB, EB, A, C] =
     new ZQueue[RA, EA, RB, EB, A, C] {
       def capacity: Int                                   = self.capacity
       def offer(a: A): ZIO[RA, EA, Boolean]               = self.offer(a)
@@ -287,7 +287,7 @@ trait ZQueue[-RA, +EA, -RB, +EB, -A, +B] extends Serializable { self =>
   /**
    * Transforms elements dequeued from this queue with an effectful function.
    */
-  def mapM[R2 <: RB, E2 >: EB, C](f: B => ZIO[R2, E2, C]): ZQueue[RA, EA, R2, E2, A, C] =
+  final def mapM[R2 <: RB, E2 >: EB, C](f: B => ZIO[R2, E2, C]): ZQueue[RA, EA, R2, E2, A, C] =
     new ZQueue[RA, EA, R2, E2, A, C] {
       def capacity: Int                                   = self.capacity
       def offer(a: A): ZIO[RA, EA, Boolean]               = self.offer(a)
@@ -315,7 +315,7 @@ object ZQueue {
     /**
      * Poll all items from the queue
      */
-    final def unsafePollAll[A](q: MutableConcurrentQueue[A]): List[A] = {
+    def unsafePollAll[A](q: MutableConcurrentQueue[A]): List[A] = {
       @tailrec
       def poll(as: List[A]): List[A] =
         q.poll(null.asInstanceOf[A]) match {
@@ -328,7 +328,7 @@ object ZQueue {
     /**
      * Poll n items from the queue
      */
-    final def unsafePollN[A](q: MutableConcurrentQueue[A], max: Int): List[A] = {
+    def unsafePollN[A](q: MutableConcurrentQueue[A], max: Int): List[A] = {
       @tailrec
       def poll(as: List[A], n: Int): List[A] =
         if (n < 1) as
@@ -343,7 +343,7 @@ object ZQueue {
     /**
      * Offer items to the queue
      */
-    final def unsafeOfferAll[A](q: MutableConcurrentQueue[A], as: List[A]): List[A] = {
+    def unsafeOfferAll[A](q: MutableConcurrentQueue[A], as: List[A]): List[A] = {
       @tailrec
       def offerAll(as: List[A]): List[A] =
         as match {
@@ -356,12 +356,12 @@ object ZQueue {
     /**
      * Remove an item from the queue
      */
-    final def unsafeRemove[A](q: MutableConcurrentQueue[A], a: A): Unit = {
+    def unsafeRemove[A](q: MutableConcurrentQueue[A], a: A): Unit = {
       unsafeOfferAll(q, unsafePollAll(q).filterNot(_ == a))
       ()
     }
 
-    final def unsafeCompletePromise[A](p: Promise[Nothing, A], a: A): Unit =
+    def unsafeCompletePromise[A](p: Promise[Nothing, A], a: A): Unit =
       p.unsafeDone(IO.succeed(a))
 
     sealed trait Strategy[A] {
@@ -375,7 +375,7 @@ object ZQueue {
     }
 
     case class Sliding[A]() extends Strategy[A] {
-      final def handleSurplus(
+      def handleSurplus(
         as: List[A],
         queue: MutableConcurrentQueue[A],
         checkShutdownState: UIO[Unit]
@@ -394,26 +394,26 @@ object ZQueue {
         IO.effectTotal(unsafeSlidingOffer(as)).map(_ => !loss)
       }
 
-      final def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = ()
+      def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = ()
 
-      final def surplusSize: Int = 0
+      def surplusSize: Int = 0
 
-      final def shutdown: UIO[Unit] = IO.unit
+      def shutdown: UIO[Unit] = IO.unit
     }
 
     case class Dropping[A]() extends Strategy[A] {
       // do nothing, drop the surplus
-      final def handleSurplus(
+      def handleSurplus(
         as: List[A],
         queue: MutableConcurrentQueue[A],
         checkShutdownState: UIO[Unit]
       ): UIO[Boolean] = IO.succeed(false)
 
-      final def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = ()
+      def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = ()
 
-      final def surplusSize: Int = 0
+      def surplusSize: Int = 0
 
-      final def shutdown: UIO[Unit] = IO.unit
+      def shutdown: UIO[Unit] = IO.unit
     }
 
     case class BackPressure[A]() extends Strategy[A] {
@@ -422,12 +422,12 @@ object ZQueue {
       // Boolean indicates if it's the last item to offer (promise should be completed once this item is added)
       private val putters = MutableConcurrentQueue.unbounded[(A, Promise[Nothing, Boolean], Boolean)]
 
-      private final def unsafeRemove(p: Promise[Nothing, Boolean]): Unit = {
+      private def unsafeRemove(p: Promise[Nothing, Boolean]): Unit = {
         unsafeOfferAll(putters, unsafePollAll(putters).filterNot(_._2 == p))
         ()
       }
 
-      final def handleSurplus(
+      def handleSurplus(
         as: List[A],
         queue: MutableConcurrentQueue[A],
         checkShutdownState: UIO[Unit]
@@ -454,7 +454,7 @@ object ZQueue {
           } yield true
         }
 
-      final def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {
+      def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {
         @tailrec
         def unsafeMovePutters(): Unit =
           if (!queue.isFull()) {
@@ -474,9 +474,9 @@ object ZQueue {
         unsafeMovePutters()
       }
 
-      final def surplusSize: Int = putters.size()
+      def surplusSize: Int = putters.size()
 
-      final def shutdown: UIO[Unit] =
+      def shutdown: UIO[Unit] =
         for {
           fiberId <- ZIO.fiberId
           putters <- IO.effectTotal(unsafePollAll(putters))
@@ -495,7 +495,7 @@ object ZQueue {
       shutdownHook.poll.flatMap(_.fold[UIO[Unit]](IO.unit)(_ => IO.interrupt))
 
     @tailrec
-    private final def pollTakersThenQueue(): Option[(Promise[Nothing, A], A)] =
+    private def pollTakersThenQueue(): Option[(Promise[Nothing, A], A)] =
       // check if there is both a taker and an item in the queue, starting by the taker
       if (!queue.isEmpty()) {
         val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
@@ -513,7 +513,7 @@ object ZQueue {
       } else None
 
     @tailrec
-    private final def unsafeCompleteTakers(): Unit =
+    private def unsafeCompleteTakers(): Unit =
       pollTakersThenQueue() match {
         case None =>
         case Some((p, a)) =>
@@ -522,13 +522,13 @@ object ZQueue {
           unsafeCompleteTakers()
       }
 
-    private final def removeTaker(taker: Promise[Nothing, A]): UIO[Unit] = IO.effectTotal(unsafeRemove(takers, taker))
+    private def removeTaker(taker: Promise[Nothing, A]): UIO[Unit] = IO.effectTotal(unsafeRemove(takers, taker))
 
     final val capacity: Int = queue.capacity
 
-    final def offer(a: A): UIO[Boolean] = offerAll(List(a))
+    def offer(a: A): UIO[Boolean] = offerAll(List(a))
 
-    final def offerAll(as: Iterable[A]): UIO[Boolean] =
+    def offerAll(as: Iterable[A]): UIO[Boolean] =
       UIO.effectSuspendTotal {
         for {
           _ <- checkShutdownState
@@ -614,7 +614,7 @@ object ZQueue {
         } yield as
       }
 
-    final def takeUpTo(max: Int): UIO[List[A]] =
+    def takeUpTo(max: Int): UIO[List[A]] =
       UIO.effectSuspendTotal {
         for {
           _ <- checkShutdownState
@@ -641,7 +641,7 @@ object ZQueue {
    * @tparam A type of the `Queue`
    * @return `UIO[Queue[A]]`
    */
-  final def bounded[A](requestedCapacity: Int): UIO[Queue[A]] =
+  def bounded[A](requestedCapacity: Int): UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, BackPressure()))
 
   /**
@@ -656,7 +656,7 @@ object ZQueue {
    * @tparam A type of the `Queue`
    * @return `UIO[Queue[A]]`
    */
-  final def dropping[A](requestedCapacity: Int): UIO[Queue[A]] =
+  def dropping[A](requestedCapacity: Int): UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, Dropping()))
 
   /**
@@ -672,7 +672,7 @@ object ZQueue {
    * @tparam A type of the `Queue`
    * @return `UIO[Queue[A]]`
    */
-  final def sliding[A](requestedCapacity: Int): UIO[Queue[A]] =
+  def sliding[A](requestedCapacity: Int): UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, Sliding()))
 
   /**
@@ -681,10 +681,10 @@ object ZQueue {
    * @tparam A type of the `Queue`
    * @return `UIO[Queue[A]]`
    */
-  final def unbounded[A]: UIO[Queue[A]] =
+  def unbounded[A]: UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.unbounded[A]).flatMap(createQueue(_, Dropping()))
 
-  private final def createQueue[A](queue: MutableConcurrentQueue[A], strategy: Strategy[A]): UIO[Queue[A]] =
+  private def createQueue[A](queue: MutableConcurrentQueue[A], strategy: Strategy[A]): UIO[Queue[A]] =
     Promise
       .make[Nothing, Unit]
       .map(p => unsafeCreate(queue, MutableConcurrentQueue.unbounded[Promise[Nothing, A]], p, strategy))

--- a/core/shared/src/main/scala/zio/ZTrace.scala
+++ b/core/shared/src/main/scala/zio/ZTrace.scala
@@ -26,7 +26,7 @@ final case class ZTrace(
   stackTrace: List[ZTraceElement],
   parentTrace: Option[ZTrace]
 ) {
-  final def prettyPrint: String = {
+  def prettyPrint: String = {
     val execTrace  = this.executionTrace.nonEmpty
     val stackTrace = this.stackTrace.nonEmpty
 
@@ -57,7 +57,7 @@ final case class ZTrace(
    * NOTE: `parentTrace` fields are still populated for members of this list,
    * despite that the next trace in the list is equivalent to `parentTrace`
    * */
-  final def parents: List[ZTrace] = {
+  def parents: List[ZTrace] = {
     val builder = List.newBuilder[ZTrace]
     var parent  = parentTrace.orNull
     while (parent ne null) {
@@ -67,7 +67,7 @@ final case class ZTrace(
     builder.result()
   }
 
-  final def ancestryLength: Int = {
+  def ancestryLength: Int = {
     @tailrec
     def go(i: Int, trace: ZTrace): Int =
       trace.parentTrace match {
@@ -80,7 +80,7 @@ final case class ZTrace(
 }
 
 object ZTrace {
-  final def truncatedParentTrace(trace: ZTrace, maxAncestors: Int): Option[ZTrace] =
+  def truncatedParentTrace(trace: ZTrace, maxAncestors: Int): Option[ZTrace] =
     if (trace.ancestryLength > maxAncestors)
       trace.parents.iterator
         .take(maxAncestors)

--- a/core/shared/src/main/scala/zio/clock/Clock.scala
+++ b/core/shared/src/main/scala/zio/clock/Clock.scala
@@ -36,13 +36,13 @@ object Clock extends Serializable {
   }
 
   trait Live extends SchedulerLive with Clock {
-    val clock: Service[Any] = new Service[Any] {
-      def currentTime(unit: TimeUnit): UIO[Long] =
+    final val clock: Service[Any] = new Service[Any] {
+      final def currentTime(unit: TimeUnit): UIO[Long] =
         IO.effectTotal(System.currentTimeMillis).map(l => unit.convert(l, TimeUnit.MILLISECONDS))
 
-      val nanoTime: UIO[Long] = IO.effectTotal(System.nanoTime)
+      final val nanoTime: UIO[Long] = IO.effectTotal(System.nanoTime)
 
-      def sleep(duration: Duration): UIO[Unit] =
+      final def sleep(duration: Duration): UIO[Unit] =
         scheduler.scheduler.flatMap(
           scheduler =>
             ZIO.effectAsyncInterrupt[Any, Nothing, Unit] { k =>
@@ -53,7 +53,7 @@ object Clock extends Serializable {
             }
         )
 
-      def currentDateTime: ZIO[Any, Nothing, OffsetDateTime] =
+      final def currentDateTime: ZIO[Any, Nothing, OffsetDateTime] =
         for {
           millis <- currentTime(TimeUnit.MILLISECONDS)
           zone   <- ZIO.effectTotal(ZoneId.systemDefault)

--- a/core/shared/src/main/scala/zio/duration/DurationSyntax.scala
+++ b/core/shared/src/main/scala/zio/duration/DurationSyntax.scala
@@ -19,35 +19,35 @@ package zio.duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit._
 
-class DurationSyntax(n: Long) {
+final class DurationSyntax(n: Long) {
 
   private[this] def asDuration(unit: TimeUnit): Duration = Duration(n, unit)
 
-  final def nanoseconds = asDuration(NANOSECONDS)
-  final def nanos       = nanoseconds
-  final def nanosecond  = nanoseconds
-  final def nano        = nanoseconds
+  def nanoseconds = asDuration(NANOSECONDS)
+  def nanos       = nanoseconds
+  def nanosecond  = nanoseconds
+  def nano        = nanoseconds
 
-  final def microseconds = asDuration(MICROSECONDS)
-  final def micros       = microseconds
-  final def microsecond  = microseconds
-  final def micro        = microseconds
+  def microseconds = asDuration(MICROSECONDS)
+  def micros       = microseconds
+  def microsecond  = microseconds
+  def micro        = microseconds
 
-  final def milliseconds = asDuration(MILLISECONDS)
-  final def millis       = milliseconds
-  final def millisecond  = milliseconds
-  final def milli        = milliseconds
+  def milliseconds = asDuration(MILLISECONDS)
+  def millis       = milliseconds
+  def millisecond  = milliseconds
+  def milli        = milliseconds
 
-  final def seconds = asDuration(SECONDS)
-  final def second  = seconds
+  def seconds = asDuration(SECONDS)
+  def second  = seconds
 
-  final def minutes = asDuration(MINUTES)
-  final def minute  = minutes
+  def minutes = asDuration(MINUTES)
+  def minute  = minutes
 
-  final def hours = asDuration(HOURS)
-  final def hour  = hours
+  def hours = asDuration(HOURS)
+  def hour  = hours
 
-  final def days = asDuration(DAYS)
-  final def day  = days
+  def days = asDuration(DAYS)
+  def day  = days
 
 }

--- a/core/shared/src/main/scala/zio/duration/package.scala
+++ b/core/shared/src/main/scala/zio/duration/package.scala
@@ -20,8 +20,8 @@ import scala.language.implicitConversions
 
 package object duration {
 
-  implicit final def durationInt(n: Int): DurationSyntax = new DurationSyntax(n.toLong)
+  implicit def durationInt(n: Int): DurationSyntax = new DurationSyntax(n.toLong)
 
-  implicit final def durationLong(n: Long): DurationSyntax = new DurationSyntax(n)
+  implicit def durationLong(n: Long): DurationSyntax = new DurationSyntax(n)
 
 }

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -56,7 +56,7 @@ trait Executor { self =>
   /**
    * Views this `Executor` as a Scala `ExecutionContext`.
    */
-  lazy val asEC: ExecutionContext =
+  lazy final val asEC: ExecutionContext =
     new ExecutionContext {
       override def execute(r: Runnable): Unit =
         if (!submit(r)) throw new RejectedExecutionException("Rejected: " + r.toString)
@@ -68,7 +68,7 @@ trait Executor { self =>
   /**
    * Views this `Executor` as a Scala `ExecutionContextExecutorService`.
    */
-  lazy val asECES: ExecutionContextExecutorService =
+  lazy final val asECES: ExecutionContextExecutorService =
     new AbstractExecutorService with ExecutionContextExecutorService {
       override val prepare: ExecutionContext                               = asEC
       override val isShutdown: Boolean                                     = false
@@ -87,7 +87,7 @@ object Executor extends DefaultExecutors with Serializable {
   /**
    * Creates an `Executor` from a Scala `ExecutionContext`.
    */
-  final def fromExecutionContext(yieldOpCount0: Int)(
+  def fromExecutionContext(yieldOpCount0: Int)(
     ec: ExecutionContext
   ): Executor =
     new Executor {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -84,11 +84,11 @@ private[zio] final class FiberContext[E, A](
   private[this] val tracer = platform.tracing.tracer
 
   @noinline
-  private[this] final def inTracingRegion: Boolean =
+  private[this] def inTracingRegion: Boolean =
     if (tracingStatus ne null) tracingStatus.peekOrElse(initialTracingStatus) else false
 
   @noinline
-  private[this] final def unwrap(lambda: AnyRef): AnyRef =
+  private[this] def unwrap(lambda: AnyRef): AnyRef =
     // This is a huge hotspot, hiding loop under
     // the match allows a faster happy path
     lambda match {
@@ -102,22 +102,22 @@ private[zio] final class FiberContext[E, A](
     }
 
   @noinline
-  private[this] final def traceLocation(lambda: AnyRef): ZTraceElement =
+  private[this] def traceLocation(lambda: AnyRef): ZTraceElement =
     tracer.traceLocation(unwrap(lambda))
 
   @noinline
-  private[this] final def addTrace(lambda: AnyRef): Unit =
+  private[this] def addTrace(lambda: AnyRef): Unit =
     execTrace.put(traceLocation(lambda))
 
-  @noinline private[this] final def pushContinuation(k: Any => IO[Any, Any]): Unit = {
+  @noinline private[this] def pushContinuation(k: Any => IO[Any, Any]): Unit = {
     if (traceStack && inTracingRegion) stackTrace.put(traceLocation(k))
     stack.push(k)
   }
 
-  private[this] final def popStackTrace(): Unit =
+  private[this] def popStackTrace(): Unit =
     stackTrace.dropLast()
 
-  private[this] final def captureTrace(lastStack: ZTraceElement): ZTrace = {
+  private[this] def captureTrace(lastStack: ZTraceElement): ZTrace = {
     val exec = if (execTrace ne null) execTrace.toReversedList else Nil
     val stack = {
       val stack0 = if (stackTrace ne null) stackTrace.toReversedList else Nil
@@ -126,7 +126,7 @@ private[zio] final class FiberContext[E, A](
     ZTrace(fiberId, exec, stack, parentTrace)
   }
 
-  private[this] final def cutAncestryTrace(trace: ZTrace): ZTrace = {
+  private[this] def cutAncestryTrace(trace: ZTrace): ZTrace = {
     val maxExecLength  = platform.tracing.tracingConfig.ancestorExecutionTraceLength
     val maxStackLength = platform.tracing.tracingConfig.ancestorStackTraceLength
     val maxAncestors   = platform.tracing.tracingConfig.ancestryLength - 1
@@ -141,14 +141,14 @@ private[zio] final class FiberContext[E, A](
     )
   }
 
-  private[zio] final def runAsync(k: Callback[E, A]): Unit =
+  private[zio] def runAsync(k: Callback[E, A]): Unit =
     register0(xx => k(Exit.flatten(xx))) match {
       case null =>
       case v    => k(v)
     }
 
   private[this] object InterruptExit extends Function[Any, IO[E, Any]] {
-    final def apply(v: Any): IO[E, Any] =
+    def apply(v: Any): IO[E, Any] =
       if (isInterruptible()) {
         interruptStatus.popDrop(())
 
@@ -159,7 +159,7 @@ private[zio] final class FiberContext[E, A](
   }
 
   private[this] object TracingRegionExit extends Function[Any, IO[E, Any]] {
-    final def apply(v: Any): IO[E, Any] = {
+    def apply(v: Any): IO[E, Any] = {
       // don't use effectTotal to avoid TracingRegionExit appearing in execution trace twice with traceEffects=true
       tracingStatus.popDrop(())
 
@@ -171,7 +171,7 @@ private[zio] final class FiberContext[E, A](
    * Unwinds the stack, looking for the first error handler, and exiting
    * interruptible / uninterruptible regions.
    */
-  private[this] final def unwindStack(): Unit = {
+  private[this] def unwindStack(): Unit = {
     var unwinding = true
 
     // Unwind the stack, looking for an error handler:
@@ -200,9 +200,9 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def executor: Executor = executors.peekOrElse(platform.executor)
+  private[this] def executor: Executor = executors.peekOrElse(platform.executor)
 
-  @inline private[this] final def raceWithImpl[R, EL, ER, E, A, B, C](
+  @inline private[this] def raceWithImpl[R, EL, ER, E, A, B, C](
     race: ZIO.RaceWith[R, EL, ER, E, A, B, C]
   ): ZIO[R, E, C] = {
     @inline def complete[E0, E1, A, B](
@@ -258,7 +258,7 @@ private[zio] final class FiberContext[E, A](
    *
    * @param io0 The `IO` to evaluate on the fiber.
    */
-  final def evaluateNow(io0: IO[E, Any]): Unit =
+  def evaluateNow(io0: IO[E, Any]): Unit =
     try {
       // Do NOT accidentally capture `curZio` in a closure, or Scala will wrap
       // it in `ObjectRef` and performance will plummet.
@@ -602,13 +602,13 @@ private[zio] final class FiberContext[E, A](
       }
     } finally Fiber._currentFiber.remove()
 
-  private[this] final def lock(executor: Executor): UIO[Unit] =
+  private[this] def lock(executor: Executor): UIO[Unit] =
     ZIO.effectTotal { executors.push(executor) } *> ZIO.yieldNow
 
-  private[this] final def unlock: UIO[Unit] =
+  private[this] def unlock: UIO[Unit] =
     ZIO.effectTotal { executors.pop() } *> ZIO.yieldNow
 
-  private[this] final def getDescriptor(): Fiber.Descriptor =
+  private[this] def getDescriptor(): Fiber.Descriptor =
     Fiber.Descriptor(
       fiberId,
       state.get.status,
@@ -621,7 +621,7 @@ private[zio] final class FiberContext[E, A](
   /**
    * Forks an `IO` with the specified failure handler.
    */
-  final def fork[E, A](zio: IO[E, A]): FiberContext[E, A] = {
+  def fork[E, A](zio: IO[E, A]): FiberContext[E, A] = {
     val isDaemon = daemonStatus.peekOrElse(false)
 
     val childFiberRefLocals: FiberRefLocals = Platform.newWeakHashMap()
@@ -666,7 +666,7 @@ private[zio] final class FiberContext[E, A](
     childContext
   }
 
-  private[this] final def evaluateLater(zio: IO[E, Any]): Unit =
+  private[this] def evaluateLater(zio: IO[E, Any]): Unit =
     executor.submitOrThrow(() => evaluateNow(zio))
 
   /**
@@ -674,30 +674,30 @@ private[zio] final class FiberContext[E, A](
    *
    * @param value The value produced by the asynchronous computation.
    */
-  private[this] final def resumeAsync(epoch: Long): IO[E, Any] => Unit = { zio =>
+  private[this] def resumeAsync(epoch: Long): IO[E, Any] => Unit = { zio =>
     if (exitAsync(epoch)) evaluateLater(zio)
   }
 
-  final def interruptAs(fiberId: Fiber.Id): UIO[Exit[E, A]] = kill0(fiberId)
+  def interruptAs(fiberId: Fiber.Id): UIO[Exit[E, A]] = kill0(fiberId)
 
   @silent("JavaConverters")
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = UIO(_children.asScala.toSet)
+  def children: UIO[Iterable[Fiber[Any, Any]]] = UIO(_children.asScala.toSet)
 
-  final def await: UIO[Exit[E, A]] = ZIO.effectAsyncMaybe[Any, Nothing, Exit[E, A]] { k =>
+  def await: UIO[Exit[E, A]] = ZIO.effectAsyncMaybe[Any, Nothing, Exit[E, A]] { k =>
     observe0(x => k(ZIO.done(x)))
   }
 
-  final def getRef[A](ref: FiberRef[A]): UIO[A] = UIO {
+  def getRef[A](ref: FiberRef[A]): UIO[A] = UIO {
     val oldValue = Option(fiberRefLocals.get(ref))
 
     oldValue.asInstanceOf[Option[A]].getOrElse(ref.initial)
   }
 
-  final def poll: UIO[Option[Exit[E, A]]] = ZIO.effectTotal(poll0)
+  def poll: UIO[Option[Exit[E, A]]] = ZIO.effectTotal(poll0)
 
-  final def id: UIO[Option[Fiber.Id]] = UIO(Some(fiberId))
+  def id: UIO[Option[Fiber.Id]] = UIO(Some(fiberId))
 
-  final def inheritRefs: UIO[Unit] = UIO.effectSuspendTotal {
+  def inheritRefs: UIO[Unit] = UIO.effectSuspendTotal {
     val locals = fiberRefLocals.asScala: @silent("JavaConverters")
     if (locals.isEmpty) UIO.unit
     else
@@ -708,12 +708,12 @@ private[zio] final class FiberContext[E, A](
       }
   }
 
-  final def status: UIO[Fiber.Status] = UIO(state.get.status)
+  def status: UIO[Fiber.Status] = UIO(state.get.status)
 
-  final def trace: UIO[Option[ZTrace]] = UIO(Some(captureTrace(null)))
+  def trace: UIO[Option[ZTrace]] = UIO(Some(captureTrace(null)))
 
   @tailrec
-  private[this] final def enterAsync(epoch: Long, register: AnyRef, blockingOn: List[Fiber.Id]): IO[E, Any] = {
+  private[this] def enterAsync(epoch: Long, register: AnyRef, blockingOn: List[Fiber.Id]): IO[E, Any] = {
     val oldState = state.get
 
     oldState match {
@@ -735,7 +735,7 @@ private[zio] final class FiberContext[E, A](
   }
 
   @tailrec
-  private[this] final def exitAsync(epoch: Long): Boolean = {
+  private[this] def exitAsync(epoch: Long): Boolean = {
     val oldState = state.get
 
     oldState match {
@@ -747,15 +747,15 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def daemonEnter(flag: DaemonStatus): UIO[Unit] = ZIO.effectTotal {
+  private[this] def daemonEnter(flag: DaemonStatus): UIO[Unit] = ZIO.effectTotal {
     daemonStatus.push(flag.toBoolean)
   }
 
-  private[this] final def daemonExit: UIO[Unit] = ZIO.effectTotal {
+  private[this] def daemonExit: UIO[Unit] = ZIO.effectTotal {
     val _ = daemonStatus.popOrElse(false)
   }
 
-  private[this] final def propagateAncestorInterruption(): Unit = {
+  private[this] def propagateAncestorInterruption(): Unit = {
     var fiber = self: FiberContext[_, _]
 
     while (fiber ne null) {
@@ -766,17 +766,17 @@ private[zio] final class FiberContext[E, A](
   }
 
   @inline
-  private final def isInterrupted(): Boolean = !state.get.interrupted.isEmpty
+  private def isInterrupted(): Boolean = !state.get.interrupted.isEmpty
 
   @inline
-  private[this] final def isInterruptible(): Boolean = interruptStatus.peekOrElse(true)
+  private[this] def isInterruptible(): Boolean = interruptStatus.peekOrElse(true)
 
   @inline
-  private[this] final def shouldInterrupt(): Boolean =
+  private[this] def shouldInterrupt(): Boolean =
     isInterrupted() && isInterruptible()
 
   @tailrec
-  private[this] final def addInterruptor(cause: Cause[Nothing]): Unit =
+  private[this] def addInterruptor(cause: Cause[Nothing]): Unit =
     if (!cause.isEmpty) {
       val oldState = state.get
 
@@ -793,7 +793,7 @@ private[zio] final class FiberContext[E, A](
     }
 
   @inline
-  private[this] final def nextInstr(value: Any): IO[E, Any] =
+  private[this] def nextInstr(value: Any): IO[E, Any] =
     if (!stack.isEmpty) {
       val k = stack.pop()
 
@@ -807,7 +807,7 @@ private[zio] final class FiberContext[E, A](
     } else done(Exit.succeed(value.asInstanceOf[A]))
 
   @tailrec
-  private[this] final def done(v: Exit[E, A]): IO[E, Any] = {
+  private[this] def done(v: Exit[E, A]): IO[E, Any] = {
     val oldState = state.get
 
     oldState match {
@@ -832,12 +832,12 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def reportUnhandled(v: Exit[E, A]): Unit = v match {
+  private[this] def reportUnhandled(v: Exit[E, A]): Unit = v match {
     case Exit.Failure(cause) => platform.reportFailure(cause)
     case _                   =>
   }
 
-  private[this] final def kill0(fiberId: Fiber.Id): UIO[Exit[E, A]] = {
+  private[this] def kill0(fiberId: Fiber.Id): UIO[Exit[E, A]] = {
     @tailrec
     def setInterruptedLoop(): Unit = {
       val oldState = state.get
@@ -870,7 +870,7 @@ private[zio] final class FiberContext[E, A](
   }
 
   @tailrec
-  private[zio] final def onDone(k: Callback[Nothing, Exit[E, A]]): Unit = {
+  private[zio] def onDone(k: Callback[Nothing, Exit[E, A]]): Unit = {
     val oldState = state.get
 
     oldState match {
@@ -883,7 +883,7 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def observe0(
+  private[this] def observe0(
     k: Callback[Nothing, Exit[E, A]]
   ): Option[IO[Nothing, Exit[E, A]]] =
     register0(k) match {
@@ -892,7 +892,7 @@ private[zio] final class FiberContext[E, A](
     }
 
   @tailrec
-  private final def register0(k: Callback[Nothing, Exit[E, A]]): Exit[E, A] = {
+  private def register0(k: Callback[Nothing, Exit[E, A]]): Exit[E, A] = {
     val oldState = state.get
 
     oldState match {
@@ -906,13 +906,13 @@ private[zio] final class FiberContext[E, A](
     }
   }
 
-  private[this] final def poll0: Option[Exit[E, A]] =
+  private[this] def poll0: Option[Exit[E, A]] =
     state.get match {
       case Done(r) => Some(r)
       case _       => None
     }
 
-  private[this] final def notifyObservers(
+  private[this] def notifyObservers(
     v: Exit[E, A],
     observers: List[Callback[Nothing, Exit[E, A]]]
   ): Unit = {

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -24,11 +24,11 @@ object MutableConcurrentQueue {
    * which is a power of 2 throughout your system. This will allow to
    * use a more performant ring buffer implementation.
    */
-  final def bounded[A](capacity: Int): MutableConcurrentQueue[A] =
+  def bounded[A](capacity: Int): MutableConcurrentQueue[A] =
     if (capacity == 1) new OneElementConcurrentQueue()
     else RingBuffer[A](capacity)
 
-  final def unbounded[A]: MutableConcurrentQueue[A] = new LinkedQueue[A]
+  def unbounded[A]: MutableConcurrentQueue[A] = new LinkedQueue[A]
 }
 
 /**

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -30,9 +30,9 @@ trait Platform { self =>
    */
   def executor: Executor
 
-  def withExecutor(e: Executor): Platform =
+  final def withExecutor(e: Executor): Platform =
     new Platform.Proxy(self) {
-      override def executor: Executor = e
+      override final def executor: Executor = e
     }
 
   /**
@@ -40,12 +40,12 @@ trait Platform { self =>
    */
   def tracing: Tracing
 
-  def withTracing(t: Tracing): Platform =
+  final def withTracing(t: Tracing): Platform =
     new Platform.Proxy(self) {
-      override def tracing: Tracing = t
+      override final def tracing: Tracing = t
     }
 
-  def withTracingConfig(config: TracingConfig): Platform =
+  final def withTracingConfig(config: TracingConfig): Platform =
     new Platform.Proxy(self) {
       override val tracing: Tracing = self.tracing.copy(tracingConfig = config)
     }
@@ -57,9 +57,9 @@ trait Platform { self =>
    */
   def fatal(t: Throwable): Boolean
 
-  def withFatal(f: Throwable => Boolean): Platform =
+  final def withFatal(f: Throwable => Boolean): Platform =
     new Platform.Proxy(self) {
-      override def fatal(t: Throwable): Boolean = f(t)
+      override final def fatal(t: Throwable): Boolean = f(t)
     }
 
   /**
@@ -67,9 +67,9 @@ trait Platform { self =>
    */
   def reportFatal(t: Throwable): Nothing
 
-  def withReportFatal(f: Throwable => Nothing): Platform =
+  final def withReportFatal(f: Throwable => Nothing): Platform =
     new Platform.Proxy(self) {
-      override def reportFatal(t: Throwable): Nothing = f(t)
+      override final def reportFatal(t: Throwable): Nothing = f(t)
     }
 
   /**
@@ -77,9 +77,9 @@ trait Platform { self =>
    */
   def reportFailure(cause: Cause[Any]): Unit
 
-  def withReportFailure(f: Cause[Any] => Unit): Platform =
+  final def withReportFailure(f: Cause[Any] => Unit): Platform =
     new Platform.Proxy(self) {
-      override def reportFailure(cause: Cause[Any]): Unit = f(cause)
+      override final def reportFailure(cause: Cause[Any]): Unit = f(cause)
     }
 }
 object Platform extends PlatformSpecific {

--- a/core/shared/src/main/scala/zio/internal/Scheduler.scala
+++ b/core/shared/src/main/scala/zio/internal/Scheduler.scala
@@ -43,7 +43,7 @@ object Scheduler {
   /**
    * Creates a new `Scheduler` from a Java `ScheduledExecutorService`.
    */
-  final def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler =
+  def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler =
     new Scheduler {
       val ConstFalse = () => false
 

--- a/core/shared/src/main/scala/zio/internal/SingleThreadedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/SingleThreadedRingBuffer.scala
@@ -72,5 +72,5 @@ private[zio] final class SingleThreadedRingBuffer[A <: AnyRef](capacity: Int) {
 }
 
 object SingleThreadedRingBuffer {
-  def apply[A <: AnyRef](capacity: Int): SingleThreadedRingBuffer[A] = new SingleThreadedRingBuffer[A](capacity)
+  final def apply[A <: AnyRef](capacity: Int): SingleThreadedRingBuffer[A] = new SingleThreadedRingBuffer[A](capacity)
 }

--- a/core/shared/src/main/scala/zio/internal/SingleThreadedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/SingleThreadedRingBuffer.scala
@@ -21,18 +21,18 @@ private[zio] final class SingleThreadedRingBuffer[A <: AnyRef](capacity: Int) {
   private[this] var size    = 0
   private[this] var current = 0
 
-  final def put(value: A): Unit = {
+  def put(value: A): Unit = {
     array(current) = value
     increment()
   }
 
-  final def dropLast(): Unit =
+  def dropLast(): Unit =
     if (size > 0) {
       decrement()
       array(current) = null
     }
 
-  final def toReversedList: List[A] = {
+  def toReversedList: List[A] = {
     val begin = current - size
 
     val newArray = if (begin < 0) {
@@ -44,7 +44,7 @@ private[zio] final class SingleThreadedRingBuffer[A <: AnyRef](capacity: Int) {
     arrayToReversedList(newArray).asInstanceOf[List[A]]
   }
 
-  @inline private[this] final def arrayToReversedList(array: Array[AnyRef]): List[AnyRef] = {
+  @inline private[this] def arrayToReversedList(array: Array[AnyRef]): List[AnyRef] = {
     var i                    = 0
     var result: List[AnyRef] = Nil
     while (i < array.length) {
@@ -54,14 +54,14 @@ private[zio] final class SingleThreadedRingBuffer[A <: AnyRef](capacity: Int) {
     result
   }
 
-  @inline private[this] final def increment(): Unit = {
+  @inline private[this] def increment(): Unit = {
     if (size < capacity) {
       size = size + 1
     }
     current = (current + 1) % capacity
   }
 
-  @inline private[this] final def decrement(): Unit = {
+  @inline private[this] def decrement(): Unit = {
     size = size - 1
     if (current > 0) {
       current = current - 1
@@ -72,5 +72,5 @@ private[zio] final class SingleThreadedRingBuffer[A <: AnyRef](capacity: Int) {
 }
 
 object SingleThreadedRingBuffer {
-  final def apply[A <: AnyRef](capacity: Int): SingleThreadedRingBuffer[A] = new SingleThreadedRingBuffer[A](capacity)
+  def apply[A <: AnyRef](capacity: Int): SingleThreadedRingBuffer[A] = new SingleThreadedRingBuffer[A](capacity)
 }

--- a/core/shared/src/main/scala/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/zio/internal/Stack.scala
@@ -27,12 +27,12 @@ private[zio] final class Stack[A <: AnyRef]() {
   /**
    * Determines if the stack is empty.
    */
-  final def isEmpty: Boolean = size == 0
+  def isEmpty: Boolean = size == 0
 
   /**
    * Pushes an item onto the stack.
    */
-  final def push(a: A): Unit =
+  def push(a: A): Unit =
     if (size == 13) {
       array = Array(array, a, null, null, null, null, null, null, null, null, null, null, null)
       size = 2
@@ -45,7 +45,7 @@ private[zio] final class Stack[A <: AnyRef]() {
   /**
    * Pops an item off the stack, or returns `null` if the stack is empty.
    */
-  final def pop(): A = {
+  def pop(): A = {
     val idx = size - 1
     var a   = array(idx)
     if (idx == 0 && nesting > 0) {
@@ -64,19 +64,19 @@ private[zio] final class Stack[A <: AnyRef]() {
   /**
    * Peeks the item on the head of the stack, or returns `null` if empty.
    */
-  final def peek(): A = {
+  def peek(): A = {
     val idx = size - 1
     var a   = array(idx)
     if (idx == 0 && nesting > 0) a = (a.asInstanceOf[Array[AnyRef]])(12)
     a.asInstanceOf[A]
   }
 
-  final def peekOrElse(a: A): A = if (size <= 0) a else peek()
+  def peekOrElse(a: A): A = if (size <= 0) a else peek()
 }
 
 private[zio] object Stack {
-  final def apply[A <: AnyRef](): Stack[A] = new Stack[A]
-  final def apply[A <: AnyRef](a: A): Stack[A] = {
+  def apply[A <: AnyRef](): Stack[A] = new Stack[A]
+  def apply[A <: AnyRef](a: A): Stack[A] = {
     val stack = new Stack[A]
 
     stack.push(a)

--- a/core/shared/src/main/scala/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/zio/internal/Stack.scala
@@ -75,8 +75,8 @@ private[zio] final class Stack[A <: AnyRef]() {
 }
 
 private[zio] object Stack {
-  def apply[A <: AnyRef](): Stack[A] = new Stack[A]
-  def apply[A <: AnyRef](a: A): Stack[A] = {
+  final def apply[A <: AnyRef](): Stack[A] = new Stack[A]
+  final def apply[A <: AnyRef](a: A): Stack[A] = {
     val stack = new Stack[A]
 
     stack.push(a)

--- a/core/shared/src/main/scala/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/zio/internal/StackBool.scala
@@ -26,7 +26,7 @@ private[zio] final class StackBool private () {
   private[this] var head  = new Entry(null)
   private[this] var _size = 0L
 
-  final def getOrElse(index: Int, b: Boolean): Boolean = {
+  def getOrElse(index: Int, b: Boolean): Boolean = {
     val i0   = _size & 63L
     val base = (64L - i0) + index
     val i    = base & 63L
@@ -44,9 +44,9 @@ private[zio] final class StackBool private () {
     }
   }
 
-  final def size: Long = _size
+  def size: Long = _size
 
-  final def push(flag: Boolean): Unit = {
+  def push(flag: Boolean): Unit = {
     val index = _size & 0X3FL
 
     if (flag) head.bits = head.bits | (1L << index)
@@ -57,7 +57,7 @@ private[zio] final class StackBool private () {
     _size += 1L
   }
 
-  final def popOrElse(b: Boolean): Boolean =
+  def popOrElse(b: Boolean): Boolean =
     if (_size == 0L) b
     else {
       _size -= 1L
@@ -68,7 +68,7 @@ private[zio] final class StackBool private () {
       ((1L << index) & head.bits) != 0L
     }
 
-  final def peekOrElse(b: Boolean): Boolean =
+  def peekOrElse(b: Boolean): Boolean =
     if (_size == 0L) b
     else {
       val size  = _size - 1L
@@ -79,9 +79,9 @@ private[zio] final class StackBool private () {
       ((1L << index) & entry.bits) != 0L
     }
 
-  final def popDrop[A](a: A): A = { popOrElse(false); a }
+  def popDrop[A](a: A): A = { popOrElse(false); a }
 
-  final def toList: List[Boolean] =
+  def toList: List[Boolean] =
     (0 until _size.toInt).map(getOrElse(_, false)).toList
 
   final override def toString: String =
@@ -94,9 +94,9 @@ private[zio] final class StackBool private () {
   final override def hashCode = toList.hashCode
 }
 private[zio] object StackBool {
-  final def apply(): StackBool = new StackBool
+  def apply(): StackBool = new StackBool
 
-  final def apply(bool: Boolean): StackBool = {
+  def apply(bool: Boolean): StackBool = {
     val stack = StackBool()
 
     stack.push(bool)
@@ -104,7 +104,7 @@ private[zio] object StackBool {
     stack
   }
 
-  final def fromIterable(it: Iterable[Boolean]): StackBool = {
+  def fromIterable(it: Iterable[Boolean]): StackBool = {
     val stack = StackBool()
     it.foldRight(stack) { (b, stack) =>
       stack.push(b)

--- a/core/shared/src/main/scala/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/zio/internal/StackBool.scala
@@ -94,9 +94,9 @@ private[zio] final class StackBool private () {
   final override def hashCode = toList.hashCode
 }
 private[zio] object StackBool {
-  def apply(): StackBool = new StackBool
+  final def apply(): StackBool = new StackBool
 
-  def apply(bool: Boolean): StackBool = {
+  final def apply(bool: Boolean): StackBool = {
     val stack = StackBool()
 
     stack.push(bool)
@@ -104,7 +104,7 @@ private[zio] object StackBool {
     stack
   }
 
-  def fromIterable(it: Iterable[Boolean]): StackBool = {
+  final def fromIterable(it: Iterable[Boolean]): StackBool = {
     val stack = StackBool()
     it.foldRight(stack) { (b, stack) =>
       stack.push(b)

--- a/core/shared/src/main/scala/zio/internal/UniqueKey.scala
+++ b/core/shared/src/main/scala/zio/internal/UniqueKey.scala
@@ -7,5 +7,5 @@ package zio.internal
 final class UniqueKey
 
 object UniqueKey {
-  def apply(): UniqueKey = new UniqueKey()
+  final def apply(): UniqueKey = new UniqueKey()
 }

--- a/core/shared/src/main/scala/zio/internal/UniqueKey.scala
+++ b/core/shared/src/main/scala/zio/internal/UniqueKey.scala
@@ -7,5 +7,5 @@ package zio.internal
 final class UniqueKey
 
 object UniqueKey {
-  final def apply(): UniqueKey = new UniqueKey()
+  def apply(): UniqueKey = new UniqueKey()
 }

--- a/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
+++ b/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
@@ -53,10 +53,10 @@ final case class TracingConfig(
   ancestryLength: Int,
   ancestorExecutionTraceLength: Int,
   ancestorStackTraceLength: Int
-)
+) extends Serializable
 
 object TracingConfig {
-  final def enabled   = TracingConfig(true, true, true, 100, 100, 10, 10, 10)
-  final def stackOnly = TracingConfig(false, false, true, 100, 100, 10, 10, 10)
-  final def disabled  = TracingConfig(false, false, false, 0, 0, 0, 0, 10)
+  def enabled   = TracingConfig(true, true, true, 100, 100, 10, 10, 10)
+  def stackOnly = TracingConfig(false, false, true, 100, 100, 10, 10, 10)
+  def disabled  = TracingConfig(false, false, false, 0, 0, 0, 0, 10)
 }

--- a/core/shared/src/main/scala/zio/internal/tracing/ZIOFn.scala
+++ b/core/shared/src/main/scala/zio/internal/tracing/ZIOFn.scala
@@ -41,22 +41,22 @@ private[zio] abstract class ZIOFn2[-A, -B, +C] extends ZIOFn with Function2[A, B
 }
 
 private[zio] object ZIOFn {
-  final def apply[A, B](traceAs: AnyRef)(real: A => B): ZIOFn1[A, B] = new ZIOFn1[A, B] {
+  def apply[A, B](traceAs: AnyRef)(real: A => B): ZIOFn1[A, B] = new ZIOFn1[A, B] {
     final val underlying: AnyRef = traceAs
-    final def apply(a: A): B     = real(a)
+    def apply(a: A): B           = real(a)
   }
 
   /**
    * Adds the specified lambda to the execution trace before `zio` is evaluated
    */
   @noinline
-  final def recordTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+  def recordTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     ZIO.unit.flatMap(ZIOFn(lambda)(_ => zio))
 
   /**
    * Adds the specified lambda to the stack trace during the evaluation of `zio`
    * */
   @noinline
-  final def recordStackTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+  def recordStackTrace[R, E, A](lambda: AnyRef)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     zio.map(ZIOFn(lambda)(ZIO.identityFn))
 }

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -78,52 +78,52 @@ final class STM[+E, +A] private[stm] (
   /**
    * Sequentially zips this value with the specified one.
    */
-  final def <*>[E1 >: E, B](that: => STM[E1, B]): STM[E1, (A, B)] =
+  def <*>[E1 >: E, B](that: => STM[E1, B]): STM[E1, (A, B)] =
     self zip that
 
   /**
    * Sequentially zips this value with the specified one, discarding the
    * second element of the tuple.
    */
-  final def <*[E1 >: E, B](that: => STM[E1, B]): STM[E1, A] =
+  def <*[E1 >: E, B](that: => STM[E1, B]): STM[E1, A] =
     self zipLeft that
 
   /**
    * Sequentially zips this value with the specified one, discarding the
    * first element of the tuple.
    */
-  final def *>[E1 >: E, B](that: => STM[E1, B]): STM[E1, B] =
+  def *>[E1 >: E, B](that: => STM[E1, B]): STM[E1, B] =
     self zipRight that
 
   /**
    * Feeds the value produced by this effect to the specified function,
    * and then runs the returned effect as well to produce its results.
    */
-  final def >>=[E1 >: E, B](f: A => STM[E1, B]): STM[E1, B] =
+  def >>=[E1 >: E, B](f: A => STM[E1, B]): STM[E1, B] =
     self flatMap f
 
   /**
    * Maps the success value of this effect to the specified constant value.
    */
-  final def as[B](b: => B): STM[E, B] = self map (_ => b)
+  def as[B](b: => B): STM[E, B] = self map (_ => b)
 
   /**
    * Maps the error value of this effect to the specified constant value.
    */
-  final def asError[E1](e: => E1)(implicit ev: CanFail[E]): STM[E1, A] =
+  def asError[E1](e: => E1)(implicit ev: CanFail[E]): STM[E1, A] =
     self mapError (_ => e)
 
   /**
    * Simultaneously filters and maps the value produced by this effect.
    */
-  final def collect[B](pf: PartialFunction[A, B]): STM[E, B] =
+  def collect[B](pf: PartialFunction[A, B]): STM[E, B] =
     collectM(pf.andThen(STM.succeed(_)))
 
   /**
    * Simultaneously filters and flatMaps the value produced by this effect.
    * Continues on the effect returned from pf.
    */
-  final def collectM[E1 >: E, B](pf: PartialFunction[A, STM[E1, B]]): STM[E1, B] =
+  def collectM[E1 >: E, B](pf: PartialFunction[A, STM[E1, B]]): STM[E1, B] =
     self.continueWithM {
       case TExit.Fail(e)    => STM.fail(e)
       case TExit.Succeed(a) => if (pf.isDefinedAt(a)) pf(a) else STM.retry
@@ -133,12 +133,12 @@ final class STM[+E, +A] private[stm] (
   /**
    * Commits this transaction atomically.
    */
-  final def commit: IO[E, A] = STM.atomically(self)
+  def commit: IO[E, A] = STM.atomically(self)
 
   /**
    * Converts the failure channel into an `Either`.
    */
-  final def either(implicit ev: CanFail[E]): STM[Nothing, Either[E, A]] =
+  def either(implicit ev: CanFail[E]): STM[Nothing, Either[E, A]] =
     fold(Left(_), Right(_))
 
   /**
@@ -146,21 +146,21 @@ final class STM[+E, +A] private[stm] (
    * not this effect succeeds. Note that as with all STM transactions,
    * if the full transaction fails, everything will be rolled back.
    */
-  final def ensuring(finalizer: STM[Nothing, Any]): STM[E, A] =
+  def ensuring(finalizer: STM[Nothing, Any]): STM[E, A] =
     foldM(e => finalizer *> STM.fail(e), a => finalizer *> STM.succeed(a))
 
   /**
    * Tries this effect first, and if it fails, succeeds with the specified
    * value.
    */
-  final def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): STM[Nothing, A1] =
+  def fallback[A1 >: A](a: => A1)(implicit ev: CanFail[E]): STM[Nothing, A1] =
     fold(_ => a, identity)
 
   /**
    * Filters the value produced by this effect, retrying the transaction until
    * the predicate returns true for the value.
    */
-  final def filter(f: A => Boolean): STM[E, A] =
+  def filter(f: A => Boolean): STM[E, A] =
     collect {
       case a if f(a) => a
     }
@@ -169,7 +169,7 @@ final class STM[+E, +A] private[stm] (
    * Feeds the value produced by this effect to the specified function,
    * and then runs the returned effect as well to produce its results.
    */
-  final def flatMap[E1 >: E, B](f: A => STM[E1, B]): STM[E1, B] =
+  def flatMap[E1 >: E, B](f: A => STM[E1, B]): STM[E1, B] =
     self.continueWithM {
       case TExit.Succeed(a) => f(a)
       case TExit.Fail(e)    => STM.fail(e)
@@ -179,14 +179,14 @@ final class STM[+E, +A] private[stm] (
   /**
    * Flattens out a nested `STM` effect.
    */
-  final def flatten[E1 >: E, B](implicit ev: A <:< STM[E1, B]): STM[E1, B] =
+  def flatten[E1 >: E, B](implicit ev: A <:< STM[E1, B]): STM[E1, B] =
     self flatMap ev
 
   /**
    * Folds over the `STM` effect, handling both failure and success, but not
    * retry.
    */
-  final def fold[B](f: E => B, g: A => B)(implicit ev: CanFail[E]): STM[Nothing, B] =
+  def fold[B](f: E => B, g: A => B)(implicit ev: CanFail[E]): STM[Nothing, B] =
     self.continueWithM {
       case TExit.Fail(e)    => STM.succeed(f(e))
       case TExit.Succeed(a) => STM.succeed(g(a))
@@ -197,7 +197,7 @@ final class STM[+E, +A] private[stm] (
    * Effectfully folds over the `STM` effect, handling both failure and
    * success.
    */
-  final def foldM[E1, B](f: E => STM[E1, B], g: A => STM[E1, B])(implicit ev: CanFail[E]): STM[E1, B] =
+  def foldM[E1, B](f: E => STM[E1, B], g: A => STM[E1, B])(implicit ev: CanFail[E]): STM[E1, B] =
     self.continueWithM {
       case TExit.Fail(e)    => f(e)
       case TExit.Succeed(a) => g(a)
@@ -207,12 +207,12 @@ final class STM[+E, +A] private[stm] (
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  final def ignore: STM[Nothing, Unit] = self.either.unit
+  def ignore: STM[Nothing, Unit] = self.either.unit
 
   /**
    * Maps the value produced by the effect.
    */
-  final def map[B](f: A => B): STM[E, B] =
+  def map[B](f: A => B): STM[E, B] =
     self.continueWithM {
       case TExit.Succeed(a) => STM.succeed(f(a))
       case TExit.Fail(e)    => STM.fail(e)
@@ -222,7 +222,7 @@ final class STM[+E, +A] private[stm] (
   /**
    * Maps from one error type to another.
    */
-  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): STM[E1, A] =
+  def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): STM[E1, A] =
     self.continueWithM {
       case TExit.Succeed(a) => STM.succeed(a)
       case TExit.Fail(e)    => STM.fail(f(e))
@@ -232,13 +232,13 @@ final class STM[+E, +A] private[stm] (
   /**
    * Converts the failure channel into an `Option`.
    */
-  final def option(implicit ev: CanFail[E]): STM[Nothing, Option[A]] =
+  def option(implicit ev: CanFail[E]): STM[Nothing, Option[A]] =
     fold(_ => None, Some(_))
 
   /**
    * Tries this effect first, and if it fails, tries the other effect.
    */
-  final def orElse[E1, A1 >: A](that: => STM[E1, A1])(implicit ev: CanFail[E]): STM[E1, A1] =
+  def orElse[E1, A1 >: A](that: => STM[E1, A1])(implicit ev: CanFail[E]): STM[E1, A1] =
     new STM(
       (journal, fiberId, stackSize) => {
         val reset = prepareResetJournal(journal)
@@ -272,42 +272,42 @@ final class STM[+E, +A] private[stm] (
    * Returns a transactional effect that will produce the value of this effect in left side, unless it
    * fails, in which case, it will produce the value of the specified effect in right side.
    */
-  final def orElseEither[E1 >: E, B](that: => STM[E1, B])(implicit ev: CanFail[E]): STM[E1, Either[A, B]] =
+  def orElseEither[E1 >: E, B](that: => STM[E1, B])(implicit ev: CanFail[E]): STM[E1, Either[A, B]] =
     (self map (Left[A, B](_))) orElse (that map (Right[A, B](_)))
 
   /**
    * Maps the success value of this effect to unit.
    */
-  final def unit: STM[E, Unit] = as(())
+  def unit: STM[E, Unit] = as(())
 
   /**
    * Same as [[filter]]
    */
-  final def withFilter(f: A => Boolean): STM[E, A] = filter(f)
+  def withFilter(f: A => Boolean): STM[E, A] = filter(f)
 
   /**
    * Named alias for `<*>`.
    */
-  final def zip[E1 >: E, B](that: => STM[E1, B]): STM[E1, (A, B)] =
+  def zip[E1 >: E, B](that: => STM[E1, B]): STM[E1, (A, B)] =
     (self zipWith that)((a, b) => a -> b)
 
   /**
    * Named alias for `<*`.
    */
-  final def zipLeft[E1 >: E, B](that: => STM[E1, B]): STM[E1, A] =
+  def zipLeft[E1 >: E, B](that: => STM[E1, B]): STM[E1, A] =
     (self zip that) map (_._1)
 
   /**
    * Named alias for `*>`.
    */
-  final def zipRight[E1 >: E, B](that: => STM[E1, B]): STM[E1, B] =
+  def zipRight[E1 >: E, B](that: => STM[E1, B]): STM[E1, B] =
     (self zip that) map (_._2)
 
   /**
    * Sequentially zips this value with the specified one, combining the values
    * using the specified combiner function.
    */
-  final def zipWith[E1 >: E, B, C](that: => STM[E1, B])(f: (A, B) => C): STM[E1, C] =
+  def zipWith[E1 >: E, B, C](that: => STM[E1, B])(f: (A, B) => C): STM[E1, C] =
     self flatMap (a => that map (b => f(a, b)))
 
   private def continueWithM[E1, B](continueM: TExit[E, A] => STM[E1, B]): STM[E1, B] =
@@ -366,7 +366,7 @@ final class STM[+E, +A] private[stm] (
 
 object STM {
 
-  private final class Resumable[E, E1, A, B](val stm: STM[E, A], val ks: Stack[internal.TExit[E, A] => STM[E1, B]])
+  private class Resumable[E, E1, A, B](val stm: STM[E, A], val ks: Stack[internal.TExit[E, A] => STM[E1, B]])
       extends Throwable(null, null, false, false)
 
   private final val MaxFrames = 200
@@ -374,7 +374,7 @@ object STM {
   private[stm] object internal {
     final val DefaultJournalSize = 4
 
-    class Versioned[A](val value: A)
+    final class Versioned[A](val value: A)
 
     type TxnId = Long
 
@@ -386,7 +386,7 @@ object STM {
     /**
      * Creates a function that can reset the journal.
      */
-    final def prepareResetJournal(journal: Journal): () => Unit = {
+    def prepareResetJournal(journal: Journal): () => Unit = {
       val saved = new MutableMap[TRef[_], Entry](journal.size)
 
       val it = journal.entrySet.iterator
@@ -401,7 +401,7 @@ object STM {
     /**
      * Commits the journal.
      */
-    final def commitJournal(journal: Journal): Unit = {
+    def commitJournal(journal: Journal): Unit = {
       val it = journal.entrySet.iterator
       while (it.hasNext) it.next.getValue.commit()
     }
@@ -409,7 +409,7 @@ object STM {
     /**
      * Allocates memory for the journal, if it is null, otherwise just clears it.
      */
-    final def allocJournal(journal: Journal): Journal =
+    def allocJournal(journal: Journal): Journal =
       if (journal eq null) new MutableMap[TRef[_], Entry](DefaultJournalSize)
       else {
         journal.clear()
@@ -419,7 +419,7 @@ object STM {
     /**
      * Determines if the journal is valid.
      */
-    final def isValid(journal: Journal): Boolean = {
+    def isValid(journal: Journal): Boolean = {
       var valid = true
       val it    = journal.entrySet.iterator
       while (valid && it.hasNext) valid = it.next.getValue.isValid
@@ -432,7 +432,7 @@ object STM {
      * journal is read only will only be accurate if the journal is valid, due
      * to short-circuiting that occurs on an invalid journal.
      */
-    final def analyzeJournal(journal: Journal): JournalAnalysis = {
+    def analyzeJournal(journal: Journal): JournalAnalysis = {
       var result = JournalAnalysis.ReadOnly: JournalAnalysis
       val it     = journal.entrySet.iterator
       while ((result ne JournalAnalysis.Invalid) && it.hasNext) {
@@ -453,13 +453,13 @@ object STM {
     /**
      * Determines if the journal is invalid.
      */
-    final def isInvalid(journal: Journal): Boolean = !isValid(journal)
+    def isInvalid(journal: Journal): Boolean = !isValid(journal)
 
     /**
      * Atomically collects and clears all the todos from any `TRef` that
      * participated in the transaction.
      */
-    final def collectTodos(journal: Journal): MutableMap[TxnId, Todo] = {
+    def collectTodos(journal: Journal): MutableMap[TxnId, Todo] = {
       import collection.JavaConverters._
 
       val allTodos  = new MutableMap[TxnId, Todo](DefaultJournalSize)
@@ -486,7 +486,7 @@ object STM {
     /**
      * Executes the todos in the current thread, sequentially.
      */
-    final def execTodos(todos: MutableMap[TxnId, Todo]): Unit = {
+    def execTodos(todos: MutableMap[TxnId, Todo]): Unit = {
       val it = todos.entrySet.iterator
       while (it.hasNext) it.next.getValue.apply()
     }
@@ -495,7 +495,7 @@ object STM {
      * For the given transaction id, adds the specified todo effect to all
      * `TRef` values.
      */
-    final def addTodo(txnId: TxnId, journal: Journal, todoEffect: Todo): Boolean = {
+    def addTodo(txnId: TxnId, journal: Journal, todoEffect: Todo): Boolean = {
       var added = false
 
       val it = journal.entrySet.iterator
@@ -522,7 +522,7 @@ object STM {
     /**
      * Runs all the todos.
      */
-    final def completeTodos[E, A](io: IO[E, A], journal: Journal, platform: Platform): TryCommit[E, A] = {
+    def completeTodos[E, A](io: IO[E, A], journal: Journal, platform: Platform): TryCommit[E, A] = {
       val todos = collectTodos(journal)
 
       if (todos.size > 0) platform.executor.submitOrThrow(() => execTodos(todos))
@@ -533,7 +533,7 @@ object STM {
     /**
      * Finds all the new todo targets that are not already tracked in the `oldJournal`.
      */
-    final def untrackedTodoTargets(oldJournal: Journal, newJournal: Journal): Journal = {
+    def untrackedTodoTargets(oldJournal: Journal, newJournal: Journal): Journal = {
       val untracked = new MutableMap[TRef[_], Entry](newJournal.size)
 
       untracked.putAll(newJournal)
@@ -558,7 +558,7 @@ object STM {
       untracked
     }
 
-    final def tryCommitAsync[E, A](
+    def tryCommitAsync[E, A](
       journal: Journal,
       platform: Platform,
       fiberId: Fiber.Id,
@@ -599,7 +599,7 @@ object STM {
       }
     }
 
-    final def tryCommit[E, A](platform: Platform, fiberId: Fiber.Id, stm: STM[E, A]): TryCommit[E, A] = {
+    def tryCommit[E, A](platform: Platform, fiberId: Fiber.Id, stm: STM[E, A]): TryCommit[E, A] = {
       var journal = null.asInstanceOf[MutableMap[TRef[_], Entry]]
       var value   = null.asInstanceOf[TExit[E, A]]
 
@@ -638,7 +638,7 @@ object STM {
       }
     }
 
-    final def makeTxnId(): Long = txnCounter.incrementAndGet()
+    def makeTxnId(): Long = txnCounter.incrementAndGet()
 
     private[this] val txnCounter: AtomicLong = new AtomicLong()
 
@@ -663,22 +663,22 @@ object STM {
 
       private[this] var _isChanged = false
 
-      final def unsafeSet(value: Any): Unit = {
+      def unsafeSet(value: Any): Unit = {
         _isChanged = true
         newValue = value.asInstanceOf[A]
       }
 
-      final def unsafeGet[B]: B = newValue.asInstanceOf[B]
+      def unsafeGet[B]: B = newValue.asInstanceOf[B]
 
       /**
        * Commits the new value to the `TRef`.
        */
-      final def commit(): Unit = tref.versioned = new Versioned(newValue)
+      def commit(): Unit = tref.versioned = new Versioned(newValue)
 
       /**
        * Creates a copy of the Entry.
        */
-      final def copy(): Entry = new Entry {
+      def copy(): Entry = new Entry {
         type A = self.A
         val tref     = self.tref
         val expected = self.expected
@@ -691,18 +691,18 @@ object STM {
        * Determines if the entry is invalid. This is the negated version of
        * `isValid`.
        */
-      final def isInvalid: Boolean = !isValid
+      def isInvalid: Boolean = !isValid
 
       /**
        * Determines if the entry is valid. That is, if the version of the
        * `TRef` is equal to the expected version.
        */
-      final def isValid: Boolean = tref.versioned eq expected
+      def isValid: Boolean = tref.versioned eq expected
 
       /**
        * Determines if the variable has been set in a transaction.
        */
-      final def isChanged: Boolean = _isChanged
+      def isChanged: Boolean = _isChanged
 
       override def toString: String =
         s"Entry(expected.value = ${expected.value}, newValue = $newValue, tref = $tref, isChanged = $isChanged)"
@@ -714,7 +714,7 @@ object STM {
        * Creates an entry for the journal, given the `TRef` being untracked, the
        * new value of the `TRef`, and the expected version of the `TRef`.
        */
-      final def apply[A0](tref0: TRef[A0], isNew0: Boolean): Entry = {
+      def apply[A0](tref0: TRef[A0], isNew0: Boolean): Entry = {
         val versioned = tref0.versioned
 
         new Entry {
@@ -727,7 +727,7 @@ object STM {
       }
     }
 
-    sealed abstract class TryCommit[+E, +A]
+    sealed abstract class TryCommit[+E, +A] extends Serializable with Product
     object TryCommit {
       final case class Done[+E, +A](io: IO[E, A]) extends TryCommit[E, A]
       final case class Suspend(journal: Journal)  extends TryCommit[Nothing, Nothing]
@@ -739,7 +739,7 @@ object STM {
   /**
    * Atomically performs a batch of operations in a single transaction.
    */
-  final def atomically[E, A](stm: STM[E, A]): IO[E, A] =
+  def atomically[E, A](stm: STM[E, A]): IO[E, A] =
     IO.effectSuspendTotalWith { (platform, fiberId) =>
       tryCommit(platform, fiberId, stm) match {
         case TryCommit.Done(io) => io // TODO: Interruptible in Suspend
@@ -756,13 +756,13 @@ object STM {
   /**
    * Checks the condition, and if it's true, returns unit, otherwise, retries.
    */
-  final def check(p: Boolean): STM[Nothing, Unit] = if (p) STM.unit else retry
+  def check(p: Boolean): STM[Nothing, Unit] = if (p) STM.unit else retry
 
   /**
    * Collects all the transactional effects in a list, returning a single
    * transactional effect that produces a list of values.
    */
-  final def collectAll[E, A](i: Iterable[STM[E, A]]): STM[E, List[A]] =
+  def collectAll[E, A](i: Iterable[STM[E, A]]): STM[E, List[A]] =
     i.foldRight[STM[E, List[A]]](STM.succeed(Nil)) {
       case (stm, acc) =>
         acc.zipWith(stm)((xs, x) => x :: xs)
@@ -771,18 +771,18 @@ object STM {
   /**
    * Kills the fiber running the effect.
    */
-  final def die(t: Throwable): STM[Nothing, Nothing] = succeed(throw t)
+  def die(t: Throwable): STM[Nothing, Nothing] = succeed(throw t)
 
   /**
    * Kills the fiber running the effect with a `RuntimeException` that contains
    * the specified message.
    */
-  final def dieMessage(m: String): STM[Nothing, Nothing] = die(new RuntimeException(m))
+  def dieMessage(m: String): STM[Nothing, Nothing] = die(new RuntimeException(m))
 
   /**
    * Returns a value modelled on provided exit status.
    */
-  final def done[E, A](exit: TExit[E, A]): STM[E, A] =
+  def done[E, A](exit: TExit[E, A]): STM[E, A] =
     exit match {
       case TExit.Retry      => STM.retry
       case TExit.Fail(e)    => STM.fail(e)
@@ -792,7 +792,7 @@ object STM {
   /**
    * Returns a value that models failure in the transaction.
    */
-  final def fail[E](e: E): STM[E, Nothing] = new STM((_, _, _) => TExit.Fail(e))
+  def fail[E](e: E): STM[E, Nothing] = new STM((_, _, _) => TExit.Fail(e))
 
   /**
    * Returns the fiber id of the fiber committing the transaction.
@@ -803,13 +803,13 @@ object STM {
    * Applies the function `f` to each element of the `Iterable[A]` and
    * returns a transactional effect that produces a new `List[B]`.
    */
-  final def foreach[E, A, B](as: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
+  def foreach[E, A, B](as: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
     collectAll(as.map(f))
 
   /**
    * Creates an STM effect from an `Either` value.
    */
-  final def fromEither[E, A](e: => Either[E, A]): STM[E, A] =
+  def fromEither[E, A](e: => Either[E, A]): STM[E, A] =
     STM.suspend {
       e match {
         case Left(t)  => STM.fail(t)
@@ -820,7 +820,7 @@ object STM {
   /**
    * Creates an STM effect from a `Try` value.
    */
-  final def fromTry[A](a: => Try[A]): STM[Throwable, A] =
+  def fromTry[A](a: => Try[A]): STM[Throwable, A] =
     STM.suspend {
       Try(a).flatten match {
         case Failure(t) => STM.fail(t)
@@ -831,7 +831,7 @@ object STM {
   /**
    * Creates an `STM` value from a partial (but pure) function.
    */
-  final def partial[A](a: => A): STM[Throwable, A] = fromTry(Try(a))
+  def partial[A](a: => A): STM[Throwable, A] = fromTry(Try(a))
 
   /**
    * Abort and retry the whole transaction when any of the underlying
@@ -842,12 +842,12 @@ object STM {
   /**
    * Returns an `STM` effect that succeeds with the specified value.
    */
-  final def succeed[A](a: A): STM[Nothing, A] = new STM((_, _, _) => TExit.Succeed(a))
+  def succeed[A](a: A): STM[Nothing, A] = new STM((_, _, _) => TExit.Succeed(a))
 
   /**
    * Suspends creation of the specified transaction lazily.
    */
-  final def suspend[E, A](stm: => STM[E, A]): STM[E, A] =
+  def suspend[E, A](stm: => STM[E, A]): STM[E, A] =
     STM.succeed(stm).flatten
 
   /**

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -24,21 +24,21 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Extracts value from ref in array.
    */
-  final def apply(index: Int): STM[Nothing, A] =
+  def apply(index: Int): STM[Nothing, A] =
     if (0 <= index && index < array.length) array(index).get
     else STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Finds the result of applying a partial function to the first value in its domain.
    */
-  final def collectFirst[B](pf: PartialFunction[A, B]): STM[Nothing, Option[B]] =
+  def collectFirst[B](pf: PartialFunction[A, B]): STM[Nothing, Option[B]] =
     find(pf.isDefinedAt).map(_.map(pf))
 
   /**
    * Finds the result of applying an transactional partial function to the
    * first value in its domain.
    */
-  final def collectFirstM[E, B](pf: PartialFunction[A, STM[E, B]]): STM[E, Option[B]] =
+  def collectFirstM[E, B](pf: PartialFunction[A, STM[E, B]]): STM[E, Option[B]] =
     find(pf.isDefinedAt).flatMap {
       case Some(a) => pf(a).map(Some(_))
       case _       => STM.succeed(None)
@@ -47,35 +47,35 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Determine if the array contains a specified value.
    */
-  final def contains(a: A): STM[Nothing, Boolean] = exists(_ == a)
+  def contains(a: A): STM[Nothing, Boolean] = exists(_ == a)
 
   /**
    * Count the values in the array matching a predicate.
    */
-  final def count(p: A => Boolean): STM[Nothing, Int] =
+  def count(p: A => Boolean): STM[Nothing, Int] =
     fold(0)((n, a) => if (p(a)) n + 1 else n)
 
   /**
    * Count the values in the array matching a transactional predicate.
    */
-  final def countM[E](p: A => STM[E, Boolean]): STM[E, Int] =
+  def countM[E](p: A => STM[E, Boolean]): STM[E, Int] =
     foldM(0)((n, a) => p(a).map(result => if (result) n + 1 else n))
 
   /**
    * Determine if the array contains a value satisfying a predicate.
    */
-  final def exists(p: A => Boolean): STM[Nothing, Boolean] = find(p).map(_.isDefined)
+  def exists(p: A => Boolean): STM[Nothing, Boolean] = find(p).map(_.isDefined)
 
   /**
    * Determine if the array contains a value satisfying a transactional predicate.
    */
-  final def existsM[E](p: A => STM[E, Boolean]): STM[E, Boolean] =
+  def existsM[E](p: A => STM[E, Boolean]): STM[E, Boolean] =
     countM(p).map(_ > 0)
 
   /**
    * Find the first element in the array matching a predicate.
    */
-  final def find(p: A => Boolean): STM[Nothing, Option[A]] =
+  def find(p: A => Boolean): STM[Nothing, Option[A]] =
     if (array.isEmpty) STM.succeed(None)
     else
       array.head.get.flatMap { a =>
@@ -86,19 +86,19 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Find the last element in the array matching a predicate.
    */
-  final def findLast(p: A => Boolean): STM[Nothing, Option[A]] =
+  def findLast(p: A => Boolean): STM[Nothing, Option[A]] =
     new TArray(array.reverse).find(p)
 
   /**
    * Find the last element in the array matching a transactional predicate.
    */
-  final def findLastM[E](p: A => STM[E, Boolean]): STM[E, Option[A]] =
+  def findLastM[E](p: A => STM[E, Boolean]): STM[E, Option[A]] =
     new TArray(array.reverse).findM(p)
 
   /**
    * Find the first element in the array matching a transactional predicate.
    */
-  final def findM[E](p: A => STM[E, Boolean]): STM[E, Option[A]] =
+  def findM[E](p: A => STM[E, Boolean]): STM[E, Option[A]] =
     if (array.isEmpty) STM.succeed(None)
     else
       array.head.get.flatMap { a =>
@@ -111,20 +111,20 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * The first entry of the array, if it exists.
    */
-  final def firstOption: STM[Nothing, Option[A]] =
+  def firstOption: STM[Nothing, Option[A]] =
     if (array.isEmpty) STM.succeed(None) else array.head.get.map(Some(_))
 
   /**
    * Atomically folds using a pure function.
    */
-  final def fold[Z](acc: Z)(op: (Z, A) => Z): STM[Nothing, Z] =
+  def fold[Z](acc: Z)(op: (Z, A) => Z): STM[Nothing, Z] =
     if (array.isEmpty) STM.succeed(acc)
     else array.head.get.flatMap(a => new TArray(array.tail).fold(op(acc, a))(op))
 
   /**
    * Atomically folds using a transactional function.
    */
-  final def foldM[E, Z](acc: Z)(op: (Z, A) => STM[E, Z]): STM[E, Z] =
+  def foldM[E, Z](acc: Z)(op: (Z, A) => STM[E, Z]): STM[E, Z] =
     if (array.isEmpty) STM.succeed(acc)
     else
       array.head.get.flatMap { a =>
@@ -135,43 +135,43 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
    * Atomically evaluate the conjunction of a predicate across the members
    * of the array.
    */
-  final def forall(p: A => Boolean): STM[Nothing, Boolean] = exists(a => !p(a)).map(!_)
+  def forall(p: A => Boolean): STM[Nothing, Boolean] = exists(a => !p(a)).map(!_)
 
   /**
    * Atomically evaluate the conjunction of a transactional predicate across
    * the members of the array.
    */
-  final def forallM[E](p: A => STM[E, Boolean]): STM[E, Boolean] =
+  def forallM[E](p: A => STM[E, Boolean]): STM[E, Boolean] =
     countM(p).map(_ == array.length)
 
   /**
    * Atomically performs transactional effect for each item in array.
    */
-  final def foreach[E](f: A => STM[E, Unit]): STM[E, Unit] =
+  def foreach[E](f: A => STM[E, Unit]): STM[E, Unit] =
     foldM(())((_, a) => f(a))
 
   /**
    * Get the first index of a specific value in the array or -1 if it does
    * not occur.
    */
-  final def indexOf(a: A): STM[Nothing, Int] = indexOf(a, 0)
+  def indexOf(a: A): STM[Nothing, Int] = indexOf(a, 0)
 
   /**
    * Get the first index of a specific value in the array, starting at a specific
    * index, or -1 if it does not occur.
    */
-  final def indexOf(a: A, from: Int): STM[Nothing, Int] = indexWhere(_ == a, from)
+  def indexOf(a: A, from: Int): STM[Nothing, Int] = indexWhere(_ == a, from)
 
   /**
    * Get the index of the first entry in the array matching a predicate.
    */
-  final def indexWhere(p: A => Boolean): STM[Nothing, Int] = indexWhere(p, 0)
+  def indexWhere(p: A => Boolean): STM[Nothing, Int] = indexWhere(p, 0)
 
   /**
    * Get the index of the first entry in the array, starting at a specific index,
    * matching a predicate.
    */
-  final def indexWhere(p: A => Boolean, from: Int): STM[Nothing, Int] = {
+  def indexWhere(p: A => Boolean, from: Int): STM[Nothing, Int] = {
     val len = array.length
     def forIndex(i: Int): STM[Nothing, Int] =
       if (i >= len) STM.succeed(-1)
@@ -184,13 +184,13 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
    * Get the index of the first entry in the array matching a transactional
    * predicate.
    */
-  final def indexWhereM[E](p: A => STM[E, Boolean]): STM[E, Int] = indexWhereM(p, 0)
+  def indexWhereM[E](p: A => STM[E, Boolean]): STM[E, Int] = indexWhereM(p, 0)
 
   /**
    * Starting at specified index, get the index of the next entry that matches
    * a transactional predicate.
    */
-  final def indexWhereM[E](p: A => STM[E, Boolean], from: Int): STM[E, Int] = {
+  def indexWhereM[E](p: A => STM[E, Boolean], from: Int): STM[E, Int] = {
     val len = array.length
     def forIndex(i: Int): STM[E, Int] =
       if (i >= len) STM.succeed(-1)
@@ -202,14 +202,14 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Get the last index of a specific value in the array or -1 if it does not occur.
    */
-  final def lastIndexOf(a: A): STM[Nothing, Int] =
+  def lastIndexOf(a: A): STM[Nothing, Int] =
     if (array.isEmpty) STM.succeed(-1) else lastIndexOf(a, array.length - 1)
 
   /**
    * Get the first index of a specific value in the array, bounded above by a
    * specific index, or -1 if it does not occur.
    */
-  final def lastIndexOf(a: A, end: Int): STM[Nothing, Int] = {
+  def lastIndexOf(a: A, end: Int): STM[Nothing, Int] = {
     def forIndex(i: Int): STM[Nothing, Int] =
       if (i < 0) STM.succeed(-1)
       else apply(i).flatMap(ai => if (ai == a) STM.succeed(i) else forIndex(i - 1))
@@ -220,25 +220,25 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * The last entry in the array, if it exists.
    */
-  final def lastOption: STM[Nothing, Option[A]] =
+  def lastOption: STM[Nothing, Option[A]] =
     if (array.isEmpty) STM.succeed(None) else array.last.get.map(Some(_))
 
   /**
    * Atomically compute the greatest element in the array, if it exists.
    */
-  final def maxOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
+  def maxOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
     reduceOption((acc, a) => if (ord.gt(a, acc)) a else acc)
 
   /**
    * Atomically compute the least element in the array, if it exists.
    */
-  final def minOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
+  def minOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
     reduceOption((acc, a) => if (ord.lt(a, acc)) a else acc)
 
   /**
    * Atomically reduce the array, if non-empty, by a binary operator.
    */
-  final def reduceOption(op: (A, A) => A): STM[Nothing, Option[A]] =
+  def reduceOption(op: (A, A) => A): STM[Nothing, Option[A]] =
     if (array.isEmpty) STM.succeed(None)
     else
       array.head.get
@@ -248,7 +248,7 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Atomically reduce the non-empty array using a transactional binary operator.
    */
-  final def reduceOptionM[E](op: (A, A) => STM[E, A]): STM[E, Option[A]] =
+  def reduceOptionM[E](op: (A, A) => STM[E, A]): STM[E, Option[A]] =
     foldM[E, Option[A]](None) { (optAcc, a) =>
       optAcc match {
         case Some(acc) => op(acc, a).map(Some(_))
@@ -259,7 +259,7 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Atomically updates all elements using a pure function.
    */
-  final def transform(f: A => A): STM[Nothing, Unit] =
+  def transform(f: A => A): STM[Nothing, Unit] =
     array.indices.foldLeft(STM.succeed(())) {
       case (tx, idx) => array(idx).update(f) *> tx
     }
@@ -267,7 +267,7 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Atomically updates all elements using a transactional effect.
    */
-  final def transformM[E](f: A => STM[E, A]): STM[E, Unit] =
+  def transformM[E](f: A => STM[E, A]): STM[E, Unit] =
     array.indices.foldLeft[STM[E, Unit]](STM.succeed(())) {
       case (tx, idx) =>
         val ref = array(idx)
@@ -277,14 +277,14 @@ final class TArray[A] private (private val array: Array[TRef[A]]) extends AnyVal
   /**
    * Updates element in the array with given function.
    */
-  final def update(index: Int, fn: A => A): STM[Nothing, A] =
+  def update(index: Int, fn: A => A): STM[Nothing, A] =
     if (0 <= index && index < array.length) array(index).update(fn)
     else STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Atomically updates element in the array with given transactional effect.
    */
-  final def updateM[E](index: Int, fn: A => STM[E, A]): STM[E, A] =
+  def updateM[E](index: Int, fn: A => STM[E, A]): STM[E, A] =
     if (0 <= index && index < array.length)
       for {
         currentVal <- array(index).get
@@ -299,16 +299,16 @@ object TArray {
   /**
    * Makes a new `TArray` that is initialized with specified values.
    */
-  final def make[A](data: A*): STM[Nothing, TArray[A]] = fromIterable(data)
+  def make[A](data: A*): STM[Nothing, TArray[A]] = fromIterable(data)
 
   /**
    * Makes an empty `TArray`.
    */
-  final def empty[A]: STM[Nothing, TArray[A]] = fromIterable(Nil)
+  def empty[A]: STM[Nothing, TArray[A]] = fromIterable(Nil)
 
   /**
    * Makes a new `TArray` initialized with provided iterable.
    */
-  final def fromIterable[A](data: Iterable[A]): STM[Nothing, TArray[A]] =
+  def fromIterable[A](data: Iterable[A]): STM[Nothing, TArray[A]] =
     STM.foreach(data)(TRef.make(_)).map(list => new TArray(list.toArray))
 }

--- a/core/shared/src/main/scala/zio/stm/TPromise.scala
+++ b/core/shared/src/main/scala/zio/stm/TPromise.scala
@@ -42,6 +42,6 @@ class TPromise[E, A] private (val ref: TRef[Option[Either[E, A]]]) extends AnyVa
 }
 
 object TPromise {
-  final def make[E, A]: STM[Nothing, TPromise[E, A]] =
+  def make[E, A]: STM[Nothing, TPromise[E, A]] =
     TRef.make[Option[Either[E, A]]](None).map(ref => new TPromise(ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -57,6 +57,6 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 }
 
 object TQueue {
-  final def make[A](capacity: Int): STM[Nothing, TQueue[A]] =
+  def make[A](capacity: Int): STM[Nothing, TQueue[A]] =
     TRef.make(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -167,7 +167,7 @@ object TReentrantLock {
     /**
      * Computes the total number of read locks acquired.
      */
-    final def readLocks: Int = readers.values.sum
+    def readLocks: Int = readers.values.sum
 
     /**
      * Determines if there is no other holder of read locks aside from the
@@ -175,18 +175,18 @@ object TReentrantLock {
      * aside from the specified fiber id, then it is safe to upgrade the
      * read lock into a write lock.
      */
-    final def noOtherHolder(fiberId: Fiber.Id): Boolean =
+    def noOtherHolder(fiberId: Fiber.Id): Boolean =
       readers.isEmpty || (readers.size == 1 && readers.contains(fiberId))
 
     /**
      * Computes the number of read locks held by the specified fiber id.
      */
-    final def readLocks(fiberId: Fiber.Id): Int = readers.get(fiberId).getOrElse(0)
+    def readLocks(fiberId: Fiber.Id): Int = readers.get(fiberId).getOrElse(0)
 
     /**
      * Adjusts the number of read locks held by the specified fiber id.
      */
-    final def adjust(fiberId: Fiber.Id, adjust: Int): ReadLock = {
+    def adjust(fiberId: Fiber.Id, adjust: Int): ReadLock = {
       val total = readLocks(fiberId)
 
       val newTotal = total + adjust
@@ -217,7 +217,7 @@ object TReentrantLock {
   /**
    * Makes a new reentrant read/write lock.
    */
-  final def make: STM[Nothing, TReentrantLock] =
+  def make: STM[Nothing, TReentrantLock] =
     TRef.make[Either[ReadLock, WriteLock]](Left(ReadLock.empty)).map(tref => new TReentrantLock(tref))
 
   private def die(message: String): Nothing =

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -111,7 +111,7 @@ object TRef {
   /**
    * Makes a new `TRef` that is initialized to the specified value.
    */
-  final def make[A](a: => A): STM[Nothing, TRef[A]] =
+  def make[A](a: => A): STM[Nothing, TRef[A]] =
     new STM((journal, _, _) => {
       val value     = a
       val versioned = new Versioned(value)
@@ -129,6 +129,6 @@ object TRef {
    * A convenience method that makes a `TRef` and immediately commits the
    * transaction to extract the value out.
    */
-  final def makeCommit[A](a: => A): UIO[TRef[A]] =
+  def makeCommit[A](a: => A): UIO[TRef[A]] =
     STM.atomically(TRef.make(a))
 }

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -44,6 +44,6 @@ class TSemaphore private (val permits: TRef[Long]) extends AnyVal {
 }
 
 object TSemaphore {
-  final def make(n: Long): STM[Nothing, TSemaphore] =
+  def make(n: Long): STM[Nothing, TSemaphore] =
     TRef.make(n).map(v => new TSemaphore(v))
 }

--- a/core/shared/src/main/scala/zio/stm/TSet.scala
+++ b/core/shared/src/main/scala/zio/stm/TSet.scala
@@ -118,16 +118,16 @@ object TSet {
   /**
    * Makes a new `TSet` that is initialized with specified values.
    */
-  final def make[A](data: A*): STM[Nothing, TSet[A]] = fromIterable(data)
+  def make[A](data: A*): STM[Nothing, TSet[A]] = fromIterable(data)
 
   /**
    * Makes an empty `TSet`.
    */
-  final def empty[A]: STM[Nothing, TSet[A]] = fromIterable(Nil)
+  def empty[A]: STM[Nothing, TSet[A]] = fromIterable(Nil)
 
   /**
    * Makes a new `TSet` initialized with provided iterable.
    */
-  final def fromIterable[A](data: Iterable[A]): STM[Nothing, TSet[A]] =
+  def fromIterable[A](data: Iterable[A]): STM[Nothing, TSet[A]] =
     TMap.fromIterable(data.map((_, ()))).map(new TSet(_))
 }

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -14,7 +14,7 @@ trait ZSinkPlatformSpecificConstructors {
    *
    * The caller of this function is responsible for closing the `OutputStream`.
    */
-  def fromOutputStream(
+  final def fromOutputStream(
     os: OutputStream
   ): ZSink[Blocking, IOException, Nothing, Chunk[Byte], Int] =
     ZSink.foldM(0)(_ => true) { (bytesWritten, byteChunk: Chunk[Byte]) =>

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -25,97 +25,97 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.await]]
    */
-  final def await[A]: Sink[Unit, Nothing, A, A] =
+  def await[A]: Sink[Unit, Nothing, A, A] =
     ZSink.await
 
   /**
    * see [[ZSink.collectAll]]
    */
-  final def collectAll[A]: Sink[Nothing, Nothing, A, List[A]] =
+  def collectAll[A]: Sink[Nothing, Nothing, A, List[A]] =
     ZSink.collectAll
 
   /**
    * see [[ZSink.collectAllN]]
    */
-  final def collectAllN[A](n: Long): ZSink[Any, Nothing, A, A, List[A]] =
+  def collectAllN[A](n: Long): ZSink[Any, Nothing, A, A, List[A]] =
     ZSink.collectAllN(n)
 
   /**
    * see [[ZSink.collectAllToSet]]
    */
-  final def collectAllToSet[A]: ZSink[Any, Nothing, Nothing, A, Set[A]] =
+  def collectAllToSet[A]: ZSink[Any, Nothing, Nothing, A, Set[A]] =
     ZSink.collectAllToSet
 
   /**
    * see [[ZSink.collectAllToSetN]]
    */
-  final def collectAllToSetN[A](n: Long): ZSink[Any, Nothing, A, A, Set[A]] =
+  def collectAllToSetN[A](n: Long): ZSink[Any, Nothing, A, A, Set[A]] =
     ZSink.collectAllToSetN(n)
 
   /**
    * see [[ZSink.collectAllToMap]]
    */
-  final def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, Nothing, A, Map[K, A]] =
+  def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, Nothing, A, Map[K, A]] =
     ZSink.collectAllToMap(key)(f)
 
   /**
    * see [[ZSink.collectAllToMapN]]
    */
-  final def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, A, A, Map[K, A]] =
+  def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, A, A, Map[K, A]] =
     ZSink.collectAllToMapN(n)(key)(f)
 
   /**
    * see [[ZSink.collectAllWhile]]
    */
-  final def collectAllWhile[A](p: A => Boolean): Sink[Nothing, A, A, List[A]] =
+  def collectAllWhile[A](p: A => Boolean): Sink[Nothing, A, A, List[A]] =
     collectAllWhileM(a => IO.succeed(p(a)))
 
   /**
    * see [[ZSink.collectAllWhileM]]
    */
-  final def collectAllWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, List[A]] =
+  def collectAllWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, List[A]] =
     ZSink.collectAllWhileM(p)
 
   /**
    * see [[ZSink.die]]
    */
-  final def die(e: Throwable): Sink[Nothing, Nothing, Any, Nothing] =
+  def die(e: Throwable): Sink[Nothing, Nothing, Any, Nothing] =
     ZSink.die(e)
 
   /**
    * see [[ZSink.dieMessage]]
    */
-  final def dieMessage(m: String): Sink[Nothing, Nothing, Any, Nothing] =
+  def dieMessage(m: String): Sink[Nothing, Nothing, Any, Nothing] =
     ZSink.dieMessage(m)
 
   /**
    * see [[ZSink.drain]]
    */
-  final def drain: Sink[Nothing, Nothing, Any, Unit] =
+  def drain: Sink[Nothing, Nothing, Any, Unit] =
     ZSink.drain
 
   /**
    * see [[ZSink.head]]
    */
-  final def head[A]: Sink[Nothing, A, A, Option[A]] =
+  def head[A]: Sink[Nothing, A, A, Option[A]] =
     ZSink.head
 
   /**
    * see [[ZSink.last]]
    */
-  final def last[A]: Sink[Nothing, Nothing, A, Option[A]] =
+  def last[A]: Sink[Nothing, Nothing, A, Option[A]] =
     ZSink.last
 
   /**
    * see [[ZSink.fail]]
    */
-  final def fail[E](e: E): Sink[E, Nothing, Any, Nothing] =
+  def fail[E](e: E): Sink[E, Nothing, Any, Nothing] =
     ZSink.fail(e)
 
   /**
    * see [[ZSink.fold]]
    */
-  final def fold[A0, A, S](
+  def fold[A0, A, S](
     z: S
   )(contFn: S => Boolean)(f: (S, A) => (S, Chunk[A0])): Sink[Nothing, A0, A, S] =
     ZSink.fold(z)(contFn)(f)
@@ -123,19 +123,19 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.foldLeft]]
    */
-  final def foldLeft[A, S](z: S)(f: (S, A) => S): Sink[Nothing, Nothing, A, S] =
+  def foldLeft[A, S](z: S)(f: (S, A) => S): Sink[Nothing, Nothing, A, S] =
     ZSink.foldLeft(z)(f)
 
   /**
    * see [[ZSink.foldLeftM]]
    */
-  final def foldLeftM[E, A, S](z: S)(f: (S, A) => IO[E, S]): Sink[E, Nothing, A, S] =
+  def foldLeftM[E, A, S](z: S)(f: (S, A) => IO[E, S]): Sink[E, Nothing, A, S] =
     ZSink.foldLeftM(z)(f)
 
   /**
    * see [[ZSink.foldM]]
    */
-  final def foldM[E, A0, A, S](
+  def foldM[E, A0, A, S](
     z: S
   )(contFn: S => Boolean)(f: (S, A) => IO[E, (S, Chunk[A0])]): Sink[E, A0, A, S] =
     ZSink.foldM(z)(contFn)(f)
@@ -143,19 +143,19 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.foldUntilM]]
    */
-  final def foldUntilM[E, S, A](z: S, max: Long)(f: (S, A) => IO[E, S]): Sink[E, A, A, S] =
+  def foldUntilM[E, S, A](z: S, max: Long)(f: (S, A) => IO[E, S]): Sink[E, A, A, S] =
     ZSink.foldUntilM(z, max)(f)
 
   /**
    * see [[ZSink.foldUntil]]
    */
-  final def foldUntil[S, A](z: S, max: Long)(f: (S, A) => S): Sink[Nothing, A, A, S] =
+  def foldUntil[S, A](z: S, max: Long)(f: (S, A) => S): Sink[Nothing, A, A, S] =
     ZSink.foldUntil(z, max)(f)
 
   /**
    * see [[ZSink.foldWeightedM]]
    */
-  final def foldWeightedM[E, E1 >: E, A, S](
+  def foldWeightedM[E, E1 >: E, A, S](
     z: S
   )(costFn: A => IO[E, Long], max: Long)(
     f: (S, A) => IO[E1, S]
@@ -164,7 +164,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.foldWeightedDecomposeM]]
    */
-  final def foldWeightedDecomposeM[E, E1 >: E, A, S](
+  def foldWeightedDecomposeM[E, E1 >: E, A, S](
     z: S
   )(costFn: A => IO[E, Long], max: Long, decompose: A => IO[E, Chunk[A]])(
     f: (S, A) => IO[E1, S]
@@ -174,7 +174,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.foldWeighted]]
    */
-  final def foldWeighted[A, S](
+  def foldWeighted[A, S](
     z: S
   )(costFn: A => Long, max: Long)(
     f: (S, A) => S
@@ -184,7 +184,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.foldWeighted]]
    */
-  final def foldWeightedDecompose[A, S](
+  def foldWeightedDecompose[A, S](
     z: S
   )(costFn: A => Long, max: Long, decompose: A => Chunk[A])(
     f: (S, A) => S
@@ -194,49 +194,49 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.fromEffect]]
    */
-  final def fromEffect[E, B](b: => IO[E, B]): Sink[E, Nothing, Any, B] =
+  def fromEffect[E, B](b: => IO[E, B]): Sink[E, Nothing, Any, B] =
     ZSink.fromEffect(b)
 
   /**
    * see [[ZSink.fromFunction]]
    */
-  final def fromFunction[A, B](f: A => B): Sink[Unit, Nothing, A, B] =
+  def fromFunction[A, B](f: A => B): Sink[Unit, Nothing, A, B] =
     ZSink.fromFunction(f)
 
   /**
    * see [[ZSink.fromFunctionM]]
    */
-  final def fromFunctionM[E, A, B](f: A => ZIO[Any, E, B]): Sink[Option[E], Nothing, A, B] =
+  def fromFunctionM[E, A, B](f: A => ZIO[Any, E, B]): Sink[Option[E], Nothing, A, B] =
     ZSink.fromFunctionM(f)
 
   /**
    * see [[ZSink.halt]]
    */
-  final def halt[E](e: Cause[E]): Sink[E, Nothing, Any, Nothing] =
+  def halt[E](e: Cause[E]): Sink[E, Nothing, Any, Nothing] =
     ZSink.halt(e)
 
   /**
    * see [[ZSink.identity]]
    */
-  final def identity[A]: Sink[Unit, Nothing, A, A] =
+  def identity[A]: Sink[Unit, Nothing, A, A] =
     ZSink.identity
 
   /**
    * see [[ZSink.ignoreWhile]]
    */
-  final def ignoreWhile[A](p: A => Boolean): Sink[Nothing, A, A, Unit] =
+  def ignoreWhile[A](p: A => Boolean): Sink[Nothing, A, A, Unit] =
     ZSink.ignoreWhile(p)
 
   /**
    * see [[ZSink.ignoreWhileM]]
    */
-  final def ignoreWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, Unit] =
+  def ignoreWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, Unit] =
     ZSink.ignoreWhileM(p)
 
   /**
    * see [[ZSink.pull1]]
    */
-  final def pull1[E, A0, A, B](
+  def pull1[E, A0, A, B](
     end: IO[E, B]
   )(input: A => Sink[E, A0, A, B]): Sink[E, A0, A, B] =
     ZSink.pull1(end)(input)
@@ -244,7 +244,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.read1]]
    */
-  final def read1[E, A](e: Option[A] => E)(p: A => Boolean): Sink[E, A, A, A] =
+  def read1[E, A](e: Option[A] => E)(p: A => Boolean): Sink[E, A, A, A] =
     ZSink.read1(e)(p)
 
   /**
@@ -260,13 +260,13 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.succeed]]
    */
-  final def succeed[A, B](b: B): Sink[Nothing, A, A, B] =
+  def succeed[A, B](b: B): Sink[Nothing, A, A, B] =
     ZSink.succeed(b)
 
   /**
    * see [[ZSink.throttleEnforce]]
    */
-  final def throttleEnforce[A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleEnforce[A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => Long
   ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, Option[A]]] =
     ZSink.throttleEnforce(units, duration, burst)(costFn)
@@ -274,7 +274,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.throttleEnforceM]]
    */
-  final def throttleEnforceM[E, A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleEnforceM[E, A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => IO[E, Long]
   ): ZManaged[Clock, E, ZSink[Clock, E, Nothing, A, Option[A]]] =
     ZSink.throttleEnforceM[Any, E, A](units, duration, burst)(costFn)
@@ -282,7 +282,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.throttleShape]]
    */
-  final def throttleShape[A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleShape[A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => Long
   ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, A]] =
     ZSink.throttleShape(units, duration, burst)(costFn)
@@ -290,7 +290,7 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.throttleShapeM]]
    */
-  final def throttleShapeM[E, A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleShapeM[E, A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => IO[E, Long]
   ): ZManaged[Clock, E, ZSink[Clock, E, Nothing, A, A]] =
     ZSink.throttleShapeM[Any, E, A](units, duration, burst)(costFn)

--- a/streams/shared/src/main/scala/zio/stream/SinkPure.scala
+++ b/streams/shared/src/main/scala/zio/stream/SinkPure.scala
@@ -38,11 +38,11 @@ private[stream] trait SinkPure[+E, +A0, -A, +B] extends ZSink[Any, E, A0, A, B] 
       def cont(state: State)           = self.cont(state)
     }
 
-  def extract(state: State) = IO.fromEither(extractPure(state))
+  final def extract(state: State) = IO.fromEither(extractPure(state))
 
   def extractPure(state: State): Either[E, (B, Chunk[A0])]
 
-  def initial = IO.succeed(initialPure)
+  final def initial = IO.succeed(initialPure)
 
   def initialPure: State
 

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -41,35 +41,35 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.apply[A]*]]
    */
-  final def apply[A](as: A*): Stream[Nothing, A] = ZStream(as: _*)
+  def apply[A](as: A*): Stream[Nothing, A] = ZStream(as: _*)
 
   /**
    * See [[ZStream.apply[R,E,A]*]]
    */
-  final def apply[E, A](pull: Managed[Nothing, Pull[Any, E, A]]): Stream[E, A] = ZStream(pull)
+  def apply[E, A](pull: Managed[Nothing, Pull[Any, E, A]]): Stream[E, A] = ZStream(pull)
 
   /**
    * See [[ZStream.bracket]]
    */
-  final def bracket[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Stream[E, A] =
+  def bracket[E, A](acquire: IO[E, A])(release: A => UIO[Any]): Stream[E, A] =
     ZStream.bracket(acquire)(release)
 
   /**
    * See [[ZStream.bracketExit]]
    */
-  final def bracketExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Stream[E, A] =
+  def bracketExit[E, A](acquire: IO[E, A])(release: (A, Exit[Any, Any]) => UIO[Any]): Stream[E, A] =
     ZStream.bracketExit(acquire)(release)
 
   /**
    *  @see [[zio.ZStream.crossN]]
    */
-  final def crossN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
+  def crossN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
     ZStream.crossN(stream1, stream2)(f)
 
   /**
    *  @see [[zio.ZStream.crossN]]
    */
-  final def crossN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
+  def crossN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
     f: (A, B, C) => D
   ): Stream[E, D] =
     ZStream.crossN(stream1, stream2, stream3)(f)
@@ -77,7 +77,7 @@ object Stream extends Serializable {
   /**
    *  @see [[zio.ZStream.crossN]]
    */
-  final def crossN[E, A, B, C, D, F](
+  def crossN[E, A, B, C, D, F](
     stream1: Stream[E, A],
     stream2: Stream[E, B],
     stream3: Stream[E, C],
@@ -90,19 +90,19 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.die]]
    */
-  final def die(ex: Throwable): Stream[Nothing, Nothing] =
+  def die(ex: Throwable): Stream[Nothing, Nothing] =
     ZStream.die(ex)
 
   /**
    * See [[ZStream.dieMessage]]
    */
-  final def dieMessage(msg: String): Stream[Nothing, Nothing] =
+  def dieMessage(msg: String): Stream[Nothing, Nothing] =
     ZStream.dieMessage(msg)
 
   /**
    * See [[ZStream.effectAsync]]
    */
-  final def effectAsync[E, A](
+  def effectAsync[E, A](
     register: (IO[Option[E], A] => Unit) => Unit,
     outputBuffer: Int = 16
   ): Stream[E, A] =
@@ -111,7 +111,7 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.effectAsyncMaybe]]
    */
-  final def effectAsyncMaybe[E, A](
+  def effectAsyncMaybe[E, A](
     register: (IO[Option[E], A] => Unit) => Option[Stream[E, A]],
     outputBuffer: Int = 16
   ): Stream[E, A] =
@@ -120,7 +120,7 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.effectAsyncM]]
    */
-  final def effectAsyncM[E, A](
+  def effectAsyncM[E, A](
     register: (IO[Option[E], A] => Unit) => IO[E, Any],
     outputBuffer: Int = 16
   ): Stream[E, A] =
@@ -129,7 +129,7 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.effectAsyncInterrupt]]
    */
-  final def effectAsyncInterrupt[E, A](
+  def effectAsyncInterrupt[E, A](
     register: (IO[Option[E], A] => Unit) => Either[Canceler[Any], Stream[E, A]],
     outputBuffer: Int = 16
   ): Stream[E, A] =
@@ -138,25 +138,25 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.fail]]
    */
-  final def fail[E](error: E): Stream[E, Nothing] =
+  def fail[E](error: E): Stream[E, Nothing] =
     ZStream.fail(error)
 
   /**
    * See [[ZStream.finalizer]]
    */
-  final def finalizer(finalizer: UIO[Any]): Stream[Nothing, Nothing] =
+  def finalizer(finalizer: UIO[Any]): Stream[Nothing, Nothing] =
     ZStream.finalizer(finalizer)
 
   /**
    * See [[ZStream.flatten]]
    */
-  final def flatten[E, A](fa: Stream[E, Stream[E, A]]): Stream[E, A] =
+  def flatten[E, A](fa: Stream[E, Stream[E, A]]): Stream[E, A] =
     ZStream.flatten(fa)
 
   /**
    * See [[ZStream.flattenPar]]
    */
-  final def flattenPar[E, A](n: Int, outputBuffer: Int = 16)(
+  def flattenPar[E, A](n: Int, outputBuffer: Int = 16)(
     fa: Stream[E, Stream[E, A]]
   ): Stream[E, A] =
     ZStream.flattenPar(n, outputBuffer)(fa)
@@ -164,7 +164,7 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.fromInputStream]]
    */
-  final def fromInputStream(
+  def fromInputStream(
     is: InputStream,
     chunkSize: Int = ZStreamChunk.DefaultChunkSize
   ): StreamEffectChunk[Any, IOException, Byte] =
@@ -173,43 +173,43 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.fromChunk]]
    */
-  final def fromChunk[A](c: Chunk[A]): Stream[Nothing, A] =
+  def fromChunk[A](c: Chunk[A]): Stream[Nothing, A] =
     ZStream.fromChunk(c)
 
   /**
    * See [[ZStream.fromEffect]]
    */
-  final def fromEffect[E, A](fa: IO[E, A]): Stream[E, A] =
+  def fromEffect[E, A](fa: IO[E, A]): Stream[E, A] =
     ZStream.fromEffect(fa)
 
   /**
    * See [[ZStream.fromEffectOption]]
    */
-  final def fromEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
+  def fromEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
     ZStream.fromEffectOption(fa)
 
   /**
    * See [[ZStream.paginate]]
    */
-  final def paginate[A, S](s: S)(f: S => (A, Option[S])): Stream[Nothing, A] =
+  def paginate[A, S](s: S)(f: S => (A, Option[S])): Stream[Nothing, A] =
     ZStream.paginate(s)(f)
 
   /**
    * See [[ZStream.paginateM]]
    */
-  final def paginateM[E, A, S](s: S)(f: S => IO[E, (A, Option[S])]): Stream[E, A] =
+  def paginateM[E, A, S](s: S)(f: S => IO[E, (A, Option[S])]): Stream[E, A] =
     ZStream.paginateM(s)(f)
 
   /**
    * See [[ZStream.repeatEffect]]
    */
-  final def repeatEffect[E, A](fa: IO[E, A]): Stream[E, A] =
+  def repeatEffect[E, A](fa: IO[E, A]): Stream[E, A] =
     ZStream.repeatEffect(fa)
 
   /**
    * See [[ZStream.repeatEffectWith]]
    */
-  final def repeatEffectWith[E, A](
+  def repeatEffectWith[E, A](
     fa: IO[E, A],
     schedule: Schedule[Any, Unit, Any]
   ): ZStream[Clock, E, A] = ZStream.repeatEffectWith(fa, schedule)
@@ -217,71 +217,71 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.repeatEffectOption]]
    */
-  final def repeatEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
+  def repeatEffectOption[E, A](fa: IO[Option[E], A]): Stream[E, A] =
     ZStream.repeatEffectOption(fa)
 
   /**
    * See [[ZStream.fromIterable]]
    */
-  final def fromIterable[A](as: Iterable[A]): Stream[Nothing, A] =
+  def fromIterable[A](as: Iterable[A]): Stream[Nothing, A] =
     ZStream.fromIterable(as)
 
   /**
    * See [[ZStream.fromIterator]]
    */
-  final def fromIterator[E, A](iterator: IO[E, Iterator[A]]): Stream[E, A] =
+  def fromIterator[E, A](iterator: IO[E, Iterator[A]]): Stream[E, A] =
     ZStream.fromIterator(iterator)
 
   /**
    * See [[ZStream.fromIteratorManaged]]
    */
-  final def fromIteratorManaged[E, A](iterator: Managed[E, Iterator[A]]): Stream[E, A] =
+  def fromIteratorManaged[E, A](iterator: Managed[E, Iterator[A]]): Stream[E, A] =
     ZStream.fromIteratorManaged(iterator)
 
   /**
    * See [[ZStream.fromJavaIterator]]
    */
-  final def fromJavaIterator[E, A](iterator: IO[E, ju.Iterator[A]]): Stream[E, A] =
+  def fromJavaIterator[E, A](iterator: IO[E, ju.Iterator[A]]): Stream[E, A] =
     ZStream.fromJavaIterator(iterator)
 
   /**
    * See [[ZStream.fromJavaIteratorManaged]]
    */
-  final def fromJavaIteratorManaged[E, A](iterator: Managed[E, ju.Iterator[A]]): Stream[E, A] =
+  def fromJavaIteratorManaged[E, A](iterator: Managed[E, ju.Iterator[A]]): Stream[E, A] =
     ZStream.fromJavaIteratorManaged(iterator)
 
   /**
    * See [[ZStream.fromQueue]]
    */
-  final def fromQueue[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
+  def fromQueue[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
     ZStream.fromQueue(queue)
 
   /**
    * See [[ZStream.fromQueueWithShutdown]]
    */
-  final def fromQueueWithShutdown[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
+  def fromQueueWithShutdown[E, A](queue: ZQueue[Nothing, Any, Any, E, Nothing, A]): Stream[E, A] =
     ZStream.fromQueueWithShutdown(queue)
 
   /**
    * See [[ZStream.halt]]
    */
-  final def halt[E](cause: Cause[E]): Stream[E, Nothing] = fromEffect(ZIO.halt(cause))
+  def halt[E](cause: Cause[E]): Stream[E, Nothing] = fromEffect(ZIO.halt(cause))
 
   /**
    * See [[ZStream.iterate]]
    */
-  final def iterate[A](a: A)(f: A => A): ZStream[Any, Nothing, A] = Stream.unfold(a)(a => Some(a -> f(a)))
+  def iterate[A](a: A)(f: A => A): ZStream[Any, Nothing, A] = Stream.unfold(a)(a => Some(a -> f(a)))
 
   /**
    * See [[ZStream.managed]]
    */
-  final def managed[E, A](managed: Managed[E, A]): Stream[E, A] =
+  def managed[E, A](managed: Managed[E, A]): Stream[E, A] =
     ZStream.managed(managed)
 
   /**
    * See [[ZStream.mergeAll]]
    */
-  final def mergeAll[E, A](n: Int, outputBuffer: Int = 16)(
+  def mergeAll[E, A](n: Int, outputBuffer: Int = 16)(
     streams: Stream[E, A]*
   ): Stream[E, A] =
     ZStream.mergeAll[Any, E, A](n, outputBuffer)(streams: _*)
@@ -289,49 +289,49 @@ object Stream extends Serializable {
   /**
    * See [[ZStream.range]]
    */
-  final def range(min: Int, max: Int): Stream[Nothing, Int] =
+  def range(min: Int, max: Int): Stream[Nothing, Int] =
     ZStream.range(min, max)
 
   /**
    * See [[ZStream.succeed]]
    */
-  final def succeed[A](a: A): Stream[Nothing, A] =
+  def succeed[A](a: A): Stream[Nothing, A] =
     ZStream.succeed(a)
 
   /**
    * See [[ZStream.unfold]]
    */
-  final def unfold[S, A](s: S)(f0: S => Option[(A, S)]): Stream[Nothing, A] =
+  def unfold[S, A](s: S)(f0: S => Option[(A, S)]): Stream[Nothing, A] =
     ZStream.unfold(s)(f0)
 
   /**
    * See [[ZStream.unfoldM]]
    */
-  final def unfoldM[E, A, S](s: S)(f0: S => IO[E, Option[(A, S)]]): Stream[E, A] =
+  def unfoldM[E, A, S](s: S)(f0: S => IO[E, Option[(A, S)]]): Stream[E, A] =
     ZStream.unfoldM(s)(f0)
 
   /**
    * See [[ZStream.unwrap]]
    */
-  final def unwrap[E, A](fa: IO[E, Stream[E, A]]): Stream[E, A] =
+  def unwrap[E, A](fa: IO[E, Stream[E, A]]): Stream[E, A] =
     ZStream.unwrap(fa)
 
   /**
    * See [[ZStream.unwrapManaged]]
    */
-  final def unwrapManaged[E, A](fa: Managed[E, ZStream[Any, E, A]]): Stream[E, A] =
+  def unwrapManaged[E, A](fa: Managed[E, ZStream[Any, E, A]]): Stream[E, A] =
     ZStream.unwrapManaged(fa)
 
   /**
    *  @see [[zio.ZStream.zipN]]
    */
-  final def zipN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
+  def zipN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
     ZStream.zipN(stream1, stream2)(f)
 
   /**
    *  @see [[zio.ZStream.zipN]]
    */
-  final def zipN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
+  def zipN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
     f: (A, B, C) => D
   ): Stream[E, D] =
     ZStream.zipN(stream1, stream2, stream3)(f)
@@ -339,7 +339,7 @@ object Stream extends Serializable {
   /**
    *  @see [[zio.ZStream.zipN]]
    */
-  final def zipN[E, A, B, C, D, F](
+  def zipN[E, A, B, C, D, F](
     stream1: Stream[E, A],
     stream2: Stream[E, B],
     stream3: Stream[E, C],

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -305,7 +305,7 @@ private[stream] class StreamEffect[-R, +E, +A](val processEffect: ZManaged[R, No
 
 private[stream] object StreamEffect extends Serializable {
 
-  case class Failure[E](e: E) extends Throwable(e.toString, null, true, false) {
+  final case class Failure[E](e: E) extends Throwable(e.toString, null, true, false) {
     override def fillInStackTrace() = this
   }
 
@@ -324,10 +324,10 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def apply[R, E, A](pull: ZManaged[R, Nothing, () => A]): StreamEffect[R, E, A] =
+  def apply[R, E, A](pull: ZManaged[R, Nothing, () => A]): StreamEffect[R, E, A] =
     new StreamEffect(pull)
 
-  final def fail[E](e: E): StreamEffect[Any, E, Nothing] =
+  def fail[E](e: E): StreamEffect[Any, E, Nothing] =
     StreamEffect {
       Managed.effectTotal {
         var done = false
@@ -340,7 +340,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def fromChunk[A](c: Chunk[A]): StreamEffect[Any, Nothing, A] =
+  def fromChunk[A](c: Chunk[A]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         var index = 0
@@ -357,7 +357,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def fromIterable[A](as: Iterable[A]): StreamEffect[Any, Nothing, A] =
+  def fromIterable[A](as: Iterable[A]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         val thunk = as.iterator
@@ -366,14 +366,14 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def fromIterator[A](iterator: Iterator[A]): StreamEffect[Any, Nothing, A] =
+  def fromIterator[A](iterator: Iterator[A]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal { () =>
         if (iterator.hasNext) iterator.next() else end
       }
     }
 
-  final def fromJavaIterator[A](iterator: ju.Iterator[A]): StreamEffect[Any, Nothing, A] = {
+  def fromJavaIterator[A](iterator: ju.Iterator[A]): StreamEffect[Any, Nothing, A] = {
     val _ = iterator // Scala 2.13 wrongly warns that iterator is unused
     fromIterator(
       new Iterator[A] {
@@ -383,7 +383,7 @@ private[stream] object StreamEffect extends Serializable {
     )
   }
 
-  final def fromInputStream(
+  def fromInputStream(
     is: InputStream,
     chunkSize: Int = ZStreamChunk.DefaultChunkSize
   ): StreamEffectChunk[Any, IOException, Byte] =
@@ -411,7 +411,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def iterate[A](a: A)(f: A => A): StreamEffect[Any, Nothing, A] =
+  def iterate[A](a: A)(f: A => A): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         var state = a
@@ -424,7 +424,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def paginate[A, S](s0: S)(f: S => (A, Option[S])): StreamEffect[Any, Nothing, A] =
+  def paginate[A, S](s0: S)(f: S => (A, Option[S])): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         var state = Option(s0)
@@ -438,7 +438,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def unfold[S, A](s: S)(f0: S => Option[(A, S)]): StreamEffect[Any, Nothing, A] =
+  def unfold[S, A](s: S)(f0: S => Option[(A, S)]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         var done  = false
@@ -460,7 +460,7 @@ private[stream] object StreamEffect extends Serializable {
       }
     }
 
-  final def succeed[A](a: A): StreamEffect[Any, Nothing, A] =
+  def succeed[A](a: A): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal {
         var done = false

--- a/streams/shared/src/main/scala/zio/stream/StreamEffectChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffectChunk.scala
@@ -225,6 +225,6 @@ private[stream] class StreamEffectChunk[-R, +E, +A](override val chunks: StreamE
 }
 
 private[stream] object StreamEffectChunk extends Serializable {
-  final def apply[R, E, A](chunks: StreamEffect[R, E, Chunk[A]]): StreamEffectChunk[R, E, A] =
+  def apply[R, E, A](chunks: StreamEffect[R, E, Chunk[A]]): StreamEffectChunk[R, E, A] =
     new StreamEffectChunk(chunks)
 }

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -60,10 +60,10 @@ object Take {
   final case class Value[A](value: A)       extends Take[Nothing, A]
   case object End                           extends Take[Nothing, Nothing]
 
-  final def fromPull[R, E, A](pull: Pull[R, E, A]): ZIO[R, Nothing, Take[E, A]] =
+  def fromPull[R, E, A](pull: Pull[R, E, A]): ZIO[R, Nothing, Take[E, A]] =
     pull.fold(_.fold[Take[E, A]](Take.End)(e => Take.Fail(Cause.fail(e))), Take.Value(_))
 
-  final def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
+  def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
     io.flatMap {
       case Take.End      => IO.succeed(None)
       case Take.Value(a) => IO.succeed(Some(a))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -739,13 +739,13 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
 object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
 
-  implicit class InputRemainderOps[R, E, A, B](private val sink: ZSink[R, E, A, A, B]) {
+  implicit final class InputRemainderOps[R, E, A, B](private val sink: ZSink[R, E, A, A, B]) {
 
     /**
      * Returns a new sink that tries to produce the `B`, but if there is an
      * error in stepping or extraction, produces `None`.
      */
-    final def ? : ZSink[R, Nothing, A, A, Option[B]] =
+    def ? : ZSink[R, Nothing, A, A, Option[B]] =
       new ZSink[R, Nothing, A, A, Option[B]] {
         type State = OptionalState
         sealed trait OptionalState
@@ -808,7 +808,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * will not improve performance, but can be used to adapt non-chunked sinks
      * wherever chunked sinks are required.
      */
-    final def chunked: ZSink[R, E, A, Chunk[A], B] =
+    def chunked: ZSink[R, E, A, Chunk[A], B] =
       new ZSink[R, E, A, Chunk[A], B] {
         type State = (sink.State, Chunk[A])
         val initial = sink.initial.map((_, Chunk.empty))
@@ -821,13 +821,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
     /**
      * Repeatedly runs this sink and accumulates its outputs to a list.
      */
-    final def collectAll: ZSink[R, E, A, A, List[B]] =
+    def collectAll: ZSink[R, E, A, A, List[B]] =
       collectAllWith[List[B]](List[B]())((bs, b) => b :: bs).map(_.reverse)
 
     /**
      * Repeatedly runs this sink until `i` outputs have been accumulated.
      */
-    final def collectAllN(
+    def collectAllN(
       i: Int
     ): ZSink[R, E, A, A, List[B]] =
       new ZSink[R, E, A, A, List[B]] {
@@ -874,13 +874,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * Repeatedly runs this sink and accumulates the outputs into a value
      * of type `S`.
      */
-    final def collectAllWith[S](z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] = collectAllWhileWith[S](_ => true)(z)(f)
+    def collectAllWith[S](z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] = collectAllWhileWith[S](_ => true)(z)(f)
 
     /**
      * Repeatedly runs this sink and accumulates its outputs for as long
      * as incoming values verify the predicate.
      */
-    final def collectAllWhile(p: A => Boolean): ZSink[R, E, A, A, List[B]] =
+    def collectAllWhile(p: A => Boolean): ZSink[R, E, A, A, List[B]] =
       collectAllWhileWith[List[B]](p)(List.empty[B])((bs, b) => b :: bs)
         .map(_.reverse)
 
@@ -888,7 +888,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * Repeatedly runs this sink and accumulates its outputs into a value
      * of type `S` for as long as the incoming values satisfy the predicate.
      */
-    final def collectAllWhileWith[S](p: A => Boolean)(z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] =
+    def collectAllWhileWith[S](p: A => Boolean)(z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] =
       new ZSink[R, E, A, A, S] {
         type State = CollectAllWhileWithState
         case class CollectAllWhileWithState(
@@ -929,13 +929,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
     /**
      * A named alias for `?`.
      */
-    final def optional: ZSink[R, Nothing, A, A, Option[B]] = ?
+    def optional: ZSink[R, Nothing, A, A, Option[B]] = ?
 
     /**
      * Produces a sink consuming all the elements of type `A` as long as
      * they verify the predicate `pred`.
      */
-    final def takeWhile(pred: A => Boolean): ZSink[R, E, A, A, B] =
+    def takeWhile(pred: A => Boolean): ZSink[R, E, A, A, B] =
       new ZSink[R, E, A, A, B] {
         type State = (sink.State, Chunk[A])
 
@@ -959,7 +959,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * Sinks that never signal completion (e.g. [[ZSink.collectAll]])
      * will not have the predicate applied to intermediate values.
      */
-    final def untilOutput(f: B => Boolean): ZSink[R, E, A, A, Option[B]] =
+    def untilOutput(f: B => Boolean): ZSink[R, E, A, A, Option[B]] =
       new ZSink[R, E, A, A, Option[B]] {
         type State = (sink.State, Option[B], Chunk[A], Boolean)
 
@@ -994,58 +994,58 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       }
   }
 
-  implicit class NoRemainderOps[R, E, A, B](private val sink: ZSink[R, E, Nothing, A, B]) extends AnyVal {
+  implicit final class NoRemainderOps[R, E, A, B](private val sink: ZSink[R, E, Nothing, A, B]) extends AnyVal {
     private def widen: ZSink[R, E, A, A, B] = sink
 
     /**
      * Returns a new sink that tries to produce the `B`, but if there is an
      * error in stepping or extraction, produces `None`.
      */
-    final def ? : ZSink[R, Nothing, A, A, Option[B]] = widen.?
+    def ? : ZSink[R, Nothing, A, A, Option[B]] = widen.?
 
     /**
      * Takes a `Sink`, and lifts it to be chunked in its input. This
      * will not improve performance, but can be used to adapt non-chunked sinks
      * wherever chunked sinks are required.
      */
-    final def chunked: ZSink[R, E, A, Chunk[A], B] = widen.chunked
+    def chunked: ZSink[R, E, A, Chunk[A], B] = widen.chunked
 
     /**
      * Accumulates the output into a list.
      */
-    final def collectAll: ZSink[R, E, A, A, List[B]] = widen.collectAll
+    def collectAll: ZSink[R, E, A, A, List[B]] = widen.collectAll
 
     /**
      * Accumulates the output into a list of maximum size `i`.
      */
-    final def collectAllN(i: Int): ZSink[R, E, A, A, List[B]] = widen.collectAllN(i)
+    def collectAllN(i: Int): ZSink[R, E, A, A, List[B]] = widen.collectAllN(i)
 
     /**
      * Accumulates the output into a value of type `S`.
      */
-    final def collectAllWith[S](z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] = widen.collectAllWith(z)(f)
+    def collectAllWith[S](z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] = widen.collectAllWith(z)(f)
 
     /**
      * Accumulates into a list for as long as incoming values verify predicate `p`.
      */
-    final def collectAllWhile(p: A => Boolean): ZSink[R, E, A, A, List[B]] = widen.collectAllWhile(p)
+    def collectAllWhile(p: A => Boolean): ZSink[R, E, A, A, List[B]] = widen.collectAllWhile(p)
 
     /**
      * Accumulates into a value of type `S` for as long as incoming values verify predicate `p`.
      */
-    final def collectAllWhileWith[S](p: A => Boolean)(z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] =
+    def collectAllWhileWith[S](p: A => Boolean)(z: S)(f: (S, B) => S): ZSink[R, E, A, A, S] =
       widen.collectAllWhileWith(p)(z)(f)
 
     /**
      * A named alias for `?`.
      */
-    final def optional: ZSink[R, Nothing, A, A, Option[B]] = widen.?
+    def optional: ZSink[R, Nothing, A, A, Option[B]] = widen.?
 
     /**
      * Produces a sink consuming all the elements of type `A` as long as
      * they verify the predicate `pred`.
      */
-    final def takeWhile(pred: A => Boolean): ZSink[R, E, A, A, B] = widen.takeWhile(pred)
+    def takeWhile(pred: A => Boolean): ZSink[R, E, A, A, B] = widen.takeWhile(pred)
 
     /**
      * Creates a sink that produces values until one verifies
@@ -1056,17 +1056,17 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * Sinks that never signal completion (e.g. [[ZSink.collectAll]])
      * will not have the predicate applied to intermediate values.
      */
-    final def untilOutput(f: B => Boolean): ZSink[R, E, A, A, Option[B]] =
+    def untilOutput(f: B => Boolean): ZSink[R, E, A, A, Option[B]] =
       widen untilOutput f
   }
 
-  implicit class InvariantOps[R, E, A0, A, B](val sink: ZSink[R, E, A0, A, B]) extends AnyVal { self =>
+  implicit final class InvariantOps[R, E, A0, A, B](val sink: ZSink[R, E, A0, A, B]) extends AnyVal { self =>
 
     /**
      * Drops all elements entering the sink for as long as the specified predicate
      * evaluates to `true`.
      */
-    final def dropWhile(pred: A => Boolean): ZSink[R, E, A0, A, B] =
+    def dropWhile(pred: A => Boolean): ZSink[R, E, A0, A, B] =
       new ZSink[R, E, A0, A, B] {
         type State = (sink.State, Boolean)
 
@@ -1113,7 +1113,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
     /**
      * Effectfully filters the inputs fed to this sink.
      */
-    final def filterM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZSink[R1, E1, A0, A, B] =
+    def filterM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZSink[R1, E1, A0, A, B] =
       new ZSink[R1, E1, A0, A, B] {
         type State = sink.State
         val initial = sink.initial
@@ -1131,21 +1131,21 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
      * Filters this sink by the specified predicate, dropping all elements for
      * which the predicate evaluates to true.
      */
-    final def filterNot(f: A => Boolean): ZSink[R, E, A0, A, B] =
+    def filterNot(f: A => Boolean): ZSink[R, E, A0, A, B] =
       filter(a => !f(a))
 
     /**
      * Effectfully filters this sink by the specified predicate, dropping all elements for
      * which the predicate evaluates to true.
      */
-    final def filterNotM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZSink[R1, E1, A0, A, B] =
+    def filterNotM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZSink[R1, E1, A0, A, B] =
       filterM(a => f(a).map(!_))
 
     /**
      * Runs `n` sinks in parallel, where `n` is the number of possible keys
      * generated by `f`.
      */
-    final def keyed[K](f: A => K): ZSink[R, E, (K, Chunk[A0]), A, Map[K, B]] =
+    def keyed[K](f: A => K): ZSink[R, E, (K, Chunk[A0]), A, Map[K, B]] =
       new ZSink[R, E, (K, Chunk[A0]), A, Map[K, B]] {
         type State = Map[K, sink.State]
 
@@ -1176,7 +1176,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   }
 
   private[ZSink] object internal {
-    sealed trait Side[+E, +S, +A]
+    sealed trait Side[+E, +S, +A] extends Serializable with Product
     object Side {
       final case class Error[E](e: E) extends Side[E, Nothing, Nothing]
       final case class State[S](s: S) extends Side[Nothing, S, Nothing]
@@ -1191,38 +1191,38 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       if (n <= 0) UIO.die(new NonpositiveArgument(s"Unexpected nonpositive unit value `$n`"))
       else UIO.unit
 
-    class NegativeArgument(message: String) extends IllegalArgumentException(message)
+    final class NegativeArgument(message: String) extends IllegalArgumentException(message)
 
-    class NonpositiveArgument(message: String) extends IllegalArgumentException(message)
+    final class NonpositiveArgument(message: String) extends IllegalArgumentException(message)
   }
 
   /**
    * Creates a sink that waits for a single value to be produced.
    */
-  final def await[A]: ZSink[Any, Unit, Nothing, A, A] = identity
+  def await[A]: ZSink[Any, Unit, Nothing, A, A] = identity
 
   /**
    * Creates a sink accumulating incoming values into a list.
    */
-  final def collectAll[A]: ZSink[Any, Nothing, Nothing, A, List[A]] =
+  def collectAll[A]: ZSink[Any, Nothing, Nothing, A, List[A]] =
     foldLeft[A, List[A]](List.empty[A])((as, a) => a :: as).map(_.reverse)
 
   /**
    * Creates a sink accumulating incoming values into a list of maximum size `n`.
    */
-  final def collectAllN[A](n: Long): ZSink[Any, Nothing, A, A, List[A]] =
+  def collectAllN[A](n: Long): ZSink[Any, Nothing, A, A, List[A]] =
     foldUntil[List[A], A](List.empty[A], n)((list, element) => element :: list).map(_.reverse)
 
   /**
    * Creates a sink accumulating incoming values into a set.
    */
-  final def collectAllToSet[A]: ZSink[Any, Nothing, Nothing, A, Set[A]] =
+  def collectAllToSet[A]: ZSink[Any, Nothing, Nothing, A, Set[A]] =
     foldLeft[A, Set[A]](Set.empty[A])((set, element) => set + element)
 
   /**
    * Creates a sink accumulating incoming values into a set of maximum size `n`.
    */
-  final def collectAllToSetN[A](n: Long): ZSink[Any, Nothing, A, A, Set[A]] = {
+  def collectAllToSetN[A](n: Long): ZSink[Any, Nothing, A, A, Set[A]] = {
     type State = (Set[A], Boolean)
     def f(state: State, a: A): (State, Chunk[A]) = {
       val newSet = state._1 + a
@@ -1239,7 +1239,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Combines elements with same key with supplied function f.
    *
    */
-  final def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): Sink[Nothing, Nothing, A, Map[K, A]] =
+  def collectAllToMap[K, A](key: A => K)(f: (A, A) => A): Sink[Nothing, Nothing, A, Map[K, A]] =
     foldLeft[A, Map[K, A]](Map.empty)((curMap, a) => {
       val k = key(a)
       curMap.get(k).fold(curMap.updated(k, a))(v => curMap.updated(k, f(v, a)))
@@ -1251,7 +1251,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    *
    * Combines elements with same key with supplied function f.
    */
-  final def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): Sink[Nothing, A, A, Map[K, A]] = {
+  def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): Sink[Nothing, A, A, Map[K, A]] = {
     type State = (Map[K, A], Boolean)
     def inner(state: State, a: A): (State, Chunk[A]) = {
       val k      = key(a)
@@ -1269,7 +1269,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Accumulates incoming elements into a list as long as they verify predicate `p`.
    */
-  final def collectAllWhile[A](p: A => Boolean): ZSink[Any, Nothing, A, A, List[A]] =
+  def collectAllWhile[A](p: A => Boolean): ZSink[Any, Nothing, A, A, List[A]] =
     fold[A, A, (List[A], Boolean)]((Nil, true))(_._2) {
       case ((as, _), a) =>
         if (p(a)) ((a :: as, true), Chunk.empty) else ((as, false), Chunk.single(a))
@@ -1278,7 +1278,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Accumulates incoming elements into a list as long as they verify effectful predicate `p`.
    */
-  final def collectAllWhileM[R, E, A](p: A => ZIO[R, E, Boolean]): ZSink[R, E, A, A, List[A]] =
+  def collectAllWhileM[R, E, A](p: A => ZIO[R, E, Boolean]): ZSink[R, E, A, A, List[A]] =
     foldM[R, E, A, A, (List[A], Boolean)]((Nil, true))(_._2) {
       case ((as, _), a) =>
         p(a).map(if (_) ((a :: as, true), Chunk.empty) else ((as, false), Chunk.single(a)))
@@ -1287,38 +1287,38 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink halting with the specified `Throwable`.
    */
-  final def die(e: Throwable): ZSink[Any, Nothing, Nothing, Any, Nothing] =
+  def die(e: Throwable): ZSink[Any, Nothing, Nothing, Any, Nothing] =
     ZSink.halt(Cause.die(e))
 
   /**
    * Creates a sink halting with the specified message, wrapped in a
    * `RuntimeException`.
    */
-  final def dieMessage(m: String): ZSink[Any, Nothing, Nothing, Any, Nothing] =
+  def dieMessage(m: String): ZSink[Any, Nothing, Nothing, Any, Nothing] =
     ZSink.halt(Cause.die(new RuntimeException(m)))
 
   /**
    * Creates a sink consuming all incoming values until completion.
    */
-  final def drain: ZSink[Any, Nothing, Nothing, Any, Unit] =
+  def drain: ZSink[Any, Nothing, Nothing, Any, Unit] =
     foldLeft(())((s, _) => s)
 
   /**
    * Creates a sink containing the first value.
    */
-  final def head[A]: ZSink[Any, Nothing, A, A, Option[A]] =
+  def head[A]: ZSink[Any, Nothing, A, A, Option[A]] =
     identity[A].optional
 
   /**
    * Creates a sink containing the last value.
    */
-  final def last[A]: ZSink[Any, Nothing, Nothing, A, Option[A]] =
+  def last[A]: ZSink[Any, Nothing, Nothing, A, Option[A]] =
     foldLeft[A, Option[A]](None) { case (_, a) => Some(a) }
 
   /**
    * Creates a sink failing with a value of type `E`.
    */
-  final def fail[E](e: E): ZSink[Any, E, Nothing, Any, Nothing] =
+  def fail[E](e: E): ZSink[Any, E, Nothing, Any, Nothing] =
     new SinkPure[E, Nothing, Any, Nothing] {
       type State = Unit
       val initialPure                    = ()
@@ -1330,7 +1330,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink by folding over a structure of type `S`.
    */
-  final def fold[A0, A, S](
+  def fold[A0, A, S](
     z: S
   )(contFn: S => Boolean)(f: (S, A) => (S, Chunk[A0])): ZSink[Any, Nothing, A0, A, S] =
     new SinkPure[Nothing, A0, A, S] {
@@ -1344,19 +1344,19 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink by folding over a structure of type `S`.
    */
-  final def foldLeft[A, S](z: S)(f: (S, A) => S): ZSink[Any, Nothing, Nothing, A, S] =
+  def foldLeft[A, S](z: S)(f: (S, A) => S): ZSink[Any, Nothing, Nothing, A, S] =
     fold(z)(_ => true)((s, a) => (f(s, a), Chunk.empty))
 
   /**
    * Creates a sink by effectfully folding over a structure of type `S`.
    */
-  final def foldLeftM[R, E, A, S](z: S)(f: (S, A) => ZIO[R, E, S]): ZSink[R, E, Nothing, A, S] =
+  def foldLeftM[R, E, A, S](z: S)(f: (S, A) => ZIO[R, E, S]): ZSink[R, E, Nothing, A, S] =
     foldM(z)(_ => true)((s, a) => f(s, a).map((_, Chunk.empty)))
 
   /**
    * Creates a sink by effectfully folding over a structure of type `S`.
    */
-  final def foldM[R, E, A0, A, S](
+  def foldM[R, E, A0, A, S](
     z: S
   )(contFn: S => Boolean)(f: (S, A) => ZIO[R, E, (S, Chunk[A0])]): ZSink[R, E, A0, A, S] =
     new ZSink[R, E, A0, A, S] {
@@ -1376,7 +1376,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * cause the stream to hang. See [[ZSink.foldWeightedDecomposeM]] for
    * a variant that can handle these.
    */
-  final def foldWeightedM[R, R1 <: R, E, E1 >: E, A, S](
+  def foldWeightedM[R, R1 <: R, E, E1 >: E, A, S](
     z: S
   )(
     costFn: A => ZIO[R, E, Long],
@@ -1393,7 +1393,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * cause an `S` aggregate to cross `max` into smaller elements. See
    * [[ZSink.foldWeightedDecompose]] for an example.
    */
-  final def foldWeightedDecomposeM[R, R1 <: R, E, E1 >: E, A, S](
+  def foldWeightedDecomposeM[R, R1 <: R, E, E1 >: E, A, S](
     z: S
   )(
     costFn: A => ZIO[R, E, Long],
@@ -1432,7 +1432,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * cause the stream to hang. See [[ZSink.foldWeightedDecompose]] for
    * a variant that can handle these.
    */
-  final def foldWeighted[A, S](
+  def foldWeighted[A, S](
     z: S
   )(costFn: A => Long, max: Long)(
     f: (S, A) => S
@@ -1464,7 +1464,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * The [[ZSink.foldWeightedDecomposeM]] allows the decompose function
    * to return a `ZIO` value, and consequently it allows the sink to fail.
    */
-  final def foldWeightedDecompose[A, S](
+  def foldWeightedDecompose[A, S](
     z: S
   )(costFn: A => Long, max: Long, decompose: A => Chunk[A])(
     f: (S, A) => S
@@ -1497,7 +1497,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    *
    * Like [[ZSink.foldWeightedM]], but with a constant cost function of 1.
    */
-  final def foldUntilM[R, E, S, A](z: S, max: Long)(f: (S, A) => ZIO[R, E, S]): ZSink[R, E, A, A, S] =
+  def foldUntilM[R, E, S, A](z: S, max: Long)(f: (S, A) => ZIO[R, E, S]): ZSink[R, E, A, A, S] =
     foldWeightedM[R, R, E, E, A, S](z)(_ => UIO.succeed(1), max)(f)
 
   /**
@@ -1506,13 +1506,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    *
    * Like [[ZSink.foldWeighted]], but with a constant cost function of 1.
    */
-  final def foldUntil[S, A](z: S, max: Long)(f: (S, A) => S): ZSink[Any, Nothing, A, A, S] =
+  def foldUntil[S, A](z: S, max: Long)(f: (S, A) => S): ZSink[Any, Nothing, A, A, S] =
     foldWeighted[A, S](z)(_ => 1, max)(f)
 
   /**
    * Creates a single-value sink produced from an effect
    */
-  final def fromEffect[R, E, B](b: => ZIO[R, E, B]): ZSink[R, E, Nothing, Any, B] =
+  def fromEffect[R, E, B](b: => ZIO[R, E, B]): ZSink[R, E, Nothing, Any, B] =
     new ZSink[R, E, Nothing, Any, B] {
       type State = Unit
       val initial                    = IO.succeed(())
@@ -1524,19 +1524,19 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink that purely transforms incoming values.
    */
-  final def fromFunction[A, B](f: A => B): ZSink[Any, Unit, Nothing, A, B] =
+  def fromFunction[A, B](f: A => B): ZSink[Any, Unit, Nothing, A, B] =
     identity.map(f)
 
   /**
    * Creates a sink that effectfully transforms incoming values.
    */
-  final def fromFunctionM[R, E, A, B](f: A => ZIO[R, E, B]): ZSink[R, Option[E], Nothing, A, B] =
+  def fromFunctionM[R, E, A, B](f: A => ZIO[R, E, B]): ZSink[R, Option[E], Nothing, A, B] =
     identity.mapError(_ => None).mapM(f(_).mapError(Some(_)))
 
   /**
    * Creates a sink halting with a specified cause.
    */
-  final def halt[E](e: Cause[E]): ZSink[Any, E, Nothing, Any, Nothing] =
+  def halt[E](e: Cause[E]): ZSink[Any, E, Nothing, Any, Nothing] =
     new Sink[E, Nothing, Any, Nothing] {
       type State = Unit
       val initial                    = UIO.succeed(())
@@ -1548,7 +1548,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a sink by that merely passes on incoming values.
    */
-  final def identity[A]: ZSink[Any, Unit, Nothing, A, A] =
+  def identity[A]: ZSink[Any, Unit, Nothing, A, A] =
     new SinkPure[Unit, Nothing, A, A] {
       type State = Option[A]
       val initialPure                  = None
@@ -1561,7 +1561,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Creates a sink by starts consuming value as soon as one fails
    * the predicate `p`.
    */
-  final def ignoreWhile[A](p: A => Boolean): ZSink[Any, Nothing, A, A, Unit] =
+  def ignoreWhile[A](p: A => Boolean): ZSink[Any, Nothing, A, A, Unit] =
     new SinkPure[Nothing, A, A, Unit] {
       type State = Chunk[A]
       val initialPure                  = Chunk.empty
@@ -1574,7 +1574,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Creates a sink by starts consuming value as soon as one fails
    * the effectful predicate `p`.
    */
-  final def ignoreWhileM[R, E, A](p: A => ZIO[R, E, Boolean]): ZSink[R, E, A, A, Unit] =
+  def ignoreWhileM[R, E, A](p: A => ZIO[R, E, Boolean]): ZSink[R, E, A, A, Unit] =
     new ZSink[R, E, A, A, Unit] {
       type State = Chunk[A]
       val initial                  = IO.succeed(Chunk.empty)
@@ -1587,7 +1587,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Returns a sink that must at least perform one extraction or else
    * will "fail" with `end`.
    */
-  final def pull1[R, R1 <: R, E, A0, A, B](
+  def pull1[R, R1 <: R, E, A0, A, B](
     end: ZIO[R1, E, B]
   )(input: A => ZSink[R, E, A0, A, B]): ZSink[R1, E, A0, A, B] =
     new ZSink[R1, E, A0, A, B] {
@@ -1619,7 +1619,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Creates a sink that consumes the first value verifying the predicate `p`
    * or fails as soon as the sink won't make any more progress.
    */
-  final def read1[E, A](e: Option[A] => E)(p: A => Boolean): ZSink[Any, E, A, A, A] =
+  def read1[E, A](e: Option[A] => E)(p: A => Boolean): ZSink[Any, E, A, A, A] =
     new SinkPure[E, A, A, A] {
       type State = (Either[E, Option[A]], Chunk[A])
 
@@ -1731,7 +1731,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Splits strings on a delimiter.
    */
-  final def splitOn(delimiter: String): ZSink[Any, Nothing, String, String, Chunk[String]] =
+  def splitOn(delimiter: String): ZSink[Any, Nothing, String, String, Chunk[String]] =
     new SinkPure[Nothing, String, String, Chunk[String]] {
       type State = SplitOnState
       case class SplitOnState(
@@ -1808,7 +1808,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a single-value sink from a value.
    */
-  final def succeed[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
+  def succeed[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
     new SinkPure[Nothing, A, A, B] {
       type State = Chunk[A]
       val initialPure                  = Chunk.empty
@@ -1824,7 +1824,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * bandwidth constraints are dropped. The weight of each element is determined by the `costFn` function.
    * Elements are mapped to `Option[A]`, and `None` denotes that a given element has been dropped.
    */
-  final def throttleEnforce[A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleEnforce[A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => Long
   ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, Option[A]]] =
     throttleEnforceM[Any, Nothing, A](units, duration, burst)(a => UIO.succeed(costFn(a)))
@@ -1836,7 +1836,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * bandwidth constraints are dropped. The weight of each element is determined by the `costFn` effectful function.
    * Elements are mapped to `Option[A]`, and `None` denotes that a given element has been dropped.
    */
-  final def throttleEnforceM[R, E, A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleEnforceM[R, E, A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => ZIO[R, E, Long]
   ): ZManaged[Clock, Nothing, ZSink[R with Clock, E, Nothing, A, Option[A]]] = {
     import ZSink.internal._
@@ -1888,7 +1888,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * the token bucket to accumulate tokens up to a `units + burst` threshold. The weight of each element is
    * determined by the `costFn` function.
    */
-  final def throttleShape[A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleShape[A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => Long
   ): ZManaged[Clock, Nothing, ZSink[Clock, Nothing, Nothing, A, A]] =
     throttleShapeM[Any, Nothing, A](units, duration, burst)(a => UIO.succeed(costFn(a)))
@@ -1899,7 +1899,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * the token bucket to accumulate tokens up to a `units + burst` threshold. The weight of each element is
    * determined by the `costFn` effectful function.
    */
-  final def throttleShapeM[R, E, A](units: Long, duration: Duration, burst: Long = 0)(
+  def throttleShapeM[R, E, A](units: Long, duration: Duration, burst: Long = 0)(
     costFn: A => ZIO[R, E, Long]
   ): ZManaged[Clock, Nothing, ZSink[R with Clock, E, Nothing, A, A]] = {
     import ZSink.internal._
@@ -1953,7 +1953,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * This sink uses the String constructor's behavior when handling malformed byte
    * sequences.
    */
-  val utf8DecodeChunk: ZSink[Any, Nothing, Chunk[Byte], Chunk[Byte], String] =
+  final val utf8DecodeChunk: ZSink[Any, Nothing, Chunk[Byte], Chunk[Byte], String] =
     new SinkPure[Nothing, Chunk[Byte], Chunk[Byte], String] {
       type State = (String, Chunk[Byte], Boolean)
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -103,13 +103,13 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
 
     sealed abstract class State
     object State {
-      case class Empty(state: sink.State, notifyConsumer: Promise[Nothing, Unit]) extends State
-      case class Leftovers(state: sink.State, leftovers: Chunk[A1], notifyConsumer: Promise[Nothing, Unit])
+      final case class Empty(state: sink.State, notifyConsumer: Promise[Nothing, Unit]) extends State
+      final case class Leftovers(state: sink.State, leftovers: Chunk[A1], notifyConsumer: Promise[Nothing, Unit])
           extends State
-      case class BatchMiddle(state: sink.State, notifyProducer: Promise[Nothing, Unit]) extends State
-      case class BatchEnd(state: sink.State, notifyProducer: Promise[Nothing, Unit])    extends State
-      case class Error(e: Cause[E1])                                                    extends State
-      case object End                                                                   extends State
+      final case class BatchMiddle(state: sink.State, notifyProducer: Promise[Nothing, Unit]) extends State
+      final case class BatchEnd(state: sink.State, notifyProducer: Promise[Nothing, Unit])    extends State
+      final case class Error(e: Cause[E1])                                                    extends State
+      case object End                                                                         extends State
     }
 
     def withStateVar[R, E, A](ref: Ref[State], permits: Semaphore)(f: State => ZIO[R, E, (A, State)]): ZIO[R, E, A] =
@@ -296,17 +296,17 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
 
     sealed abstract class State
     object State {
-      case class Empty(state: sink.State, notifyConsumer: Promise[Nothing, Unit]) extends State
-      case class Leftovers(state: sink.State, leftovers: Chunk[A1], notifyConsumer: Promise[Nothing, Unit])
+      final case class Empty(state: sink.State, notifyConsumer: Promise[Nothing, Unit]) extends State
+      final case class Leftovers(state: sink.State, leftovers: Chunk[A1], notifyConsumer: Promise[Nothing, Unit])
           extends State
-      case class BatchMiddle(
+      final case class BatchMiddle(
         state: sink.State,
         notifyProducer: Promise[Nothing, Unit],
         notifyConsumer: Promise[Nothing, Unit]
       ) extends State
-      case class BatchEnd(state: sink.State, notifyProducer: Promise[Nothing, Unit]) extends State
-      case class Error(e: Cause[E1])                                                 extends State
-      case object End                                                                extends State
+      final case class BatchEnd(state: sink.State, notifyProducer: Promise[Nothing, Unit]) extends State
+      final case class Error(e: Cause[E1])                                                 extends State
+      case object End                                                                      extends State
     }
 
     def withStateVar[R, E, A](ref: Ref[State], permits: Semaphore)(f: State => ZIO[R, E, (A, State)]): ZIO[R, E, A] =
@@ -2771,39 +2771,39 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream from a scoped [[Pull]].
    */
-  final def apply[R, E, A](pull: ZManaged[R, Nothing, Pull[R, E, A]]): ZStream[R, E, A] =
+  def apply[R, E, A](pull: ZManaged[R, Nothing, Pull[R, E, A]]): ZStream[R, E, A] =
     new ZStream[R, E, A](ZStream.Structure.Iterator(pull))
 
   /**
    * Accesses the environment of the stream.
    */
-  final def access[R]: AccessPartiallyApplied[R] =
+  def access[R]: AccessPartiallyApplied[R] =
     new AccessPartiallyApplied[R]
 
   /**
    * Accesses the environment of the stream in the context of an effect.
    */
-  final def accessM[R]: AccessMPartiallyApplied[R] =
+  def accessM[R]: AccessMPartiallyApplied[R] =
     new AccessMPartiallyApplied[R]
 
   /**
    * Accesses the environment of the stream in the context of a stream.
    */
-  final def accessStream[R]: AccessStreamPartiallyApplied[R] =
+  def accessStream[R]: AccessStreamPartiallyApplied[R] =
     new AccessStreamPartiallyApplied[R]
 
   /**
    * Creates a stream from a single value that will get cleaned up after the
    * stream is consumed
    */
-  final def bracket[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, Any]): ZStream[R, E, A] =
+  def bracket[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, Any]): ZStream[R, E, A] =
     managed(ZManaged.make(acquire)(release))
 
   /**
    * Creates a stream from a single value that will get cleaned up after the
    * stream is consumed
    */
-  final def bracketExit[R, E, A](
+  def bracketExit[R, E, A](
     acquire: ZIO[R, E, A]
   )(release: (A, Exit[Any, Any]) => ZIO[R, Nothing, Any]): ZStream[R, E, A] =
     managed(ZManaged.makeExit(acquire)(release))
@@ -2815,7 +2815,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    *
    * See also [[ZStream#zipN]] for the more common point-wise variant.
    */
-  final def crossN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
+  def crossN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
     f: (A, B) => C
   ): ZStream[R, E, C] =
     zStream1.crossWith(zStream2)(f)
@@ -2827,7 +2827,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    *
    * See also [[ZStream#zipN]] for the more common point-wise variant.
    */
-  final def crossN[R, E, A, B, C, D](
+  def crossN[R, E, A, B, C, D](
     zStream1: ZStream[R, E, A],
     zStream2: ZStream[R, E, B],
     zStream3: ZStream[R, E, C]
@@ -2847,7 +2847,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    *
    * See also [[ZStream#zipN]] for the more common point-wise variant.
    */
-  final def crossN[R, E, A, B, C, D, F](
+  def crossN[R, E, A, B, C, D, F](
     zStream1: ZStream[R, E, A],
     zStream2: ZStream[R, E, B],
     zStream3: ZStream[R, E, C],
@@ -2865,13 +2865,13 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * The stream that always dies with `ex`.
    */
-  final def die(ex: Throwable): Stream[Nothing, Nothing] =
+  def die(ex: Throwable): Stream[Nothing, Nothing] =
     halt(Cause.die(ex))
 
   /**
    * The stream that always dies with an exception described by `msg`.
    */
-  final def dieMessage(msg: String): Stream[Nothing, Nothing] =
+  def dieMessage(msg: String): Stream[Nothing, Nothing] =
     halt(Cause.die(new RuntimeException(msg)))
 
   /**
@@ -2879,7 +2879,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * The optionality of the error type `E` can be used to signal the end of the stream,
    * by setting it to `None`.
    */
-  final def effectAsync[R, E, A](
+  def effectAsync[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => Unit,
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
@@ -2894,7 +2894,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * The optionality of the error type `E` can be used to signal the end of the stream,
    * by setting it to `None`.
    */
-  final def effectAsyncMaybe[R, E, A](
+  def effectAsyncMaybe[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
@@ -2943,7 +2943,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * The registration of the callback itself returns an effect. The optionality of the
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
-  final def effectAsyncM[R, E, A](
+  def effectAsyncM[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
@@ -2986,7 +2986,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * The optionality of the error type `E` can be used to signal the end of the stream, by
    * setting it to `None`.
    */
-  final def effectAsyncInterrupt[R, E, A](
+  def effectAsyncInterrupt[R, E, A](
     register: (ZIO[R, Option[E], A] => Unit) => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
@@ -3034,19 +3034,19 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Accesses the whole environment of the stream.
    */
-  final def environment[R]: ZStream[R, Nothing, R] =
+  def environment[R]: ZStream[R, Nothing, R] =
     ZStream.fromEffect(ZIO.environment[R])
 
   /**
    * The stream that always fails with `error`
    */
-  final def fail[E](error: E): Stream[E, Nothing] =
+  def fail[E](error: E): Stream[E, Nothing] =
     StreamEffect.fail[E](error)
 
   /**
    * Creates an empty stream that never fails and executes the finalizer when it ends.
    */
-  final def finalizer[R](finalizer: ZIO[R, Nothing, Any]): ZStream[R, Nothing, Nothing] =
+  def finalizer[R](finalizer: ZIO[R, Nothing, Any]): ZStream[R, Nothing, Nothing] =
     ZStream {
       for {
         finalizerRef <- ZManaged.finalizerRef[R](_ => UIO.unit)
@@ -3057,7 +3057,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Flattens nested streams.
    */
-  final def flatten[R, E, A](fa: ZStream[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
+  def flatten[R, E, A](fa: ZStream[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
     fa.flatMap(identity)
 
   /**
@@ -3065,7 +3065,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * concurrent merge. Up to `n` streams may be consumed in parallel and up to
    * `outputBuffer` elements may be buffered by this operator.
    */
-  final def flattenPar[R, E, A](n: Int, outputBuffer: Int = 16)(
+  def flattenPar[R, E, A](n: Int, outputBuffer: Int = 16)(
     fa: ZStream[R, E, ZStream[R, E, A]]
   ): ZStream[R, E, A] =
     fa.flatMapPar(n, outputBuffer)(identity)
@@ -3073,7 +3073,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Like [[flattenPar]], but executes all streams concurrently.
    */
-  final def flattenParUnbounded[R, E, A](outputBuffer: Int = 16)(
+  def flattenParUnbounded[R, E, A](outputBuffer: Int = 16)(
     fa: ZStream[R, E, ZStream[R, E, A]]
   ): ZStream[R, E, A] =
     flattenPar(Int.MaxValue, outputBuffer)(fa)
@@ -3081,7 +3081,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream from a [[java.io.InputStream]]
    */
-  final def fromInputStream(
+  def fromInputStream(
     is: InputStream,
     chunkSize: Int = ZStreamChunk.DefaultChunkSize
   ): StreamEffectChunk[Any, IOException, Byte] =
@@ -3090,19 +3090,19 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream from a [[zio.Chunk]] of values
    */
-  final def fromChunk[A](c: Chunk[A]): Stream[Nothing, A] =
+  def fromChunk[A](c: Chunk[A]): Stream[Nothing, A] =
     StreamEffect.fromChunk(c)
 
   /**
    * Creates a stream from an effect producing a value of type `A`
    */
-  final def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
+  def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
     managed(fa.toManaged_)
 
   /**
    * Creates a stream from an effect producing a value of type `A` or an empty Stream
    */
-  final def fromEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
+  def fromEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
     ZStream.unwrap {
       fa.fold(_.fold[ZStream[Any, E, Nothing]](ZStream.empty)(ZStream.fail(_)), ZStream.succeed(_))
     }
@@ -3110,37 +3110,37 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream from an iterable collection of values
    */
-  final def fromIterable[A](as: Iterable[A]): Stream[Nothing, A] =
+  def fromIterable[A](as: Iterable[A]): Stream[Nothing, A] =
     StreamEffect.fromIterable(as)
 
   /**
    * Creates a stream from an iterator
    */
-  final def fromIterator[R, E, A](iterator: ZIO[R, E, Iterator[A]]): ZStream[R, E, A] =
+  def fromIterator[R, E, A](iterator: ZIO[R, E, Iterator[A]]): ZStream[R, E, A] =
     fromEffect(iterator).flatMap(StreamEffect.fromIterator)
 
   /**
    * Creates a stream from a Java iterator
    */
-  final def fromJavaIterator[R, E, A](iterator: ZIO[R, E, ju.Iterator[A]]): ZStream[R, E, A] =
+  def fromJavaIterator[R, E, A](iterator: ZIO[R, E, ju.Iterator[A]]): ZStream[R, E, A] =
     fromEffect(iterator).flatMap(StreamEffect.fromJavaIterator)
 
   /**
    * Creates a stream from a managed iterator
    */
-  final def fromIteratorManaged[R, E, A](iterator: ZManaged[R, E, Iterator[A]]): ZStream[R, E, A] =
+  def fromIteratorManaged[R, E, A](iterator: ZManaged[R, E, Iterator[A]]): ZStream[R, E, A] =
     managed(iterator).flatMap(StreamEffect.fromIterator)
 
   /**
    * Creates a stream from a managed iterator
    */
-  final def fromJavaIteratorManaged[R, E, A](iterator: ZManaged[R, E, ju.Iterator[A]]): ZStream[R, E, A] =
+  def fromJavaIteratorManaged[R, E, A](iterator: ZManaged[R, E, ju.Iterator[A]]): ZStream[R, E, A] =
     managed(iterator).flatMap(StreamEffect.fromJavaIterator)
 
   /**
    * Creates a stream from a [[zio.ZQueue]] of values
    */
-  final def fromQueue[R, E, A](queue: ZQueue[Nothing, Any, R, E, Nothing, A]): ZStream[R, E, A] =
+  def fromQueue[R, E, A](queue: ZQueue[Nothing, Any, R, E, Nothing, A]): ZStream[R, E, A] =
     ZStream {
       ZManaged.succeed {
         queue.take.catchAllCause(
@@ -3156,24 +3156,24 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream from a [[zio.ZQueue]] of values. The queue will be shutdown once the stream is closed.
    */
-  final def fromQueueWithShutdown[R, E, A](queue: ZQueue[Nothing, Any, R, E, Nothing, A]): ZStream[R, E, A] =
+  def fromQueueWithShutdown[R, E, A](queue: ZQueue[Nothing, Any, R, E, Nothing, A]): ZStream[R, E, A] =
     fromQueue(queue).ensuringFirst(queue.shutdown)
 
   /**
    * The stream that always halts with `cause`.
    */
-  final def halt[E](cause: Cause[E]): ZStream[Any, E, Nothing] = fromEffect(ZIO.halt(cause))
+  def halt[E](cause: Cause[E]): ZStream[Any, E, Nothing] = fromEffect(ZIO.halt(cause))
 
   /**
    * The infinite stream of iterative function application: a, f(a), f(f(a)), f(f(f(a))), ...
    */
-  final def iterate[A](a: A)(f: A => A): ZStream[Any, Nothing, A] =
+  def iterate[A](a: A)(f: A => A): ZStream[Any, Nothing, A] =
     StreamEffect.iterate(a)(f)
 
   /**
    * Creates a single-valued stream from a managed resource
    */
-  final def managed[R, E, A](managed: ZManaged[R, E, A]): ZStream[R, E, A] =
+  def managed[R, E, A](managed: ZManaged[R, E, A]): ZStream[R, E, A] =
     ZStream {
       for {
         doneRef   <- Ref.make(false).toManaged_
@@ -3198,7 +3198,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * Up to `n` streams may be consumed in parallel and up to
    * `outputBuffer` elements may be buffered by this operator.
    */
-  final def mergeAll[R, E, A](n: Int, outputBuffer: Int = 16)(
+  def mergeAll[R, E, A](n: Int, outputBuffer: Int = 16)(
     streams: ZStream[R, E, A]*
   ): ZStream[R, E, A] =
     flattenPar(n, outputBuffer)(fromIterable(streams))
@@ -3206,7 +3206,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Like [[mergeAll]], but runs all streams concurrently.
    */
-  final def mergeAllUnbounded[R, E, A](outputBuffer: Int = 16)(
+  def mergeAllUnbounded[R, E, A](outputBuffer: Int = 16)(
     streams: ZStream[R, E, A]*
   ): ZStream[R, E, A] = mergeAll(Int.MaxValue, outputBuffer)(streams: _*)
 
@@ -3215,7 +3215,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * the unfolding of the state. This is useful for embedding paginated APIs,
    * hence the name.
    */
-  final def paginate[A, S](s: S)(f: S => (A, Option[S])): Stream[Nothing, A] =
+  def paginate[A, S](s: S)(f: S => (A, Option[S])): Stream[Nothing, A] =
     StreamEffect.paginate(s)(f)
 
   /**
@@ -3223,7 +3223,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * the unfolding of the state. This is useful for embedding paginated APIs,
    * hence the name.
    */
-  final def paginateM[R, E, A, S](s: S)(f: S => ZIO[R, E, (A, Option[S])]): ZStream[R, E, A] =
+  def paginateM[R, E, A, S](s: S)(f: S => ZIO[R, E, (A, Option[S])]): ZStream[R, E, A] =
     ZStream {
       for {
         ref <- Ref.make[Option[S]](Some(s)).toManaged_
@@ -3236,25 +3236,25 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Constructs a stream from a range of integers (lower bound included, upper bound not included)
    */
-  final def range(min: Int, max: Int): Stream[Nothing, Int] =
+  def range(min: Int, max: Int): Stream[Nothing, Int] =
     iterate(min)(_ + 1).takeWhile(_ < max)
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats forever
    */
-  final def repeatEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
+  def repeatEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
     fromEffect(fa).forever
 
   /**
    * Creates a stream from an effect producing values of type `A` until it fails with None.
    */
-  final def repeatEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
+  def repeatEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
     ZStream(ZManaged.succeed(fa))
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats using the specified schedule
    */
-  final def repeatEffectWith[R, E, A](
+  def repeatEffectWith[R, E, A](
     fa: ZIO[R, E, A],
     schedule: Schedule[R, Unit, _]
   ): ZStream[R, E, A] =
@@ -3263,19 +3263,19 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a single-valued pure stream
    */
-  final def succeed[A](a: A): Stream[Nothing, A] =
+  def succeed[A](a: A): Stream[Nothing, A] =
     StreamEffect.succeed(a)
 
   /**
    * Creates a stream by peeling off the "layers" of a value of type `S`
    */
-  final def unfold[S, A](s: S)(f0: S => Option[(A, S)]): Stream[Nothing, A] =
+  def unfold[S, A](s: S)(f0: S => Option[(A, S)]): Stream[Nothing, A] =
     StreamEffect.unfold(s)(f0)
 
   /**
    * Creates a stream by effectfully peeling off the "layers" of a value of type `S`
    */
-  final def unfoldM[R, E, A, S](s: S)(f0: S => ZIO[R, E, Option[(A, S)]]): ZStream[R, E, A] =
+  def unfoldM[R, E, A, S](s: S)(f0: S => ZIO[R, E, Option[(A, S)]]): ZStream[R, E, A] =
     ZStream {
       for {
         done <- Ref.make(false).toManaged_
@@ -3300,19 +3300,19 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Creates a stream produced from an effect
    */
-  final def unwrap[R, E, A](fa: ZIO[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
+  def unwrap[R, E, A](fa: ZIO[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
     flatten(fromEffect(fa))
 
   /**
    * Creates a stream produced from a [[ZManaged]]
    */
-  final def unwrapManaged[R, E, A](fa: ZManaged[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
+  def unwrapManaged[R, E, A](fa: ZManaged[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
     flatten(managed(fa))
 
   /**
    * Zips the specified streams together with the specified function.
    */
-  final def zipN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
+  def zipN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
     f: (A, B) => C
   ): ZStream[R, E, C] =
     zStream1.zipWith(zStream2)((l, r) => l.flatMap(a => r.map(b => f(a, b))))
@@ -3320,7 +3320,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
   /**
    * Zips with specified streams together with the specified function.
    */
-  final def zipN[R, E, A, B, C, D](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B], zStream3: ZStream[R, E, C])(
+  def zipN[R, E, A, B, C, D](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B], zStream3: ZStream[R, E, C])(
     f: (A, B, C) => D
   ): ZStream[R, E, D] =
     (zStream1 <&> zStream2 <&> zStream3).map {
@@ -3332,7 +3332,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * combining their results with the specified `f` function. If any effect
    * fails, then the other effects will be interrupted.
    */
-  final def zipN[R, E, A, B, C, D, F](
+  def zipN[R, E, A, B, C, D, F](
     zStream1: ZStream[R, E, A],
     zStream2: ZStream[R, E, B],
     zStream3: ZStream[R, E, C],
@@ -3357,7 +3357,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
       ZStream.environment[R].flatMap(f)
   }
 
-  private[stream] final def exitToInputStreamRead(exit: Exit[Option[Throwable], Byte]): Int = exit match {
+  private[stream] def exitToInputStreamRead(exit: Exit[Option[Throwable], Byte]): Int = exit match {
     case Exit.Success(value) => value.toInt
     case Exit.Failure(cause) =>
       cause.failureOrCause match {

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -142,7 +142,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Transforms all elements of the stream for as long as the specified partial function is defined.
    */
-   def collectWhile[B](p: PartialFunction[A, B]): ZStreamChunk[R, E, B] =
+  def collectWhile[B](p: PartialFunction[A, B]): ZStreamChunk[R, E, B] =
     ZStreamChunk {
       ZStream {
         for {
@@ -164,7 +164,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Drops the specified number of elements from this stream.
    */
-   def drop(n: Int): ZStreamChunk[R, E, A] =
+  def drop(n: Int): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -201,7 +201,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Drops all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-   def dropWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
+  def dropWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -254,7 +254,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Filters this stream by the specified predicate, retaining all elements for
    * which the predicate evaluates to true.
    */
-   def filter(pred: A => Boolean): ZStreamChunk[R, E, A] =
+  def filter(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk(self.chunks.map(_.filter(pred)))
 
   /**
@@ -282,13 +282,13 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Returns a stream made of the concatenation of all the chunks in this stream
    */
-   def flattenChunks: ZStream[R, E, A] = chunks.flatMap(ZStream.fromChunk)
+  def flattenChunks: ZStream[R, E, A] = chunks.flatMap(ZStream.fromChunk)
 
   /**
    * Executes a pure fold over the stream of values - reduces all elements in the stream to a value of type `S`.
    * See [[ZStream.fold]]
    */
-   def fold[A1 >: A, S](s: S)(f: (S, A1) => S): ZIO[R, E, S] =
+  def fold[A1 >: A, S](s: S)(f: (S, A1) => S): ZIO[R, E, S] =
     chunks
       .foldWhileManagedM[R, E, Chunk[A1], S](s)(_ => true) { (s: S, as: Chunk[A1]) =>
         as.foldM[Any, Nothing, S](s)((s, a) => ZIO.succeed(f(s, a)))
@@ -396,7 +396,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Returns a stream made of the elements of this stream transformed with `f0`
    */
-   def map[B](f: A => B): ZStreamChunk[R, E, B] =
+  def map[B](f: A => B): ZStreamChunk[R, E, B] =
     ZStreamChunk(chunks.map(_.map(f)))
 
   /**
@@ -416,7 +416,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Maps each element to an iterable and flattens the iterables into the output of
    * this stream.
    */
-   def mapConcat[B](f: A => Iterable[B]): ZStreamChunk[R, E, B] =
+  def mapConcat[B](f: A => Iterable[B]): ZStreamChunk[R, E, B] =
     mapConcatChunk(f andThen Chunk.fromIterable)
 
   /**
@@ -553,7 +553,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Takes the specified number of elements from this stream.
    */
-   def take(n: Int): ZStreamChunk[R, E, A] =
+  def take(n: Int): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -576,7 +576,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Takes all elements of the stream until the specified predicate evaluates
    * to `true`.
    */
-   def takeUntil(pred: A => Boolean): ZStreamChunk[R, E, A] =
+  def takeUntil(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -600,7 +600,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Takes all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-   def takeWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
+  def takeWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -628,7 +628,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
     })
 
   @silent("never used")
-   def toInputStream(implicit ev0: E <:< Throwable, ev1: A <:< Byte): ZManaged[R, E, java.io.InputStream] =
+  def toInputStream(implicit ev0: E <:< Throwable, ev1: A <:< Byte): ZManaged[R, E, java.io.InputStream] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -142,7 +142,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Transforms all elements of the stream for as long as the specified partial function is defined.
    */
-  def collectWhile[B](p: PartialFunction[A, B]): ZStreamChunk[R, E, B] =
+   def collectWhile[B](p: PartialFunction[A, B]): ZStreamChunk[R, E, B] =
     ZStreamChunk {
       ZStream {
         for {
@@ -164,7 +164,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Drops the specified number of elements from this stream.
    */
-  def drop(n: Int): ZStreamChunk[R, E, A] =
+   def drop(n: Int): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -201,7 +201,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Drops all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-  def dropWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
+   def dropWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -254,7 +254,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Filters this stream by the specified predicate, retaining all elements for
    * which the predicate evaluates to true.
    */
-  def filter(pred: A => Boolean): ZStreamChunk[R, E, A] =
+   def filter(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk(self.chunks.map(_.filter(pred)))
 
   /**
@@ -282,13 +282,13 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Returns a stream made of the concatenation of all the chunks in this stream
    */
-  def flattenChunks: ZStream[R, E, A] = chunks.flatMap(ZStream.fromChunk)
+   def flattenChunks: ZStream[R, E, A] = chunks.flatMap(ZStream.fromChunk)
 
   /**
    * Executes a pure fold over the stream of values - reduces all elements in the stream to a value of type `S`.
    * See [[ZStream.fold]]
    */
-  def fold[A1 >: A, S](s: S)(f: (S, A1) => S): ZIO[R, E, S] =
+   def fold[A1 >: A, S](s: S)(f: (S, A1) => S): ZIO[R, E, S] =
     chunks
       .foldWhileManagedM[R, E, Chunk[A1], S](s)(_ => true) { (s: S, as: Chunk[A1]) =>
         as.foldM[Any, Nothing, S](s)((s, a) => ZIO.succeed(f(s, a)))
@@ -396,7 +396,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Returns a stream made of the elements of this stream transformed with `f0`
    */
-  def map[B](f: A => B): ZStreamChunk[R, E, B] =
+   def map[B](f: A => B): ZStreamChunk[R, E, B] =
     ZStreamChunk(chunks.map(_.map(f)))
 
   /**
@@ -416,7 +416,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Maps each element to an iterable and flattens the iterables into the output of
    * this stream.
    */
-  final def mapConcat[B](f: A => Iterable[B]): ZStreamChunk[R, E, B] =
+   def mapConcat[B](f: A => Iterable[B]): ZStreamChunk[R, E, B] =
     mapConcatChunk(f andThen Chunk.fromIterable)
 
   /**
@@ -553,7 +553,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
   /**
    * Takes the specified number of elements from this stream.
    */
-  def take(n: Int): ZStreamChunk[R, E, A] =
+   def take(n: Int): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -576,7 +576,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Takes all elements of the stream until the specified predicate evaluates
    * to `true`.
    */
-  def takeUntil(pred: A => Boolean): ZStreamChunk[R, E, A] =
+   def takeUntil(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -600,7 +600,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Takes all elements of the stream for as long as the specified predicate
    * evaluates to `true`.
    */
-  def takeWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
+   def takeWhile(pred: A => Boolean): ZStreamChunk[R, E, A] =
     ZStreamChunk {
       ZStream {
         for {
@@ -628,7 +628,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
     })
 
   @silent("never used")
-  def toInputStream(implicit ev0: E <:< Throwable, ev1: A <:< Byte): ZManaged[R, E, java.io.InputStream] =
+   def toInputStream(implicit ev0: E <:< Throwable, ev1: A <:< Byte): ZManaged[R, E, java.io.InputStream] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process
@@ -692,18 +692,18 @@ object ZStreamChunk extends Serializable {
   /**
    * Creates a `ZStreamChunk` from a stream of chunks
    */
-  final def apply[R, E, A](chunkStream: ZStream[R, E, Chunk[A]]): ZStreamChunk[R, E, A] =
+  def apply[R, E, A](chunkStream: ZStream[R, E, Chunk[A]]): ZStreamChunk[R, E, A] =
     new ZStreamChunk[R, E, A](chunkStream)
 
   /**
    * Creates a `ZStreamChunk` from a variable list of chunks
    */
-  final def fromChunks[A](as: Chunk[A]*): StreamChunk[Nothing, A] =
+  def fromChunks[A](as: Chunk[A]*): StreamChunk[Nothing, A] =
     new StreamEffectChunk(StreamEffect.fromIterable(as))
 
   /**
    * Creates a `ZStreamChunk` from a chunk
    */
-  final def succeed[A](as: Chunk[A]): StreamChunk[Nothing, A] =
+  def succeed[A](as: Chunk[A]): StreamChunk[Nothing, A] =
     new StreamEffectChunk(StreamEffect.succeed(as))
 }

--- a/streams/shared/src/main/scala/zio/stream/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/package.scala
@@ -5,7 +5,7 @@ package object stream {
   type Stream[+E, +A] = ZStream[Any, E, A]
 
   type StreamChunk[+E, +A] = ZStreamChunk[Any, E, A]
-  val StreamChunk = ZStreamChunk
+  final val StreamChunk = ZStreamChunk
 
   type Sink[+E, +A0, -A, +B] = ZSink[Any, E, A0, A, B]
 


### PR DESCRIPTION
I was being bothered by a lot of inconsistencies between final and non final functions. I only covered zio package (core). Afterwards, I extended this to also include vals and classes. 

## The rules followed

1. All methods on classes / traits declared final, by default.

2. No methods on objects declared final.

3. No methods on final classes declared final.

4. All classes inside objects should be defined final.

5. All final classes and potentially classes have their constructors and parameters private.

6. All vals are final. Either in objects or final classes. (Discussed with @regiskuckaertz I have yet to dig deep into the reasoning behind this. Hope he can shed more light)

7. Inside objects or final classes any private val or method does not need to be final. 

8. Inside objects or final classes any package private val or method must be final.

9. If the class has all members final. Make the class final. Remove final annotations from members

**These rules are followed until exceptions are found. But, until exceptions are found (for new code, I believe this should be the standard.**

Let me know your thoughts :D I will still go over everything again for a second round I believe I missed some small cases just to make everything normalized. Also, do let me know, if this is taking things too far.