### PR TITLE
zio-test: Custom JUnit runner for runnable specs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,13 +241,7 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
 lazy val testJunitRunnerJVM = crossProject(JVMPlatform)
   .in(file("test-junit"))
   .settings(stdSettings("zio-test-junit"))
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.1",
-      "junit"              % "junit"                    % "4.12"
-    ),
-    mainClass in (Test, run) := Some("zio.test.sbt.TestMain")
-  )
+  .settings(libraryDependencies ++= Seq("junit" % "junit" % "4.12"))
   .dependsOn(test)
   .jvm
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,8 @@ lazy val root = project
     stacktracerJS,
     stacktracerJVM,
     testRunnerJS,
-    testRunnerJVM
+    testRunnerJVM,
+    testJunitRunnerJVM
   )
   .enablePlugins(ScalaJSPlugin)
 
@@ -237,6 +238,19 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(core)
   .dependsOn(test)
 
+lazy val testJunitRunnerJVM = crossProject(JVMPlatform)
+  .in(file("test-junit"))
+  .settings(stdSettings("zio-test-junit"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.1",
+      "junit"              % "junit"                    % "4.12"
+    ),
+    mainClass in (Test, run) := Some("zio.test.sbt.TestMain")
+  )
+  .dependsOn(test)
+  .jvm
+
 lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
 lazy val testRunnerJS = testRunner.js
   .settings(
@@ -256,8 +270,10 @@ lazy val examples = crossProject(JVMPlatform, JSPlatform)
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3" % Test)
   .dependsOn(testRunner)
 
-lazy val examplesJS  = examples.js
-lazy val examplesJVM = examples.jvm.settings(dottySettings)
+lazy val examplesJS = examples.js
+lazy val examplesJVM = examples.jvm
+  .settings(dottySettings)
+  .dependsOn(testJunitRunnerJVM)
 
 lazy val isScala211 = Def.setting {
   scalaVersion.value.startsWith("2.11")

--- a/build.sbt
+++ b/build.sbt
@@ -238,12 +238,13 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(core)
   .dependsOn(test)
 
-lazy val testJunitRunnerJVM = crossProject(JVMPlatform)
+lazy val testJunitRunner = crossProject(JVMPlatform)
   .in(file("test-junit"))
   .settings(stdSettings("zio-test-junit"))
   .settings(libraryDependencies ++= Seq("junit" % "junit" % "4.12"))
   .dependsOn(test)
-  .jvm
+
+lazy val testJunitRunnerJVM = testJunitRunner.jvm.settings(dottySettings)
 
 lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
 lazy val testRunnerJS = testRunner.js

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
@@ -1,0 +1,15 @@
+package zio.examples.test
+
+import zio.test.junit.DefaultSpecWithJUnit
+import zio.test.{Assertion, assert, suite, test}
+
+class ExampleSpecWithJUnit extends DefaultSpecWithJUnit {
+  def spec = suite("some suite")(
+    test("failing test") {
+      assert(1)(Assertion.equalTo(2))
+    },
+    test("passing test") {
+      assert(1)(Assertion.equalTo(1))
+    }
+  )
+}

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
@@ -1,9 +1,9 @@
 package zio.examples.test
 
-import zio.test.junit.DefaultSpecWithJUnit
+import zio.test.junit.JUnitRunnableSpec
 import zio.test.{Assertion, assert, suite, test}
 
-class ExampleSpecWithJUnit extends DefaultSpecWithJUnit {
+class ExampleSpecWithJUnit extends JUnitRunnableSpec {
   def spec = suite("some suite")(
     test("failing test") {
       assert(1)(Assertion.equalTo(2))

--- a/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
@@ -1,13 +1,13 @@
 package zio.examples.test
 
 import zio.test.Assertion._
-import zio.test.junit.DefaultSpecWithJUnit
+import zio.test.junit.JUnitRunnableSpec
 import zio.test.mock.Expectation.{unit, value, valueF}
 import zio.test.mock.{MockClock, MockConsole, MockRandom}
 import zio.test.{assertM, suite, testM}
 import zio.{clock, console, random}
 
-class MockingExampleSpecWithJUnit extends DefaultSpecWithJUnit {
+class MockingExampleSpecWithJUnit extends JUnitRunnableSpec {
 
   def spec = suite("suite with mocks")(
     testM("expect call returning output") {

--- a/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
@@ -2,80 +2,84 @@ package zio.examples.test
 
 import zio.test.Assertion._
 import zio.test.junit.JUnitRunnableSpec
-import zio.test.mock.Expectation.{unit, value, valueF}
-import zio.test.mock.{MockClock, MockConsole, MockRandom}
-import zio.test.{assertM, suite, testM}
-import zio.{clock, console, random}
+import zio.test.mock.Expectation.{ unit, value, valueF }
+import zio.test.mock.{ MockClock, MockConsole, MockRandom }
+import zio.test.{ assertM, suite, testM }
+import zio.{ clock, console, random }
 
 class MockingExampleSpecWithJUnit extends JUnitRunnableSpec {
 
   def spec = suite("suite with mocks")(
-    testM("expect call returning output") {
-      val app     = clock.nanoTime
-      val mockEnv = MockClock.nanoTime returns value(1000L)
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(1000L))
-    },
-    testM("expect call with input satisfying assertion") {
-      val app     = console.putStrLn("foo")
-      val mockEnv = MockConsole.putStrLn(equalTo("foo")) returns unit
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(isUnit)
-    },
-    testM("expect call with input satisfying assertion and transforming it into output") {
-      val app     = random.nextInt(1)
-      val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns valueF(_ + 41)
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(42))
-    },
-    testM("expect call with input satisfying assertion and returning output") {
-      val app     = random.nextInt(1)
-      val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns value(42)
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(42))
-    },
-    testM("expect call for overloaded method") {
-      val app     = random.nextInt
-      val mockEnv = MockRandom.nextInt._1 returns value(42)
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(42))
-    },
-    testM("expect calls from multiple modules") {
-      val app        = random.nextInt.map(_.toString) >>= console.putStrLn
-      val randomEnv  = MockRandom.nextInt._1 returns value(42)
-      val consoleEnv = MockConsole.putStrLn(equalTo("42")) returns unit
+    suite("expect")(
+      testM("expect call returning output") {
+        val app     = clock.nanoTime
+        val mockEnv = MockClock.nanoTime returns value(1000L)
+        val result  = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(1000L))
+      },
+      testM("expect call with input satisfying assertion") {
+        val app     = console.putStrLn("foo")
+        val mockEnv = MockConsole.putStrLn(equalTo("foo")) returns unit
+        val result  = app.provideManaged(mockEnv)
+        assertM(result)(isUnit)
+      },
+      testM("expect call with input satisfying assertion and transforming it into output") {
+        val app     = random.nextInt(1)
+        val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns valueF(_ + 41)
+        val result  = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(42))
+      },
+      testM("expect call with input satisfying assertion and returning output") {
+        val app     = random.nextInt(1)
+        val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns value(42)
+        val result  = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(42))
+      },
+      testM("expect call for overloaded method") {
+        val app     = random.nextInt
+        val mockEnv = MockRandom.nextInt._1 returns value(42)
+        val result  = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(42))
+      },
+      testM("expect calls from multiple modules") {
+        val app        = random.nextInt.map(_.toString) >>= console.putStrLn
+        val randomEnv  = MockRandom.nextInt._1 returns value(42)
+        val consoleEnv = MockConsole.putStrLn(equalTo("42")) returns unit
 
-      val mockEnv = (randomEnv &&& consoleEnv).map {
-        case (r, c) =>
-          new MockRandom with MockConsole {
-            val random  = r.random
-            val console = c.console
-          }
+        val mockEnv = (randomEnv &&& consoleEnv).map {
+          case (r, c) =>
+            new MockRandom with MockConsole {
+              val random  = r.random
+              val console = c.console
+            }
+        }
+
+        val result = app.provideManaged(mockEnv)
+        assertM(result)(isUnit)
       }
+    ),
+    suite("failure")(
+      testM("failure if invalid method") {
+        val app = random.nextInt
+        val mockEnv = MockRandom.nextLong._0 returns value(42)
+        val result = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(42))
+      },
+      testM("failure if invalid arguments") {
+        val app = console.putStrLn("foo")
+        val mockEnv = MockConsole.putStrLn(equalTo("bar")) returns unit
+        val result = app.provideManaged(mockEnv)
+        assertM(result)(isUnit)
+      },
+      testM("failure if unmet expectations") {
+        val app = random.nextInt
+        val mockEnv =
+          (MockRandom.nextInt._1 returns value(42)) *>
+            (MockRandom.nextInt._1 returns value(42))
 
-      val result = app.provideManaged(mockEnv)
-      assertM(result)(isUnit)
-    },
-    testM("failure if invalid method") {
-      val app     = random.nextInt
-      val mockEnv = MockRandom.nextLong._0 returns value(42)
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(42))
-    },
-    testM("failure if invalid arguments") {
-      val app     = console.putStrLn("foo")
-      val mockEnv = MockConsole.putStrLn(equalTo("bar")) returns unit
-      val result  = app.provideManaged(mockEnv)
-      assertM(result)(isUnit)
-    },
-    testM("failure if unmet expectations") {
-      val app = random.nextInt
-      val mockEnv =
-        (MockRandom.nextInt._1 returns value(42)) *>
-          (MockRandom.nextInt._1 returns value(42))
-
-      val result = app.provideManaged(mockEnv)
-      assertM(result)(equalTo(42))
-    }
+        val result = app.provideManaged(mockEnv)
+        assertM(result)(equalTo(42))
+      }
+    )
   )
 }

--- a/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
@@ -1,0 +1,81 @@
+package zio.examples.test
+
+import zio.test.Assertion._
+import zio.test.junit.DefaultSpecWithJUnit
+import zio.test.mock.Expectation.{unit, value, valueF}
+import zio.test.mock.{MockClock, MockConsole, MockRandom}
+import zio.test.{assertM, suite, testM}
+import zio.{clock, console, random}
+
+class MockingExampleSpecWithJUnit extends DefaultSpecWithJUnit {
+
+  def spec = suite("suite with mocks")(
+    testM("expect call returning output") {
+      val app     = clock.nanoTime
+      val mockEnv = MockClock.nanoTime returns value(1000L)
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(1000L))
+    },
+    testM("expect call with input satisfying assertion") {
+      val app     = console.putStrLn("foo")
+      val mockEnv = MockConsole.putStrLn(equalTo("foo")) returns unit
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(isUnit)
+    },
+    testM("expect call with input satisfying assertion and transforming it into output") {
+      val app     = random.nextInt(1)
+      val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns valueF(_ + 41)
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect call with input satisfying assertion and returning output") {
+      val app     = random.nextInt(1)
+      val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns value(42)
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect call for overloaded method") {
+      val app     = random.nextInt
+      val mockEnv = MockRandom.nextInt._1 returns value(42)
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect calls from multiple modules") {
+      val app        = random.nextInt.map(_.toString) >>= console.putStrLn
+      val randomEnv  = MockRandom.nextInt._1 returns value(42)
+      val consoleEnv = MockConsole.putStrLn(equalTo("42")) returns unit
+
+      val mockEnv = (randomEnv &&& consoleEnv).map {
+        case (r, c) =>
+          new MockRandom with MockConsole {
+            val random  = r.random
+            val console = c.console
+          }
+      }
+
+      val result = app.provideManaged(mockEnv)
+      assertM(result)(isUnit)
+    },
+    testM("failure if invalid method") {
+      val app     = random.nextInt
+      val mockEnv = MockRandom.nextLong._0 returns value(42)
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("failure if invalid arguments") {
+      val app     = console.putStrLn("foo")
+      val mockEnv = MockConsole.putStrLn(equalTo("bar")) returns unit
+      val result  = app.provideManaged(mockEnv)
+      assertM(result)(isUnit)
+    },
+    testM("failure if unmet expectations") {
+      val app = random.nextInt
+      val mockEnv =
+        (MockRandom.nextInt._1 returns value(42)) *>
+          (MockRandom.nextInt._1 returns value(42))
+
+      val result = app.provideManaged(mockEnv)
+      assertM(result)(equalTo(42))
+    }
+  )
+}

--- a/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
@@ -1,85 +1,92 @@
 package zio.examples.test
 
+import zio.{clock, console, random}
+import zio.test.{DefaultRunnableSpec, assertM, suite, testM}
 import zio.test.Assertion._
 import zio.test.junit.JUnitRunnableSpec
-import zio.test.mock.Expectation.{ unit, value, valueF }
-import zio.test.mock.{ MockClock, MockConsole, MockRandom }
-import zio.test.{ assertM, suite, testM }
-import zio.{ clock, console, random }
+import zio.test.mock.{MockClock, MockConsole, MockRandom}
+import zio.test.mock.Expectation.{unit, value, valueF}
 
 class MockingExampleSpecWithJUnit extends JUnitRunnableSpec {
 
   def spec = suite("suite with mocks")(
-    suite("expect")(
-      testM("expect call returning output") {
-        val app     = clock.nanoTime
-        val mockEnv = MockClock.nanoTime returns value(1000L)
-        val result  = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(1000L))
-      },
-      testM("expect call with input satisfying assertion") {
-        val app     = console.putStrLn("foo")
-        val mockEnv = MockConsole.putStrLn(equalTo("foo")) returns unit
-        val result  = app.provideManaged(mockEnv)
-        assertM(result)(isUnit)
-      },
-      testM("expect call with input satisfying assertion and transforming it into output") {
-        val app     = random.nextInt(1)
-        val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns valueF(_ + 41)
-        val result  = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(42))
-      },
-      testM("expect call with input satisfying assertion and returning output") {
-        val app     = random.nextInt(1)
-        val mockEnv = MockRandom.nextInt._0(equalTo(1)) returns value(42)
-        val result  = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(42))
-      },
-      testM("expect call for overloaded method") {
-        val app     = random.nextInt
-        val mockEnv = MockRandom.nextInt._1 returns value(42)
-        val result  = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(42))
-      },
-      testM("expect calls from multiple modules") {
-        val app        = random.nextInt.map(_.toString) >>= console.putStrLn
-        val randomEnv  = MockRandom.nextInt._1 returns value(42)
-        val consoleEnv = MockConsole.putStrLn(equalTo("42")) returns unit
+    testM("expect call returning output") {
+      import MockClock._
 
-        val mockEnv = (randomEnv &&& consoleEnv).map {
-          case (r, c) =>
-            new MockRandom with MockConsole {
-              val random  = r.random
-              val console = c.console
-            }
-        }
+      val app     = clock.nanoTime
+      val mockEnv = nanoTime returns value(1000L)
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(1000L))
+    },
+    testM("expect call with input satisfying assertion") {
+      import MockConsole._
 
-        val result = app.provideManaged(mockEnv)
-        assertM(result)(isUnit)
-      }
-    ),
-    suite("failure")(
-      testM("failure if invalid method") {
-        val app = random.nextInt
-        val mockEnv = MockRandom.nextLong._0 returns value(42)
-        val result = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(42))
-      },
-      testM("failure if invalid arguments") {
-        val app = console.putStrLn("foo")
-        val mockEnv = MockConsole.putStrLn(equalTo("bar")) returns unit
-        val result = app.provideManaged(mockEnv)
-        assertM(result)(isUnit)
-      },
-      testM("failure if unmet expectations") {
-        val app = random.nextInt
-        val mockEnv =
-          (MockRandom.nextInt._1 returns value(42)) *>
-            (MockRandom.nextInt._1 returns value(42))
+      val app     = console.putStrLn("foo")
+      val mockEnv = putStrLn(equalTo("foo")) returns unit
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(isUnit)
+    },
+    testM("expect call with input satisfying assertion and transforming it into output") {
+      import MockRandom._
 
-        val result = app.provideManaged(mockEnv)
-        assertM(result)(equalTo(42))
-      }
-    )
+      val app     = random.nextInt(1)
+      val mockEnv = nextInt._0(equalTo(1)) returns valueF(_ + 41)
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect call with input satisfying assertion and returning output") {
+      import MockRandom._
+
+      val app     = random.nextInt(1)
+      val mockEnv = nextInt._0(equalTo(1)) returns value(42)
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect call for overloaded method") {
+      import MockRandom._
+
+      val app     = random.nextInt
+      val mockEnv = nextInt._1 returns value(42)
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("expect calls from multiple modules") {
+      import MockRandom._
+      import MockConsole._
+
+      val app        = random.nextInt.map(_.toString) >>= console.putStrLn
+      val randomEnv  = nextInt._1 returns value(42)
+      val consoleEnv = putStrLn(equalTo("42")) returns unit
+
+      val result = app.provideLayer(randomEnv ++ consoleEnv)
+      assertM(result)(isUnit)
+    },
+    testM("failure if invalid method") {
+      import MockRandom._
+
+      val app     = random.nextInt
+      val mockEnv = nextLong._0 returns value(42)
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42))
+    },
+    testM("failure if invalid arguments") {
+      import MockConsole._
+
+      val app     = console.putStrLn("foo")
+      val mockEnv = putStrLn(equalTo("bar")) returns unit
+      val result  = app.provideLayer(mockEnv)
+      assertM(result)(isUnit)
+    },
+    testM("failure if unmet expectations") {
+      import MockRandom._
+
+      val app = random.nextInt
+      val mockEnv =
+        (nextInt._1 returns value(42)) *>
+          (nextInt._1 returns value(42))
+
+      val result = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42))
+    }
   )
 }

