### PR TITLE
Fix broken scaladoc links and fail build on scaladoc warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ mdoc: &mdoc
     - run:
         name: Generate documentation
         command: |
-          ./sbt coreJVM/doc coreJS/doc streamsJVM/doc streamsJS/doc testJVM/doc testJS/doc
+          ./sbt -Dfatal.warnings=true coreJVM/doc coreJS/doc streamsJVM/doc streamsJS/doc testJVM/doc testJS/doc
           ./sbt ++${SCALA_VERSION}! mdoc
     - <<: *clean_cache
     - <<: *save_cache

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -407,7 +407,7 @@ object Fiber {
    * @param id            The fiber's unique identifier
    * @param interruptors  The set of fibers attempting to interrupt the fiber or its ancestors.
    * @param executor      The [[zio.internal.Executor]] executing this fiber
-   * @param children      The fiber's forked children. This will only be populated if the fiber is supervised (via [[ZIO#supervised]]).
+   * @param children      The fiber's forked children.
    */
   final case class Descriptor(
     id: Fiber.Id,

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -452,19 +452,19 @@ object IO {
     ZIO.lock(executor)(io)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C]*]]
    */
   final def mapN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapN(io1, io2)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapN(io1, io2, io3)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F
@@ -472,19 +472,19 @@ object IO {
     ZIO.mapN(io1, io2, io3, io4)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapParN(io1, io2)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapParN(io1, io2, io3)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -452,19 +452,19 @@ object IO {
     ZIO.lock(executor)(io)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapN(io1, io2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapN(io1, io2, io3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F
@@ -472,19 +472,19 @@ object IO {
     ZIO.mapN(io1, io2, io3, io4)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[E, A, B, C](io1: IO[E, A], io2: IO[E, B])(f: (A, B) => C): IO[E, C] =
     ZIO.mapParN(io1, io2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[E, A, B, C, D](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C])(f: (A, B, C) => D): IO[E, D] =
     ZIO.mapParN(io1, io2, io3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[E, A, B, C, D, F](io1: IO[E, A], io2: IO[E, B], io3: IO[E, C], io4: IO[E, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -180,13 +180,13 @@ object Managed {
     ZManaged.makeInterruptible(acquire)(release)
 
   /**
-   *  @see [[zio.ZManaged.mapN]]
+   *  @see [[zio.ZManaged.mapN[R,E,A,B,C]*]]
    */
   final def mapN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
     ZManaged.mapN(managed1, managed2)(f)
 
   /**
-   *  @see [[zio.ZManaged.mapN]]
+   *  @see [[zio.ZManaged.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
     f: (A, B, C) => D
@@ -194,7 +194,7 @@ object Managed {
     ZManaged.mapN(managed1, managed2, managed3)(f)
 
   /**
-   *  @see [[zio.ZManaged.mapN]]
+   *  @see [[zio.ZManaged.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[E, A, B, C, D, F](
     managed1: Managed[E, A],
@@ -207,13 +207,13 @@ object Managed {
     ZManaged.mapN(managed1, managed2, managed3, managed4)(f)
 
   /**
-   *  @see [[zio.ZManaged.mapParN]]
+   *  @see [[zio.ZManaged.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[E, A, B, C](managed1: Managed[E, A], managed2: Managed[E, B])(f: (A, B) => C): Managed[E, C] =
     ZManaged.mapParN(managed1, managed2)(f)
 
   /**
-   *  @see [[zio.ZManaged.mapParN]]
+   *  @see [[zio.ZManaged.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[E, A, B, C, D](managed1: Managed[E, A], managed2: Managed[E, B], managed3: Managed[E, C])(
     f: (A, B, C) => D
@@ -221,7 +221,7 @@ object Managed {
     ZManaged.mapParN(managed1, managed2, managed3)(f)
 
   /**
-   *  @see [[zio.ZManaged.mapParN]]
+   *  @see [[zio.ZManaged.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[E, A, B, C, D, F](
     managed1: Managed[E, A],

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -435,13 +435,13 @@ object RIO {
   final def left[R, A](a: A): RIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C]*]]
    */
   final def mapN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapN(rio1, rio2)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(
     f: (A, B, C) => D
@@ -449,7 +449,7 @@ object RIO {
     ZIO.mapN(rio1, rio2, rio3)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F
@@ -457,19 +457,19 @@ object RIO {
     ZIO.mapN(rio1, rio2, rio3, rio4)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapParN(rio1, rio2)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(f: (A, B, C) => D): RIO[R, D] =
     ZIO.mapParN(rio1, rio2, rio3)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -435,13 +435,13 @@ object RIO {
   final def left[R, A](a: A): RIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapN(rio1, rio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(
     f: (A, B, C) => D
@@ -449,7 +449,7 @@ object RIO {
     ZIO.mapN(rio1, rio2, rio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F
@@ -457,19 +457,19 @@ object RIO {
     ZIO.mapN(rio1, rio2, rio3, rio4)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C](rio1: RIO[R, A], rio2: RIO[R, B])(f: (A, B) => C): RIO[R, C] =
     ZIO.mapParN(rio1, rio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C, D](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C])(f: (A, B, C) => D): RIO[R, D] =
     ZIO.mapParN(rio1, rio2, rio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C, D, F](rio1: RIO[R, A], rio2: RIO[R, B], rio3: RIO[R, C], rio4: RIO[R, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -447,19 +447,19 @@ object Task {
     ZIO.lock(executor)(task)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapN(task1, task2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapN(task1, task2, task3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F
@@ -467,19 +467,19 @@ object Task {
     ZIO.mapN(task1, task2, task3, task4)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapParN(task1, task2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapParN(task1, task2, task3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -447,19 +447,19 @@ object Task {
     ZIO.lock(executor)(task)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C]*]]
    */
   final def mapN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapN(task1, task2)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapN(task1, task2, task3)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F
@@ -467,19 +467,19 @@ object Task {
     ZIO.mapN(task1, task2, task3, task4)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[A, B, C](task1: Task[A], task2: Task[B])(f: (A, B) => C): Task[C] =
     ZIO.mapParN(task1, task2)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[A, B, C, D](task1: Task[A], task2: Task[B], task3: Task[C])(f: (A, B, C) => D): Task[D] =
     ZIO.mapParN(task1, task2, task3)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[A, B, C, D, F](task1: Task[A], task2: Task[B], task3: Task[C], task4: Task[D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -352,37 +352,37 @@ object UIO {
     ZIO.lock(executor)(uio)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C]*]]
    */
   final def mapN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapN(uio1, uio2)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapN(uio1, uio2, uio3)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(f: (A, B, C, D) => F): UIO[F] =
     ZIO.mapN(uio1, uio2, uio3, uio4)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapParN(uio1, uio2)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapParN(uio1, uio2, uio3)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -352,37 +352,37 @@ object UIO {
     ZIO.lock(executor)(uio)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapN(uio1, uio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapN(uio1, uio2, uio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(f: (A, B, C, D) => F): UIO[F] =
     ZIO.mapN(uio1, uio2, uio3, uio4)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C](uio1: UIO[A], uio2: UIO[B])(f: (A, B) => C): UIO[C] =
     ZIO.mapParN(uio1, uio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C, D](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C])(f: (A, B, C) => D): UIO[D] =
     ZIO.mapParN(uio1, uio2, uio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[A, B, C, D, F](uio1: UIO[A], uio2: UIO[B], uio3: UIO[C], uio4: UIO[D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -381,13 +381,13 @@ object URIO {
   final def left[R, A](a: A): URIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C]*]]
    */
   final def mapN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapN(urio1, urio2)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D]*]]
    */
   final def mapN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
@@ -395,7 +395,7 @@ object URIO {
     ZIO.mapN(urio1, urio2, urio3)(f)
 
   /**
-   *  @see mapN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapN[R,E,A,B,C,D,F]*]]
    */
   final def mapN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F
@@ -403,13 +403,13 @@ object URIO {
     ZIO.mapN(urio1, urio2, urio3, urio4)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C]*]]
    */
   final def mapParN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapParN(urio1, urio2)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D]*]]
    */
   final def mapParN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
@@ -417,7 +417,7 @@ object URIO {
     ZIO.mapParN(urio1, urio2, urio3)(f)
 
   /**
-   *  @see mapParN in [[zio.ZIO$ ZIO]]
+   *  @see [[zio.ZIO.mapParN[R,E,A,B,C,D,F]*]]
    */
   final def mapParN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -248,7 +248,7 @@ object URIO {
     ZIO.foldLeft(in)(zero)(f)
 
   /**
-   * @see [[zio.ZIO.foldRight]
+   * @see [[zio.ZIO.foldRight]]
    */
   final def foldRight[R, S, A](in: Iterable[A])(zero: S)(f: (A, S) => URIO[R, S]): URIO[R, S] =
     ZIO.foldRight(in)(zero)(f)
@@ -381,13 +381,13 @@ object URIO {
   final def left[R, A](a: A): URIO[R, Either[A, Nothing]] = ZIO.left(a)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapN(urio1, urio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
@@ -395,7 +395,7 @@ object URIO {
     ZIO.mapN(urio1, urio2, urio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapN]]
+   *  @see mapN in [[zio.ZIO$ ZIO]]
    */
   final def mapN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F
@@ -403,13 +403,13 @@ object URIO {
     ZIO.mapN(urio1, urio2, urio3, urio4)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C](urio1: URIO[R, A], urio2: URIO[R, B])(f: (A, B) => C): URIO[R, C] =
     ZIO.mapParN(urio1, urio2)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C, D](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C])(
     f: (A, B, C) => D
@@ -417,7 +417,7 @@ object URIO {
     ZIO.mapParN(urio1, urio2, urio3)(f)
 
   /**
-   *  @see [[zio.ZIO.mapParN]]
+   *  @see mapParN in [[zio.ZIO$ ZIO]]
    */
   final def mapParN[R, A, B, C, D, F](urio1: URIO[R, A], urio2: URIO[R, B], urio3: URIO[R, C], urio4: URIO[R, D])(
     f: (A, B, C, D) => F

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1692,7 +1692,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self &&& that
 }
 
-private[zio] trait ZIOFunctions extends Serializable {
+object ZIO {
 
   /**
    * Submerges the error case of an `Either` into the `ZIO`. The inverse
@@ -1850,21 +1850,21 @@ private[zio] trait ZIOFunctions extends Serializable {
    * Checks the daemon status, and produces the effect returned by the
    * specified callback.
    */
-  final def checkDaemon[R, E, A](f: DaemonStatus => ZIO[R, E, A]): ZIO[R, E, A] =
+  final def checkDaemon[R, E, A](f: DaemonS => ZIO[R, E, A]): ZIO[R, E, A] =
     new ZIO.CheckDaemon(f)
 
   /**
    * Checks the interrupt status, and produces the effect returned by the
    * specified callback.
    */
-  final def checkInterruptible[R, E, A](f: InterruptStatus => ZIO[R, E, A]): ZIO[R, E, A] =
+  final def checkInterruptible[R, E, A](f: InterruptS => ZIO[R, E, A]): ZIO[R, E, A] =
     new ZIO.CheckInterrupt(f)
 
   /**
    * Checks the ZIO Tracing status, and produces the effect returned by the
    * specified callback.
    */
-  final def checkTraced[R, E, A](f: TracingStatus => ZIO[R, E, A]): ZIO[R, E, A] =
+  final def checkTraced[R, E, A](f: TracingS => ZIO[R, E, A]): ZIO[R, E, A] =
     new ZIO.CheckTracing(f)
 
   /**
@@ -2904,9 +2904,6 @@ private[zio] trait ZIOFunctions extends Serializable {
    */
   final def _2[R, E, A, B](implicit ev: R <:< (A, B)): ZIO[R, E, B] = fromFunction[R, B](_._2)
 
-}
-
-object ZIO extends ZIOFunctions {
   def apply[A](a: => A): Task[A] = effect(a)
 
   private val _IdentityFn: Any => Any = (a: Any) => a

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -61,13 +61,13 @@ object Stream extends Serializable {
     ZStream.bracketExit(acquire)(release)
 
   /**
-   *  @see [[zio.ZStream.crossN]]
+   *  @see [[ZStream.crossN[R,E,A,B,C]*]]
    */
   final def crossN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
     ZStream.crossN(stream1, stream2)(f)
 
   /**
-   *  @see [[zio.ZStream.crossN]]
+   *  @see [[ZStream.crossN[R,E,A,B,C,D]*]]
    */
   final def crossN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
     f: (A, B, C) => D
@@ -75,7 +75,7 @@ object Stream extends Serializable {
     ZStream.crossN(stream1, stream2, stream3)(f)
 
   /**
-   *  @see [[zio.ZStream.crossN]]
+   *  @see [[ZStream.crossN[R,E,A,B,C,D,F]*]]
    */
   final def crossN[E, A, B, C, D, F](
     stream1: Stream[E, A],
@@ -323,13 +323,13 @@ object Stream extends Serializable {
     ZStream.unwrapManaged(fa)
 
   /**
-   *  @see [[zio.ZStream.zipN]]
+   *  @see [[ZStream.zipN[R,E,A,B,C]*]]
    */
   final def zipN[E, A, B, C](stream1: Stream[E, A], stream2: Stream[E, B])(f: (A, B) => C): Stream[E, C] =
     ZStream.zipN(stream1, stream2)(f)
 
   /**
-   *  @see [[zio.ZStream.zipN]]
+   *  @see [[ZStream.zipN[R,E,A,B,C,D]*]]
    */
   final def zipN[E, A, B, C, D](stream1: Stream[E, A], stream2: Stream[E, B], stream3: Stream[E, C])(
     f: (A, B, C) => D
@@ -337,7 +337,7 @@ object Stream extends Serializable {
     ZStream.zipN(stream1, stream2, stream3)(f)
 
   /**
-   *  @see [[zio.ZStream.zipN]]
+   *  @see [[ZStream.zipN[R,E,A,B,C,D,F]*]]
    */
   final def zipN[E, A, B, C, D, F](
     stream1: Stream[E, A],

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2813,7 +2813,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * with a specified function. Subsequent streams would be run multiple times,
    * for every combination of elements in the prior streams.
    *
-   * See also [[ZStream#zipN]] for the more common point-wise variant.
+   * See also [[ZStream#zipN[R,E,A,B,C]*]] for the more common point-wise variant.
    */
   final def crossN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
     f: (A, B) => C
@@ -2825,7 +2825,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * with a specified function. Subsequent stream would be run multiple times,
    * for every combination of elements in the prior streams.
    *
-   * See also [[ZStream#zipN]] for the more common point-wise variant.
+   * See also [[ZStream#zipN[R,E,A,B,C,D]*]] for the more common point-wise variant.
    */
   final def crossN[R, E, A, B, C, D](
     zStream1: ZStream[R, E, A],
@@ -2845,7 +2845,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * with a specified function. Subsequent stream would be run multiple times,
    * for every combination of elements in the prior streams.
    *
-   * See also [[ZStream#zipN]] for the more common point-wise variant.
+   * See also [[ZStream#zipN[R,E,A,B,C,D,F]*]] for the more common point-wise variant.
    */
   final def crossN[R, E, A, B, C, D, F](
     zStream1: ZStream[R, E, A],

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -404,39 +404,46 @@ object TestAspect extends TimeoutVariants {
   def parallelN(n: Int): TestAspectPoly = executionStrategy(ExecutionStrategy.ParallelN(n))
 
   /**
-   * An aspect that restores a given [[Restorable]]'s state to its starting state after the test is run.
+   * An aspect that restores a given [[zio.test.environment.Restorable Restorable]]'s state to its starting state 
+   * after the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restore[R0](service: R0 => Restorable): TestAspectAtLeastR[R0] =
     around(ZIO.accessM[R0](r => service(r).save))(restore => restore)
 
   /**
-   * An aspect that restores the [[TestClock]]'s state to its starting state after the test is run.
+   * An aspect that restores the [[zio.test.environment.TestClock TestClock]]'s state to its starting state after 
+   * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestClock: TestAspectAtLeastR[TestClock] = restore[TestClock](_.clock)
 
   /**
-   * An aspect that restores the [[TestConsole]]'s state to its starting state after the test is run.
+   * An aspect that restores the [[zio.test.environment.TestConsole TestConsole]]'s state to its starting state after 
+   * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestConsole: TestAspectAtLeastR[TestConsole] = restore[TestConsole](_.console)
 
   /**
-   * An aspect that restores the [[TestRandom]]'s state to its starting state after the test is run.
+   * An aspect that restores the [[zio.test.environment.TestRandom TestRandom]]'s state to its starting state after 
+   * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestRandom: TestAspectAtLeastR[TestRandom] = restore[TestRandom](_.random)
 
   /**
-   * An aspect that restores the [[TestSystem]]'s state to its starting state after the test is run.
+   * An aspect that restores the [[zio.test.environment.TestSystem TestSystem]]'s state to its starting state after 
+   * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestSystem: TestAspectAtLeastR[ZTestEnv] = restore[TestSystem](_.system)
 
   /**
    * An aspect that restores all state in the standard provided test environments
-   * ([[TestClock]], [[TestConsole]], [[TestRandom]] and [[TestSystem]]) to their starting state after the test is run.
+   * ([[zio.test.environment.TestClock TestClock]], [[zio.test.environment.TestConsole TestConsole]], 
+   * [[zio.test.environment.TestRandom TestRandom]] and [[zio.test.environment.TestSystem TestSystem]]) to their 
+   * starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestEnvironment: TestAspectAtLeastR[ZTestEnv] =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -404,7 +404,7 @@ object TestAspect extends TimeoutVariants {
   def parallelN(n: Int): TestAspectPoly = executionStrategy(ExecutionStrategy.ParallelN(n))
 
   /**
-   * An aspect that restores a given [[zio.test.environment.Restorable Restorable]]'s state to its starting state 
+   * An aspect that restores a given [[zio.test.environment.Restorable Restorable]]'s state to its starting state
    * after the test is run.
    * Note that this is only useful when repeating tests.
    */
@@ -412,28 +412,28 @@ object TestAspect extends TimeoutVariants {
     around(ZIO.accessM[R0](r => service(r).save))(restore => restore)
 
   /**
-   * An aspect that restores the [[zio.test.environment.TestClock TestClock]]'s state to its starting state after 
+   * An aspect that restores the [[zio.test.environment.TestClock TestClock]]'s state to its starting state after
    * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestClock: TestAspectAtLeastR[TestClock] = restore[TestClock](_.clock)
 
   /**
-   * An aspect that restores the [[zio.test.environment.TestConsole TestConsole]]'s state to its starting state after 
+   * An aspect that restores the [[zio.test.environment.TestConsole TestConsole]]'s state to its starting state after
    * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestConsole: TestAspectAtLeastR[TestConsole] = restore[TestConsole](_.console)
 
   /**
-   * An aspect that restores the [[zio.test.environment.TestRandom TestRandom]]'s state to its starting state after 
+   * An aspect that restores the [[zio.test.environment.TestRandom TestRandom]]'s state to its starting state after
    * the test is run.
    * Note that this is only useful when repeating tests.
    */
   def restoreTestRandom: TestAspectAtLeastR[TestRandom] = restore[TestRandom](_.random)
 
   /**
-   * An aspect that restores the [[zio.test.environment.TestSystem TestSystem]]'s state to its starting state after 
+   * An aspect that restores the [[zio.test.environment.TestSystem TestSystem]]'s state to its starting state after
    * the test is run.
    * Note that this is only useful when repeating tests.
    */
@@ -441,8 +441,8 @@ object TestAspect extends TimeoutVariants {
 
   /**
    * An aspect that restores all state in the standard provided test environments
-   * ([[zio.test.environment.TestClock TestClock]], [[zio.test.environment.TestConsole TestConsole]], 
-   * [[zio.test.environment.TestRandom TestRandom]] and [[zio.test.environment.TestSystem TestSystem]]) to their 
+   * ([[zio.test.environment.TestClock TestClock]], [[zio.test.environment.TestConsole TestConsole]],
+   * [[zio.test.environment.TestRandom TestRandom]] and [[zio.test.environment.TestSystem TestSystem]]) to their
    * starting state after the test is run.
    * Note that this is only useful when repeating tests.
    */

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -83,7 +83,8 @@ package object test extends CompileVariants {
   type TestExecutor[+R, E, L, -T, +S] = (ZSpec[R, E, L, T], ExecutionStrategy) => UIO[ExecutedSpec[E, L, S]]
 
   /**
-   * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable]] [[TestEnvironment]] objects
+   * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable Restorable]] 
+   * [[zio.test.environment.TestEnvironment TestEnvironment]] objects
    */
   type ZTestEnv = TestClock with TestConsole with TestRandom with TestSystem
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -83,7 +83,7 @@ package object test extends CompileVariants {
   type TestExecutor[+R, E, L, -T, +S] = (ZSpec[R, E, L, T], ExecutionStrategy) => UIO[ExecutedSpec[E, L, S]]
 
   /**
-   * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable Restorable]] 
+   * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable Restorable]]
    * [[zio.test.environment.TestEnvironment TestEnvironment]] objects
    */
   type ZTestEnv = TestClock with TestConsole with TestRandom with TestSystem


### PR DESCRIPTION
Adresses #2485. Note that I couldn't generate proper links from `IO, RIO, Task and URIO` to `ZIO.mapN` and `ZIO.mapParN` as it seems that scaladoc doesn't support disambiguating inherited methods (I've opened a pr to scaladoc here https://github.com/scala/scala/pull/8607). In the mean time I replaced those links to links directly to the `ZIO` object to avoid the warnings.