### PR TITLE
ZIO Test: Don't Exit After Running Tests in Ammonite

### DIFF
--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -56,6 +56,11 @@ trait RunnableSpec[R, E, L, T, S] extends AbstractRunnableSpec {
   }
 
   private def doExit(exitCode: Int): Unit =
-    try sys.exit(exitCode)
+    try if (!isAmmonite) sys.exit(exitCode)
     catch { case _: SecurityException => }
+
+  private def isAmmonite: Boolean =
+    sys.env.exists {
+      case (k, v) => k.contains("JAVA_MAIN_CLASS") && v == "ammonite.Main"
+    }
 }


### PR DESCRIPTION
Resolves #2510. The Java main class is set to `ammonite.Main` when running an interactive session in Ammonite. So we check for that in `doExit` and don't exit if we are in an Ammonite session to avoid terminating the user's interactive session.