--- a/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockingExampleSpecWithJUnit.scala
@@ -1,7 +1,7 @@
 package zio.examples.test
 
 import zio.{clock, console, random}
-import zio.test.{DefaultRunnableSpec, assertM, suite, testM}
+import zio.test.{assertM, suite, testM}
 import zio.test.Assertion._
 import zio.test.junit.JUnitRunnableSpec
 import zio.test.mock.{MockClock, MockConsole, MockRandom}

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -14,6 +14,16 @@ import zio.test.TestFailure.{ Assertion, Runtime }
 import zio.test.TestSuccess.{ Ignored, Succeeded }
 import zio.test._
 
+/**
+ * Custom JUnit 4 runner for ZIO Test Specs.<br/>
+ * Any instance of [[zio.test.AbstractRunnableSpec]], that is a class (JUnit won't run objects),
+ * if annotated with `@RunWith(classOf[ZTestJUnitRunner])` can be run by IDEs and build tools that support JUnit.<br/>
+ * Your spec can also extend [[JUnitRunnableSpec]] to inherit the annotation.
+ * In order to expose the structure of the test to JUnit (and the external tools), `getDescription` has to execute Suite level effects.
+ * This means that these effects will be executed twice (first in `getDescription` and then in `run`).
+ * <br/><br/>
+ * Scala.JS is not supported, as JUnit TestFramework for SBT under Scala.JS doesn't support custom runners.
+ */
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
   private val className = klass.getName.stripSuffix("$")
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -4,35 +4,20 @@ import org.junit.runner.manipulation.{ Filter, Filterable }
 import org.junit.runner.notification.{ Failure, RunNotifier }
 import org.junit.runner.{ Description, RunWith, Runner }
 import zio.ZIO.effectTotal
