### PR TITLE
ZIO Test: 'after' aspect does not run effect if test fails or dies (#2529)

### DIFF
--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -26,17 +26,17 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Parallelly zips the this result with the specified result discarding the first element of the tuple or else returns the failed `Cause[E1]`
    */
-  final def &>[E1 >: E, B](that: Exit[E1, B]): Exit[E1, B] = zipWith(that)((_, _), _ && _).map(_._2)
+  final def &>[E1 >: E, B](that: Exit[E1, B]): Exit[E1, B] = zipWith(that)((_, b) => b, _ && _)
 
   /**
    * Sequentially zips the this result with the specified result discarding the first element of the tuple or else returns the failed `Cause[E1]`
    */
-  final def *>[E1 >: E, B](that: Exit[E1, B]): Exit[E1, B] = zipWith(that)((_, _), _ ++ _).map(_._2)
+  final def *>[E1 >: E, B](that: Exit[E1, B]): Exit[E1, B] = zipWith(that)((_, b) => b, _ ++ _)
 
   /**
    * Parallelly zips the this result with the specified result discarding the second element of the tuple or else returns the failed `Cause[E1]`
    */
-  final def <&[E1 >: E, B](that: Exit[E1, B]): Exit[E1, A] = zipWith(that)((_, _), _ && _).map(_._1)
+  final def <&[E1 >: E, B](that: Exit[E1, B]): Exit[E1, A] = zipWith(that)((a, _) => a, _ && _)
 
   /**
    * Parallelly zips the this result with the specified result or else returns the failed `Cause[E1]`
@@ -46,7 +46,7 @@ sealed trait Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Sequentially zips the this result with the specified result discarding the second element of the tuple or else returns the failed `Cause[E1]`
    */
-  final def <*[E1 >: E, B](that: Exit[E1, B]): Exit[E1, A] = zipWith(that)((_, _), _ ++ _).map(_._1)
+  final def <*[E1 >: E, B](that: Exit[E1, B]): Exit[E1, A] = zipWith(that)((a, _) => a, _ ++ _)
 
   /**
    * Sequentially zips the this result with the specified result or else returns the failed `Cause[E1]`

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -25,6 +25,32 @@ object TestAspectSpec extends ZIOBaseSpec {
         assert(after, equalTo(-1))
       }
     },
+    testM("after evaluates in case if test IO fails") {
+      for {
+        ref <- Ref.make(0)
+        spec = testM("test") {
+          ZIO.fail("error")
+        } @@ after(ref.set(-1))
+        result <- isSuccess(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isFalse) &&
+        assert(after)(equalTo(-1))
+      }
+    },
+    testM("after evaluates in case if test IO dies") {
+      for {
+        ref <- Ref.make(0)
+        spec = testM("test") {
+          ZIO.dieMessage("death")
+        } @@ after(ref.set(-1))
+        result <- isSuccess(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isFalse) &&
+        assert(after)(equalTo(-1))
+      }
+    },
     testM("dotty applies test aspect only on Dotty") {
       for {
         ref    <- Ref.make(false)

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -119,7 +119,9 @@ object TestAspect extends TimeoutVariants {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
-        test.run.zipWith(effect.catchAllCause(cause => ZIO.fail(TestFailure.Runtime(cause))).run)(_ <* _).flatMap(ZIO.done)
+        test.run
+          .zipWith(effect.catchAllCause(cause => ZIO.fail(TestFailure.Runtime(cause))).run)(_ <* _)
+          .flatMap(ZIO.done)
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -119,7 +119,7 @@ object TestAspect extends TimeoutVariants {
       def perTest[R >: Nothing <: R0, E >: E0 <: Any, S](
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
-        test <* effect.catchAllCause(cause => ZIO.fail(TestFailure.Runtime(cause)))
+        test.run.zipWith(effect.catchAllCause(cause => ZIO.fail(TestFailure.Runtime(cause))).run)(_ <* _).flatMap(ZIO.done)
     }
 
   /**


### PR DESCRIPTION
Minor changes in Exit.scala are about avoiding the creation of additional objects and unrelated to the fix.