### PR TITLE
ZIO Test: Minor Documentation Fix

### DIFF
--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -456,7 +456,7 @@ for {
 It is worth noticing that no actual environment variables or properties will be set during testing so there will be
 no impact on other parts of the system.
 
-### Test Aspects
+## Test Aspects
 
 Test aspects are used to modify existing tests or even entire suites that you have already created. Test aspects are
 applied to a test or suite using the `@@` operator. This is an example test suite showing the use of aspects to modify 


### PR DESCRIPTION
If you look at the website [here](https://zio.dev/docs/howto/howto_test_effects) the link for "Test Aspects" on the right hand side appears as a subcategory of "Using Test Environment" when it should appear at the same level. This fixes that.