+import zio._
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{ SuiteCase, TestCase }
+import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
 import zio.test.TestFailure.{ Assertion, Runtime }
 import zio.test.TestSuccess.{ Ignored, Succeeded }
-import zio.test.{ ExecutedSpec, _ }
-import zio.{ DefaultRuntime, URIO, ZIO }
-
-import scala.util.Try
+import zio.test._
 
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
   private val className = klass.getName.stripSuffix("$")
 
   private lazy val spec: AbstractRunnableSpec = {
-    Try(loadObject())
-      .getOrElse(
-        klass
-          .newInstance()
-          .asInstanceOf[AbstractRunnableSpec]
-      )
-  }
-
-  private def loadObject(): AbstractRunnableSpec = {
-    import org.portablescala.reflect._
-    val fqn = className + "$"
-    Reflect
-      .lookupLoadableModuleClass(fqn, klass.getClassLoader)
-      .getOrElse(throw new ClassNotFoundException("failed to load object: " + fqn))
-      .loadModule()
+    klass
+      .newInstance()
       .asInstanceOf[AbstractRunnableSpec]
   }
 
@@ -56,11 +41,10 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
         case TestCase(label, _) =>
           effectTotal(description.addChild(testDescription(label.toString, path)))
       }
+
     unsafeRun(
-      spec.runner.executor.environment.use[Any, spec.Failure, Unit] { env =>
-        traverse(filteredSpec, description)
-          .provide(env)
-      }
+      traverse(filteredSpec, description)
+        .provideManaged(spec.runner.executor.environment)
     )
     description
   }
@@ -71,55 +55,62 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       override val clock: Clock.Service[Any]      = Clock.Live.clock
     }
     zio
-      .Runtime((), spec.runner.platform)
-      .unsafeRun(
-        for {
-          executedSpec <- spec.runner.run(filteredSpec).provide(env)
-          _            <- notifyOnResults(notifier, executedSpec)
-        } yield {}
-      )
+      .Runtime(env, spec.runner.platform)
+      .unsafeRun {
+        val instrumented = instrumentSpec(filteredSpec, notifier)
+        spec.runner.run(instrumented)
+      }
   }
 
