### PR TITLE
Minor cleanup on type annotations.

### DIFF
--- a/core/shared/src/main/scala/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/zio/FunctionIO.scala
@@ -206,8 +206,8 @@ object FunctionIO extends Serializable {
     final def unsafeCoerce[E2] = error.asInstanceOf[E2]
   }
 
-  private[zio] final class Pure[E, A, B](val run: A => IO[E, B]) extends FunctionIO[E, A, B] {}
-  private[zio] final class Impure[E, A, B](val apply0: A => B) extends FunctionIO[E, A, B] {
+  private[zio] final class Pure[+E, -A, +B](val run: A => IO[E, B]) extends FunctionIO[E, A, B] {}
+  private[zio] final class Impure[+E, -A, +B](val apply0: A => B) extends FunctionIO[E, A, B] {
     val run: A => IO[E, B] = a =>
       IO.effectSuspendTotal {
         try IO.succeed[B](apply0(a))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1197,9 +1197,9 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   private[ZSink] object internal {
     sealed trait Side[+E, +S, +A]
     object Side {
-      final case class Error[E](e: E) extends Side[E, Nothing, Nothing]
-      final case class State[S](s: S) extends Side[Nothing, S, Nothing]
-      final case class Value[A](a: A) extends Side[Nothing, Nothing, A]
+      final case class Error[+E](e: E) extends Side[E, Nothing, Nothing]
+      final case class State[+S](s: S) extends Side[Nothing, S, Nothing]
+      final case class Value[+A](a: A) extends Side[Nothing, Nothing, A]
     }
 
     def assertNonNegative(n: Long): UIO[Unit] =

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -216,7 +216,7 @@ object Expectation {
    * Models a call on module `M` capability that takes input arguments `I` and returns an effect
    * that may fail with an error `E` or produce a single `A`.
    */
-  private[mock] final case class Call[M, I, E, A](
+  private[mock] final case class Call[M, I, +E, A](
     method: Method[M, I, A],
     assertion: Assertion[I],
     returns: I => IO[E, A]
@@ -228,7 +228,7 @@ object Expectation {
    * The `A` value in `next` is not used, it's only required to fit the flatMap signature,
    * which we want to be able to use the for-comprehension syntax.
    */
-  private[mock] final case class FlatMap[M, E, A, B](
+  private[mock] final case class FlatMap[M, +E, A, +B](
     current: Expectation[M, E, A],
     next: A => Expectation[M, E, B]
   ) extends Expectation[M, E, B]

--- a/test/shared/src/main/scala/zio/test/mock/ReturnExpectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/ReturnExpectation.scala
@@ -28,6 +28,6 @@ sealed trait ReturnExpectation[-I, +E, +A] {
 
 object ReturnExpectation {
 
-  private[mock] final case class Succeed[I, +A](io: I => IO[Nothing, A]) extends ReturnExpectation[I, Nothing, A]
-  private[mock] final case class Fail[I, +E](io: I => IO[E, Nothing])    extends ReturnExpectation[I, E, Nothing]
+  private[mock] final case class Succeed[-I, +A](io: I => IO[Nothing, A]) extends ReturnExpectation[I, Nothing, A]
+  private[mock] final case class Fail[-I, +E](io: I => IO[E, Nothing])    extends ReturnExpectation[I, E, Nothing]
 }


### PR DESCRIPTION
@adamgfraser 

To follow up on type annotations on GADTS. I had noticed there were some left. Additionally, I believe the entire mock package in zio-test. `ArgumentExpectation`, `Method`, `Mockable` etc might need some review on its variance. I would love to do that as a learning experience. I did not have the time just yet. Perhaps, I am just plain wrong on that one.

Do you agree with my changes?