-  private def notifyOnResults[L, R, S](
+  private def reportRuntimeFailure[S, R, L](notifier: RunNotifier, path: Vector[String], label: R, cause: Cause[L]) =
+    for {
+      rendered <- FailureRenderer.renderCause(cause, 0).map(renderToString)
+      _        <- notifier.fireTestFailure(label, path, rendered, cause.dieOption.orNull)
+    } yield ()
+
+  private def reportAssertionFailure[S, R, L](
     notifier: RunNotifier,
-    executedSpec: ExecutedSpec[L, R, S],
+    path: Vector[String],
+    label: R,
+    result: TestResult
+  ) =
+    FailureRenderer
+      .renderTestFailure("", result)
+      .flatMap { rendered =>
+        notifier.fireTestFailure(label, path, renderToString(rendered))
+      }
+
+  private def testDescription(label: String, path: Vector[String]) = {
+    val uniqueId = path.mkString(":") + ":" + label
+    Description.createTestDescription(path.headOption.getOrElse(className), label, uniqueId)
+  }
+
+  private def instrumentSpec[R, E, L, S](
+    zspec: ZSpec[R, E, L, S],
+    notifier: RunNotifier,
     path: Vector[String] = Vector.empty
-  ): ZIO[Any, Nothing, Unit] =
-    executedSpec.caseValue match {
-      case SuiteCase(label, specs, _) =>
-        specs.flatMap(ZIO.foreach(_)(notifyOnResults(notifier, _, path :+ label.toString))).unit
-      case TestCase(label, result) =>
-        result.flatMap {
-          case (Left(Assertion(result)), _) =>
-            FailureRenderer
-              .renderTestFailure("", result)
-              .map(renderToString)
-              .flatMap { text =>
-                effectTotal {
-                  notifier.fireTestFailure(new Failure(testDescription(label.toString, path), new TestFailed(text)))
-                }
-              }
-          case (Left(Runtime(cause)), _) =>
-            for {
-              rendered <- FailureRenderer.renderCause(cause, 0).map(renderToString)
-              _ <- effectTotal {
-                    notifier.fireTestFailure(
-                      new Failure(
-                        testDescription(label.toString, path),
-                        new TestFailed(rendered, cause.dieOption.orNull)
-                      )
-                    )
-                  }
-            } yield ()
-
-          case (Right(Succeeded(_)), _) =>
-            effectTotal { notifier.fireTestFinished(testDescription(label.toString, path)) }
-          case (Right(Ignored), _) => effectTotal { notifier.fireTestIgnored(testDescription(label.toString, path)) }
+  ): ZSpec[R, E, L, S] = {
+    type ZSpecCase = SpecCase[R, TestFailure[E], L, TestSuccess[S], Spec[R, TestFailure[E], L, TestSuccess[S]]]
+    def instrumentTest(label: L, test: ZIO[R, TestFailure[E], TestSuccess[S]]) =
+      notifier.fireTestStarted(label, path) *> test.tapBoth(
+        {
+          case Assertion(result) => reportAssertionFailure(notifier, path, label, result)
+          case Runtime(cause)    => reportRuntimeFailure(notifier, path, label, cause)
+        }, {
+          case Succeeded(_) => notifier.fireTestFinished(label, path)
+          case Ignored      => notifier.fireTestIgnored(label, path)
         }
-    }
-
-  private def testDescription(label: String, path: Vector[String]) =
-    Description.createTestDescription(className, label, path.mkString(":") + ":" + label)
+      )
+    def loop(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
+      specCase match {
+        case TestCase(label, test) => TestCase(label, instrumentTest(label, test))
+        case SuiteCase(label, specs, es) =>
+          val instrumented =
+            specs.flatMap(ZIO.foreach(_)(s => ZIO.succeed(Spec(loop(s.caseValue, path :+ label.toString)))))
+          SuiteCase(label, instrumented.map(_.toVector), es)
+      }
+    Spec(loop(zspec.caseValue))
+  }
 
   private def filteredSpec: ZSpec[spec.Environment, spec.Failure, spec.Label, spec.Test] =
     spec.spec
@@ -130,9 +121,35 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
     this.filter = filter
 
   private def renderToString(message: Message) =
-    message.lines.map { line =>
-      line.fragments.map(_.text).fold("")(_ + _)
+    message.lines.map {
+      _.fragments.map(_.text).fold("")(_ + _)
     }.mkString("\n")
+
+  private implicit class NotifierOps(val notifier: RunNotifier) {
+    def fireTestFailure[L](
+      label: L,
+      path: Vector[String],
+      renderedText: String,
+      throwable: Throwable = null
+    ): UIO[Unit] =
+      effectTotal {
+        notifier.fireTestFailure(
+          new Failure(testDescription(label.toString, path), new TestFailed(renderedText, throwable))
+        )
+      }
+
+    def fireTestStarted[L](label: L, path: Vector[String]): UIO[Unit] = effectTotal {
+      notifier.fireTestStarted(testDescription(label.toString, path))
+    }
+
+    def fireTestFinished[L](label: L, path: Vector[String]): UIO[Unit] = effectTotal {
+      notifier.fireTestFinished(testDescription(label.toString, path))
+    }
+
+    def fireTestIgnored[L](label: L, path: Vector[String]): UIO[Unit] = effectTotal {
+      notifier.fireTestIgnored(testDescription(label.toString, path))
+    }
+  }
 }
 
 private[junit] class TestFailed(message: String, cause: Throwable = null)

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -69,10 +69,10 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       _        <- notifier.fireTestFailure(label, path, rendered, cause.dieOption.orNull)
     } yield ()
 
-  private def reportAssertionFailure[S, R, L](
+  private def reportAssertionFailure[L](
     notifier: RunNotifier,
     path: Vector[String],
-    label: R,
+    label: L,
     result: TestResult
   ): ZIO[Any, Nothing, Unit] =
     FailureRenderer

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,17 +1,18 @@
 package zio.test.junit
 
-import org.junit.runner.manipulation.{ Filter, Filterable }
-import org.junit.runner.notification.{ Failure, RunNotifier }
-import org.junit.runner.{ Description, Result, RunWith, Runner }
+import com.github.ghik.silencer.silent
+import org.junit.runner.manipulation.{Filter, Filterable}
+import org.junit.runner.notification.{Failure, RunNotifier}
+import org.junit.runner.{Description, RunWith, Runner}
+
 import zio.ZIO.effectTotal
 import zio._
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
-import zio.test.TestFailure.{ Assertion, Runtime }
-import zio.test.TestSuccess.{ Ignored, Succeeded }
+import zio.test.Spec.{SpecCase, SuiteCase, TestCase}
+import zio.test.TestFailure.{Assertion, Runtime}
+import zio.test.TestSuccess.{Ignored, Succeeded}
 import zio.test._
-import com.github.ghik.silencer.silent
 
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
   private val className = klass.getName.stripSuffix("$")

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -58,7 +58,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       .Runtime(env, spec.runner.platform)
       .unsafeRun {
         val instrumented = instrumentSpec(filteredSpec, notifier)
-        spec.runner.run(instrumented)
+        spec.runner.run(instrumented).unit
       }
   }
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -38,8 +38,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
           effectTotal(description.addChild(suiteDesc)) *>
             specs
               .flatMap(ZIO.foreach(_)(traverse(_, suiteDesc, path :+ label.toString)))
-              .catchAll(_ => ZIO.unit)
-              .unit
+              .ignore
         case TestCase(label, _) =>
           effectTotal(description.addChild(testDescription(label.toString, path)))
       }

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -158,4 +158,4 @@ private[junit] class TestFailed(message: String, cause: Throwable = null)
     extends Throwable(message, cause, false, false)
 
 @RunWith(classOf[ZTestJUnitRunner])
-abstract class DefaultSpecWithJUnit extends DefaultRunnableSpec
+abstract class JUnitRunnableSpec extends DefaultRunnableSpec

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,15 +1,15 @@
 package zio.test.junit
 
-import org.junit.runner.manipulation.{Filter, Filterable}
-import org.junit.runner.notification.{Failure, RunNotifier}
-import org.junit.runner.{Description, Result, RunWith, Runner}
+import org.junit.runner.manipulation.{ Filter, Filterable }
+import org.junit.runner.notification.{ Failure, RunNotifier }
+import org.junit.runner.{ Description, Result, RunWith, Runner }
 import zio.ZIO.effectTotal
 import zio._
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{SpecCase, SuiteCase, TestCase}
-import zio.test.TestFailure.{Assertion, Runtime}
-import zio.test.TestSuccess.{Ignored, Succeeded}
+import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
+import zio.test.TestFailure.{ Assertion, Runtime }
+import zio.test.TestSuccess.{ Ignored, Succeeded }
 import zio.test._
 import com.github.ghik.silencer.silent
 
@@ -103,7 +103,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       )
     def loop(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
       specCase match {
-        case TestCase(label, test) => TestCase(label, instrumentTest(label, path , test))
+        case TestCase(label, test) => TestCase(label, instrumentTest(label, path, test))
         case SuiteCase(label, specs, es) =>
           @silent("inferred to be `Any`")
           val instrumented =

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -15,7 +15,6 @@ import zio.{ DefaultRuntime, URIO, ZIO }
 import scala.util.Try
 
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
-
   private val className = klass.getName.stripSuffix("$")
 
   private lazy val spec: AbstractRunnableSpec = {
@@ -58,9 +57,10 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
           effectTotal(description.addChild(testDescription(label.toString, path)))
       }
     unsafeRun(
-      traverse(filteredSpec, description)
-      // we expect to be able to extract structure without the environment
-        .provide(null.asInstanceOf[spec.Environment])
+      spec.runner.executor.environment.use[Any, spec.Failure, Unit] { env =>
+        traverse(filteredSpec, description)
+          .provide(env)
+      }
     )
     description
   }

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -11,6 +11,7 @@ import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
 import zio.test.TestFailure.{ Assertion, Runtime }
 import zio.test.TestSuccess.{ Ignored, Succeeded }
 import zio.test._
+import com.github.ghik.silencer.silent
 
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
   private val className = klass.getName.stripSuffix("$")
@@ -73,7 +74,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
     path: Vector[String],
     label: R,
     result: TestResult
-  ) =
+  ): ZIO[Any, Nothing, Unit] =
     FailureRenderer
       .renderTestFailure("", result)
       .flatMap { rendered =>
@@ -105,6 +106,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       specCase match {
         case TestCase(label, test) => TestCase(label, instrumentTest(label, test))
         case SuiteCase(label, specs, es) =>
+          @silent("inferred to be `Any`")
           val instrumented =
             specs.flatMap(ZIO.foreach(_)(s => ZIO.succeed(Spec(loop(s.caseValue, path :+ label.toString)))))
           SuiteCase(label, instrumented.map(_.toVector), es)

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,16 +1,16 @@
 package zio.test.junit
 
-import org.junit.runner.manipulation.{Filter, Filterable}
-import org.junit.runner.notification.{Failure, RunNotifier}
-import org.junit.runner.{Description, RunWith, Runner}
+import org.junit.runner.manipulation.{ Filter, Filterable }
+import org.junit.runner.notification.{ Failure, RunNotifier }
+import org.junit.runner.{ Description, RunWith, Runner }
 import zio.ZIO.effectTotal
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{SuiteCase, TestCase}
-import zio.test.TestFailure.{Assertion, Runtime}
-import zio.test.TestSuccess.{Ignored, Succeeded}
-import zio.test.{ExecutedSpec, _}
-import zio.{DefaultRuntime, URIO, ZIO}
+import zio.test.Spec.{ SuiteCase, TestCase }
+import zio.test.TestFailure.{ Assertion, Runtime }
+import zio.test.TestSuccess.{ Ignored, Succeeded }
+import zio.test.{ ExecutedSpec, _ }
+import zio.{ DefaultRuntime, URIO, ZIO }
 
 import scala.util.Try
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,0 +1,143 @@
+package zio.test.junit
+
+import org.junit.runner.manipulation.{ Filter, Filterable }
+import org.junit.runner.notification.{ Failure, RunNotifier }
+import org.junit.runner.{ Description, RunWith, Runner }
+import zio.ZIO.effectTotal
+import zio.clock.Clock
+import zio.test.FailureRenderer.FailureMessage.Message
+import zio.test.Spec.{ SuiteCase, TestCase }
+import zio.test.TestFailure.{ Assertion, Runtime }
+import zio.test.TestSuccess.{ Ignored, Succeeded }
+import zio.test.environment.TestEnvironment
+import zio.test.{ ExecutedSpec, _ }
+import zio.{ DefaultRuntime, URIO, ZIO }
+
+import scala.util.Try
+
+class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
+
+  private val className = klass.getName.stripSuffix("$")
+
+  private lazy val spec: AbstractRunnableSpec = {
+    Try(loadObject())
+      .getOrElse(
+        klass
+          .newInstance()
+          .asInstanceOf[AbstractRunnableSpec]
+      )
+  }
+
+  private def loadObject(): AbstractRunnableSpec = {
+    import org.portablescala.reflect._
+    val fqn = className + "$"
+    Reflect
+      .lookupLoadableModuleClass(fqn, klass.getClassLoader)
+      .getOrElse(throw new ClassNotFoundException("failed to load object: " + fqn))
+      .loadModule()
+      .asInstanceOf[AbstractRunnableSpec]
+  }
+
+  private var filter = Filter.ALL
+
+  lazy val getDescription: Description = {
+    val description = Description.createSuiteDescription(className)
+    def traverse[R, E, L, S](
+      spec: ZSpec[R, E, L, S],
+      description: Description,
+      path: Vector[String] = Vector.empty
+    ): URIO[R, Unit] =
+      spec.caseValue match {
+        case SuiteCase(label, specs, _) =>
+          val suiteDesc = Description.createSuiteDescription(label.toString, path.mkString(":"))
+          effectTotal(description.addChild(suiteDesc)) *>
+            specs
+              .flatMap(ZIO.foreach(_)(traverse(_, suiteDesc, path :+ label.toString)))
+              .catchAll(_ => ZIO.unit)
+              .unit
+        case TestCase(label, _) =>
+          effectTotal(description.addChild(testDescription(label.toString, path)))
+      }
+    unsafeRun(
+      traverse(filteredSpec, description)
+      // we expect to be able to extract structure without the environment
+        .provide(null.asInstanceOf[spec.Environment])
+    )
+    description
+  }
+
+  override def run(notifier: RunNotifier): Unit = {
+    val env = new TestLogger with Clock {
+      override def testLogger: TestLogger.Service = spec.runner.defaultTestLogger.testLogger
+      override val clock: Clock.Service[Any]      = Clock.Live.clock
+    }
+    zio
+      .Runtime((), spec.runner.platform)
+      .unsafeRun(
+        for {
+          executedSpec <- spec.runner.run(filteredSpec).provide(env)
+          _            <- notifyOnResults(notifier, executedSpec)
+        } yield {}
+      )
+  }
+
+  private def notifyOnResults[L, R, S](
+    notifier: RunNotifier,
+    executedSpec: ExecutedSpec[L, R, S],
+    path: Vector[String] = Vector.empty
+  ): ZIO[Any, Nothing, Unit] =
+    executedSpec.caseValue match {
+      case SuiteCase(label, specs, _) =>
+        specs.flatMap(ZIO.foreach(_)(notifyOnResults(notifier, _, path :+ label.toString))).unit
+      case TestCase(label, result) =>
+        result.flatMap {
+          case (Left(Assertion(result)), _) =>
+            FailureRenderer
+              .renderTestFailure("", result)
+              .map(renderToString)
+              .flatMap { text =>
+                effectTotal {
+                  notifier.fireTestFailure(new Failure(testDescription(label.toString, path), new TestFailed(text)))
+                }
+              }
+          case (Left(Runtime(cause)), _) =>
+            for {
+              rendered <- FailureRenderer.renderCause(cause, 0).map(renderToString)
+              _ <- effectTotal {
+                    notifier.fireTestFailure(
+                      new Failure(
+                        testDescription(label.toString, path),
+                        new TestFailed(rendered, cause.dieOption.orNull)
+                      )
+                    )
+                  }
+            } yield ()
+
+          case (Right(Succeeded(_)), _) =>
+            effectTotal { notifier.fireTestFinished(testDescription(label.toString, path)) }
+          case (Right(Ignored), _) => effectTotal { notifier.fireTestIgnored(testDescription(label.toString, path)) }
+        }
+    }
+
+  private def testDescription(label: String, path: Vector[String]) =
+    Description.createTestDescription(className, label, path.mkString(":") + ":" + label)
+
+  private def filteredSpec: ZSpec[spec.Environment, spec.Failure, spec.Label, spec.Test] =
+    spec.spec
+      .filterLabels(l => filter.shouldRun(testDescription(l.toString, Vector.empty)))
+      .getOrElse(spec.spec)
+
+  override def filter(filter: Filter): Unit =
+    this.filter = filter
+
+  private def renderToString(message: Message) =
+    message.lines.map { line =>
+      line.fragments.map(_.text).fold("")(_ + _)
+    }.mkString("\n")
+}
+
+private[junit] class TestFailed(message: String, cause: Throwable = null)
+    extends Throwable(message, cause, false, false)
+
+@RunWith(classOf[ZTestJUnitRunner])
+abstract class DefaultSpecWithJUnit extends DefaultRunnableSpec

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,17 +1,17 @@
 package zio.test.junit
 
 import com.github.ghik.silencer.silent
-import org.junit.runner.manipulation.{Filter, Filterable}
-import org.junit.runner.notification.{Failure, RunNotifier}
-import org.junit.runner.{Description, RunWith, Runner}
+import org.junit.runner.manipulation.{ Filter, Filterable }
+import org.junit.runner.notification.{ Failure, RunNotifier }
+import org.junit.runner.{ Description, RunWith, Runner }
 
 import zio.ZIO.effectTotal
 import zio._
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{SpecCase, SuiteCase, TestCase}
-import zio.test.TestFailure.{Assertion, Runtime}
-import zio.test.TestSuccess.{Ignored, Succeeded}
+import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
+import zio.test.TestFailure.{ Assertion, Runtime }
+import zio.test.TestSuccess.{ Ignored, Succeeded }
 import zio.test._
 
 class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,17 +1,16 @@
 package zio.test.junit
 
-import org.junit.runner.manipulation.{ Filter, Filterable }
-import org.junit.runner.notification.{ Failure, RunNotifier }
-import org.junit.runner.{ Description, RunWith, Runner }
+import org.junit.runner.manipulation.{Filter, Filterable}
+import org.junit.runner.notification.{Failure, RunNotifier}
+import org.junit.runner.{Description, RunWith, Runner}
 import zio.ZIO.effectTotal
 import zio.clock.Clock
 import zio.test.FailureRenderer.FailureMessage.Message
-import zio.test.Spec.{ SuiteCase, TestCase }
-import zio.test.TestFailure.{ Assertion, Runtime }
-import zio.test.TestSuccess.{ Ignored, Succeeded }
-import zio.test.environment.TestEnvironment
-import zio.test.{ ExecutedSpec, _ }
-import zio.{ DefaultRuntime, URIO, ZIO }
+import zio.test.Spec.{SuiteCase, TestCase}
+import zio.test.TestFailure.{Assertion, Runtime}
+import zio.test.TestSuccess.{Ignored, Succeeded}
+import zio.test.{ExecutedSpec, _}
+import zio.{DefaultRuntime, URIO, ZIO}
 
 import scala.util.Try
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -29,8 +29,8 @@ object ReportingTestUtils {
   def cyan(s: String): String =
     SConsole.CYAN + s + SConsole.RESET
 
-  def yellowThenCyan(s: String): String =
-    SConsole.YELLOW + s + SConsole.CYAN
+  def yellow(s: String): String =
+    SConsole.YELLOW + s + SConsole.RESET
 
   def reportStats(success: Int, ignore: Int, failure: Int) = {
     val total = success + ignore + failure
@@ -72,11 +72,11 @@ object ReportingTestUtils {
     expectedFailure("Value falls within range"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(" + yellowThenCyan("equalTo(42)") + " || (isGreaterThan(5) && isLessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
     ),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && " + yellowThenCyan("isLessThan(10)") + "))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
     )
   )
 
@@ -100,10 +100,10 @@ object ReportingTestUtils {
     expectedFailure("Multiple nested failures"),
     withOffset(2)(s"${blue("3")} did not satisfy ${cyan("isGreaterThan(4)")}\n"),
     withOffset(2)(
-      s"${blue("Some(3)")} did not satisfy ${cyan("isSome(" + yellowThenCyan("isGreaterThan(4)") + ")")}\n"
+      s"${blue("Some(3)")} did not satisfy ${cyan("isSome(") + yellow("isGreaterThan(4)") + cyan(")")}\n"
     ),
     withOffset(2)(
-      s"${blue("Right(Some(3))")} did not satisfy ${cyan("isRight(" + yellowThenCyan("isSome(isGreaterThan(4))") + ")")}\n"
+      s"${blue("Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
     )
   )
 
@@ -122,7 +122,7 @@ object ReportingTestUtils {
     expectedFailure("labeled failures"),
     withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
     withOffset(2)(
-      s"${blue("Some(0)")} did not satisfy ${cyan("(isSome(" + yellowThenCyan("equalTo(1)") + ") ?? \"third\")")}\n"
+      s"${blue("Some(0)")} did not satisfy ${cyan("(isSome(") + yellow("equalTo(1)") + cyan(") ?? \"third\")")}\n"
     )
   )
 
@@ -133,7 +133,7 @@ object ReportingTestUtils {
     expectedFailure("Not combinator"),
     withOffset(2)(s"${blue("100")} satisfied ${cyan("equalTo(100)")}\n"),
     withOffset(2)(
-      s"${blue("100")} did not satisfy ${cyan("not(" + yellowThenCyan("equalTo(100)") + ")")}\n"
+      s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}\n"
     )
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -6,7 +6,7 @@ import zio.{ UIO, ZIO }
 object TestUtils {
 
   def execute[E, L, S](spec: ZSpec[TestEnvironment, E, L, S]): UIO[ExecutedSpec[E, L, S]] =
-    TestExecutor.managed(environment.testEnvironmentManaged)(spec, ExecutionStrategy.Sequential)
+    TestExecutor.managed(environment.testEnvironmentManaged).run(spec, ExecutionStrategy.Sequential)
 
   def forAllTests[E, L, S](
     execSpec: UIO[ExecutedSpec[E, L, S]]

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -16,8 +16,11 @@
 
 package zio.test
 
+import java.util.regex.Pattern
+
 import zio.duration.Duration
-import zio.test.ConsoleUtils._
+import zio.test.ConsoleUtils.{ cyan, red, _ }
+import zio.test.FailureRenderer.FailureMessage.{ Fragment, Message }
 import zio.test.RenderedResult.CaseType._
 import zio.test.RenderedResult.Status._
 import zio.test.RenderedResult.{ CaseType, Status }
@@ -25,17 +28,19 @@ import zio.test.mock.MockException.{ InvalidArgumentsException, InvalidMethodExc
 import zio.test.mock.{ Method, MockException }
 import zio.{ Cause, UIO, URIO }
 
+import scala.io.AnsiColor
+
 object DefaultTestReporter {
 
   def render[E, S](
     executedSpec: ExecutedSpec[E, String, S],
     testAnnotationRenderer: TestAnnotationRenderer
-  ): UIO[Seq[RenderedResult]] = {
+  ): UIO[Seq[RenderedResult[String]]] = {
     def loop(
       executedSpec: ExecutedSpec[E, String, S],
       depth: Int,
       ancestors: List[TestAnnotationMap]
-    ): UIO[Seq[RenderedResult]] =
+    ): UIO[Seq[RenderedResult[String]]] =
       executedSpec.caseValue match {
         case c @ Spec.SuiteCase(label, executedSpecs, _) =>
           for {
@@ -140,107 +145,28 @@ object DefaultTestReporter {
     withOffset(offset)(red("- " + label))
 
   private def renderFailureDetails(failureDetails: FailureDetails, offset: Int): UIO[Seq[String]] =
-    failureDetails match {
-      case FailureDetails(assertionFailureDetails, genFailureDetails) =>
-        renderAssertionFailureDetails(assertionFailureDetails, offset).map(
-          renderGenFailureDetails(genFailureDetails, offset) ++ _
-        )
-    }
-
-  private def renderGenFailureDetails[A](failureDetails: Option[GenFailureDetails], offset: Int): Seq[String] =
-    failureDetails match {
-      case Some(details) =>
-        val shrinked = details.shrinkedInput.toString
-        val initial  = details.initialInput.toString
-        val renderShrinked = withOffset(offset + tabSize)(
-          s"Test failed after ${details.iterations + 1} iteration${if (details.iterations > 0) "s" else ""} with input: ${red(shrinked)}"
-        )
-        if (initial == shrinked) Seq(renderShrinked)
-        else Seq(renderShrinked, withOffset(offset + tabSize)(s"Original input before shrinking was: ${red(initial)}"))
-      case None => Seq()
-    }
-
-  private def renderAssertionFailureDetails(failureDetails: ::[AssertionValue], offset: Int): UIO[Seq[String]] = {
-    def loop(failureDetails: List[AssertionValue], rendered: Seq[String]): UIO[Seq[String]] =
-      failureDetails match {
-        case fragment :: whole :: failureDetails =>
-          renderWhole(fragment, whole, offset).flatMap(s => loop(whole :: failureDetails, rendered :+ s))
-        case _ =>
-          UIO.succeed(rendered)
-      }
-    for {
-      fragment <- renderFragment(failureDetails.head, offset)
-      rest     <- loop(failureDetails, Seq())
-    } yield Seq(fragment) ++ rest
-  }
-
-  private def renderWhole(fragment: AssertionValue, whole: AssertionValue, offset: Int): UIO[String] =
-    renderSatisfied(whole).map { satisfied =>
-      withOffset(offset + tabSize) {
-        blue(whole.value.toString) +
-          satisfied +
-          highlight(cyan(whole.assertion.toString), fragment.assertion.toString)
-      }
-    }
-
-  private def renderFragment(fragment: AssertionValue, offset: Int): UIO[String] =
-    renderSatisfied(fragment).map { satisfied =>
-      withOffset(offset + tabSize) {
-        blue(fragment.value.toString) +
-          satisfied +
-          cyan(fragment.assertion.toString)
-      }
-    }
-
-  private def renderSatisfied(fragment: AssertionValue): UIO[String] =
-    fragment.assertion.test(fragment.value).map { p =>
-      if (p) " satisfied " else " did not satisfy "
-    }
+    FailureRenderer
+      .renderFailureDetails(failureDetails, offset)
+      .map(renderToStringLines)
 
   private def renderCause(cause: Cause[Any], offset: Int): UIO[String] =
-    cause.dieOption match {
-      case Some(TestTimeoutException(message)) => UIO.succeed(message)
-      case Some(exception: MockException) =>
-        renderMockException(exception).map(_.split("\n").map(withOffset(offset + tabSize)).mkString("\n"))
-      case _ => UIO.succeed(cause.prettyPrint.split("\n").map(withOffset(offset + tabSize)).mkString("\n"))
+    FailureRenderer
+      .renderCause(cause, offset)
+      .map(renderToStringLines(_).mkString("\n"))
+
+  private def renderToStringLines(message: Message): Seq[String] = {
+    def renderFragment(f: Fragment) =
+      if (f.ansiColorCode.nonEmpty) f.ansiColorCode + f.text + AnsiColor.RESET
+      else f.text
+    message.lines.map { line =>
+      withOffset(line.offset)(line.fragments.foldLeft("") { (str, f) =>
+        str + renderFragment(f)
+      })
     }
-
-  private def renderMockException(exception: MockException): UIO[String] =
-    exception match {
-      case InvalidArgumentsException(method, args, assertion) =>
-        renderTestFailure(s"$method called with invalid arguments", assert(args)(assertion))
-
-      case InvalidMethodException(method, expectedMethod, assertion) =>
-        UIO.succeed(
-          List(
-            red(s"- invalid call to $method"),
-            renderExpectation(expectedMethod, assertion, tabSize)
-          ).mkString("\n")
-        )
-
-      case UnmetExpectationsException(expectations) =>
-        UIO.succeed((red(s"- unmet expectations") :: expectations.map {
-          case (expectedMethod, assertion) => renderExpectation(expectedMethod, assertion, tabSize)
-        }).mkString("\n"))
-    }
-
-  private def renderTestFailure(label: String, testResult: TestResult): UIO[String] =
-    testResult.run.flatMap(
-      _.failures.fold(UIO.succeed(""))(
-        _.fold(
-          details => renderFailure(label, 0, details).map(failures => rendered(Test, label, Failed, 0, failures: _*))
-        )(_.zipWith(_)(_ && _), _.zipWith(_)(_ || _), _.map(!_)).map(_.rendered.mkString("\n"))
-      )
-    )
-
-  private def renderExpectation[M, I, A](method: Method[M, I, A], assertion: Assertion[I], offset: Int): String =
-    withOffset(offset)(s"expected $method with arguments ${cyan(assertion.toString)}")
+  }
 
   private def withOffset(n: Int)(s: String): String =
     " " * n + s
-
-  private def highlight(string: String, substring: String): String =
-    string.replace(substring, yellowThenCyan(substring))
 
   private val tabSize = 2
 
@@ -250,7 +176,7 @@ object DefaultTestReporter {
     result: Status,
     offset: Int,
     rendered: String*
-  ): RenderedResult =
+  ): RenderedResult[String] =
     RenderedResult(caseType, label, result, offset, rendered)
 }
 
@@ -269,10 +195,10 @@ object RenderedResult {
   }
 }
 
-case class RenderedResult(caseType: CaseType, label: String, status: Status, offset: Int, rendered: Seq[String]) {
+case class RenderedResult[T](caseType: CaseType, label: String, status: Status, offset: Int, rendered: Seq[T]) {
   self =>
 
-  def &&(that: RenderedResult): RenderedResult =
+  def &&(that: RenderedResult[T]): RenderedResult[T] =
     (self.status, that.status) match {
       case (Ignored, _)     => that
       case (_, Ignored)     => self
@@ -281,7 +207,7 @@ case class RenderedResult(caseType: CaseType, label: String, status: Status, off
       case (_, Passed)      => self
     }
 
-  def ||(that: RenderedResult): RenderedResult =
+  def ||(that: RenderedResult[T]): RenderedResult[T] =
     (self.status, that.status) match {
       case (Ignored, _)     => that
       case (_, Ignored)     => self
@@ -290,17 +216,201 @@ case class RenderedResult(caseType: CaseType, label: String, status: Status, off
       case (_, Passed)      => that
     }
 
-  def unary_! : RenderedResult =
+  def unary_! : RenderedResult[T] =
     self.status match {
       case Ignored => self
       case Failed  => self.copy(status = Passed)
       case Passed  => self.copy(status = Failed)
     }
 
-  def withAnnotations(annotations: Seq[String]): RenderedResult =
+  def withAnnotations(annotations: Seq[String])(implicit ev: T =:= String): RenderedResult[T] = {
+    val strRendered = rendered.map(ev)
     if (rendered.isEmpty || annotations.isEmpty) self
     else {
-      val renderedAnnotations = annotations.mkString(" - ", ", ", "")
-      self.copy(rendered = Seq(rendered.head + renderedAnnotations) ++ rendered.tail)
+      val renderedAnnotations     = annotations.mkString(" - ", ", ", "")
+      val renderedWithAnnotations = Seq(strRendered.head + renderedAnnotations) ++ strRendered.tail
+      self.copy(rendered = renderedWithAnnotations.asInstanceOf[Seq[T]])
     }
+  }
+}
+
+object FailureRenderer {
+
+  private val tabSize = 2
+
+  object FailureMessage {
+    case class Message(lines: Vector[Line] = Vector.empty) {
+      def :+(line: Line)       = Message(lines :+ line)
+      def ++(message: Message) = Message(lines ++ message.lines)
+      def map(f: Line => Line) = copy(lines = lines.map(f))
+    }
+    object Message {
+      def apply(lines: Seq[Line]): Message = Message(lines.toVector)
+      def apply(lineText: String): Message = Fragment(lineText).toLine.toMessage
+    }
+    case class Line(fragments: Vector[Fragment] = Vector.empty, offset: Int = 0) {
+      def :+(fragment: Fragment)    = Line(fragments :+ fragment)
+      def +(fragment: Fragment)     = Line(fragments :+ fragment)
+      def prepend(message: Message) = Message(this +: message.lines)
+      def +(line: Line)             = Message(Vector(this, line))
+      def ++(line: Line)            = copy(fragments = fragments ++ line.fragments)
+      def withOffset(shift: Int)    = copy(offset = offset + shift)
+      def toMessage                 = Message(Vector(this))
+    }
+    object Line {
+      def fromString(text: String, offset: Int = 0): Line = Fragment(text).toLine.withOffset(offset)
+    }
+    case class Fragment(text: String, ansiColorCode: String = "") {
+      def +:(line: Line)      = prepend(line)
+      def prepend(line: Line) = Line(this +: line.fragments, line.offset)
+      def +(f: Fragment)      = Line(Vector(this, f))
+      def toLine              = Line(Vector(this))
+    }
+  }
+
+  import FailureMessage._
+
+  def renderFailureDetails(failureDetails: FailureDetails, offset: Int): UIO[Message] =
+    failureDetails match {
+      case FailureDetails(assertionFailureDetails, genFailureDetails) =>
+        renderAssertionFailureDetails(assertionFailureDetails, offset).map(
+          renderGenFailureDetails(genFailureDetails, offset) ++ _
+        )
+    }
+
+  private def renderAssertionFailureDetails(failureDetails: ::[AssertionValue], offset: Int): UIO[Message] = {
+    def loop(failureDetails: List[AssertionValue], rendered: Message): UIO[Message] =
+      failureDetails match {
+        case fragment :: whole :: failureDetails =>
+          renderWhole(fragment, whole, offset).flatMap(s => loop(whole :: failureDetails, rendered :+ s))
+        case _ =>
+          UIO.succeed(rendered)
+      }
+    for {
+      fragment <- renderFragment(failureDetails.head, offset)
+      rest     <- loop(failureDetails, Message())
+    } yield fragment.toMessage ++ rest
+  }
+
+  private def renderGenFailureDetails[A](failureDetails: Option[GenFailureDetails], offset: Int): Message =
+    failureDetails match {
+      case Some(details) =>
+        val shrinked = details.shrinkedInput.toString
+        val initial  = details.initialInput.toString
+        val renderShrinked = withOffset(offset + tabSize)(
+          Fragment(
+            s"Test failed after ${details.iterations + 1} iteration${if (details.iterations > 0) "s" else ""} with input: "
+          ) +
+            red(shrinked)
+        )
+        if (initial == shrinked) renderShrinked.toMessage
+        else
+          renderShrinked + withOffset(offset + tabSize)(
+            Fragment(s"Original input before shrinking was: ") + red(initial)
+          )
+      case None => Message()
+    }
+
+  private def renderWhole(fragment: AssertionValue, whole: AssertionValue, offset: Int): UIO[Line] =
+    renderSatisfied(whole).map { satisfied =>
+      withOffset(offset + tabSize) {
+        blue(whole.value.toString) +
+          satisfied ++
+          highlight(cyan(whole.assertion.toString), fragment.assertion.toString)
+      }
+    }
+
+  private def renderFragment(fragment: AssertionValue, offset: Int): UIO[Line] =
+    renderSatisfied(fragment).map { satisfied =>
+      withOffset(offset + tabSize) {
+        blue(fragment.value.toString) +
+          satisfied +
+          cyan(fragment.assertion.toString)
+      }
+    }
+
+  private def highlight(fragment: Fragment, substring: String, colorCode: String = AnsiColor.YELLOW): Line = {
+    val parts = fragment.text.split(Pattern.quote(substring))
+    if (parts.size == 1) fragment.toLine
+    else
+      parts.foldLeft(Line()) { (line, part) =>
+        if (line.fragments.size < parts.size * 2 - 2)
+          line + Fragment(part, fragment.ansiColorCode) + Fragment(substring, colorCode)
+        else line + Fragment(part, fragment.ansiColorCode)
+      }
+  }
+
+  private def renderSatisfied(fragment: AssertionValue): UIO[Fragment] =
+    fragment.assertion.test(fragment.value).map { p =>
+      Fragment(if (p) " satisfied " else " did not satisfy ")
+    }
+
+  def renderCause(cause: Cause[Any], offset: Int): UIO[Message] =
+    cause.dieOption match {
+      case Some(TestTimeoutException(message)) => UIO.succeed(Message(message))
+      case Some(exception: MockException) =>
+        renderMockException(exception).map(_.map(withOffset(offset + tabSize)))
+      case _ =>
+        UIO.succeed(
+          Message(
+            cause.prettyPrint
+              .split("\n")
+              .map(s => withOffset(offset + tabSize)(Line.fromString(s)))
+              .toVector
+          )
+        )
+    }
+
+  private def renderMockException(exception: MockException): UIO[Message] =
+    exception match {
+      case InvalidArgumentsException(method, args, assertion) =>
+        renderTestFailure(s"$method called with invalid arguments", assert(args)(assertion))
+
+      case InvalidMethodException(method, expectedMethod, assertion) =>
+        UIO.succeed(
+          Message(Seq(red(s"- invalid call to $method").toLine, renderExpectation(expectedMethod, assertion, tabSize)))
+        )
+
+      case UnmetExpectationsException(expectations) =>
+        UIO.succeed(Message(red(s"- unmet expectations").toLine +: expectations.map {
+          case (expectedMethod, assertion) => renderExpectation(expectedMethod, assertion, tabSize)
+        }))
+    }
+
+  private def renderExpectation[M, I, A](method: Method[M, I, A], assertion: Assertion[I], offset: Int): Line =
+    withOffset(offset)(Fragment(s"expected $method with arguments ") + cyan(assertion.toString))
+
+  def renderTestFailure(label: String, testResult: TestResult): UIO[Message] =
+    testResult.run.flatMap(
+      _.failures.fold(UIO.succeed(Message()))(
+        _.fold(
+          details =>
+            renderFailure(label, 0, details)
+              .map(failures => rendered(Test, label, Failed, 0, failures.lines: _*))
+        )(_.zipWith(_)(_ && _), _.zipWith(_)(_ || _), _.map(!_))
+          .map(_.rendered)
+          .map(Message.apply)
+      )
+    )
+
+  private def rendered[T](
+    caseType: CaseType,
+    label: String,
+    result: Status,
+    offset: Int,
+    rendered: T*
+  ): RenderedResult[T] =
+    RenderedResult(caseType, label, result, offset, rendered)
+
+  private def renderFailure(label: String, offset: Int, details: FailureDetails): UIO[Message] =
+    renderFailureDetails(details, offset).map(renderFailureLabel(label, offset).prepend)
+
+  private def renderFailureLabel(label: String, offset: Int): Line =
+    withOffset(offset)(red("- " + label).toLine)
+
+  private def red(s: String)                                      = FailureMessage.Fragment(s, AnsiColor.RED)
+  private def blue(s: String)                                     = FailureMessage.Fragment(s, AnsiColor.BLUE)
+  private def cyan(s: String)                                     = FailureMessage.Fragment(s, AnsiColor.CYAN)
+  private def withOffset(i: Int)(line: FailureMessage.Line): Line = line.withOffset(i)
+
 }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -18,6 +18,8 @@ package zio.test
 
 import java.util.regex.Pattern
 
+import scala.io.AnsiColor
+
 import zio.duration.Duration
 import zio.test.ConsoleUtils.{ cyan, red, _ }
 import zio.test.FailureRenderer.FailureMessage.{ Fragment, Message }
@@ -27,8 +29,6 @@ import zio.test.RenderedResult.{ CaseType, Status }
 import zio.test.mock.MockException.{ InvalidArgumentsException, InvalidMethodException, UnmetExpectationsException }
 import zio.test.mock.{ Method, MockException }
 import zio.{ Cause, UIO, URIO }
-
-import scala.io.AnsiColor
 
 object DefaultTestReporter {
 

--- a/test/shared/src/main/scala/zio/test/RenderUtils.scala
+++ b/test/shared/src/main/scala/zio/test/RenderUtils.scala
@@ -31,7 +31,4 @@ private[test] object ConsoleUtils {
 
   def cyan(s: String): String =
     SConsole.CYAN + s + SConsole.RESET
-
-  def yellowThenCyan(s: String): String =
-    SConsole.YELLOW + s + SConsole.CYAN
 }

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -42,7 +42,7 @@ final case class TestRunner[R, E, L, -T, S](
    * Runs the spec, producing the execution results.
    */
   def run(spec: ZSpec[R, E, L, T]): URIO[TestLogger with Clock, ExecutedSpec[E, L, S]] =
-    executor(spec, ExecutionStrategy.ParallelN(4)).timed.flatMap {
+    executor.run(spec, ExecutionStrategy.ParallelN(4)).timed.flatMap {
       case (duration, results) => reporter(duration, results).as(results)
     }
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -82,13 +82,6 @@ package object test extends CompileVariants {
   }
 
   /**
-   * A `TestExecutor[R, E, L, T, S]` is capable of executing specs containing
-   * tests of type `T`, annotated with labels of type `L`, that require an
-   * environment `R` and may fail with an `E` or succeed with a `S`.
-   */
-  type TestExecutor[+R, E, L, -T, +S] = (ZSpec[R, E, L, T], ExecutionStrategy) => UIO[ExecutedSpec[E, L, S]]
-
-  /**
    * A `ZRTestEnv` is an alias for all ZIO provided [[zio.test.environment.Restorable Restorable]]
    * [[zio.test.environment.TestEnvironment TestEnvironment]] objects
    */


### PR DESCRIPTION
Annotating your spec with `@RunWith(classOf[ZTestJUnitRunner])` or extending `DefaultSpecWithJUnit` should allow running zio tests under most build tools like bazel, maven, gradle. Such Specs can also be run from Intellij (and probably other IDEs)

* Refactored DefaultTestReporter to allow access to relevant rendering functions.
* Test results are not being mapped correctly to spec structure by Intellij - still trying to figure it out

![ide](http://g.recordit.co/v7nLNshwUq.gif)

cc: @adamgfraser 