### PR TITLE
ZIO Test: Migrate All Tests To Use Curried Assert

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,6 @@ lazy val coreTests = crossProject(JSPlatform, JVMPlatform)
   .settings(skip in publish := true)
   .settings(Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat)
   .enablePlugins(BuildInfoPlugin)
-  .settings(scalacOptions ++= { if (isDotty.value) Seq() else Seq("-P:silencer:globalFilters=assert") })
 
 lazy val coreTestsJVM = coreTests.jvm
   .settings(dottySettings)
@@ -153,7 +152,6 @@ lazy val streamsTests = crossProject(JSPlatform, JVMPlatform)
   .settings(skip in publish := true)
   .settings(Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars)
   .enablePlugins(BuildInfoPlugin)
-  .settings(scalacOptions ++= { if (isDotty.value) Seq() else Seq("-P:silencer:globalFilters=assert") })
 
 lazy val streamsTestsJVM = streamsTests.jvm.dependsOn(coreTestsJVM % "test->compile")
 
@@ -187,7 +185,6 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.test"))
   .settings(skip in publish := true)
   .enablePlugins(BuildInfoPlugin)
-  .settings(scalacOptions ++= { if (isDotty.value) Seq() else Seq("-P:silencer:globalFilters=assert") })
 
 lazy val testTestsJVM = testTests.jvm.settings(
   dottySettings,

--- a/core-tests/js/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/js/src/test/scala/zio/internal/OneShotSpec.scala
@@ -12,12 +12,12 @@ object OneShotSpec extends ZIOBaseSpec {
         val oneShot = OneShot.make[Int]
         oneShot.set(1)
 
-        assert(oneShot.get(), equalTo(1))
+        assert(oneShot.get())(equalTo(1))
       },
       test("set must not accept a null value") {
         val oneShot = OneShot.make[Object]
 
-        assert(oneShot.set(null), throwsA[Error])
+        assert(oneShot.set(null))(throwsA[Error])
       },
       test("isSet must report if a value is set") {
         val oneShot = OneShot.make[Int]
@@ -28,18 +28,18 @@ object OneShotSpec extends ZIOBaseSpec {
 
         val resultAfterSet = oneShot.isSet
 
-        assert(resultBeforeSet, isFalse) && assert(resultAfterSet, isTrue)
+        assert(resultBeforeSet)(isFalse) && assert(resultAfterSet)(isTrue)
       },
       test("get must fail if no value is set") {
         val oneShot = OneShot.make[Object]
 
-        assert(oneShot.get(), throwsA[Error])
+        assert(oneShot.get())(throwsA[Error])
       },
       test("cannot set value twice") {
         val oneShot = OneShot.make[Int]
         oneShot.set(1)
 
-        assert(oneShot.set(2), throwsA[Error])
+        assert(oneShot.set(2))(throwsA[Error])
       }
     )
   )

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -125,16 +125,15 @@ object StackTracesSpec extends DefaultRunnableSpec {
         trace <- fiberAncestry
       } yield trace
 
-      fiber causeMust {
-        cause =>
-          assert(cause.traces)(isNonEmpty) &&
-          assert(cause.traces.head.parentTrace.isEmpty)(isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(
-            isTrue
-          )
+      fiber causeMust { cause =>
+        assert(cause.traces)(isNonEmpty) &&
+        assert(cause.traces.head.parentTrace.isEmpty)(isFalse) &&
+        assert(cause.traces.head.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+        assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+        assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+        assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(
+          isTrue
+        )
       }
     },
     testM("fiber ancestry example with uploads") {

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -16,10 +16,10 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield {
         show(trace)
 
-        assert(trace.executionTrace.size, equalTo(2)) &&
-        assert(trace.executionTrace.count(_.prettyPrint.contains("basicTest")), equalTo(1)) &&
-        assert(trace.stackTrace.size, equalTo(3)) &&
-        assert(trace.stackTrace.count(_.prettyPrint.contains("basicTest")), equalTo(1))
+        assert(trace.executionTrace.size)(equalTo(2)) &&
+        assert(trace.executionTrace.count(_.prettyPrint.contains("basicTest")))(equalTo(1)) &&
+        assert(trace.stackTrace.size)(equalTo(3)) &&
+        assert(trace.stackTrace.count(_.prettyPrint.contains("basicTest")))(equalTo(1))
       }
     },
     testM("foreachTrace") {
@@ -28,11 +28,11 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield {
         show(trace)
 
-        assert(trace.stackTrace.size, equalTo(3)) &&
-        assert(trace.stackTrace.exists(_.prettyPrint.contains("foreachTest")), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("foreachTest")), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("foreach_")), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("effectTotal")), isTrue)
+        assert(trace.stackTrace.size)(equalTo(3)) &&
+        assert(trace.stackTrace.exists(_.prettyPrint.contains("foreachTest")))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("foreachTest")))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("foreach_")))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("effectTotal")))(isTrue)
       }
     },
     testM("foreach fail") {
@@ -41,14 +41,14 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield {
         val (trace1, trace2) = trace
 
-        assert(trace1.stackTrace.exists(_.prettyPrint.contains("foreach_")), isTrue) &&
-        assert(trace1.stackTrace.exists(_.prettyPrint.contains("foreachFail")), isTrue) &&
-        assert(trace1.executionTrace.exists(_.prettyPrint.contains("foreach_")), isTrue) &&
-        assert(trace1.executionTrace.exists(_.prettyPrint.contains("foreachFail")), isTrue) &&
-        assert(trace2.stackTrace.size, equalTo(3)) &&
-        assert(trace2.stackTrace.exists(_.prettyPrint.contains("foreachFail")), isTrue) &&
-        assert(trace2.executionTrace.exists(_.prettyPrint.contains("foreach_")), isTrue) &&
-        assert(trace2.executionTrace.exists(_.prettyPrint.contains("foreachFail")), isTrue)
+        assert(trace1.stackTrace.exists(_.prettyPrint.contains("foreach_")))(isTrue) &&
+        assert(trace1.stackTrace.exists(_.prettyPrint.contains("foreachFail")))(isTrue) &&
+        assert(trace1.executionTrace.exists(_.prettyPrint.contains("foreach_")))(isTrue) &&
+        assert(trace1.executionTrace.exists(_.prettyPrint.contains("foreachFail")))(isTrue) &&
+        assert(trace2.stackTrace.size)(equalTo(3)) &&
+        assert(trace2.stackTrace.exists(_.prettyPrint.contains("foreachFail")))(isTrue) &&
+        assert(trace2.executionTrace.exists(_.prettyPrint.contains("foreach_")))(isTrue) &&
+        assert(trace2.executionTrace.exists(_.prettyPrint.contains("foreachFail")))(isTrue)
 
       }
     },
@@ -58,13 +58,13 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield trace
 
       io causeMust { cause =>
-        assert(cause.traces.head.stackTrace.size, equalTo(4)) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(4)) &&
         assert(cause.traces.head.stackTrace.exists {
           (_: ZTraceElement) match {
             case s: SourceLocation => s.method contains "foreachParFail"
             case _                 => false
           }
-        }, isTrue)
+        })(isTrue)
       }
     },
     testM("foreachParN fail") {
@@ -74,13 +74,13 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield trace
 
       io causeMust { cause =>
-        assert(cause.traces.head.stackTrace.size, equalTo(4)) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(4)) &&
         assert(cause.traces.head.stackTrace.exists {
           (_: ZTraceElement) match {
             case s: SourceLocation => s.method contains "foreachParNFail"
             case _                 => false
           }
-        }, isTrue)
+        })(isTrue)
       }
     },
     testM("left-associative fold") {
@@ -94,9 +94,8 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield {
         show(trace)
 
-        assert(trace.stackTrace.size, equalTo(2)) &&
-        assert(
-          trace.executionTrace.count(x => x.prettyPrint.contains("leftAssociativeFold")),
+        assert(trace.stackTrace.size)(equalTo(2)) &&
+        assert(trace.executionTrace.count(x => x.prettyPrint.contains("leftAssociativeFold")))(
           equalTo((expectedExecutionTrace))
         )
       }
@@ -109,16 +108,16 @@ object StackTracesSpec extends DefaultRunnableSpec {
         show(trace1)
         show(trace2)
 
-        assert(trace1.executionTrace.size, equalTo(1)) &&
-        assert(trace1.stackTrace.size, equalTo(6)) &&
-        assert(trace1.stackTrace.exists(_.prettyPrint.contains("method2")), isTrue) &&
-        assert(trace1.stackTrace.exists(_.prettyPrint.contains("method1")), isTrue) &&
-        assert(trace1.stackTrace.exists(_.prettyPrint.contains("io")), isTrue) &&
-        assert(trace2.stackTrace.size, equalTo(3)) &&
-        assert(trace2.stackTrace.exists(_.prettyPrint.contains("tuple")), isTrue) &&
-        assert(trace2.executionTrace.exists(_.prettyPrint.contains("method2")), isTrue) &&
-        assert(trace2.executionTrace.exists(_.prettyPrint.contains("method1")), isTrue) &&
-        assert(trace2.executionTrace.exists(_.prettyPrint.contains("io")), isTrue)
+        assert(trace1.executionTrace.size)(equalTo(1)) &&
+        assert(trace1.stackTrace.size)(equalTo(6)) &&
+        assert(trace1.stackTrace.exists(_.prettyPrint.contains("method2")))(isTrue) &&
+        assert(trace1.stackTrace.exists(_.prettyPrint.contains("method1")))(isTrue) &&
+        assert(trace1.stackTrace.exists(_.prettyPrint.contains("io")))(isTrue) &&
+        assert(trace2.stackTrace.size)(equalTo(3)) &&
+        assert(trace2.stackTrace.exists(_.prettyPrint.contains("tuple")))(isTrue) &&
+        assert(trace2.executionTrace.exists(_.prettyPrint.contains("method2")))(isTrue) &&
+        assert(trace2.executionTrace.exists(_.prettyPrint.contains("method1")))(isTrue) &&
+        assert(trace2.executionTrace.exists(_.prettyPrint.contains("io")))(isTrue)
       }
     },
     testM("fiber ancestry") {
@@ -128,13 +127,12 @@ object StackTracesSpec extends DefaultRunnableSpec {
 
       fiber causeMust {
         cause =>
-          assert(cause.traces, isNonEmpty) &&
-          assert(cause.traces.head.parentTrace.isEmpty, isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.isEmpty, isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.isEmpty, isFalse) &&
-          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty, isFalse) &&
-          assert(
-            cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty,
+          assert(cause.traces)(isNonEmpty) &&
+          assert(cause.traces.head.parentTrace.isEmpty)(isFalse) &&
+          assert(cause.traces.head.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(isFalse) &&
+          assert(cause.traces.head.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.get.parentTrace.isEmpty)(
             isTrue
           )
       }
@@ -143,12 +141,12 @@ object StackTracesSpec extends DefaultRunnableSpec {
       fiberAncestryUploadExample
         .uploadUsers(List(new fiberAncestryUploadExample.User)) causeMust {
         cause =>
-          assert(cause.traces.head.stackTrace.size, equalTo(3)) &&
-          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("uploadUsers"), isTrue) &&
-          assert(cause.traces(1).stackTrace, isEmpty) &&
-          assert(cause.traces(1).executionTrace.size, equalTo(1)) &&
-          assert(cause.traces(1).executionTrace.head.prettyPrint.contains("uploadTo"), isTrue) &&
-          assert(cause.traces(1).parentTrace.isEmpty, isFalse) &&
+          assert(cause.traces.head.stackTrace.size)(equalTo(3)) &&
+          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("uploadUsers"))(isTrue) &&
+          assert(cause.traces(1).stackTrace)(isEmpty) &&
+          assert(cause.traces(1).executionTrace.size)(equalTo(1)) &&
+          assert(cause.traces(1).executionTrace.head.prettyPrint.contains("uploadTo"))(isTrue) &&
+          assert(cause.traces(1).parentTrace.isEmpty)(isFalse) &&
           assert(
             cause
               .traces(1)
@@ -157,17 +155,16 @@ object StackTracesSpec extends DefaultRunnableSpec {
               .parentTrace
               .get
               .stackTrace
-              .exists(_.prettyPrint.contains("uploadUsers")),
-            isTrue
-          )
+              .exists(_.prettyPrint.contains("uploadUsers"))
+          )(isTrue)
       }
     },
     testM("fiber ancestry has a limited size") {
       fiberAncestryIsLimitedFixture.recursiveFork(10000) causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.parents.size, equalTo(10)) &&
-        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("recursiveFork")), isTrue) &&
-        assert(cause.traces.head.parents.head.stackTrace.exists(_.prettyPrint.contains("recursiveFork")), isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.parents.size)(equalTo(10)) &&
+        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("recursiveFork")))(isTrue) &&
+        assert(cause.traces.head.parents.head.stackTrace.exists(_.prettyPrint.contains("recursiveFork")))(isTrue)
       }
     },
     testM("blocking trace") {
@@ -178,8 +175,8 @@ object StackTracesSpec extends DefaultRunnableSpec {
       io causeMust { cause =>
         val trace = cause.traces.head
 
-        assert(trace.stackTrace.exists(_.prettyPrint.contains("blockingTrace")), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("blockingTrace")), isTrue)
+        assert(trace.stackTrace.exists(_.prettyPrint.contains("blockingTrace")))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("blockingTrace")))(isTrue)
       }
     },
     testM("tracing regions") {
@@ -188,16 +185,13 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield trace
 
       io causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("traceThis")), isTrue) &&
-        assert(
-          cause.traces.head.executionTrace.exists {
-            case SourceLocation(_, _, m, _) => m == "tracingRegions"
-            case NoLocation(_)              => true
-          },
-          isFalse
-        ) &&
-        assert(cause.traces.head.stackTrace.size, equalTo(3))
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("traceThis")))(isTrue) &&
+        assert(cause.traces.head.executionTrace.exists {
+          case SourceLocation(_, _, m, _) => m == "tracingRegions"
+          case NoLocation(_)              => true
+        })(isFalse) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(3))
       }
     },
     testM("tracing region is inherited on fork") {
@@ -206,10 +200,10 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield trace
 
       io causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.executionTrace.isEmpty, isTrue) &&
-        assert(cause.traces.head.stackTrace.isEmpty, isTrue) &&
-        assert(cause.traces.head.parentTrace.isEmpty, isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.executionTrace.isEmpty)(isTrue) &&
+        assert(cause.traces.head.stackTrace.isEmpty)(isTrue) &&
+        assert(cause.traces.head.parentTrace.isEmpty)(isTrue)
       }
     },
     testM("execution trace example with conditional") {
@@ -220,9 +214,9 @@ object StackTracesSpec extends DefaultRunnableSpec {
       io causeMust { cause =>
         val trace = cause.traces.head
 
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("doSideWork")), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("doMainWork")), isTrue) &&
-        assert(trace.stackTrace.head.prettyPrint.contains("doWork"), isTrue)
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("doSideWork")))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("doMainWork")))(isTrue) &&
+        assert(trace.stackTrace.head.prettyPrint.contains("doWork"))(isTrue)
       }
     },
     testM("mapError fully preserves previous stack trace") {
@@ -235,13 +229,13 @@ object StackTracesSpec extends DefaultRunnableSpec {
           // mapError does not change the trace in any way from its state during `fail()`
           // as a consequence, `executionTrace` is not updated with finalizer info, etc...
           // but overall it's a good thing since you're not losing traces at the border between your domain errors & Throwable
-          assert(cause.traces.size, equalTo(1)) &&
-          assert(cause.traces.head.executionTrace.size, equalTo(2)) &&
-          assert(cause.traces.head.executionTrace.head.prettyPrint.contains("fail"), isTrue) &&
-          assert(cause.traces.head.stackTrace.size, equalTo(6)) &&
-          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("succ"), isTrue) &&
-          assert(cause.traces.head.stackTrace(1).prettyPrint.contains("mapError"), isTrue) &&
-          assert(cause.traces.head.stackTrace(2).prettyPrint.contains("mapErrorPreservesTrace"), isTrue)
+          assert(cause.traces.size)(equalTo(1)) &&
+          assert(cause.traces.head.executionTrace.size)(equalTo(2)) &&
+          assert(cause.traces.head.executionTrace.head.prettyPrint.contains("fail"))(isTrue) &&
+          assert(cause.traces.head.stackTrace.size)(equalTo(6)) &&
+          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("succ"))(isTrue) &&
+          assert(cause.traces.head.stackTrace(1).prettyPrint.contains("mapError"))(isTrue) &&
+          assert(cause.traces.head.stackTrace(2).prettyPrint.contains("mapErrorPreservesTrace"))(isTrue)
       }
     },
     testM("catchSome with optimized effect path") {
@@ -250,13 +244,13 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield trace
 
       io causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.executionTrace.size, equalTo(2)) &&
-        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("fail")), isTrue) &&
-        assert(cause.traces.head.stackTrace.size, equalTo(6)) &&
-        assert(cause.traces.head.stackTrace.head.prettyPrint.contains("badMethod"), isTrue) &&
-        assert(cause.traces.head.stackTrace(1).prettyPrint.contains("apply"), isTrue) && // PartialFunction.apply
-        assert(cause.traces.head.stackTrace(2).prettyPrint.contains("catchSomeWithOptimizedEffect"), isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.executionTrace.size)(equalTo(2)) &&
+        assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("fail")))(isTrue) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(6)) &&
+        assert(cause.traces.head.stackTrace.head.prettyPrint.contains("badMethod"))(isTrue) &&
+        assert(cause.traces.head.stackTrace(1).prettyPrint.contains("apply"))(isTrue) && // PartialFunction.apply
+        assert(cause.traces.head.stackTrace(2).prettyPrint.contains("catchSomeWithOptimizedEffect"))(isTrue)
       }
     },
     testM("catchAll with optimized effect path") {
@@ -267,12 +261,12 @@ object StackTracesSpec extends DefaultRunnableSpec {
       io causeMust {
         cause =>
           // after we refail and lose the trace, the only continuation we have left is the map from yield
-          assert(cause.traces.size, equalTo(1)) &&
-          assert(cause.traces.head.executionTrace.size, equalTo(3)) &&
-          assert(cause.traces.head.executionTrace.head.prettyPrint.contains("refailAndLoseTrace"), isTrue) &&
-          assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("fail")), isTrue) &&
-          assert(cause.traces.head.stackTrace.size, equalTo(4)) &&
-          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("catchAllWithOptimizedEffect"), isTrue)
+          assert(cause.traces.size)(equalTo(1)) &&
+          assert(cause.traces.head.executionTrace.size)(equalTo(3)) &&
+          assert(cause.traces.head.executionTrace.head.prettyPrint.contains("refailAndLoseTrace"))(isTrue) &&
+          assert(cause.traces.head.executionTrace.exists(_.prettyPrint.contains("fail")))(isTrue) &&
+          assert(cause.traces.head.stackTrace.size)(equalTo(4)) &&
+          assert(cause.traces.head.stackTrace.head.prettyPrint.contains("catchAllWithOptimizedEffect"))(isTrue)
       }
     },
     testM("foldM with optimized effect path") {
@@ -281,33 +275,33 @@ object StackTracesSpec extends DefaultRunnableSpec {
       } yield {
         show(trace)
 
-        assert(trace.stackTrace.size, equalTo(3)) &&
-        assert(trace.stackTrace.exists(_.prettyPrint.contains("foldMWithOptimizedEffect")), isTrue) &&
-        assert(trace.executionTrace.size, equalTo(3)) &&
-        assert(trace.executionTrace.head.prettyPrint.contains("mkTrace"), isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("fail")), isTrue)
+        assert(trace.stackTrace.size)(equalTo(3)) &&
+        assert(trace.stackTrace.exists(_.prettyPrint.contains("foldMWithOptimizedEffect")))(isTrue) &&
+        assert(trace.executionTrace.size)(equalTo(3)) &&
+        assert(trace.executionTrace.head.prettyPrint.contains("mkTrace"))(isTrue) &&
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("fail")))(isTrue)
 
       }
     },
     testM("single effect for-comprehension") {
       singleTaskForCompFixture.selectHumans causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.stackTrace.size, equalTo(3)) &&
-        assert(cause.traces.head.stackTrace.head.prettyPrint.contains("selectHumans"), isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(3)) &&
+        assert(cause.traces.head.stackTrace.head.prettyPrint.contains("selectHumans"))(isTrue)
       }
     },
     testM("single effectTotal for-comprehension") {
       singleUIOForCompFixture.selectHumans causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.stackTrace.size, equalTo(3)) &&
-        assert(cause.traces.head.stackTrace.exists(_.prettyPrint.contains("selectHumans")), isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(3)) &&
+        assert(cause.traces.head.stackTrace.exists(_.prettyPrint.contains("selectHumans")))(isTrue)
       }
     },
     testM("single suspendWith for-comprehension") {
       singleEffectTotalWithForCompFixture.selectHumans causeMust { cause =>
-        assert(cause.traces.size, equalTo(1)) &&
-        assert(cause.traces.head.stackTrace.size, equalTo(3)) &&
-        assert(cause.traces.head.stackTrace.exists(_.prettyPrint.contains("selectHumans")), isTrue)
+        assert(cause.traces.size)(equalTo(1)) &&
+        assert(cause.traces.head.stackTrace.size)(equalTo(3)) &&
+        assert(cause.traces.head.stackTrace.exists(_.prettyPrint.contains("selectHumans")))(isTrue)
       }
     }
   )
@@ -618,7 +612,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
           show(cause)
           check(cause)
         },
-        _ => assert(false, isTrue)
+        _ => assert(false)(isTrue)
       )
   }
 }

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -33,7 +33,7 @@ object FiberRefSpecJvm extends ZIOBaseSpec {
         value0                   <- fiberRef.get
         values                   <- UIO(resRef.get())
         (value1, value2, value3) = values
-      } yield assert((value0, value1, value2, value3), equalTo((update1, initial, update2, initial)))
+      } yield assert((value0, value1, value2, value3))(equalTo((update1, initial, update2, initial)))
     }
   )
 }

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -30,7 +30,7 @@ object RTSSpec extends ZIOBaseSpec {
 
       val env = new Clock.Live with Blocking.Live
 
-      assertM(io.provide(env), isTrue)
+      assertM(io.provide(env))(isTrue)
     },
     testM("blocking IO is effect blocking") {
       for {
@@ -42,7 +42,7 @@ object RTSSpec extends ZIOBaseSpec {
         _     <- IO.succeed(start.get())
         res   <- fiber.interrupt
         value <- done.get
-      } yield assert(res, isInterrupted) && assert(value, isTrue)
+      } yield assert(res)(isInterrupted) && assert(value)(isTrue)
     },
     testM("cancelation is guaranteed") {
       val io =
@@ -58,7 +58,7 @@ object RTSSpec extends ZIOBaseSpec {
           result <- release.await
         } yield result == 42
 
-      assertM(io, isTrue)
+      assertM(io)(isTrue)
     } @@ flaky,
     testM("Fiber dump looks correct") {
       for {
@@ -67,7 +67,7 @@ object RTSSpec extends ZIOBaseSpec {
         dump    <- fiber.dump
         dumpStr <- dump.fold[URIO[Clock, String]](IO.succeed(""))(_.prettyPrintM)
         _       <- UIO(println(dumpStr))
-      } yield assert(dump, anything)
+      } yield assert(dump)(anything)
     },
     testM("interruption causes") {
       for {
@@ -75,7 +75,7 @@ object RTSSpec extends ZIOBaseSpec {
         producer <- queue.offer(42).forever.fork
         rez      <- producer.interrupt
         _        <- UIO(println(rez.fold(_.prettyPrint, _ => "")))
-      } yield assert(rez, anything)
+      } yield assert(rez)(anything)
     },
     testM("interruption of unending bracket") {
       val io =
@@ -95,7 +95,7 @@ object RTSSpec extends ZIOBaseSpec {
           exitValue  <- exitLatch.await
         } yield (startValue + exitValue) == 42
 
-      assertM(io, isTrue)
+      assertM(io)(isTrue)
     } @@ jvm(nonFlaky),
     testM("deadlock regression 1") {
       import java.util.concurrent.Executors
@@ -112,7 +112,7 @@ object RTSSpec extends ZIOBaseSpec {
         }
       }
 
-      assertM(ZIO.effect(e.shutdown()), isUnit)
+      assertM(ZIO.effect(e.shutdown()))(isUnit)
     },
     testM("second callback call is ignored") {
       for {
@@ -125,7 +125,7 @@ object RTSSpec extends ZIOBaseSpec {
                 Thread.sleep(1000)
                 k(IO.succeed("ok"))
               }
-      } yield assert(res, equalTo("ok"))
+      } yield assert(res)(equalTo("ok"))
     },
     testM("check interruption regression 1") {
       val c = new AtomicInteger(0)
@@ -144,7 +144,7 @@ object RTSSpec extends ZIOBaseSpec {
                 .repeat(Schedule.doUntil[Int](_ >= 1)) <* f.interrupt
         } yield c
 
-      assertM(zio.provide(Clock.Live), isGreaterThanEqualTo(1))
+      assertM(zio.provide(Clock.Live))(isGreaterThanEqualTo(1))
     }
   )
 }

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -19,13 +19,13 @@ object SerializableSpec extends ZIOBaseSpec {
         count       <- semaphore.available
         returnSem   <- serializeAndBack(semaphore)
         returnCount <- returnSem.available
-      } yield assert(returnCount, equalTo(count))
+      } yield assert(returnCount)(equalTo(count))
     },
     testM("Clock is serializable") {
       for {
         time1 <- clock.nanoTime
         time2 <- serializeAndBack(clock.nanoTime).flatten
-      } yield assert(time1, isLessThanEqualTo(time2))
+      } yield assert(time1)(isLessThanEqualTo(time2))
     },
     testM("Queue is serializable") {
       for {
@@ -35,8 +35,8 @@ object SerializableSpec extends ZIOBaseSpec {
         v1          <- returnQueue.take
         _           <- returnQueue.offer(20)
         v2          <- returnQueue.take
-      } yield assert(v1, equalTo(10)) &&
-        assert(v2, equalTo(20))
+      } yield assert(v1)(equalTo(10)) &&
+        assert(v2)(equalTo(20))
     },
     testM("Ref is serializable") {
       val current = "This is some value"
@@ -44,7 +44,7 @@ object SerializableSpec extends ZIOBaseSpec {
         ref       <- Ref.make(current)
         returnRef <- serializeAndBack(ref)
         value     <- returnRef.get
-      } yield assert(value, equalTo(current))
+      } yield assert(value)(equalTo(current))
     },
     testM("IO is serializable") {
       val list = List("1", "2", "3")
@@ -52,7 +52,7 @@ object SerializableSpec extends ZIOBaseSpec {
       for {
         returnIO <- serializeAndBack(io)
         result   <- returnIO
-      } yield assert(result, equalTo(list))
+      } yield assert(result)(equalTo(list))
     },
     testM("FunctionIO is serializable") {
       import FunctionIO._
@@ -60,7 +60,7 @@ object SerializableSpec extends ZIOBaseSpec {
       for {
         returnKleisli <- serializeAndBack(v)
         computeV      <- returnKleisli.run(9)
-      } yield assert(computeV, equalTo(10))
+      } yield assert(computeV)(equalTo(10))
     },
     testM("FiberStatus is serializable") {
       val list = List("1", "2", "3")
@@ -70,7 +70,7 @@ object SerializableSpec extends ZIOBaseSpec {
         status         <- fiber.await
         returnedStatus <- serializeAndBack(status)
       } yield {
-        assert(returnedStatus.getOrElse(_ => List.empty), equalTo(list))
+        assert(returnedStatus.getOrElse(_ => List.empty))(equalTo(list))
       }
     },
     testM("Duration is serializable") {
@@ -78,52 +78,52 @@ object SerializableSpec extends ZIOBaseSpec {
       val duration = Duration.fromNanos(1)
       for {
         returnDuration <- serializeAndBack(duration)
-      } yield assert(returnDuration, equalTo(duration))
+      } yield assert(returnDuration)(equalTo(duration))
     },
     testSync("Cause.die is serializable") {
       val cause = Cause.die(TestException("test"))
-      assert(serializeAndDeserialize(cause), equalTo(cause))
+      assert(serializeAndDeserialize(cause))(equalTo(cause))
     },
     testSync("Cause.fail is serializable") {
       val cause = Cause.fail("test")
-      assert(serializeAndDeserialize(cause), equalTo(cause))
+      assert(serializeAndDeserialize(cause))(equalTo(cause))
     },
     testSync("Cause.traced is serializable") {
       val fiberId = Fiber.Id(0L, 0L)
       val cause   = Cause.traced(Cause.fail("test"), ZTrace(fiberId, List.empty, List.empty, None))
-      assert(serializeAndDeserialize(cause), equalTo(cause))
+      assert(serializeAndDeserialize(cause))(equalTo(cause))
     },
     testSync("Cause.&& is serializable") {
       val cause = Cause.fail("test") && Cause.fail("Another test")
-      assert(serializeAndDeserialize(cause), equalTo(cause))
+      assert(serializeAndDeserialize(cause))(equalTo(cause))
     },
     testSync("Cause.++ is serializable") {
       val cause = Cause.fail("test") ++ Cause.fail("Another test")
-      assert(serializeAndDeserialize(cause), equalTo(cause))
+      assert(serializeAndDeserialize(cause))(equalTo(cause))
     },
     testSync("Exit.succeed is serializable") {
       val exit = Exit.succeed("test")
-      assert(serializeAndDeserialize(exit), equalTo(exit))
+      assert(serializeAndDeserialize(exit))(equalTo(exit))
     },
     testSync("Exit.fail is serializable") {
       val exit = Exit.fail("test")
-      assert(serializeAndDeserialize(exit), equalTo(exit))
+      assert(serializeAndDeserialize(exit))(equalTo(exit))
     },
     testSync("Exit.die is serializable") {
       val exit = Exit.die(TestException("test"))
-      assert(serializeAndDeserialize(exit), equalTo(exit))
+      assert(serializeAndDeserialize(exit))(equalTo(exit))
     },
     testSync("FiberFailure is serializable") {
       val failure = FiberFailure(Cause.fail("Uh oh"))
-      assert(serializeAndDeserialize(failure), equalTo(failure))
+      assert(serializeAndDeserialize(failure))(equalTo(failure))
     },
     testSync("InterruptStatus.interruptible is serializable") {
       val interruptStatus = InterruptStatus.interruptible
-      assert(serializeAndDeserialize(interruptStatus), equalTo(interruptStatus))
+      assert(serializeAndDeserialize(interruptStatus))(equalTo(interruptStatus))
     },
     testSync("InterruptStatus.uninterruptible is serializable") {
       val interruptStatus = InterruptStatus.uninterruptible
-      assert(serializeAndDeserialize(interruptStatus), equalTo(interruptStatus))
+      assert(serializeAndDeserialize(interruptStatus))(equalTo(interruptStatus))
     },
     testM("Promise is serializable") {
       for {
@@ -132,50 +132,50 @@ object SerializableSpec extends ZIOBaseSpec {
         value             <- promise.await
         deserialized      <- serializeAndBack(promise)
         deserializedValue <- deserialized.await
-      } yield assert(deserializedValue, equalTo(value))
+      } yield assert(deserializedValue)(equalTo(value))
     },
     testM("Schedule is serializable") {
       val schedule = Schedule.recurs(5)
       for {
         out1 <- ZIO.unit.repeat(schedule)
         out2 <- ZIO.unit.repeat(serializeAndDeserialize(schedule))
-      } yield assert(out2, equalTo(out1))
+      } yield assert(out2)(equalTo(out1))
     } @@ scala2Only,
     testM("Chunk.single is serializable") {
       val chunk = Chunk.single(1)
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     },
     testM("Chunk.fromArray is serializable") {
       val chunk = Chunk.fromArray(Array(1, 2, 3))
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     },
     testM("Chunk.++ is serializable") {
       val chunk = Chunk.single(1) ++ Chunk.single(2)
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     },
     testM("Chunk slice is serializable") {
       val chunk = Chunk.fromArray((1 to 100).toArray).take(10)
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     },
     testM("Chunk.empty is serializable") {
       val chunk = Chunk.empty
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     } @@ scala2Only,
     testM("Chunk.fromIterable is serializable") {
       val chunk = Chunk.fromIterable(Vector(1, 2, 3))
       for {
         deserialized <- serializeAndBack(chunk)
-      } yield assert(deserialized, equalTo(chunk))
+      } yield assert(deserialized)(equalTo(chunk))
     },
     testM("FiberRef is serializable") {
       val value = 10
@@ -183,21 +183,21 @@ object SerializableSpec extends ZIOBaseSpec {
         init   <- FiberRef.make(value)
         ref    <- serializeAndBack(init)
         result <- ref.get
-      } yield assert(result, equalTo(value))
+      } yield assert(result)(equalTo(value))
     },
     testM("ZManaged is serializable") {
       for {
         managed <- serializeAndBack(ZManaged.make(UIO.unit)(_ => UIO.unit))
         result  <- managed.use(_ => UIO.unit)
-      } yield assert(result, equalTo(()))
+      } yield assert(result)(equalTo(()))
     },
     testSync("SuperviseStatus.supervised is serializable") {
       val supervised = SuperviseStatus.supervised
-      assert(serializeAndDeserialize(supervised), equalTo(supervised))
+      assert(serializeAndDeserialize(supervised))(equalTo(supervised))
     },
     testSync("SuperviseStatus.unsupervised is serializable") {
       val unsupervised = SuperviseStatus.unsupervised
-      assert(serializeAndDeserialize(unsupervised), equalTo(unsupervised))
+      assert(serializeAndDeserialize(unsupervised))(equalTo(unsupervised))
     },
     testSync("ZTrace is serializable") {
       val trace = ZTrace(
@@ -207,29 +207,29 @@ object SerializableSpec extends ZIOBaseSpec {
         None
       )
 
-      assert(serializeAndDeserialize(trace), equalTo(trace))
+      assert(serializeAndDeserialize(trace))(equalTo(trace))
     },
     testM("TracingStatus.Traced is serializable") {
       val traced = TracingStatus.Traced
       for {
         result <- serializeAndBack(traced)
-      } yield assert(result, equalTo(traced))
+      } yield assert(result)(equalTo(traced))
     },
     testM("TracingStatus.Untraced is serializable") {
       val traced = TracingStatus.Untraced
       for {
         result <- serializeAndBack(traced)
-      } yield assert(result, equalTo(traced))
+      } yield assert(result)(equalTo(traced))
     },
     testSync("Random is serializable") {
       val rnd = Random.Live
-      assert(serializeAndDeserialize(rnd), equalTo(rnd))
+      assert(serializeAndDeserialize(rnd))(equalTo(rnd))
     },
     testM("TracingStatus.Untraced is serializable") {
       for {
         system <- serializeAndBack(zio.system.System.Live)
         result <- system.system.property("notpresent")
-      } yield assert(result, equalTo(Option.empty[String]))
+      } yield assert(result)(equalTo(Option.empty[String]))
     }
   )
 }

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -13,18 +13,18 @@ object BlockingSpec extends ZIOBaseSpec {
   def spec = suite("BlockingSpec")(
     suite("Make a Blocking Service and verify that")(
       testM("effectBlocking completes successfully") {
-        assertM(effectBlocking(()), isUnit)
+        assertM(effectBlocking(()))(isUnit)
       },
       testM("effectBlockingCancelable completes successfully") {
-        assertM(effectBlockingCancelable(())(UIO.unit), isUnit)
+        assertM(effectBlockingCancelable(())(UIO.unit))(isUnit)
       },
       testM("effectBlocking can be interrupted") {
-        assertM(effectBlocking(Thread.sleep(50000)).timeout(Duration.Zero), isNone)
+        assertM(effectBlocking(Thread.sleep(50000)).timeout(Duration.Zero))(isNone)
       } @@ ignore,
       testM("effectBlockingCancelable can be interrupted") {
         val release = new AtomicBoolean(false)
         val cancel  = UIO.effectTotal(release.set(true))
-        assertM(effectBlockingCancelable(blockingAtomic(release))(cancel).timeout(Duration.Zero), isNone)
+        assertM(effectBlockingCancelable(blockingAtomic(release))(cancel).timeout(Duration.Zero))(isNone)
       }
     )
   )

--- a/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpecJVM.scala
@@ -21,8 +21,8 @@ object MutableConcurrentQueueJVM extends ZIOBaseSpec {
         val returnQ = serializeAndDeserialize(q)
         returnQ.offer(2)
 
-        (assert(returnQ.poll(-1), equalTo(1))
-        && assert(returnQ.poll(-1), equalTo(-1)))
+        (assert(returnQ.poll(-1))(equalTo(1))
+        && assert(returnQ.poll(-1))(equalTo(-1)))
       },
       test("a pow 2 capacity ring buffer") {
         val q = MutableConcurrentQueue.bounded[Int](3)
@@ -30,9 +30,9 @@ object MutableConcurrentQueueJVM extends ZIOBaseSpec {
         val returnQ = serializeAndDeserialize(q)
         returnQ.offer(2)
 
-        (assert(returnQ.poll(-1), equalTo(1))
-        && assert(returnQ.poll(-1), equalTo(2))
-        && assert(returnQ.poll(-1), equalTo(-1)))
+        (assert(returnQ.poll(-1))(equalTo(1))
+        && assert(returnQ.poll(-1))(equalTo(2))
+        && assert(returnQ.poll(-1))(equalTo(-1)))
       },
       test("an arbitrary capacity ring buffer") {
         val q = MutableConcurrentQueue.bounded[Int](2)
@@ -40,9 +40,9 @@ object MutableConcurrentQueueJVM extends ZIOBaseSpec {
         val returnQ = serializeAndDeserialize(q)
         returnQ.offer(2)
 
-        (assert(returnQ.poll(-1), equalTo(1))
-        && assert(returnQ.poll(-1), equalTo(2))
-        && assert(returnQ.poll(-1), equalTo(-1)))
+        (assert(returnQ.poll(-1))(equalTo(1))
+        && assert(returnQ.poll(-1))(equalTo(2))
+        && assert(returnQ.poll(-1))(equalTo(-1)))
       }
     )
   )

--- a/core-tests/jvm/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/OneShotSpec.scala
@@ -13,12 +13,12 @@ object OneShotSpec extends ZIOBaseSpec {
           val oneShot = OneShot.make[Int]
           oneShot.set(1)
 
-          assert(oneShot.get(), equalTo(1))
+          assert(oneShot.get())(equalTo(1))
         },
         test("set must not accept a null value") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.set(null), throwsA[Error])
+          assert(oneShot.set(null))(throwsA[Error])
         },
         test("isSet must report if a value is set") {
           val oneShot = OneShot.make[Int]
@@ -29,18 +29,18 @@ object OneShotSpec extends ZIOBaseSpec {
 
           val resultAfterSet = oneShot.isSet
 
-          assert(resultBeforeSet, isFalse) && assert(resultAfterSet, isTrue)
+          assert(resultBeforeSet)(isFalse) && assert(resultAfterSet)(isTrue)
         },
         test("get must fail if no value is set") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.get(10000L), throwsA[Error])
+          assert(oneShot.get(10000L))(throwsA[Error])
         },
         test("cannot set value twice") {
           val oneShot = OneShot.make[Int]
           oneShot.set(1)
 
-          assert(oneShot.set(2), throwsA[Error])
+          assert(oneShot.set(2))(throwsA[Error])
         }
       )
     )

--- a/core-tests/jvm/src/test/scala/zio/platform/PlatformSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/platform/PlatformSpec.scala
@@ -11,11 +11,11 @@ object PlatformSpec extends ZIOBaseSpec {
     suite("PlatformLive fatal:")(
       test("Platform.fatal should identify a nonFatal exception") {
         val nonFatal = new Exception
-        assert(PlatformLive.Default.fatal(nonFatal), isFalse)
+        assert(PlatformLive.Default.fatal(nonFatal))(isFalse)
       },
       test("Platform.fatal should identify a fatal exception") {
         val fatal = new OutOfMemoryError
-        assert(PlatformLive.Default.fatal(fatal), isTrue)
+        assert(PlatformLive.Default.fatal(fatal))(isTrue)
       }
     )
   )

--- a/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
@@ -12,23 +12,23 @@ object SystemSpec extends ZIOBaseSpec {
   def spec = suite("SystemSpec")(
     suite("Fetch an environment variable and check that")(
       testM("If it exists, return a reasonable value") {
-        assertM(live(system.env("PATH")), isSome(containsString(File.separator + "bin")))
+        assertM(live(system.env("PATH")))(isSome(containsString(File.separator + "bin")))
       },
       testM("If it does not exist, return None") {
-        assertM(live(system.env("QWERTY")), isNone)
+        assertM(live(system.env("QWERTY")))(isNone)
       }
     ),
     suite("Fetch a VM property and check that")(
       testM("If it exists, return a reasonable value") {
-        assertM(live(property("java.vm.name")), isSome(containsString("VM")))
+        assertM(live(property("java.vm.name")))(isSome(containsString("VM")))
       },
       testM("If it does not exist, return None") {
-        assertM(live(property("qwerty")), isNone)
+        assertM(live(property("qwerty")))(isNone)
       }
     ),
     suite("Fetch the system's line separator and check that")(
       testM("it is identical to System.lineSeparator") {
-        assertM(live(lineSeparator), equalTo(java.lang.System.lineSeparator))
+        assertM(live(lineSeparator))(equalTo(java.lang.System.lineSeparator))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/CanFailSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CanFailSpec.scala
@@ -15,7 +15,7 @@ object CanFailSpec extends ZIOBaseSpec {
             io.orElse(uio)
             """
       }
-      assertM(result, isRight(anything))
+      assertM(result)(isRight(anything))
     },
     testM("useless combinators don't compile") {
       val result = typeCheck {
@@ -26,7 +26,7 @@ object CanFailSpec extends ZIOBaseSpec {
             uio.orElse(io)
             """
       }
-      assertM(result, isLeft(anything))
+      assertM(result)(isLeft(anything))
     }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -14,7 +14,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
         _    <- p.await
         _    <- UIO(f.cancel)
         test <- p2.await
-      } yield assert(test, equalTo(42))
+      } yield assert(test)(equalTo(42))
     },
     testM("cancel returns the exit reason") {
       for {
@@ -27,14 +27,14 @@ object CancelableFutureSpec extends ZIOBaseSpec {
         _  <- p2.await
         e1 <- ZIO.fromFuture(_ => f1.cancel)
         e2 <- ZIO.fromFuture(_ => f2.cancel)
-      } yield assert(e1.succeeded, isTrue) && assert(e2.succeeded, isFalse)
+      } yield assert(e1.succeeded)(isTrue) && assert(e2.succeeded)(isFalse)
     },
     testM("is a scala.concurrent.Future") {
       for {
         f <- ZIO(42).toFuture
         v <- ZIO.fromFuture(_ => f)
       } yield {
-        assert(v, equalTo(42))
+        assert(v)(equalTo(42))
       }
     }
   )

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -11,105 +11,105 @@ object CauseSpec extends ZIOBaseSpec {
     suite("Cause")(
       testM("`Cause#died` and `Cause#stripFailures` are consistent") {
         check(causes) { c =>
-          assert(c.stripFailures, if (c.died) isSome(anything) else isNone)
+          assert(c.stripFailures)(if (c.died) isSome(anything) else isNone)
         }
       },
       testM("`Cause.equals` is symmetric") {
         check(causes, causes) { (a, b) =>
-          assert(a == b, equalTo(b == a))
+          assert(a == b)(equalTo(b == a))
         }
       },
       testM("`Cause.equals` and `Cause.hashCode` satisfy the contract") {
         check(equalCauses) {
           case (a, b) =>
-            assert(a.hashCode, equalTo(b.hashCode))
+            assert(a.hashCode)(equalTo(b.hashCode))
         }
       },
       testM("`Cause#untraced` removes all traces") {
         check(causes) { c =>
-          assert(c.untraced.traces.headOption, isNone)
+          assert(c.untraced.traces.headOption)(isNone)
         }
       },
       zio.test.test("`Cause.failures is stack safe") {
         val n     = 100000
         val cause = List.fill(n)(Cause.fail("fail")).reduce(_ && _)
-        assert(cause.failures.length, equalTo(n))
+        assert(cause.failures.length)(equalTo(n))
       }
     ),
     suite("Then")(
       testM("`Then.equals` satisfies associativity") {
         check(causes, causes, causes) { (a, b, c) =>
-          assert(Then(Then(a, b), c), equalTo(Then(a, Then(b, c)))) &&
-          assert(Then(a, Then(b, c)), equalTo(Then(Then(a, b), c)))
+          assert(Then(Then(a, b), c))(equalTo(Then(a, Then(b, c)))) &&
+          assert(Then(a, Then(b, c)))(equalTo(Then(Then(a, b), c)))
         }
       },
       testM("`Then.equals` satisfies distributivity") {
         check(causes, causes, causes) { (a, b, c) =>
-          assert(Then(a, Both(b, c)), equalTo(Both(Then(a, b), Then(a, c)))) &&
-          assert(Then(Both(a, b), c), equalTo(Both(Then(a, c), Then(b, c))))
+          assert(Then(a, Both(b, c)))(equalTo(Both(Then(a, b), Then(a, c)))) &&
+          assert(Then(Both(a, b), c))(equalTo(Both(Then(a, c), Then(b, c))))
         }
       }
     ),
     suite("Both")(
       testM("`Both.equals` satisfies associativity") {
         check(causes, causes, causes) { (a, b, c) =>
-          assert(Both(Both(a, b), c), equalTo(Both(a, Both(b, c)))) &&
-          assert(Both(a, Both(b, c)), equalTo(Both(Both(a, b), c)))
+          assert(Both(Both(a, b), c))(equalTo(Both(a, Both(b, c)))) &&
+          assert(Both(a, Both(b, c)))(equalTo(Both(Both(a, b), c)))
         }
       },
       testM("`Both.equals` satisfies distributivity") {
         check(causes, causes, causes) { (a, b, c) =>
-          assert(Both(Then(a, b), Then(a, c)), equalTo(Then(a, Both(b, c)))) &&
-          assert(Both(Then(a, c), Then(b, c)), equalTo(Then(Both(a, b), c)))
+          assert(Both(Then(a, b), Then(a, c)))(equalTo(Then(a, Both(b, c)))) &&
+          assert(Both(Then(a, c), Then(b, c)))(equalTo(Then(Both(a, b), c)))
         }
       },
       testM("`Both.equals` satisfies commutativity") {
         check(causes, causes) { (a, b) =>
-          assert(Both(a, b), equalTo(Both(b, a)))
+          assert(Both(a, b))(equalTo(Both(b, a)))
         }
       }
     ),
     suite("Meta")(
       testM("`Meta` is excluded from equals") {
         check(causes) { c =>
-          assert(Cause.stackless(c), equalTo(c)) &&
-          assert(c, equalTo(Cause.stackless(c)))
+          assert(Cause.stackless(c))(equalTo(c)) &&
+          assert(c)(equalTo(Cause.stackless(c)))
         }
       },
       testM("`Meta` is excluded from hashCode") {
         check(causes) { c =>
-          assert(Cause.stackless(c).hashCode, equalTo(c.hashCode))
+          assert(Cause.stackless(c).hashCode)(equalTo(c.hashCode))
         }
       }
     ),
     suite("Empty")(
       testM("`Empty` is empty element for `Then`") {
         check(causes) { c =>
-          assert(Then(c, Cause.empty), equalTo(c)) &&
-          assert(Then(Cause.empty, c), equalTo(c))
+          assert(Then(c, Cause.empty))(equalTo(c)) &&
+          assert(Then(Cause.empty, c))(equalTo(c))
         }
       },
       testM("`Empty` is empty element for `Both`") {
         check(causes) { c =>
-          assert(Both(c, Cause.empty), equalTo(c)) &&
-          assert(Both(Cause.empty, c), equalTo(c))
+          assert(Both(c, Cause.empty))(equalTo(c)) &&
+          assert(Both(Cause.empty, c))(equalTo(c))
         }
       }
     ),
     suite("Monad Laws:")(
       testM("Left identity") {
         check(causes) { c =>
-          assert(c.flatMap(Cause.fail), equalTo(c))
+          assert(c.flatMap(Cause.fail))(equalTo(c))
         }
       },
       testM("Right identity") {
         check(errors, errorCauseFunctions) { (e, f) =>
-          assert(Cause.fail(e).flatMap(f), equalTo(f(e)))
+          assert(Cause.fail(e).flatMap(f))(equalTo(f(e)))
         }
       },
       testM("Associativity") {
         check(causes, errorCauseFunctions, errorCauseFunctions) { (c, f, g) =>
-          assert(c.flatMap(f).flatMap(g), equalTo(c.flatMap(e => f(e).flatMap(g))))
+          assert(c.flatMap(f).flatMap(g))(equalTo(c.flatMap(e => f(e).flatMap(g))))
         }
       }
     ),
@@ -120,7 +120,7 @@ object CauseSpec extends ZIOBaseSpec {
             case Cause.Fail(e2) => e1 == e2
             case _              => false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       },
       testM("Die") {
@@ -129,7 +129,7 @@ object CauseSpec extends ZIOBaseSpec {
             case Cause.Die(t2) => t1 == t2
             case _             => false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       },
       testM("Interrupt") {
@@ -138,7 +138,7 @@ object CauseSpec extends ZIOBaseSpec {
             case Cause.Interrupt(fiberId2) => fiberId1 == fiberId2
             case _                         => false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       },
       testM("Traced") {
@@ -148,7 +148,7 @@ object CauseSpec extends ZIOBaseSpec {
             case Cause.Traced(cause2, trace2) => cause1 == cause2 && trace1 == trace2
             case _                            => false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       },
       testM("Meta") {
@@ -164,7 +164,7 @@ object CauseSpec extends ZIOBaseSpec {
               case (Cause.Both(left1, right1), Cause.Both(left2, right2))       => left1 == left2 && right1 == right2
               case _                                                            => false
             }
-            assert(result, isTrue)
+            assert(result)(isTrue)
         }
       },
       testM("Then") {
@@ -177,7 +177,7 @@ object CauseSpec extends ZIOBaseSpec {
               println("WARNING!!!")
               false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       },
       testM("Both") {
@@ -186,7 +186,7 @@ object CauseSpec extends ZIOBaseSpec {
             case Cause.Both(left2, right2) => left1 == left2 && right1 == right2
             case _                         => false
           }
-          assert(result, isTrue)
+          assert(result)(isTrue)
         }
       }
     )

--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -108,7 +108,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromCharBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromCharBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     ),
@@ -164,7 +164,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromDoubleBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromDoubleBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     ),
@@ -220,7 +220,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromFloatBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromFloatBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     ),
@@ -229,7 +229,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         UIO.effectTotal {
           val array  = Array(1, 2, 3)
           val buffer = IntBuffer.wrap(array)
-          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk(1, 2, 3)))
+          assert(Chunk.fromIntBuffer(buffer))(equalTo(Chunk(1, 2, 3)))
         }
       },
       testM("int array buffer partial copying") {
@@ -242,7 +242,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk(5, 6, 7)))
+          assert(Chunk.fromIntBuffer(buffer))(equalTo(Chunk(5, 6, 7)))
         }
       },
       testM("int array buffer slice copying") {
@@ -256,7 +256,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           buffer.position(3)
           buffer.limit(7)
           val newBuffer = buffer.slice()
-          assert(Chunk.fromIntBuffer(newBuffer), equalTo(Chunk(3, 4, 5, 6)))
+          assert(Chunk.fromIntBuffer(newBuffer))(equalTo(Chunk(3, 4, 5, 6)))
         }
       },
       testM("direct int buffer copying") {
@@ -276,7 +276,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromIntBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromIntBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     ),
@@ -332,7 +332,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromLongBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromLongBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     ),
@@ -388,7 +388,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
           }
           buffer.position(5)
           buffer.limit(8)
-          assert(Chunk.fromShortBuffer(buffer), equalTo(Chunk.fromArray(array)))
+          assert(Chunk.fromShortBuffer(buffer))(equalTo(Chunk.fromArray(array)))
         }
       }
     )

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -9,31 +9,31 @@ object ChunkSpec extends ZIOBaseSpec {
     suite("concatenated")(
       zio.test.test("size must match length") {
         val chunk = Chunk.empty ++ Chunk.fromArray(Array(1, 2)) ++ Chunk(3, 4, 5) ++ Chunk.single(6)
-        assert(chunk.size, equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length))
       }
     ),
     suite("empty")(
       zio.test.test("size must match length") {
         val chunk = Chunk.empty
-        assert(chunk.size, equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length))
       }
     ),
     suite("fromArray")(
       zio.test.test("size must match length") {
         val chunk = Chunk.fromArray(Array(1, 2, 3))
-        assert(chunk.size, equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length))
       }
     ),
     suite("fromIterable")(
       zio.test.test("size must match length") {
         val chunk = Chunk.fromIterable(List("1", "2", "3"))
-        assert(chunk.size, equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length))
       }
     ),
     suite("single")(
       zio.test.test("size must match length") {
         val chunk = Chunk.single(true)
-        assert(chunk.size, equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -16,21 +16,21 @@ object FiberRefSpec extends ZIOBaseSpec {
         for {
           fiberRef <- FiberRef.make(initial)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("`get` returns the current value for a child") {
         for {
           fiberRef <- FiberRef.make(initial)
           child    <- fiberRef.get.fork
           value    <- child.join
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("`set` updates the current value") {
         for {
           fiberRef <- FiberRef.make(initial)
           _        <- fiberRef.set(update)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(update))
+        } yield assert(value)(equalTo(update))
       },
       testM("`set` by a child doesn't update parent's value") {
         for {
@@ -39,14 +39,14 @@ object FiberRefSpec extends ZIOBaseSpec {
           _        <- (fiberRef.set(update) *> promise.succeed(())).fork
           _        <- promise.await
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("`locally` restores original value") {
         for {
           fiberRef <- FiberRef.make(initial)
           local    <- fiberRef.locally(update)(fiberRef.get)
           value    <- fiberRef.get
-        } yield assert(local, equalTo(update)) && assert(value, equalTo(initial))
+        } yield assert(local)(equalTo(update)) && assert(value)(equalTo(initial))
       },
       testM("`locally` restores parent's value") {
         for {
@@ -54,7 +54,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           child    <- fiberRef.locally(update)(fiberRef.get).fork
           local    <- child.join
           value    <- fiberRef.get
-        } yield assert(local, equalTo(update)) && assert(value, equalTo(initial))
+        } yield assert(local)(equalTo(update)) && assert(value)(equalTo(initial))
       },
       testM("`locally` restores undefined value") {
         for {
@@ -63,7 +63,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           fiberRef   <- child.await.flatMap(ZIO.done)
           localValue <- fiberRef.locally(update)(fiberRef.get)
           value      <- fiberRef.get
-        } yield assert(localValue, equalTo(update)) && assert(value, equalTo(initial))
+        } yield assert(localValue)(equalTo(update)) && assert(value)(equalTo(initial))
       },
       testM("its value is inherited on join") {
         for {
@@ -71,21 +71,21 @@ object FiberRefSpec extends ZIOBaseSpec {
           child    <- fiberRef.set(update).fork
           _        <- child.join
           value    <- fiberRef.get
-        } yield assert(value, equalTo(update))
+        } yield assert(value)(equalTo(update))
       },
       testM("initial value is always available") {
         for {
           child    <- FiberRef.make(initial).fork
           fiberRef <- child.await.flatMap(ZIO.done)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("`update` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
           value1   <- fiberRef.update(_ => update)
           value2   <- fiberRef.get
-        } yield assert(value1, equalTo(update)) && assert(value2, equalTo(update))
+        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
       testM("`updateSome` changes value") {
         for {
@@ -94,7 +94,7 @@ object FiberRefSpec extends ZIOBaseSpec {
                      case _ => update
                    }
           value2 <- fiberRef.get
-        } yield assert(value1, equalTo(update)) && assert(value2, equalTo(update))
+        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
       testM("`updateSome` changes value") {
         for {
@@ -103,7 +103,7 @@ object FiberRefSpec extends ZIOBaseSpec {
                      case _ => update
                    }
           value2 <- fiberRef.get
-        } yield assert(value1, equalTo(update)) && assert(value2, equalTo(update))
+        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
       testM("`updateSome` not changes value") {
         for {
@@ -112,14 +112,14 @@ object FiberRefSpec extends ZIOBaseSpec {
                      case _ if false => update
                    }
           value2 <- fiberRef.get
-        } yield assert(value1, equalTo(initial)) && assert(value2, equalTo(initial))
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(initial))
       },
       testM("`modify` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
           value1   <- fiberRef.modify(_ => (1, update))
           value2   <- fiberRef.get
-        } yield assert(value1, equalTo(1)) && assert(value2, equalTo(update))
+        } yield assert(value1)(equalTo(1)) && assert(value2)(equalTo(update))
       },
       testM("`modifySome` not changes value") {
         for {
@@ -128,14 +128,14 @@ object FiberRefSpec extends ZIOBaseSpec {
                      case _ if false => (1, update)
                    }
           value2 <- fiberRef.get
-        } yield assert(value1, equalTo(2)) && assert(value2, equalTo(initial))
+        } yield assert(value1)(equalTo(2)) && assert(value2)(equalTo(initial))
       },
       testM("its value is inherited after simple race") {
         for {
           fiberRef <- FiberRef.make(initial)
           _        <- fiberRef.set(update1).race(fiberRef.set(update2))
           value    <- fiberRef.get
-        } yield assert(value, equalTo(update1)) || assert(value, equalTo(update2))
+        } yield assert(value)(equalTo(update1)) || assert(value)(equalTo(update2))
       },
       testM("its value is inherited after a race with a bad winner") {
         for {
@@ -144,7 +144,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           goodLoser = fiberRef.set(update2) *> looseTimeAndCpu
           _         <- badWinner.race(goodLoser)
           value     <- fiberRef.get
-        } yield assert(value, equalTo(update2))
+        } yield assert(value)(equalTo(update2))
       },
       testM("its value is not inherited after a race of losers") {
         for {
@@ -153,7 +153,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           loser2   = fiberRef.set(update2) *> ZIO.fail("ups2")
           _        <- loser1.race(loser2).catchAll(_ => ZIO.unit)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("the value of the loser is inherited in zipPar") {
         for {
@@ -163,7 +163,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           loser    = latch.await *> fiberRef.set(update2) *> looseTimeAndCpu
           _        <- winner.zipPar(loser)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(update2))
+        } yield assert(value)(equalTo(update2))
       },
       testM("nothing gets inherited with a failure in zipPar") {
         for {
@@ -173,7 +173,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           failure2 = fiberRef.set(update2) *> ZIO.fail(":-O")
           _        <- success.zipPar(failure1.zipPar(failure2)).orElse(ZIO.unit)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("combine function is applied on join - 1") {
         for {
@@ -181,7 +181,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           child    <- fiberRef.update(_ + 1).fork
           _        <- child.join
           value    <- fiberRef.get
-        } yield assert(value, equalTo(1))
+        } yield assert(value)(equalTo(1))
       },
       testM("combine function is applied on join - 2") {
         for {
@@ -190,14 +190,14 @@ object FiberRefSpec extends ZIOBaseSpec {
           _        <- fiberRef.update(_ + 2)
           _        <- child.join
           value    <- fiberRef.get
-        } yield assert(value, equalTo(2))
+        } yield assert(value)(equalTo(2))
       },
       testM("its value is inherited in a trivial race") {
         for {
           fiberRef <- FiberRef.make(initial)
           _        <- fiberRef.set(update).raceAll(Iterable.empty)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(update))
+        } yield assert(value)(equalTo(update))
       },
       testM("the value of the winner is inherited when racing two ZIOs with raceAll") {
         for {
@@ -213,7 +213,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           loser2  = fiberRef.set(update2) *> ZIO.fail(":-O")
           _       <- loser2.raceAll(List(winner2))
           value2  <- fiberRef.get <* fiberRef.set(initial)
-        } yield assert((value1, value2), equalTo((update1, update1)))
+        } yield assert((value1, value2))(equalTo((update1, update1)))
       } @@ flaky,
       testM("the value of the winner is inherited when racing many ZIOs with raceAll") {
         for {
@@ -232,7 +232,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           losers2 = Iterable.fill(n)(loser2)
           _       <- winner2.raceAll(losers2)
           value2  <- fiberRef.get <* fiberRef.set(initial)
-        } yield assert((value1, value2), equalTo((update1, update1)))
+        } yield assert((value1, value2))(equalTo((update1, update1)))
       },
       testM("nothing gets inherited when racing failures with raceAll") {
         for {
@@ -240,7 +240,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           loser    = fiberRef.set(update) *> ZIO.fail("darn")
           _        <- loser.raceAll(Iterable.fill(63)(loser)).orElse(ZIO.unit)
           value    <- fiberRef.get
-        } yield assert(value, equalTo(initial))
+        } yield assert(value)(equalTo(initial))
       },
       testM("an unsafe handle is initialized and updated properly") {
         for {
@@ -251,7 +251,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           value2   <- UIO(handle.get())
           _        <- UIO(handle.set(update2))
           value3   <- fiberRef.get
-        } yield assert((value1, value2, value3), equalTo((initial, update1, update2)))
+        } yield assert((value1, value2, value3))(equalTo((initial, update1, update2)))
       },
       testM("unsafe handles work properly when initialized in a race") {
         for {
@@ -262,7 +262,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           doUpdate   = fiberRef.set(update)
           _          <- ZIO.raceAll(doUpdate, Iterable.fill(64)(doUpdate))
           value2     <- UIO(handle.get())
-        } yield assert(value1, equalTo(initial)) && assert(value2, equalTo(update))
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(update))
       },
       testM("unsafe handles work properly when accessed concurrently") {
         for {
@@ -272,7 +272,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           n      = 64
           fiber  <- ZIO.forkAll(1.to(n).map(setAndGet))
           values <- fiber.join
-        } yield assert(values, equalTo(1.to(n).toList))
+        } yield assert(values)(equalTo(1.to(n).toList))
       },
       testM("unsafe handles don't see updates from other fibers") {
         for {
@@ -283,7 +283,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           fiber    <- ZIO.forkAll(Iterable.fill(n)(fiberRef.set(update).race(UIO(handle.set(update)))))
           _        <- fiber.await
           value2   <- UIO(handle.get())
-        } yield assert(value1, equalTo(initial)) && assert(value2, equalTo(initial))
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(initial))
       },
       testM("unsafe handles keep their values if there are async boundaries") {
         for {
@@ -295,7 +295,7 @@ object FiberRefSpec extends ZIOBaseSpec {
               _      <- setRefOrHandle(fiberRef, handle, i)
               _      <- ZIO.yieldNow
               value  <- UIO(handle.get())
-            } yield assert(value, equalTo(i))
+            } yield assert(value)(equalTo(i))
 
           n       = 64
           results <- ZIO.reduceAllPar(test(1), 2.to(n).map(test))(_ && _)
@@ -309,7 +309,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           _        <- UIO(handle.remove())
           value1   <- fiberRef.get
           value2   <- UIO(handle.get())
-        } yield assert((value1, value2), equalTo((initial, initial)))
+        } yield assert((value1, value2))(equalTo((initial, initial)))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -17,7 +17,7 @@ object FiberSpec extends ZIOBaseSpec {
         _     <- fiber.toManaged.use(_ => IO.unit)
         _     <- fiber.await
         value <- ref.get
-      } yield assert(value, isTrue)
+      } yield assert(value)(isTrue)
     }),
     suite("`inheritLocals` works for Fiber created using:")(
       testM("`map`") {
@@ -28,7 +28,7 @@ object FiberSpec extends ZIOBaseSpec {
                   }
           _     <- child.map(_ => ()).inheritRefs
           value <- fiberRef.get
-        } yield assert(value, equalTo(update))
+        } yield assert(value)(equalTo(update))
       },
       testM("`orElse`") {
         for {
@@ -40,7 +40,7 @@ object FiberSpec extends ZIOBaseSpec {
           _        <- latch1.await *> latch2.await
           _        <- child1.orElse(child2).inheritRefs
           value    <- fiberRef.get
-        } yield assert(value, equalTo("child1"))
+        } yield assert(value)(equalTo("child1"))
       },
       testM("`zip`") {
         for {
@@ -52,7 +52,7 @@ object FiberSpec extends ZIOBaseSpec {
           _        <- latch1.await *> latch2.await
           _        <- child1.zip(child2).inheritRefs
           value    <- fiberRef.get
-        } yield assert(value, equalTo("child1"))
+        } yield assert(value)(equalTo("child1"))
       }
     ),
     suite("`Fiber.join` on interrupted Fiber")(
@@ -61,29 +61,29 @@ object FiberSpec extends ZIOBaseSpec {
 
         for {
           exit <- Fiber.interruptAs(fiberId).join.run
-        } yield assert(exit, equalTo(Exit.interrupt(fiberId)))
+        } yield assert(exit)(equalTo(Exit.interrupt(fiberId)))
       }
     ),
     suite("if one composed fiber fails then all must fail")(
       testM("`await`") {
         for {
           exit <- Fiber.fail("fail").zip(Fiber.never).await
-        } yield assert(exit, fails(equalTo("fail")))
+        } yield assert(exit)(fails(equalTo("fail")))
       },
       testM("`join`") {
         for {
           exit <- Fiber.fail("fail").zip(Fiber.never).join.run
-        } yield assert(exit, fails(equalTo("fail")))
+        } yield assert(exit)(fails(equalTo("fail")))
       },
       testM("`awaitAll`") {
         for {
           exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).run
-        } yield assert(exit, succeeds(isUnit))
+        } yield assert(exit)(succeeds(isUnit))
       },
       testM("`joinAll`") {
         for {
           exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).run
-        } yield assert(exit, succeeds(isUnit))
+        } yield assert(exit)(succeeds(isUnit))
       },
       testM("shard example") {
         def shard[R, E, A](queue: Queue[A], n: Int, worker: A => ZIO[R, E, Unit]): ZIO[R, E, Nothing] = {
@@ -96,7 +96,7 @@ object FiberSpec extends ZIOBaseSpec {
           worker = (n: Int) => if (n == 100) ZIO.fail("fail") else queue.offer(n).unit
           exit   <- shard(queue, 4, worker).run
           _      <- queue.shutdown
-        } yield assert(exit, fails(equalTo("fail")))
+        } yield assert(exit)(fails(equalTo("fail")))
       }
     ),
     testM("grandparent interruption is propagated to grandchild despite parent termination") {

--- a/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
@@ -9,35 +9,35 @@ object FunctionIOSpec extends ZIOBaseSpec {
   def spec = suite("FunctionIOSpec")(
     suite("Check if the functions in `FunctionIO` work correctly")(
       testM("`fromFunction` lifts from A => B into effectful function") {
-        assertM(add1.run(4), equalTo(5))
+        assertM(add1.run(4))(equalTo(5))
       },
       testM("`identity` returns the identity of the input without modification") {
-        assertM(identity[Int].run(1), equalTo(1))
+        assertM(identity[Int].run(1))(equalTo(1))
       },
       testM("`>>>` is a symbolic operator of `andThen`which does a Backwards composition of effectful functions") {
-        assertM((add1 >>> mul2).run(6), equalTo(14))
+        assertM((add1 >>> mul2).run(6))(equalTo(14))
       },
       testM("`<<<` is a symbolic operator of `compose` which compose two effectful functions") {
-        assertM((add1 <<< mul2).run(6), equalTo(13))
+        assertM((add1 <<< mul2).run(6))(equalTo(13))
       },
       testM("`zipWith` zips the output of two effectful functions") {
-        assertM(add1.zipWith(mul2)(_ -> _).run(6), equalTo(7 -> 12))
+        assertM(add1.zipWith(mul2)(_ -> _).run(6))(equalTo(7 -> 12))
       },
       testM("`&&&` zips the output of two effectful functions and returns a tuple of their result") {
-        assertM((add1 &&& mul2).run(6), equalTo(7 -> 12))
+        assertM((add1 &&& mul2).run(6))(equalTo(7 -> 12))
       },
       testM("`|||` computes two effectful functions left and right from from an Either input") {
         for {
           l1 <- (add1 ||| mul2).run(Left(25))
           r1 <- (add1 ||| mul2).run(Right(25))
-        } yield assert(l1, equalTo(26)) &&
-          assert(r1, equalTo(50))
+        } yield assert(l1)(equalTo(26)) &&
+          assert(r1)(equalTo(50))
       },
       testM("`first` returns a tuple: the output on the first element and input on the second element") {
-        assertM(mul2.first.run(100), equalTo(200 -> 100))
+        assertM(mul2.first.run(100))(equalTo(200 -> 100))
       },
       testM("`second` returns a tuple: the input on the first element and output on the second element") {
-        assertM(mul2.second.run(100), equalTo(100 -> 200))
+        assertM(mul2.second.run(100))(equalTo(100 -> 200))
       },
       testM(
         "`left` takes an Either as input and computes it if it is Left otherwise returns the same value of the input"
@@ -45,7 +45,7 @@ object FunctionIOSpec extends ZIOBaseSpec {
         for {
           v1 <- mul2.left[Int].run(Left(6))
           v2 <- succeed(1).left[String].run(Right("hi"))
-        } yield assert(v1, isLeft(equalTo(12))) && assert(v2, isRight(equalTo("hi")))
+        } yield assert(v1)(isLeft(equalTo(12))) && assert(v2)(isRight(equalTo("hi")))
       },
       testM(
         "`right`takes an Either as input and computes it if it is Right otherwise returns the same value of the input"
@@ -53,10 +53,10 @@ object FunctionIOSpec extends ZIOBaseSpec {
         for {
           v1 <- mul2.right[String].run(Left("no value"))
           v2 <- mul2.right[Int].run(Right(7))
-        } yield assert(v1, isLeft(equalTo("no value"))) && assert(v2, isRight(equalTo(14)))
+        } yield assert(v1)(isLeft(equalTo("no value"))) && assert(v2)(isRight(equalTo(14)))
       },
       testM("`asEffect` returns the input value")(
-        assertM(mul2.asEffect.run(56), equalTo(56))
+        assertM(mul2.asEffect.run(56))(equalTo(56))
       ),
       testM("`test` check a condition and returns an Either output: Left if the condition is true otherwise false") {
         val tester =
@@ -65,7 +65,7 @@ object FunctionIOSpec extends ZIOBaseSpec {
         for {
           v1 <- tester.run(List(1, 2, 5))
           v2 <- tester.run(List(1, 2, 5, 6))
-        } yield assert(v1, isRight(equalTo(List(1, 2, 5)))) && assert(v2, isLeft(equalTo(List(1, 2, 5, 6))))
+        } yield assert(v1)(isRight(equalTo(List(1, 2, 5)))) && assert(v2)(isLeft(equalTo(List(1, 2, 5, 6))))
       },
       suite("`ifThenElse`")(
         testM(
@@ -76,7 +76,7 @@ object FunctionIOSpec extends ZIOBaseSpec {
           for {
             v1 <- checker.run(-1)
             v2 <- checker.run(1)
-          } yield assert(v1, equalTo("is negative")) && assert(v2, equalTo("is positive"))
+          } yield assert(v1)(equalTo("is negative")) && assert(v2)(equalTo("is positive"))
         },
         testM(
           "check a pure condition if it is true then computes an effectful function `then0` else computes `else0`"
@@ -87,12 +87,12 @@ object FunctionIOSpec extends ZIOBaseSpec {
           for {
             v1 <- checker.run(-1)
             v2 <- checker.run(1)
-          } yield assert(v1, equalTo("is negative")) && assert(v2, equalTo("is positive"))
+          } yield assert(v1)(equalTo("is negative")) && assert(v2)(equalTo("is positive"))
         }
       ),
       suite("`whileDo`")(
         testM("take a condition and run the body until the condition will be  false with impure function") {
-          assertM(whileDo[Nothing, Int](lessThan10)(add1).run(1), equalTo(10))
+          assertM(whileDo[Nothing, Int](lessThan10)(add1).run(1))(equalTo(10))
         },
         testM(
           "take a condition and run the body until the condition will be  false with pure function"
@@ -100,26 +100,23 @@ object FunctionIOSpec extends ZIOBaseSpec {
           val lestThan10M = fromFunctionM[Nothing, Int, Boolean](a => IO.succeed[Boolean](a < 10))
           val add1M       = fromFunctionM[Nothing, Int, Int](a => IO.effectTotal[Int](a + 1))
 
-          assertM(whileDo[Nothing, Int](lestThan10M)(add1M).run(1), equalTo(10))
+          assertM(whileDo[Nothing, Int](lestThan10M)(add1M).run(1))(equalTo(10))
         }
       ),
       testM("`_1` extracts out the first element of a tuple") {
-        assertM(_1[Nothing, Int, String].run((1, "hi")), equalTo(1))
+        assertM(_1[Nothing, Int, String].run((1, "hi")))(equalTo(1))
       },
       testM("`_2` extracts out the second element of a tuple") {
-        assertM(_2[Nothing, Int, String].run((1, "hi")), equalTo("hi"))
+        assertM(_2[Nothing, Int, String].run((1, "hi")))(equalTo("hi"))
       },
       testM("`fail` returns a failure") {
-        assertM(
-          FunctionIO.fail[String]("error").run(1).either,
-          isLeft(equalTo("error"))
-        )
+        assertM(FunctionIO.fail[String]("error").run(1).either)(isLeft(equalTo("error")))
       },
       testM("`effect` can translate an Exception to an error") {
-        assertM(thrower.run(9).either, isLeft(equalTo("error")))
+        assertM(thrower.run(9).either)(isLeft(equalTo("error")))
       },
       testM("`ignore` ignores a effect failure") {
-        assertM(thrower.run(9).ignore, isUnit)
+        assertM(thrower.run(9).ignore)(isUnit)
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
@@ -15,7 +15,7 @@ object NeedsEnvSpec extends ZIOBaseSpec {
             sayHello.provide(Console.Live)
             """
       }
-      assertM(result, isRight(isUnit))
+      assertM(result)(isRight(isUnit))
     },
     testM("useless combinators don't compile") {
       val result = typeCheck {
@@ -26,7 +26,7 @@ object NeedsEnvSpec extends ZIOBaseSpec {
             uio.provide(Console.Live)
             """
       }
-      assertM(result, isLeft(anything))
+      assertM(result)(isLeft(anything))
     }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -11,7 +11,7 @@ object PromiseSpec extends ZIOBaseSpec {
         p <- Promise.make[Nothing, Int]
         s <- p.succeed(32)
         v <- p.await
-      } yield assert(s, isTrue) && assert(v, equalTo(32))
+      } yield assert(s)(isTrue) && assert(v)(equalTo(32))
     },
     testM("complete a promise using complete") {
       for {
@@ -20,9 +20,9 @@ object PromiseSpec extends ZIOBaseSpec {
         s  <- p.complete(r.update(_ + 1))
         v1 <- p.await
         v2 <- p.await
-      } yield assert(s, isTrue) &&
-        assert(v1, equalTo(14)) &&
-        assert(v2, equalTo(14))
+      } yield assert(s)(isTrue) &&
+        assert(v1)(equalTo(14)) &&
+        assert(v2)(equalTo(14))
     },
     testM("complete a promise using completeWith") {
       for {
@@ -31,16 +31,16 @@ object PromiseSpec extends ZIOBaseSpec {
         s  <- p.completeWith(r.update(_ + 1))
         v1 <- p.await
         v2 <- p.await
-      } yield assert(s, isTrue) &&
-        assert(v1, equalTo(14)) &&
-        assert(v2, equalTo(15))
+      } yield assert(s)(isTrue) &&
+        assert(v1)(equalTo(14)) &&
+        assert(v2)(equalTo(15))
     },
     testM("fail a promise using fail") {
       for {
         p <- Promise.make[String, Int]
         s <- p.fail("error with fail")
         v <- p.await.run
-      } yield assert(s, isTrue) && assert(v, fails(equalTo("error with fail")))
+      } yield assert(s)(isTrue) && assert(v)(fails(equalTo("error with fail")))
     },
     testM("fail a promise using complete") {
       for {
@@ -49,9 +49,9 @@ object PromiseSpec extends ZIOBaseSpec {
         s  <- p.complete(r.modify(as => (as.head, as.tail)).flip)
         v1 <- p.await.run
         v2 <- p.await.run
-      } yield assert(s, isTrue) &&
-        assert(v1, fails(equalTo("first error"))) &&
-        assert(v2, fails(equalTo("first error")))
+      } yield assert(s)(isTrue) &&
+        assert(v1)(fails(equalTo("first error"))) &&
+        assert(v2)(fails(equalTo("first error")))
     },
     testM("fail a promise using completeWith") {
       for {
@@ -60,9 +60,9 @@ object PromiseSpec extends ZIOBaseSpec {
         s  <- p.completeWith(r.modify(as => (as.head, as.tail)).flip)
         v1 <- p.await.run
         v2 <- p.await.run
-      } yield assert(s, isTrue) &&
-        assert(v1, fails(equalTo("first error"))) &&
-        assert(v2, fails(equalTo("second error")))
+      } yield assert(s)(isTrue) &&
+        assert(v1)(fails(equalTo("first error"))) &&
+        assert(v2)(fails(equalTo("second error")))
     },
     testM("complete a promise twice") {
       for {
@@ -70,54 +70,54 @@ object PromiseSpec extends ZIOBaseSpec {
         _ <- p.succeed(1)
         s <- p.complete(IO.succeed(9))
         v <- p.await
-      } yield assert(s, isFalse) && assert(v, equalTo(1))
+      } yield assert(s)(isFalse) && assert(v)(equalTo(1))
     },
     testM("interrupt a promise") {
       for {
         p <- Promise.make[Exception, Int]
         s <- p.interrupt
-      } yield assert(s, isTrue)
+      } yield assert(s)(isTrue)
     },
     testM("poll a promise that is not completed yet") {
       for {
         p       <- Promise.make[String, Int]
         attempt <- p.poll
-      } yield assert(attempt, isNone)
+      } yield assert(attempt)(isNone)
     },
     testM("poll a promise that is completed") {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.succeed(12)
         result <- p.poll.someOrFail("fail").flatten.run
-      } yield assert(result, succeeds(equalTo(12)))
+      } yield assert(result)(succeeds(equalTo(12)))
     },
     testM("poll a promise that is failed") {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.fail("failure")
         result <- p.poll.someOrFail("fail").flatten.run
-      } yield assert(result, fails(equalTo("failure")))
+      } yield assert(result)(fails(equalTo("failure")))
     },
     testM("poll a promise that is interrupted") {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.interrupt
         result <- p.poll.someOrFail("fail").flatten.run
-      } yield assert(result, isInterrupted)
+      } yield assert(result)(isInterrupted)
     },
     testM("isDone when a promise is completed") {
       for {
         p <- Promise.make[String, Int]
         _ <- p.succeed(0)
         d <- p.isDone
-      } yield assert(d, isTrue)
+      } yield assert(d)(isTrue)
     },
     testM("isDone when a promise is failed") {
       for {
         p <- Promise.make[String, Int]
         _ <- p.fail("failure")
         d <- p.isDone
-      } yield assert(d, isTrue)
+      } yield assert(d)(isTrue)
     }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -12,26 +12,26 @@ object RefMSpec extends ZIOBaseSpec {
       for {
         refM  <- RefM.make(current)
         value <- refM.get
-      } yield assert(value, equalTo(current))
+      } yield assert(value)(equalTo(current))
     },
     testM("set") {
       for {
         refM  <- RefM.make(current)
         _     <- refM.set(update)
         value <- refM.get
-      } yield assert(value, equalTo(update))
+      } yield assert(value)(equalTo(update))
     },
     testM("update") {
       for {
         refM  <- RefM.make(current)
         value <- refM.update(_ => IO.effectTotal(update))
-      } yield assert(value, equalTo(update))
+      } yield assert(value)(equalTo(update))
     },
     testM("update with failure") {
       for {
         refM  <- RefM.make[String](current)
         value <- refM.update(_ => IO.fail(failure)).run
-      } yield assert(value, fails(equalTo(failure)))
+      } yield assert(value)(fails(equalTo(failure)))
     },
     testM("updateSome") {
       for {
@@ -53,20 +53,20 @@ object RefMSpec extends ZIOBaseSpec {
       for {
         refM  <- RefM.make[State](Active)
         value <- refM.updateSome { case Active => IO.fail(failure) }.run
-      } yield assert(value, fails(equalTo(failure)))
+      } yield assert(value)(fails(equalTo(failure)))
     },
     testM("modify") {
       for {
         refM  <- RefM.make(current)
         r     <- refM.modify(_ => IO.effectTotal(("hello", update)))
         value <- refM.get
-      } yield assert(r, equalTo("hello")) && assert(value, equalTo(update))
+      } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
     },
     testM("modify with failure") {
       for {
         refM <- RefM.make[String](current)
         r    <- refM.modify(_ => IO.fail(failure)).run
-      } yield assert(r, fails(equalTo(failure)))
+      } yield assert(r)(fails(equalTo(failure)))
     },
     testM("modify twice") {
       for {
@@ -78,9 +78,9 @@ object RefMSpec extends ZIOBaseSpec {
                case Changed => IO.succeed("closed"  -> Closed)
              }
         value2 <- refM.get
-      } yield assert(r1, equalTo("changed")) &&
+      } yield assert(r1)(equalTo("changed")) &&
         assert(value1)(equalTo(Changed)) &&
-        assert(r2, equalTo("closed")) &&
+        assert(r2)(equalTo("closed")) &&
         assert(value2)(equalTo(Closed))
     },
     testM("modifySome") {
@@ -101,13 +101,13 @@ object RefMSpec extends ZIOBaseSpec {
       for {
         refM  <- RefM.make[State](Active)
         value <- refM.modifySome("State doesn't change") { case Active => IO.fail(failure) }.run
-      } yield assert(value, fails(equalTo(failure)))
+      } yield assert(value)(fails(equalTo(failure)))
     },
     testM("modifySome with fatal error") {
       for {
         refM  <- RefM.make[State](Active)
         value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
-      } yield assert(value, dies(hasMessage(fatalError)))
+      } yield assert(value)(dies(hasMessage(fatalError)))
     },
     testM("interrupt parent fiber and update") {
       for {

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -10,20 +10,20 @@ object RefSpec extends ZIOBaseSpec {
       for {
         ref   <- Ref.make(current)
         value <- ref.get
-      } yield assert(value, equalTo(current))
+      } yield assert(value)(equalTo(current))
     },
     testM("set") {
       for {
         ref   <- Ref.make(current)
         _     <- ref.set(update)
         value <- ref.get
-      } yield assert(value, equalTo(update))
+      } yield assert(value)(equalTo(update))
     },
     testM("update") {
       for {
         ref   <- Ref.make(current)
         value <- ref.update(_ => update)
-      } yield assert(value, equalTo(update))
+      } yield assert(value)(equalTo(update))
     },
     testM("updateSome") {
       for {
@@ -46,13 +46,13 @@ object RefSpec extends ZIOBaseSpec {
         ref   <- Ref.make(current)
         r     <- ref.modify[String](_ => ("hello", update))
         value <- ref.get
-      } yield assert(r, equalTo("hello")) && assert(value, equalTo(update))
+      } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
     },
     testM("modifySome") {
       for {
         ref   <- Ref.make[State](Active)
         value <- ref.modifySome[String]("State doesn't change") { case Closed => ("active", Active) }
-      } yield assert(value, equalTo("State doesn't change"))
+      } yield assert(value)(equalTo("State doesn't change"))
     },
     testM("modifySome twice") {
       for {
@@ -62,7 +62,7 @@ object RefSpec extends ZIOBaseSpec {
                    case Active  => ("changed", Changed)
                    case Changed => ("closed", Closed)
                  }
-      } yield assert(value1, equalTo("changed")) && assert(value2, equalTo("closed"))
+      } yield assert(value1)(equalTo("changed")) && assert(value2)(equalTo("closed"))
     }
   )
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -37,7 +37,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           ref <- Ref.make(0)
           _   <- ref.update(_ + 1).repeat(Schedule.once)
           res <- ref.get
-        } yield assert(res, equalTo(2))
+        } yield assert(res)(equalTo(2))
       },
       testM("for 'recurs(a positive given number)' repeats that additional number of time") {
         checkRepeat(Schedule.recurs(42), expected = 42)
@@ -91,7 +91,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         err => IO.succeed(err),
         _ => IO.succeed("it should not be a success at all")
       )
-      assertM(failed, equalTo("Error: 1"))
+      assertM(failed)(equalTo("Error: 1"))
     },
     testM("Repeat a scheduled repeat repeats the whole number") {
       val n = 42
@@ -100,7 +100,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         io  = ref.update(_ + 1).repeat(Schedule.recurs(n))
         _   <- io.repeat(Schedule.recurs(1))
         res <- ref.get
-      } yield assert(res, equalTo((n + 1) * 2))
+      } yield assert(res)(equalTo((n + 1) * 2))
     },
     suite("Repeat an action 2 times and call `ensuring` should")(
       testM("run the specified finalizer as soon as the schedule is complete") {
@@ -110,7 +110,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           _          <- r.update(_ + 2).repeat(Schedule.recurs(2)).ensuring(p.succeed(()))
           v          <- r.get
           finalizerV <- p.poll
-        } yield assert(v, equalTo(6)) && assert(finalizerV.isDefined, equalTo(true))
+        } yield assert(v)(equalTo(6)) && assert(finalizerV.isDefined)(equalTo(true))
       }
     ),
     suite("Retry on failure according to a provided strategy")(
@@ -120,7 +120,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           ref <- Ref.make(0)
           _   <- ref.update(_ + 1).retry(Schedule.once)
           i   <- ref.get
-        } yield assert(i, equalTo(1))
+        } yield assert(i)(equalTo(1))
       },
       testM("retry 0 time for `recurs(0)`") {
         val failed = (for {
@@ -132,7 +132,7 @@ object ScheduleSpec extends ZIOBaseSpec {
             _ => IO.succeed("it should not be a success")
           )
         failed.map { actual =>
-          assert(actual, equalTo("Error: 1"))
+          assert(actual)(equalTo("Error: 1"))
         }
       },
       testM("retry exactly one time for `once` when second time succeeds") {
@@ -141,7 +141,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           ref <- Ref.make(0)
           _   <- failOn0(ref).retry(Schedule.once)
           r   <- ref.get
-        } yield assert(r, equalTo(2))
+        } yield assert(r)(equalTo(2))
       },
       testM("retry exactly one time for `once` even if still in error") {
         // no more than one retry on retry `once`
@@ -152,19 +152,19 @@ object ScheduleSpec extends ZIOBaseSpec {
           err => IO.succeed(err),
           _ => IO.succeed("A failure was expected")
         )
-        assertM(retried, equalTo("Error: 2"))
+        assertM(retried)(equalTo("Error: 2"))
       },
       testM("for a given number of times with random jitter in (0, 1)") {
         val schedule  = Schedule.spaced(500.millis).jittered(0, 1)
         val scheduled = TestClock.setTime(Duration.Infinity) *> run(schedule >>> testElapsed)(List.fill(5)(()))
         val expected  = List(0.millis, 250.millis, 500.millis, 750.millis, 1000.millis)
-        assertM(TestRandom.feedDoubles(0.5, 0.5, 0.5, 0.5, 0.5) *> scheduled, equalTo(expected))
+        assertM(TestRandom.feedDoubles(0.5, 0.5, 0.5, 0.5, 0.5) *> scheduled)(equalTo(expected))
       },
       testM("for a given number of times with random jitter in custom interval") {
         val schedule  = Schedule.spaced(500.millis).jittered(2, 4)
         val scheduled = TestClock.setTime(Duration.Infinity) *> run(schedule >>> testElapsed)((List.fill(5)(())))
         val expected  = List(0, 1500, 3000, 5000, 7000).map(_.millis)
-        assertM(TestRandom.feedDoubles(0.5, 0.5, 1, 1, 0.5) *> scheduled, equalTo(expected))
+        assertM(TestRandom.feedDoubles(0.5, 0.5, 1, 1, 0.5) *> scheduled)(equalTo(expected))
       },
       testM("fixed delay with error predicate") {
         var i = 0
@@ -174,44 +174,37 @@ object ScheduleSpec extends ZIOBaseSpec {
         val strategy = Schedule.spaced(200.millis).whileInput[String](_ == "KeepTryingError")
         val expected = (800.millis, "GiveUpError", 4)
         val result   = io.retryOrElseEither(strategy, (e: String, r: Int) => TestClock.fiberTime.map((_, e, r)))
-        assertM(TestClock.setTime(Duration.Infinity) *> result, isLeft(equalTo(expected)))
+        assertM(TestClock.setTime(Duration.Infinity) *> result)(isLeft(equalTo(expected)))
       },
       testM("fibonacci delay") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.fibonacci(100.millis) >>> testElapsed)(List.fill(5)(())),
-          equalTo(List(0, 1, 2, 4, 7).map(i => (i * 100).millis))
-        )
+            .setTime(Duration.Infinity) *> run(Schedule.fibonacci(100.millis) >>> testElapsed)(List.fill(5)(()))
+        )(equalTo(List(0, 1, 2, 4, 7).map(i => (i * 100).millis)))
       },
       testM("linear delay") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.linear(100.millis) >>> testElapsed)(List.fill(5)(())),
-          equalTo(List(0, 1, 3, 6, 10).map(i => (i * 100).millis))
-        )
+            .setTime(Duration.Infinity) *> run(Schedule.linear(100.millis) >>> testElapsed)(List.fill(5)(()))
+        )(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 100).millis)))
       },
       testM("modified linear delay") {
-        assertM(
-          TestClock.setTime(Duration.Infinity) *> run(Schedule.linear(100.millis).modifyDelay {
-            case (_, d) => ZIO.succeed(d * 2)
-          } >>> testElapsed)(List.fill(5)(())),
-          equalTo(List(0, 1, 3, 6, 10).map(i => (i * 200).millis))
-        )
+        assertM(TestClock.setTime(Duration.Infinity) *> run(Schedule.linear(100.millis).modifyDelay {
+          case (_, d) => ZIO.succeed(d * 2)
+        } >>> testElapsed)(List.fill(5)(())))(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 200).millis)))
       },
       testM("exponential delay with default factor") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis) >>> testElapsed)(List.fill(5)(())),
-          equalTo(List(0, 2, 6, 14, 30).map(i => (i * 100).millis))
-        )
+            .setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis) >>> testElapsed)(List.fill(5)(()))
+        )(equalTo(List(0, 2, 6, 14, 30).map(i => (i * 100).millis)))
       },
       testM("exponential delay with other factor") {
         assertM(
           TestClock.setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis, 3.0) >>> testElapsed)(
             List.fill(5)(())
-          ),
-          equalTo(List(0, 3, 12, 39, 120).map(i => (i * 100).millis))
-        )
+          )
+        )(equalTo(List(0, 3, 12, 39, 120).map(i => (i * 100).millis)))
       }
     ),
     suite("Retry according to a provided strategy")(
@@ -221,7 +214,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         val io = IO.effectTotal(i += 1).flatMap { _ =>
           if (i < 5) IO.fail("KeepTryingError") else IO.succeed(i)
         }
-        assertM(io.retry(strategy), equalTo(5))
+        assertM(io.retry(strategy))(equalTo(5))
       }
     ),
     suite("Return the result of the fallback after failing and no more retries left")(
@@ -229,7 +222,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         for {
           ref <- Ref.make(0)
           o   <- alwaysFail(ref).retryOrElse(Schedule.once, ioSucceed)
-        } yield assert(o, equalTo("OrElse": Any))
+        } yield assert(o)(equalTo("OrElse": Any))
       },
       testM("if fallback failed - retryOrElse") {
         val failed = (for {
@@ -240,7 +233,7 @@ object ScheduleSpec extends ZIOBaseSpec {
             err => IO.succeed(err),
             _ => IO.succeed("it should not be a success")
           )
-        assertM(failed, equalTo("OrElseFailed"))
+        assertM(failed)(equalTo("OrElseFailed"))
       },
       testM("if fallback succeed - retryOrElseEither") {
         for {
@@ -258,7 +251,7 @@ object ScheduleSpec extends ZIOBaseSpec {
             err => IO.succeed(err),
             _ => IO.succeed("it should not be a success")
           )
-        assertM(failed, equalTo("OrElseFailed"))
+        assertM(failed)(equalTo("OrElseFailed"))
       }
     ),
     suite("Return the result after successful retry")(
@@ -266,7 +259,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         for {
           ref <- Ref.make(0)
           o   <- failOn0(ref).retryOrElse(Schedule.once, ioFail)
-        } yield assert(o, equalTo(2))
+        } yield assert(o)(equalTo(2))
       },
       testM("retry exactly one time for `once` when second time succeeds - retryOrElse0") {
         for {
@@ -282,7 +275,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           p          <- Promise.make[Nothing, Unit]
           v          <- IO.fail("oh no").retry(Schedule.recurs(2)).ensuring(p.succeed(())).option
           finalizerV <- p.poll
-        } yield assert(v.isEmpty, equalTo(true)) && assert(finalizerV.isDefined, equalTo(true))
+        } yield assert(v.isEmpty)(equalTo(true)) && assert(finalizerV.isDefined)(equalTo(true))
       }
     ),
     testM("`ensuring` should only call finalizer once.") {
@@ -292,7 +285,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         s      <- sched.initial
         _      <- sched.update((), s).flip
         _      <- sched.update((), s).flip
-        result <- ref.get.map(assert(_, equalTo(1)))
+        result <- ref.get.map(assert(_)(equalTo(1)))
       } yield result
     },
     testM("Retry type parameters should infer correctly") {
@@ -316,9 +309,8 @@ object ScheduleSpec extends ZIOBaseSpec {
         TestClock
           .setTime(Duration.Infinity) *> run(
           (Schedule.stop || (Schedule.spaced(2.seconds) && Schedule.stop)) >>> testElapsed
-        )(List.fill(5)(())),
-        equalTo(List(Duration.Zero))
-      )
+        )(List.fill(5)(()))
+      )(equalTo(List(Duration.Zero)))
     }
   )
 
@@ -351,7 +343,7 @@ object ScheduleSpec extends ZIOBaseSpec {
   }
 
   def checkRepeat[B](schedule: Schedule[Any, Int, B], expected: B): ZIO[Any with Clock, Nothing, TestResult] =
-    assertM(repeat(schedule), equalTo(expected))
+    assertM(repeat(schedule))(equalTo(expected))
 
   /**
    * A function that increments ref each time it is called.

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -15,14 +15,14 @@ object SemaphoreSpec extends ZIOBaseSpec {
         for {
           semaphore <- Semaphore.make(n)
           available <- IO.foreach((0L until n).toList)(_ => semaphore.withPermit(semaphore.available))
-        } yield assert(available, forall(equalTo(19L)))
+        } yield assert(available)(forall(equalTo(19L)))
       },
       testM("`acquire` permits in parallel") {
         val n = 20L
         for {
           semaphore <- Semaphore.make(n)
           available <- IO.foreachPar((0L until n).toList)(_ => semaphore.withPermit(semaphore.available))
-        } yield assert(available, forall(isLessThan(20L)))
+        } yield assert(available)(forall(isLessThan(20L)))
       },
       testM("`acquireN`s can be parallel with `releaseN`s") {
         offsettingWithPermits(
@@ -48,7 +48,7 @@ object SemaphoreSpec extends ZIOBaseSpec {
           s       <- Semaphore.make(n)
           _       <- s.withPermit(IO.fail("fail")).either
           permits <- s.available
-        } yield assert(permits, equalTo(1L))
+        } yield assert(permits)(equalTo(1L))
       },
       testM("`withPermit` does not leak fibers or permits upon cancellation") {
         val n = 1L
@@ -57,7 +57,7 @@ object SemaphoreSpec extends ZIOBaseSpec {
           fiber   <- s.withPermit(IO.never).fork
           _       <- fiber.interrupt
           permits <- s.available
-        } yield assert(permits, equalTo(1L))
+        } yield assert(permits)(equalTo(1L))
       },
       testM("`withPermitManaged` does not leak fibers or permits upon cancellation") {
         for {
@@ -65,7 +65,7 @@ object SemaphoreSpec extends ZIOBaseSpec {
           fiber   <- s.withPermitManaged.use(_ => IO.never).fork
           _       <- fiber.interrupt
           permits <- s.available
-        } yield assert(permits, equalTo(1L))
+        } yield assert(permits)(equalTo(1L))
       }
     )
   )
@@ -78,6 +78,6 @@ object SemaphoreSpec extends ZIOBaseSpec {
       fiber     <- withPermits(semaphore, permits).fork
       _         <- fiber.join
       count     <- semaphore.available
-    } yield assert(count, equalTo(20L))
+    } yield assert(count)(equalTo(20L))
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -18,20 +18,20 @@ object ZIOSpec extends ZIOBaseSpec {
   def spec = suite("ZIO")(
     suite("absorbWith")(
       testM("on fail") {
-        assertM(TaskExampleError.absorbWith(identity).run, fails(equalTo(ExampleError)))
+        assertM(TaskExampleError.absorbWith(identity).run)(fails(equalTo(ExampleError)))
       },
       testM("on die") {
-        assertM(TaskExampleDie.absorbWith(identity).run, fails(equalTo(ExampleError)))
+        assertM(TaskExampleDie.absorbWith(identity).run)(fails(equalTo(ExampleError)))
       },
       testM("on success") {
-        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError), equalTo(1))
+        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError))(equalTo(1))
       }
     ),
     suite("bimap")(
       testM("maps over both error and value channels") {
         checkM(Gen.anyInt) { i =>
           val res = IO.fail(i).bimap(_.toString, identity).either
-          assertM(res, isLeft(equalTo(i.toString)))
+          assertM(res)(isLeft(equalTo(i.toString)))
         }
       }
     ),
@@ -41,14 +41,14 @@ object ZIOSpec extends ZIOBaseSpec {
           release  <- Ref.make(false)
           result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
           released <- release.get
-        } yield assert(result, equalTo(43)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(43)) && assert(released)(isTrue)
       },
       testM("bracket_ happy path") {
         for {
           release  <- Ref.make(false)
           result   <- IO.succeed(42).bracket_(release.set(true), ZIO.effectTotal(0))
           released <- release.get
-        } yield assert(result, equalTo(0)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(0)) && assert(released)(isTrue)
       },
       testM("bracketExit happy path") {
         for {
@@ -59,7 +59,7 @@ object ZIOSpec extends ZIOBaseSpec {
                      (_: Int) => IO.succeed(0L)
                    )
           released <- release.get
-        } yield assert(result, equalTo(0L)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(0L)) && assert(released)(isTrue)
       },
       testM("bracketExit error handling") {
         val releaseDied: Throwable = new RuntimeException("release died")
@@ -72,8 +72,8 @@ object ZIOSpec extends ZIOBaseSpec {
                    )
                    .run
           cause <- exit.foldM(cause => ZIO.succeed(cause), _ => ZIO.fail("effect should have failed"))
-        } yield assert(cause.failures, equalTo(List("use failed"))) &&
-          assert(cause.defects, equalTo(List(releaseDied)))
+        } yield assert(cause.failures)(equalTo(List("use failed"))) &&
+          assert(cause.defects)(equalTo(List(releaseDied)))
       }
     ),
     suite("bracketFork")(
@@ -82,14 +82,14 @@ object ZIOSpec extends ZIOBaseSpec {
           release  <- Ref.make(false)
           result   <- ZIO.bracketFork(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
           released <- release.get
-        } yield assert(result, equalTo(43)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(43)) && assert(released)(isTrue)
       },
       testM("bracketFork_ happy path") {
         for {
           release  <- Ref.make(false)
           result   <- IO.succeed(42).bracketFork_(release.set(true), ZIO.effectTotal(0))
           released <- release.get
-        } yield assert(result, equalTo(0)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(0)) && assert(released)(isTrue)
       },
       testM("bracketForkExit happy path") {
         for {
@@ -100,7 +100,7 @@ object ZIOSpec extends ZIOBaseSpec {
                      (_: Int) => IO.succeed(0L)
                    )
           released <- release.get
-        } yield assert(result, equalTo(0L)) && assert(released, isTrue)
+        } yield assert(result)(equalTo(0L)) && assert(released)(isTrue)
       },
       testM("bracketForkExit error handling") {
         val releaseDied: Throwable = new RuntimeException("release died")
@@ -113,8 +113,8 @@ object ZIOSpec extends ZIOBaseSpec {
                    )
                    .run
           cause <- exit.foldM(cause => ZIO.succeed(cause), _ => ZIO.fail("effect should have failed"))
-        } yield assert(cause.failures, equalTo(List("use failed"))) &&
-          assert(cause.defects, equalTo(List(releaseDied)))
+        } yield assert(cause.failures)(equalTo(List("use failed"))) &&
+          assert(cause.defects)(equalTo(List(releaseDied)))
       }
     ),
     suite("cached")(
@@ -130,7 +130,7 @@ object ZIOSpec extends ZIOBaseSpec {
           c     <- cache
           _     <- TestClock.adjust(59.minutes)
           d     <- cache
-        } yield assert(a, equalTo(b)) && assert(b, not(equalTo(c))) && assert(c, equalTo(d))
+        } yield assert(a)(equalTo(b)) && assert(b)(not(equalTo(c))) && assert(c)(equalTo(d))
       }
     ),
     suite("catchSomeCause")(
@@ -138,7 +138,7 @@ object ZIOSpec extends ZIOBaseSpec {
         ZIO.interrupt.catchSomeCause {
           case c if c.interrupted => ZIO.succeed(true)
         }.sandbox.map(
-          assert(_, isTrue)
+          assert(_)(isTrue)
         )
       },
       testM("halts if cause doesn't match") {
@@ -146,7 +146,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ZIO.interrupt.catchSomeCause {
             case c if (!c.interrupted) => ZIO.succeed(true)
           }.sandbox.either.map(
-            assert(_, isLeft(equalTo(Cause.interrupt(fiberId))))
+            assert(_)(isLeft(equalTo(Cause.interrupt(fiberId))))
           )
         }
       }
@@ -160,22 +160,22 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.collect(s"value was not 0")({ case v @ 0 => v })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("value was not 0"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("value was not 0"))))
       }
     ),
     suite("collectAllPar")(
       testM("returns the list in the same order") {
         val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
         val res  = IO.collectAllPar(list)
-        assertM(res, equalTo(List(1, 2, 3)))
+        assertM(res)(equalTo(List(1, 2, 3)))
       }
     ),
     suite("collectAllParN")(
       testM("returns results in the same order") {
         val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
         val res  = IO.collectAllParN(2)(list)
-        assertM(res, equalTo(List(1, 2, 3)))
+        assertM(res)(equalTo(List(1, 2, 3)))
       }
     ),
     suite("collectM")(
@@ -191,9 +191,9 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.succeed(v) })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(partialBadCase, isLeft(isLeft(equalTo("Partial failed!")))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("Predicate failed!"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(partialBadCase)(isLeft(isLeft(equalTo("Partial failed!")))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("Predicate failed!"))))
       }
     ),
     suite("companion object method consistency")(
@@ -203,7 +203,7 @@ object ZIOSpec extends ZIOBaseSpec {
           for {
             abs1 <- ioEither.absolve
             abs2 <- IO.absolve(ioEither)
-          } yield assert(abs1, equalTo(abs2))
+          } yield assert(abs1)(equalTo(abs2))
         }
       },
       testM("firstSuccessOf") {
@@ -212,14 +212,14 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           race1 <- io.firstSuccessOf(ios)
           race2 <- IO.firstSuccessOf(io, ios)
-        } yield assert(race1, equalTo(race2))
+        } yield assert(race1)(equalTo(race2))
       },
       testM("flatten") {
         checkM(Gen.alphaNumericString) { str =>
           for {
             flatten1 <- IO.effectTotal(IO.effectTotal(str)).flatten
             flatten2 <- IO.flatten(IO.effectTotal(IO.effectTotal(str)))
-          } yield assert(flatten1, equalTo(flatten2))
+          } yield assert(flatten1)(equalTo(flatten2))
         }
       },
       testM("raceAll") {
@@ -228,7 +228,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           race1 <- io.raceAll(ios)
           race2 <- IO.raceAll(io, ios)
-        } yield assert(race1, equalTo(race2))
+        } yield assert(race1)(equalTo(race2))
       }
     ),
     suite("done")(
@@ -241,10 +241,10 @@ object ZIOSpec extends ZIOBaseSpec {
         val terminated: Exit[Error, Int]  = Exit.die(error)
         val failed: Exit[Error, Int]      = Exit.fail(error)
 
-        assertM(IO.done(completed), equalTo(1)) &&
-        assertM(IO.done(interrupted).run, isInterrupted) &&
-        assertM(IO.done(terminated).run, dies(equalTo(error))) &&
-        assertM(IO.done(failed).run, fails(equalTo(error)))
+        assertM(IO.done(completed))(equalTo(1)) &&
+        assertM(IO.done(interrupted).run)(isInterrupted) &&
+        assertM(IO.done(terminated).run)(dies(equalTo(error))) &&
+        assertM(IO.done(failed).run)(fails(equalTo(error)))
       }
     ),
     suite("doUntil")(
@@ -254,14 +254,14 @@ object ZIOSpec extends ZIOBaseSpec {
           out    <- Ref.make(0)
           _      <- (in.update(_ - 1) <* out.update(_ + 1)).doUntil(_ == 0)
           result <- out.get
-        } yield assert(result, equalTo(10))
+        } yield assert(result)(equalTo(10))
       },
       testM("doUntil always evaluates effect once") {
         for {
           ref    <- Ref.make(0)
           _      <- ref.update(_ + 1).doUntil(_ => true)
           result <- ref.get
-        } yield assert(result, equalTo(1))
+        } yield assert(result)(equalTo(1))
       }
     ),
     suite("doWhile")(
@@ -271,14 +271,14 @@ object ZIOSpec extends ZIOBaseSpec {
           out    <- Ref.make(0)
           _      <- (in.update(_ - 1) <* out.update(_ + 1)).doWhile(_ >= 0)
           result <- out.get
-        } yield assert(result, equalTo(11))
+        } yield assert(result)(equalTo(11))
       },
       testM("doWhile always evaluates effect once") {
         for {
           ref    <- Ref.make(0)
           _      <- ref.update(_ + 1).doWhile(_ => false)
           result <- ref.get
-        } yield assert(result, equalTo(1))
+        } yield assert(result)(equalTo(1))
       }
     ),
     suite("eventually")(
@@ -291,16 +291,16 @@ object ZIOSpec extends ZIOBaseSpec {
           n   <- effect(ref).eventually
         } yield n
 
-        assertM(test, equalTo(10))
+        assertM(test)(equalTo(10))
       }
     ),
     suite("fallback")(
       testM("executes an effect and returns its value if it succeeds") {
         import zio.CanFail.canFail
-        assertM(ZIO.succeed(1).fallback(2), equalTo(1))
+        assertM(ZIO.succeed(1).fallback(2))(equalTo(1))
       },
       testM("returns the specified value if the effect fails") {
-        assertM(ZIO.fail("fail").fallback(1), equalTo(1))
+        assertM(ZIO.fail("fail").fallback(1))(equalTo(1))
       }
     ),
     suite("filterOrElse")(
@@ -312,8 +312,8 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.filterOrElse[Any, String, Int](_ == 0)(a => ZIO.fail(s"$a was not 0"))).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("1 was not 0"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("1 was not 0"))))
       }
     ),
     suite("filterOrElse_")(
@@ -325,8 +325,8 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.filterOrElse_[Any, String, Int](_ == 0)(ZIO.fail(s"Predicate failed!"))).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("Predicate failed!"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("Predicate failed!"))))
       }
     ),
     suite("filterOrFail")(
@@ -338,41 +338,41 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.filterOrFail(_ == 0)("Predicate failed!")).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("Predicate failed!"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("Predicate failed!"))))
       }
     ),
     suite("flattenErrorOption")(
       testM("fails when given Some error") {
         val task: IO[String, Int] = IO.fail(Some("Error")).flattenErrorOption("Default")
-        assertM(task.run, fails(equalTo("Error")))
+        assertM(task.run)(fails(equalTo("Error")))
       },
       testM("fails with Default when given None error") {
         val task: IO[String, Int] = IO.fail(None).flattenErrorOption("Default")
-        assertM(task.run, fails(equalTo("Default")))
+        assertM(task.run)(fails(equalTo("Default")))
       },
       testM("succeeds when given a value") {
         val task: IO[String, Int] = IO.succeed(1).flattenErrorOption("Default")
-        assertM(task, equalTo(1))
+        assertM(task)(equalTo(1))
       }
     ),
     suite("foldLeft")(
       testM("with a successful step function sums the list properly") {
         checkM(Gen.listOf(Gen.anyInt)) { l =>
           val res = IO.foldLeft(l)(0)((acc, el) => IO.succeed(acc + el))
-          assertM(res, equalTo(l.sum))
+          assertM(res)(equalTo(l.sum))
         }
       },
       testM("`with a failing step function returns a failed IO") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
           val res = IO.foldLeft(l)(0)((_, _) => IO.fail("fail"))
-          assertM(res.run, fails(equalTo("fail")))
+          assertM(res.run)(fails(equalTo("fail")))
         }
       },
       testM("run sequentially from left to right") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
           val res = IO.foldLeft(l)(List.empty[Int])((acc, el) => IO.succeed(el :: acc))
-          assertM(res, equalTo(l.reverse))
+          assertM(res)(equalTo(l.reverse))
         }
       }
     ),
@@ -380,19 +380,19 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("with a successful step function sums the list properly") {
         checkM(Gen.listOf(Gen.anyInt)) { l =>
           val res = IO.foldRight(l)(0)((el, acc) => IO.succeed(acc + el))
-          assertM(res, equalTo(l.sum))
+          assertM(res)(equalTo(l.sum))
         }
       },
       testM("`with a failing step function returns a failed IO") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
           val res = IO.foldRight(l)(0)((_, _) => IO.fail("fail"))
-          assertM(res.run, fails(equalTo("fail")))
+          assertM(res.run)(fails(equalTo("fail")))
         }
       },
       testM("run sequentially from right to left") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
           val res = IO.foldRight(l)(List.empty[Int])((el, acc) => IO.succeed(el :: acc))
-          assertM(res, equalTo(l))
+          assertM(res)(equalTo(l))
         }
       }
     ),
@@ -400,7 +400,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns the list of results") {
         checkAllM(functionIOGen, listGen) { (f, list) =>
           val res = IO.foreach(list)(f)
-          assertM(res, isSubtype[List[Int]](anything) && hasSize(equalTo(100)))
+          assertM(res)(isSubtype[List[Int]](anything) && hasSize(equalTo(100)))
         }
       },
       testM("both evaluates effects and returns the list of results in the same order") {
@@ -409,12 +409,12 @@ object ZIOSpec extends ZIOBaseSpec {
           ref     <- Ref.make(List.empty[String])
           res     <- IO.foreach(list)(x => ref.update(_ :+ x) *> IO.effectTotal[Int](x.toInt))
           effects <- ref.get
-        } yield assert(effects, equalTo(list)) && assert(res, equalTo(List(1, 2, 3)))
+        } yield assert(effects)(equalTo(list)) && assert(res)(equalTo(List(1, 2, 3)))
       },
       testM("fails if one of the effects fails") {
         val list = List("1", "h", "3")
         val res  = IO.foreach(list)(x => IO.effectTotal[Int](x.toInt))
-        assertM(res.run, dies(isSubtype[NumberFormatException](anything)))
+        assertM(res.run)(dies(isSubtype[NumberFormatException](anything)))
       }
     ),
     suite("foreach_")(
@@ -424,7 +424,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ref <- Ref.make(List.empty[Int])
           _   <- ZIO.foreach_(as)(a => ref.update(_ :+ a))
           rs  <- ref.get
-        } yield assert(rs, equalTo(as))
+        } yield assert(rs)(equalTo(as))
       },
       testM("can be run twice") {
         val as = List(1, 2, 3, 4, 5)
@@ -434,28 +434,28 @@ object ZIOSpec extends ZIOBaseSpec {
           _   <- zio
           _   <- zio
           sum <- ref.get
-        } yield assert(sum, equalTo(30))
+        } yield assert(sum)(equalTo(30))
       }
     ),
     suite("foreachPar")(
       testM("returns results in the same order") {
         val list = List("1", "2", "3")
         val res  = IO.foreachPar(list)(x => IO.effectTotal[Int](x.toInt))
-        assertM(res, equalTo(List(1, 2, 3)))
+        assertM(res)(equalTo(List(1, 2, 3)))
       },
       testM("runs effects in parallel") {
         assertM(for {
           p <- Promise.make[Nothing, Unit]
           _ <- UIO.foreachPar(List(UIO.never, p.succeed(())))(a => a).fork
           _ <- p.await
-        } yield true, isTrue)
+        } yield true)(isTrue)
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
         val odds = ZIO.foreachPar(ints) { n =>
           if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd")
         }
-        assertM(odds.flip, equalTo("not odd"))
+        assertM(odds.flip)(equalTo("not odd"))
       },
       testM("interrupts effects on first failure") {
         for {
@@ -469,7 +469,7 @@ object ZIOSpec extends ZIOBaseSpec {
           )
           e <- ZIO.foreachPar(actions)(a => a).flip
           v <- ref.get
-        } yield assert(e, equalTo("C")) && assert(v, isFalse)
+        } yield assert(e)(equalTo("C")) && assert(v)(isFalse)
       }
     ),
     suite("foreachPar_")(
@@ -479,15 +479,15 @@ object ZIOSpec extends ZIOBaseSpec {
           ref <- Ref.make(Seq.empty[Int])
           _   <- ZIO.foreachPar_(as)(a => ref.update(_ :+ a))
           rs  <- ref.get
-        } yield assert(rs, hasSize(equalTo(as.length))) &&
-          assert(rs.toSet, equalTo(as.toSet))
+        } yield assert(rs)(hasSize(equalTo(as.length))) &&
+          assert(rs.toSet)(equalTo(as.toSet))
       }
     ),
     suite("foreachParN")(
       testM("returns the list of results in the appropriate order") {
         val list = List(1, 2, 3)
         val res  = IO.foreachParN(2)(list)(x => IO.effectTotal(x.toString))
-        assertM(res, equalTo(List("1", "2", "3")))
+        assertM(res)(equalTo(List("1", "2", "3")))
       },
       testM("works on large lists") {
         val n   = 10
@@ -501,14 +501,14 @@ object ZIOSpec extends ZIOBaseSpec {
           _ <- UIO.foreachParN(2)(List(UIO.never, p.succeed(())))(identity).fork
           _ <- p.await
         } yield true
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
         val odds = ZIO.foreachParN(4)(ints) { n =>
           if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd")
         }
-        assertM(odds.either, isLeft(equalTo("not odd")))
+        assertM(odds.either)(isLeft(equalTo("not odd")))
       },
       testM("interrupts effects on first failure") {
         val actions = List(
@@ -517,7 +517,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ZIO.fail("C")
         )
         val io = ZIO.foreachParN(4)(actions)(a => a)
-        assertM(io.either, isLeft(equalTo("C")))
+        assertM(io.either)(isLeft(equalTo("C")))
       }
     ),
     suite("foreachParN_")(
@@ -527,36 +527,36 @@ object ZIOSpec extends ZIOBaseSpec {
           ref <- Ref.make(Seq.empty[Int])
           _   <- ZIO.foreachParN_(2)(as)(a => ref.update(_ :+ a))
           rs  <- ref.get
-        } yield assert(rs, hasSize(equalTo(as.length))) &&
-          assert(rs.toSet, equalTo(as.toSet))
+        } yield assert(rs)(hasSize(equalTo(as.length))) &&
+          assert(rs.toSet)(equalTo(as.toSet))
       }
     ),
     suite("forkAll")(
       testM("returns the list of results in the same order") {
         val list = List(1, 2, 3).map(IO.effectTotal[Int](_))
         val res  = IO.forkAll(list).flatMap[Any, Nothing, List[Int]](_.join)
-        assertM(res, equalTo(List(1, 2, 3)))
+        assertM(res)(equalTo(List(1, 2, 3)))
       },
       testM("happy-path") {
         val list = (1 to 1000).toList
-        assertM(ZIO.forkAll(list.map(a => ZIO.effectTotal(a))).flatMap(_.join), equalTo(list))
+        assertM(ZIO.forkAll(list.map(a => ZIO.effectTotal(a))).flatMap(_.join))(equalTo(list))
       },
       testM("empty input") {
-        assertM(ZIO.forkAll(List.empty).flatMap(_.join), equalTo(List.empty))
+        assertM(ZIO.forkAll(List.empty).flatMap(_.join))(equalTo(List.empty))
       },
       testM("propagate failures") {
         val boom = new Exception
         for {
           fiber  <- ZIO.forkAll(List(ZIO.fail(boom)))
           result <- fiber.join.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("propagates defects") {
         val boom = new Exception("boom")
         for {
           fiber  <- ZIO.forkAll(List(ZIO.die(boom)))
           result <- fiber.join.sandbox.flip
-        } yield assert(result, equalTo(Cause.die(boom)))
+        } yield assert(result)(equalTo(Cause.die(boom)))
       } @@ flaky
     ),
     suite("forkWithErrorHandler")(
@@ -581,7 +581,7 @@ object ZIOSpec extends ZIOBaseSpec {
           v1    <- ZIO.effectTotal(ref.get)
           _     <- Live.live(clock.sleep(10.milliseconds))
           v2    <- ZIO.effectTotal(ref.get)
-        } yield assert(v1, equalTo(v2))
+        } yield assert(v1)(equalTo(v2))
       },
       testM("interruption blocks on interruption of the Future") {
         import scala.concurrent.Promise
@@ -592,56 +592,56 @@ object ZIOSpec extends ZIOBaseSpec {
                   }.fork
           _      <- ZIO.fromFuture(_ => latch.future).orDie
           result <- Live.withLive(fiber.interrupt)(_.timeout(10.milliseconds))
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       }
     ),
     suite("head")(
       testM("on non empty list") {
-        assertM(ZIO.succeed(List(1, 2, 3)).head.either, isRight(equalTo(1)))
+        assertM(ZIO.succeed(List(1, 2, 3)).head.either)(isRight(equalTo(1)))
       },
       testM("on empty list") {
-        assertM(ZIO.succeed(List.empty).head.either, isLeft(isNone))
+        assertM(ZIO.succeed(List.empty).head.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.fail("Fail").head.either, isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").head.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("ignore")(
       testM("return success as Unit") {
-        assertM(ZIO.succeed(11).ignore, equalTo(()))
+        assertM(ZIO.succeed(11).ignore)(equalTo(()))
       },
       testM("return failure as Unit") {
-        assertM(ZIO.fail(123).ignore, equalTo(()))
+        assertM(ZIO.fail(123).ignore)(equalTo(()))
       },
       testM("not catch throwable") {
-        assertM(ZIO.die(ExampleError).ignore.run, dies(equalTo(ExampleError)))
+        assertM(ZIO.die(ExampleError).ignore.run)(dies(equalTo(ExampleError)))
       }
     ),
     suite("left")(
       testM("on Left value") {
-        assertM(ZIO.succeed(Left("Left")).left, equalTo("Left"))
+        assertM(ZIO.succeed(Left("Left")).left)(equalTo("Left"))
       },
       testM("on Right value") {
-        assertM(ZIO.succeed(Right("Right")).left.either, isLeft(isNone))
+        assertM(ZIO.succeed(Right("Right")).left.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.fail("Fail").left.either, isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").left.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("leftOrFail")(
       testM("on Left value") {
-        assertM(UIO(Left(42)).leftOrFail(ExampleError), equalTo(42))
+        assertM(UIO(Left(42)).leftOrFail(ExampleError))(equalTo(42))
       },
       testM("on Right value") {
-        assertM(UIO(Right(12)).leftOrFail(ExampleError).flip, equalTo(ExampleError))
+        assertM(UIO(Right(12)).leftOrFail(ExampleError).flip)(equalTo(ExampleError))
       }
     ),
     suite("leftOrFailException")(
       testM("on Left value") {
-        assertM(ZIO.succeed(Left(42)).leftOrFailException, equalTo(42))
+        assertM(ZIO.succeed(Left(42)).leftOrFailException)(equalTo(42))
       },
       testM("on Right value") {
-        assertM(ZIO.succeed(Right(2)).leftOrFailException.run, fails(Assertion.anything))
+        assertM(ZIO.succeed(Right(2)).leftOrFailException.run)(fails(Assertion.anything))
       }
     ),
     suite("mapN")(
@@ -650,7 +650,7 @@ object ZIOSpec extends ZIOBaseSpec {
           def f(i: Int, s: String): String = i.toString + s
           val actual                       = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str))(f)
           val expected                     = f(int, str)
-          assertM(actual, equalTo(expected))
+          assertM(actual)(equalTo(expected))
         }
       },
       testM("with Tuple3") {
@@ -658,7 +658,7 @@ object ZIOSpec extends ZIOBaseSpec {
           def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
           val actual                                    = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
           val expected                                  = f(int, str1, str2)
-          assertM(actual, equalTo(expected))
+          assertM(actual)(equalTo(expected))
         }
       },
       testM("with Tuple4") {
@@ -667,7 +667,7 @@ object ZIOSpec extends ZIOBaseSpec {
             def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
             val actual                                                = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
             val expected                                              = f(int, str1, str2, str3)
-            assertM(actual, equalTo(expected))
+            assertM(actual)(equalTo(expected))
         }
       }
     ),
@@ -677,7 +677,7 @@ object ZIOSpec extends ZIOBaseSpec {
           def f(i: Int, s: String): String = i.toString + s
           val actual                       = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str))(f)
           val expected                     = f(int, str)
-          assertM(actual, equalTo(expected))
+          assertM(actual)(equalTo(expected))
         }
       },
       testM("with Tuple3") {
@@ -685,7 +685,7 @@ object ZIOSpec extends ZIOBaseSpec {
           def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
           val actual                                    = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
           val expected                                  = f(int, str1, str2)
-          assertM(actual, equalTo(expected))
+          assertM(actual)(equalTo(expected))
         }
       },
       testM("with Tuple4") {
@@ -694,7 +694,7 @@ object ZIOSpec extends ZIOBaseSpec {
             def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
             val actual                                                = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
             val expected                                              = f(int, str1, str2, str3)
-            assertM(actual, equalTo(expected))
+            assertM(actual)(equalTo(expected))
         }
       }
     ),
@@ -702,13 +702,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("non-memoized returns new instances on repeated calls") {
         val io = random.nextString(10)
         (io <*> io)
-          .map(tuple => assert(tuple._1, not(equalTo(tuple._2))))
+          .map(tuple => assert(tuple._1)(not(equalTo(tuple._2))))
       },
       testM("memoized returns the same instance on repeated calls") {
         val ioMemo = random.nextString(10).memoize
         ioMemo
           .flatMap(io => io <*> io)
-          .map(tuple => assert(tuple._1, equalTo(tuple._2)))
+          .map(tuple => assert(tuple._1)(equalTo(tuple._2)))
       }
     ),
     suite("merge")(
@@ -718,17 +718,17 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           a <- zio.merge
           b <- zio.flip.merge
-        } yield assert(a, equalTo(b))
+        } yield assert(a)(equalTo(b))
       }
     ),
     suite("none")(
       testM("on Some fails with None") {
         val task: IO[Option[Throwable], Unit] = Task(Some(1)).none
-        assertM(task.run, fails(isNone))
+        assertM(task.run)(fails(isNone))
       },
       testM("on None succeeds with ()") {
         val task: IO[Option[Throwable], Unit] = Task(None).none
-        assertM(task, isUnit)
+        assertM(task)(isUnit)
       },
       testM("fails with Some(ex) when effect fails with ex") {
         val ex                                = new RuntimeException("Failed Task")
@@ -746,7 +746,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("not catch throwable") {
         import zio.CanFail.canFail
-        assertM(ZIO.die(ExampleError).option.run, dies(equalTo(ExampleError)))
+        assertM(ZIO.die(ExampleError).option.run)(dies(equalTo(ExampleError)))
       },
       testM("catch throwable after sandboxing") {
         assertM(ZIO.die(ExampleError).sandbox.option)(equalTo(None))
@@ -755,15 +755,15 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("optional")(
       testM("fails when given Some error") {
         val task: IO[String, Option[Int]] = IO.fail(Some("Error")).optional
-        assertM(task.run, fails(equalTo("Error")))
+        assertM(task.run)(fails(equalTo("Error")))
       },
       testM("succeeds with None given None error") {
         val task: IO[String, Option[Int]] = IO.fail(None).optional
-        assertM(task, isNone)
+        assertM(task)(isNone)
       },
       testM("ucceeds with Some given a value") {
         val task: IO[String, Option[Int]] = IO.succeed(1).optional
-        assertM(task, isSome(equalTo(1)))
+        assertM(task)(isSome(equalTo(1)))
       }
     ),
     suite("orElse")(
@@ -776,10 +776,10 @@ object ZIOSpec extends ZIOBaseSpec {
           both  <- (ZIO.halt(Cause.Both(interrupt(fiberId), die(ex))) <> IO.unit).run
           thn   <- (ZIO.halt(Cause.Then(interrupt(fiberId), die(ex))) <> IO.unit).run
           fail  <- (ZIO.fail(ex) <> IO.unit).run
-        } yield assert(plain, dies(equalTo(ex))) &&
-          assert(both, dies(equalTo(ex))) &&
-          assert(thn, dies(equalTo(ex))) &&
-          assert(fail, succeeds(isUnit))
+        } yield assert(plain)(dies(equalTo(ex))) &&
+          assert(both)(dies(equalTo(ex))) &&
+          assert(thn)(dies(equalTo(ex))) &&
+          assert(fail)(succeeds(isUnit))
       },
       testM("left failed and right died with kept cause") {
         val z1                = Task.fail(new Throwable("1"))
@@ -790,7 +790,7 @@ object ZIOSpec extends ZIOBaseSpec {
           case _ =>
             Task(false)
         }
-        assertM(orElse, equalTo(true))
+        assertM(orElse)(equalTo(true))
       },
       testM("left failed and right failed with kept cause") {
         val z1                = Task.fail(new Throwable("1"))
@@ -801,7 +801,7 @@ object ZIOSpec extends ZIOBaseSpec {
           case _ =>
             Task(false)
         }
-        assertM(orElse, equalTo(true))
+        assertM(orElse)(equalTo(true))
       }
     ),
     suite("parallelErrors")(
@@ -810,15 +810,14 @@ object ZIOSpec extends ZIOBaseSpec {
           f1     <- IO.fail("error1").fork
           f2     <- IO.succeed("success1").fork
           errors <- f1.zip(f2).join.parallelErrors[String].flip
-        } yield assert(errors, equalTo(List("error1")))
+        } yield assert(errors)(equalTo(List("error1")))
       },
       testM("allFailures") {
         for {
           f1     <- IO.fail("error1").fork
           f2     <- IO.fail("error2").fork
           errors <- f1.zip(f2).join.parallelErrors[String].flip
-        } yield assert(
-          errors,
+        } yield assert(errors)(
           equalTo(List("error1", "error2")) ||
             equalTo(List("error1")) ||
             equalTo(List("error2"))
@@ -831,19 +830,19 @@ object ZIOSpec extends ZIOBaseSpec {
         val in = List.range(0, 10)
         for {
           res <- ZIO.partitionM(in)(a => ZIO.succeed(a))
-        } yield assert(res._1, isEmpty) && assert(res._2, equalTo(in))
+        } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects only failures") {
         val in = List.fill(10)(0)
         for {
           res <- ZIO.partitionM(in)(a => ZIO.fail(a))
-        } yield assert(res._1, equalTo(in)) && assert(res._2, isEmpty)
+        } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
           res <- ZIO.partitionM(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
-        } yield assert(res._1, equalTo(List(0, 2, 4, 6, 8))) && assert(res._2, equalTo(List(1, 3, 5, 7, 9)))
+        } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
     suite("partitionMPar")(
@@ -852,19 +851,19 @@ object ZIOSpec extends ZIOBaseSpec {
         val in = List.range(0, 1000)
         for {
           res <- ZIO.partitionMPar(in)(a => ZIO.succeed(a))
-        } yield assert(res._1, isEmpty) && assert(res._2, equalTo(in))
+        } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
           res <- ZIO.partitionMPar(in)(a => ZIO.fail(a))
-        } yield assert(res._1, equalTo(in)) && assert(res._2, isEmpty)
+        } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
           res <- ZIO.partitionMPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
-        } yield assert(res._1, equalTo(List(0, 2, 4, 6, 8))) && assert(res._2, equalTo(List(1, 3, 5, 7, 9)))
+        } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
     suite("partitionMParN")(
@@ -873,30 +872,30 @@ object ZIOSpec extends ZIOBaseSpec {
         val in = List.range(0, 1000)
         for {
           res <- ZIO.partitionMParN(3)(in)(a => ZIO.succeed(a))
-        } yield assert(res._1, isEmpty) && assert(res._2, equalTo(in))
+        } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
           res <- ZIO.partitionMParN(3)(in)(a => ZIO.fail(a))
-        } yield assert(res._1, equalTo(in)) && assert(res._2, isEmpty)
+        } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
           res <- ZIO.partitionMParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
-        } yield assert(res._1, equalTo(List(0, 2, 4, 6, 8))) && assert(res._2, equalTo(List(1, 3, 5, 7, 9)))
+        } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
     suite("raceAll")(
       testM("returns first success") {
-        assertM(ZIO.fail("Fail").raceAll(List(IO.succeed(24))), equalTo(24))
+        assertM(ZIO.fail("Fail").raceAll(List(IO.succeed(24))))(equalTo(24))
       },
       testM("returns last failure") {
-        assertM(live(ZIO.sleep(100.millis) *> ZIO.fail(24)).raceAll(List(ZIO.fail(25))).flip, equalTo(24))
+        assertM(live(ZIO.sleep(100.millis) *> ZIO.fail(24)).raceAll(List(ZIO.fail(25))).flip)(equalTo(24))
       } @@ flaky,
       testM("returns success when it happens after failure") {
-        assertM(ZIO.fail(42).raceAll(List(IO.succeed(24) <* live(ZIO.sleep(100.millis)))), equalTo(24))
+        assertM(ZIO.fail(42).raceAll(List(IO.succeed(24) <* live(ZIO.sleep(100.millis)))))(equalTo(24))
       }
     ),
     suite("replicate")(
@@ -910,18 +909,18 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("positive") {
         val lst: Iterable[UIO[Int]] = ZIO.replicate(2)(ZIO.succeed(12))
-        assertM(ZIO.sequence(lst), equalTo(List(12, 12)))
+        assertM(ZIO.sequence(lst))(equalTo(List(12, 12)))
       }
     ),
     suite("right")(
       testM("on Right value") {
-        assertM(ZIO.succeed(Right("Right")).right, equalTo("Right"))
+        assertM(ZIO.succeed(Right("Right")).right)(equalTo("Right"))
       },
       testM("on Left value") {
-        assertM(ZIO.succeed(Left("Left")).right.either, isLeft(isNone))
+        assertM(ZIO.succeed(Left("Left")).right.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.fail("Fail").right.either, isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").right.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("refineToOrDie")(
@@ -935,33 +934,33 @@ object ZIOSpec extends ZIOBaseSpec {
         }
         val expected =
           "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"
-        assertM(result, isLeft(equalTo(expected)))
+        assertM(result)(isLeft(equalTo(expected)))
       } @@ scala2Only
     ),
     suite("rightOrFail")(
       testM("on Right value") {
-        assertM(UIO(Right(42)).rightOrFail(ExampleError), equalTo(42))
+        assertM(UIO(Right(42)).rightOrFail(ExampleError))(equalTo(42))
       },
       testM("on Left value") {
-        assertM(UIO(Left(1)).rightOrFail(ExampleError).flip, equalTo(ExampleError))
+        assertM(UIO(Left(1)).rightOrFail(ExampleError).flip)(equalTo(ExampleError))
       }
     ),
     suite("rightOrFailException")(
       testM("on Right value") {
-        assertM(ZIO.succeed(Right(42)).rightOrFailException, equalTo(42))
+        assertM(ZIO.succeed(Right(42)).rightOrFailException)(equalTo(42))
       },
       testM("on Left value") {
-        assertM(ZIO.succeed(Left(2)).rightOrFailException.run, fails(Assertion.anything))
+        assertM(ZIO.succeed(Left(2)).rightOrFailException.run)(fails(Assertion.anything))
       }
     ),
     suite("some")(
       testM("extracts the value from Some") {
         val task: IO[Option[Throwable], Int] = Task(Some(1)).some
-        assertM(task, equalTo(1))
+        assertM(task)(equalTo(1))
       },
       testM("fails on None") {
         val task: IO[Option[Throwable], Int] = Task(None).some
-        assertM(task.run, fails(isNone))
+        assertM(task.run)(fails(isNone))
       },
       testM("fails when given an exception") {
         val ex                               = new RuntimeException("Failed Task")
@@ -971,28 +970,28 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
-        assertM(ZIO.succeed(Some(42)).someOrFailException, equalTo(42))
+        assertM(ZIO.succeed(Some(42)).someOrFailException)(equalTo(42))
       },
       testM("fails when given a None") {
         val task = ZIO.succeed(Option.empty[Int]).someOrFailException
-        assertM(task.run, fails(isSubtype[NoSuchElementException](anything)))
+        assertM(task.run)(fails(isSubtype[NoSuchElementException](anything)))
       },
       suite("without another error type")(
         testM("succeed something") {
-          assertM(ZIO.succeed(Option(3)).someOrFailException, equalTo(3))
+          assertM(ZIO.succeed(Option(3)).someOrFailException)(equalTo(3))
         },
         testM("succeed nothing") {
-          assertM(ZIO.succeed(None: Option[Int]).someOrFailException.run, fails(Assertion.anything))
+          assertM(ZIO.succeed(None: Option[Int]).someOrFailException.run)(fails(Assertion.anything))
         }
       ),
       suite("with throwable as base error type")(
         testM("return something") {
-          assertM(Task(Option(3)).someOrFailException, equalTo(3))
+          assertM(Task(Option(3)).someOrFailException)(equalTo(3))
         }
       ),
       suite("with exception as base error type")(
         testM("return something") {
-          assertM((ZIO.succeed(Option(3)): IO[Exception, Option[Int]]).someOrFailException, equalTo(3))
+          assertM((ZIO.succeed(Option(3)): IO[Exception, Option[Int]]).someOrFailException)(equalTo(3))
         }
       )
     ),
@@ -1005,8 +1004,8 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.reject({ case v if v != 0 => "Partial failed!" })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("Partial failed!"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("Partial failed!"))))
       }
     ),
     suite("rejectM")(
@@ -1022,9 +1021,9 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.fail("Partial failed!") })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
-        assertM(goodCase, isRight(equalTo(0))) &&
-        assertM(partialBadCase, isLeft(isLeft(equalTo("Partial failed!")))) &&
-        assertM(badCase, isLeft(isLeft(equalTo("Partial failed!"))))
+        assertM(goodCase)(isRight(equalTo(0))) &&
+        assertM(partialBadCase)(isLeft(isLeft(equalTo("Partial failed!")))) &&
+        assertM(badCase)(isLeft(isLeft(equalTo("Partial failed!"))))
       }
     ),
     suite("RTS synchronous correctness")(
@@ -1032,7 +1031,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val op1 = IO.effectTotal[String]("1")
         val op2 = IO.effectTotal[String]("2")
 
-        assertM(op1.zipWith(op2)(_ + _), equalTo("12"))
+        assertM(op1.zipWith(op2)(_ + _))(equalTo("12"))
       },
       testM("now must be eager") {
         val io =
@@ -1043,7 +1042,7 @@ object ZIOSpec extends ZIOBaseSpec {
             case _: Throwable => IO.succeed(true)
           }
 
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       },
       testM("effectSuspend must be lazy") {
         val io =
@@ -1054,22 +1053,22 @@ object ZIOSpec extends ZIOBaseSpec {
             case _: Throwable => IO.succeed(true)
           }
 
-        assertM(io, isFalse)
+        assertM(io)(isFalse)
       },
       testM("effectSuspendTotal must not catch throwable") {
         val io = ZIO.effectSuspendTotal[Any, Nothing, Any](throw ExampleError).sandbox.either
-        assertM(io, isLeft(equalTo(Cause.die(ExampleError))))
+        assertM(io)(isLeft(equalTo(Cause.die(ExampleError))))
       },
       testM("effectSuspend must catch throwable") {
         val io = ZIO.effectSuspend[Any, Nothing](throw ExampleError).either
-        assertM(io, isLeft(equalTo(ExampleError)))
+        assertM(io)(isLeft(equalTo(ExampleError)))
       },
       testM("effectSuspendWith must catch throwable") {
         val io = ZIO.effectSuspendWith[Any, Nothing]((_, _) => throw ExampleError).either
-        assertM(io, isLeft(equalTo(ExampleError)))
+        assertM(io)(isLeft(equalTo(ExampleError)))
       },
       testM("effectSuspendTotal must be evaluatable") {
-        assertM(IO.effectSuspendTotal(IO.effectTotal(42)), equalTo(42))
+        assertM(IO.effectSuspendTotal(IO.effectTotal(42)))(equalTo(42))
       },
       testM("point, bind, map") {
         def fibIo(n: Int): Task[BigInt] =
@@ -1080,7 +1079,7 @@ object ZIOSpec extends ZIOBaseSpec {
               b <- fibIo(n - 2)
             } yield a + b
 
-        assertM(fibIo(10), equalTo(fib(10)))
+        assertM(fibIo(10))(equalTo(fib(10)))
       },
       testM("effect, bind, map") {
         def fibIo(n: Int): Task[BigInt] =
@@ -1091,7 +1090,7 @@ object ZIOSpec extends ZIOBaseSpec {
               b <- fibIo(n - 2)
             } yield a + b
 
-        assertM(fibIo(10), equalTo(fib(10)))
+        assertM(fibIo(10))(equalTo(fib(10)))
       },
       testM("effect, bind, map, redeem") {
         def fibIo(n: Int): Task[BigInt] =
@@ -1102,14 +1101,14 @@ object ZIOSpec extends ZIOBaseSpec {
               b <- fibIo(n - 2)
             } yield a + b
 
-        assertM(fibIo(10), equalTo(fib(10)))
+        assertM(fibIo(10))(equalTo(fib(10)))
       },
       testM("sync effect") {
         def sumIo(n: Int): Task[Int] =
           if (n <= 0) IO.effectTotal(0)
           else IO.effectTotal(n).flatMap(b => sumIo(n - 1).map(a => a + b))
 
-        assertM(sumIo(1000), equalTo(sum(1000)))
+        assertM(sumIo(1000))(equalTo(sum(1000)))
       },
       testM("deep effects") {
         def incLeft(n: Int, ref: Ref[Int]): Task[Int] =
@@ -1132,25 +1131,25 @@ object ZIOSpec extends ZIOBaseSpec {
             v   <- incRight(1000, ref)
           } yield v == 1000
 
-        assertM(l.zipWith(r)(_ && _), isTrue)
+        assertM(l.zipWith(r)(_ && _))(isTrue)
       },
       testM("flip must make error into value") {
         val io = IO.fail(ExampleError).flip
-        assertM(io, equalTo(ExampleError))
+        assertM(io)(equalTo(ExampleError))
       },
       testM("flip must make value into error") {
         val io = IO.succeed(42).flip
-        assertM(io.either, isLeft(equalTo(42)))
+        assertM(io.either)(isLeft(equalTo(42)))
       },
       testM("flipping twice returns identical value") {
         val io = IO.succeed(42)
-        assertM(io.flip.flip, equalTo(42))
+        assertM(io.flip.flip)(equalTo(42))
       }
     ),
     suite("RTS failure")(
       testM("error in sync effect") {
         val io = IO.effect[Unit](throw ExampleError).fold[Option[Throwable]](Some(_), _ => None)
-        assertM(io, isSome(equalTo(ExampleError)))
+        assertM(io)(isSome(equalTo(ExampleError)))
       },
       testM("attempt . fail") {
         val io1 = TaskExampleError.either
@@ -1158,36 +1157,36 @@ object ZIOSpec extends ZIOBaseSpec {
 
         io1.zipWith(io2) {
           case (r1, r2) =>
-            assert(r1, isLeft(equalTo(ExampleError))) && assert(r2, isLeft(equalTo(ExampleError)))
+            assert(r1)(isLeft(equalTo(ExampleError))) && assert(r2)(isLeft(equalTo(ExampleError)))
         }
       },
       testM("deep attempt sync effect error") {
-        assertM(deepErrorEffect(100).either, isLeft(equalTo(ExampleError)))
+        assertM(deepErrorEffect(100).either)(isLeft(equalTo(ExampleError)))
       },
       testM("deep attempt fail error") {
-        assertM(deepErrorFail(100).either, isLeft(equalTo(ExampleError)))
+        assertM(deepErrorFail(100).either)(isLeft(equalTo(ExampleError)))
       },
       testM("attempt . sandbox . terminate") {
         val io = IO.effectTotal[Int](throw ExampleError).sandbox.either
-        assertM(io, isLeft(equalTo(Cause.die(ExampleError))))
+        assertM(io)(isLeft(equalTo(Cause.die(ExampleError))))
       },
       testM("fold . sandbox . terminate") {
         val io = IO.effectTotal[Int](throw ExampleError).sandbox.fold(Some(_), Function.const(None))
-        assertM(io, isSome(equalTo(Cause.die(ExampleError))))
+        assertM(io)(isSome(equalTo(Cause.die(ExampleError))))
       },
       testM("catch sandbox terminate") {
         val io = IO.effectTotal(throw ExampleError).sandbox.merge
-        assertM(io, equalTo(Cause.die(ExampleError)))
+        assertM(io)(equalTo(Cause.die(ExampleError)))
       },
       testM("uncaught fail") {
-        assertM(TaskExampleError.run, fails(equalTo(ExampleError)))
+        assertM(TaskExampleError.run)(fails(equalTo(ExampleError)))
       },
       testM("uncaught sync effect error") {
         val io = IO.effectTotal[Int](throw ExampleError)
-        assertM(io.run, dies(equalTo(ExampleError)))
+        assertM(io.run)(dies(equalTo(ExampleError)))
       },
       testM("deep uncaught sync effect error") {
-        assertM(deepErrorEffect(100).run, fails(equalTo(ExampleError)))
+        assertM(deepErrorEffect(100).run)(fails(equalTo(ExampleError)))
       },
       testM("catch failing finalizers with fail") {
         val io = IO
@@ -1201,7 +1200,7 @@ object ZIOSpec extends ZIOBaseSpec {
           Cause.die(InterruptCause2) ++
           Cause.die(InterruptCause3)
 
-        assertM(io.run, equalTo(Exit.halt(expectedCause)))
+        assertM(io.run)(equalTo(Exit.halt(expectedCause)))
       },
       testM("catch failing finalizers with terminate") {
         val io = IO
@@ -1215,7 +1214,7 @@ object ZIOSpec extends ZIOBaseSpec {
           Cause.die(InterruptCause2) ++
           Cause.die(InterruptCause3)
 
-        assertM(io.run, equalTo(Exit.halt(expectedCause)))
+        assertM(io.run)(equalTo(Exit.halt(expectedCause)))
       },
       testM("run preserves interruption status") {
         for {
@@ -1224,18 +1223,18 @@ object ZIOSpec extends ZIOBaseSpec {
           _    <- p.await
           _    <- f.interrupt
           test <- f.await.map(_.interrupted)
-        } yield assert(test, isTrue)
+        } yield assert(test)(isTrue)
       },
       testM("run swallows inner interruption") {
         for {
           p   <- Promise.make[Nothing, Int]
           _   <- IO.interrupt.run *> p.succeed(42)
           res <- p.await
-        } yield assert(res, equalTo(42))
+        } yield assert(res)(equalTo(42))
       },
       testM("timeout a long computation") {
         val io = (clock.sleep(5.seconds) *> IO.succeed(true)).timeout(10.millis)
-        assertM(io.provide(Clock.Live), isNone)
+        assertM(io.provide(Clock.Live))(isNone)
       },
       testM("catchAllCause") {
         val io =
@@ -1244,11 +1243,11 @@ object ZIOSpec extends ZIOBaseSpec {
             f <- ZIO.fail("Uh oh!")
           } yield f
 
-        assertM(io.catchAllCause(ZIO.succeed), equalTo(Cause.fail("Uh oh!")))
+        assertM(io.catchAllCause(ZIO.succeed))(equalTo(Cause.fail("Uh oh!")))
       },
       testM("exception in fromFuture does not kill fiber") {
         val io = ZIO.fromFuture(_ => throw ExampleError).either
-        assertM(io, isLeft(equalTo(ExampleError)))
+        assertM(io)(isLeft(equalTo(ExampleError)))
       }
     ),
     suite("RTS finalizers")(
@@ -1258,8 +1257,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val io = Task.fail(ExampleError).ensuring(IO.effectTotal { finalized = true; () })
 
         for {
-          a1 <- assertM(io.run, fails(equalTo(ExampleError)))
-          a2 = assert(finalized, isTrue)
+          a1 <- assertM(io.run)(fails(equalTo(ExampleError)))
+          a2 = assert(finalized)(isTrue)
         } yield a1 && a2
       },
       testM("fail on error") {
@@ -1271,8 +1270,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val io = Task.fail(ExampleError).onError(cleanup)
 
         for {
-          a1 <- assertM(io.run, fails(equalTo(ExampleError)))
-          a2 = assert(finalized, isTrue)
+          a1 <- assertM(io.run)(fails(equalTo(ExampleError)))
+          a2 = assert(finalized)(isTrue)
         } yield a1 && a2
       },
       testM("finalizer errors not caught") {
@@ -1284,7 +1283,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val expectedCause: Cause[Throwable] =
           Cause.Then(Cause.fail(ExampleError), Cause.Then(Cause.die(e2), Cause.die(e3)))
 
-        assertM(io.sandbox.flip, equalTo(expectedCause))
+        assertM(io.sandbox.flip)(equalTo(expectedCause))
       },
       testM("finalizer errors reported") {
         @volatile var reported: Exit[Nothing, Int] = null
@@ -1296,47 +1295,47 @@ object ZIOSpec extends ZIOBaseSpec {
           .flatMap(_.await.flatMap[Any, Nothing, Any](e => UIO.effectTotal { reported = e }))
 
         for {
-          a1 <- assertM(io, anything)
-          a2 = assert(reported.succeeded, isFalse)
+          a1 <- assertM(io)(anything)
+          a2 = assert(reported.succeeded)(isFalse)
         } yield a1 && a2
       },
       testM("bracket exit is usage result") {
         val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.succeed[Int](42))
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("error in just acquisition") {
         val io = IO.bracket(TaskExampleError)(_ => IO.unit)(_ => IO.unit)
-        assertM(io.run, fails(equalTo(ExampleError)))
+        assertM(io.run)(fails(equalTo(ExampleError)))
       },
       testM("error in just release") {
         val io = IO.bracket(IO.unit)(_ => IO.die(ExampleError))(_ => IO.unit)
-        assertM(io.run, dies(equalTo(ExampleError)))
+        assertM(io.run)(dies(equalTo(ExampleError)))
       },
       testM("error in just usage") {
         val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.fail(ExampleError))
-        assertM(io.run, fails(equalTo(ExampleError)))
+        assertM(io.run)(fails(equalTo(ExampleError)))
       },
       testM("rethrown caught error in acquisition") {
         val io = IO.absolve(IO.bracket(TaskExampleError)(_ => IO.unit)(_ => IO.unit).either)
-        assertM(io.flip, equalTo(ExampleError))
+        assertM(io.flip)(equalTo(ExampleError))
       },
       testM("rethrown caught error in release") {
         val io = IO.bracket(IO.unit)(_ => IO.die(ExampleError))(_ => IO.unit)
-        assertM(io.run, dies(equalTo(ExampleError)))
+        assertM(io.run)(dies(equalTo(ExampleError)))
       },
       testM("rethrown caught error in usage") {
         val io = IO.absolve(IO.unit.bracket_(IO.unit)(TaskExampleError).either)
-        assertM(io.run, fails(equalTo(ExampleError)))
+        assertM(io.run)(fails(equalTo(ExampleError)))
       },
       testM("test eval of async fail") {
         val io1 = IO.unit.bracket_(AsyncUnit[Nothing])(asyncExampleError[Unit])
         val io2 = AsyncUnit[Throwable].bracket_(IO.unit)(asyncExampleError[Unit])
 
         for {
-          a1 <- assertM(io1.run, fails(equalTo(ExampleError)))
-          a2 <- assertM(io2.run, fails(equalTo(ExampleError)))
-          a3 <- assertM(IO.absolve(io1.either).run, fails(equalTo(ExampleError)))
-          a4 <- assertM(IO.absolve(io2.either).run, fails(equalTo(ExampleError)))
+          a1 <- assertM(io1.run)(fails(equalTo(ExampleError)))
+          a2 <- assertM(io2.run)(fails(equalTo(ExampleError)))
+          a3 <- assertM(IO.absolve(io1.either).run)(fails(equalTo(ExampleError)))
+          a4 <- assertM(IO.absolve(io2.either).run)(fails(equalTo(ExampleError)))
         } yield a1 && a2 && a3 && a4
       },
       testM("bracket regression 1") {
@@ -1360,7 +1359,7 @@ object ZIOSpec extends ZIOBaseSpec {
             l <- ref.get
           } yield l
 
-        assertM(io.provide(Clock.Live), hasSameElements(List("start 1", "release 1", "start 2", "release 2")))
+        assertM(io.provide(Clock.Live))(hasSameElements(List("start 1", "release 1", "start 2", "release 2")))
       },
       testM("interrupt waits for finalizer") {
         val io =
@@ -1376,21 +1375,21 @@ object ZIOSpec extends ZIOBaseSpec {
             test <- r.get
           } yield test
 
-        assertM(io.provide(Clock.Live), isTrue)
+        assertM(io.provide(Clock.Live))(isTrue)
       }
     ),
     suite("RTS synchronous stack safety")(
       testM("deep map of now") {
-        assertM(deepMapNow(10000), equalTo(10000))
+        assertM(deepMapNow(10000))(equalTo(10000))
       },
       testM("deep map of sync effect") {
-        assertM(deepMapEffect(10000), equalTo(10000))
+        assertM(deepMapEffect(10000))(equalTo(10000))
       },
       testM("deep attempt") {
         val io = (0 until 10000).foldLeft(IO.effect(())) { (acc, _) =>
           acc.either.unit
         }
-        assertM(io, equalTo(()))
+        assertM(io)(equalTo(()))
       },
       testM("deep flatMap") {
         def fib(n: Int, a: BigInt = 0, b: BigInt = 1): IO[Error, BigInt] =
@@ -1405,7 +1404,7 @@ object ZIOSpec extends ZIOBaseSpec {
           "113796925398360272257523782552224175572745930353730513145086634176691092536145985470146129334641866902783673042322088625863396052888690096969577173696370562180400527049497109023054114771394568040040412172632376"
         )
 
-        assertM(fib(1000), equalTo(expected))
+        assertM(fib(1000))(equalTo(expected))
       },
       testM("deep absolve/attempt is identity") {
         import zio.CanFail.canFail
@@ -1413,24 +1412,24 @@ object ZIOSpec extends ZIOBaseSpec {
           IO.absolve(acc.either)
         }
 
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("deep async absolve/attempt is identity") {
         val io = (0 until 1000).foldLeft(IO.effectAsync[Int, Int](k => k(IO.succeed(42)))) { (acc, _) =>
           IO.absolve(acc.either)
         }
 
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       }
     ),
     suite("RTS asynchronous correctness")(
       testM("simple async must return") {
         val io = IO.effectAsync[Throwable, Int](k => k(IO.succeed(42)))
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("simple asyncIO must return") {
         val io = IO.effectAsyncM[Throwable, Int](k => IO.effectTotal(k(IO.succeed(42))))
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("deep asyncIO doesn't block threads") {
         def stackIOs(clock: Clock.Service[Any], count: Int): UIO[Int] =
@@ -1446,7 +1445,7 @@ object ZIOSpec extends ZIOBaseSpec {
 
         val io = clock.clockService.flatMap(stackIOs(_, procNum + 1))
 
-        assertM(io.provide(Clock.Live), equalTo(42))
+        assertM(io.provide(Clock.Live))(equalTo(42))
       },
       testM("interrupt of asyncPure register") {
         for {
@@ -1460,7 +1459,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _ <- acquire.await
           _ <- fiber.interrupt.fork
           a <- release.await
-        } yield assert(a, isUnit)
+        } yield assert(a)(isUnit)
       },
       testM("effectAsync should not resume fiber twice after interruption") {
         for {
@@ -1484,8 +1483,8 @@ object ZIOSpec extends ZIOBaseSpec {
           result     <- withLive(fork.interrupt)(_.timeout(5.seconds))
           unexpected <- unexpectedPlace.get
         } yield {
-          assert(unexpected, isEmpty) &&
-          assert(result, isNone) // timeout happens
+          assert(unexpected)(isEmpty) &&
+          assert(result)(isNone) // timeout happens
         }
       } @@ flaky,
       testM("effectAsyncMaybe should not resume fiber twice after synchronous result") {
@@ -1514,26 +1513,26 @@ object ZIOSpec extends ZIOBaseSpec {
           result     <- withLive(fork.interrupt)(_.timeout(5.seconds))
           unexpected <- unexpectedPlace.get
         } yield {
-          assert(unexpected, isEmpty) &&
-          assert(result, isNone) // timeout happens
+          assert(unexpected)(isEmpty) &&
+          assert(result)(isNone) // timeout happens
         }
       } @@ flaky,
       testM("sleep 0 must return") {
-        assertM(clock.sleep(1.nanos).provide(Clock.Live), isUnit)
+        assertM(clock.sleep(1.nanos).provide(Clock.Live))(isUnit)
       },
       testM("shallow bind of async chain") {
         val io = (0 until 10).foldLeft[Task[Int]](IO.succeed[Int](0)) { (acc, _) =>
           acc.flatMap(n => IO.effectAsync[Throwable, Int](_(IO.succeed(n + 1))))
         }
 
-        assertM(io, equalTo(10))
+        assertM(io)(equalTo(10))
       },
       testM("effectAsyncM can fail before registering") {
         val zio = ZIO
           .effectAsyncM[Any, String, Nothing](_ => ZIO.fail("Ouch"))
           .flip
 
-        assertM(zio, equalTo("Ouch"))
+        assertM(zio)(equalTo("Ouch"))
       },
       testM("effectAsyncM can defect before registering") {
         val zio = ZIO
@@ -1541,7 +1540,7 @@ object ZIOSpec extends ZIOBaseSpec {
           .run
           .map(_.fold(_.defects.headOption.map(_.getMessage), _ => None))
 
-        assertM(zio, isSome(equalTo("Ouch")))
+        assertM(zio)(isSome(equalTo("Ouch")))
       }
     ),
     suite("RTS concurrency correctness")(
@@ -1549,11 +1548,11 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           f <- IO.succeed(42).fork
           r <- f.join
-        } yield assert(r, equalTo(42))
+        } yield assert(r)(equalTo(42))
       },
       testM("deep fork/join identity") {
         val n = 20
-        assertM(concurrentFib(n), equalTo(fib(n)))
+        assertM(concurrentFib(n))(equalTo(fib(n)))
       },
       testM("asyncPure creation is interruptible") {
         for {
@@ -1566,7 +1565,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _     <- acquire.await
           _     <- fiber.interrupt
           a     <- release.await
-        } yield assert(a, equalTo(42))
+        } yield assert(a)(equalTo(42))
       },
       testM("asyncInterrupt runs cancel token on interrupt") {
         for {
@@ -1584,14 +1583,14 @@ object ZIOSpec extends ZIOBaseSpec {
               }
           _      <- fiber.interrupt
           result <- release.await
-        } yield assert(result, equalTo(42))
+        } yield assert(result)(equalTo(42))
       },
       testM("daemon fiber is unsupervised") {
         for {
           ref  <- Ref.make(Option.empty[Fiber[Any, Any]])
           _    <- withLatch(release => (release *> UIO.never).fork.daemon.tap(fiber => ref.set(Some(fiber))))
           fibs <- ZIO.children
-        } yield assert(fibs, isEmpty)
+        } yield assert(fibs)(isEmpty)
       },
       testM("daemon fiber race interruption") {
         def plus1(ref: Ref[Int], latch: Promise[Nothing, Unit]) =
@@ -1613,7 +1612,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _           <- fiber.interrupt
           res         <- ref.get
           interrupted <- interruptionRef.get
-        } yield assert(interrupted, equalTo(2)) && assert(res, equalTo(0))
+        } yield assert(interrupted)(equalTo(2)) && assert(res)(equalTo(0))
 
         io.daemon
       },
@@ -1655,7 +1654,7 @@ object ZIOSpec extends ZIOBaseSpec {
           children2 <- ZIO.children
           _         <- l1End.succeed(())
           _         <- ZIO.traverse_(latchEnds)(_.succeed(()))
-        } yield assert(children1.size, equalTo(1)) && assert(children2.size, equalTo(3))
+        } yield assert(children1.size)(equalTo(1)) && assert(children2.size)(equalTo(3))
 
         io.nonDaemon
       },
@@ -1704,8 +1703,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _                      <- l1End.succeed(())
             _                      <- l2End.succeed(())
             _                      <- ZIO.traverse_(latchEnds)(_.succeed(()))
-          } yield assert(children1.size, equalTo(0)) && assert(children2.size, equalTo(3)) && assert(
-            children3.size,
+          } yield assert(children1.size)(equalTo(0)) && assert(children2.size)(equalTo(3)) && assert(children3.size)(
             equalTo(3)
           )
 
@@ -1725,7 +1723,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _      <- fiber.interrupt
           res1   <- p1.await
           res2   <- p2.await
-        } yield assert(res1, isUnit) && assert(res2, isUnit)
+        } yield assert(res1)(isUnit) && assert(res2)(isUnit)
       },
       testM("supervise fibers") {
         def makeChild(n: Int): URIO[Clock, Fiber[Nothing, Unit]] =
@@ -1740,35 +1738,35 @@ object ZIOSpec extends ZIOBaseSpec {
             value <- counter.get
           } yield value
 
-        assertM(io.provide(Clock.Live), equalTo(2))
+        assertM(io.provide(Clock.Live))(equalTo(2))
       } @@ nonFlaky(100),
       testM("race of fail with success") {
         val io = IO.fail(42).race(IO.succeed(24)).either
-        assertM(io, isRight(equalTo(24)))
+        assertM(io)(isRight(equalTo(24)))
       },
       testM("race of terminate with success") {
         val io = IO.die(new Throwable {}).race(IO.succeed(24))
-        assertM(io, equalTo(24))
+        assertM(io)(equalTo(24))
       },
       testM("race of fail with fail") {
         val io = IO.fail(42).race(IO.fail(42)).either
-        assertM(io, isLeft(equalTo(42)))
+        assertM(io)(isLeft(equalTo(42)))
       },
       testM("race of value & never") {
         val io = IO.effectTotal(42).race(IO.never)
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("firstSuccessOf of values") {
         val io = IO.firstSuccessOf(IO.fail(0), List(IO.succeed(100))).either
-        assertM(io, isRight(equalTo(100)))
+        assertM(io)(isRight(equalTo(100)))
       },
       testM("firstSuccessOf of failures") {
         val io = ZIO.firstSuccessOf(IO.fail(0).delay(10.millis), List(IO.fail(101))).either
-        assertM(io.provide(Clock.Live), isLeft(equalTo(101)))
+        assertM(io.provide(Clock.Live))(isLeft(equalTo(101)))
       },
       testM("firstSuccessOF of failures & 1 success") {
         val io = ZIO.firstSuccessOf(IO.fail(0), List(IO.succeed(102).delay(1.millis))).either
-        assertM(io.provide(Clock.Live), isRight(equalTo(102)))
+        assertM(io.provide(Clock.Live))(isRight(equalTo(102)))
       },
       testM("raceAttempt interrupts loser on success") {
         for {
@@ -1779,7 +1777,7 @@ object ZIOSpec extends ZIOBaseSpec {
           race   = winner raceAttempt loser
           _      <- race
           b      <- effect.await
-        } yield assert(b, equalTo(42))
+        } yield assert(b)(equalTo(42))
       },
       testM("raceAttempt interrupts loser on failure") {
         for {
@@ -1790,11 +1788,11 @@ object ZIOSpec extends ZIOBaseSpec {
           race   = winner raceAttempt loser
           _      <- race.either
           b      <- effect.await
-        } yield assert(b, equalTo(42))
+        } yield assert(b)(equalTo(42))
       },
       testM("par regression") {
         val io = IO.succeed[Int](1).zipPar(IO.succeed[Int](2)).flatMap(t => IO.succeed(t._1 + t._2)).map(_ == 3)
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       } @@ jvm(nonFlaky),
       testM("par of now values") {
         def countdown(n: Int): UIO[Int] =
@@ -1802,50 +1800,50 @@ object ZIOSpec extends ZIOBaseSpec {
           else
             IO.succeed[Int](1).zipPar(IO.succeed[Int](2)).flatMap(t => countdown(n - 1).map(y => t._1 + t._2 + y))
 
-        assertM(countdown(50), equalTo(150))
+        assertM(countdown(50))(equalTo(150))
       },
       testM("mergeAll") {
         val io = IO.mergeAll(List("a", "aa", "aaa", "aaaa").map(IO.succeed[String](_)))(0) { (b, a) =>
           b + a.length
         }
 
-        assertM(io, equalTo(10))
+        assertM(io)(equalTo(10))
       },
       testM("mergeAllEmpty") {
         val io = IO.mergeAll(List.empty[UIO[Int]])(0)(_ + _)
-        assertM(io, equalTo(0))
+        assertM(io)(equalTo(0))
       },
       testM("reduceAll") {
         val io = IO.reduceAll(IO.effectTotal(1), List(2, 3, 4).map(IO.succeed[Int](_)))(_ + _)
-        assertM(io, equalTo(10))
+        assertM(io)(equalTo(10))
       },
       testM("reduceAll Empty List") {
         val io = IO.reduceAll(IO.effectTotal(1), Seq.empty)(_ + _)
-        assertM(io, equalTo(1))
+        assertM(io)(equalTo(1))
       },
       testM("timeout of failure") {
         val io = IO.fail("Uh oh").timeout(1.hour)
-        assertM(io.provide(Clock.Live).run, fails(equalTo("Uh oh")))
+        assertM(io.provide(Clock.Live).run)(fails(equalTo("Uh oh")))
       },
       testM("timeout of terminate") {
         val io: ZIO[Clock, Nothing, Option[Int]] = IO.die(ExampleError).timeout(1.hour)
-        assertM(io.provide(Clock.Live).run, dies(equalTo(ExampleError)))
+        assertM(io.provide(Clock.Live).run)(dies(equalTo(ExampleError)))
       }
     ),
     suite("RTS option tests")(
       testM("lifting a value to an option") {
-        assertM(ZIO.some(42), isSome(equalTo(42)))
+        assertM(ZIO.some(42))(isSome(equalTo(42)))
       },
       testM("using the none value") {
-        assertM(ZIO.none, isNone)
+        assertM(ZIO.none)(isNone)
       }
     ),
     suite("RTS either helper tests")(
       testM("lifting a value into right") {
-        assertM(ZIO.right(42), isRight(equalTo(42)))
+        assertM(ZIO.right(42))(isRight(equalTo(42)))
       },
       testM("lifting a value into left") {
-        assertM(ZIO.left(42), isLeft(equalTo(42)))
+        assertM(ZIO.left(42))(isLeft(equalTo(42)))
       }
     ),
     suite("RTS interruption")(
@@ -1856,7 +1854,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _ <- f.interrupt
           } yield true
 
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       },
       testM("interrupt of never") {
         val io =
@@ -1865,7 +1863,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _     <- fiber.interrupt
           } yield 42
 
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("asyncPure is interruptible") {
         val io =
@@ -1874,7 +1872,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _     <- fiber.interrupt
           } yield 42
 
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("async is interruptible") {
         val io =
@@ -1883,7 +1881,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _     <- fiber.interrupt
           } yield 42
 
-        assertM(io, equalTo(42))
+        assertM(io)(equalTo(42))
       },
       testM("bracket is uninterruptible") {
         val io =
@@ -1893,7 +1891,7 @@ object ZIOSpec extends ZIOBaseSpec {
             res     <- promise.await *> fiber.interrupt.timeoutTo(42)(_ => 0)(1.second)
           } yield res
 
-        assertM(io.provide(Clock.Live), equalTo(42))
+        assertM(io.provide(Clock.Live))(equalTo(42))
       },
       testM("bracketExit is uninterruptible") {
         val io =
@@ -1909,19 +1907,19 @@ object ZIOSpec extends ZIOBaseSpec {
             res <- promise.await *> fiber.interrupt.timeoutTo(42)(_ => 0)(1.second)
           } yield res
 
-        assertM(io.provide(Clock.Live), equalTo(42))
+        assertM(io.provide(Clock.Live))(equalTo(42))
       },
       testM("bracket use is interruptible") {
         for {
           fiber <- IO.unit.bracket(_ => IO.unit)(_ => IO.never).fork
           res   <- fiber.interrupt
-        } yield assert(res, isInterrupted)
+        } yield assert(res)(isInterrupted)
       },
       testM("bracketExit use is interruptible") {
         for {
           fiber <- IO.bracketExit(IO.unit)((_, _: Exit[Any, Any]) => IO.unit)(_ => IO.never).fork
           res   <- fiber.interrupt.timeoutTo(42)(_ => 0)(1.second)
-        } yield assert(res, equalTo(0))
+        } yield assert(res)(equalTo(0))
       },
       testM("bracket release called on interrupt") {
         val io =
@@ -1934,7 +1932,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _     <- p2.await
           } yield ()
 
-        assertM(io.timeoutTo(42)(_ => 0)(1.second), equalTo(0))
+        assertM(io.timeoutTo(42)(_ => 0)(1.second))(equalTo(0))
       },
       testM("bracketExit release called on interrupt") {
         for {
@@ -1948,7 +1946,7 @@ object ZIOSpec extends ZIOBaseSpec {
 
           _ <- fiber.interrupt
           r <- done.await.timeoutTo(42)(_ => 0)(60.second)
-        } yield assert(r, equalTo(0))
+        } yield assert(r)(equalTo(0))
       },
       testM("bracketFork acquire returns immediately on interrupt") {
         for {
@@ -1961,7 +1959,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _   <- p1.await
           res <- s.interrupt
           _   <- p3.succeed(())
-        } yield assert(res, isInterrupted)
+        } yield assert(res)(isInterrupted)
       },
       testM("bracketForkExit acquire returns immediately on interrupt") {
         for {
@@ -1976,19 +1974,19 @@ object ZIOSpec extends ZIOBaseSpec {
           _   <- p1.await
           res <- s.interrupt
           _   <- p3.succeed(())
-        } yield assert(res, isInterrupted)
+        } yield assert(res)(isInterrupted)
       },
       testM("bracketFork use is interruptible") {
         for {
           fiber <- IO.unit.bracketFork(_ => IO.unit)(_ => IO.never).fork
           res   <- fiber.interrupt
-        } yield assert(res, isInterrupted)
+        } yield assert(res)(isInterrupted)
       },
       testM("bracketForkExit use is interruptible") {
         for {
           fiber <- IO.bracketForkExit(IO.unit)((_, _: Exit[Any, Any]) => IO.unit)(_ => IO.never).fork
           res   <- fiber.interrupt.timeoutTo(42)(_ => 0)(1.second).provide(Clock.Live)
-        } yield assert(res, equalTo(0))
+        } yield assert(res)(equalTo(0))
       },
       testM("bracketFork release called on interrupt in separate fiber") {
         val io =
@@ -2001,7 +1999,7 @@ object ZIOSpec extends ZIOBaseSpec {
             _     <- p2.await
           } yield ()
 
-        assertM(io.timeoutTo(42)(_ => 0)(1.second), equalTo(0)).provide(Clock.Live)
+        assertM(io.timeoutTo(42)(_ => 0)(1.second))(equalTo(0)).provide(Clock.Live)
       },
       testM("bracketForkExit release called on interrupt in separate fiber") {
         for {
@@ -2015,7 +2013,7 @@ object ZIOSpec extends ZIOBaseSpec {
 
           _ <- fiber.interrupt
           r <- done.await.timeoutTo(42)(_ => 0)(1.second).provide(Clock.Live)
-        } yield assert(r, equalTo(0))
+        } yield assert(r)(equalTo(0))
       },
       testM("catchAll + ensuring + interrupt") {
         import zio.CanFail.canFail
@@ -2026,7 +2024,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _    <- cont.await
           _    <- f1.interrupt
           res  <- p1.await
-        } yield assert(res, isTrue)
+        } yield assert(res)(isTrue)
       },
       testM("finalizer can detect interruption") {
         for {
@@ -2038,7 +2036,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _   <- c.await
           _   <- f1.interrupt
           res <- p1.await
-        } yield assert(res, isTrue)
+        } yield assert(res)(isTrue)
       },
       testM("interruption of raced") {
         for {
@@ -2050,7 +2048,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _     <- cont1.await *> cont2.await
           _     <- raced.interrupt
           count <- ref.get
-        } yield assert(count, equalTo(2))
+        } yield assert(count)(equalTo(2))
       },
       testM("recovery of error in finalizer") {
         for {
@@ -2064,7 +2062,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- recovered.get
-        } yield assert(value, isTrue)
+        } yield assert(value)(isTrue)
       },
       testM("recovery of interruptible") {
         for {
@@ -2080,7 +2078,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- recovered.get
-        } yield assert(value, isTrue)
+        } yield assert(value)(isTrue)
       },
       testM("sandbox of interruptible") {
         for {
@@ -2094,7 +2092,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- recovered.get
-        } yield assert(value, isSome(isLeft(equalTo(Cause.interrupt(selfId)))))
+        } yield assert(value)(isSome(isLeft(equalTo(Cause.interrupt(selfId)))))
       },
       testM("run of interruptible") {
         for {
@@ -2107,7 +2105,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- recovered.get
-        } yield assert(value, isSome(isInterrupted))
+        } yield assert(value)(isSome(isInterrupted))
       },
       testM("alternating interruptibility") {
         for {
@@ -2119,7 +2117,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- counter.get
-        } yield assert(value, equalTo(2))
+        } yield assert(value)(equalTo(2))
       },
       testM("interruption after defect") {
         for {
@@ -2131,7 +2129,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- ref.get
-        } yield assert(value, isTrue)
+        } yield assert(value)(isTrue)
       },
       testM("interruption after defect 2") {
         for {
@@ -2143,7 +2141,7 @@ object ZIOSpec extends ZIOBaseSpec {
                   }
           _     <- fiber.interrupt
           value <- ref.get
-        } yield assert(value, isTrue)
+        } yield assert(value)(isTrue)
       },
       testM("interruptibleFork returns immediately on interrupt") {
         for {
@@ -2157,7 +2155,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _   <- p1.await
           res <- s.interrupt
           _   <- p3.succeed(())
-        } yield assert(res, isInterrupted)
+        } yield assert(res)(isInterrupted)
       },
       testM("interruptibleFork forks execution and interrupts fork") {
         val io =
@@ -2176,7 +2174,7 @@ object ZIOSpec extends ZIOBaseSpec {
             test <- r.get
           } yield test
 
-        assertM(io.provide(Clock.Live), isTrue)
+        assertM(io.provide(Clock.Live))(isTrue)
       },
       testM("cause reflects interruption") {
         val io =
@@ -2189,7 +2187,7 @@ object ZIOSpec extends ZIOBaseSpec {
             finished <- finished.get
           } yield exit.interrupted == true || finished == true
 
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       } @@ jvm(nonFlaky),
       testM("bracket use inherits interrupt status") {
         val io =
@@ -2207,7 +2205,7 @@ object ZIOSpec extends ZIOBaseSpec {
             value <- ref.get
           } yield value
 
-        assertM(io.provide(Clock.Live), isTrue)
+        assertM(io.provide(Clock.Live))(isTrue)
       },
       testM("bracket use inherits interrupt status 2") {
         val io =
@@ -2229,7 +2227,7 @@ object ZIOSpec extends ZIOBaseSpec {
             value <- ref.get
           } yield value
 
-        assertM(io.provide(Clock.Live), isTrue)
+        assertM(io.provide(Clock.Live))(isTrue)
       },
       testM("async can be uninterruptible") {
         val io =
@@ -2242,7 +2240,7 @@ object ZIOSpec extends ZIOBaseSpec {
             value <- ref.get
           } yield value
 
-        assertM(io.provide(Clock.Live), isTrue)
+        assertM(io.provide(Clock.Live))(isTrue)
       }
     ),
     suite("RTS environment")(
@@ -2254,7 +2252,7 @@ object ZIOSpec extends ZIOBaseSpec {
             v3 <- ZIO.environment[Int]
           } yield (v1, v2, v3)
 
-        assertM(zio.provide(4), equalTo((4, 2, 4)))
+        assertM(zio.provide(4))(equalTo((4, 2, 4)))
       },
       testM("provideManaged is modular") {
         def managed(v: Int): ZManaged[Any, Nothing, Int] =
@@ -2267,11 +2265,11 @@ object ZIOSpec extends ZIOBaseSpec {
             v3 <- ZIO.environment[Int]
           } yield (v1, v2, v3)
 
-        assertM(zio.provideManaged(managed(4)), equalTo((4, 2, 4)))
+        assertM(zio.provideManaged(managed(4)))(equalTo((4, 2, 4)))
       },
       testM("effectAsync can use environment") {
         val zio = ZIO.effectAsync[Int, Nothing, Int](cb => cb(ZIO.environment[Int]))
-        assertM(zio.provide(10), equalTo(10))
+        assertM(zio.provide(10))(equalTo(10))
       }
     ),
     suite("RTS forking inheritability")(
@@ -2281,7 +2279,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ref   <- Ref.make(InterruptStatus.interruptible)
           _     <- ZIO.uninterruptible((ZIO.checkInterruptible(ref.set) *> latch.succeed(())).fork *> latch.await)
           v     <- ref.get
-        } yield assert(v, equalTo(InterruptStatus.uninterruptible))
+        } yield assert(v)(equalTo(InterruptStatus.uninterruptible))
       },
       testM("executor is heritable") {
         val io =
@@ -2294,13 +2292,13 @@ object ZIOSpec extends ZIOBaseSpec {
             v <- ref.get
           } yield v.contains(exec)
 
-        assertM(io, isTrue)
+        assertM(io)(isTrue)
       } @@ jvm(nonFlaky(100))
     ),
     suite("someOrFail")(
       testM("extracts the optional value") {
         val task: Task[Int] = UIO(Some(42)).someOrFail(exampleError)
-        assertM(task, equalTo(42))
+        assertM(task)(equalTo(42))
       },
       testM("fails when given a None") {
         val task: Task[Int] = UIO(Option.empty[Int]).someOrFail(exampleError)
@@ -2315,22 +2313,22 @@ object ZIOSpec extends ZIOBaseSpec {
           result    <- increment.summarized((a: Int, b: Int) => (a, b))(increment)
         } yield {
           val ((start, end), value) = result
-          assert(start, equalTo(1)) &&
-          assert(value, equalTo(2)) &&
-          assert(end, equalTo(3))
+          assert(start)(equalTo(1)) &&
+          assert(value)(equalTo(2)) &&
+          assert(end)(equalTo(3))
         }
       }
     ),
     suite("timeoutFork")(
       testM("returns `Right` with the produced value if the effect completes before the timeout elapses") {
-        assertM(ZIO.unit.timeoutFork(100.millis), isRight(isUnit))
+        assertM(ZIO.unit.timeoutFork(100.millis))(isRight(isUnit))
       },
       testM("returns `Left` with the interrupting fiber otherwise") {
         for {
           fiber  <- ZIO.never.uninterruptible.timeoutFork(100.millis).fork
           _      <- TestClock.adjust(100.millis)
           result <- fiber.join
-        } yield assert(result, isLeft(anything))
+        } yield assert(result)(isLeft(anything))
       }
     ),
     suite("unsandbox")(
@@ -2340,7 +2338,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           message <- failure.unsandbox.foldM(e => IO.succeed(e.getMessage), _ => IO.succeed("unexpected"))
           result  <- success.unsandbox
-        } yield assert(message, equalTo("fail")) && assert(result, equalTo(100))
+        } yield assert(message)(equalTo("fail")) && assert(result)(equalTo(100))
       },
       testM("no information is lost during composition") {
         val causes = Gen.causes(Gen.anyString, Gen.throwable)
@@ -2349,8 +2347,8 @@ object ZIOSpec extends ZIOBaseSpec {
         checkM(causes) { c =>
           for {
             result <- cause(ZIO.halt(c).sandbox.mapErrorCause(e => e.untraced).unsandbox)
-          } yield assert(result, equalTo(c)) &&
-            assert(result.prettyPrint, equalTo(c.prettyPrint))
+          } yield assert(result)(equalTo(c)) &&
+            assert(result.prettyPrint)(equalTo(c.prettyPrint))
         }
       }
     ),
@@ -2358,26 +2356,26 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
         val res = IO.validateM(in)(a => ZIO.fail(a)).flip
-        assertM(res, equalTo(in))
+        assertM(res)(equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
         val res = ZIO.validateM(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
-        assertM(res.flip, equalTo(List(1, 3, 5, 7, 9)))
+        assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
         val res = IO.validateM(in)(a => ZIO.succeed(a))
-        assertM(res, equalTo(in))
+        assertM(res)(equalTo(in))
       }
     ),
     suite("validateFirstM")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
         val res = IO.validateFirstM(in)(a => ZIO.fail(a)).flip
-        assertM(res, equalTo(in))
+        assertM(res)(equalTo(in))
       },
       testM("short circuits on first success validation") {
         import zio.CanFail.canFail
@@ -2387,7 +2385,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           counter    <- Ref.make(0)
           res        <- ZIO.validateFirstM(in)(a => counter.update(_ + 1) *> f(a))
-          assertions <- assertM(ZIO.succeed(res), equalTo(6)) && assertM(counter.get, equalTo(6))
+          assertions <- assertM(ZIO.succeed(res))(equalTo(6)) && assertM(counter.get)(equalTo(6))
         } yield assertions
       }
     ),
@@ -2403,9 +2401,9 @@ object ZIOSpec extends ZIOBaseSpec {
           _         <- IO.fail(failure).when(false)
           failed    <- IO.fail(failure).when(true).either
         } yield {
-          assert(val1, equalTo(0)) &&
-          assert(val2, equalTo(2)) &&
-          assert(failed, isLeft(equalTo(failure)))
+          assert(val1)(equalTo(0)) &&
+          assert(val2)(equalTo(2)) &&
+          assert(failed)(isLeft(equalTo(failure)))
         }
       }
     ),
@@ -2419,7 +2417,7 @@ object ZIOSpec extends ZIOBaseSpec {
           res1 <- ref.get
           _    <- ZIO.whenCase(v2) { case Some(_) => ref.set(true) }
           res2 <- ref.get
-        } yield assert(res1, isFalse) && assert(res2, isTrue)
+        } yield assert(res1)(isFalse) && assert(res2)(isTrue)
       }
     ),
     suite("whenCaseM")(
@@ -2432,7 +2430,7 @@ object ZIOSpec extends ZIOBaseSpec {
           res1 <- ref.get
           _    <- ZIO.whenCaseM(IO.succeed(v2)) { case Some(_) => ref.set(true) }
           res2 <- ref.get
-        } yield assert(res1, isFalse) && assert(res2, isTrue)
+        } yield assert(res1)(isFalse) && assert(res2)(isTrue)
       }
     ),
     suite("whenM")(
@@ -2452,11 +2450,11 @@ object ZIOSpec extends ZIOBaseSpec {
           _              <- IO.fail(failure).whenM(conditionFalse)
           failed         <- IO.fail(failure).whenM(conditionTrue).either
         } yield {
-          assert(val1, equalTo(0)) &&
-          assert(conditionVal1, equalTo(1)) &&
-          assert(val2, equalTo(2)) &&
-          assert(conditionVal2, equalTo(2)) &&
-          assert(failed, isLeft(equalTo(failure)))
+          assert(val1)(equalTo(0)) &&
+          assert(conditionVal1)(equalTo(1)) &&
+          assert(val2)(equalTo(2)) &&
+          assert(conditionVal2)(equalTo(2)) &&
+          assert(failed)(isLeft(equalTo(failure)))
         }
       }
     ),
@@ -2464,19 +2462,19 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("tuple value is extracted correctly from task") {
         for {
           (i, j, k) <- Task((1, 2, 3))
-        } yield assert((i, j, k), equalTo((1, 2, 3)))
+        } yield assert((i, j, k))(equalTo((1, 2, 3)))
       },
       testM("condition in for-comprehension syntax works correctly for task") {
         for {
           n <- Task(3) if n > 0
-        } yield assert(n, equalTo(3))
+        } yield assert(n)(equalTo(3))
       },
       testM("unsatisfied condition should fail with NoSuchElementException") {
         val task =
           for {
             n <- Task(3) if n > 10
           } yield n
-        assertM(task.run, fails(isSubtype[NoSuchElementException](anything)))
+        assertM(task.run)(fails(isSubtype[NoSuchElementException](anything)))
       },
       testM("withFilter doesn't compile with IO that fails with type other than Throwable") {
         val result = typeCheck {
@@ -2489,21 +2487,21 @@ object ZIOSpec extends ZIOBaseSpec {
               """
         }
         val expected = "Cannot prove that NoSuchElementException <:< String."
-        if (TestVersion.isScala2) assertM(result, isLeft(equalTo(expected)))
-        else assertM(result, isLeft(anything))
+        if (TestVersion.isScala2) assertM(result)(isLeft(equalTo(expected)))
+        else assertM(result)(isLeft(anything))
       }
     ),
     suite("zipPar")(
       testM("does not swallow exit causes of loser") {
         ZIO.interrupt.zipPar(IO.interrupt).run.map {
-          case Exit.Failure(cause) => assert(cause.interruptors, not(isEmpty))
-          case _                   => assert(false, isTrue)
+          case Exit.Failure(cause) => assert(cause.interruptors)(not(isEmpty))
+          case _                   => assert(false)(isTrue)
         }
       },
       testM("does not report failure when interrupting loser after it succeeded") {
         val io          = ZIO.interrupt.zipPar(IO.succeed(1))
         val interrupted = io.sandbox.either.map(_.left.map(_.interrupted))
-        assertM(interrupted, isLeft(isTrue))
+        assertM(interrupted)(isLeft(isTrue))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -12,19 +12,17 @@ object ZManagedSpec extends ZIOBaseSpec {
   def spec = suite("ZManaged")(
     suite("absorbWith")(
       testM("on fail") {
-        assertM(
-          ZManagedExampleError.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed).run,
+        assertM(ZManagedExampleError.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed).run)(
           fails(equalTo(ExampleError))
         )
       },
       testM("on die") {
-        assertM(
-          ZManagedExampleDie.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed).run,
+        assertM(ZManagedExampleDie.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed).run)(
           fails(equalTo(ExampleError))
         )
       },
       testM("on success") {
-        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError), equalTo(1))
+        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError))(equalTo(1))
       }
     ),
     suite("make")(
@@ -34,7 +32,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => ZManaged.make(effects.update(x :: _))(_ => effects.update(x :: _))
           program = res(1) *> res(2) *> res(3)
           values  <- program.use_(ZIO.unit) *> effects.get
-        } yield assert(values, equalTo(List(1, 2, 3, 3, 2, 1)))
+        } yield assert(values)(equalTo(List(1, 2, 3, 3, 2, 1)))
       },
       testM("Properly performs parallel acquire and release") {
         for {
@@ -43,7 +41,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           b        = ZManaged.make(UIO.succeed("B"))(_ => log.update("B" :: _))
           result   <- a.zipWithPar(b)(_ + _).use(ZIO.succeed)
           cleanups <- log.get
-        } yield assert(result.length, equalTo(2)) && assert(cleanups, hasSize(equalTo(2)))
+        } yield assert(result.length)(equalTo(2)) && assert(cleanups)(hasSize(equalTo(2)))
       },
       testM("Constructs an uninterruptible Managed value") {
         doInterrupt(io => ZManaged.make(io)(_ => IO.unit), _ => None)
@@ -65,7 +63,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         def managed3: ZManaged[R2, E, A]         = ZManaged.make(acquire2)(release3)
         def managed4: ZManaged[R2, E, A]         = ZManaged.make(acquire3)(release2)
         lazy val result                          = (managed1, managed2, managed3, managed4)
-        ZIO.succeed(assert(result, anything))
+        ZIO.succeed(assert(result)(anything))
       }
     ),
     suite("makeEffect")(
@@ -79,7 +77,7 @@ object ZManagedSpec extends ZIOBaseSpec {
 
         for {
           _ <- program.use_(ZIO.unit)
-        } yield assert(effects, equalTo(List(1, 2, 3, 3, 2, 1)))
+        } yield assert(effects)(equalTo(List(1, 2, 3, 3, 2, 1)))
       }
     ),
     suite("reserve")(
@@ -104,10 +102,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           exits  <- Ref.make[List[Exit[Any, Any]]](Nil)
           _      <- res(exits).use_(ZIO.die(ex)).run
           result <- exits.get
-        } yield assert(
-          result,
-          equalTo(List[Exit[Any, Any]](Exit.Failure(Cause.Die(ex)), Exit.Failure(Cause.Die(ex))))
-        )
+        } yield assert(result)(equalTo(List[Exit[Any, Any]](Exit.Failure(Cause.Die(ex)), Exit.Failure(Cause.Die(ex)))))
       },
       testM("Invokes with the failure of the subsequent acquire") {
         val useEx     = new RuntimeException("Use died")
@@ -123,21 +118,19 @@ object ZManagedSpec extends ZIOBaseSpec {
           exits  <- Ref.make[List[Exit[Any, Any]]](Nil)
           _      <- res(exits).use_(ZIO.die(useEx)).run
           result <- exits.get
-        } yield assert(result, equalTo(List[Exit[Any, Any]](Exit.Failure(Cause.Die(acquireEx)))))
+        } yield assert(result)(equalTo(List[Exit[Any, Any]](Exit.Failure(Cause.Die(acquireEx)))))
       }
     ),
     suite("fromEffect")(
       testM("Performed interruptibly") {
-        assertM(
-          ZManaged.fromEffect(ZIO.checkInterruptible(ZIO.succeed)).use(ZIO.succeed),
+        assertM(ZManaged.fromEffect(ZIO.checkInterruptible(ZIO.succeed)).use(ZIO.succeed))(
           equalTo(InterruptStatus.interruptible)
         )
       }
     ),
     suite("fromEffectUninterruptible")(
       testM("Performed uninterruptibly") {
-        assertM(
-          ZManaged.fromEffectUninterruptible(ZIO.checkInterruptible(ZIO.succeed)).use(ZIO.succeed),
+        assertM(ZManaged.fromEffectUninterruptible(ZIO.checkInterruptible(ZIO.succeed)).use(ZIO.succeed))(
           equalTo(InterruptStatus.uninterruptible)
         )
       }
@@ -151,14 +144,14 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .ensuring(effects.update("Second" :: _))
                 .use_(ZIO.unit)
           result <- effects.get
-        } yield assert(result, equalTo(List("Second", "First")))
+        } yield assert(result)(equalTo(List("Second", "First")))
       },
       testM("Runs on failures") {
         for {
           effects <- Ref.make[List[String]](Nil)
           _       <- ZManaged.fromEffect(ZIO.fail(())).ensuring(effects.update("Ensured" :: _)).use_(ZIO.unit).either
           result  <- effects.get
-        } yield assert(result, equalTo(List("Ensured")))
+        } yield assert(result)(equalTo(List("Ensured")))
       },
       testM("Works when finalizers have defects") {
         for {
@@ -169,7 +162,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
                 .run
           result <- effects.get
-        } yield assert(result, equalTo(List("Ensured")))
+        } yield assert(result)(equalTo(List("Ensured")))
       }
     ),
     suite("ensuringFirst")(
@@ -181,14 +174,14 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .ensuringFirst(effects.update("Second" :: _))
                 .use_(ZIO.unit)
           result <- effects.get
-        } yield assert(result, equalTo(List("First", "Second")))
+        } yield assert(result)(equalTo(List("First", "Second")))
       },
       testM("Runs on failures") {
         for {
           effects <- Ref.make[List[String]](Nil)
           _       <- ZManaged.fromEffect(ZIO.fail(())).ensuringFirst(effects.update("Ensured" :: _)).use_(ZIO.unit).either
           result  <- effects.get
-        } yield assert(result, equalTo(List("Ensured")))
+        } yield assert(result)(equalTo(List("Ensured")))
       },
       testM("Works when finalizers have defects") {
         for {
@@ -199,16 +192,16 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
                 .run
           result <- effects.get
-        } yield assert(result, equalTo(List("Ensured")))
+        } yield assert(result)(equalTo(List("Ensured")))
       }
     ),
     suite("fallback")(
       testM("executes an effect and returns its value if it succeeds") {
         import zio.CanFail.canFail
-        assertM(ZManaged.succeed(1).fallback(2).use(ZIO.succeed), equalTo(1))
+        assertM(ZManaged.succeed(1).fallback(2).use(ZIO.succeed))(equalTo(1))
       },
       testM("returns the specified value if the effect fails") {
-        assertM(ZManaged.fail("fail").fallback(1).use(ZIO.succeed), equalTo(1))
+        assertM(ZManaged.fail("fail").fallback(1).use(ZIO.succeed))(equalTo(1))
       }
     ),
     testM("eventually") {
@@ -223,7 +216,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         ref <- Ref.make(0)
         _   <- ZManaged.make(acquire(ref))(_ => UIO.unit).eventually.use(_ => UIO.unit)
         r   <- ref.get
-      } yield assert(r, equalTo(10))
+      } yield assert(r)(equalTo(10))
     },
     suite("flatMap")(
       testM("All finalizers run even when finalizers have defects") {
@@ -238,7 +231,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 _ <- ZManaged.finalizer(effects.update("Third" :: _))
               } yield ()).use_(ZIO.unit).run
           result <- effects.get
-        } yield assert(result, equalTo(List("First", "Second", "Third")))
+        } yield assert(result)(equalTo(List("First", "Second", "Third")))
       }
     ),
     suite("foldM")(
@@ -248,7 +241,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = Managed.fromEffect(IO.fail(())).foldM(_ => res(1), _ => Managed.unit)
           values  <- program.use_(ZIO.unit).ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 1)))
+        } yield assert(values)(equalTo(List(1, 1)))
       },
       testM("Runs onSuccess on success") {
         import zio.CanFail.canFail
@@ -257,7 +250,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = ZManaged.succeed(()).foldM(_ => Managed.unit, _ => res(1))
           values  <- program.use_(ZIO.unit).ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 1)))
+        } yield assert(values)(equalTo(List(1, 1)))
       },
       testM("Invokes cleanups") {
         for {
@@ -265,7 +258,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = res(1).flatMap(_ => ZManaged.fail(())).foldM(_ => res(2), _ => res(3))
           values  <- program.use_(ZIO.unit).ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 2, 2, 1)))
+        } yield assert(values)(equalTo(List(1, 2, 2, 1)))
       },
       testM("Invokes cleanups on interrupt - 1") {
         import zio.CanFail.canFail
@@ -274,7 +267,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = res(1).flatMap(_ => ZManaged.interrupt).foldM(_ => res(2), _ => res(3))
           values  <- program.use_(ZIO.unit).sandbox.ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 1)))
+        } yield assert(values)(equalTo(List(1, 1)))
       },
       testM("Invokes cleanups on interrupt - 2") {
         for {
@@ -282,7 +275,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = res(1).flatMap(_ => ZManaged.fail(())).foldM(_ => res(2), _ => res(3))
           values  <- program.use_(ZIO.interrupt).sandbox.ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 2, 2, 1)))
+        } yield assert(values)(equalTo(List(1, 2, 2, 1)))
       },
       testM("Invokes cleanups on interrupt - 3") {
         for {
@@ -290,7 +283,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => Managed.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = res(1).flatMap(_ => ZManaged.fail(())).foldM(_ => res(2) *> ZManaged.interrupt, _ => res(3))
           values  <- program.use_(ZIO.unit).sandbox.ignore *> effects.get
-        } yield assert(values, equalTo(List(1, 2, 2, 1)))
+        } yield assert(values)(equalTo(List(1, 2, 2, 1)))
       }
     ),
     suite("foreach")(
@@ -299,7 +292,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.succeed(int)
 
         val managed = ZManaged.foreach(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.foreach(List(1, 2, 3, 4))(_ => res))
@@ -310,7 +303,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res     = (x: Int) => ZManaged.make(effects.update(x :: _).unit)(_ => effects.update(x :: _))
           program = ZManaged.foreach(List(1, 2, 3))(res)
           values  <- program.use_(ZIO.unit) *> effects.get
-        } yield assert(values, equalTo(List(1, 2, 3, 3, 2, 1)))
+        } yield assert(values)(equalTo(List(1, 2, 3, 3, 2, 1)))
       }
     ),
     suite("foreachPar")(
@@ -319,7 +312,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.succeed(int)
 
         val managed = ZManaged.foreachPar(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.foreachPar(List(1, 2, 3, 4))(_ => res))
@@ -337,7 +330,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.succeed(int)
 
         val managed = ZManaged.foreachParN(2)(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Uses at most n fibers for reservation") {
         testFinalizersPar(4, res => ZManaged.foreachParN(2)(List(1, 2, 3, 4))(_ => res))
@@ -386,7 +379,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .fork
                 .use_(latch.await)
           result <- finalized.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("Acquires interruptibly") {
         for {
@@ -407,7 +400,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           _      <- useLatch.await
           _      <- fib.interrupt
           result <- finalized.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       }
     ),
     suite("fromAutoCloseable")(
@@ -420,7 +413,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           })
           _      <- ZManaged.fromAutoCloseable(closeable).use_(ZIO.unit)
           result <- effects.get
-        } yield assert(result, equalTo(List("Closed")))
+        } yield assert(result)(equalTo(List("Closed")))
       }
     ),
     suite("mergeAll")(
@@ -429,7 +422,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.succeed(int)
 
         val managed = ZManaged.mergeAll(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.mergeAll(List.fill(4)(res))(()) { case (_, b) => b })
@@ -441,7 +434,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.succeed(int)
 
         val managed = ZManaged.mergeAllPar(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Runs reservations in parallel") {
         testReservePar(4, res => ZManaged.mergeAllPar(List.fill(4)(res))(()) { case (_, b) => b })
@@ -458,7 +451,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         def res(int: Int) =
           ZManaged.succeed(int)
         val managed = ZManaged.mergeAllParN(2)(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Uses at most n fibers for reservation") {
         testReservePar(2, res => ZManaged.mergeAllParN(2)(List.fill(4)(res))(0) { case (a, _) => a })
@@ -486,7 +479,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
                 .run
           count <- releases.get
-        } yield assert(count, equalTo(3))
+        } yield assert(count)(equalTo(3))
       }
     ),
     suite("onExit")(
@@ -500,10 +493,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
           result     <- resultRef.get
-        } yield assert(finalizers, equalTo(List("Second", "First"))) && assert(
-          result,
-          isSome(succeeds(equalTo("42")))
-        )
+        } yield assert(finalizers)(equalTo(List("Second", "First"))) && assert(result)(isSome(succeeds(equalTo("42"))))
       }
     ),
     suite("onExitFirst")(
@@ -517,10 +507,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
           result     <- resultRef.get
-        } yield assert(finalizers, equalTo(List("First", "Second"))) && assert(
-          result,
-          isSome(succeeds(equalTo("42")))
-        )
+        } yield assert(finalizers)(equalTo(List("First", "Second"))) && assert(result)(isSome(succeeds(equalTo("42"))))
       }
     ),
     suite("preallocate")(
@@ -529,7 +516,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ref    <- Ref.make(0)
           res    = ZManaged.reserve(Reservation(ZIO.interrupt, _ => ref.update(_ + 1)))
           _      <- res.preallocate.run.ignore
-          result <- assertM(ref.get, equalTo(1))
+          result <- assertM(ref.get)(equalTo(1))
         } yield result
       },
       testM("runs finalizer when resource closes") {
@@ -537,18 +524,18 @@ object ZManagedSpec extends ZIOBaseSpec {
           ref    <- Ref.make(0)
           res    = ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1)))
           _      <- res.preallocate.flatMap(_.use_(ZIO.unit))
-          result <- assertM(ref.get, equalTo(1))
+          result <- assertM(ref.get)(equalTo(1))
         } yield result
       },
       testM("propagates failures in acquire") {
         for {
           exit <- ZManaged.fromEffect(ZIO.fail("boom")).preallocate.either
-        } yield assert(exit, isLeft(equalTo("boom")))
+        } yield assert(exit)(isLeft(equalTo("boom")))
       },
       testM("propagates failures in reserve") {
         for {
           exit <- ZManaged.make(ZIO.fail("boom"))(_ => ZIO.unit).preallocate.either
-        } yield assert(exit, isLeft(equalTo("boom")))
+        } yield assert(exit)(isLeft(equalTo("boom")))
       }
     ),
     suite("preallocateManaged")(
@@ -558,7 +545,7 @@ object ZManagedSpec extends ZIOBaseSpec {
             .reserve(Reservation(ZIO.interrupt, _ => ref.update(_ + 1)))
             .preallocateManaged
             .use_(ZIO.unit)
-            .run *> assertM(ref.get, equalTo(1))
+            .run *> assertM(ref.get)(equalTo(1))
         }
       },
       testM("eagerly run acquisition when preallocateManaged is invoked") {
@@ -568,14 +555,13 @@ object ZManagedSpec extends ZIOBaseSpec {
                      .reserve(Reservation(ref.update(_ + 1), _ => ZIO.unit))
                      .preallocateManaged
                      .use(r => ref.get.zip(r.use_(ref.get)))
-        } yield assert(result, equalTo((1, 1)))
+        } yield assert(result)(equalTo((1, 1)))
       },
       testM("run release on scope exit") {
         Ref.make(0).flatMap { ref =>
           ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1))).preallocateManaged.use_(ZIO.unit) *> assertM(
-            ref.get,
-            equalTo(1)
-          )
+            ref.get
+          )(equalTo(1))
         }
       },
       testM("don't run release twice") {
@@ -583,7 +569,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged
             .reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1)))
             .preallocateManaged
-            .use(_.use_(ZIO.unit)) *> assertM(ref.get, equalTo(1))
+            .use(_.use_(ZIO.unit)) *> assertM(ref.get)(equalTo(1))
         }
       }
     ),
@@ -595,7 +581,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         val managed = ZManaged.reduceAll(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (a1, a2) => a1 ++ a2
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(
@@ -612,7 +598,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         val managed = ZManaged.reduceAllPar(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (a1, a2) => a1 ++ a2
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs reservations in parallel") {
         testReservePar(
@@ -641,7 +627,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         val managed = ZManaged.reduceAllParN(2)(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (acc, a) => a ++ acc
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res, equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Uses at most n fibers for reservation") {
         testFinalizersPar(
@@ -678,7 +664,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 .use_(ZIO.unit)
                 .run
           count <- releases.get
-        } yield assert(count, equalTo(3))
+        } yield assert(count)(equalTo(3))
       }
     ),
     suite("retry")(
@@ -689,7 +675,7 @@ object ZManagedSpec extends ZIOBaseSpec {
             .make(retries.update(_ + 1).flatMap(r => if (r == 3) ZIO.unit else ZIO.fail(())))(_ => ZIO.unit)
           _ <- program.retry(Schedule.recurs(3)).use(_ => ZIO.unit).ignore
           r <- retries.get
-        } yield assert(r, equalTo(3))
+        } yield assert(r)(equalTo(3))
       },
       testM("Should retry the acquisition") {
         for {
@@ -699,7 +685,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           )
           _ <- program.retry(Schedule.recurs(3)).use(_ => ZIO.unit).ignore
           r <- retries.get
-        } yield assert(r, equalTo(3))
+        } yield assert(r)(equalTo(3))
       },
       testM("Should share retries between both") {
         for {
@@ -720,7 +706,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           _  <- program.retry(Schedule.recurs(6)).use(_ => ZIO.unit).ignore
           r1 <- retries1.get
           r2 <- retries2.get
-        } yield assert(r1, equalTo(3)) && assert(r2, equalTo(3))
+        } yield assert(r1)(equalTo(3)) && assert(r2)(equalTo(3))
       }
     ),
     suite("scope")(
@@ -730,7 +716,7 @@ object ZManagedSpec extends ZIOBaseSpec {
             ref    <- Ref.make(0)
             res    = ZManaged.reserve(Reservation(ZIO.interrupt, _ => ref.update(_ + 1)))
             _      <- preallocate(res).run.ignore
-            result <- assertM(ref.get, equalTo(1))
+            result <- assertM(ref.get)(equalTo(1))
           } yield result
         }
       },
@@ -740,7 +726,7 @@ object ZManagedSpec extends ZIOBaseSpec {
             ref    <- Ref.make(0)
             res    = ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1)))
             _      <- preallocate(res).flatMap(_.use_(ZIO.unit))
-            result <- assertM(ref.get, equalTo(1))
+            result <- assertM(ref.get)(equalTo(1))
           } yield result
         }
       },
@@ -748,14 +734,14 @@ object ZManagedSpec extends ZIOBaseSpec {
         ZManaged.scope.use { preallocate =>
           for {
             exit <- preallocate(ZManaged.fromEffect(ZIO.fail("boom"))).either
-          } yield assert(exit, isLeft(equalTo("boom")))
+          } yield assert(exit)(isLeft(equalTo("boom")))
         }
       },
       testM("propagates failures in reserve") {
         ZManaged.scope.use { preallocate =>
           for {
             exit <- preallocate(ZManaged.make(ZIO.fail("boom"))(_ => ZIO.unit)).either
-          } yield assert(exit, isLeft(equalTo("boom")))
+          } yield assert(exit)(isLeft(equalTo("boom")))
         }
       },
       testM("eagerly run acquisition when preallocate is invoked") {
@@ -766,21 +752,21 @@ object ZManagedSpec extends ZIOBaseSpec {
             r1  <- ref.get
             _   <- res.use_(ZIO.unit)
             r2  <- ref.get
-          } yield assert(r1, equalTo(1)) && assert(r2, equalTo(1))
+          } yield assert(r1)(equalTo(1)) && assert(r2)(equalTo(1))
         }
       },
       testM("run release on scope exit") {
         Ref.make(0).flatMap { ref =>
           ZManaged.scope.use { preallocate =>
             preallocate(ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1))))
-          } *> assertM(ref.get, equalTo(1))
+          } *> assertM(ref.get)(equalTo(1))
         }
       },
       testM("don't run release twice") {
         Ref.make(0).flatMap { ref =>
           ZManaged.scope.use { preallocate =>
             preallocate(ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1)))).flatMap(_.use_(ZIO.unit))
-          } *> assertM(ref.get, equalTo(1))
+          } *> assertM(ref.get)(equalTo(1))
         }
       },
       testM("allow preallocate to be called multiple times") {
@@ -788,7 +774,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ZManaged.scope.use { preallocate =>
             val res = ZManaged.reserve(Reservation(ZIO.unit, _ => ref.update(_ + 1)))
             preallocate(res) *> preallocate(res)
-          } *> assertM(ref.get, equalTo(2))
+          } *> assertM(ref.get)(equalTo(2))
         }
       }
     ),
@@ -799,7 +785,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         )
         val test = managed.timed.use {
           case (duration, _) =>
-            ZIO.succeed(assert(duration.toNanos, isGreaterThanEqualTo(40.milliseconds.toNanos)))
+            ZIO.succeed(assert(duration.toNanos)(isGreaterThanEqualTo(40.milliseconds.toNanos)))
         }
         def awaitSleeps(n: Int): ZIO[TestClock, Nothing, Unit] =
           TestClock.sleeps.flatMap {
@@ -819,13 +805,13 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("timeout")(
       testM("Returns Some if the timeout isn't reached") {
         val managed = ZManaged.make(ZIO.succeed(1))(_ => ZIO.unit)
-        managed.timeout(Duration.Infinity).use(res => ZIO.succeed(assert(res, isSome(equalTo(1)))))
+        managed.timeout(Duration.Infinity).use(res => ZIO.succeed(assert(res)(isSome(equalTo(1)))))
       },
       testM("Returns None if the reservation takes longer than d") {
         for {
           latch   <- Promise.make[Nothing, Unit]
           managed = ZManaged.make(latch.await)(_ => ZIO.unit)
-          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res, isNone)))
+          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res)(isNone)))
           _       <- latch.succeed(())
         } yield res
       },
@@ -833,7 +819,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         for {
           latch   <- Promise.make[Nothing, Unit]
           managed = ZManaged.reserve(Reservation(latch.await, _ => ZIO.unit))
-          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res, isNone)))
+          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res)(isNone)))
           _       <- latch.succeed(())
         } yield res
       },
@@ -845,7 +831,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res          <- managed.timeout(Duration.Zero).use(ZIO.succeed)
           _            <- reserveLatch.succeed(())
           _            <- releaseLatch.await
-        } yield assert(res, isNone)
+        } yield assert(res)(isNone)
       },
       testM("Runs finalizers if returning None and reservation is successful after timeout") {
         for {
@@ -857,7 +843,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           res <- managed.timeout(Duration.Zero).use(ZIO.succeed)
           _   <- acquireLatch.succeed(())
           _   <- releaseLatch.await
-        } yield assert(res, isNone)
+        } yield assert(res)(isNone)
       }
     ),
     suite("withEarlyRelease")(
@@ -868,7 +854,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           result <- managed.use {
                      case (canceler, _) => canceler *> ref.get
                    }
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("The canceler should run uninterruptibly") {
         for {
@@ -884,7 +870,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                          _            <- ref.set(false)
                        } yield interruption
                    }
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("If completed, the canceler should cause the regular finalizer to not run") {
         for {
@@ -894,7 +880,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           _       <- managed.use(_._1).ensuring(latch.succeed(()))
           _       <- latch.await
           result  <- ref.get
-        } yield assert(result, equalTo(1))
+        } yield assert(result)(equalTo(1))
       },
       testM("The canceler will run with an exit value indicating the effect was interrupted") {
         for {
@@ -902,7 +888,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           managed = ZManaged.makeExit(ZIO.unit)((_, e) => ref.set(e.interrupted))
           _       <- managed.withEarlyRelease.use(_._1)
           result  <- ref.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       }
     ),
     suite("withEarlyReleaseExit")(
@@ -912,7 +898,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           managed = ZManaged.makeExit(ZIO.unit)((_, e) => ref.set(e.succeeded))
           _       <- managed.withEarlyReleaseExit(Exit.unit).use(_._1)
           result  <- ref.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       }
     ),
     suite("zipPar")(
@@ -923,7 +909,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           second = ZManaged.fromEffect(latch.await *> ZIO.fail(()))
           _      <- first.zipPar(second).use_(ZIO.unit)
         } yield ()).run
-          .map(assert(_, fails(equalTo(()))))
+          .map(assert(_)(fails(equalTo(()))))
       },
       testM("Runs finalizers if one acquisition fails") {
         for {
@@ -932,7 +918,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           second   = ZManaged.reserve(Reservation(ZIO.fail(()), _ => releases.update(_ + 1)))
           _        <- first.zipPar(second).use(_ => ZIO.unit).ignore
           r        <- releases.get
-        } yield assert(r, equalTo(1))
+        } yield assert(r)(equalTo(1))
       },
       testM("Does not swallow acquisition if one acquisition fails") {
         ZIO.fiberId.flatMap { selfId =>
@@ -953,7 +939,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           second       = ZManaged.fromEffect(reserveLatch.await *> ZIO.fail(()))
           _            <- first.zipPar(second).use_(ZIO.unit).orElse(ZIO.unit)
           count        <- releases.get
-        } yield assert(count, equalTo(1))
+        } yield assert(count)(equalTo(1))
       }
     ),
     suite("flatten")(
@@ -962,7 +948,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           val test = for {
             flatten1 <- ZManaged.succeed(ZManaged.succeed(str)).flatten
             flatten2 <- ZManaged.flatten(ZManaged.succeed(ZManaged.succeed(str)))
-          } yield assert(flatten1, equalTo(flatten2))
+          } yield assert(flatten1)(equalTo(flatten2))
           test.use[Any, Nothing, TestResult](r => ZIO.succeed(r))
         }
       }
@@ -974,7 +960,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           val test = for {
             abs1 <- managedEither.absolve
             abs2 <- ZManaged.absolve(managedEither)
-          } yield assert(abs1, equalTo(abs2))
+          } yield assert(abs1)(equalTo(abs2))
           test.use[Any, Nothing, TestResult](result => ZIO.succeed(result))
         }
       }
@@ -996,7 +982,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fib.interrupt
           result <- effects.get
-        } yield assert(result, equalTo(List("Second", "First")))
+        } yield assert(result)(equalTo(List("Second", "First")))
       }
     ),
     suite("memoize")(
@@ -1011,7 +997,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                 use *> use *> use
               }
           res <- effects.get
-        } yield assert(res, equalTo(List(1, 2, 3, 3, 2, 1)))
+        } yield assert(res)(equalTo(List(1, 2, 3, 3, 2, 1)))
       },
       testM("acquires and releases nothing if the inner managed is never used") {
         for {
@@ -1019,7 +1005,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           released <- Ref.make(false)
           managed  = Managed.make(acquired.set(true))(_ => released.set(true))
           _        <- managed.memoize.use_(ZIO.unit)
-          res      <- assertM(acquired.get zip released.get, equalTo((false, false)))
+          res      <- assertM(acquired.get zip released.get)(equalTo((false, false)))
         } yield res
       },
       testM("behaves like an ordinary ZManaged if flattened") {
@@ -1028,8 +1014,8 @@ object ZManagedSpec extends ZIOBaseSpec {
           acquire  = resource.update(_ + 1)
           release  = resource.update(_ - 1)
           managed  = ZManaged.make(acquire)(_ => release).memoize.flatten
-          res1     <- managed.use_(assertM(resource.get, equalTo(1)))
-          res2     <- assertM(resource.get, equalTo(0))
+          res1     <- managed.use_(assertM(resource.get)(equalTo(1)))
+          res2     <- assertM(resource.get)(equalTo(0))
         } yield res1 && res2
       },
       testM("properly raises an error if acquiring fails") {
@@ -1041,9 +1027,9 @@ object ZManagedSpec extends ZIOBaseSpec {
                    for {
                      v1 <- memoized.use_(ZIO.unit).either
                      v2 <- memoized.use_(ZIO.unit).either
-                   } yield assert(v1, equalTo(v2)) && assert(v1, isLeft(equalTo(error)))
+                   } yield assert(v1)(equalTo(v2)) && assert(v1)(isLeft(equalTo(error)))
                  }
-          res2 <- assertM(released.get, isFalse)
+          res2 <- assertM(released.get)(isFalse)
         } yield res1 && res2
       },
       testM("behaves properly if acquiring dies") {
@@ -1052,9 +1038,9 @@ object ZManagedSpec extends ZIOBaseSpec {
           ohNoes   = ";-0"
           managed  = Managed.make(ZIO.dieMessage(ohNoes))(_ => released.set(true))
           res1 <- managed.memoize.use { memoized =>
-                   assertM(memoized.use_(ZIO.unit).run, dies(hasMessage(ohNoes)))
+                   assertM(memoized.use_(ZIO.unit).run)(dies(hasMessage(ohNoes)))
                  }
-          res2 <- assertM(released.get, isFalse)
+          res2 <- assertM(released.get)(isFalse)
         } yield res1 && res2
       },
       testM("behaves properly if releasing dies") {
@@ -1065,7 +1051,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           memoized.use_(ZIO.unit)
         }
 
-        assertM(program.run, dies(hasMessage(myBad)))
+        assertM(program.run)(dies(hasMessage(myBad)))
       },
       testM("behaves properly if use dies") {
         val darn = "darn"
@@ -1077,7 +1063,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                  memoized.use_(ZIO.dieMessage(darn))
                }.run
           v2 <- released.get
-        } yield assert(v1, dies(hasMessage(darn))) && assert(v2, isTrue)
+        } yield assert(v1)(dies(hasMessage(darn))) && assert(v2)(isTrue)
       },
       testM("behaves properly if use is interrupted") {
         for {
@@ -1092,11 +1078,11 @@ object ZManagedSpec extends ZIOBaseSpec {
                     memoized.use_(latch1.succeed(()) *> latch2.await)
                   }.fork
           _    <- latch1.await
-          res1 <- assertM(resource.get, equalTo(1))
+          res1 <- assertM(resource.get)(equalTo(1))
           _    <- fiber.interrupt
           _    <- latch3.await
-          res2 <- assertM(resource.get, equalTo(0))
-          res3 <- assertM(latch2.isDone, isFalse)
+          res2 <- assertM(resource.get)(equalTo(0))
+          res3 <- assertM(latch2.isDone)(isFalse)
         } yield res1 && res2 && res3
       }
     ),
@@ -1107,7 +1093,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         for {
           a <- managed.merge.use(ZIO.succeed)
           b <- managed.flip.merge.use(ZIO.succeed)
-        } yield assert(a, equalTo(b))
+        } yield assert(a)(equalTo(b))
       }
     ),
     suite("catch")(
@@ -1119,7 +1105,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           } yield f
 
         val errorToVal = zm.catchAllCause(c => ZManaged.succeed(c.failureOption.getOrElse(c.toString)))
-        assertM(errorToVal.use(ZIO.succeed), equalTo("Uh oh!"))
+        assertM(errorToVal.use(ZIO.succeed))(equalTo("Uh oh!"))
       },
       testM("catchAllSomeCause transforms cause if matched") {
         val zm: ZManaged[Any, String, String] =
@@ -1131,7 +1117,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         val errorToVal = zm.catchSomeCause {
           case Cause.Fail("Uh oh!") => ZManaged.succeed("matched")
         }
-        assertM(errorToVal.use(ZIO.succeed), equalTo("matched"))
+        assertM(errorToVal.use(ZIO.succeed))(equalTo("matched"))
       },
       testM("catchAllSomeCause keeps the failure cause if not matched") {
         val zm: ZManaged[Any, String, String] =
@@ -1144,7 +1130,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           case Cause.Fail("not matched") => ZManaged.succeed("matched")
         }
         val executed = errorToVal.use[Any, String, String](ZIO.succeed).run
-        assertM(executed, fails(equalTo("Uh oh!")))
+        assertM(executed)(fails(equalTo("Uh oh!")))
       }
     ),
     suite("collect")(
@@ -1154,7 +1140,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         }
         val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeed)
 
-        assertM(effect, equalTo(84))
+        assertM(effect)(equalTo(84))
       },
       testM("collectM produces given error, if PF not matched") {
         val managed = ZManaged.succeed[Any, Int](42).collectM("Oh No!") {
@@ -1162,7 +1148,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         }
         val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeed)
 
-        assertM(effect.run, fails(equalTo("Oh No!")))
+        assertM(effect.run)(fails(equalTo("Oh No!")))
       }
     )
   )
@@ -1195,7 +1181,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       managedFiber       <- managed(reachedAcquisition.succeed(()) *> never.await).use_(IO.unit).fork
       _                  <- reachedAcquisition.await
       interruption       <- managedFiber.interruptAs(fiberId).timeout(5.seconds).provide(zio.clock.Clock.Live)
-    } yield assert(interruption.map(_.untraced), equalTo(expected(fiberId)))
+    } yield assert(interruption.map(_.untraced))(equalTo(expected(fiberId)))
 
   def testFinalizersPar[R, E](
     n: Int,
@@ -1207,7 +1193,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       res      = f(baseRes)
       _        <- res.use_(ZIO.unit)
       count    <- releases.get
-    } yield assert(count, equalTo(n))
+    } yield assert(count)(equalTo(n))
 
   def testAcquirePar[R, E](
     n: Int,
@@ -1224,7 +1210,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       _     <- res.use_(ZIO.unit).fork *> countDown
       count <- effects.get
       _     <- reserveLatch.succeed(())
-    } yield assert(count, equalTo(n))
+    } yield assert(count)(equalTo(n))
 
   def testReservePar[R, E, A](
     n: Int,
@@ -1241,5 +1227,5 @@ object ZManagedSpec extends ZIOBaseSpec {
       _     <- res.use_(ZIO.unit).fork *> countDown
       count <- effects.get
       _     <- reserveLatch.succeed(())
-    } yield assert(count, equalTo(n))
+    } yield assert(count)(equalTo(n))
 }

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -18,10 +18,10 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1    <- queue.take
         o2    <- queue.offer(20)
         v2    <- queue.take
-      } yield assert(v1, equalTo(10)) &&
-        assert(v2, equalTo(20)) &&
-        assert(o1, isTrue) &&
-        assert(o2, isTrue)
+      } yield assert(v1)(equalTo(10)) &&
+        assert(v2)(equalTo(20)) &&
+        assert(o1)(isTrue) &&
+        assert(o2)(isTrue)
     },
     testM("sequential take and offer") {
       for {
@@ -29,7 +29,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         f1    <- queue.take.zipWith(queue.take)(_ + _).fork
         _     <- queue.offer("don't ") *> queue.offer("give up :D")
         v     <- f1.join
-      } yield assert(v, equalTo("don't give up :D"))
+      } yield assert(v)(equalTo("don't give up :D"))
     },
     testM("parallel takes and sequential offers ") {
       for {
@@ -38,7 +38,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         values = Range.inclusive(1, 10).toList
         _      <- values.map(queue.offer).foldLeft[UIO[Boolean]](IO.succeed(false))(_ *> _)
         v      <- f.join
-      } yield assert(v.toSet, equalTo(values.toSet))
+      } yield assert(v.toSet)(equalTo(values.toSet))
     },
     testM("parallel offers and sequential takes") {
       for {
@@ -50,7 +50,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- queue.take.flatMap(i => out.update(i :: _)).repeat(Schedule.recurs(9))
         l      <- out.get
         _      <- f.join
-      } yield assert(l.toSet, equalTo(values.toSet))
+      } yield assert(l.toSet)(equalTo(values.toSet))
     },
     testM("offers are suspended by back pressure") {
       for {
@@ -61,7 +61,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _            <- waitForSize(queue, 11)
         isSuspended  <- refSuspended.get
         _            <- f.interrupt
-      } yield assert(isSuspended, isTrue)
+      } yield assert(isSuspended)(isTrue)
     },
     testM("back pressured offers are retrieved") {
       for {
@@ -73,7 +73,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- queue.take.flatMap(i => out.update(i :: _)).repeat(Schedule.recurs(9))
         l      <- out.get
         _      <- f.join
-      } yield assert(l.toSet, equalTo(values.toSet))
+      } yield assert(l.toSet)(equalTo(values.toSet))
     },
     testM("take interruption") {
       for {
@@ -82,7 +82,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, -1)
         _     <- f.interrupt
         size  <- queue.size
-      } yield assert(size, equalTo(0))
+      } yield assert(size)(equalTo(0))
     },
     testM("offer interruption") {
       for {
@@ -93,7 +93,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, 3)
         _     <- f.interrupt
         size  <- queue.size
-      } yield assert(size, equalTo(2))
+      } yield assert(size)(equalTo(2))
     },
     testM("queue is ordered") {
       for {
@@ -104,9 +104,9 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1    <- queue.take
         v2    <- queue.take
         v3    <- queue.take
-      } yield assert(v1, equalTo(1)) &&
-        assert(v2, equalTo(2)) &&
-        assert(v3, equalTo(3))
+      } yield assert(v1)(equalTo(1)) &&
+        assert(v2)(equalTo(2)) &&
+        assert(v3)(equalTo(3))
     },
     testM("takeAll") {
       for {
@@ -115,7 +115,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(2)
         _     <- queue.offer(3)
         v     <- queue.takeAll
-      } yield assert(v, equalTo(List(1, 2, 3)))
+      } yield assert(v)(equalTo(List(1, 2, 3)))
     },
     testM("takeAll with empty queue") {
       for {
@@ -124,8 +124,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(1)
         _     <- queue.take
         v     <- queue.takeAll
-      } yield assert(c, equalTo(List.empty[Int])) &&
-        assert(v, equalTo(List.empty[Int]))
+      } yield assert(c)(equalTo(List.empty[Int])) &&
+        assert(v)(equalTo(List.empty[Int]))
     },
     testM("takeAll doesn't return more than the queue size") {
       for {
@@ -136,8 +136,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- waitForSize(queue, 5)
         v      <- queue.takeAll
         c      <- queue.take
-      } yield assert(v.toSet, equalTo(values.toSet)) &&
-        assert(c, equalTo(5))
+      } yield assert(v.toSet)(equalTo(values.toSet)) &&
+        assert(c)(equalTo(5))
     },
     testM("takeUpTo") {
       for {
@@ -145,19 +145,19 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(10)
         _     <- queue.offer(20)
         list  <- queue.takeUpTo(2)
-      } yield assert(list, equalTo(List(10, 20)))
+      } yield assert(list)(equalTo(List(10, 20)))
     },
     testM("takeUpTo with empty queue") {
       for {
         queue <- Queue.bounded[Int](100)
         list  <- queue.takeUpTo(2)
-      } yield assert(list.isEmpty, isTrue)
+      } yield assert(list.isEmpty)(isTrue)
     },
     testM("takeUpTo with empty queue, with max higher than queue size") {
       for {
         queue <- Queue.bounded[Int](100)
         list  <- queue.takeUpTo(101)
-      } yield assert(list.isEmpty, isTrue)
+      } yield assert(list.isEmpty)(isTrue)
     },
     testM("takeUpTo with remaining items") {
       for {
@@ -167,7 +167,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(30)
         _     <- queue.offer(40)
         list  <- queue.takeUpTo(2)
-      } yield assert(list, equalTo(List(10, 20)))
+      } yield assert(list)(equalTo(List(10, 20)))
     },
     testM("takeUpTo with not enough items") {
       for {
@@ -177,7 +177,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(30)
         _     <- queue.offer(40)
         list  <- queue.takeUpTo(10)
-      } yield assert(list, equalTo(List(10, 20, 30, 40)))
+      } yield assert(list)(equalTo(List(10, 20, 30, 40)))
     },
     testM("takeUpTo 0") {
       for {
@@ -187,14 +187,14 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(30)
         _     <- queue.offer(40)
         list  <- queue.takeUpTo(0)
-      } yield assert(list.isEmpty, isTrue)
+      } yield assert(list.isEmpty)(isTrue)
     },
     testM("takeUpTo -1") {
       for {
         queue <- Queue.bounded[Int](100)
         _     <- queue.offer(10)
         list  <- queue.takeUpTo(-1)
-      } yield assert(list.isEmpty, isTrue)
+      } yield assert(list.isEmpty)(isTrue)
     },
     testM("multiple takeUpTo") {
       for {
@@ -205,8 +205,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(30)
         _     <- queue.offer(40)
         list2 <- queue.takeUpTo(2)
-      } yield assert(list1, equalTo(List(10, 20))) &&
-        assert(list2, equalTo(List(30, 40)))
+      } yield assert(list1)(equalTo(List(10, 20))) &&
+        assert(list2)(equalTo(List(30, 40)))
     },
     testM("consecutive takeUpTo") {
       for {
@@ -217,8 +217,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(40)
         list1 <- queue.takeUpTo(2)
         list2 <- queue.takeUpTo(2)
-      } yield assert(list1, equalTo(List(10, 20))) &&
-        assert(list2, equalTo(List(30, 40)))
+      } yield assert(list1)(equalTo(List(10, 20))) &&
+        assert(list2)(equalTo(List(30, 40)))
     },
     testM("takeUpTo doesn't return back-pressured offers") {
       for {
@@ -229,7 +229,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- waitForSize(queue, 5)
         l      <- queue.takeUpTo(5)
         _      <- f.interrupt
-      } yield assert(l, equalTo(List(1, 2, 3, 4)))
+      } yield assert(l)(equalTo(List(1, 2, 3, 4)))
     },
     testM("offerAll with takeAll") {
       for {
@@ -238,7 +238,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- queue.offerAll(orders)
         _      <- waitForSize(queue, 10)
         l      <- queue.takeAll
-      } yield assert(l, equalTo(orders))
+      } yield assert(l)(equalTo(orders))
     },
     testM("offerAll with takeAll and back pressure") {
       for {
@@ -248,8 +248,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         size   <- waitForSize(queue, 3)
         l      <- queue.takeAll
         _      <- f.interrupt
-      } yield assert(size, equalTo(3)) &&
-        assert(l, equalTo(List(1, 2)))
+      } yield assert(size)(equalTo(3)) &&
+        assert(l)(equalTo(List(1, 2)))
     },
     testM("offerAll with takeAll and back pressure + interruption") {
       for {
@@ -262,8 +262,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _       <- f.interrupt
         l1      <- queue.takeAll
         l2      <- queue.takeAll
-      } yield assert(l1, equalTo(orders1)) &&
-        assert(l2, equalTo(List.empty[Int]))
+      } yield assert(l1)(equalTo(orders1)) &&
+        assert(l2)(equalTo(List.empty[Int]))
     },
     testM("offerAll with takeAll and back pressure, check ordering") {
       for {
@@ -273,7 +273,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- waitForSize(queue, 128)
         l      <- queue.takeAll
         _      <- f.interrupt
-      } yield assert(l, equalTo(Range.inclusive(1, 64).toList))
+      } yield assert(l)(equalTo(Range.inclusive(1, 64).toList))
     },
     testM("offerAll with pending takers") {
       for {
@@ -284,8 +284,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- queue.offerAll(orders)
         l      <- takers.join
         s      <- queue.size
-      } yield assert(l.toSet, equalTo(orders.toSet)) &&
-        assert(s, equalTo(0))
+      } yield assert(l.toSet)(equalTo(orders.toSet)) &&
+        assert(s)(equalTo(0))
     },
     testM("offerAll with pending takers, check ordering") {
       for {
@@ -297,8 +297,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         l      <- takers.join
         s      <- queue.size
         values = orders.take(64)
-      } yield assert(l.toSet, equalTo(values.toSet)) &&
-        assert(s, equalTo(64))
+      } yield assert(l.toSet)(equalTo(values.toSet)) &&
+        assert(s)(equalTo(64))
     },
     testM("offerAll with pending takers, check ordering of taker resolution") {
       for {
@@ -312,8 +312,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         l      <- takers.join
         s      <- queue.size
         _      <- f.interrupt
-      } yield assert(l.toSet, equalTo(values.toSet)) &&
-        assert(s, equalTo(-100))
+      } yield assert(l.toSet)(equalTo(values.toSet)) &&
+        assert(s)(equalTo(-100))
     },
     testM("offerAll with take and back pressure") {
       for {
@@ -324,9 +324,9 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1     <- queue.take
         v2     <- queue.take
         v3     <- queue.take
-      } yield assert(v1, equalTo(1)) &&
-        assert(v2, equalTo(2)) &&
-        assert(v3, equalTo(3))
+      } yield assert(v1)(equalTo(1)) &&
+        assert(v2)(equalTo(2)) &&
+        assert(v3)(equalTo(3))
     },
     testM("multiple offerAll with back pressure") {
       for {
@@ -342,11 +342,11 @@ object ZQueueSpec extends ZIOBaseSpec {
         v3      <- queue.take
         v4      <- queue.take
         v5      <- queue.take
-      } yield assert(v1, equalTo(1)) &&
-        assert(v2, equalTo(2)) &&
-        assert(v3, equalTo(3)) &&
-        assert(v4, equalTo(4)) &&
-        assert(v5, equalTo(5))
+      } yield assert(v1)(equalTo(1)) &&
+        assert(v2)(equalTo(2)) &&
+        assert(v3)(equalTo(3)) &&
+        assert(v4)(equalTo(4)) &&
+        assert(v5)(equalTo(5))
     },
     testM("offerAll + takeAll, check ordering") {
       for {
@@ -356,7 +356,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- queue.offerAll(orders)
         _      <- waitForSize(queue, 1000)
         v1     <- queue.takeAll
-      } yield assert(v1, equalTo(Range.inclusive(1, 1000).toList))
+      } yield assert(v1)(equalTo(Range.inclusive(1, 1000).toList))
     },
     testM("combination of offer, offerAll, take, takeAll") {
       for {
@@ -370,10 +370,10 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1     <- queue.take
         v2     <- queue.take
         v3     <- queue.take
-      } yield assert(v, equalTo(Range.inclusive(1, 32).toList)) &&
-        assert(v1, equalTo(33)) &&
-        assert(v2, equalTo(34)) &&
-        assert(v3, equalTo(35))
+      } yield assert(v)(equalTo(Range.inclusive(1, 32).toList)) &&
+        assert(v1)(equalTo(33)) &&
+        assert(v2)(equalTo(34)) &&
+        assert(v3)(equalTo(35))
     },
     testM("shutdown with take fiber") {
       for {
@@ -383,7 +383,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- waitForSize(queue, -1)
         _      <- queue.shutdown
         res    <- f.join.sandbox.either
-      } yield assert(res.left.map(_.untraced), isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res.left.map(_.untraced))(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with offer fiber") {
       for {
@@ -395,7 +395,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- waitForSize(queue, 3)
         _      <- queue.shutdown
         res    <- f.join.sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with offer") {
       for {
@@ -403,7 +403,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](1)
         _      <- queue.shutdown
         res    <- queue.offer(1).sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with take") {
       for {
@@ -411,7 +411,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](1)
         _      <- queue.shutdown
         res    <- queue.take.sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with takeAll") {
       for {
@@ -419,7 +419,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](1)
         _      <- queue.shutdown
         res    <- queue.takeAll.sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with takeUpTo") {
       for {
@@ -427,7 +427,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](1)
         _      <- queue.shutdown
         res    <- queue.takeUpTo(1).sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("shutdown with size") {
       for {
@@ -435,7 +435,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](1)
         _      <- queue.shutdown
         res    <- queue.size.sandbox.either
-      } yield assert(res, isLeft(equalTo(Cause.interrupt(selfId))))
+      } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
     testM("back-pressured offer completes after take") {
       for {
@@ -446,8 +446,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1    <- queue.take
         v2    <- queue.take
         _     <- f.join
-      } yield assert(v1, equalTo(1)) &&
-        assert(v2, equalTo(2))
+      } yield assert(v1)(equalTo(1)) &&
+        assert(v2)(equalTo(2))
     },
     testM("back-pressured offer completes after takeAll") {
       for {
@@ -457,7 +457,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, 3)
         v1    <- queue.takeAll
         _     <- f.join
-      } yield assert(v1, equalTo(List(1, 2)))
+      } yield assert(v1)(equalTo(List(1, 2)))
     },
     testM("back-pressured offer completes after takeUpTo") {
       for {
@@ -467,7 +467,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, 3)
         v1    <- queue.takeUpTo(2)
         _     <- f.join
-      } yield assert(v1, equalTo(List(1, 2)))
+      } yield assert(v1)(equalTo(List(1, 2)))
     },
     testM("back-pressured offerAll completes after takeAll") {
       for {
@@ -479,9 +479,9 @@ object ZQueueSpec extends ZIOBaseSpec {
         v2    <- queue.takeAll
         v3    <- queue.takeAll
         _     <- f.join
-      } yield assert(v1, equalTo(List(1, 2))) &&
-        assert(v2, equalTo(List(3, 4))) &&
-        assert(v3, equalTo(List(5)))
+      } yield assert(v1)(equalTo(List(1, 2))) &&
+        assert(v2)(equalTo(List(3, 4))) &&
+        assert(v3)(equalTo(List(5)))
     },
     testM("sliding strategy with offer") {
       for {
@@ -490,17 +490,17 @@ object ZQueueSpec extends ZIOBaseSpec {
         v1    <- queue.offer(2)
         v2    <- queue.offer(3)
         l     <- queue.takeAll
-      } yield assert(l, equalTo(List(2, 3))) &&
-        assert(v1, isTrue) &&
-        assert(v2, isFalse)
+      } yield assert(l)(equalTo(List(2, 3))) &&
+        assert(v1)(isTrue) &&
+        assert(v2)(isFalse)
     },
     testM("sliding strategy with offerAll") {
       for {
         queue <- Queue.sliding[Int](2)
         v     <- queue.offerAll(List(1, 2, 3))
         size  <- queue.size
-      } yield assert(size, equalTo(2)) &&
-        assert(v, isFalse)
+      } yield assert(size)(equalTo(2)) &&
+        assert(v)(isFalse)
     },
     testM("sliding strategy with enough capacity") {
       for {
@@ -509,15 +509,15 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offer(2)
         _     <- queue.offer(3)
         l     <- queue.takeAll
-      } yield assert(l, equalTo(List(1, 2, 3)))
+      } yield assert(l)(equalTo(List(1, 2, 3)))
     },
     testM("sliding strategy with offerAll and takeAll") {
       for {
         queue <- Queue.sliding[Int](2)
         v1    <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
         l     <- queue.takeAll
-      } yield assert(l, equalTo(List(5, 6))) &&
-        assert(v1, isFalse)
+      } yield assert(l)(equalTo(List(5, 6))) &&
+        assert(v1)(isFalse)
     },
     testM("awaitShutdown") {
       for {
@@ -526,7 +526,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- (queue.awaitShutdown *> p.succeed(true)).fork
         _     <- queue.shutdown
         res   <- p.await
-      } yield assert(res, isTrue)
+      } yield assert(res)(isTrue)
     },
     testM("multiple awaitShutdown") {
       for {
@@ -538,8 +538,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.shutdown
         res1  <- p1.await
         res2  <- p2.await
-      } yield assert(res1, isTrue) &&
-        assert(res2, isTrue)
+      } yield assert(res1)(isTrue) &&
+        assert(res2)(isTrue)
     },
     testM("awaitShutdown when queue is already shutdown") {
       for {
@@ -548,7 +548,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         p     <- Promise.make[Nothing, Boolean]
         _     <- (queue.awaitShutdown *> p.succeed(true)).fork
         res   <- p.await
-      } yield assert(res, isTrue)
+      } yield assert(res)(isTrue)
     },
     testM("dropping strategy with offerAll") {
       for {
@@ -557,7 +557,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         iter     = Range.inclusive(1, 5)
         _        <- queue.offerAll(iter)
         ta       <- queue.takeAll
-      } yield assert(ta, equalTo(List(1, 2, 3, 4)))
+      } yield assert(ta)(equalTo(List(1, 2, 3, 4)))
     },
     testM("dropping strategy with offerAll, check offer returns false") {
       for {
@@ -565,7 +565,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue    <- Queue.dropping[Int](capacity)
         v1       <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
         _        <- queue.takeAll
-      } yield assert(v1, isFalse)
+      } yield assert(v1)(isFalse)
     },
     testM("dropping strategy with offerAll, check ordering") {
       for {
@@ -574,7 +574,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         iter     = Range.inclusive(1, 256)
         _        <- queue.offerAll(iter)
         ta       <- queue.takeAll
-      } yield assert(ta, equalTo(Range.inclusive(1, 128).toList))
+      } yield assert(ta)(equalTo(Range.inclusive(1, 128).toList))
     },
     testM("dropping strategy with pending taker") {
       for {
@@ -585,8 +585,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _        <- waitForSize(queue, -1)
         oa       <- queue.offerAll(iter.toList)
         j        <- f.join
-      } yield assert(j, equalTo(1)) &&
-        assert(oa, isFalse)
+      } yield assert(j)(equalTo(1)) &&
+        assert(oa)(isFalse)
     },
     testM("sliding strategy with pending taker") {
       for {
@@ -597,8 +597,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         _        <- waitForSize(queue, -1)
         oa       <- queue.offerAll(iter.toList)
         t        <- queue.take
-      } yield assert(t, equalTo(3)) &&
-        assert(oa, isFalse)
+      } yield assert(t)(equalTo(3)) &&
+        assert(oa)(isFalse)
     },
     testM("sliding strategy, check offerAll returns true") {
       for {
@@ -606,7 +606,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue    <- Queue.sliding[Int](capacity)
         iter     = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
-      } yield assert(oa, isTrue)
+      } yield assert(oa)(isTrue)
     },
     testM("bounded strategy, check offerAll returns true") {
       for {
@@ -614,13 +614,13 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue    <- Queue.bounded[Int](capacity)
         iter     = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
-      } yield assert(oa, isTrue)
+      } yield assert(oa)(isTrue)
     },
     testM("poll on empty queue") {
       for {
         queue <- Queue.bounded[Int](5)
         t     <- queue.poll
-      } yield assert(t, isNone)
+      } yield assert(t)(isNone)
     },
     testM("poll on queue just emptied") {
       for {
@@ -629,7 +629,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         _     <- queue.offerAll(iter.toList)
         _     <- queue.takeAll
         t     <- queue.poll
-      } yield assert(t, isNone)
+      } yield assert(t)(isNone)
     },
     testM("multiple polls") {
       for {
@@ -640,45 +640,45 @@ object ZQueueSpec extends ZIOBaseSpec {
         t2    <- queue.poll
         t3    <- queue.poll
         t4    <- queue.poll
-      } yield assert(t1, isSome(equalTo(1))) &&
-        assert(t2, isSome(equalTo(2))) &&
-        assert(t3, isNone) &&
-        assert(t4, isNone)
+      } yield assert(t1)(isSome(equalTo(1))) &&
+        assert(t2)(isSome(equalTo(2))) &&
+        assert(t3)(isNone) &&
+        assert(t4)(isNone)
     },
     testM("queue map") {
       for {
         q <- Queue.bounded[Int](100).map(_.map(_.toString))
         _ <- q.offer(10)
         v <- q.take
-      } yield assert(v, equalTo("10"))
+      } yield assert(v)(equalTo("10"))
     },
     testM("queue map identity") {
       for {
         q <- Queue.bounded[Int](100).map(_.map(identity))
         _ <- q.offer(10)
         v <- q.take
-      } yield assert(v, equalTo(10))
+      } yield assert(v)(equalTo(10))
     },
     testM("queue mapM") {
       for {
         q <- Queue.bounded[Int](100).map(_.mapM(IO.succeed))
         _ <- q.offer(10)
         v <- q.take
-      } yield assert(v, equalTo(10))
+      } yield assert(v)(equalTo(10))
     },
     testM("queue mapM with success") {
       for {
         q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
         _ <- q.offer(IO.succeed(10))
         v <- q.take.sandbox.either
-      } yield assert(v, isRight(equalTo(10)))
+      } yield assert(v)(isRight(equalTo(10)))
     },
     testM("queue mapM with failure") {
       for {
         q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
         _ <- q.offer(IO.fail("Ouch"))
         v <- q.take.run
-      } yield assert(v, fails(equalTo("Ouch")))
+      } yield assert(v)(fails(equalTo("Ouch")))
     },
     testM("queue both") {
       for {
@@ -687,14 +687,14 @@ object ZQueueSpec extends ZIOBaseSpec {
         q  = q1 both q2
         _  <- q.offer(10)
         v  <- q.take
-      } yield assert(v, equalTo((10, 10)))
+      } yield assert(v)(equalTo((10, 10)))
     },
     testM("queue contramap") {
       for {
         q <- Queue.bounded[String](100).map(_.contramap[Int](_.toString))
         _ <- q.offer(10)
         v <- q.take
-      } yield assert(v, equalTo("10"))
+      } yield assert(v)(equalTo("10"))
     },
     testM("queue filterInput") {
       for {
@@ -703,8 +703,8 @@ object ZQueueSpec extends ZIOBaseSpec {
         s1 <- q.size
         _  <- q.offer(2)
         s2 <- q.size
-      } yield assert(s1, equalTo(0)) &&
-        assert(s2, equalTo(1))
+      } yield assert(s1)(equalTo(0)) &&
+        assert(s2)(equalTo(1))
     },
     testM("queue isShutdown") {
       for {
@@ -716,10 +716,10 @@ object ZQueueSpec extends ZIOBaseSpec {
         r3    <- queue.isShutdown
         _     <- queue.shutdown
         r4    <- queue.isShutdown
-      } yield assert(r1, isFalse) &&
-        assert(r2, isFalse) &&
-        assert(r3, isFalse) &&
-        assert(r4, isTrue)
+      } yield assert(r1)(isFalse) &&
+        assert(r2)(isFalse) &&
+        assert(r3)(isFalse) &&
+        assert(r4)(isTrue)
     },
     testM("shutdown race condition with offer") {
       for {

--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -14,335 +14,333 @@ object DurationSpec extends ZIOBaseSpec {
   def spec = suite("DurationSpec")(
     suite("Make a Duration from positive nanos and check that: ")(
       test("The Duration is Finite") {
-        assert(Duration.fromNanos(1), isSubtype[Duration.Finite](Assertion.anything))
+        assert(Duration.fromNanos(1))(isSubtype[Duration.Finite](Assertion.anything))
       },
       test("Copy with a negative nanos returns Zero") {
-        assert(Duration.fromNanos(1).asInstanceOf[Duration.Finite].copy(-1), equalTo(Duration.Zero))
+        assert(Duration.fromNanos(1).asInstanceOf[Duration.Finite].copy(-1))(equalTo(Duration.Zero))
       },
       test("Multiplying with a negative factor returns Zero") {
-        assert(Duration.fromNanos(1) * -1.0, equalTo(Duration.Zero: Duration))
+        assert(Duration.fromNanos(1) * -1.0)(equalTo(Duration.Zero: Duration))
       },
       test("Its stdlib representation is correct") {
         val duration: ScalaDuration = Duration.fromNanos(1234L).asScala
         val expected: ScalaDuration = ScalaFiniteDuration(1234L, TimeUnit.NANOSECONDS)
-        assert(duration, equalTo(expected))
+        assert(duration)(equalTo(expected))
       },
       test("Its JDK representation is correct") {
-        assert(Duration.fromNanos(2345L).asJava, equalTo(JavaDuration.ofNanos(2345L)))
+        assert(Duration.fromNanos(2345L).asJava)(equalTo(JavaDuration.ofNanos(2345L)))
       },
       test("It identifies as 'zero'") {
-        assert(Duration.fromNanos(0L).isZero, equalTo(true))
+        assert(Duration.fromNanos(0L).isZero)(equalTo(true))
       },
       test("Creating it with a j.u.c.TimeUnit is identical") {
-        assert(Duration(12L, TimeUnit.NANOSECONDS), equalTo(Duration.fromNanos(12L)))
+        assert(Duration(12L, TimeUnit.NANOSECONDS))(equalTo(Duration.fromNanos(12L)))
       },
       test("It knows its length in ns") {
-        assert(Duration.fromNanos(123L).toNanos, equalTo(123L))
+        assert(Duration.fromNanos(123L).toNanos)(equalTo(123L))
       },
       test("It knows its length in ms") {
-        assert(Duration.fromNanos(123000000L).toMillis, equalTo(123L))
+        assert(Duration.fromNanos(123000000L).toMillis)(equalTo(123L))
       },
       test("max(1 ns, 2 ns) is 2 ns") {
-        assert(Duration.fromNanos(1L).max(Duration.fromNanos(2L)), equalTo(Duration.fromNanos(2L)))
+        assert(Duration.fromNanos(1L).max(Duration.fromNanos(2L)))(equalTo(Duration.fromNanos(2L)))
       },
       test("min(1 ns, 2 ns) is 1 ns") {
-        assert(Duration.fromNanos(1L).min(Duration.fromNanos(2L)), equalTo(Duration.fromNanos(1L)))
+        assert(Duration.fromNanos(1L).min(Duration.fromNanos(2L)))(equalTo(Duration.fromNanos(1L)))
       },
       test("max(2 ns, 1 ns) is 2 ns") {
-        assert(Duration.fromNanos(2L).max(Duration.fromNanos(1L)), equalTo(Duration.fromNanos(2L)))
+        assert(Duration.fromNanos(2L).max(Duration.fromNanos(1L)))(equalTo(Duration.fromNanos(2L)))
       },
       test("min(2 ns, 1 ns) is 1 ns") {
-        assert(Duration.fromNanos(2L).min(Duration.fromNanos(1L)), equalTo(Duration.fromNanos(1L)))
+        assert(Duration.fromNanos(2L).min(Duration.fromNanos(1L)))(equalTo(Duration.fromNanos(1L)))
       },
       test("10 ns + 20 ns = 30 ns") {
-        assert(Duration.fromNanos(10L) + Duration.fromNanos(20L), equalTo(Duration.fromNanos(30L)))
+        assert(Duration.fromNanos(10L) + Duration.fromNanos(20L))(equalTo(Duration.fromNanos(30L)))
       },
       test("10 ns * NaN = Infinity") {
-        assert(Duration.fromNanos(10L) * Double.NaN, equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromNanos(10L) * Double.NaN)(equalTo(Duration.Infinity: Duration))
       },
       test("10 ns compared to Infinity is -1") {
-        assert(Duration.fromNanos(10L) compare Duration.Infinity, equalTo(-1))
+        assert(Duration.fromNanos(10L) compare Duration.Infinity)(equalTo(-1))
       },
       test("10 ns compared to 10 ns is 0") {
-        assert(Duration.fromNanos(10L) compare Duration.fromNanos(10L), equalTo(0))
+        assert(Duration.fromNanos(10L) compare Duration.fromNanos(10L))(equalTo(0))
       },
       test("+ with positive overflow results in Infinity") {
-        assert(Duration.fromNanos(Long.MaxValue - 1) + Duration.fromNanos(42), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromNanos(Long.MaxValue - 1) + Duration.fromNanos(42))(equalTo(Duration.Infinity: Duration))
       },
       test("* with negative duration results in zero") {
-        assert(Duration.fromNanos(42) * -7, equalTo(Duration.Zero: Duration))
+        assert(Duration.fromNanos(42) * -7)(equalTo(Duration.Zero: Duration))
       },
       test("* with overflow to positive results in Infinity") {
-        assert(Duration.fromNanos(Long.MaxValue) * 3, equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromNanos(Long.MaxValue) * 3)(equalTo(Duration.Infinity: Duration))
       },
       test("* with overflow to negative results in Infinity") {
-        assert(Duration.fromNanos(Long.MaxValue) * 2, equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromNanos(Long.MaxValue) * 2)(equalTo(Duration.Infinity: Duration))
       },
       test("Folding picks up the correct value") {
-        assert(Duration.fromNanos(Long.MaxValue).fold("Infinity", _ => "Finite"), equalTo("Finite"))
+        assert(Duration.fromNanos(Long.MaxValue).fold("Infinity", _ => "Finite"))(equalTo("Finite"))
       }
     ),
     suite("Make a Duration from negative nanos and check that:")(
       test("The Duration is Zero ") {
-        assert(Duration.fromNanos(-1), equalTo(Duration.Zero: Duration))
+        assert(Duration.fromNanos(-1))(equalTo(Duration.Zero: Duration))
       }
     ),
     suite("Take Infinity and check that: ")(
       test("toMillis returns Long.MaxValue nanoseconds in milliseconds") {
-        assert(Duration.Infinity.toMillis, equalTo(Long.MaxValue / 1000000))
+        assert(Duration.Infinity.toMillis)(equalTo(Long.MaxValue / 1000000))
       },
       test("toNanos returns Long.MaxValue nanoseconds") {
-        assert(Duration.Infinity.toNanos, equalTo(Long.MaxValue))
+        assert(Duration.Infinity.toNanos)(equalTo(Long.MaxValue))
       },
       test("Infinity + Infinity = Infinity") {
-        assert(Duration.Infinity + Duration.Infinity, equalTo(Duration.Infinity: Duration))
+        assert(Duration.Infinity + Duration.Infinity)(equalTo(Duration.Infinity: Duration))
       },
       test("Infinity + 1 ns = Infinity") {
-        assert(Duration.Infinity + Duration.fromNanos(1L), equalTo(Duration.Infinity: Duration))
+        assert(Duration.Infinity + Duration.fromNanos(1L))(equalTo(Duration.Infinity: Duration))
       },
       test("1 ns + Infinity = Infinity") {
-        assert(Duration.fromNanos(1L) + Duration.Infinity, equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromNanos(1L) + Duration.Infinity)(equalTo(Duration.Infinity: Duration))
       },
       test("Infinity * 10 = Infinity") {
-        assert(Duration.Infinity * 10.0, equalTo(Duration.Infinity: Duration))
+        assert(Duration.Infinity * 10.0)(equalTo(Duration.Infinity: Duration))
       },
       test("Infinity compared to Infinity is 0") {
-        assert(Duration.Infinity compare Duration.Infinity, equalTo(0))
+        assert(Duration.Infinity compare Duration.Infinity)(equalTo(0))
       },
       test("Infinity compared to 1 ns is 1") {
-        assert(Duration.Infinity compare Duration.fromNanos(1L), equalTo(1))
+        assert(Duration.Infinity compare Duration.fromNanos(1L))(equalTo(1))
       },
       test("Infinity is not zero") {
-        assert(Duration.Infinity.isZero, equalTo(false))
+        assert(Duration.Infinity.isZero)(equalTo(false))
       },
       test("It converts into the infinite s.c.d.Duration") {
-        assert(Duration.Infinity.asScala, equalTo(ScalaDuration.Inf: ScalaDuration))
+        assert(Duration.Infinity.asScala)(equalTo(ScalaDuration.Inf: ScalaDuration))
       },
       test("It converts into a Long.MaxValue second-long JDK Duration") {
-        assert(Duration.Infinity.asJava, equalTo(JavaDuration.ofMillis(Long.MaxValue)))
+        assert(Duration.Infinity.asJava)(equalTo(JavaDuration.ofMillis(Long.MaxValue)))
       },
       test("Folding picks up the correct value") {
-        assert(Duration.Infinity.fold("Infinity", _ => "Finite"), equalTo("Infinity"))
+        assert(Duration.Infinity.fold("Infinity", _ => "Finite"))(equalTo("Infinity"))
       },
       test("Infinity * -10 = Zero") {
-        assert(Duration.Infinity * -10, equalTo(Duration.Zero: Duration))
+        assert(Duration.Infinity * -10)(equalTo(Duration.Zero: Duration))
       }
     ),
     suite("Make a Scala stdlib s.c.d.Duration and check that: ")(
       test("A negative s.c.d.Duration converts to Zero") {
-        assert(Duration.fromScala(ScalaDuration(-1L, TimeUnit.NANOSECONDS)), equalTo(Duration.Zero: Duration))
+        assert(Duration.fromScala(ScalaDuration(-1L, TimeUnit.NANOSECONDS)))(equalTo(Duration.Zero: Duration))
       },
       test("The infinite s.c.d.Duration converts to Infinity") {
-        assert(Duration.fromScala(ScalaDuration.Inf), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromScala(ScalaDuration.Inf))(equalTo(Duration.Infinity: Duration))
       },
       test("A positive s.c.d.Duration converts to a Finite") {
-        assert(Duration.fromScala(ScalaDuration(1L, TimeUnit.NANOSECONDS)), equalTo(Duration.fromNanos(1L)))
+        assert(Duration.fromScala(ScalaDuration(1L, TimeUnit.NANOSECONDS)))(equalTo(Duration.fromNanos(1L)))
       }
     ),
     suite("Make a Java stdlib j.t.Duration and check that: ")(
       test("A negative j.t.Duration converts to Zero") {
-        assert(Duration.fromJava(JavaDuration.ofNanos(-1L)), equalTo(Duration.Zero: Duration))
+        assert(Duration.fromJava(JavaDuration.ofNanos(-1L)))(equalTo(Duration.Zero: Duration))
       },
       test("A Long.MaxValue second j.t.Duration converts to Infinity") {
-        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue)), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue)))(equalTo(Duration.Infinity: Duration))
       },
       test(
         "A nano-adjusted Long.MaxValue second j.t.Duration converts to Infinity"
       ) {
-        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue, 1L)), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue, 1L)))(equalTo(Duration.Infinity: Duration))
       },
       test(
         "A j.t.Duration constructed from Infinity converts to Infinity"
       ) {
-        assert(Duration.fromJava(Duration.Infinity.asJava), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromJava(Duration.Infinity.asJava))(equalTo(Duration.Infinity: Duration))
       },
       test(
         "A Long.MaxValue - 1 second j.t.Duration converts to Infinity"
       ) {
-        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue - 1)), equalTo(Duration.Infinity: Duration))
+        assert(Duration.fromJava(JavaDuration.ofSeconds(Long.MaxValue - 1)))(equalTo(Duration.Infinity: Duration))
       },
       test(
         "A +ve j.t.Duration whose nano conversion overflows converts to Infinity"
       ) {
-        assert(
-          Duration.fromJava(JavaDuration.ofNanos(Long.MaxValue).plus(JavaDuration.ofNanos(1L))),
+        assert(Duration.fromJava(JavaDuration.ofNanos(Long.MaxValue).plus(JavaDuration.ofNanos(1L))))(
           equalTo(Duration.Infinity: Duration)
         )
       },
       test(
         "A -ve j.t.Duration whose nano conversion overflows converts to Zero"
       ) {
-        assert(
-          Duration.fromJava(JavaDuration.ofNanos(Long.MinValue).minus(JavaDuration.ofNanos(1L))),
+        assert(Duration.fromJava(JavaDuration.ofNanos(Long.MinValue).minus(JavaDuration.ofNanos(1L))))(
           equalTo(Duration.Zero: Duration)
         )
       },
       test("A positive j.t.Duration converts to a Finite") {
-        assert(Duration.fromJava(JavaDuration.ofNanos(1L)), equalTo(Duration.fromNanos(1L)))
+        assert(Duration.fromJava(JavaDuration.ofNanos(1L)))(equalTo(Duration.fromNanos(1L)))
       }
     ),
     suite("Check multiplication with finite durations: ")(
       test("Zero multiplied with zero") {
-        assert(Duration.Zero * 0, equalTo(Duration.Zero: Duration))
+        assert(Duration.Zero * 0)(equalTo(Duration.Zero: Duration))
       },
       test("Zero multiplied with one") {
-        assert(Duration.Zero * 1, equalTo(Duration.Zero: Duration))
+        assert(Duration.Zero * 1)(equalTo(Duration.Zero: Duration))
       },
       test("One second multiplied with 60") {
-        assert(Duration(1, TimeUnit.SECONDS) * 60, equalTo(Duration(1, TimeUnit.MINUTES)))
+        assert(Duration(1, TimeUnit.SECONDS) * 60)(equalTo(Duration(1, TimeUnit.MINUTES)))
       }
     ),
     suite("Render duration:")(
       test(" 0 ns") {
-        assert(Duration(0, TimeUnit.NANOSECONDS).render, equalTo("0 ns"))
+        assert(Duration(0, TimeUnit.NANOSECONDS).render)(equalTo("0 ns"))
       },
       test(" < 1 ms") {
-        assert(Duration(23456, TimeUnit.NANOSECONDS).render, equalTo("23456 ns"))
+        assert(Duration(23456, TimeUnit.NANOSECONDS).render)(equalTo("23456 ns"))
       },
       test(" 1 ms") {
-        assert(Duration(1, TimeUnit.MILLISECONDS).render, equalTo("1 ms"))
+        assert(Duration(1, TimeUnit.MILLISECONDS).render)(equalTo("1 ms"))
       },
       test(" 1 s") {
-        assert(Duration(1, TimeUnit.SECONDS).render, equalTo("1 s"))
+        assert(Duration(1, TimeUnit.SECONDS).render)(equalTo("1 s"))
       },
       test(" 2 s 500 ms") {
-        assert(Duration(2500, TimeUnit.MILLISECONDS).render, equalTo("2 s 500 ms"))
+        assert(Duration(2500, TimeUnit.MILLISECONDS).render)(equalTo("2 s 500 ms"))
       },
       test(" 1 min") {
-        assert(Duration(1, TimeUnit.MINUTES).render, equalTo("1 m"))
+        assert(Duration(1, TimeUnit.MINUTES).render)(equalTo("1 m"))
       },
       test(" 2 min 30 s") {
-        assert(Duration(150, TimeUnit.SECONDS).render, equalTo("2 m 30 s"))
+        assert(Duration(150, TimeUnit.SECONDS).render)(equalTo("2 m 30 s"))
       },
       test(" 1 h 1 min") {
-        assert(Duration(61, TimeUnit.MINUTES).render, equalTo("1 h 1 m"))
+        assert(Duration(61, TimeUnit.MINUTES).render)(equalTo("1 h 1 m"))
       },
       test(" 3 d 2 h 5 min") {
-        assert(Duration(4445, TimeUnit.MINUTES).render, equalTo("3 d 2 h 5 m"))
+        assert(Duration(4445, TimeUnit.MINUTES).render)(equalTo("3 d 2 h 5 m"))
       }
     ),
     suite("Long:")(
       test("1L.nano         = fromNanos(1L)") {
-        assert(1L.nano, equalTo(Duration.fromNanos(1L)))
+        assert(1L.nano)(equalTo(Duration.fromNanos(1L)))
       },
       test("2L.nanos        = fromNanos(2L)") {
-        assert(2L.nanos, equalTo(Duration.fromNanos(2L)))
+        assert(2L.nanos)(equalTo(Duration.fromNanos(2L)))
       },
       test("1L.nanosecond   = fromNanos(1L)") {
-        assert(1L.nanosecond, equalTo(Duration.fromNanos(1L)))
+        assert(1L.nanosecond)(equalTo(Duration.fromNanos(1L)))
       },
       test("2L.nanoseconds  = fromNanos(2L)") {
-        assert(2L.nanoseconds, equalTo(Duration.fromNanos(2L)))
+        assert(2L.nanoseconds)(equalTo(Duration.fromNanos(2L)))
       },
       test("1L.micro        = fromNanos(1000L)") {
-        assert(1L.micro, equalTo(Duration.fromNanos(1000L)))
+        assert(1L.micro)(equalTo(Duration.fromNanos(1000L)))
       },
       test("2L.micros       = fromNanos(2000L)") {
-        assert(2L.micros, equalTo(Duration.fromNanos(2000L)))
+        assert(2L.micros)(equalTo(Duration.fromNanos(2000L)))
       },
       test("1L.microsecond  = fromNanos(1000L)") {
-        assert(1L.microsecond, equalTo(Duration.fromNanos(1000L)))
+        assert(1L.microsecond)(equalTo(Duration.fromNanos(1000L)))
       },
       test("2L.microseconds = fromNanos(2000L)") {
-        assert(2L.microseconds, equalTo(Duration.fromNanos(2000L)))
+        assert(2L.microseconds)(equalTo(Duration.fromNanos(2000L)))
       },
       test("1L.milli        = fromNanos(1000000L)") {
-        assert(1L.milli, equalTo(Duration.fromNanos(1000000L)))
+        assert(1L.milli)(equalTo(Duration.fromNanos(1000000L)))
       },
       test("2L.millis       = fromNanos(2000000L)") {
-        assert(2L.millis, equalTo(Duration.fromNanos(2000000L)))
+        assert(2L.millis)(equalTo(Duration.fromNanos(2000000L)))
       },
       test("1L.millisecond  = fromNanos(1000000L)") {
-        assert(1L.millisecond, equalTo(Duration.fromNanos(1000000L)))
+        assert(1L.millisecond)(equalTo(Duration.fromNanos(1000000L)))
       },
       test("2L.milliseconds = fromNanos(2000000L)") {
-        assert(2L.milliseconds, equalTo(Duration.fromNanos(2000000L)))
+        assert(2L.milliseconds)(equalTo(Duration.fromNanos(2000000L)))
       },
       test("1L.second       = fromNanos(1000000000L)") {
-        assert(1L.second, equalTo(Duration.fromNanos(1000000000L)))
+        assert(1L.second)(equalTo(Duration.fromNanos(1000000000L)))
       },
       test("2L.seconds      = fromNanos(2000000000L)") {
-        assert(2L.seconds, equalTo(Duration.fromNanos(2000000000L)))
+        assert(2L.seconds)(equalTo(Duration.fromNanos(2000000000L)))
       },
       test("1L.minute       = fromNanos(60000000000L)") {
-        assert(1L.minute, equalTo(Duration.fromNanos(60000000000L)))
+        assert(1L.minute)(equalTo(Duration.fromNanos(60000000000L)))
       },
       test("2L.minutes      = fromNanos(120000000000L)") {
-        assert(2L.minutes, equalTo(Duration.fromNanos(120000000000L)))
+        assert(2L.minutes)(equalTo(Duration.fromNanos(120000000000L)))
       },
       test("1L.hour         = fromNanos(3600000000000L)") {
-        assert(1L.hour, equalTo(Duration.fromNanos(3600000000000L)))
+        assert(1L.hour)(equalTo(Duration.fromNanos(3600000000000L)))
       },
       test("2L.hours        = fromNanos(7200000000000L)") {
-        assert(2L.hours, equalTo(Duration.fromNanos(7200000000000L)))
+        assert(2L.hours)(equalTo(Duration.fromNanos(7200000000000L)))
       },
       test("1L.day          = fromNanos(86400000000000L)") {
-        assert(1L.day, equalTo(Duration.fromNanos(86400000000000L)))
+        assert(1L.day)(equalTo(Duration.fromNanos(86400000000000L)))
       },
       test("2L.days         = fromNanos(172800000000000L)") {
-        assert(2L.days, equalTo(Duration.fromNanos(172800000000000L)))
+        assert(2L.days)(equalTo(Duration.fromNanos(172800000000000L)))
       }
     ),
     suite("Int:")(
       test("1.nano         = fromNanos(1L)") {
-        assert(1.nano, equalTo(Duration.fromNanos(1L)))
+        assert(1.nano)(equalTo(Duration.fromNanos(1L)))
       },
       test("2.nanos        = fromNanos(2L)") {
-        assert(2.nanos, equalTo(Duration.fromNanos(2L)))
+        assert(2.nanos)(equalTo(Duration.fromNanos(2L)))
       },
       test("1.nanosecond   = fromNanos(1L)") {
-        assert(1.nanosecond, equalTo(Duration.fromNanos(1L)))
+        assert(1.nanosecond)(equalTo(Duration.fromNanos(1L)))
       },
       test("2.nanoseconds  = fromNanos(2L)") {
-        assert(2.nanos, equalTo(Duration.fromNanos(2L)))
+        assert(2.nanos)(equalTo(Duration.fromNanos(2L)))
       },
       test("1.micro        = fromNanos(1000L)") {
-        assert(1.micro, equalTo(Duration.fromNanos(1000L)))
+        assert(1.micro)(equalTo(Duration.fromNanos(1000L)))
       },
       test("2.micros       = fromNanos(2000L)") {
-        assert(2.micros, equalTo(Duration.fromNanos(2000L)))
+        assert(2.micros)(equalTo(Duration.fromNanos(2000L)))
       },
       test("1.microsecond  = fromNanos(1000L)") {
-        assert(1.microsecond, equalTo(Duration.fromNanos(1000L)))
+        assert(1.microsecond)(equalTo(Duration.fromNanos(1000L)))
       },
       test("2.microseconds = fromNanos(2000L)") {
-        assert(2.microseconds, equalTo(Duration.fromNanos(2000L)))
+        assert(2.microseconds)(equalTo(Duration.fromNanos(2000L)))
       },
       test("1.milli        = fromNanos(1000000L)") {
-        assert(1.milli, equalTo(Duration.fromNanos(1000000L)))
+        assert(1.milli)(equalTo(Duration.fromNanos(1000000L)))
       },
       test("2.millis       = fromNanos(2000000L)") {
-        assert(2.millis, equalTo(Duration.fromNanos(2000000L)))
+        assert(2.millis)(equalTo(Duration.fromNanos(2000000L)))
       },
       test("1.millisecond  = fromNanos(1000000L)") {
-        assert(1.millisecond, equalTo(Duration.fromNanos(1000000L)))
+        assert(1.millisecond)(equalTo(Duration.fromNanos(1000000L)))
       },
       test("2.milliseconds = fromNanos(2000000L)") {
-        assert(2.milliseconds, equalTo(Duration.fromNanos(2000000L)))
+        assert(2.milliseconds)(equalTo(Duration.fromNanos(2000000L)))
       },
       test("1.second       = fromNanos(1000000000L)") {
-        assert(1.second, equalTo(Duration.fromNanos(1000000000L)))
+        assert(1.second)(equalTo(Duration.fromNanos(1000000000L)))
       },
       test("2.seconds      = fromNanos(2000000000L)") {
-        assert(2.seconds, equalTo(Duration.fromNanos(2000000000L)))
+        assert(2.seconds)(equalTo(Duration.fromNanos(2000000000L)))
       },
       test("1.minute       = fromNanos(60000000000L)") {
-        assert(1.minute, equalTo(Duration.fromNanos(60000000000L)))
+        assert(1.minute)(equalTo(Duration.fromNanos(60000000000L)))
       },
       test("2.minutes      = fromNanos(120000000000L)") {
-        assert(2.minutes, equalTo(Duration.fromNanos(120000000000L)))
+        assert(2.minutes)(equalTo(Duration.fromNanos(120000000000L)))
       },
       test("1.hour         = fromNanos(3600000000000L)") {
-        assert(1.hour, equalTo(Duration.fromNanos(3600000000000L)))
+        assert(1.hour)(equalTo(Duration.fromNanos(3600000000000L)))
       },
       test("2.hours        = fromNanos(7200000000000L)") {
-        assert(2.hours, equalTo(Duration.fromNanos(7200000000000L)))
+        assert(2.hours)(equalTo(Duration.fromNanos(7200000000000L)))
       },
       test("1.day          = fromNanos(86400000000000L)") {
-        assert(1.day, equalTo(Duration.fromNanos(86400000000000L)))
+        assert(1.day)(equalTo(Duration.fromNanos(86400000000000L)))
       },
       test("2.days         = fromNanos(76800000000000L)") {
-        assert(2.days, equalTo(Duration.fromNanos(172800000000000L)))
+        assert(2.days)(equalTo(Duration.fromNanos(172800000000000L)))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
@@ -49,37 +49,33 @@ object ExecutorSpec extends ZIOBaseSpec {
       test("When converted to an EC, it reports Throwables to stdout") {
         val t = new CheckPrintThrowable
         TestExecutor.failing.asEC.reportFailure(t)
-        assert(t.printed, isTrue)
+        assert(t.printed)(isTrue)
       }
     ),
     suite("Create an executor that cannot have tasks submitted to and check that:")(
       test("It throws an exception upon submission") {
-        assert(
-          TestExecutor.failing.submitOrThrow(TestExecutor.runnable),
-          throwsA[RejectedExecutionException]
-        )
+        assert(TestExecutor.failing.submitOrThrow(TestExecutor.runnable))(throwsA[RejectedExecutionException])
       }
     ),
     suite("Create a yielding executor and check that:")(
       test("Runnables can be submitted ") {
-        assert(TestExecutor.y.submitOrThrow(TestExecutor.runnable), not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.y.submitOrThrow(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When converted to an ExecutionContext, it accepts Runnables") {
-        assert(TestExecutor.y.asEC.execute(TestExecutor.runnable), not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.y.asEC.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When created from an EC, must not throw when fed an effect ") {
-        assert(
-          Executor.fromExecutionContext(1)(TestExecutor.ec).submit(TestExecutor.runnable),
+        assert(Executor.fromExecutionContext(1)(TestExecutor.ec).submit(TestExecutor.runnable))(
           not(throwsA[RejectedExecutionException])
         )
       }
     ),
     suite("Create an unyielding executor and check that:")(
       test("Runnables can be submitted") {
-        assert(TestExecutor.u.submitOrThrow(TestExecutor.runnable), not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.u.submitOrThrow(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When converted to an ExecutionContext, it accepts Runnables") {
-        assert(TestExecutor.u.asEC.execute(TestExecutor.runnable), not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.u.asEC.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
@@ -17,29 +17,29 @@ object MutableConcurrentQueueSpec extends ZIOBaseSpec {
       test("of capacity 1 return a queue of capacity 1") {
         val q = MutableConcurrentQueue.bounded(1)
 
-        assert(q.capacity, equalTo(1))
+        assert(q.capacity)(equalTo(1))
       },
       test("of capacity 2 return a queue of capacity 2") {
         val q = MutableConcurrentQueue.bounded(2)
 
-        assert(q.capacity, equalTo(2))
+        assert(q.capacity)(equalTo(2))
       },
       test("of capacity 3 return a queue of capacity 3") {
         val q = MutableConcurrentQueue.bounded(3)
 
-        assert(q.capacity, equalTo(3))
+        assert(q.capacity)(equalTo(3))
       }
     ),
     suite("With a RingBuffer of capacity 2")(
       test("`offer` of 2 items succeeds, further offers fail") {
         val q = MutableConcurrentQueue.bounded[Int](2)
 
-        (assert(q.offer(1), isTrue)
-        && assert(q.size(), equalTo(1))
-        && assert(q.offer(2), isTrue)
-        && assert(q.size(), equalTo(2))
-        && assert(q.offer(3), isFalse)
-        && assert(q.isFull(), isTrue))
+        (assert(q.offer(1))(isTrue)
+        && assert(q.size())(equalTo(1))
+        && assert(q.offer(2))(isTrue)
+        && assert(q.size())(equalTo(2))
+        && assert(q.offer(3))(isFalse)
+        && assert(q.isFull())(isTrue))
       },
       test(
         "`poll` of 2 items from full queue succeeds, further `poll`s return default value"
@@ -48,10 +48,10 @@ object MutableConcurrentQueueSpec extends ZIOBaseSpec {
         q.offer(1)
         q.offer(2)
 
-        (assert(q.poll(-1), equalTo(1))
-        && assert(q.poll(-1), equalTo(2))
-        && assert(q.poll(-1), equalTo(-1))
-        && assert(q.isEmpty(), isTrue))
+        (assert(q.poll(-1))(equalTo(1))
+        && assert(q.poll(-1))(equalTo(2))
+        && assert(q.poll(-1))(equalTo(-1))
+        && assert(q.isEmpty())(isTrue))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -11,11 +11,11 @@ object StackBoolSpec extends ZIOBaseSpec {
 
   def spec = suite("StackBoolSpec")(
     testM("Size tracking") {
-      checkAll(gen)(list => assert(StackBool.fromIterable(list).size.toInt, equalTo(list.length)))
+      checkAll(gen)(list => assert(StackBool.fromIterable(list).size.toInt)(equalTo(list.length)))
     },
     testM("From/to list identity") {
       checkAll(gen) { list =>
-        assert(StackBool.fromIterable(list).toList, equalTo(list))
+        assert(StackBool.fromIterable(list).toList)(equalTo(list))
       }
     },
     testM("Push/pop example") {
@@ -24,9 +24,9 @@ object StackBoolSpec extends ZIOBaseSpec {
 
         list.foreach(stack.push)
 
-        list.reverse.foldLeft(assert(true, equalTo(true))) {
+        list.reverse.foldLeft(assert(true)(equalTo(true))) {
           case (result, flag) =>
-            result && assert(stack.popOrElse(!flag), equalTo(flag))
+            result && assert(stack.popOrElse(!flag))(equalTo(flag))
         }
       }
     },
@@ -36,19 +36,19 @@ object StackBoolSpec extends ZIOBaseSpec {
 
         list.foreach(stack.push)
 
-        list.reverse.foldLeft(assert(true, equalTo(true))) {
+        list.reverse.foldLeft(assert(true)(equalTo(true))) {
           case (result, flag) =>
             val peeked = stack.peekOrElse(!flag)
             val popped = stack.popOrElse(!flag)
 
-            result && assert(peeked, equalTo(popped))
+            result && assert(peeked)(equalTo(popped))
         }
       }
     },
     test("GetOrElse index out of bounds") {
       val stack  = StackBool()
       val result = stack.getOrElse(100, true)
-      assert(result, equalTo(true))
+      assert(result)(equalTo(true))
     }
   )
 

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -11,27 +11,27 @@ object STMSpec extends ZIOBaseSpec {
   def spec = suite("STMSpec")(
     suite("Using `STM.atomically` to perform different computations and call:")(
       testM("`STM.succeed` to make a successful computation and check the value") {
-        assertM(STM.succeed("Hello World").commit, equalTo("Hello World"))
+        assertM(STM.succeed("Hello World").commit)(equalTo("Hello World"))
       },
       testM("`STM.failed` to make a failed computation and check the value") {
-        assertM(STM.fail("Bye bye World").commit.run, fails(equalTo("Bye bye World")))
+        assertM(STM.fail("Bye bye World").commit.run)(fails(equalTo("Bye bye World")))
       },
       suite("`either` to convert")(
         testM("A successful computation into Right(a)") {
           import zio.CanFail.canFail
-          assertM(STM.succeed(42).either.commit, isRight(equalTo(42)))
+          assertM(STM.succeed(42).either.commit)(isRight(equalTo(42)))
         },
         testM("A failed computation into Left(e)") {
-          assertM(STM.fail("oh no!").either.commit, isLeft(equalTo("oh no!")))
+          assertM(STM.fail("oh no!").either.commit)(isLeft(equalTo("oh no!")))
         }
       ),
       suite("fallback")(
         testM("Tries this effect first") {
           import zio.CanFail.canFail
-          assertM(STM.succeed(1).fallback(2).commit, equalTo(1))
+          assertM(STM.succeed(1).fallback(2).commit)(equalTo(1))
         },
         testM("If it fails, succeeds with the specified value") {
-          assertM(STM.fail("fail").fallback(1).commit, equalTo(1))
+          assertM(STM.fail("fail").fallback(1).commit)(equalTo(1))
         }
       ),
       testM("`fold` to handle both failure and success") {
@@ -40,7 +40,7 @@ object STMSpec extends ZIOBaseSpec {
           s <- STM.succeed("Yes!").fold(_ => -1, _ => 1)
           f <- STM.fail("No!").fold(_ => -1, _ => 1)
         } yield (s, f)
-        assertM(stm.commit, equalTo((1, -1)))
+        assertM(stm.commit)(equalTo((1, -1)))
       },
       testM("`foldM` to fold over the `STM` effect, and handle failure and success") {
         import zio.CanFail.canFail
@@ -48,32 +48,32 @@ object STMSpec extends ZIOBaseSpec {
           s <- STM.succeed("Yes!").foldM(_ => STM.succeed("No!"), STM.succeed)
           f <- STM.fail("No!").foldM(STM.succeed, _ => STM.succeed("Yes!"))
         } yield (s, f)
-        assertM(stm.commit, equalTo(("Yes!", "No!")))
+        assertM(stm.commit)(equalTo(("Yes!", "No!")))
       },
       testM("`mapError` to map from one error to another") {
-        assertM(STM.fail(-1).mapError(_ => "oh no!").commit.run, fails(equalTo("oh no!")))
+        assertM(STM.fail(-1).mapError(_ => "oh no!").commit.run)(fails(equalTo("oh no!")))
       },
       testM("`orElse` to try another computation when the computation is failed") {
         import zio.CanFail.canFail
         (for {
           s <- STM.succeed(1) orElse STM.succeed(2)
           f <- STM.fail("failed") orElse STM.succeed("try this")
-        } yield assert((s, f), equalTo((1, "try this")))).commit
+        } yield assert((s, f))(equalTo((1, "try this")))).commit
       },
       suite("`option` to convert:")(
         testM("A successful computation into Some(a)") {
           import zio.CanFail.canFail
-          assertM(STM.succeed(42).option.commit, isSome(equalTo(42)))
+          assertM(STM.succeed(42).option.commit)(isSome(equalTo(42)))
         },
         testM("A failed computation into None") {
-          assertM(STM.fail("oh no!").option.commit, isNone)
+          assertM(STM.fail("oh no!").option.commit)(isNone)
         }
       ),
       testM("`zip` to return a tuple of two computations") {
-        assertM((STM.succeed(1) <*> STM.succeed('A')).commit, equalTo((1, 'A')))
+        assertM((STM.succeed(1) <*> STM.succeed('A')).commit)(equalTo((1, 'A')))
       },
       testM("`zipWith` to perform an action to two computations") {
-        assertM(STM.succeed(578).zipWith(STM.succeed(2))(_ + _).commit, equalTo(580))
+        assertM(STM.succeed(578).zipWith(STM.succeed(2))(_ + _).commit)(equalTo(580))
       }
     ),
     suite("Make a new `TRef` and")(
@@ -81,14 +81,14 @@ object STMSpec extends ZIOBaseSpec {
         (for {
           intVar <- TRef.make(14)
           v      <- intVar.get
-        } yield assert(v, equalTo(14))).commit
+        } yield assert(v)(equalTo(14))).commit
       },
       testM("set a new value") {
         (for {
           intVar <- TRef.make(14)
           _      <- intVar.set(42)
           v      <- intVar.get
-        } yield assert(v, equalTo(42))).commit
+        } yield assert(v)(equalTo(42))).commit
       }
     ),
     suite("Using `STM.atomically` perform concurrent computations")(
@@ -98,7 +98,7 @@ object STMSpec extends ZIOBaseSpec {
           fiber <- ZIO.forkAll(List.fill(10)(incrementVarN(99, tVar)))
           _     <- fiber.join
           value <- tVar.get.commit
-        } yield assert(value, equalTo(1000))
+        } yield assert(value)(equalTo(1000))
       },
       testM(
         "compute a `TRef` from 2 variables, increment the first `TRef` and decrement the second `TRef` in different fibers"
@@ -112,7 +112,7 @@ object STMSpec extends ZIOBaseSpec {
           fiber                     <- ZIO.forkAll(List.fill(10)(compute3VarN(99, tvar1, tvar2, tvar3)))
           _                         <- fiber.join
           value                     <- tvar3.get.commit
-        } yield assert(value, equalTo(10000))
+        } yield assert(value)(equalTo(10000))
       }
     ),
     suite("Using `STM.atomically` perform concurrent computations that")(
@@ -127,7 +127,7 @@ object STMSpec extends ZIOBaseSpec {
                      _  <- tvar2.set("Succeeded!")
                      v2 <- tvar2.get
                    } yield v2).commit
-          } yield assert(join, equalTo("Succeeded!"))
+          } yield assert(join)(equalTo("Succeeded!"))
         },
         testM(
           "resume directly when the condition is already satisfied and change again the tvar with non satisfying value, the transaction shouldn't be suspended."
@@ -137,7 +137,7 @@ object STMSpec extends ZIOBaseSpec {
             join <- tvar.get.filter(_ == 42).commit
             _    <- tvar.set(9).commit
             v    <- tvar.get.commit
-          } yield assert(v, equalTo(9)) && assert(join, equalTo(42))
+          } yield assert(v)(equalTo(9)) && assert(join)(equalTo(42))
         },
         testM("resume after satisfying the condition") {
           val barrier = new UnpureBarrier
@@ -161,7 +161,7 @@ object STMSpec extends ZIOBaseSpec {
             _    <- done.await
             newV <- tvar2.get.commit
             join <- fiber.join
-          } yield assert(old, equalTo("Failed!")) && assert(newV, equalTo(join))
+          } yield assert(old)(equalTo("Failed!")) && assert(newV)(equalTo(join))
         },
         suite("have a complex condition lock should suspend the whole transaction and")(
           testM("resume directly when the condition is already satisfied") {
@@ -173,7 +173,7 @@ object STMSpec extends ZIOBaseSpec {
               _         <- sender.get.filter(_ == 50).commit
               senderV   <- sender.get.commit
               receiverV <- receiver.get.commit
-            } yield assert(senderV, equalTo(50)) && assert(receiverV, equalTo(150))
+            } yield assert(senderV)(equalTo(50)) && assert(receiverV)(equalTo(150))
           }
         )
       ),
@@ -189,7 +189,7 @@ object STMSpec extends ZIOBaseSpec {
             _          <- f.join
             senderV    <- sender.get.commit
             receiverV  <- receiver.get.commit
-          } yield assert(senderV, equalTo(150)) && assert(receiverV, equalTo(0))
+          } yield assert(senderV)(equalTo(150)) && assert(receiverV)(equalTo(0))
         },
         testM("run 10 transactions `toReceiver` and 10 `toSender` concurrently.") {
           for {
@@ -204,7 +204,7 @@ object STMSpec extends ZIOBaseSpec {
             _          <- f2.join
             senderV    <- sender.get.commit
             receiverV  <- receiver.get.commit
-          } yield assert(senderV, equalTo(100)) && assert(receiverV, equalTo(0))
+          } yield assert(senderV)(equalTo(100)) && assert(receiverV)(equalTo(0))
         },
         testM("run transactions `toReceiver` 10 times and `toSender` 10 times each in 100 fibers concurrently.") {
           for {
@@ -217,7 +217,7 @@ object STMSpec extends ZIOBaseSpec {
             _            <- f.join
             senderV      <- sender.get.commit
             receiverV    <- receiver.get.commit
-          } yield assert(senderV, equalTo(100)) && assert(receiverV, equalTo(0))
+          } yield assert(senderV)(equalTo(100)) && assert(receiverV)(equalTo(0))
         }
       ),
       testM(
@@ -237,7 +237,7 @@ object STMSpec extends ZIOBaseSpec {
                   )
           _ <- fiber.join
           v <- tvar.get.commit
-        } yield assert(v, equalTo(21))
+        } yield assert(v)(equalTo(21))
       },
       suite("Perform atomically a transaction with a condition that couldn't be satisfied, it should be suspended")(
         testM("interrupt the fiber should terminate the transaction") {
@@ -254,7 +254,7 @@ object STMSpec extends ZIOBaseSpec {
             _ <- fiber.interrupt
             _ <- tvar.set(10).commit
             v <- liveClockSleep(10.millis) *> tvar.get.commit
-          } yield assert(v, equalTo(10))
+          } yield assert(v)(equalTo(10))
         },
         testM(
           "interrupt the fiber that has executed the transaction in 100 different fibers, should terminate all transactions"
@@ -272,7 +272,7 @@ object STMSpec extends ZIOBaseSpec {
             _ <- fiber.interrupt
             _ <- tvar.set(-1).commit
             v <- liveClockSleep(10.millis) *> tvar.get.commit
-          } yield assert(v, equalTo(-1))
+          } yield assert(v)(equalTo(-1))
         },
         testM("interrupt the fiber and observe it, it should be resumed with Interrupted Cause") {
           for {
@@ -281,18 +281,16 @@ object STMSpec extends ZIOBaseSpec {
             f       <- v.get.flatMap(v => STM.check(v == 0)).commit.fork
             _       <- f.interrupt
             observe <- f.join.sandbox.either
-          } yield assert(observe, isLeft(equalTo(Cause.interrupt(selfId))))
+          } yield assert(observe)(isLeft(equalTo(Cause.interrupt(selfId))))
         }
       ),
       testM("Using `collect` filter and map simultaneously the value produced by the transaction") {
-        assertM(
-          STM.succeed((1 to 20).toList).collect { case l if l.forall(_ > 0) => "Positive" }.commit,
+        assertM(STM.succeed((1 to 20).toList).collect { case l if l.forall(_ > 0) => "Positive" }.commit)(
           equalTo("Positive")
         )
       },
       testM("Using `collectM` filter and map simultaneously the value produced by the transaction") {
-        assertM(
-          STM.succeed((1 to 20).toList).collectM { case l if l.forall(_ > 0) => STM.succeed("Positive") }.commit,
+        assertM(STM.succeed((1 to 20).toList).collectM { case l if l.forall(_ > 0) => STM.succeed("Positive") }.commit)(
           equalTo("Positive")
         )
       }
@@ -304,7 +302,7 @@ object STMSpec extends ZIOBaseSpec {
         _     <- permutation(tvar1, tvar2).commit
         v1    <- tvar1.get.commit
         v2    <- tvar2.get.commit
-      } yield assert(v1, equalTo(2)) && assert(v2, equalTo(1))
+      } yield assert(v1)(equalTo(2)) && assert(v2)(equalTo(1))
     },
     testM("Permute 2 variables in 100 fibers, the 2 variables should contains the same values") {
       for {
@@ -316,7 +314,7 @@ object STMSpec extends ZIOBaseSpec {
         _     <- f.join
         v1    <- tvar1.get.commit
         v2    <- tvar2.get.commit
-      } yield assert(v1, equalTo(oldV1)) && assert(v2, equalTo(oldV2))
+      } yield assert(v1)(equalTo(oldV1)) && assert(v2)(equalTo(oldV2))
     },
     testM(
       "Using `collectAll` collect a list of transactional effects to a single transaction that produces a list of values"
@@ -325,7 +323,7 @@ object STMSpec extends ZIOBaseSpec {
         it    <- UIO((1 to 100).map(TRef.make(_)))
         tvars <- STM.collectAll(it).commit
         res   <- UIO.collectAllPar(tvars.map(_.get.commit))
-      } yield assert(res, equalTo((1 to 100).toList))
+      } yield assert(res)(equalTo((1 to 100).toList))
     },
     testM(
       "Using `foreach` perform an action in each value and return a single transaction that contains the result"
@@ -335,7 +333,7 @@ object STMSpec extends ZIOBaseSpec {
         _         <- STM.foreach(1 to 100)(a => tvar.update(_ + a)).commit
         expectedV = (1 to 100).sum
         v         <- tvar.get.commit
-      } yield assert(v, equalTo(expectedV))
+      } yield assert(v)(equalTo(expectedV))
     },
     testM("Using `foreach_` performs actions in order") {
       val as = List(1, 2, 3, 4, 5)
@@ -343,7 +341,7 @@ object STMSpec extends ZIOBaseSpec {
         ref <- TRef.makeCommit(List.empty[Int])
         _   <- STM.foreach_(as)(a => ref.update(_ :+ a)).commit
         bs  <- ref.get.commit
-      } yield assert(bs, equalTo(as))
+      } yield assert(bs)(equalTo(as))
     },
     testM(
       "Using `orElseEither` tries 2 computations and returns either left if the left computation succeed or right if the right one succeed"
@@ -354,10 +352,10 @@ object STMSpec extends ZIOBaseSpec {
         leftV1  <- STM.succeed(1).orElseEither(STM.succeed("No me!")).commit
         leftV2  <- STM.succeed(2).orElseEither(STM.fail("No!")).commit
         failedV <- STM.fail(-1).orElseEither(STM.fail(-2)).commit.either
-      } yield assert(rightV, isRight(equalTo(42))) &&
-        assert(leftV1, isLeft(equalTo(1))) &&
-        assert(leftV2, isLeft(equalTo(2))) &&
-        assert(failedV, isLeft(equalTo(-2)))
+      } yield assert(rightV)(isRight(equalTo(42))) &&
+        assert(leftV1)(isLeft(equalTo(1))) &&
+        assert(leftV2)(isLeft(equalTo(2))) &&
+        assert(failedV)(isLeft(equalTo(-2)))
     },
     suite("Failure must")(
       testM("rollback full transaction") {
@@ -368,7 +366,7 @@ object STMSpec extends ZIOBaseSpec {
                 _ <- STM.fail("Error!")
               } yield ()).commit.either
           v <- tvar.get.commit
-        } yield assert(e, isLeft(equalTo("Error!"))) && assert(v, equalTo(0))
+        } yield assert(e)(isLeft(equalTo("Error!"))) && assert(v)(equalTo(0))
       },
       testM("be ignored") {
         for {
@@ -378,7 +376,7 @@ object STMSpec extends ZIOBaseSpec {
                 _ <- STM.fail("Error!")
               } yield ()).commit.ignore
           v <- tvar.get.commit
-        } yield assert(e, equalTo(())) && assert(v, equalTo(0))
+        } yield assert(e)(equalTo(())) && assert(v)(equalTo(0))
       }
     ),
     suite("orElse must")(
@@ -390,7 +388,7 @@ object STMSpec extends ZIOBaseSpec {
           right = tvar.update(_ + 100).unit
           _     <- (left orElse right).commit
           v     <- tvar.get.commit
-        } yield assert(v, equalTo(100))
+        } yield assert(v)(equalTo(100))
       },
       testM("rollback left failure") {
         for {
@@ -399,7 +397,7 @@ object STMSpec extends ZIOBaseSpec {
           right = tvar.update(_ + 100).unit
           _     <- (left orElse right).commit
           v     <- tvar.get.commit
-        } yield assert(v, equalTo(100))
+        } yield assert(v)(equalTo(100))
       },
       testM("local reset, not global") {
         for {
@@ -410,7 +408,7 @@ object STMSpec extends ZIOBaseSpec {
                      _       <- STM.partial(throw new RuntimeException).orElse(STM.unit)
                      newVal2 <- ref.get
                    } yield (newVal1, newVal2))
-        } yield assert(result, equalTo(2 -> 2))
+        } yield assert(result)(equalTo(2 -> 2))
       }
     ),
     suite("STM issue 2073") {
@@ -421,29 +419,29 @@ object STMSpec extends ZIOBaseSpec {
           sumFiber <- r0.get.flatMap(v0 => r1.get.map(_ + v0)).commit.fork
           _        <- r0.update(_ + 1).flatMap(_ => r1.update(_ + 1)).commit
           sum      <- sumFiber.join
-        } yield assert(sum, equalTo(0) || equalTo(2))
+        } yield assert(sum)(equalTo(0) || equalTo(2))
       } @@ nonFlaky(5000)
     },
     suite("STM stack safety")(
       testM("long map chains") {
-        assertM(chain(10000)(_.map(_ + 1)), equalTo(10000))
+        assertM(chain(10000)(_.map(_ + 1)))(equalTo(10000))
       },
       testM("long collect chains") {
-        assertM(chain(10000)(_.collect { case a: Int => a + 1 }), equalTo(10000))
+        assertM(chain(10000)(_.collect { case a: Int => a + 1 }))(equalTo(10000))
       },
       testM("long collectM chains") {
-        assertM(chain(10000)(_.collectM { case a: Int => STM.succeed(a + 1) }), equalTo(10000))
+        assertM(chain(10000)(_.collectM { case a: Int => STM.succeed(a + 1) }))(equalTo(10000))
       },
       testM("long flatMap chains") {
-        assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))), equalTo(10000))
+        assertM(chain(10000)(_.flatMap(a => STM.succeed(a + 1))))(equalTo(10000))
       },
       testM("long fold chains") {
         import zio.CanFail.canFail
-        assertM(chain(10000)(_.fold(_ => 0, _ + 1)), equalTo(10000))
+        assertM(chain(10000)(_.fold(_ => 0, _ + 1)))(equalTo(10000))
       },
       testM("long foldM chains") {
         import zio.CanFail.canFail
-        assertM(chain(10000)(_.foldM(_ => STM.succeed(0), a => STM.succeed(a + 1))), equalTo(10000))
+        assertM(chain(10000)(_.foldM(_ => STM.succeed(0), a => STM.succeed(a + 1))))(equalTo(10000))
       },
       testM("long mapError chains") {
         def chain(depth: Int): ZIO[Any, Int, Nothing] = {
@@ -454,7 +452,7 @@ object STMSpec extends ZIOBaseSpec {
           loop(depth, STM.fail(0))
         }
 
-        assertM(chain(10000).run, fails(equalTo(10000)))
+        assertM(chain(10000).run)(fails(equalTo(10000)))
       },
       testM("long orElse chains") {
         def chain(depth: Int): ZIO[Any, Int, Nothing] = {
@@ -469,7 +467,7 @@ object STMSpec extends ZIOBaseSpec {
           loop(depth, 0, STM.fail(0))
         }
 
-        assertM(chain(10000).run, fails(equalTo(10000)))
+        assertM(chain(10000).run)(fails(equalTo(10000)))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -28,13 +28,13 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- makeTArray(1)(42)
           value  <- tArray(0)
         } yield value
-        assertM(res.commit, equalTo(42))
+        assertM(res.commit)(equalTo(42))
       },
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
           result <- ZIO.effect(tArray(-1)).run
-        } yield assert(result, fails(isArrayIndexOutOfBoundsException))
+        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
       }
     ),
     suite("collectFirst")(
@@ -44,7 +44,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirst {
                      case Some(i) if i > 2 => i.toString
                    }.commit
-        } yield assert(result, isSome(equalTo("4")))
+        } yield assert(result)(isSome(equalTo("4")))
       },
       testM("succeeds for empty") {
         for {
@@ -52,7 +52,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirst {
                      case any => any
                    }.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
@@ -60,7 +60,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirst {
                      case Some(i) if i > n => i.toString
                    }.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -70,7 +70,7 @@ object TArraySpec extends ZIOBaseSpec {
                       }.commit.fork
           _      <- STM.foreach(0 until N)(i => tArray.update(i, _ => Some(1))).commit
           result <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime.toString)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime.toString)) || isNone)
       }
     ),
     suite("collectFirstM")(
@@ -80,7 +80,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirstM {
                      case Some(i) if i > 2 => STM.succeed(i.toString)
                    }.commit
-        } yield assert(result, isSome(equalTo("4")))
+        } yield assert(result)(isSome(equalTo("4")))
       },
       testM("succeeds for empty") {
         for {
@@ -88,7 +88,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirstM {
                      case any => STM.succeed(any)
                    }.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
@@ -96,7 +96,7 @@ object TArraySpec extends ZIOBaseSpec {
           result <- tArray.collectFirstM {
                      case Some(i) if i > n => STM.succeed(i.toString)
                    }.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -106,7 +106,7 @@ object TArraySpec extends ZIOBaseSpec {
                       }.commit.fork
           _      <- STM.foreach(0 until N)(i => tArray.update(i, _ => Some(1))).commit
           result <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime.toString)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime.toString)) || isNone)
       },
       testM("fails on errors before result found") {
         for {
@@ -115,7 +115,7 @@ object TArraySpec extends ZIOBaseSpec {
                      case Some(i) if i > 2 => STM.succeed(i.toString)
                      case _                => STM.fail(boom)
                    }.commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("succeeds on errors after result found") {
         for {
@@ -124,7 +124,7 @@ object TArraySpec extends ZIOBaseSpec {
                      case Some(i) if i > 2 => STM.succeed(i.toString)
                      case Some(7)          => STM.fail(boom)
                    }.commit
-        } yield assert(result, isSome(equalTo("4")))
+        } yield assert(result)(isSome(equalTo("4")))
       }
     ),
     suite("contains")(
@@ -132,19 +132,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.contains(3).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("false when not in the array") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.contains(n + 1).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("false for empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.contains(0).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       }
     ),
     suite("count")(
@@ -152,19 +152,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.count(_ % 2 == 0).commit
-        } yield assert(result, equalTo(5))
+        } yield assert(result)(equalTo(5))
       },
       testM("zero for absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.count(_ > n).commit
-        } yield assert(result, equalTo(0))
+        } yield assert(result)(equalTo(0))
       },
       testM("zero for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.count(_ => true).commit
-        } yield assert(result, equalTo(0))
+        } yield assert(result)(equalTo(0))
       }
     ),
     suite("countM")(
@@ -172,19 +172,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.countM(i => STM.succeed(i % 2 == 0)).commit
-        } yield assert(result, equalTo(5))
+        } yield assert(result)(equalTo(5))
       },
       testM("zero for absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.countM(i => STM.succeed(i > n)).commit
-        } yield assert(result, equalTo(0))
+        } yield assert(result)(equalTo(0))
       },
       testM("zero for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.countM(_ => STM.succeed(true)).commit
-        } yield assert(result, equalTo(0))
+        } yield assert(result)(equalTo(0))
       }
     ),
     suite("exists")(
@@ -192,19 +192,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.exists(_ % 2 == 0).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.exists(_ % 11 == 0).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("false for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.exists(_ => true).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       }
     ),
     suite("existsM")(
@@ -212,31 +212,31 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.existsM(i => STM.succeed(i % 2 == 0)).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.existsM(i => STM.succeed(i % 11 == 0)).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("false for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.existsM(_ => STM.succeed(true)).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("fails for errors before witness") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.existsM(i => if (i == 4) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("fails for errors after witness") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.existsM(i => if (i == 6) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       }
     ),
     suite("find")(
@@ -244,19 +244,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.find(_ % 5 == 0).commit
-        } yield assert(result, isSome(equalTo(5)))
+        } yield assert(result)(isSome(equalTo(5)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
           result <- tArray.find(_ => true).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.find(_ > n).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -264,7 +264,7 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.find(_ % largePrime == 0).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime)) || isNone)
       }
     ),
     suite("findLast")(
@@ -272,19 +272,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLast(_ % 5 == 0).commit
-        } yield assert(result, isSome(equalTo(10)))
+        } yield assert(result)(isSome(equalTo(10)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
           result <- tArray.findLast(_ => true).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLast(_ > n).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -292,7 +292,7 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.findLast(_ % largePrime == 0).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime * 4)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime * 4)) || isNone)
       }
     ),
     suite("findLastM")(
@@ -300,19 +300,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLastM(i => STM.succeed(i % 5 == 0)).commit
-        } yield assert(result, isSome(equalTo(10)))
+        } yield assert(result)(isSome(equalTo(10)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
           result <- tArray.findLastM(_ => STM.succeed(true)).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLastM(i => STM.succeed(i > n)).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -320,19 +320,19 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.findLastM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime * 4)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime * 4)) || isNone)
       },
       testM("succeeds on errors before result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLastM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 7 == 0)).commit
-        } yield assert(result, isSome(equalTo(7)))
+        } yield assert(result)(isSome(equalTo(7)))
       },
       testM("fails on errors after result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findLastM(i => if (i == 8) STM.fail(boom) else STM.succeed(i % 7 == 0)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       }
     ),
     suite("findM")(
@@ -340,19 +340,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findM(i => STM.succeed(i % 5 == 0)).commit
-        } yield assert(result, isSome(equalTo(5)))
+        } yield assert(result)(isSome(equalTo(5)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
           result <- tArray.findM(_ => STM.succeed(true)).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findM(i => STM.succeed(i > n)).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -360,19 +360,19 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.findM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo(largePrime)) || isNone)
+        } yield assert(result)(isSome(equalTo(largePrime)) || isNone)
       },
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.findM(i => if (i == 6) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit
-        } yield assert(result, isSome(equalTo(5)))
+        } yield assert(result)(isSome(equalTo(5)))
       }
     ),
     suite("firstOption")(
@@ -380,13 +380,13 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.firstOption.commit
-        } yield assert(result, isSome(equalTo(1)))
+        } yield assert(result)(isSome(equalTo(1)))
       },
       testM("is none for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.firstOption.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       }
     ),
     suite("fold")(
@@ -396,7 +396,7 @@ object TArraySpec extends ZIOBaseSpec {
           sum1Fiber <- tArray.fold(0)(_ + _).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ + 1)).commit
           sum1      <- sum1Fiber.join
-        } yield assert(sum1, equalTo(0) || equalTo(N))
+        } yield assert(sum1)(equalTo(0) || equalTo(N))
       }
     ),
     suite("foldM")(
@@ -406,7 +406,7 @@ object TArraySpec extends ZIOBaseSpec {
           sum1Fiber <- tArray.foldM(0)((z, a) => STM.succeed(z + a)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ + 1)).commit
           sum1      <- sum1Fiber.join
-        } yield assert(sum1, equalTo(0) || equalTo(N))
+        } yield assert(sum1)(equalTo(0) || equalTo(N))
       },
       testM("returns effect failure") {
         def failInTheMiddle(acc: Int, a: Int): STM[Exception, Int] =
@@ -415,7 +415,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray(N)(1).commit
           res    <- tArray.foldM(0)(failInTheMiddle).commit.either
-        } yield assert(res, isLeft(equalTo(boom)))
+        } yield assert(res)(isLeft(equalTo(boom)))
       }
     ),
     suite("forall")(
@@ -423,19 +423,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forall(_ < n + 1).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forall(_ < n - 1).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("true for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.forall(_ => false).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       }
     ),
     suite("forallM")(
@@ -443,31 +443,31 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forallM(i => STM.succeed(i < n + 1)).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forallM(i => STM.succeed(i < n - 1)).commit
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       },
       testM("true for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.forallM(_ => STM.succeed(false)).commit
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("fails for errors before counterexample") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forallM(i => if (i == 4) STM.fail(boom) else STM.succeed(i != 5)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("fails for errors after counterexample") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.forallM(i => if (i == 6) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       }
     ),
     suite("foreach")(
@@ -477,7 +477,7 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- makeTArray(n)(1).commit
           _      <- tArray.foreach(a => ref.update(_ + a).unit).commit.fork
           value  <- ref.get.commit
-        } yield assert(value, equalTo(0) || equalTo(n))
+        } yield assert(value)(equalTo(0) || equalTo(n))
       }
     ),
     suite("indexOf")(
@@ -485,43 +485,43 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(2).commit
-        } yield assert(result, equalTo(1))
+        } yield assert(result)(equalTo(1))
       },
       testM("-1 for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.indexOf(1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for absent") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(4).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("correct index if in array, with offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(2, 2).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("-1 if absent after offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(1, 7).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for negative offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(2, -1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for too high offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.indexOf(2, 9).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       }
     ),
     suite("indexWhere")(
@@ -529,19 +529,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ % 5 == 0).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("-1 for empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.indexWhere(_ => true).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ > n).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("is atomic") {
         for {
@@ -549,31 +549,31 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.indexWhere(_ % largePrime == 0).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, equalTo(largePrime - 1) || equalTo(-1))
+        } yield assert(result)(equalTo(largePrime - 1) || equalTo(-1))
       },
       testM("correct index if in array, with offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ % 2 == 0, 5).commit
-        } yield assert(result, equalTo(5))
+        } yield assert(result)(equalTo(5))
       },
       testM("-1 if absent after offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ % 7 == 0, 7).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for negative offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ => true, -1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for too high offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhere(_ => true, n + 1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       }
     ),
     suite("indexWhereM")(
@@ -581,19 +581,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => STM.succeed(i % 5 == 0)).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("-1 for empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.indexWhereM(_ => STM.succeed(true)).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for absent") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => STM.succeed(i > n)).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("is atomic") {
         for {
@@ -601,49 +601,49 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.indexWhereM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, equalTo(largePrime - 1) || equalTo(-1))
+        } yield assert(result)(equalTo(largePrime - 1) || equalTo(-1))
       },
       testM("correct index if in array, with offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => STM.succeed(i % 2 == 0), 5).commit
-        } yield assert(result, equalTo(5))
+        } yield assert(result)(equalTo(5))
       },
       testM("-1 if absent after offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => STM.succeed(i % 7 == 0), 7).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for negative offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(_ => STM.succeed(true), -1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for too high offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(_ => STM.succeed(true), n + 1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       },
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => if (i == 6) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("succeeds when error excluded by offset") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.indexWhereM(i => if (i == 1) STM.fail(boom) else STM.succeed(i % 5 == 0), 2).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       }
     ),
     suite("lastIndexOf")(
@@ -651,43 +651,43 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(2).commit
-        } yield assert(result, equalTo(7))
+        } yield assert(result)(equalTo(7))
       },
       testM("-1 for empty") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.lastIndexOf(1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for absent") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(4).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("correct index if in array, with limit") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(2, 6).commit
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("-1 if absent before limit") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(3, 1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for negative offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(2, -1).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       },
       testM("-1 for too high offset") {
         for {
           tArray <- makeRepeats(3)(3).commit
           result <- tArray.lastIndexOf(2, 9).commit
-        } yield assert(result, equalTo(-1))
+        } yield assert(result)(equalTo(-1))
       }
     ),
     suite("lastOption")(
@@ -695,13 +695,13 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.lastOption.commit
-        } yield assert(result, isSome(equalTo(n)))
+        } yield assert(result)(isSome(equalTo(n)))
       },
       testM("is none for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.lastOption.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       }
     ),
     suite("transform")(
@@ -713,7 +713,7 @@ object TArraySpec extends ZIOBaseSpec {
           _              <- transformFiber.join
           first          <- tArray(0).commit
           last           <- tArray(N - 1).commit
-        } yield assert((first, last), equalTo(("a+b+c", "a+b+c")) || equalTo(("a+c+b", "a+c+b")))
+        } yield assert((first, last))(equalTo(("a+b+c", "a+b+c")) || equalTo(("a+c+b", "a+c+b")))
       }
     ),
     suite("transformM")(
@@ -725,7 +725,7 @@ object TArraySpec extends ZIOBaseSpec {
           _              <- transformFiber.join
           first          <- tArray(0).commit
           last           <- tArray(N - 1).commit
-        } yield assert((first, last), equalTo(("a+b+c", "a+b+c")) || equalTo(("a+c+b", "a+c+b")))
+        } yield assert((first, last))(equalTo(("a+b+c", "a+b+c")) || equalTo(("a+c+b", "a+c+b")))
       },
       testM("updates all or nothing") {
         for {
@@ -733,7 +733,7 @@ object TArraySpec extends ZIOBaseSpec {
           _      <- tArray.update(N / 2, _ => 1).commit
           result <- tArray.transformM(a => if (a == 0) STM.succeed(42) else STM.fail(boom)).commit.either
           first  <- tArray(0).commit
-        } yield assert(result.left.map(r => (first, r)), isLeft(equalTo((0, boom))))
+        } yield assert(result.left.map(r => (first, r)))(isLeft(equalTo((0, boom))))
       }
     ),
     suite("update")(
@@ -741,13 +741,13 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray(1)(42).commit
           items  <- (tArray.update(0, a => -a) *> valuesOf(tArray)).commit
-        } yield assert(items, equalTo(List(-42)))
+        } yield assert(items)(equalTo(List(-42)))
       },
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
           result <- ZIO.effect(tArray.update(-1, identity)).run
-        } yield assert(result, fails(isArrayIndexOutOfBoundsException))
+        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
       }
     ),
     suite("updateM")(
@@ -755,19 +755,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray(1)(42).commit
           items  <- (tArray.updateM(0, a => STM.succeed(-a)) *> valuesOf(tArray)).commit
-        } yield assert(items, equalTo(List(-42)))
+        } yield assert(items)(equalTo(List(-42)))
       },
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(10)(0).commit
           result <- ZIO.effect(tArray.updateM(10, STM.succeed)).run
-        } yield assert(result, fails(isArrayIndexOutOfBoundsException))
+        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
       },
       testM("updateM failure") {
         for {
           tArray <- makeTArray(n)(0).commit
           result <- tArray.updateM(0, _ => STM.fail(boom)).commit.either
-        } yield assert(result, isLeft(equalTo(boom)))
+        } yield assert(result)(isLeft(equalTo(boom)))
       }
     ),
     suite("maxOption")(
@@ -775,13 +775,13 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.maxOption.commit
-        } yield assert(result, isSome(equalTo(n)))
+        } yield assert(result)(isSome(equalTo(n)))
       },
       testM("returns none for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.maxOption.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       }
     ),
     suite("minOption")(
@@ -789,13 +789,13 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.minOption.commit
-        } yield assert(result, isSome(equalTo(1)))
+        } yield assert(result)(isSome(equalTo(1)))
       },
       testM("returns none for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.minOption.commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       }
     ),
     suite("reduceOption")(
@@ -803,19 +803,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.reduceOption(_ + _).commit
-        } yield assert(result, isSome(equalTo((n * (n + 1)) / 2)))
+        } yield assert(result)(isSome(equalTo((n * (n + 1)) / 2)))
       },
       testM("returns single entry") {
         for {
           tArray <- makeTArray(1)(1).commit
           result <- tArray.reduceOption(_ + _).commit
-        } yield assert(result, isSome(equalTo(1)))
+        } yield assert(result)(isSome(equalTo(1)))
       },
       testM("returns None for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.reduceOption(_ + _).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -823,7 +823,7 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.reduceOption(_ + _).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo((N * (N + 1)) / 2)) || isSome(equalTo(N)))
+        } yield assert(result)(isSome(equalTo((N * (N + 1)) / 2)) || isSome(equalTo(N)))
       }
     ),
     suite("reduceOptionM")(
@@ -831,19 +831,19 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.reduceOptionM(sumSucceed).commit
-        } yield assert(result, isSome(equalTo((n * (n + 1)) / 2)))
+        } yield assert(result)(isSome(equalTo((n * (n + 1)) / 2)))
       },
       testM("returns single entry") {
         for {
           tArray <- makeTArray(1)(1).commit
           result <- tArray.reduceOptionM(sumSucceed).commit
-        } yield assert(result, isSome(equalTo(1)))
+        } yield assert(result)(isSome(equalTo(1)))
       },
       testM("returns None for an empty array") {
         for {
           tArray <- TArray.empty[Int].commit
           result <- tArray.reduceOptionM(sumSucceed).commit
-        } yield assert(result, isNone)
+        } yield assert(result)(isNone)
       },
       testM("is atomic") {
         for {
@@ -851,13 +851,13 @@ object TArraySpec extends ZIOBaseSpec {
           findFiber <- tArray.reduceOptionM(sumSucceed).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
-        } yield assert(result, isSome(equalTo((N * (N + 1)) / 2)) || isSome(equalTo(N)))
+        } yield assert(result)(isSome(equalTo((N * (N + 1)) / 2)) || isSome(equalTo(N)))
       },
       testM("fails on errors") {
         for {
           tArray <- makeStair(n).commit
           result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.fail(boom) else STM.succeed(a + b)).commit.flip
-        } yield assert(result, equalTo(boom))
+        } yield assert(result)(equalTo(boom))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -26,53 +26,53 @@ object TMapSpec extends ZIOBaseSpec {
     suite("factories")(
       testM("apply") {
         val tx = TMap.make("a" -> 1, "b" -> 2, "c" -> 2, "b" -> 3).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List("a" -> 1, "b" -> 3, "c" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("a" -> 1, "b" -> 3, "c" -> 2)))
       },
       testM("empty") {
         val tx = TMap.empty[String, Int].flatMap(_.toList)
-        assertM(tx.commit, isEmpty)
+        assertM(tx.commit)(isEmpty)
       },
       testM("fromIterable") {
         val tx = TMap.fromIterable(List("a" -> 1, "b" -> 2, "c" -> 2, "b" -> 3)).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List("a" -> 1, "b" -> 3, "c" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("a" -> 1, "b" -> 3, "c" -> 2)))
       }
     ),
     suite("lookups")(
       testM("get existing element") {
         val tx = TMap.make("a" -> 1, "b" -> 2).flatMap(_.get("a"))
-        assertM(tx.commit, isSome(equalTo(1)))
+        assertM(tx.commit)(isSome(equalTo(1)))
       },
       testM("get non-existing element") {
         val tx = TMap.empty[String, Int].flatMap(_.get("a"))
-        assertM(tx.commit, isNone)
+        assertM(tx.commit)(isNone)
       },
       testM("getOrElse existing element") {
         val tx = TMap.make("a" -> 1, "b" -> 2).flatMap(_.getOrElse("a", 10))
-        assertM(tx.commit, equalTo(1))
+        assertM(tx.commit)(equalTo(1))
       },
       testM("getOrElse non-existing element") {
         val tx = TMap.empty[String, Int].flatMap(_.getOrElse("a", 10))
-        assertM(tx.commit, equalTo(10))
+        assertM(tx.commit)(equalTo(10))
       },
       testM("contains existing element") {
         val tx = TMap.make("a" -> 1, "b" -> 2).flatMap(_.contains("a"))
-        assertM(tx.commit, isTrue)
+        assertM(tx.commit)(isTrue)
       },
       testM("contains non-existing element") {
         val tx = TMap.empty[String, Int].flatMap(_.contains("a"))
-        assertM(tx.commit, isFalse)
+        assertM(tx.commit)(isFalse)
       },
       testM("collect all elements") {
         val tx = TMap.make("a" -> 1, "b" -> 2, "c" -> 3).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List("a" -> 1, "b" -> 2, "c" -> 3)))
+        assertM(tx.commit)(hasSameElements(List("a" -> 1, "b" -> 2, "c" -> 3)))
       },
       testM("collect all keys") {
         val tx = TMap.make("a" -> 1, "b" -> 2, "c" -> 3).flatMap(_.keys)
-        assertM(tx.commit, hasSameElements(List("a", "b", "c")))
+        assertM(tx.commit)(hasSameElements(List("a", "b", "c")))
       },
       testM("collect all values") {
         val tx = TMap.make("a" -> 1, "b" -> 2, "c" -> 3).flatMap(_.values)
-        assertM(tx.commit, hasSameElements(List(1, 2, 3)))
+        assertM(tx.commit)(hasSameElements(List(1, 2, 3)))
       }
     ),
     suite("insertion and removal")(
@@ -84,7 +84,7 @@ object TMapSpec extends ZIOBaseSpec {
             e    <- tmap.get("a")
           } yield e
 
-        assertM(tx.commit, isSome(equalTo(1)))
+        assertM(tx.commit)(isSome(equalTo(1)))
       },
       testM("overwrite existing element") {
         val tx =
@@ -94,7 +94,7 @@ object TMapSpec extends ZIOBaseSpec {
             e    <- tmap.get("a")
           } yield e
 
-        assertM(tx.commit, isSome(equalTo(10)))
+        assertM(tx.commit)(isSome(equalTo(10)))
       },
       testM("remove existing element") {
         val tx =
@@ -104,7 +104,7 @@ object TMapSpec extends ZIOBaseSpec {
             e    <- tmap.get("a")
           } yield e
 
-        assertM(tx.commit, isNone)
+        assertM(tx.commit)(isNone)
       },
       testM("remove non-existing element") {
         val tx =
@@ -114,7 +114,7 @@ object TMapSpec extends ZIOBaseSpec {
             e    <- tmap.get("a")
           } yield e
 
-        assertM(tx.commit, isNone)
+        assertM(tx.commit)(isNone)
       },
       testM("add many keys with negative hash codes") {
         val expected = Range(1, 1000).map(i => HashContainer(-i) -> i).toList
@@ -126,7 +126,7 @@ object TMapSpec extends ZIOBaseSpec {
             e    <- tmap.toList
           } yield e
 
-        assertM(tx.commit, hasSameElements(expected))
+        assertM(tx.commit)(hasSameElements(expected))
       }
     ),
     suite("transformations")(
@@ -138,7 +138,7 @@ object TMapSpec extends ZIOBaseSpec {
             b    <- tmap.merge("b", 2)(_ + _)
           } yield (a, b)
 
-        assertM(tx.commit, equalTo((3, 2)))
+        assertM(tx.commit)(equalTo((3, 2)))
       },
       testM("retainIf") {
         val tx =
@@ -150,7 +150,7 @@ object TMapSpec extends ZIOBaseSpec {
             aaa  <- tmap.contains("aaa")
           } yield (a, aa, aaa)
 
-        assertM(tx.commit, equalTo((false, true, false)))
+        assertM(tx.commit)(equalTo((false, true, false)))
       },
       testM("removeIf") {
         val tx =
@@ -162,7 +162,7 @@ object TMapSpec extends ZIOBaseSpec {
             aaa  <- tmap.contains("aaa")
           } yield (a, aa, aaa)
 
-        assertM(tx.commit, equalTo((true, false, true)))
+        assertM(tx.commit)(equalTo((true, false, true)))
       },
       testM("transform") {
         val tx =
@@ -172,7 +172,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("b" -> 2, "bb" -> 4, "bbb" -> 6)))
+        assertM(tx.commit)(hasSameElements(List("b" -> 2, "bb" -> 4, "bbb" -> 6)))
       },
       testM("transform with keys with negative hash codes") {
         val tx =
@@ -182,10 +182,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(
-          tx.commit,
-          hasSameElements(List(HashContainer(2) -> 2, HashContainer(4) -> 4, HashContainer(6) -> 6))
-        )
+        assertM(tx.commit)(hasSameElements(List(HashContainer(2) -> 2, HashContainer(4) -> 4, HashContainer(6) -> 6)))
       },
       testM("transform and shrink") {
         val tx =
@@ -195,7 +192,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("key" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("key" -> 2)))
       },
       testM("transformM") {
         val tx =
@@ -205,7 +202,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("b" -> 2, "bb" -> 4, "bbb" -> 6)))
+        assertM(tx.commit)(hasSameElements(List("b" -> 2, "bb" -> 4, "bbb" -> 6)))
       },
       testM("transformM and shrink") {
         val tx =
@@ -215,7 +212,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("key" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("key" -> 2)))
       },
       testM("transformValues") {
         val tx =
@@ -225,7 +222,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("a" -> 2, "aa" -> 4, "aaa" -> 6)))
+        assertM(tx.commit)(hasSameElements(List("a" -> 2, "aa" -> 4, "aaa" -> 6)))
       },
       testM("transformValuesM") {
         val tx =
@@ -235,7 +232,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List("a" -> 2, "aa" -> 4, "aaa" -> 6)))
+        assertM(tx.commit)(hasSameElements(List("a" -> 2, "aa" -> 4, "aaa" -> 6)))
       }
     ),
     suite("folds")(
@@ -246,7 +243,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.fold(0)((acc, kv) => acc + kv._2)
           } yield res
 
-        assertM(tx.commit, equalTo(6))
+        assertM(tx.commit)(equalTo(6))
       },
       testM("fold on empty map") {
         val tx =
@@ -255,7 +252,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.fold(0)((acc, kv) => acc + kv._2)
           } yield res
 
-        assertM(tx.commit, equalTo(0))
+        assertM(tx.commit)(equalTo(0))
       },
       testM("foldM on non-empty map") {
         val tx =
@@ -264,7 +261,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.foldM(0)((acc, kv) => STM.succeed(acc + kv._2))
           } yield res
 
-        assertM(tx.commit, equalTo(6))
+        assertM(tx.commit)(equalTo(6))
       },
       testM("foldM on empty map") {
         val tx =
@@ -273,7 +270,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.foldM(0)((acc, kv) => STM.succeed(acc + kv._2))
           } yield res
 
-        assertM(tx.commit, equalTo(0))
+        assertM(tx.commit)(equalTo(0))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
@@ -32,13 +32,13 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
       for {
         lock  <- TReentrantLock.make.commit
         count <- lock.readLock.use(count => ZIO.succeed(count))
-      } yield assert(count, equalTo(1))
+      } yield assert(count)(equalTo(1))
     },
     testM("2 read locks from same fiber") {
       for {
         lock  <- TReentrantLock.make.commit
         count <- lock.readLock.use(_ => lock.readLock.use(count => ZIO.succeed(count)))
-      } yield assert(count, equalTo(2))
+      } yield assert(count)(equalTo(2))
     },
     testM("2 read locks from different fibers") {
       for {
@@ -51,7 +51,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         reader2 <- lock.readLock.use(count => wlatch.succeed(()) as count).fork
         _       <- wlatch.await
         count   <- reader2.join
-      } yield assert(count, equalTo(2))
+      } yield assert(count)(equalTo(2))
     } @@ timeout(10.seconds),
     testM("1 write lock then 1 read lock, different fibers") {
       for {
@@ -67,9 +67,9 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         option <- reader.poll.repeat(pollSchedule)
         _      <- wlatch.succeed(())
         rcount <- reader.join
-      } yield assert(locks, equalTo(1)) &&
-        assert(option, isNone) &&
-        assert(1, equalTo(rcount))
+      } yield assert(locks)(equalTo(1)) &&
+        assert(option)(isNone) &&
+        assert(1)(equalTo(rcount))
     } @@ timeout(10.seconds),
     testM("1 write lock then 1 write lock, different fibers") {
       for {
@@ -85,9 +85,9 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         option <- reader.poll.repeat(pollSchedule)
         _      <- wlatch.succeed(())
         rcount <- reader.join
-      } yield assert(locks, equalTo(1)) &&
-        assert(option, isNone) &&
-        assert(1, equalTo(rcount))
+      } yield assert(locks)(equalTo(1)) &&
+        assert(option)(isNone) &&
+        assert(1)(equalTo(rcount))
     } @@ timeout(10.seconds),
     testM("write lock followed by read lock from same fiber") {
       for {
@@ -96,7 +96,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         rcount <- lock.writeLock
                    .use(_ => lock.readLock.use(count => lock.writeLocks.commit.flatMap(ref.set(_)) as count))
         wcount <- ref.get
-      } yield assert(rcount, equalTo(1)) && assert(wcount, equalTo(1))
+      } yield assert(rcount)(equalTo(1)) && assert(wcount)(equalTo(1))
     },
     testM("upgrade read lock to write lock from same fiber") {
       for {
@@ -105,7 +105,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         rcount <- lock.readLock
                    .use(_ => lock.writeLock.use(count => lock.writeLocks.commit.flatMap(ref.set(_)) as count))
         wcount <- ref.get
-      } yield assert(rcount, equalTo(1)) && assert(wcount, equalTo(1))
+      } yield assert(rcount)(equalTo(1)) && assert(wcount)(equalTo(1))
     },
     testM("read to writer upgrade with other readers") {
       for {
@@ -120,7 +120,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         option <- writer.poll.repeat(pollSchedule)
         _      <- rlatch.succeed(())
         count  <- writer.join
-      } yield assert(option, isNone) && assert(count, equalTo(1))
+      } yield assert(option)(isNone) && assert(count)(equalTo(1))
     } @@ timeout(10.seconds)
   )
 }

--- a/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
@@ -26,34 +26,34 @@ object TSetSpec extends ZIOBaseSpec {
     suite("factories")(
       testM("apply") {
         val tx = TSet.make(1, 2, 2, 3).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List(1, 2, 3)))
+        assertM(tx.commit)(hasSameElements(List(1, 2, 3)))
 
       },
       testM("empty") {
         val tx = TSet.empty[Int].flatMap(_.toList)
-        assertM(tx.commit, isEmpty)
+        assertM(tx.commit)(isEmpty)
       },
       testM("fromIterable") {
         val tx = TSet.fromIterable(List(1, 2, 2, 3)).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List(1, 2, 3)))
+        assertM(tx.commit)(hasSameElements(List(1, 2, 3)))
       }
     ),
     suite("lookups")(
       testM("contains existing element") {
         val tx = TSet.make(1, 2, 3, 4).flatMap(_.contains(1))
-        assertM(tx.commit, isTrue)
+        assertM(tx.commit)(isTrue)
       },
       testM("contains non-existing element") {
         val tx = TSet.make(1, 2, 3, 4).flatMap(_.contains(0))
-        assertM(tx.commit, isFalse)
+        assertM(tx.commit)(isFalse)
       },
       testM("collect all elements") {
         val tx = TSet.make(1, 2, 3, 4).flatMap(_.toList)
-        assertM(tx.commit, hasSameElements(List(1, 2, 3, 4)))
+        assertM(tx.commit)(hasSameElements(List(1, 2, 3, 4)))
       },
       testM("cardinality") {
         val tx = TSet.make(1, 2, 3, 4).flatMap(_.size)
-        assertM(tx.commit, equalTo(4))
+        assertM(tx.commit)(equalTo(4))
       }
     ),
     suite("insertion and removal")(
@@ -65,7 +65,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1)))
+        assertM(tx.commit)(hasSameElements(List(1)))
       },
       testM("add duplicate element") {
         val tx =
@@ -75,7 +75,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1)))
+        assertM(tx.commit)(hasSameElements(List(1)))
       },
       testM("remove existing element") {
         val tx =
@@ -85,7 +85,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(2)))
+        assertM(tx.commit)(hasSameElements(List(2)))
       },
       testM("remove non-existing element") {
         val tx =
@@ -95,7 +95,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1, 2)))
+        assertM(tx.commit)(hasSameElements(List(1, 2)))
       }
     ),
     suite("transformations")(
@@ -109,7 +109,7 @@ object TSetSpec extends ZIOBaseSpec {
             aaa  <- tset.contains("aaa")
           } yield (a, aa, aaa)
 
-        assertM(tx.commit, equalTo((false, true, false)))
+        assertM(tx.commit)(equalTo((false, true, false)))
       },
       testM("removeIf") {
         val tx =
@@ -121,7 +121,7 @@ object TSetSpec extends ZIOBaseSpec {
             aaa  <- tset.contains("aaa")
           } yield (a, aa, aaa)
 
-        assertM(tx.commit, equalTo((true, false, true)))
+        assertM(tx.commit)(equalTo((true, false, true)))
       },
       testM("transform") {
         val tx =
@@ -131,7 +131,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(2, 4, 6)))
+        assertM(tx.commit)(hasSameElements(List(2, 4, 6)))
       },
       testM("transform and shrink") {
         val tx =
@@ -141,7 +141,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1)))
+        assertM(tx.commit)(hasSameElements(List(1)))
       },
       testM("transformM") {
         val tx =
@@ -151,7 +151,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(2, 4, 6)))
+        assertM(tx.commit)(hasSameElements(List(2, 4, 6)))
       },
       testM("transformM and shrink") {
         val tx =
@@ -161,7 +161,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1)))
+        assertM(tx.commit)(hasSameElements(List(1)))
       }
     ),
     suite("folds")(
@@ -172,7 +172,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.fold(0)(_ + _)
           } yield res
 
-        assertM(tx.commit, equalTo(6))
+        assertM(tx.commit)(equalTo(6))
       },
       testM("fold on empty set") {
         val tx =
@@ -181,7 +181,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.fold(0)(_ + _)
           } yield res
 
-        assertM(tx.commit, equalTo(0))
+        assertM(tx.commit)(equalTo(0))
       },
       testM("foldM on non-empty set") {
         val tx =
@@ -190,7 +190,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.foldM(0)((acc, a) => STM.succeed(acc + a))
           } yield res
 
-        assertM(tx.commit, equalTo(6))
+        assertM(tx.commit)(equalTo(6))
       },
       testM("foldM on empty set") {
         val tx =
@@ -199,7 +199,7 @@ object TSetSpec extends ZIOBaseSpec {
             res  <- tset.foldM(0)((acc, a) => STM.succeed(acc + a))
           } yield res
 
-        assertM(tx.commit, equalTo(0))
+        assertM(tx.commit)(equalTo(0))
       }
     ),
     suite("set operations")(
@@ -212,7 +212,7 @@ object TSetSpec extends ZIOBaseSpec {
             res   <- tset1.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(2, 3)))
+        assertM(tx.commit)(hasSameElements(List(2, 3)))
       },
       testM("intersect") {
         val tx =
@@ -223,7 +223,7 @@ object TSetSpec extends ZIOBaseSpec {
             res   <- tset1.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1)))
+        assertM(tx.commit)(hasSameElements(List(1)))
       },
       testM("union") {
         val tx =
@@ -234,7 +234,7 @@ object TSetSpec extends ZIOBaseSpec {
             res   <- tset1.toList
           } yield res
 
-        assertM(tx.commit, hasSameElements(List(1, 2, 3, 4, 5)))
+        assertM(tx.commit)(hasSameElements(List(1, 2, 3, 4, 5)))
       }
     )
   )

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -14,52 +14,52 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("apply") {
       check(chunkWithIndex(Gen.unit)) {
         case (chunk, i) =>
-          assert(chunk.apply(i), equalTo(chunk.toSeq.apply(i)))
+          assert(chunk.apply(i))(equalTo(chunk.toSeq.apply(i)))
       }
     },
     testM("length") {
       check(largeChunks(intGen)) { chunk =>
-        assert(chunk.length, equalTo(chunk.toSeq.length))
+        assert(chunk.length)(equalTo(chunk.toSeq.length))
       }
     },
     testM("equality") {
       check(mediumChunks(intGen), mediumChunks(intGen)) { (c1, c2) =>
-        assert(c1.equals(c2), equalTo(c1.toSeq.equals(c2.toSeq)))
+        assert(c1.equals(c2))(equalTo(c1.toSeq.equals(c2.toSeq)))
       }
     },
     test("inequality") {
-      assert(Chunk(1, 2, 3, 4, 5), Assertion.not(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
+      assert(Chunk(1, 2, 3, 4, 5))(Assertion.not(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
     },
     testM("materialize") {
       check(mediumChunks(intGen)) { c =>
-        assert(c.materialize.toSeq, equalTo(c.toSeq))
+        assert(c.materialize.toSeq)(equalTo(c.toSeq))
       }
     },
     testM("foldLeft") {
       check(stringGen, Gen.function2(stringGen), smallChunks(intGen)) { (s0, f, c) =>
-        assert(c.fold(s0)(f), equalTo(c.toArray.foldLeft(s0)(f)))
+        assert(c.fold(s0)(f))(equalTo(c.toArray.foldLeft(s0)(f)))
       }
     },
     test("mapAccum") {
-      assert(Chunk(1, 1, 1).mapAccum(0)((s, el) => (s + el, s + el)), equalTo((3, Chunk(1, 2, 3))))
+      assert(Chunk(1, 1, 1).mapAccum(0)((s, el) => (s + el, s + el)))(equalTo((3, Chunk(1, 2, 3))))
     },
     suite("mapAccumM")(
       testM("mapAccumM happy path") {
-        assertM(Chunk(1, 1, 1).mapAccumM(0)((s, el) => UIO.succeed((s + el, s + el))), equalTo((3, Chunk(1, 2, 3))))
+        assertM(Chunk(1, 1, 1).mapAccumM(0)((s, el) => UIO.succeed((s + el, s + el))))(equalTo((3, Chunk(1, 2, 3))))
       },
       testM("mapAccumM error") {
-        Chunk(1, 1, 1).mapAccumM(0)((_, _) => IO.fail("Ouch")).either.map(assert(_, isLeft(equalTo("Ouch"))))
+        Chunk(1, 1, 1).mapAccumM(0)((_, _) => IO.fail("Ouch")).either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("map") {
       val fn = Gen.function[Random with Sized, Int, String](stringGen)
       check(smallChunks(intGen), fn) { (c, f) =>
-        assert(c.map(f).toSeq, equalTo(c.toSeq.map(f)))
+        assert(c.map(f).toSeq)(equalTo(c.toSeq.map(f)))
       }
     },
     suite("mapM")(
       testM("mapM happy path")(checkM(mediumChunks(stringGen), Gen.function(Gen.boolean)) { (chunk, f) =>
-        chunk.mapM(s => UIO.succeed(f(s))).map(assert(_, equalTo(chunk.map(f))))
+        chunk.mapM(s => UIO.succeed(f(s))).map(assert(_)(equalTo(chunk.map(f))))
       }),
       testM("mapM error") {
         Chunk(1, 2, 3).mapM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
@@ -68,18 +68,18 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("flatMap") {
       val fn = Gen.function[Random with Sized, Int, Chunk[Int]](smallChunks(intGen))
       check(smallChunks(intGen), fn) { (c, f) =>
-        assert(c.flatMap(f).toSeq, equalTo(c.toSeq.flatMap(f.andThen(_.toSeq))))
+        assert(c.flatMap(f).toSeq)(equalTo(c.toSeq.flatMap(f.andThen(_.toSeq))))
       }
     },
     testM("filter") {
       val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
       check(mediumChunks(stringGen), fn) { (chunk, p) =>
-        assert(chunk.filter(p).toSeq, equalTo(chunk.toSeq.filter(p)))
+        assert(chunk.filter(p).toSeq)(equalTo(chunk.toSeq.filter(p)))
       }
     },
     suite("filterM")(
       testM("filterM happy path")(checkM(mediumChunks(stringGen), Gen.function(Gen.boolean)) { (chunk, p) =>
-        chunk.filterM(s => UIO.succeed(p(s))).map(assert(_, equalTo(chunk.filter(p))))
+        chunk.filterM(s => UIO.succeed(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
       }),
       testM("filterM error") {
         Chunk(1, 2, 3).filterM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
@@ -87,28 +87,28 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     testM("drop chunk") {
       check(largeChunks(intGen), intGen) { (chunk, n) =>
-        assert(chunk.drop(n).toSeq, equalTo(chunk.toSeq.drop(n)))
+        assert(chunk.drop(n).toSeq)(equalTo(chunk.toSeq.drop(n)))
       }
     },
     testM("take chunk") {
       check(chunkWithIndex(Gen.unit)) {
         case (c, n) =>
-          assert(c.take(n).toSeq, equalTo(c.toSeq.take(n)))
+          assert(c.take(n).toSeq)(equalTo(c.toSeq.take(n)))
       }
     },
     testM("dropWhile chunk") {
       check(mediumChunks(intGen), toBoolFn[Random, Int]) { (c, p) =>
-        assert(c.dropWhile(p).toSeq, equalTo(c.toSeq.dropWhile(p)))
+        assert(c.dropWhile(p).toSeq)(equalTo(c.toSeq.dropWhile(p)))
       }
     },
     testM("takeWhile chunk") {
       check(mediumChunks(intGen), toBoolFn[Random, Int]) { (c, p) =>
-        assert(c.takeWhile(p).toSeq, equalTo(c.toSeq.takeWhile(p)))
+        assert(c.takeWhile(p).toSeq)(equalTo(c.toSeq.takeWhile(p)))
       }
     },
     testM("toArray") {
       check(mediumChunks(intGen)) { c =>
-        assert(c.toArray.toSeq, equalTo(c.toSeq))
+        assert(c.toArray.toSeq)(equalTo(c.toSeq))
       }
     },
     test("non-homogeneous element type") {
@@ -120,31 +120,31 @@ object ChunkSpec extends ZIOBaseSpec {
       val actual   = Chunk.fromIterable(vector).map(identity)
       val expected = Chunk.fromArray(vector.toArray)
 
-      assert(actual, equalTo(expected))
+      assert(actual)(equalTo(expected))
     },
     test("toArray for an empty Chunk of type String") {
-      assert(Chunk.empty.toArray[String], equalTo(Array.empty[String]))
+      assert(Chunk.empty.toArray[String])(equalTo(Array.empty[String]))
     },
     test("to Array for an empty Chunk using filter") {
-      assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String], equalTo(Array.empty[String]))
+      assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
     },
     testM("toArray with elements of type String") {
       check(mediumChunks(stringGen)) { c =>
-        assert(c.toArray.toSeq, equalTo(c.toSeq))
+        assert(c.toArray.toSeq)(equalTo(c.toSeq))
       }
     },
     test("toArray for a Chunk of any type") {
       val v: Vector[Any] = Vector("String", 1, Value(2))
-      assert(Chunk.fromIterable(v).toArray.toVector, equalTo(v))
+      assert(Chunk.fromIterable(v).toArray.toVector)(equalTo(v))
     },
     suite("collect")(
       test("collect empty Chunk") {
-        assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty, Assertion.isTrue)
+        assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
       },
       testM("collect chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
         check(mediumChunks(intGen), pfGen) { (c, pf) =>
-          assert(c.collect(pf).toSeq, equalTo(c.toSeq.collect(pf)))
+          assert(c.collect(pf).toSeq)(equalTo(c.toSeq.collect(pf)))
         }
       }
     ),
@@ -158,21 +158,21 @@ object ChunkSpec extends ZIOBaseSpec {
           for {
             result   <- c.collectM(pf).map(_.toList)
             expected <- UIO.sequence(c.toList.collect(pf))
-          } yield assert(result, equalTo(expected))
+          } yield assert(result)(equalTo(expected))
         }
       },
       testM("collectM chunk that fails") {
-        Chunk(1, 2).collectM { case 2 => IO.fail("Ouch") }.either.map(assert(_, isLeft(equalTo("Ouch"))))
+        Chunk(1, 2).collectM { case 2 => IO.fail("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     suite("collectWhile")(
       test("collectWhile empty Chunk") {
-        assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty, Assertion.isTrue)
+        assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
       },
       testM("collectWhile chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
         check(mediumChunks(intGen), pfGen) { (c, pf) =>
-          assert(c.collectWhile(pf).toSeq, equalTo(c.toSeq.takeWhile(pf.isDefinedAt).map(pf.apply)))
+          assert(c.collectWhile(pf).toSeq)(equalTo(c.toSeq.takeWhile(pf.isDefinedAt).map(pf.apply)))
         }
       }
     ),
@@ -186,11 +186,11 @@ object ChunkSpec extends ZIOBaseSpec {
           for {
             result   <- c.collectWhileM(pf).map(_.toList)
             expected <- UIO.sequence(c.toList.takeWhile(pf.isDefinedAt).map(pf.apply))
-          } yield assert(result, equalTo(expected))
+          } yield assert(result)(equalTo(expected))
         }
       },
       testM("collectWhileM chunk that fails") {
-        Chunk(1, 2).collectWhileM { case _ => IO.fail("Ouch") }.either.map(assert(_, isLeft(equalTo("Ouch"))))
+        Chunk(1, 2).collectWhileM { case _ => IO.fail("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("foreach") {
@@ -198,43 +198,43 @@ object ChunkSpec extends ZIOBaseSpec {
         var sum = 0
         c.foreach(sum += _)
 
-        assert(sum, equalTo(c.toSeq.sum))
+        assert(sum)(equalTo(c.toSeq.sum))
       }
     },
     testM("concat chunk") {
       check(smallChunks(intGen), smallChunks(intGen)) { (c1, c2) =>
-        assert((c1 ++ c2).toSeq, equalTo(c1.toSeq ++ c2.toSeq))
+        assert((c1 ++ c2).toSeq)(equalTo(c1.toSeq ++ c2.toSeq))
       }
     },
     test("chunk transitivity") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       val c3 = Chunk(1, 2, 3)
-      assert(c1 == c2 && c2 == c3 && c1 == c3, Assertion.isTrue)
+      assert(c1 == c2 && c2 == c3 && c1 == c3)(Assertion.isTrue)
     },
     test("chunk symmetry") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
-      assert(c1 == c2 && c2 == c1, Assertion.isTrue)
+      assert(c1 == c2 && c2 == c1)(Assertion.isTrue)
     },
     test("chunk reflexivity") {
       val c1 = Chunk(1, 2, 3)
-      assert(c1 == c1, Assertion.isTrue)
+      assert(c1 == c1)(Assertion.isTrue)
     },
     test("chunk negation") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
-      assert(c1 != c2 == !(c1 == c2), Assertion.isTrue)
+      assert(c1 != c2 == !(c1 == c2))(Assertion.isTrue)
     },
     test("chunk substitutivity") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
-      assert(c1 == c2 && c1.toString == c2.toString, Assertion.isTrue)
+      assert(c1 == c2 && c1.toString == c2.toString)(Assertion.isTrue)
     },
     test("chunk consistency") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
-      assert(c1 == c2 && c1.hashCode == c2.hashCode, Assertion.isTrue)
+      assert(c1 == c2 && c1.hashCode == c2.hashCode)(Assertion.isTrue)
     },
     test("nullArrayBug") {
       val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
@@ -242,7 +242,7 @@ object ChunkSpec extends ZIOBaseSpec {
       // foreach should not throw
       c.foreach(_ => ())
 
-      assert(c.filter(_ => false).map(_ * 2).length, equalTo(0))
+      assert(c.filter(_ => false).map(_ * 2).length)(equalTo(0))
     },
     test("toArrayOnConcatOfSlice") {
       val onlyOdd: Int => Boolean = _ % 2 != 0
@@ -252,18 +252,18 @@ object ChunkSpec extends ZIOBaseSpec {
 
       val array = concat.toArray
 
-      assert(array, equalTo(Array(1, 1, 1, 3, 3, 3)))
+      assert(array)(equalTo(Array(1, 1, 1, 3, 3, 3)))
     },
     test("toArrayOnConcatOfEmptyAndInts") {
-      assert(Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3)), equalTo(Chunk(1, 2, 3)))
+      assert(Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3)))(equalTo(Chunk(1, 2, 3)))
     },
     test("filterConstFalseResultsInEmptyChunk") {
       assert(Chunk.fromArray(Array(1, 2, 3)).filter(_ => false))(equalTo(Chunk.empty))
     },
     test("def testzipAllWith") {
-      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _), equalTo(Chunk(4, 4, 4))) &&
-      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2))(_ => 0, _ => 0)(_ + _), equalTo(Chunk(4, 4, 0))) &&
-      assert(Chunk(1, 2).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _), equalTo(Chunk(4, 4, 0)))
+      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 4))) &&
+      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0))) &&
+      assert(Chunk(1, 2).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0)))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -17,33 +17,33 @@ object SinkSpec extends ZIOBaseSpec {
       suite("as")(
         testM("happy path") {
           val sink = ZSink.identity[Int].as("const")
-          assertM(sinkIteration(sink, 1), equalTo(("const", Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo(("const", Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.as("const")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.as("const")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.as("const")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("asError")(
         testM("init error") {
           val sink = initErrorSink.asError("Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         },
         testM("step error") {
           val sink = stepErrorSink.asError("Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         },
         testM("extract error") {
           val sink = extractErrorSink.asError("Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         }
       ),
       suite("chunked")(
@@ -57,15 +57,15 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.chunked
-          assertM(sinkIteration(sink, Chunk.single(1)).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, Chunk.single(1)).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.chunked
-          assertM(sinkIteration(sink, Chunk.single(1)).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, Chunk.single(1)).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.chunked
-          assertM(sinkIteration(sink, Chunk.single(1)).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, Chunk.single(1)).either)(isLeft(equalTo("Ouch")))
         },
         testM("leftover") {
           val sink = ZSink.collectAllN[Int](2).chunked
@@ -74,7 +74,7 @@ object SinkSpec extends ZIOBaseSpec {
             step           <- sink.step(init, Chunk(1, 2, 3, 4, 5))
             result         <- sink.extract(step)
             (b, leftovers) = result
-          } yield assert(b, equalTo(List(1, 2))) && assert(leftovers, equalTo(Chunk(3, 4, 5)))
+          } yield assert(b)(equalTo(List(1, 2))) && assert(leftovers)(equalTo(Chunk(3, 4, 5)))
         },
         testM("leftover append") {
           val sink = ZSink.ignoreWhile[Int](_ < 0).chunked
@@ -82,7 +82,7 @@ object SinkSpec extends ZIOBaseSpec {
             init   <- sink.initial
             step   <- sink.step(init, Chunk(1, 2, 3, 4, 5))
             result <- sink.extract(step)
-          } yield assert(result._2, equalTo(Chunk(1, 2, 3, 4, 5)))
+          } yield assert(result._2)(equalTo(Chunk(1, 2, 3, 4, 5)))
         }
       ),
       suite("collectAll")(
@@ -92,15 +92,15 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.collectAll
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.collectAll
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.collectAll
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("interaction with succeed") {
           val sink = ZSink.succeed[Int, Int](5).collectAll
@@ -111,7 +111,7 @@ object SinkSpec extends ZIOBaseSpec {
                   .flatMap(sink.step(_, 2))
                   .flatMap(sink.step(_, 3))
             result <- sink.extract(s)
-          } yield assert(result, equalTo(List(5, 5, 5, 5) -> Chunk(1, 2, 3)))
+          } yield assert(result)(equalTo(List(5, 5, 5, 5) -> Chunk(1, 2, 3)))
         },
         testM("interaction with ignoreWhile") {
           val sink = ZSink.ignoreWhile[Int](_ < 5).collectAll
@@ -123,7 +123,7 @@ object SinkSpec extends ZIOBaseSpec {
                        .flatMap(sink.step(_, 5))
                        .flatMap(sink.step(_, 6))
                        .flatMap(sink.extract)
-          } yield assert(result, equalTo(List((), ()) -> Chunk(5, 6)))
+          } yield assert(result)(equalTo(List((), ()) -> Chunk(5, 6)))
         }
       ),
       suite("collectAllN")(
@@ -136,7 +136,7 @@ object SinkSpec extends ZIOBaseSpec {
                        .flatMap(sink.step(_, 3))
                        .flatMap(sink.step(_, 4))
                        .flatMap(sink.extract)
-          } yield assert(result, equalTo(List(1, 2, 3) -> Chunk(4)))
+          } yield assert(result)(equalTo(List(1, 2, 3) -> Chunk(4)))
         },
         testM("empty list") {
           val sink = ZSink.identity[Int].collectAllN(0)
@@ -147,15 +147,15 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.collectAllN(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.collectAllN(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.collectAllN(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("collectAllWhile")(
@@ -168,7 +168,7 @@ object SinkSpec extends ZIOBaseSpec {
             step3  <- sink.step(step2, 3)
             step4  <- sink.step(step3, 4)
             result <- sink.extract(step4)
-          } yield assert(result, equalTo(List(List(1, 2, 3)) -> Chunk.single(4)))
+          } yield assert(result)(equalTo(List(List(1, 2, 3)) -> Chunk.single(4)))
         },
         testM("false predicate") {
           val sink = ZSink.identity[Int].collectAllWhile(_ < 0)
@@ -176,69 +176,69 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.collectAllWhile(_ < 4)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.collectAllWhile(_ < 4)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.collectAllWhile(_ < 4)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("contramap")(
         testM("happy path") {
           val sink = ZSink.identity[Int].contramap[String](_.toInt)
-          assertM(sinkIteration(sink, "1"), equalTo(1 -> Chunk.empty))
+          assertM(sinkIteration(sink, "1"))(equalTo(1 -> Chunk.empty))
         },
         testM("init error") {
           val sink = initErrorSink.contramap[String](_.toInt)
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.contramap[String](_.toInt)
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.contramap[String](_.toInt)
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("contramapM")(
         testM("happy path") {
           val sink = ZSink.identity[Int].contramapM[Any, Unit, String](s => UIO.succeed(s.toInt))
-          assertM(sinkIteration(sink, "1"), equalTo((1, Chunk.empty)))
+          assertM(sinkIteration(sink, "1"))(equalTo((1, Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
-          assertM(sinkIteration(sink, "1").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("dimap")(
         testM("happy path") {
           val sink = ZSink.identity[Int].dimap[String, String](_.toInt)(_.toString.reverse)
-          assertM(sinkIteration(sink, "123"), equalTo(("321", Chunk.empty)))
+          assertM(sinkIteration(sink, "123"))(equalTo(("321", Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-          assertM(sinkIteration(sink, "123").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "123").either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-          assertM(sinkIteration(sink, "123").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "123").either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.dimap[String, String](_.toInt)(_.toString.reverse)
-          assertM(sinkIteration(sink, "123").either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, "123").either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("drop")(
@@ -250,7 +250,7 @@ object SinkSpec extends ZIOBaseSpec {
             step2  <- sink.step(step1, 2)
             step3  <- sink.step(step2, 3)
             result <- sink.extract(step3)
-          } yield assert(result, equalTo((List(1, 2, 3), Chunk.empty)))
+          } yield assert(result)(equalTo((List(1, 2, 3), Chunk.empty)))
         },
         testM("happy path - drops more than one element") {
           val sink = ZSink.collectAll[Int].drop(3)
@@ -262,45 +262,45 @@ object SinkSpec extends ZIOBaseSpec {
             step4  <- sink.step(step3, 4)
             step5  <- sink.step(step4, 5)
             result <- sink.extract(step5)
-          } yield assert(result, equalTo((List(4, 5), Chunk.empty)))
+          } yield assert(result)(equalTo((List(4, 5), Chunk.empty)))
         },
         testM("happy path") {
           val sink = ZSink.identity[Int].drop(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo(())))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("init error") {
           val sink = initErrorSink.drop(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.drop(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.drop(1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("dropWhile")(
         testM("happy path") {
           val sink = ZSink.identity[Int].dropWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo(())))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("false predicate") {
           val sink = ZSink.identity[Int].dropWhile(_ > 5)
-          assertM(sinkIteration(sink, 1), equalTo((1, Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.dropWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.dropWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.dropWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("flatMap")(
@@ -310,15 +310,15 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("self done") {
           val sink = ZSink.succeed(3).flatMap(n => ZSink.collectAllN[Int](n.toLong))
@@ -330,7 +330,7 @@ object SinkSpec extends ZIOBaseSpec {
             step4  <- sink.step(step3, 4)
             step5  <- sink.step(step4, 5)
             result <- sink.extract(step5)
-          } yield assert(result, equalTo((List(1, 2, 3), Chunk(4, 5))))
+          } yield assert(result)(equalTo((List(1, 2, 3), Chunk(4, 5))))
         },
         testM("self more") {
           val sink = ZSink.collectAll[Int].flatMap(list => ZSink.succeed[Int, Int](list.headOption.getOrElse(0)))
@@ -360,51 +360,51 @@ object SinkSpec extends ZIOBaseSpec {
             step2  <- sink.step(step1, 2)
             step3  <- sink.step(step2, 3)
             result <- sink.extract(step3)
-          } yield assert(result, equalTo(((), Chunk.single(3))))
+          } yield assert(result)(equalTo(((), Chunk.single(3))))
         }
       ),
       suite("filter")(
         testM("happy path") {
           val sink = ZSink.identity[Int].filter(_ < 5)
-          assertM(sinkIteration(sink, 1), equalTo((1, Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         },
         testM("false predicate") {
           val sink = ZSink.identity[Int].filter(_ > 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo(())))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("init error") {
           val sink = initErrorSink.filter(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.filter(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extractError") {
           val sink = extractErrorSink.filter(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("filterM")(
         testM("happy path") {
           val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeed(n < 5))
-          assertM(sinkIteration(sink, 1), equalTo((1, Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         },
         testM("false predicate") {
           val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeed(n > 5))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo(())))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("init error") {
           val sink = initErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extractError") {
           val sink = extractErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("keyed")(
@@ -414,79 +414,79 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.keyed(_ + 1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.keyed(_ + 1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.keyed(_ + 1)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("map")(
         testM("happy path") {
           val sink = ZSink.identity[Int].map(_.toString)
-          assertM(sinkIteration(sink, 1), equalTo(("1", Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo(("1", Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.map(_.toString)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.map(_.toString)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.map(_.toString)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("mapError")(
         testM("init error") {
           val sink = initErrorSink.mapError(_ => "Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         },
         testM("step error") {
           val sink = stepErrorSink.mapError(_ => "Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         },
         testM("extract error") {
           val sink = extractErrorSink.mapError(_ => "Error")
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Error")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Error")))
         }
       ),
       suite("mapM")(
         testM("happy path") {
           val sink = ZSink.identity[Int].mapM[Any, Unit, String](n => UIO.succeed(n.toString))
-          assertM(sinkIteration(sink, 1), equalTo(("1", Chunk.empty)))
+          assertM(sinkIteration(sink, 1))(equalTo(("1", Chunk.empty)))
         },
         testM("init error") {
           val sink = initErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("mapRemainder")(
         testM("init error") {
           val sink = initErrorSink.mapRemainder(_.toLong)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.mapRemainder(_.toLong)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.mapRemainder(_.toLong)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("optional")(
@@ -540,7 +540,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error both") {
           val sink = initErrorSink orElse initErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error left") {
           val sink = stepErrorSink orElse ZSink.identity[Int]
@@ -552,7 +552,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("step error both") {
           val sink = stepErrorSink orElse stepErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error left") {
           val sink = extractErrorSink orElse ZSink.identity[Int]
@@ -564,7 +564,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("extract error both") {
           val sink = extractErrorSink orElse extractErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("left short right long") {
           val sink = ZSink.collectAllN[Int](2) orElse ZSink.collectAll[Int]
@@ -614,10 +614,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error both") {
           val sink = initErrorSink raceBoth initErrorSink
-          assertM(
-            sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]),
-            equalTo(List("Ouch", "Ouch"))
-          )
+          assertM(sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]))(equalTo(List("Ouch", "Ouch")))
         },
         testM("step error left") {
           val sink = stepErrorSink raceBoth ZSink.identity[Int]
@@ -629,10 +626,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("step error both") {
           val sink = stepErrorSink raceBoth stepErrorSink
-          assertM(
-            sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]),
-            equalTo(List("Ouch", "Ouch"))
-          )
+          assertM(sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]))(equalTo(List("Ouch", "Ouch")))
         },
         testM("extract error left") {
           val sink = extractErrorSink raceBoth ZSink.identity[Int]
@@ -644,10 +638,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("extract error both") {
           val sink = extractErrorSink raceBoth extractErrorSink
-          assertM(
-            sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]),
-            equalTo(List("Ouch", "Ouch"))
-          )
+          assertM(sinkIteration(sink, 1).foldCause(_.failures, _ => List.empty[String]))(equalTo(List("Ouch", "Ouch")))
         },
         testM("left wins") {
           val sink = ZSink.collectAllN[Int](2) raceBoth ZSink.collectAll[Int]
@@ -680,23 +671,23 @@ object SinkSpec extends ZIOBaseSpec {
             step5  <- sink.step(step4, 5)
             cont   = sink.cont(step5)
             result <- sink.extract(step5)
-          } yield assert(cont, isFalse) && assert(result, equalTo((List(1, 2, 3, 4), Chunk.single(5))))
+          } yield assert(cont)(isFalse) && assert(result)(equalTo((List(1, 2, 3, 4), Chunk.single(5))))
         },
         testM("false predicate") {
           val sink = ZSink.identity[Int].takeWhile(_ > 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo(())))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("init error") {
           val sink = initErrorSink.takeWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.takeWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.takeWhile(_ < 5)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       testM("tapInput") {
@@ -709,7 +700,7 @@ object SinkSpec extends ZIOBaseSpec {
           _      <- sinkIteration(sink, 2)
           _      <- sinkIteration(sink, 3)
           result <- ref.get
-        } yield assert(result, equalTo(6))
+        } yield assert(result)(equalTo(6))
       },
       testM("tapOutput") {
         for {
@@ -721,7 +712,7 @@ object SinkSpec extends ZIOBaseSpec {
           _      <- sinkIteration(sink, 2)
           _      <- sinkIteration(sink, 3)
           result <- ref.get
-        } yield assert(result, equalTo(12))
+        } yield assert(result)(equalTo(12))
       },
       suite("untilOutput")(
         testM("happy path") {
@@ -743,15 +734,15 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error") {
           val sink = initErrorSink.untilOutput(_ == 0)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
           val sink = stepErrorSink.untilOutput(_ == 0)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
           val sink = extractErrorSink.untilOutput(_ == 0)
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("zip (<*>)")(
@@ -761,39 +752,39 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("init error left") {
           val sink = initErrorSink <*> ZSink.identity[Int]
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("init error right") {
           val sink = ZSink.identity[Int] <*> initErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("init error both") {
           val sink = initErrorSink <*> initErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error left") {
           val sink = stepErrorSink <*> ZSink.identity[Int]
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("step error right") {
           val sink = ZSink.identity[Int] <*> stepErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("step error both") {
           val sink = stepErrorSink <*> stepErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error left") {
           val sink = extractErrorSink <*> ZSink.identity[Int]
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("extract error right") {
           val sink = ZSink.identity[Int] <*> extractErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft[Any](equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft[Any](equalTo("Ouch")))
         },
         testM("extract error both") {
           val sink = extractErrorSink <*> extractErrorSink
-          assertM(sinkIteration(sink, 1).either, isLeft(equalTo("Ouch")))
+          assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         }
       ),
       suite("zipLeft (<*)")(
@@ -852,8 +843,8 @@ object SinkSpec extends ZIOBaseSpec {
             .map { result =>
               val (l, r) = result.unzip
 
-              assert(l, equalTo(expectedResult) ?? "Left sink result") &&
-              assert(r, equalTo(expectedResult) ?? "Right sink result")
+              assert(l)(equalTo(expectedResult) ?? "Left sink result") &&
+              assert(r)(equalTo(expectedResult) ?? "Right sink result")
             }
         }
       ),
@@ -873,16 +864,14 @@ object SinkSpec extends ZIOBaseSpec {
       testM("head")(
         assertM(
           Stream[Int](1, 2, 3)
-            .run(ZSink.head[Int]),
-          isSome(equalTo(1))
-        )
+            .run(ZSink.head[Int])
+        )(isSome(equalTo(1)))
       ),
       testM("last")(
         assertM(
           Stream[Int](1, 2, 3)
-            .run(ZSink.last[Int]),
-          isSome(equalTo(3))
-        )
+            .run(ZSink.last[Int])
+        )(isSome(equalTo(3)))
       ),
       testM("foldLeft")(
         checkM(
@@ -893,7 +882,7 @@ object SinkSpec extends ZIOBaseSpec {
           for {
             xs <- s.run(ZSink.foldLeft(z)(f))
             ys <- s.runCollect.map(_.foldLeft(z)(f))
-          } yield assert(xs, equalTo(ys))
+          } yield assert(xs)(equalTo(ys))
         }
       ),
       suite("fold")(
@@ -902,7 +891,7 @@ object SinkSpec extends ZIOBaseSpec {
             for {
               xs <- s.run(ZSink.foldLeft(z)(f))
               ys <- s.runCollect.map(_.foldLeft(z)(f))
-            } yield assert(xs, equalTo(ys))
+            } yield assert(xs)(equalTo(ys))
         }),
         testM("short circuits") {
           val empty: Stream[Nothing, Int]     = ZStream.empty
@@ -943,10 +932,7 @@ object SinkSpec extends ZIOBaseSpec {
                              .map(_.reverse)
                              .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
                              .run
-            } yield assert(foldResult.succeeded, isTrue) implies assert(
-              foldResult,
-              succeeds(equalTo(sinkResult))
-            )
+            } yield assert(foldResult.succeeded)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
           }
         },
         testM("short circuits") {
@@ -977,48 +963,42 @@ object SinkSpec extends ZIOBaseSpec {
         testM("collectAllN")(
           assertM(
             Stream[Int](1, 2, 3)
-              .run(Sink.collectAllN[Int](2)),
-            equalTo(List(1, 2))
-          )
+              .run(Sink.collectAllN[Int](2))
+          )(equalTo(List(1, 2)))
         ),
         testM("collectAllToSet")(
           assertM(
             Stream[Int](1, 2, 3, 3, 4)
-              .run(Sink.collectAllToSet[Int]),
-            equalTo(Set(1, 2, 3, 4))
-          )
+              .run(Sink.collectAllToSet[Int])
+          )(equalTo(Set(1, 2, 3, 4)))
         ),
         testM("collectAllToSetN")(
           assertM(
             Stream[Int](1, 2, 1, 2, 3, 3, 4)
-              .run(Sink.collectAllToSetN[Int](3)),
-            equalTo(Set(1, 2, 3))
-          )
+              .run(Sink.collectAllToSetN[Int](3))
+          )(equalTo(Set(1, 2, 3)))
         ),
         testM("collectAllToMap")(
           assertM(
             Stream
               .range(0, 10)
-              .run(Sink.collectAllToMap[Int, Int](value => value % 3)(_ + _)),
-            equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))
-          )
+              .run(Sink.collectAllToMap[Int, Int](value => value % 3)(_ + _))
+          )(equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15)))
         ),
         suite("collectAllToMapN")(
           testM("stop collecting when map size exceeds limit")(
             assertM(
               Stream
                 .range(0, 10)
-                .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _)),
-              equalTo(Map[Int, Int](0 -> 0, 1 -> 1))
-            )
+                .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _))
+            )(equalTo(Map[Int, Int](0 -> 0, 1 -> 1)))
           ),
           testM("keep collecting as long as map size does not exceed the limit")(
             assertM(
               Stream
                 .range(0, 10)
-                .run(Sink.collectAllToMapN[Int, Int](3)(value => value % 3)(_ + _)),
-              equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))
-            )
+                .run(Sink.collectAllToMapN[Int, Int](3)(value => value % 3)(_ + _))
+            )(equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15)))
           )
         ),
         testM("collectAllWhile")(
@@ -1026,7 +1006,7 @@ object SinkSpec extends ZIOBaseSpec {
             for {
               sinkResult <- s.run(ZSink.collectAllWhile(f))
               listResult <- s.runCollect.map(_.takeWhile(f)).run
-            } yield assert(listResult.succeeded, isTrue) implies assert(listResult, succeeds(equalTo(sinkResult)))
+            } yield assert(listResult.succeeded)(isTrue) implies assert(listResult)(succeeds(equalTo(sinkResult)))
           }
         )
       ),
@@ -1037,9 +1017,8 @@ object SinkSpec extends ZIOBaseSpec {
               .aggregate(
                 Sink.foldWeighted[Long, List[Long]](List())(_ * 2, 12)((acc, el) => el :: acc).map(_.reverse)
               )
-              .runCollect,
-            equalTo(List(List(1L, 5L), List(2L, 3L)))
-          )
+              .runCollect
+          )(equalTo(List(List(1L, 5L), List(2L, 3L))))
         ),
         testM("foldWeightedDecompose")(
           assertM(
@@ -1052,9 +1031,8 @@ object SinkSpec extends ZIOBaseSpec {
                   }
                   .map(_.reverse)
               )
-              .runCollect,
-            equalTo(List(List(1), List(4), List(1, 1)))
-          )
+              .runCollect
+          )(equalTo(List(List(1), List(4), List(1, 1))))
         ),
         testM("foldWeightedM")(
           assertM(
@@ -1066,9 +1044,8 @@ object SinkSpec extends ZIOBaseSpec {
                   )
                   .map(_.reverse)
               )
-              .runCollect,
-            equalTo(List(List(1L, 5L), List(2L, 3L)))
-          )
+              .runCollect
+          )(equalTo(List(List(1L, 5L), List(2L, 3L))))
         ),
         testM("foldWeightedDecomposeM")(
           assertM(
@@ -1084,41 +1061,36 @@ object SinkSpec extends ZIOBaseSpec {
                   }
                   .map(_.reverse)
               )
-              .runCollect,
-            equalTo(List(List(1), List(4), List(1, 1)))
-          )
+              .runCollect
+          )(equalTo(List(List(1), List(4), List(1, 1))))
         ),
         testM("foldUntil")(
           assertM(
             Stream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(Sink.foldUntil(0L, 3)(_ + (_: Long)))
-              .runCollect,
-            equalTo(List(3L, 3L))
-          )
+              .runCollect
+          )(equalTo(List(3L, 3L)))
         ),
         testM("foldUntilM")(
           assertM(
             Stream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(Sink.foldUntilM(0L, 3)((s, a: Long) => UIO.succeed(s + a)))
-              .runCollect,
-            equalTo(List(3L, 3L))
-          )
+              .runCollect
+          )(equalTo(List(3L, 3L)))
         ),
         testM("fromFunction")(
           assertM(
             Stream(1, 2, 3, 4, 5)
               .aggregate(Sink.fromFunction[Int, String](_.toString))
-              .runCollect,
-            equalTo(List("1", "2", "3", "4", "5"))
-          )
+              .runCollect
+          )(equalTo(List("1", "2", "3", "4", "5")))
         ),
         testM("fromFunctionM")(
           assertM(
             Stream("1", "2", "3", "4", "5")
               .transduce(Sink.fromFunctionM[Throwable, String, Int](s => Task(s.toInt)))
-              .runCollect,
-            equalTo(List(1, 2, 3, 4, 5))
-          )
+              .runCollect
+          )(equalTo(List(1, 2, 3, 4, 5)))
         )
       ),
       testM("fromOutputStream") {
@@ -1130,16 +1102,13 @@ object SinkSpec extends ZIOBaseSpec {
 
         for {
           bytesWritten <- stream.run(ZSink.fromOutputStream(output))
-        } yield assert(bytesWritten, equalTo(10)) && assert(
-          new String(output.toByteArray, "UTF-8"),
-          equalTo(data)
-        )
+        } yield assert(bytesWritten)(equalTo(10)) && assert(new String(output.toByteArray, "UTF-8"))(equalTo(data))
       },
       testM("pull1") {
         val stream = Stream.fromIterable(List(1))
         val sink   = Sink.pull1(IO.succeed(Option.empty[Int]))((i: Int) => Sink.succeed[Int, Option[Int]](Some(i)))
 
-        assertM(stream.run(sink), isSome(equalTo(1)))
+        assertM(stream.run(sink))(isSome(equalTo(1)))
       },
       suite("splitLines")(
         testM("preserves data")(
@@ -1151,7 +1120,7 @@ object SinkSpec extends ZIOBaseSpec {
               middle             <- ZSink.splitLines.step(initial, data)
               res                <- ZSink.splitLines.extract(middle)
               (result, leftover) = res
-            } yield assert((result ++ leftover).toArray[String].mkString("\n"), equalTo(lines.mkString("\n")))
+            } yield assert((result ++ leftover).toArray[String].mkString("\n"))(equalTo(lines.mkString("\n")))
           }
         ),
         testM("handles leftovers") {
@@ -1160,45 +1129,40 @@ object SinkSpec extends ZIOBaseSpec {
             middle             <- ZSink.splitLines.step(initial, "abc\nbc")
             res                <- ZSink.splitLines.extract(middle)
             (result, leftover) = res
-          } yield assert(result.toArray[String].mkString("\n"), equalTo("abc")) && assert(
-            leftover.toArray[String].mkString,
-            equalTo("bc")
-          )
+          } yield assert(result.toArray[String].mkString("\n"))(equalTo("abc")) && assert(
+            leftover.toArray[String].mkString
+          )(equalTo("bc"))
         },
         testM("aggregates") {
           assertM(
             Stream("abc", "\n", "bc", "\n", "bcd", "bcd")
               .aggregate(ZSink.splitLines)
-              .runCollect,
-            equalTo(List(Chunk("abc"), Chunk("bc"), Chunk("bcdbcd")))
-          )
+              .runCollect
+          )(equalTo(List(Chunk("abc"), Chunk("bc"), Chunk("bcdbcd"))))
         },
         testM("single newline edgecase") {
           assertM(
             Stream("\n")
               .aggregate(ZSink.splitLines)
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List(""))
-          )
+              .runCollect
+          )(equalTo(List("")))
         },
         testM("no newlines in data") {
           assertM(
             Stream("abc", "abc", "abc")
               .aggregate(ZSink.splitLines)
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List("abcabcabc"))
-          )
+              .runCollect
+          )(equalTo(List("abcabcabc")))
         },
         testM("\\r\\n on the boundary") {
           assertM(
             Stream("abc\r", "\nabc")
               .aggregate(ZSink.splitLines)
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List("abc", "abc"))
-          )
+              .runCollect
+          )(equalTo(List("abc", "abc")))
         }
       ),
       testM("splitLinesChunk")(
@@ -1211,7 +1175,7 @@ object SinkSpec extends ZIOBaseSpec {
             middle             <- ZSink.splitLinesChunk.step(initial, chunks)
             res                <- ZSink.splitLinesChunk.extract(middle)
             (result, leftover) = res
-          } yield assert((result ++ leftover.flatten).toArray[String].toList, equalTo(ys))
+          } yield assert((result ++ leftover.flatten).toArray[String].toList)(equalTo(ys))
         }
       ),
       suite("splitOn")(
@@ -1224,7 +1188,7 @@ object SinkSpec extends ZIOBaseSpec {
             middle             <- sink.step(initial, data)
             res                <- sink.extract(middle)
             (result, leftover) = res
-          } yield assert((result ++ leftover).toArray[String].mkString("|"), equalTo(data))
+          } yield assert((result ++ leftover).toArray[String].mkString("|"))(equalTo(data))
         }),
         testM("handles leftovers") {
           val sink = ZSink.splitOn("\n")
@@ -1233,45 +1197,40 @@ object SinkSpec extends ZIOBaseSpec {
             middle             <- sink.step(initial, "abc\nbc")
             res                <- sink.extract(middle)
             (result, leftover) = res
-          } yield assert(result.toArray[String].mkString("\n"), equalTo("abc")) && assert(
-            leftover.toArray[String].mkString,
-            equalTo("bc")
-          )
+          } yield assert(result.toArray[String].mkString("\n"))(equalTo("abc")) && assert(
+            leftover.toArray[String].mkString
+          )(equalTo("bc"))
         },
         testM("aggregates") {
           assertM(
             Stream("abc", "delimiter", "bc", "delimiter", "bcd", "bcd")
               .aggregate(ZSink.splitOn("delimiter"))
-              .runCollect,
-            equalTo(List(Chunk("abc"), Chunk("bc"), Chunk("bcdbcd")))
-          )
+              .runCollect
+          )(equalTo(List(Chunk("abc"), Chunk("bc"), Chunk("bcdbcd"))))
         },
         testM("single newline edgecase") {
           assertM(
             Stream("test")
               .aggregate(ZSink.splitOn("test"))
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List(""))
-          )
+              .runCollect
+          )(equalTo(List("")))
         },
         testM("no delimiter in data") {
           assertM(
             Stream("abc", "abc", "abc")
               .aggregate(ZSink.splitOn("hello"))
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List("abcabcabc"))
-          )
+              .runCollect
+          )(equalTo(List("abcabcabc")))
         },
         testM("delimiter on the boundary") {
           assertM(
             Stream("abc<", ">abc")
               .aggregate(ZSink.splitOn("<>"))
               .mapConcatChunk(identity)
-              .runCollect,
-            equalTo(List("abc", "abc"))
-          )
+              .runCollect
+          )(equalTo(List("abc", "abc")))
         }
       ),
       suite("throttleEnforce")(
@@ -1296,7 +1255,7 @@ object SinkSpec extends ZIOBaseSpec {
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)
-            } yield assert(List(res1, res2, res3, res4, res5), equalTo(List(Some(1), Some(2), None, None, Some(5))))
+            } yield assert(List(res1, res2, res3, res4, res5))(equalTo(List(Some(1), Some(2), None, None, Some(5))))
 
           ZSink.throttleEnforce[Int](1, 10.milliseconds)(_ => 1).use(sinkTest)
         },
@@ -1321,10 +1280,7 @@ object SinkSpec extends ZIOBaseSpec {
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)
-            } yield assert(
-              List(res1, res2, res3, res4, res5),
-              equalTo(List(Some(1), Some(2), Some(3), None, Some(5)))
-            )
+            } yield assert(List(res1, res2, res3, res4, res5))(equalTo(List(Some(1), Some(2), Some(3), None, Some(5))))
 
           ZSink.throttleEnforce[Int](1, 10.milliseconds, 1)(_ => 1).use(sinkTest)
         }
@@ -1344,7 +1300,7 @@ object SinkSpec extends ZIOBaseSpec {
               _     <- clock.sleep(4.seconds)
               step3 <- sink.step(init3, 3)
               res3  <- sink.extract(step3).map(_._1)
-            } yield assert(List(res1, res2, res3), equalTo(List(1, 2, 3)))
+            } yield assert(List(res1, res2, res3))(equalTo(List(1, 2, 3)))
 
           for {
             fiber <- ZSink
@@ -1366,7 +1322,7 @@ object SinkSpec extends ZIOBaseSpec {
               step2   <- sink.step(init2, 2)
               res2    <- sink.extract(step2).map(_._1)
               elapsed <- clock.currentTime(TimeUnit.SECONDS)
-            } yield assert(elapsed, equalTo(0L)) && assert(List(res1, res2), equalTo(List(1, 2)))
+            } yield assert(elapsed)(equalTo(0L)) && assert(List(res1, res2))(equalTo(List(1, 2)))
 
           ZSink.throttleShape[Int](1, 0.seconds)(_ => 100000L).use(sinkTest)
         },
@@ -1386,7 +1342,7 @@ object SinkSpec extends ZIOBaseSpec {
               _     <- clock.sleep(4.seconds)
               step3 <- sink.step(init3, 3)
               res3  <- sink.extract(step3).map(_._1)
-            } yield assert(List(res1, res2, res3), equalTo(List(1, 2, 3)))
+            } yield assert(List(res1, res2, res3))(equalTo(List(1, 2, 3)))
 
           for {
             fiber <- ZSink
@@ -1403,9 +1359,8 @@ object SinkSpec extends ZIOBaseSpec {
             Stream(Chunk.fromArray(s.getBytes("UTF-8")))
               .aggregate(ZSink.utf8DecodeChunk)
               .runCollect
-              .map(_.mkString),
-            equalTo(s)
-          )
+              .map(_.mkString)
+          )(equalTo(s))
         }),
         testM("incomplete chunk 1") {
           for {
@@ -1414,9 +1369,9 @@ object SinkSpec extends ZIOBaseSpec {
             state2      <- ZSink.utf8DecodeChunk.step(state1, Chunk(0xA2.toByte))
             result      <- ZSink.utf8DecodeChunk.extract(state2)
             (string, _) = result
-          } yield assert(ZSink.utf8DecodeChunk.cont(state1), isTrue) &&
-            assert(ZSink.utf8DecodeChunk.cont(state2), isFalse) &&
-            assert(string.getBytes("UTF-8"), equalTo(Array(0xC2.toByte, 0xA2.toByte)))
+          } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isTrue) &&
+            assert(ZSink.utf8DecodeChunk.cont(state2))(isFalse) &&
+            assert(string.getBytes("UTF-8"))(equalTo(Array(0xC2.toByte, 0xA2.toByte)))
         },
         testM("incomplete chunk 2") {
           for {
@@ -1425,9 +1380,9 @@ object SinkSpec extends ZIOBaseSpec {
             state2      <- ZSink.utf8DecodeChunk.step(state1, Chunk(0xB9.toByte))
             result      <- ZSink.utf8DecodeChunk.extract(state2)
             (string, _) = result
-          } yield assert(ZSink.utf8DecodeChunk.cont(state1), isTrue) &&
-            assert(ZSink.utf8DecodeChunk.cont(state2), isFalse) &&
-            assert(string.getBytes("UTF-8"), equalTo(Array(0xE0.toByte, 0xA4.toByte, 0xB9.toByte)))
+          } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isTrue) &&
+            assert(ZSink.utf8DecodeChunk.cont(state2))(isFalse) &&
+            assert(string.getBytes("UTF-8"))(equalTo(Array(0xE0.toByte, 0xA4.toByte, 0xB9.toByte)))
         },
         testM("incomplete chunk 3") {
           for {
@@ -1436,9 +1391,9 @@ object SinkSpec extends ZIOBaseSpec {
             state2      <- ZSink.utf8DecodeChunk.step(state1, Chunk(0x88.toByte))
             result      <- ZSink.utf8DecodeChunk.extract(state2)
             (string, _) = result
-          } yield assert(ZSink.utf8DecodeChunk.cont(state1), isTrue) &&
-            assert(ZSink.utf8DecodeChunk.cont(state2), isFalse) &&
-            assert(string.getBytes("UTF-8"), equalTo(Array(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte)))
+          } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isTrue) &&
+            assert(ZSink.utf8DecodeChunk.cont(state2))(isFalse) &&
+            assert(string.getBytes("UTF-8"))(equalTo(Array(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte)))
         },
         testM("chunk with leftover") {
           for {
@@ -1449,8 +1404,7 @@ object SinkSpec extends ZIOBaseSpec {
                          Chunk(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte, 0xF0.toByte, 0x90.toByte)
                        )
             result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap(identity).toArray[Byte])
-          } yield assert(ZSink.utf8DecodeChunk.cont(state1), isFalse) && assert(
-            result,
+          } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isFalse) && assert(result)(
             equalTo(Array(0xF0.toByte, 0x90.toByte))
           )
         }
@@ -1524,11 +1478,8 @@ object SinkSpec extends ZIOBaseSpec {
         val partialParse = src1.run(start.chunked).run
         val fullParse    = (src1 ++ src2).run(start.chunked).run
 
-        assertM(partialParse, fails(equalTo("Expected closing brace; instead: None"))).zipWith(
-          assertM(
-            fullParse,
-            succeeds(equalTo(List(123, 4)))
-          )
+        assertM(partialParse)(fails(equalTo("Expected closing brace; instead: None"))).zipWith(
+          assertM(fullParse)(succeeds(equalTo(List(123, 4))))
         )(_ && _)
       }
     )

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -70,8 +70,8 @@ trait SinkUtils {
       } yield {
         res match {
           case Right(((b, c), rem)) =>
-            assert(swapped, isRight(equalTo(((c, b), rem))))
-          case _ => assert(true, isTrue)
+            assert(swapped)(isRight(equalTo(((c, b), rem))))
+          case _ => assert(true)(isTrue)
         }
       }
 
@@ -87,9 +87,9 @@ trait SinkUtils {
       } yield {
         val (_, shorter) = if (rem1.length <= rem2.length) (rem2, rem1) else (rem1, rem2)
         // assert(longer, equalTo(rem))
-        assert(rem.endsWith(shorter), isTrue)
+        assert(rem.endsWith(shorter))(isTrue)
       }
-      maybeProp.catchAll(_ => UIO.succeed(assert(true, isTrue)))
+      maybeProp.catchAll(_ => UIO.succeed(assert(true)(isTrue)))
     }
 
     def laws[A, B, C](

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
@@ -15,9 +15,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
           Stream
             .fromIterable(list)
             .buffer(2)
-            .run(Sink.collectAll[Int]),
-          equalTo(list)
-        )
+            .run(Sink.collectAll[Int])
+        )(equalTo(list))
       }),
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
@@ -25,9 +24,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
           (Stream.range(0, 10) ++ Stream.fail(e))
             .buffer(2)
             .run(Sink.collectAll[Int])
-            .run,
-          fails(equalTo(e))
-        )
+            .run
+        )(fails(equalTo(e)))
       },
       testM("fast producer progress independently") {
         for {
@@ -41,7 +39,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
                   l <- ref.get
                 } yield l
               }
-        } yield assert(l.reverse, equalTo((1 to 4).toList))
+        } yield assert(l.reverse)(equalTo((1 to 4).toList))
       }
     ),
     suite("Stream.bufferDropping")(
@@ -51,9 +49,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
           (Stream.range(1, 1000) ++ Stream.fail(e) ++ Stream.range(1001, 2000))
             .bufferDropping(2)
             .runCollect
-            .run,
-          fails(equalTo(e))
-        )
+            .run
+        )(fails(equalTo(e)))
       },
       testM("fast producer progress independently") {
         for {
@@ -82,8 +79,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
                           snapshot2 <- ref.get
                         } yield (zero, snapshot1, snapshot2)
                       }
-        } yield assert(snapshots._1, equalTo(0)) && assert(snapshots._2, equalTo(List(8, 7, 6, 5, 4, 3, 2, 1))) &&
-          assert(snapshots._3, equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 8, 7, 6, 5, 4, 3, 2, 1)))
+        } yield assert(snapshots._1)(equalTo(0)) && assert(snapshots._2)(equalTo(List(8, 7, 6, 5, 4, 3, 2, 1))) &&
+          assert(snapshots._3)(equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 8, 7, 6, 5, 4, 3, 2, 1)))
       } @@ flaky
     ),
     suite("Stream.bufferSliding")(
@@ -93,9 +90,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
           (Stream.range(1, 1000) ++ Stream.fail(e) ++ Stream.range(1001, 2000))
             .bufferSliding(2)
             .runCollect
-            .run,
-          fails(equalTo(e))
-        )
+            .run
+        )(fails(equalTo(e)))
       },
       testM("fast producer progress independently") {
         for {
@@ -124,11 +120,8 @@ object StreamBufferSpec extends ZIOBaseSpec {
                           snapshot2 <- ref.get
                         } yield (zero, snapshot1, snapshot2)
                       }
-        } yield assert(snapshots._1, equalTo(0)) && assert(
-          snapshots._2,
-          equalTo(List(16, 15, 14, 13, 12, 11, 10, 9))
-        ) &&
-          assert(snapshots._3, equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9)))
+        } yield assert(snapshots._1)(equalTo(0)) && assert(snapshots._2)(equalTo(List(16, 15, 14, 13, 12, 11, 10, 9))) &&
+          assert(snapshots._3)(equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9)))
       }
     ) @@ flaky,
     suite("Stream.bufferUnbounded")(
@@ -137,13 +130,12 @@ object StreamBufferSpec extends ZIOBaseSpec {
           Stream
             .fromIterable(list)
             .bufferUnbounded
-            .runCollect,
-          equalTo(list)
-        )
+            .runCollect
+        )(equalTo(list))
       }),
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
-        assertM((Stream.range(0, 10) ++ Stream.fail(e)).bufferUnbounded.runCollect.run, fails(equalTo(e)))
+        assertM((Stream.range(0, 10) ++ Stream.fail(e)).bufferUnbounded.runCollect.run)(fails(equalTo(e)))
       },
       testM("fast producer progress independently") {
         for {
@@ -160,7 +152,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
                   l <- ref.get
                 } yield l
               }
-        } yield assert(l.reverse, equalTo(Range(1, 1000).toList))
+        } yield assert(l.reverse)(equalTo(Range(1, 1000).toList))
       }
     )
   )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -15,17 +15,17 @@ object StreamChunkSpec extends ZIOBaseSpec {
     testM("StreamChunk.catchAllCauseErrors") {
       val s1 = StreamChunk(Stream(Chunk(1), Chunk(2, 3))) ++ StreamChunk(Stream.fail("Boom"))
       val s2 = StreamChunk(Stream(Chunk(4, 5), Chunk(6)))
-      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_, equalTo(List(1, 2, 3, 4, 5, 6))))
+      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
     },
     testM("StreamChunk.catchAllCauseDefects") {
       val s1 = StreamChunk(Stream(Chunk(1), Chunk(2, 3))) ++ StreamChunk(Stream.dieMessage("Boom"))
       val s2 = StreamChunk(Stream(Chunk(4, 5), Chunk(6)))
-      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_, equalTo(List(1, 2, 3, 4, 5, 6))))
+      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
     },
     testM("StreamChunk.catchAllCauseHappyPath") {
       val s1 = StreamChunk(Stream(Chunk(1), Chunk(2, 3)))
       val s2 = StreamChunk(Stream(Chunk(4, 5), Chunk(6)))
-      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_, equalTo(List(1, 2, 3))))
+      s1.catchAllCause(_ => s2).flattenChunks.runCollect.map(assert(_)(equalTo(List(1, 2, 3))))
     },
     testM("StreamChunk.catchAllCauseFinalizers") {
       for {
@@ -34,7 +34,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         s2     = StreamChunk((Stream(Chunk(4, 5), Chunk(6)) ++ Stream.fail("Boom")).ensuring(fins.update("s2" :: _)))
         _      <- s1.catchAllCause(_ => s2).flattenChunks.runCollect.run
         result <- fins.get
-      } yield assert(result, equalTo(List("s2", "s1")))
+      } yield assert(result)(equalTo(List("s2", "s1")))
     },
     testM("StreamChunk.either") {
       val s = StreamChunk(Stream(Chunk(1), Chunk(2, 3))) ++ StreamChunk(Stream.fail("Boom"))
@@ -43,14 +43,14 @@ object StreamChunkSpec extends ZIOBaseSpec {
     testM("StreamChunk.orElse") {
       val s1 = StreamChunk(Stream(Chunk(1), Chunk(2, 3))) ++ StreamChunk(Stream.fail("Boom"))
       val s2 = StreamChunk(Stream(Chunk(4, 5), Chunk(6)))
-      s1.orElse(s2).flattenChunks.runCollect.map(assert(_, equalTo(List(1, 2, 3, 4, 5, 6))))
+      s1.orElse(s2).flattenChunks.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
     },
     testM("StreamChunk.map") {
       checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, f) =>
         for {
           res1 <- slurp(s.map(f))
           res2 <- slurp(s).map(_.map(f))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.filter") {
@@ -58,7 +58,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.filter(p))
           res2 <- slurp(s).map(_.filter(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     suite("StreamChunk.filterM")(
@@ -66,7 +66,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.filterM(s => UIO.succeed(p(s))))
           res2 <- slurp(s).map(_.filter(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }),
       testM("filterM error") {
         Chunk(1, 2, 3).filterM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
@@ -77,7 +77,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.filterNot(p))
           res2 <- slurp(s).map(_.filterNot(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.mapConcat") {
@@ -86,7 +86,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.mapConcat(f))
           res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.mapConcatChunk") {
@@ -95,7 +95,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.mapConcatChunk(f))
           res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     suite("StreamChunk.mapConcatChunkM")(
@@ -105,7 +105,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           for {
             res1 <- slurp(s.mapConcatChunkM(s => UIO.succeed(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatM error") {
@@ -124,7 +124,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           for {
             res1 <- slurp(s.mapConcatM(s => UIO.succeed(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatM error") {
@@ -141,21 +141,21 @@ object StreamChunkSpec extends ZIOBaseSpec {
         .mapError(_.toInt)
         .run(Sink.drain)
         .either
-        .map(assert(_, isLeft(equalTo(123))))
+        .map(assert(_)(isLeft(equalTo(123))))
     },
     testM("StreamChunk.mapErrorCause") {
       StreamChunk(Stream.halt(Cause.fail("123")))
         .mapErrorCause(_.map(_.toInt))
         .run(Sink.drain)
         .either
-        .map(assert(_, isLeft(equalTo(123))))
+        .map(assert(_)(isLeft(equalTo(123))))
     },
     testM("StreamChunk.drop") {
       checkM(chunksOfStrings, intGen) { (s, n) =>
         for {
           res1 <- slurp(s.drop(n))
           res2 <- slurp(s).map(_.drop(n))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.take") {
@@ -163,7 +163,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.take(n))
           res2 <- slurp(s).map(_.take(n))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.dropUntil") {
@@ -179,7 +179,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.dropWhile(p))
           res2 <- slurp(s).map(_.dropWhile(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.takeUntil") {
@@ -195,7 +195,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.takeWhile(p))
           res2 <- slurp(s).map(_.takeWhile(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.mapAccum") {
@@ -203,7 +203,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.mapAccum(0)((acc, el) => (acc + el, acc + el)))
           res2 <- slurp(s).map(_.scanLeft(0)((acc, el) => acc + el).drop(1))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     suite("StreamChunk.mapAccumM")(
@@ -212,7 +212,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           for {
             res1 <- slurp(s.mapAccumM(0)((acc, el) => UIO.succeed((acc + el, acc + el))))
             res2 <- slurp(s).map(_.scanLeft(0)((acc, el) => acc + el).drop(1))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapAccumM error") {
@@ -221,7 +221,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           .mapAccumM(0)((_, _) => IO.fail("Ouch"))
           .run(Sink.drain)
           .either
-          .map(assert(_, isLeft(equalTo("Ouch"))))
+          .map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("StreamChunk.mapM") {
@@ -229,7 +229,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.mapM(a => IO.succeed(f(a))))
           res2 <- slurp(s).map(_.map(f))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.++") {
@@ -237,7 +237,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s1).zipWith(slurp(s2))(_ ++ _)
           res2 <- slurp(s1 ++ s2)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.zipWithIndex") {
@@ -245,7 +245,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.zipWithIndex)
           res2 <- slurp(s).map(_.zipWithIndex.map(t => (t._1, t._2.toLong)))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.foreach0") {
@@ -259,7 +259,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
                      IO.succeed(false)
                  }.flatMap(_ => acc.update(_.reverse))
           res2 <- slurp(s.takeWhile(cont)).map(_.toList)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.foreach") {
@@ -268,7 +268,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           acc  <- Ref.make[List[Int]](Nil)
           res1 <- s.foreach(a => acc.update(a :: _).unit).flatMap(_ => acc.update(_.reverse))
           res2 <- slurp(s).map(_.toList)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.monadLaw1") {
@@ -277,7 +277,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(ZStreamChunk.succeed(Chunk(x)).flatMap(f))
           res2 <- slurp(f(x))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.monadLaw2") {
@@ -285,7 +285,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(m.flatMap(i => ZStreamChunk.succeed(Chunk(i))))
           res2 <- slurp(m)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.monadLaw3") {
@@ -300,7 +300,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(leftStream)
           res2 <- slurp(rightStream)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.tap") {
@@ -311,7 +311,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
           tap           <- slurp(s.tap(a => acc.update(a :: _).unit)).run
           list          <- acc.get.run
         } yield {
-          assert(withoutEffect, equalTo(tap)) && (assert(withoutEffect.succeeded, isFalse) || assert(withoutEffect)(
+          assert(withoutEffect)(equalTo(tap)) && (assert(withoutEffect.succeeded)(isFalse) || assert(withoutEffect)(
             equalTo(list.map(_.reverse))
           ))
         }
@@ -320,7 +320,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
     suite("StreamChunk.via")(
       testM("happy path") {
         val s = StreamChunk.fromChunks(Chunk(1), Chunk.empty, Chunk(2, 3, 4), Chunk(5, 6))
-        s.via(_.map(_.toString)).runCollect.map(assert(_, equalTo(List("1", "2", "3", "4", "5", "6"))))
+        s.via(_.map(_.toString)).runCollect.map(assert(_)(equalTo(List("1", "2", "3", "4", "5", "6"))))
       },
       testM("introduce error") {
         val s = StreamChunk.fromChunks(Chunk(1), Chunk.empty, Chunk(2, 3, 4), Chunk(5, 6))
@@ -332,7 +332,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- s.fold(zero)(f)
           res2 <- slurp(s).map(_.foldLeft(zero)(f))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.foldWhileM") {
@@ -345,7 +345,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- s.foldWhileM[Any, Nothing, String, Int](zero)(cont)((acc, a) => IO.succeed(f(acc, a)))
           res2 <- slurp(s).map(l => foldLazyList(l.toList, zero)(cont)(f))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.flattenChunks") {
@@ -353,7 +353,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- s.flattenChunks.fold[String, List[String]](Nil)((acc, a) => a :: acc).map(_.reverse)
           res2 <- slurp(s)
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.collect") {
@@ -364,7 +364,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.collect(p))
           res2 <- slurp(s).map(_.collect(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.collectWhile") {
@@ -375,7 +375,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         for {
           res1 <- slurp(s.collectWhile(pf))
           res2 <- slurp(s).map(_.takeWhile(pf.isDefinedAt).map(pf.apply))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.toInputStream") {
@@ -392,7 +392,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
             .toList
         )
       }
-      assertM(inputStreamResult.run, succeeds(equalTo(orig1 ++ orig2)))
+      assertM(inputStreamResult.run)(succeeds(equalTo(orig1 ++ orig2)))
     },
     testM("StreamChunk.ensuring") {
       for {
@@ -406,7 +406,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
               _ <- StreamChunk(Stream.fromEffect(log.update("Use" :: _)).flatMap(_ => Stream.empty))
             } yield ()).ensuring(log.update("Ensuring" :: _)).run(Sink.drain)
         execution <- log.get
-      } yield assert(execution, equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+      } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
     },
     testM("StreamChunk.ensuringFirst") {
       for {
@@ -420,7 +420,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
               _ <- StreamChunk(Stream.fromEffect(log.update("Use" :: _)).flatMap(_ => Stream.empty))
             } yield ()).ensuringFirst(log.update("Ensuring" :: _)).run(Sink.drain)
         execution <- log.get
-      } yield assert(execution, equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+      } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
     },
     testM("StreamChunk.ChunkN") {
       val s1 = StreamChunk(Stream(Chunk(1, 2, 3, 4, 5), Chunk(6, 7), Chunk(8, 9, 10, 11)))

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
@@ -25,14 +25,14 @@ object StreamDrainForkSpec extends ZIOBaseSpec {
               )
               .runDrain
         result <- bgInterrupted.get
-      } yield assert(result, isTrue)
+      } yield assert(result)(isTrue)
     },
     testM("fails the foreground stream if the background fails with a typed error") {
-      assertM(ZStream.never.drainFork(ZStream.fail("Boom")).runDrain.run, fails(equalTo("Boom")))
+      assertM(ZStream.never.drainFork(ZStream.fail("Boom")).runDrain.run)(fails(equalTo("Boom")))
     },
     testM("fails the foreground stream if the background fails with a defect") {
       val ex = new RuntimeException("Boom")
-      assertM(ZStream.never.drainFork(ZStream.die(ex)).runDrain.run, dies(equalTo(ex)))
+      assertM(ZStream.never.drainFork(ZStream.die(ex)).runDrain.run)(dies(equalTo(ex)))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -19,7 +19,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           }(global)
         }
 
-        assertM(s.take(list.size).runCollect, equalTo(list))
+        assertM(s.take(list.size).runCollect)(equalTo(list))
       })
     ),
     suite("Stream.effectAsyncMaybe")(
@@ -38,7 +38,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           Some(Stream.fromIterable(list))
         }
 
-        assertM(s.runCollect.map(_.take(list.size)), equalTo(list))
+        assertM(s.runCollect.map(_.take(list.size)))(equalTo(list))
       }),
       testM("effectAsyncMaybe None")(checkM(Gen.listOf(Gen.anyInt)) { list =>
         val s = Stream.effectAsyncMaybe[Throwable, Int] { k =>
@@ -48,7 +48,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           None
         }
 
-        assertM(s.take(list.size).runCollect, equalTo(list))
+        assertM(s.take(list.size).runCollect)(equalTo(list))
       }),
       testM("effectAsyncMaybe back pressure") {
         for {
@@ -69,7 +69,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           _      <- waitForValue(refCnt.get, 7)
           isDone <- refDone.get
           _      <- run.interrupt
-        } yield assert(isDone, isFalse)
+        } yield assert(isDone)(isFalse)
       }
     ),
     suite("Stream.effectAsyncM")(
@@ -89,7 +89,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
                     .fork
           _ <- latch.await
           s <- fiber.join
-        } yield assert(s, equalTo(list))
+        } yield assert(s)(equalTo(list))
       }),
       testM("effectAsyncM signal end stream") {
         for {
@@ -122,7 +122,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           _      <- waitForValue(refCnt.get, 7)
           isDone <- refDone.get
           _      <- run.interrupt
-        } yield assert(isDone, isFalse)
+        } yield assert(isDone)(isFalse)
       }
     ),
     suite("Stream.effectAsyncInterrupt")(
@@ -143,14 +143,14 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- cancelled.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("effectAsyncInterrupt Right")(checkM(Gen.listOf(Gen.anyInt)) { list =>
         val s = Stream.effectAsyncInterrupt[Throwable, Int] { _ =>
           Right(Stream.fromIterable(list))
         }
 
-        assertM(s.take(list.size).runCollect, equalTo(list))
+        assertM(s.take(list.size).runCollect)(equalTo(list))
       }),
       testM("effectAsyncInterrupt signal end stream ") {
         for {
@@ -184,8 +184,8 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           _      <- waitForValue(refCnt.get, 7)
           isDone <- refDone.get
           exit   <- run.interrupt
-        } yield assert(isDone, isFalse) &&
-          assert(exit.untraced, failsCause(containsCause(Cause.interrupt(selfId))))
+        } yield assert(isDone)(isFalse) &&
+          assert(exit.untraced)(failsCause(containsCause(Cause.interrupt(selfId))))
       }
     )
   )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamHaltWhenSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamHaltWhenSpec.scala
@@ -19,7 +19,7 @@ object StreamHaltWhenSpec extends ZIOBaseSpec {
         _      <- halt.succeed(())
         _      <- latch.succeed(())
         result <- interrupted.get
-      } yield assert(result, isFalse)
+      } yield assert(result)(isFalse)
     },
     testM("propagates errors") {
       for {
@@ -29,7 +29,7 @@ object StreamHaltWhenSpec extends ZIOBaseSpec {
                    .haltWhen(halt)
                    .runDrain
                    .either
-      } yield assert(result, isLeft(equalTo("Fail")))
+      } yield assert(result)(isLeft(equalTo("Fail")))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamInterruptWhenSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamInterruptWhenSpec.scala
@@ -19,7 +19,7 @@ object StreamInterruptWhenSpec extends ZIOBaseSpec {
         _      <- halt.succeed(())
         _      <- fiber.await
         result <- interrupted.get
-      } yield assert(result, isTrue)
+      } yield assert(result)(isTrue)
     },
     testM("propagates errors") {
       for {
@@ -29,7 +29,7 @@ object StreamInterruptWhenSpec extends ZIOBaseSpec {
                    .haltWhen(halt)
                    .runDrain
                    .either
-      } yield assert(result, isLeft(equalTo("Fail")))
+      } yield assert(result)(isLeft(equalTo("Fail")))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -48,7 +48,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
           ref   <- Ref.make(false)
           pulls <- Stream.bracket(IO.fail("Ouch"))(_ => ref.set(true)).process.use(nPulls(_, 3))
           fin   <- ref.get
-        } yield assert(fin, isFalse) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
+        } yield assert(fin)(isFalse) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
       },
       testM("is safe to pull again after inner failure") {
         for {
@@ -86,7 +86,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .process
                     .use(nPulls(_, 3))
           fin <- ref.get
-        } yield assert(fin, isTrue) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
+        } yield assert(fin)(isTrue) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
       }
     ),
     suite("Stream.flatten")(
@@ -224,7 +224,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .process
                     .use(nPulls(_, 3))
           fin <- ref.get
-        } yield assert(fin, isTrue) && assert(pulls)(equalTo(List(Right(1), Left(Some("Ouch")), Right(3))))
+        } yield assert(fin)(isTrue) && assert(pulls)(equalTo(List(Right(1), Left(Some("Ouch")), Right(3))))
       },
       testM("is safe to pull again after error sync case") {
         Stream
@@ -349,7 +349,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .process
                     .use(nPulls(_, 4))
           fin <- ref.get
-        } yield assert(fin, isTrue) && assert(pulls)(equalTo(List(Right(1), Right(2), Left(None), Left(None))))
+        } yield assert(fin)(isTrue) && assert(pulls)(equalTo(List(Right(1), Right(2), Left(None), Left(None))))
       },
       testM("is safe to pull again after failed acquisition") {
         for {
@@ -359,7 +359,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .process
                     .use(nPulls(_, 3))
           fin <- ref.get
-        } yield assert(fin, isFalse) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
+        } yield assert(fin)(isFalse) && assert(pulls)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None))))
       },
       testM("is safe to pull again after inner failure") {
         for {
@@ -372,7 +372,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
                     .process
                     .use(nPulls(_, 8))
           fin <- ref.get
-        } yield assert(fin, isTrue) && assert(pulls)(
+        } yield assert(fin)(isTrue) && assert(pulls)(
           equalTo(
             List(
               Right("2"),

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -31,11 +31,11 @@ object StreamSpec extends ZIOBaseSpec {
     suite("Stream.absolve")(
       testM("happy path")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { xs =>
         val stream = ZStream.fromIterable(xs.map(Right(_)))
-        assertM(stream.absolve.runCollect, equalTo(xs))
+        assertM(stream.absolve.runCollect)(equalTo(xs))
       }),
       testM("failure")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { xs =>
         val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
-        assertM(stream.absolve.runCollect.run, fails(equalTo("Ouch")))
+        assertM(stream.absolve.runCollect.run)(fails(equalTo("Ouch")))
       }),
       testM("round-trip #1")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt)), Gen.anyString) { (xs, s) =>
         val xss    = ZStream.fromIterable(xs.map(Right(_)))
@@ -43,7 +43,7 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           res1 <- stream.runCollect
           res2 <- stream.absolve.either.runCollect
-        } yield assert(res1, startsWith(res2))
+        } yield assert(res1)(startsWith(res2))
       }),
       testM("round-trip #2")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt)), Gen.anyString) { (xs, s) =>
         val xss    = ZStream.fromIterable(xs)
@@ -51,36 +51,36 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           res1 <- stream.runCollect.run
           res2 <- stream.either.absolve.runCollect.run
-        } yield assert(res1, fails(equalTo(s))) && assert(res2, fails(equalTo(s)))
+        } yield assert(res1)(fails(equalTo(s))) && assert(res2)(fails(equalTo(s)))
       })
     ),
     testM("Stream.access") {
       for {
         result <- ZStream.access[String](identity).provide("test").runHead.get
-      } yield assert(result, equalTo("test"))
+      } yield assert(result)(equalTo("test"))
     },
     suite("Stream.accessM")(
       testM("accessM") {
         for {
           result <- ZStream.accessM[String](ZIO.succeed).provide("test").runHead.get
-        } yield assert(result, equalTo("test"))
+        } yield assert(result)(equalTo("test"))
       },
       testM("accessM fails") {
         for {
           result <- ZStream.accessM[Int](_ => ZIO.fail("fail")).provide(0).runHead.run
-        } yield assert(result, fails(equalTo("fail")))
+        } yield assert(result)(fails(equalTo("fail")))
       }
     ),
     suite("Stream.accessStream")(
       testM("accessStream") {
         for {
           result <- ZStream.accessStream[String](ZStream.succeed).provide("test").runHead.get
-        } yield assert(result, equalTo("test"))
+        } yield assert(result)(equalTo("test"))
       },
       testM("accessStream fails") {
         for {
           result <- ZStream.accessStream[Int](_ => ZStream.fail("fail")).provide(0).runHead.run
-        } yield assert(result, fails(equalTo("fail")))
+        } yield assert(result)(fails(equalTo("fail")))
       }
     ),
     suite("Stream.aggregateAsync")(
@@ -89,8 +89,8 @@ object StreamSpec extends ZIOBaseSpec {
           .aggregateAsync(ZSink.foldUntil(List[Int](), 3)((acc, el: Int) => el :: acc).map(_.reverse))
           .runCollect
           .map { result =>
-            assert(result.flatten, equalTo(List(1, 1, 1, 1))) &&
-            assert(result.forall(_.length <= 3), isTrue)
+            assert(result.flatten)(equalTo(List(1, 1, 1, 1))) &&
+            assert(result.forall(_.length <= 3))(isTrue)
           }
       },
       testM("error propagation") {
@@ -99,9 +99,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream(1, 1, 1, 1)
             .aggregateAsync(ZSink.die(e))
             .runCollect
-            .run,
-          dies(equalTo(e))
-        )
+            .run
+        )(dies(equalTo(e)))
       },
       testM("error propagation") {
         val e = new RuntimeException("Boom")
@@ -113,9 +112,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream(1, 1)
             .aggregateAsync(sink)
             .runCollect
-            .run,
-          dies(equalTo(e))
-        )
+            .run
+        )(dies(equalTo(e)))
       },
       testM("interruption propagation") {
         for {
@@ -131,7 +129,7 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- cancelled.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("interruption propagation") {
         for {
@@ -145,7 +143,7 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- cancelled.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("leftover handling") {
         val data = List(1, 2, 2, 3, 2, 3)
@@ -159,9 +157,8 @@ object StreamSpec extends ZIOBaseSpec {
                 .map(_.reverse)
             )
             .runCollect
-            .map(_.flatten),
-          equalTo(data)
-        )
+            .map(_.flatten)
+        )(equalTo(data))
       }
     ),
     suite("Stream.aggregateAsyncWithinEither")(
@@ -187,9 +184,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream(1, 1, 1, 1)
             .aggregateAsyncWithinEither(ZSink.die(e), Schedule.spaced(30.minutes))
             .runCollect
-            .run,
-          dies(equalTo(e))
-        )
+            .run
+        )(dies(equalTo(e)))
       },
       testM("error propagation") {
         val e = new RuntimeException("Boom")
@@ -201,9 +197,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream(1, 1)
             .aggregateAsyncWithinEither(sink, Schedule.spaced(30.minutes))
             .runCollect
-            .run,
-          dies(equalTo(e))
-        )
+            .run
+        )(dies(equalTo(e)))
       },
       testM("interruption propagation") {
         for {
@@ -223,7 +218,7 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- cancelled.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("interruption propagation") {
         for {
@@ -241,7 +236,7 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- cancelled.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("aggregateAsyncWithinEitherLeftoverHandling") {
         val data = List(1, 2, 2, 3, 2, 3)
@@ -259,9 +254,8 @@ object StreamSpec extends ZIOBaseSpec {
               case Right(v) => v
             }
             .runCollect
-            .map(_.flatten),
-          equalTo(data)
-        )
+            .map(_.flatten)
+        )(equalTo(data))
       }
     ),
     suite("Stream.aggregateAsyncWithin")(
@@ -279,7 +273,7 @@ object StreamSpec extends ZIOBaseSpec {
                        Schedule.spaced(30.minutes)
                      )
                      .runCollect
-        } yield assert(result, equalTo(List(List(1, 1, 1, 1), List(2))))
+        } yield assert(result)(equalTo(List(List(1, 1, 1, 1), List(2))))
       }
     ),
     suite("Stream.bracket")(
@@ -289,7 +283,7 @@ object StreamSpec extends ZIOBaseSpec {
           iteratorStream = Stream.bracket(UIO(0 to 2))(_ => done.set(true)).flatMap(Stream.fromIterable)
           result         <- iteratorStream.run(Sink.collectAll[Int])
           released       <- done.get
-        } yield assert(result, equalTo(List(0, 1, 2))) && assert(released, isTrue)
+        } yield assert(result)(equalTo(List(0, 1, 2))) && assert(released)(isTrue)
       ),
       testM("bracket short circuits")(
         for {
@@ -300,7 +294,7 @@ object StreamSpec extends ZIOBaseSpec {
             .take(2)
           result   <- iteratorStream.run(Sink.collectAll[Int])
           released <- done.get
-        } yield assert(result, equalTo(List(0, 1))) && assert(released, isTrue)
+        } yield assert(result)(equalTo(List(0, 1))) && assert(released)(isTrue)
       ),
       testM("no acquisition when short circuiting")(
         for {
@@ -308,7 +302,7 @@ object StreamSpec extends ZIOBaseSpec {
           iteratorStream = (Stream(1) ++ Stream.bracket(acquired.set(true))(_ => UIO.unit)).take(0)
           _              <- iteratorStream.run(Sink.drain)
           result         <- acquired.get
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       ),
       testM("releases when there are defects") {
         for {
@@ -319,7 +313,7 @@ object StreamSpec extends ZIOBaseSpec {
                 .run(Sink.drain)
                 .run
           released <- ref.get
-        } yield assert(released, isTrue)
+        } yield assert(released)(isTrue)
       },
       testM("flatMap associativity doesn't affect bracket lifetime")(
         for {
@@ -332,7 +326,7 @@ object StreamSpec extends ZIOBaseSpec {
                          .bracket(Ref.make(true))(_.set(false))
                          .flatMap(Stream.succeed(_).flatMap(r => Stream.fromEffect(r.get)))
                          .run(Sink.await[Boolean])
-        } yield assert(leftAssoc -> rightAssoc, equalTo(true -> true))
+        } yield assert(leftAssoc -> rightAssoc)(equalTo(true -> true))
       )
     ),
     suite("Stream.broadcast")(
@@ -346,9 +340,9 @@ object StreamSpec extends ZIOBaseSpec {
                 out1     <- s1.runCollect
                 out2     <- s2.runCollect
                 expected = Range(0, 5).toList
-              } yield assert(out1, equalTo(expected)) && assert(out2, equalTo(expected))
+              } yield assert(out1)(equalTo(expected)) && assert(out2)(equalTo(expected))
             case _ =>
-              UIO(assert((), Assertion.nothing))
+              UIO(assert(())(Assertion.nothing))
           }
       },
       testM("Errors") {
@@ -360,7 +354,7 @@ object StreamSpec extends ZIOBaseSpec {
               expected = Left("Boom")
             } yield assert(out1)(equalTo(expected)) && assert(out2)(equalTo(expected))
           case _ =>
-            UIO(assert((), Assertion.nothing))
+            UIO(assert(())(Assertion.nothing))
         }
       },
       testM("BackPressure") {
@@ -378,12 +372,11 @@ object StreamSpec extends ZIOBaseSpec {
                 _         <- s2.runDrain
                 _         <- fib.await
                 snapshot2 <- ref.get
-              } yield assert(snapshot1, equalTo(List(2, 1, 0))) && assert(
-                snapshot2,
+              } yield assert(snapshot1)(equalTo(List(2, 1, 0))) && assert(snapshot2)(
                 equalTo(Range(0, 5).toList.reverse)
               )
             case _ =>
-              UIO(assert((), Assertion.nothing))
+              UIO(assert(())(Assertion.nothing))
           }
       },
       testM("Unsubscribe") {
@@ -392,9 +385,9 @@ object StreamSpec extends ZIOBaseSpec {
             for {
               _    <- s1.process.use_(ZIO.unit).ignore
               out2 <- s2.runCollect
-            } yield assert(out2, equalTo(Range(0, 5).toList))
+            } yield assert(out2)(equalTo(Range(0, 5).toList))
           case _ =>
-            UIO(assert((), Assertion.nothing))
+            UIO(assert(())(Assertion.nothing))
         }
       }
     ),
@@ -402,17 +395,17 @@ object StreamSpec extends ZIOBaseSpec {
       testM("recovery from errors") {
         val s1 = Stream(1, 2) ++ Stream.fail("Boom")
         val s2 = Stream(3, 4)
-        s1.catchAllCause(_ => s2).runCollect.map(assert(_, equalTo(List(1, 2, 3, 4))))
+        s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
       },
       testM("recovery from defects") {
         val s1 = Stream(1, 2) ++ Stream.dieMessage("Boom")
         val s2 = Stream(3, 4)
-        s1.catchAllCause(_ => s2).runCollect.map(assert(_, equalTo(List(1, 2, 3, 4))))
+        s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
       },
       testM("happy path") {
         val s1 = Stream(1, 2)
         val s2 = Stream(3, 4)
-        s1.catchAllCause(_ => s2).runCollect.map(assert(_, equalTo(List(1, 2))))
+        s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2))))
       },
       testM("executes finalizers") {
         for {
@@ -421,7 +414,7 @@ object StreamSpec extends ZIOBaseSpec {
           s2     = (Stream(3, 4) ++ Stream.fail("Boom")).ensuring(fins.update("s2" :: _))
           _      <- s1.catchAllCause(_ => s2).runCollect.run
           result <- fins.get
-        } yield assert(result, equalTo(List("s2", "s1")))
+        } yield assert(result)(equalTo(List("s2", "s1")))
       }
     ),
     suite("Stream.chunkN")(
@@ -429,19 +422,15 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(Stream.empty.chunkN(1).runCollect)(equalTo(Nil))
       },
       testM("non-positive chunk size") {
-        assertM(Stream(1, 2, 3).chunkN(0).chunks.runCollect, equalTo(List(Chunk(1), Chunk(2), Chunk(3))))
+        assertM(Stream(1, 2, 3).chunkN(0).chunks.runCollect)(equalTo(List(Chunk(1), Chunk(2), Chunk(3))))
       },
       testM("full last chunk") {
-        assertM(
-          Stream(1, 2, 3, 4, 5, 6).chunkN(2).chunks.runCollect,
+        assertM(Stream(1, 2, 3, 4, 5, 6).chunkN(2).chunks.runCollect)(
           equalTo(List(Chunk(1, 2), Chunk(3, 4), Chunk(5, 6)))
         )
       },
       testM("non-full last chunk") {
-        assertM(
-          Stream(1, 2, 3, 4, 5).chunkN(2).chunks.runCollect,
-          equalTo(List(Chunk(1, 2), Chunk(3, 4), Chunk(5)))
-        )
+        assertM(Stream(1, 2, 3, 4, 5).chunkN(2).chunks.runCollect)(equalTo(List(Chunk(1, 2), Chunk(3, 4), Chunk(5))))
       },
       testM("error") {
         (Stream(1, 2, 3, 4, 5) ++ Stream.fail("broken"))
@@ -449,13 +438,13 @@ object StreamSpec extends ZIOBaseSpec {
           .catchAll(_ => ZStreamChunk.succeed(Chunk(6)))
           .chunks
           .runCollect
-          .map(assert(_, equalTo(List(Chunk(1, 2, 3), Chunk(4, 5), Chunk(6)))))
+          .map(assert(_)(equalTo(List(Chunk(1, 2, 3), Chunk(4, 5), Chunk(6)))))
       }
     ),
     testM("Stream.collect") {
       assertM(Stream(Left(1), Right(2), Left(3)).collect {
         case Right(n) => n
-      }.runCollect, equalTo(List(2)))
+      }.runCollect)(equalTo(List(2)))
     },
     suite("Stream.collectM")(
       testM("collectM") {
@@ -464,9 +453,8 @@ object StreamSpec extends ZIOBaseSpec {
             .collectM[Any, Throwable, Int] {
               case Right(n) => ZIO(n * 2)
             }
-            .runCollect,
-          equalTo(List(4))
-        )
+            .runCollect
+        )(equalTo(List(4)))
       },
       testM("collectM fails") {
         assertM(
@@ -475,24 +463,20 @@ object StreamSpec extends ZIOBaseSpec {
               case Right(_) => ZIO.fail("Ouch")
             }
             .runDrain
-            .either,
-          isLeft(isNonEmptyString)
-        )
+            .either
+        )(isLeft(isNonEmptyString))
       }
     ),
     suite("Stream.collectWhile")(
       testM("collectWhile") {
-        assertM(
-          Stream(Some(1), Some(2), Some(3), None, Some(4)).collectWhile {
-            case Some(v) => v
-          }.runCollect,
-          equalTo(List(1, 2, 3))
-        )
+        assertM(Stream(Some(1), Some(2), Some(3), None, Some(4)).collectWhile {
+          case Some(v) => v
+        }.runCollect)(equalTo(List(1, 2, 3)))
       },
       testM("collectWhile short circuits") {
         assertM((Stream(Option(1)) ++ Stream.fail("Ouch")).collectWhile {
           case None => 1
-        }.runDrain.either, isRight(isUnit))
+        }.runDrain.either)(isRight(isUnit))
       }
     ),
     suite("Stream.collectWhileM")(
@@ -502,9 +486,8 @@ object StreamSpec extends ZIOBaseSpec {
             .collectWhileM[Any, Throwable, Int] {
               case Some(v) => ZIO(v * 2)
             }
-            .runCollect,
-          equalTo(List(2, 4, 6))
-        )
+            .runCollect
+        )(equalTo(List(2, 4, 6)))
       },
       testM("collectWhileM short circuits") {
         assertM(
@@ -513,9 +496,8 @@ object StreamSpec extends ZIOBaseSpec {
               case None => ZIO.succeed(1)
             }
             .runDrain
-            .either,
-          isRight(isUnit)
-        )
+            .either
+        )(isRight(isUnit))
       },
       testM("collectWhileM fails") {
         assertM(
@@ -524,9 +506,8 @@ object StreamSpec extends ZIOBaseSpec {
               case Some(_) => ZIO.fail("Ouch")
             }
             .runDrain
-            .either,
-          isLeft(isNonEmptyString)
-        )
+            .either
+        )(isLeft(isNonEmptyString))
       }
     ),
     suite("Stream.concat")(
@@ -534,8 +515,7 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           listConcat   <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
           streamConcat <- (s1 ++ s2).runCollect.run
-        } yield assert(streamConcat.succeeded && listConcat.succeeded, isTrue) implies assert(
-          streamConcat,
+        } yield assert(streamConcat.succeeded && listConcat.succeeded)(isTrue) implies assert(streamConcat)(
           equalTo(listConcat)
         )
       }),
@@ -545,7 +525,7 @@ object StreamSpec extends ZIOBaseSpec {
           _ <- (Stream.finalizer(log.update("Second" :: _)) ++ Stream
                 .finalizer(log.update("First" :: _))).runDrain
           execution <- log.get
-        } yield assert(execution, equalTo(List("First", "Second")))
+        } yield assert(execution)(equalTo(List("First", "Second")))
       }
     ),
     suite("Stream.distributedWithDynamic")(
@@ -573,14 +553,14 @@ object StreamSpec extends ZIOBaseSpec {
         ref <- Ref.make(List[Int]())
         _   <- Stream.range(0, 10).mapM(i => ref.update(i :: _)).drain.run(Sink.drain)
         l   <- ref.get
-      } yield assert(l.reverse, equalTo(Range(0, 10).toList))
+      } yield assert(l.reverse)(equalTo(Range(0, 10).toList))
     ),
     suite("Stream.dropUntil")(testM("dropUntil") {
       checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
         for {
           res1 <- s.dropUntil(p).runCollect
           res2 <- s.runCollect.map(StreamUtils.dropUntil(_)(p))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }
     }),
     suite("Stream.dropWhile")(
@@ -589,7 +569,7 @@ object StreamSpec extends ZIOBaseSpec {
           for {
             res1 <- s.dropWhile(p).runCollect
             res2 <- s.runCollect.map(_.dropWhile(p))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       ),
       testM("short circuits") {
@@ -598,9 +578,8 @@ object StreamSpec extends ZIOBaseSpec {
             .take(1)
             .dropWhile(_ => true)
             .runDrain
-            .either,
-          isRight(isUnit)
-        )
+            .either
+        )(isRight(isUnit))
       }
     ),
     testM("Stream.either") {
@@ -615,7 +594,7 @@ object StreamSpec extends ZIOBaseSpec {
               _ <- Stream.fromEffect(log.update("Use" :: _))
             } yield ()).ensuring(log.update("Ensuring" :: _)).runDrain
         execution <- log.get
-      } yield assert(execution, equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+      } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
     },
     testM("Stream.ensuringFirst") {
       for {
@@ -625,24 +604,24 @@ object StreamSpec extends ZIOBaseSpec {
               _ <- Stream.fromEffect(log.update("Use" :: _))
             } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
         execution <- log.get
-      } yield assert(execution, equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+      } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
     },
     testM("Stream.environment") {
       for {
         result <- ZStream.environment[String].provide("test").runHead.get
-      } yield assert(result, equalTo("test"))
+      } yield assert(result)(equalTo("test"))
     },
     testM("Stream.filter")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
       for {
         res1 <- s.filter(p).runCollect
         res2 <- s.runCollect.map(_.filter(p))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     testM("Stream.filterM")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
       for {
         res1 <- s.filterM(s => IO.succeed(p(s))).runCollect
         res2 <- s.runCollect.map(_.filter(p))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     suite("Stream.finalizer")(
       testM("happy path") {
@@ -653,14 +632,14 @@ object StreamSpec extends ZIOBaseSpec {
                 _ <- Stream.finalizer(log.update("Use" :: _))
               } yield ()).ensuring(log.update("Ensuring" :: _)).runDrain
           execution <- log.get
-        } yield assert(execution, equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+        } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
       },
       testM("finalizer is not run if stream is not pulled") {
         for {
           ref <- Ref.make(false)
           _   <- Stream.finalizer(ref.set(true)).process.use(_ => UIO.unit)
           fin <- ref.get
-        } yield assert(fin, isFalse)
+        } yield assert(fin)(isFalse)
       }
     ),
     suite("Stream.flatMap")(
@@ -677,13 +656,13 @@ object StreamSpec extends ZIOBaseSpec {
         val stream   = fib(20)
         val expected = 6765
 
-        assertM(stream.runCollect, equalTo(List(expected)))
+        assertM(stream.runCollect)(equalTo(List(expected)))
       },
       testM("left identity")(checkM(Gen.anyInt, Gen.function(pureStreamOfInts)) { (x, f) =>
         for {
           res1 <- Stream(x).flatMap(f).runCollect
           res2 <- f(x).runCollect
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }),
       testM("right identity")(
         checkM(pureStreamOfInts)(
@@ -691,7 +670,7 @@ object StreamSpec extends ZIOBaseSpec {
             for {
               res1 <- m.flatMap(i => Stream(i)).runCollect
               res2 <- m.runCollect
-            } yield assert(res1, equalTo(res2))
+            } yield assert(res1)(equalTo(res2))
         )
       ),
       testM("associativity") {
@@ -701,7 +680,7 @@ object StreamSpec extends ZIOBaseSpec {
           for {
             leftStream  <- m.flatMap(f).flatMap(g).runCollect
             rightStream <- m.flatMap(x => f(x).flatMap(g)).runCollect
-          } yield assert(leftStream, equalTo(rightStream))
+          } yield assert(leftStream)(equalTo(rightStream))
         }
       },
       testM("inner finalizers") {
@@ -719,7 +698,7 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fiber.interrupt
           result <- effects.get
-        } yield assert(result, equalTo(List(3, 3, 2, 1, 1)))
+        } yield assert(result)(equalTo(List(3, 3, 2, 1, 1)))
 
       },
       testM("finalizer ordering") {
@@ -734,7 +713,7 @@ object StreamSpec extends ZIOBaseSpec {
           } yield ()
           _      <- stream.runDrain
           result <- effects.get
-        } yield assert(result, equalTo(List(1, 2, 3, 4, 4, 4, 3, 2, 3, 4, 4, 4, 3, 2, 1).reverse))
+        } yield assert(result)(equalTo(List(1, 2, 3, 4, 4, 4, 3, 2, 3, 4, 4, 4, 3, 2, 1).reverse))
       }
     ),
     suite("Stream.flatMapPar / flattenPar / mergeAll")(
@@ -742,14 +721,14 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           flatMap    <- Stream.fromIterable(m).flatMap(i => Stream(i, i)).runCollect
           flatMapPar <- Stream.fromIterable(m).flatMapPar(1)(i => Stream(i, i)).runCollect
-        } yield assert(flatMap, equalTo(flatMapPar))
+        } yield assert(flatMap)(equalTo(flatMapPar))
       }),
       testM("consistent with flatMap")(checkM(Gen.int(1, Int.MaxValue), Gen.small(Gen.listOfN(_)(Gen.anyInt))) {
         (n, m) =>
           for {
             flatMap    <- Stream.fromIterable(m).flatMap(i => Stream(i, i)).runCollect.map(_.toSet)
             flatMapPar <- Stream.fromIterable(m).flatMapPar(n)(i => Stream(i, i)).runCollect.map(_.toSet)
-          } yield assert(n, isGreaterThan(0)) implies assert(flatMap, equalTo(flatMapPar))
+          } yield assert(n)(isGreaterThan(0)) implies assert(flatMap)(equalTo(flatMapPar))
       }),
       testM("short circuiting") {
         assertM(
@@ -759,9 +738,8 @@ object StreamSpec extends ZIOBaseSpec {
               Stream(1)
             )
             .take(1)
-            .run(Sink.collectAll[Int]),
-          equalTo(List(1))
-        )
+            .run(Sink.collectAll[Int])
+        )(equalTo(List(1)))
       },
       testM("interruption propagation") {
         for {
@@ -779,7 +757,7 @@ object StreamSpec extends ZIOBaseSpec {
           _         <- latch.await
           _         <- fiber.interrupt
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue)
+        } yield assert(cancelled)(isTrue)
       },
       testM("inner errors interrupt all fibers") {
         for {
@@ -794,7 +772,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .either
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, isLeft(equalTo("Ouch")))
+        } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
       },
       testM("outer errors interrupt all fibers") {
         for {
@@ -809,7 +787,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .either
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, isLeft(equalTo("Ouch")))
+        } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
       },
       testM("inner defects interrupt all fibers") {
         val ex = new RuntimeException("Ouch")
@@ -826,7 +804,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .run
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, dies(equalTo(ex)))
+        } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
       },
       testM("outer defects interrupt all fibers") {
         val ex = new RuntimeException()
@@ -843,7 +821,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .run
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, dies(equalTo(ex)))
+        } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
       },
       testM("finalizer ordering") {
         for {
@@ -857,7 +835,7 @@ object StreamSpec extends ZIOBaseSpec {
                 .flatMapPar(2)(identity)
                 .runDrain
           results <- execution.get
-        } yield assert(results, equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire")))
+        } yield assert(results)(equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire")))
       }
     ),
     suite("Stream.flatMapParSwitch")(
@@ -872,7 +850,7 @@ object StreamSpec extends ZIOBaseSpec {
                 }
                 .runDrain
           result <- semaphore.withPermit(lastExecuted.get)
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("guarantee ordering with parallelism") {
         for {
@@ -886,16 +864,15 @@ object StreamSpec extends ZIOBaseSpec {
                 }
                 .runDrain
           result <- semaphore.withPermits(4)(lastExecuted.get)
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       },
       testM("short circuiting") {
         assertM(
           Stream(Stream.never, Stream(1))
             .flatMapParSwitch(2)(identity)
             .take(1)
-            .runCollect,
-          equalTo(List(1))
-        )
+            .runCollect
+        )(equalTo(List(1)))
       },
       testM("interruption propagation") {
         for {
@@ -913,7 +890,7 @@ object StreamSpec extends ZIOBaseSpec {
           _         <- latch.await
           _         <- fiber.interrupt
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue)
+        } yield assert(cancelled)(isTrue)
       } @@ flaky,
       testM("inner errors interrupt all fibers") {
         for {
@@ -926,7 +903,7 @@ object StreamSpec extends ZIOBaseSpec {
                      Stream.fromEffect(latch.await *> IO.fail("Ouch"))
                    ).flatMapParSwitch(2)(identity).runDrain.either
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, isLeft(equalTo("Ouch")))
+        } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
       } @@ flaky,
       testM("outer errors interrupt all fibers") {
         for {
@@ -941,7 +918,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .runDrain
                      .either
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, isLeft(equalTo("Ouch")))
+        } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
       },
       testM("inner defects interrupt all fibers") {
         val ex = new RuntimeException("Ouch")
@@ -958,7 +935,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .run
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, dies(equalTo(ex)))
+        } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
       },
       testM("outer defects interrupt all fibers") {
         val ex = new RuntimeException()
@@ -975,7 +952,7 @@ object StreamSpec extends ZIOBaseSpec {
                      .run(Sink.drain)
                      .run
           cancelled <- substreamCancelled.get
-        } yield assert(cancelled, isTrue) && assert(result, dies(equalTo(ex)))
+        } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
       },
       testM("finalizer ordering") {
         for {
@@ -990,7 +967,7 @@ object StreamSpec extends ZIOBaseSpec {
                 .flatMapParSwitch(2)(identity)
                 .runDrain
           results <- execution.get
-        } yield assert(results, equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire")))
+        } yield assert(results)(equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire")))
       }
     ),
     suite("Stream.foreach/foreachWhile")(
@@ -999,7 +976,7 @@ object StreamSpec extends ZIOBaseSpec {
           ref <- Ref.make(0)
           _   <- Stream(1, 1, 1, 1, 1).foreach[Any, Nothing](a => ref.update(_ + a))
           sum <- ref.get
-        } yield assert(sum, equalTo(5))
+        } yield assert(sum)(equalTo(5))
       },
       testM("foreachWhile") {
         for {
@@ -1013,14 +990,14 @@ object StreamSpec extends ZIOBaseSpec {
                   )
               )
           sum <- ref.get
-        } yield assert(sum, equalTo(3))
+        } yield assert(sum)(equalTo(3))
       },
       testM("foreachWhile short circuits") {
         for {
           flag    <- Ref.make(true)
           _       <- (Stream(true, true, false) ++ Stream.fromEffect(flag.set(false)).drain).foreachWhile(ZIO.succeed)
           skipped <- flag.get
-        } yield assert(skipped, isTrue)
+        } yield assert(skipped)(isTrue)
       }
     ),
     testM("Stream.forever") {
@@ -1030,10 +1007,10 @@ object StreamSpec extends ZIOBaseSpec {
               _ => ref.modify(sum => (if (sum >= 9) false else true, sum + 1))
             )
         sum <- ref.get
-      } yield assert(sum, equalTo(10))
+      } yield assert(sum)(equalTo(10))
     },
     testM("Stream.fromChunk")(checkM(smallChunks(Gen.anyInt)) { c =>
-      assertM(Stream.fromChunk(c).runCollect, equalTo(c.toSeq.toList))
+      assertM(Stream.fromChunk(c).runCollect)(equalTo(c.toSeq.toList))
     }),
     testM("Stream.fromInputStream") {
       import java.io.ByteArrayInputStream
@@ -1041,14 +1018,14 @@ object StreamSpec extends ZIOBaseSpec {
       val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
       val is        = new ByteArrayInputStream(data)
       ZStream.fromInputStream(is, chunkSize).run(Sink.collectAll[Chunk[Byte]]) map { chunks =>
-        assert(chunks.flatMap(_.toArray[Byte]).toArray, equalTo(data))
+        assert(chunks.flatMap(_.toArray[Byte]).toArray)(equalTo(data))
       }
     },
     testM("Stream.fromIterable")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
-      assertM(Stream.fromIterable(l).runCollect, equalTo(l))
+      assertM(Stream.fromIterable(l).runCollect)(equalTo(l))
     }),
     testM("Stream.fromIterator")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
-      assertM(Stream.fromIterator(UIO.effectTotal(l.iterator)).runCollect, equalTo(l))
+      assertM(Stream.fromIterator(UIO.effectTotal(l.iterator)).runCollect)(equalTo(l))
     }),
     testM("Stream.fromQueue")(checkM(smallChunks(Gen.anyInt)) { c =>
       for {
@@ -1064,16 +1041,16 @@ object StreamSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, -1)
         _     <- queue.shutdown
         items <- fiber.join
-      } yield assert(items, equalTo(c.toSeq.toList))
+      } yield assert(items)(equalTo(c.toSeq.toList))
     }),
     suite("Stream.fromEffectOption")(
       testM("emit one element with success") {
         val fa: ZIO[Any, Option[Int], Int] = ZIO.succeed(5)
-        assertM(Stream.fromEffectOption(fa).runCollect, equalTo(List(5)))
+        assertM(Stream.fromEffectOption(fa).runCollect)(equalTo(List(5)))
       },
       testM("emit one element with failure") {
         val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(Some(5))
-        assertM(Stream.fromEffectOption(fa).runCollect.either, isLeft(equalTo(5)))
+        assertM(Stream.fromEffectOption(fa).runCollect.either)(isLeft(equalTo(5)))
       },
       testM("do not emit any element") {
         val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(None)
@@ -1093,9 +1070,8 @@ object StreamSpec extends ZIOBaseSpec {
                   .map((k -> _))
             }
             .runCollect
-            .map(_.toMap),
-          equalTo((0 to 100).map((_.toString -> 1000)).toMap)
-        )
+            .map(_.toMap)
+        )(equalTo((0 to 100).map((_.toString -> 1000)).toMap))
       },
       testM("first") {
         val words = List.fill(1000)(0 to 100).flatten.map(_.toString())
@@ -1110,9 +1086,8 @@ object StreamSpec extends ZIOBaseSpec {
                   .map((k -> _))
             }
             .runCollect
-            .map(_.toMap),
-          equalTo((0 to 1).map((_.toString -> 1000)).toMap)
-        )
+            .map(_.toMap)
+        )(equalTo((0 to 1).map((_.toString -> 1000)).toMap))
       },
       testM("filter") {
         val words = List.fill(1000)(0 to 100).flatten
@@ -1127,9 +1102,8 @@ object StreamSpec extends ZIOBaseSpec {
                   .map((k -> _))
             }
             .runCollect
-            .map(_.toMap),
-          equalTo((0 to 5).map((_ -> 1000)).toMap)
-        )
+            .map(_.toMap)
+        )(equalTo((0 to 5).map((_ -> 1000)).toMap))
       },
       testM("outer errors") {
         val words = List("abc", "test", "test", "foo")
@@ -1137,16 +1111,12 @@ object StreamSpec extends ZIOBaseSpec {
           (Stream.fromIterable(words) ++ Stream.fail("Boom"))
             .groupByKey(identity) { case (_, s) => s.drain }
             .runCollect
-            .either,
-          isLeft(equalTo("Boom"))
-        )
+            .either
+        )(isLeft(equalTo("Boom")))
       }
     ),
     testM("Stream.grouped")(
-      assertM(
-        Stream(1, 2, 3, 4).grouped(2).run(ZSink.collectAll[List[Int]]),
-        equalTo(List(List(1, 2), List(3, 4)))
-      )
+      assertM(Stream(1, 2, 3, 4).grouped(2).run(ZSink.collectAll[List[Int]]))(equalTo(List(List(1, 2), List(3, 4))))
     ),
     suite("Stream.runHead")(
       testM("nonempty stream")(
@@ -1161,7 +1131,7 @@ object StreamSpec extends ZIOBaseSpec {
         val s1 = Stream(2, 3)
         val s2 = Stream(5, 6, 7)
 
-        assertM(s1.interleave(s2).runCollect, equalTo(List(2, 5, 3, 6, 7)))
+        assertM(s1.interleave(s2).runCollect)(equalTo(List(2, 5, 3, 6, 7)))
       },
       testM("interleaveWith") {
         def interleave(b: List[Boolean], s1: => List[Int], s2: => List[Int]): List[Int] =
@@ -1195,12 +1165,12 @@ object StreamSpec extends ZIOBaseSpec {
             s1                <- s1.runCollect
             s2                <- s2.runCollect
             interleavedLists  = interleave(b, s1, s2)
-          } yield assert(interleavedStream, equalTo(interleavedLists))
+          } yield assert(interleavedStream)(equalTo(interleavedLists))
         }
       }
     ),
     testM("Stream.iterate")(
-      assertM(Stream.iterate(1)(_ + 1).take(10).runCollect, equalTo((1 to 10).toList))
+      assertM(Stream.iterate(1)(_ + 1).take(10).runCollect)(equalTo((1 to 10).toList))
     ),
     suite("Stream.runLast")(
       testM("nonempty stream")(
@@ -1214,39 +1184,38 @@ object StreamSpec extends ZIOBaseSpec {
       for {
         res1 <- s.map(f).runCollect
         res2 <- s.runCollect.map(_.map(f))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     testM("Stream.mapAccum") {
-      assertM(Stream(1, 1, 1).mapAccum(0)((acc, el) => (acc + el, acc + el)).runCollect, equalTo(List(1, 2, 3)))
+      assertM(Stream(1, 1, 1).mapAccum(0)((acc, el) => (acc + el, acc + el)).runCollect)(equalTo(List(1, 2, 3)))
     },
     suite("Stream.mapAccumM")(
       testM("mapAccumM happy path") {
         assertM(
           Stream(1, 1, 1)
             .mapAccumM[Any, Nothing, Int, Int](0)((acc, el) => IO.succeed((acc + el, acc + el)))
-            .runCollect,
-          equalTo(List(1, 2, 3))
-        )
+            .runCollect
+        )(equalTo(List(1, 2, 3)))
       },
       testM("mapAccumM error") {
         Stream(1, 1, 1)
           .mapAccumM(0)((_, _) => IO.fail("Ouch"))
           .runCollect
           .either
-          .map(assert(_, isLeft(equalTo("Ouch"))))
+          .map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("Stream.mapConcat")(checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
       for {
         res1 <- s.mapConcat(f).runCollect
         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     testM("Stream.mapConcatChunk")(checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
       for {
         res1 <- s.mapConcatChunk(f).runCollect
         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     suite("Stream.mapConcatChunkM")(
       testM("mapConcatChunkM happy path") {
@@ -1254,7 +1223,7 @@ object StreamSpec extends ZIOBaseSpec {
           for {
             res1 <- s.mapConcatChunkM(b => UIO.succeed(f(b))).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatChunkM error") {
@@ -1271,7 +1240,7 @@ object StreamSpec extends ZIOBaseSpec {
           for {
             res1 <- s.mapConcatM(b => UIO.succeed(f(b))).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
-          } yield assert(res1, equalTo(res2))
+          } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatM error") {
@@ -1288,7 +1257,7 @@ object StreamSpec extends ZIOBaseSpec {
         .mapError(_.toInt)
         .runCollect
         .either
-        .map(assert(_, isLeft(equalTo(123))))
+        .map(assert(_)(isLeft(equalTo(123))))
     },
     testM("Stream.mapErrorCause") {
       Stream
@@ -1296,7 +1265,7 @@ object StreamSpec extends ZIOBaseSpec {
         .mapErrorCause(_.map(_.toInt))
         .runCollect
         .either
-        .map(assert(_, isLeft(equalTo(123))))
+        .map(assert(_)(isLeft(equalTo(123))))
     },
     testM("Stream.mapM") {
       checkM(Gen.small(Gen.listOfN(_)(Gen.anyByte)), Gen.function(successes(Gen.anyByte))) { (data, f) =>
@@ -1305,7 +1274,7 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           l <- s.mapM(f).runCollect
           r <- IO.foreach(data)(f)
-        } yield assert(l, equalTo(r))
+        } yield assert(l)(equalTo(r))
       }
     },
     testM("Stream.repeatEffect")(
@@ -1313,9 +1282,8 @@ object StreamSpec extends ZIOBaseSpec {
         Stream
           .repeatEffect(IO.succeed(1))
           .take(2)
-          .run(Sink.collectAll[Int]),
-        equalTo(List(1, 1))
-      )
+          .run(Sink.collectAll[Int])
+      )(equalTo(List(1, 1)))
     ),
     suite("Stream.repeatEffectOption")(
       testM("emit elements")(
@@ -1323,9 +1291,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream
             .repeatEffectOption(IO.succeed(1))
             .take(2)
-            .run(Sink.collectAll[Int]),
-          equalTo(List(1, 1))
-        )
+            .run(Sink.collectAll[Int])
+        )(equalTo(List(1, 1)))
       ),
       testM("emit elements until pull fails with None")(
         for {
@@ -1338,7 +1305,7 @@ object StreamSpec extends ZIOBaseSpec {
                   .repeatEffectOption(fa)
                   .take(10)
                   .run(Sink.collectAll[Int])
-        } yield assert(res, equalTo(List(1, 2, 3, 4)))
+        } yield assert(res)(equalTo(List(1, 2, 3, 4)))
       )
     ),
     testM("Stream.repeatEffectWith")(
@@ -1349,7 +1316,7 @@ object StreamSpec extends ZIOBaseSpec {
               .take(2)
               .run(Sink.drain)
         result <- ref.get
-      } yield assert(result, equalTo(List(1, 1)))).provide(Clock.Live)
+      } yield assert(result)(equalTo(List(1, 1)))).provide(Clock.Live)
     ),
     suite("Stream.mapMPar")(
       testM("foreachParN equivalence") {
@@ -1359,7 +1326,7 @@ object StreamSpec extends ZIOBaseSpec {
           for {
             l <- s.mapMPar(8)(f).runCollect
             r <- IO.foreachParN(8)(data)(f)
-          } yield assert(l, equalTo(r))
+          } yield assert(l)(equalTo(r))
         }
       },
       testM("order when n = 1") {
@@ -1367,7 +1334,7 @@ object StreamSpec extends ZIOBaseSpec {
           queue  <- Queue.unbounded[Int]
           _      <- Stream.range(0, 9).mapMPar(1)(queue.offer).runDrain
           result <- queue.takeAll
-        } yield assert(result, equalTo(result.sorted))
+        } yield assert(result)(equalTo(result.sorted))
       },
       testM("interruption propagation") {
         for {
@@ -1382,13 +1349,13 @@ object StreamSpec extends ZIOBaseSpec {
           _      <- latch.await
           _      <- fib.interrupt
           result <- interrupted.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       },
       testM("guarantee ordering")(checkM(Gen.int(1, 4096), Gen.listOf(Gen.anyInt)) { (n: Int, m: List[Int]) =>
         for {
           mapM    <- Stream.fromIterable(m).mapM(UIO.succeed).runCollect
           mapMPar <- Stream.fromIterable(m).mapMPar(n)(UIO.succeed).runCollect
-        } yield assert(n, isGreaterThan(0)) implies assert(mapM, equalTo(mapMPar))
+        } yield assert(n)(isGreaterThan(0)) implies assert(mapM)(equalTo(mapMPar))
       })
     ),
     suite("Stream merging")(
@@ -1401,8 +1368,7 @@ object StreamSpec extends ZIOBaseSpec {
                           }
                           .map(_.toSet)
                           .run
-        } yield assert(!mergedStream.succeeded && !mergedLists.succeeded, isTrue) || assert(
-          mergedStream,
+        } yield assert(!mergedStream.succeeded && !mergedLists.succeeded)(isTrue) || assert(mergedStream)(
           equalTo(mergedLists)
         )
       }),
@@ -1420,7 +1386,7 @@ object StreamSpec extends ZIOBaseSpec {
 
         for {
           merge <- s1.mergeWith(s2)(_.toString, _.toString).runCollect
-        } yield assert(merge, hasSameElements(List("1", "2", "1", "2")))
+        } yield assert(merge)(hasSameElements(List("1", "2", "1", "2")))
       },
       testM("mergeWith short circuit") {
         val s1 = Stream(1, 2)
@@ -1428,21 +1394,20 @@ object StreamSpec extends ZIOBaseSpec {
 
         assertM(
           s1.mergeWith(s2)(_.toString, _.toString)
-            .run(Sink.succeed[String, String]("done")),
-          equalTo("done")
-        )
+            .run(Sink.succeed[String, String]("done"))
+        )(equalTo("done"))
       },
       testM("mergeWith prioritizes failure") {
         val s1 = Stream.never
         val s2 = Stream.fail("Ouch")
 
-        assertM(s1.mergeWith(s2)(_ => (), _ => ()).runCollect.either, isLeft(equalTo("Ouch")))
+        assertM(s1.mergeWith(s2)(_ => (), _ => ()).runCollect.either)(isLeft(equalTo("Ouch")))
       }
     ),
     testM("Stream.orElse") {
       val s1 = Stream(1, 2, 3) ++ Stream.fail("Boom")
       val s2 = Stream(4, 5, 6)
-      s1.orElse(s2).runCollect.map(assert(_, equalTo(List(1, 2, 3, 4, 5, 6))))
+      s1.orElse(s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
     },
     testM("Stream.paginate") {
       val s = (0, List(1, 2, 3))
@@ -1453,7 +1418,7 @@ object StreamSpec extends ZIOBaseSpec {
           case (x, x0 :: xs) => x -> Some(x0 -> xs)
         }
         .runCollect
-        .map(assert(_, equalTo(List(0, 1, 2, 3))))
+        .map(assert(_)(equalTo(List(0, 1, 2, 3))))
     },
     testM("Stream.paginateM") {
       val s = (0, List(1, 2, 3))
@@ -1464,9 +1429,8 @@ object StreamSpec extends ZIOBaseSpec {
             case (x, Nil)      => ZIO.succeed(x -> None)
             case (x, x0 :: xs) => ZIO.succeed(x -> Some(x0 -> xs))
           }
-          .runCollect,
-        equalTo(List(0, 1, 2, 3))
-      )
+          .runCollect
+      )(equalTo(List(0, 1, 2, 3)))
     },
     suite("Stream.partitionEither")(
       testM("allows repeated runs without hanging") {
@@ -1475,7 +1439,7 @@ object StreamSpec extends ZIOBaseSpec {
           .partitionEither(i => ZIO.succeed(if (i % 2 == 0) Left(i) else Right(i)))
           .map { case (evens, odds) => evens.mergeEither(odds) }
           .use(_.runCollect)
-        assertM(ZIO.sequence(Range(0, 100).toList.map(_ => stream)).map(_ => 0), equalTo(0))
+        assertM(ZIO.sequence(Range(0, 100).toList.map(_ => stream)).map(_ => 0))(equalTo(0))
       },
       testM("values") {
         Stream
@@ -1489,7 +1453,7 @@ object StreamSpec extends ZIOBaseSpec {
               for {
                 out1 <- s1.runCollect
                 out2 <- s2.runCollect
-              } yield assert(out1, equalTo(List(0, 2, 4))) && assert(out2, equalTo(List(1, 3, 5)))
+              } yield assert(out1)(equalTo(List(0, 2, 4))) && assert(out2)(equalTo(List(1, 3, 5)))
           }
       },
       testM("errors") {
@@ -1501,7 +1465,7 @@ object StreamSpec extends ZIOBaseSpec {
             for {
               out1 <- s1.runCollect.either
               out2 <- s2.runCollect.either
-            } yield assert(out1, isLeft(equalTo("Boom"))) && assert(out2, isLeft(equalTo("Boom")))
+            } yield assert(out1)(isLeft(equalTo("Boom"))) && assert(out2)(isLeft(equalTo("Boom")))
         }
       },
       testM("backpressure") {
@@ -1522,8 +1486,9 @@ object StreamSpec extends ZIOBaseSpec {
                 other     <- s2.runCollect
                 _         <- fib.await
                 snapshot2 <- ref.get
-              } yield assert(snapshot1, equalTo(List(2, 0))) && assert(snapshot2, equalTo(List(4, 2, 0))) && assert(
-                other,
+              } yield assert(snapshot1)(equalTo(List(2, 0))) && assert(snapshot2)(equalTo(List(4, 2, 0))) && assert(
+                other
+              )(
                 equalTo(
                   List(
                     1,
@@ -1563,7 +1528,7 @@ object StreamSpec extends ZIOBaseSpec {
                 .take(2)
                 .run(Sink.drain)
           result <- ref.get
-        } yield assert(result, equalTo(List(1, 1)))).provide(Clock.Live)
+        } yield assert(result)(equalTo(List(1, 1)))).provide(Clock.Live)
       )
     ),
     suite("Stream.repeatEither")(
@@ -1597,7 +1562,7 @@ object StreamSpec extends ZIOBaseSpec {
                 .take(3) // take one schedule output
                 .run(Sink.drain)
           result <- ref.get
-        } yield assert(result, equalTo(List(1, 1)))).provide(Clock.Live)
+        } yield assert(result)(equalTo(List(1, 1)))).provide(Clock.Live)
       }
     ),
     suite("Stream.schedule")(
@@ -1605,9 +1570,8 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(
           Stream("A", "B", "C")
             .scheduleElementsWith(Schedule.recurs(0) *> Schedule.fromFunction((_) => 123))(identity, _.toString)
-            .run(Sink.collectAll[String]),
-          equalTo(List("A", "123", "B", "123", "C", "123"))
-        )
+            .run(Sink.collectAll[String])
+        )(equalTo(List("A", "123", "B", "123", "C", "123")))
       ),
       testM("scheduleElementsEither")(
         assertM(
@@ -1620,9 +1584,8 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(
           Stream("A", "B", "C", "A", "B", "C")
             .scheduleWith(Schedule.recurs(2) *> Schedule.fromFunction((_) => "Done"))(_.toLowerCase, identity)
-            .run(Sink.collectAll[String]),
-          equalTo(List("a", "b", "c", "Done", "a", "b", "c", "Done"))
-        )
+            .run(Sink.collectAll[String])
+        )(equalTo(List("a", "b", "c", "Done", "a", "b", "c", "Done")))
       ),
       testM("scheduleEither")(
         assertM(
@@ -1635,27 +1598,24 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(
           Stream("A", "B", "C")
             .scheduleElements(Schedule.once)
-            .run(Sink.collectAll[String]),
-          equalTo(List("A", "A", "B", "B", "C", "C"))
-        )
+            .run(Sink.collectAll[String])
+        )(equalTo(List("A", "A", "B", "B", "C", "C")))
       ),
       testM("short circuits in schedule")(
         assertM(
           Stream("A", "B", "C")
             .scheduleElements(Schedule.once)
             .take(4)
-            .run(Sink.collectAll[String]),
-          equalTo(List("A", "A", "B", "B"))
-        )
+            .run(Sink.collectAll[String])
+        )(equalTo(List("A", "A", "B", "B")))
       ),
       testM("short circuits after schedule")(
         assertM(
           Stream("A", "B", "C")
             .scheduleElements(Schedule.once)
             .take(3)
-            .run(Sink.collectAll[String]),
-          equalTo(List("A", "A", "B"))
-        )
+            .run(Sink.collectAll[String])
+        )(equalTo(List("A", "A", "B")))
       )
     ),
     suite("Stream.take")(
@@ -1663,10 +1623,7 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           takeStreamResult <- s.take(n).runCollect.run
           takeListResult   <- s.runCollect.map(_.take(n)).run
-        } yield assert(takeListResult.succeeded, isTrue) implies assert(
-          takeStreamResult,
-          equalTo(takeListResult)
-        )
+        } yield assert(takeListResult.succeeded)(isTrue) implies assert(takeStreamResult)(equalTo(takeListResult))
       }),
       testM("take short circuits")(
         for {
@@ -1674,7 +1631,7 @@ object StreamSpec extends ZIOBaseSpec {
           stream = (Stream(1) ++ Stream.fromEffect(ran.set(true)).drain).take(0)
           _      <- stream.run(Sink.drain)
           result <- ran.get
-        } yield assert(result, isFalse)
+        } yield assert(result)(isFalse)
       ),
       testM("take(0) short circuits")(
         for {
@@ -1684,33 +1641,29 @@ object StreamSpec extends ZIOBaseSpec {
       testM("take(1) short circuits")(
         for {
           ints <- (Stream(1) ++ Stream.never).take(1).run(Sink.collectAll[Int])
-        } yield assert(ints, equalTo(List(1)))
+        } yield assert(ints)(equalTo(List(1)))
       ),
       testM("takeUntil") {
         checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             streamTakeUntil <- s.takeUntil(p).runCollect.run
             listTakeUntil   <- s.runCollect.map(StreamUtils.takeUntil(_)(p)).run
-          } yield assert(listTakeUntil.succeeded, isTrue) implies assert(
-            streamTakeUntil,
-            equalTo(listTakeUntil)
-          )
+          } yield assert(listTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(equalTo(listTakeUntil))
         }
       },
       testM("takeWhile")(checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
         for {
           streamTakeWhile <- s.takeWhile(p).runCollect.run
           listTakeWhile   <- s.runCollect.map(_.takeWhile(p)).run
-        } yield assert(listTakeWhile.succeeded, isTrue) implies assert(streamTakeWhile, equalTo(listTakeWhile))
+        } yield assert(listTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(listTakeWhile))
       }),
       testM("takeWhile short circuits")(
         assertM(
           (Stream(1) ++ Stream.fail("Ouch"))
             .takeWhile(_ => false)
             .runDrain
-            .either,
-          isRight(isUnit)
-        )
+            .either
+        )(isRight(isUnit))
       )
     ),
     testM("Stream.tap") {
@@ -1718,7 +1671,7 @@ object StreamSpec extends ZIOBaseSpec {
         ref <- Ref.make(0)
         res <- Stream(1, 1).tap[Any, Nothing](a => ref.update(_ + a)).runCollect
         sum <- ref.get
-      } yield assert(res, equalTo(List(1, 1))) && assert(sum, equalTo(2))
+      } yield assert(res)(equalTo(List(1, 1))) && assert(sum)(equalTo(2))
     },
     suite("Stream.timeout")(
       testM("succeed") {
@@ -1726,9 +1679,8 @@ object StreamSpec extends ZIOBaseSpec {
           Stream
             .succeed(1)
             .timeout(Duration.Infinity)
-            .runCollect,
-          equalTo(List(1))
-        )
+            .runCollect
+        )(equalTo(List(1)))
       },
       testM("should interrupt stream") {
         assertM(
@@ -1739,9 +1691,8 @@ object StreamSpec extends ZIOBaseSpec {
             .runDrain
             .sandbox
             .ignore
-            .map(_ => true),
-          isTrue
-        )
+            .map(_ => true)
+        )(isTrue)
       }
     ),
     suite("Stream.throttleEnforce")(
@@ -1749,9 +1700,8 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(
           Stream(1, 2, 3, 4)
             .throttleEnforce(0, Duration.Infinity)(_ => 0)
-            .runCollect,
-          equalTo(List(1, 2, 3, 4))
-        )
+            .runCollect
+        )(equalTo(List(1, 2, 3, 4)))
       },
       testM("no bandwidth") {
         assertM(
@@ -1765,9 +1715,8 @@ object StreamSpec extends ZIOBaseSpec {
       assertM(
         Stream(1, 2, 3, 4)
           .throttleShape(1, Duration.Infinity)(_ => 0)
-          .runCollect,
-        equalTo(List(1, 2, 3, 4))
-      )
+          .runCollect
+      )(equalTo(List(1, 2, 3, 4)))
     }),
     testM("Stream.toQueue")(checkM(smallChunks(Gen.anyInt)) { c: Chunk[Int] =>
       val s = Stream.fromChunk(c)
@@ -1787,11 +1736,11 @@ object StreamSpec extends ZIOBaseSpec {
         val parser = ZSink.collectAllWhile[Char](_.isDigit).map(_.mkString.toInt) <* ZSink
           .collectAllWhile[Char](_ == ',')
 
-        assertM(s.aggregate(parser).runCollect, equalTo(List(12, 34)))
+        assertM(s.aggregate(parser).runCollect)(equalTo(List(12, 34)))
       },
       testM("no remainder") {
         val sink = Sink.fold(100)(_ % 2 == 0)((s, a: Int) => (s + a, Chunk[Int]()))
-        assertM(ZStream(1, 2, 3, 4).aggregate(sink).runCollect, equalTo(List(101, 105, 104)))
+        assertM(ZStream(1, 2, 3, 4).aggregate(sink).runCollect)(equalTo(List(101, 105, 104)))
       },
       testM("with remainder") {
         val sink = Sink
@@ -1805,11 +1754,11 @@ object StreamSpec extends ZIOBaseSpec {
           }
           .map(_._1)
 
-        assertM(ZStream(1, 2, 3).aggregate(sink).runCollect, equalTo(List(203, 4)))
+        assertM(ZStream(1, 2, 3).aggregate(sink).runCollect)(equalTo(List(203, 4)))
       },
       testM("with a sink that always signals more") {
         val sink = Sink.foldLeft(0)((s, a: Int) => s + a)
-        assertM(ZStream(1, 2, 3).aggregate(sink).runCollect, equalTo(List(1 + 2 + 3)))
+        assertM(ZStream(1, 2, 3).aggregate(sink).runCollect)(equalTo(List(1 + 2 + 3)))
       },
       testM("managed") {
         final class TestSink(ref: Ref[Int]) extends ZSink[Any, Throwable, Int, Int, List[Int]] {
@@ -1836,12 +1785,12 @@ object StreamSpec extends ZIOBaseSpec {
           result   <- stream.aggregateManaged(sink).runCollect
           i        <- resource.get
           _        <- if (i != 2000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
-        } yield assert(result, equalTo(List(List(1, 1), List(2, 2), List(3, 3), List(4, 4))))
+        } yield assert(result)(equalTo(List(List(1, 1), List(2, 2), List(3, 3), List(4, 4))))
       },
       testM("propagate managed error") {
         val fail = "I'm such a failure!"
         val sink = ZManaged.fail(fail)
-        assertM(ZStream(1, 2, 3).aggregateManaged(sink).runCollect.either, isLeft(equalTo(fail)))
+        assertM(ZStream(1, 2, 3).aggregateManaged(sink).runCollect.either)(isLeft(equalTo(fail)))
       }
     ),
     testM("Stream.unfold") {
@@ -1851,9 +1800,8 @@ object StreamSpec extends ZIOBaseSpec {
             if (i < 10) Some((i, i + 1))
             else None
           }
-          .runCollect,
-        equalTo((0 to 9).toList)
-      )
+          .runCollect
+      )(equalTo((0 to 9).toList))
     },
     testM("Stream.unfoldM") {
       assertM(
@@ -1862,15 +1810,14 @@ object StreamSpec extends ZIOBaseSpec {
             if (i < 10) IO.succeed(Some((i, i + 1)))
             else IO.succeed(None)
           }
-          .runCollect,
-        equalTo((0 to 9).toList)
-      )
+          .runCollect
+      )(equalTo((0 to 9).toList))
     },
     testM("Stream.unNone")(checkM(Gen.small(pureStreamGen(Gen.option(Gen.anyInt), _))) { s =>
       for {
         res1 <- (s.unNone.runCollect)
         res2 <- (s.runCollect.map(_.flatten))
-      } yield assert(res1, equalTo(res2))
+      } yield assert(res1)(equalTo(res2))
     }),
     suite("Stream.unTake")(
       testM("unTake happy path") {
@@ -1880,9 +1827,8 @@ object StreamSpec extends ZIOBaseSpec {
             .toQueue[Nothing, Int](1)
             .use { q =>
               Stream.fromQueue(q).unTake.run(Sink.collectAll[Int])
-            },
-          equalTo(Range(0, 10).toList)
-        )
+            }
+        )(equalTo(Range(0, 10).toList))
       },
       testM("unTake with error") {
         val e = new RuntimeException("boom")
@@ -1899,7 +1845,7 @@ object StreamSpec extends ZIOBaseSpec {
     suite("Stream.via")(
       testM("happy path") {
         val s = Stream(1, 2, 3)
-        s.via(_.map(_.toString)).runCollect.map(assert(_, equalTo(List("1", "2", "3"))))
+        s.via(_.map(_.toString)).runCollect.map(assert(_)(equalTo(List("1", "2", "3"))))
       },
       testM("introduce error") {
         val s = Stream(1, 2, 3)
@@ -1911,27 +1857,26 @@ object StreamSpec extends ZIOBaseSpec {
         val s1 = Stream(1, 2, 3)
         val s2 = Stream(1, 2)
 
-        assertM(s1.zipWith(s2)((a, b) => a.flatMap(a => b.map(a + _))).runCollect, equalTo(List(2, 4)))
+        assertM(s1.zipWith(s2)((a, b) => a.flatMap(a => b.map(a + _))).runCollect)(equalTo(List(2, 4)))
       },
       testM("zipWithIndex")(checkM(pureStreamOfBytes) { s =>
         for {
           res1 <- (s.zipWithIndex.runCollect)
           res2 <- (s.runCollect.map(_.zipWithIndex.map(t => (t._1, t._2.toLong))))
-        } yield assert(res1, equalTo(res2))
+        } yield assert(res1)(equalTo(res2))
       }),
       testM("zipWith ignore RHS") {
         val s1 = Stream(1, 2, 3)
         val s2 = Stream(1, 2)
-        assertM(s1.zipWith(s2)((a, _) => a).runCollect, equalTo(List(1, 2, 3)))
+        assertM(s1.zipWith(s2)((a, _) => a).runCollect)(equalTo(List(1, 2, 3)))
       },
       testM("zipWith prioritizes failure") {
         assertM(
           Stream.never
             .zipWith(Stream.fail("Ouch"))((_, _) => None)
             .runCollect
-            .either,
-          isLeft(equalTo("Ouch"))
-        )
+            .either
+        )(isLeft(equalTo("Ouch")))
       },
       testM("zipWithLatest") {
         import zio.test.environment.TestClock
@@ -1950,7 +1895,7 @@ object StreamSpec extends ZIOBaseSpec {
           _  <- TestClock.setTime(140.millis)
           d  <- q.take
           _  <- TestClock.setTime(210.millis)
-        } yield assert(List(a, b, c, d), equalTo(List(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2)))
+        } yield assert(List(a, b, c, d))(equalTo(List(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2)))
       }
     ),
     testM("Stream.toInputStream") {
@@ -1966,7 +1911,7 @@ object StreamSpec extends ZIOBaseSpec {
                                   .toList
                               )
                             }
-      } yield assert(streamResult, equalTo(inputStreamResult))
+      } yield assert(streamResult)(equalTo(inputStreamResult))
     }
   )
 }

--- a/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
@@ -24,15 +24,15 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
     zio.test.test(label)(assertion)
 
   val test1 = makeTest("Addition works fine") {
-    assert(1 + 1, equalTo(2))
+    assert(1 + 1)(equalTo(2))
   }
 
   val test2 = makeTest("Subtraction works fine") {
-    assert(1 - 1, equalTo(0))
+    assert(1 - 1)(equalTo(0))
   }
 
   val test3 = makeTest("Value falls within range") {
-    assert(52, equalTo(42) || (isGreaterThan(5) && isLessThan(10)))
+    assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10)))
   }
 
   val test3Expected = Vector(
@@ -58,7 +58,7 @@ object SummaryBuilderSpec extends AsyncBaseSpec {
   )
 
   val test5 = makeTest("Addition works fine") {
-    assert(1 + 1, equalTo(3))
+    assert(1 + 1)(equalTo(3))
   }
 
   val test5Expected = Vector(

--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -12,13 +12,13 @@ object AnnotationsSpec extends ZIOBaseSpec {
         a   <- Annotations.get(count)
         map <- Annotations.withAnnotation(ZIO.unit <* Annotations.annotate(count, 2)).map(_._2)
         b   = map.get(count)
-      } yield assert(a, equalTo(1)) && assert(b, equalTo(2))
+      } yield assert(a)(equalTo(1)) && assert(b)(equalTo(2))
     },
     testM("withAnnotation returns annotation map with result") {
       for {
         map <- Annotations.withAnnotation(Annotations.annotate(count, 3) *> ZIO.fail("fail")).flip.map(_._2)
         c   = map.get(count)
-      } yield assert(c, equalTo(3))
+      } yield assert(c)(equalTo(3))
     }
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -10,67 +10,67 @@ object AssertionSpec extends ZIOBaseSpec {
 
   def spec = suite("AssertionSpec")(
     test("and must succeed when both assertions are satisfied") {
-      assert(sampleUser, nameStartsWithU && ageGreaterThan20)
+      assert(sampleUser)(nameStartsWithU && ageGreaterThan20)
     },
     test("and must fail when one of assertions is not satisfied") {
-      assert(sampleUser, nameStartsWithA && ageGreaterThan20)
+      assert(sampleUser)(nameStartsWithA && ageGreaterThan20)
     } @@ failure,
     test("anything must always succeeds") {
-      assert(42, anything)
+      assert(42)(anything)
     },
     test("approximatelyEquals must succeed when number is within range") {
-      assert(5.5, approximatelyEquals(5.0, 3.0))
+      assert(5.5)(approximatelyEquals(5.0, 3.0))
     },
     test("approximatelyEquals must fail when number is not within range") {
-      assert(50.0, approximatelyEquals(5.0, 3.0))
+      assert(50.0)(approximatelyEquals(5.0, 3.0))
     } @@ failure,
     test("contains must succeed when iterable contains specified element") {
-      assert(Seq("zio", "scala"), contains("zio"))
+      assert(Seq("zio", "scala"))(contains("zio"))
     },
     test("contains must fail when iterable does not contain specified element") {
-      assert(Seq("zio", "scala"), contains("java"))
+      assert(Seq("zio", "scala"))(contains("java"))
     } @@ failure,
     test("containsString must succeed when string is found") {
-      assert("this is a value", containsString("is a"))
+      assert("this is a value")(containsString("is a"))
     },
     test("containsString must return false when the string is not contained") {
-      assert("this is a value", containsString("_NOTHING_"))
+      assert("this is a value")(containsString("_NOTHING_"))
     } @@ failure,
     test("dies must succeed when exception satisfy specified assertion") {
-      assert(Exit.die(someException), dies(equalTo(someException)))
+      assert(Exit.die(someException))(dies(equalTo(someException)))
     },
     test("dies must fail when exception does not satisfy specified assertion") {
-      assert(Exit.die(new RuntimeException("Bam!")), dies(equalTo(someException)))
+      assert(Exit.die(new RuntimeException("Bam!")))(dies(equalTo(someException)))
     } @@ failure,
     test("endWith must succeed when the supplied value ends with the specified sequence") {
-      assert(List(1, 2, 3, 4, 5), endsWith(List(3, 4, 5)))
+      assert(List(1, 2, 3, 4, 5))(endsWith(List(3, 4, 5)))
     },
     test("startsWith must fail when the supplied value does not end with the specified sequence") {
-      assert(List(1, 2, 3, 4, 5), endsWith(List(1, 2, 3)))
+      assert(List(1, 2, 3, 4, 5))(endsWith(List(1, 2, 3)))
     } @@ failure,
     test("endsWithString must succeed when the supplied value ends with the specified string") {
-      assert("zio", endsWithString("o"))
+      assert("zio")(endsWithString("o"))
     },
     test("endsWithString must fail when the supplied value does not end with the specified string") {
-      assert("zio", endsWithString("z"))
+      assert("zio")(endsWithString("z"))
     } @@ failure,
     test("equalsIgnoreCase must succeed when the supplied value matches") {
-      assert("Some String", equalsIgnoreCase("some string"))
+      assert("Some String")(equalsIgnoreCase("some string"))
     },
     test("equalsIgnoreCase must fail when the supplied value does not match") {
-      assert("Some Other String", equalsIgnoreCase("some string"))
+      assert("Some Other String")(equalsIgnoreCase("some string"))
     } @@ failure,
     test("equalTo must succeed when value equals specified value") {
-      assert(42, equalTo(42))
+      assert(42)(equalTo(42))
     },
     test("equalTo must fail when value does not equal specified value") {
-      assert(0, equalTo(42))
+      assert(0)(equalTo(42))
     } @@ failure,
     test("equalTo must succeed when array equals specified array") {
-      assert(Array(1, 2, 3), equalTo(Array(1, 2, 3)))
+      assert(Array(1, 2, 3))(equalTo(Array(1, 2, 3)))
     },
     test("equalTo must fail when array does not equal specified array") {
-      assert(Array(1, 2, 3), equalTo(Array(1, 2, 4)))
+      assert(Array(1, 2, 3))(equalTo(Array(1, 2, 4)))
     } @@ failure,
     test("equalTo must not have type inference issues") {
       assert(List(1, 2, 3).filter(_ => false))(equalTo(List.empty))
@@ -85,19 +85,19 @@ object AssertionSpec extends ZIOBaseSpec {
       )
     } @@ scala2Only,
     test("exists must succeed when at least one element of iterable satisfy specified assertion") {
-      assert(Seq(1, 42, 5), exists(equalTo(42)))
+      assert(Seq(1, 42, 5))(exists(equalTo(42)))
     },
     test("exists must fail when all elements of iterable do not satisfy specified assertion") {
-      assert(Seq(1, 42, 5), exists(equalTo(0)))
+      assert(Seq(1, 42, 5))(exists(equalTo(0)))
     } @@ failure,
     test("exists must fail when iterable is empty") {
       assert(Seq[String]())(exists(hasField("length", _.length, isWithin(0, 3))))
     } @@ failure,
     test("fails must succeed when error value satisfy specified assertion") {
-      assert(Exit.fail("Some Error"), fails(equalTo("Some Error")))
+      assert(Exit.fail("Some Error"))(fails(equalTo("Some Error")))
     },
     test("fails must fail when error value does not satisfy specified assertion") {
-      assert(Exit.fail("Other Error"), fails(equalTo("Some Error")))
+      assert(Exit.fail("Other Error"))(fails(equalTo("Some Error")))
     } @@ failure,
     test("forall must succeed when all elements of iterable satisfy specified assertion") {
       assert(Seq("a", "bb", "ccc"))(forall(hasField("length", _.length, isWithin(0, 3))))
@@ -109,206 +109,203 @@ object AssertionSpec extends ZIOBaseSpec {
       assert(Seq[String]())(forall(hasField("length", _.length, isWithin(0, 3))))
     },
     test("forall must work with iterables that are not lists") {
-      assert(SortedSet(1, 2, 3), forall(isGreaterThan(0)))
+      assert(SortedSet(1, 2, 3))(forall(isGreaterThan(0)))
     },
     test("hasAt must fail when an index is outside of a sequence range") {
-      assert(Seq(1, 2, 3), hasAt(-1)(anything))
+      assert(Seq(1, 2, 3))(hasAt(-1)(anything))
     } @@ failure,
     test("hasAt must fail when an index is outside of a sequence range 2") {
-      assert(Seq(1, 2, 3), hasAt(3)(anything))
+      assert(Seq(1, 2, 3))(hasAt(3)(anything))
     } @@ failure,
     test("hasAt must fail when a value is not equal to a specific assertion") {
-      assert(Seq(1, 2, 3), hasAt(1)(equalTo(1)))
+      assert(Seq(1, 2, 3))(hasAt(1)(equalTo(1)))
     } @@ failure,
     test("hasAt must succeed when a value is equal to a specific assertion") {
-      assert(Seq(1, 2, 3), hasAt(1)(equalTo(2)))
+      assert(Seq(1, 2, 3))(hasAt(1)(equalTo(2)))
     },
     test("hasField must succeed when field value satisfy specified assertion") {
-      assert(SampleUser("User", 23), hasField[SampleUser, Int]("age", _.age, isWithin(0, 99)))
+      assert(SampleUser("User", 23))(hasField[SampleUser, Int]("age", _.age, isWithin(0, 99)))
     },
     test("hasFirst must fail when an iterable is empty") {
-      assert(Seq(), hasFirst(anything))
+      assert(Seq())(hasFirst(anything))
     } @@ failure,
     test("hasFirst must succeed when a head is equal to a specific assertion") {
-      assert(Seq(1, 2, 3), hasFirst(equalTo(1)))
+      assert(Seq(1, 2, 3))(hasFirst(equalTo(1)))
     },
     test("hasFirst must fail when a head is not equal to a specific assertion") {
-      assert(Seq(1, 2, 3), hasFirst(equalTo(100)))
+      assert(Seq(1, 2, 3))(hasFirst(equalTo(100)))
     } @@ failure,
     test("hasLast must fail when an iterable is empty") {
-      assert(Seq(), hasLast(anything))
+      assert(Seq())(hasLast(anything))
     } @@ failure,
     test("hasLast must succeed when a last is equal to a specific assertion") {
-      assert(Seq(1, 2, 3), hasLast(equalTo(3)))
+      assert(Seq(1, 2, 3))(hasLast(equalTo(3)))
     },
     test("hasLast must fail when a last is not equal to specific assertion") {
-      assert(Seq(1, 2, 3), hasLast(equalTo(100)))
+      assert(Seq(1, 2, 3))(hasLast(equalTo(100)))
     } @@ failure,
     test("hasSameElements must succeed when both iterables contain the same elements") {
-      assert(Seq(1, 2, 3), hasSameElements(Seq(1, 2, 3)))
+      assert(Seq(1, 2, 3))(hasSameElements(Seq(1, 2, 3)))
     },
     test("hasSameElements must fail when the iterables do not contain the same elements") {
-      assert(Seq(1, 2, 3, 4), hasSameElements(Seq(1, 2, 3)))
+      assert(Seq(1, 2, 3, 4))(hasSameElements(Seq(1, 2, 3)))
     } @@ failure,
     test("hasSameElements must succeed when both iterables contain the same elements in different order") {
-      assert(Seq(4, 3, 1, 2), hasSameElements(Seq(1, 2, 3, 4)))
+      assert(Seq(4, 3, 1, 2))(hasSameElements(Seq(1, 2, 3, 4)))
     },
     test(
       "hasSameElements must fail when both iterables have the same size, have the same values but they appear a different number of times."
     ) {
-      assert(
-        Seq("a", "a", "b", "b", "b", "c", "c", "c", "c", "c"),
+      assert(Seq("a", "a", "b", "b", "b", "c", "c", "c", "c", "c"))(
         hasSameElements(Seq("a", "a", "a", "a", "a", "b", "b", "c", "c", "c"))
       )
     } @@ failure,
     test("hasSize must succeed when iterable size is equal to specified assertion") {
-      assert(Seq(1, 2, 3), hasSize(equalTo(3)))
+      assert(Seq(1, 2, 3))(hasSize(equalTo(3)))
     },
     test("isCase must fail when unapply fails (returns None)") {
-      assert(42, isCase[Int, String](termName = "term", _ => None, equalTo("number: 42")))
+      assert(42)(isCase[Int, String](termName = "term", _ => None, equalTo("number: 42")))
     } @@ failure,
     test("isCase must succeed when unapplied Proj satisfy specified assertion")(
-      assert(
-        sampleUser,
+      assert(sampleUser)(
         isCase[SampleUser, (String, Int)](
-          termName = "SampleUser",
-          { case SampleUser(name, age) => Some((name, age)) },
+          termName = "SampleUser", { case SampleUser(name, age) => Some((name, age)) },
           equalTo((sampleUser.name, sampleUser.age))
         )
       )
     ),
     test("isEmpty must succeed when the traversable is empty") {
-      assert(Seq(), isEmpty)
+      assert(Seq())(isEmpty)
     },
     test("isEmpty must fail when the traversable is not empty") {
-      assert(Seq(1, 2, 3), isEmpty)
+      assert(Seq(1, 2, 3))(isEmpty)
     } @@ failure,
     test("isEmptyString must succeed when the string is empty") {
-      assert("", isEmptyString)
+      assert("")(isEmptyString)
     },
     test("isEmptyString must fail when the string is not empty") {
-      assert("some string", isEmptyString)
+      assert("some string")(isEmptyString)
     } @@ failure,
     test("isFalse must succeed when supplied value is false") {
-      assert(false, isFalse)
+      assert(false)(isFalse)
     },
     test("isGreaterThan must succeed when specified value is greater than supplied value") {
-      assert(42, isGreaterThan(0))
+      assert(42)(isGreaterThan(0))
     },
     test("isGreaterThan must fail when specified value is less than or equal supplied value") {
-      assert(42, isGreaterThan(42))
+      assert(42)(isGreaterThan(42))
     } @@ failure,
     test("isGreaterThanEqualTo must succeed when specified value is greater than or equal supplied value") {
-      assert(42, isGreaterThanEqualTo(42))
+      assert(42)(isGreaterThanEqualTo(42))
     },
     test("isLeft must succeed when supplied value is Left and satisfy specified assertion") {
-      assert(Left(42), isLeft(equalTo(42)))
+      assert(Left(42))(isLeft(equalTo(42)))
     },
     test("isLessThan must succeed when specified value is less than supplied value") {
-      assert(0, isLessThan(42))
+      assert(0)(isLessThan(42))
     },
     test("isLessThan must fail when specified value is greater than or equal supplied value") {
-      assert(42, isLessThan(42))
+      assert(42)(isLessThan(42))
     } @@ failure,
     test("isLessThanEqualTo must succeed when specified value is less than or equal supplied value") {
-      assert(42, isLessThanEqualTo(42))
+      assert(42)(isLessThanEqualTo(42))
     },
     test("isNone must succeed when specified value is None") {
-      assert(None, isNone)
+      assert(None)(isNone)
     },
     test("isNone must fail when specified value is not None") {
-      assert(Some(42), isNone)
+      assert(Some(42))(isNone)
     } @@ failure,
     test("isNonEmpty must succeed when the traversable is not empty") {
-      assert(Seq(1, 2, 3), isNonEmpty)
+      assert(Seq(1, 2, 3))(isNonEmpty)
     },
     test("isNonEmpty must fail when the traversable is empty") {
-      assert(Seq(), isNonEmpty)
+      assert(Seq())(isNonEmpty)
     } @@ failure,
     test("isNonEmptyString must succeed when the string is not empty") {
-      assert("some string", isNonEmptyString)
+      assert("some string")(isNonEmptyString)
     },
     test("isNonEmptyString must fail when the string is empty") {
-      assert("", isNonEmptyString)
+      assert("")(isNonEmptyString)
     } @@ failure,
     test("isNull must succeed when specified value is null") {
-      assert(null, isNull)
+      assert(null)(isNull)
     },
     test("isNull must fail when specified value is not null") {
-      assert("not null", isNull)
+      assert("not null")(isNull)
     } @@ failure,
     test("isRight must succeed when supplied value is Right and satisfy specified assertion") {
-      assert(Right(42), isRight(equalTo(42)))
+      assert(Right(42))(isRight(equalTo(42)))
     },
     test("isSome must succeed when supplied value is Some and satisfy specified assertion") {
-      assert(Some("zio"), isSome(equalTo("zio")))
+      assert(Some("zio"))(isSome(equalTo("zio")))
     },
     test("isSome must fail when supplied value is None") {
-      assert(None, isSome(equalTo("zio")))
+      assert(None)(isSome(equalTo("zio")))
     } @@ failure,
     test("isTrue must succeed when supplied value is true") {
-      assert(true, isTrue)
+      assert(true)(isTrue)
     },
     test("isUnit must succeed when supplied value is ()") {
-      assert((), isUnit)
+      assert(())(isUnit)
     },
     testM("isUnit must not compile when supplied value is not ()") {
       val result = typeCheck("assert(10, isUnit)")
       assertM(result)(isLeft(anything))
     },
     test("isWithin must succeed when supplied value is within range (inclusive)") {
-      assert(10, isWithin(0, 10))
+      assert(10)(isWithin(0, 10))
     },
     test("isWithin must fail when supplied value is out of range") {
-      assert(42, isWithin(0, 10))
+      assert(42)(isWithin(0, 10))
     } @@ failure,
     test("matches must succeed when the string matches the regex") {
-      assert("(123) 456-7890", matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
+      assert("(123) 456-7890")(matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
     },
     test("matches must fail when the string does not match the regex") {
-      assert("456-7890", matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
+      assert("456-7890")(matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
     } @@ failure,
     test("negate must succeed when negation of assertion is true") {
-      assert(sampleUser, nameStartsWithA.negate)
+      assert(sampleUser)(nameStartsWithA.negate)
     },
     test("not must succeed when negation of specified assertion is true") {
-      assert(0, not(equalTo(42)))
+      assert(0)(not(equalTo(42)))
     },
     test("nothing must always fail") {
-      assert(42, nothing)
+      assert(42)(nothing)
     } @@ failure,
     test("or must succeed when one of assertions is satisfied") {
-      assert(sampleUser, (nameStartsWithA || nameStartsWithU) && ageGreaterThan20)
+      assert(sampleUser)((nameStartsWithA || nameStartsWithU) && ageGreaterThan20)
     },
     test("or must fail when both assertions are not satisfied") {
-      assert(sampleUser, nameStartsWithA || ageLessThan20)
+      assert(sampleUser)(nameStartsWithA || ageLessThan20)
     } @@ failure,
     test("startsWith must succeed when the supplied value starts with the specified sequence") {
-      assert(List(1, 2, 3, 4, 5), startsWith(List(1, 2, 3)))
+      assert(List(1, 2, 3, 4, 5))(startsWith(List(1, 2, 3)))
     },
     test("startsWith must fail when the supplied value does not start with the specified sequence") {
-      assert(List(1, 2, 3, 4, 5), startsWith(List(3, 4, 5)))
+      assert(List(1, 2, 3, 4, 5))(startsWith(List(3, 4, 5)))
     } @@ failure,
     test("startsWithString must succeed when the supplied value starts with the specified string") {
-      assert("zio", startsWithString("z"))
+      assert("zio")(startsWithString("z"))
     },
     test("startsWithString must fail when the supplied value does not start with the specified string") {
-      assert("zio", startsWithString("o"))
+      assert("zio")(startsWithString("o"))
     } @@ failure,
     test("succeeds must succeed when supplied value is Exit.succeed and satisfy specified assertion") {
-      assert(Exit.succeed("Some Error"), succeeds(equalTo("Some Error")))
+      assert(Exit.succeed("Some Error"))(succeeds(equalTo("Some Error")))
     },
     test("succeeds must fail when supplied value is Exit.fail") {
-      assert(Exit.fail("Some Error"), succeeds(equalTo("Some Error")))
+      assert(Exit.fail("Some Error"))(succeeds(equalTo("Some Error")))
     } @@ failure,
     testM("test must return true when given element satisfy assertion") {
-      assertM(nameStartsWithU.test(sampleUser), isTrue)
+      assertM(nameStartsWithU.test(sampleUser))(isTrue)
     },
     testM("test must return false when given element does not satisfy assertion") {
-      assertM(nameStartsWithA.test(sampleUser), isFalse)
+      assertM(nameStartsWithA.test(sampleUser))(isFalse)
     },
     test("throws must succeed when given assertion is correct") {
-      assert(throw sampleException, throws(equalTo(sampleException)))
+      assert(throw sampleException)(throws(equalTo(sampleException)))
     }
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/BoolAlgebraSpec.scala
@@ -7,74 +7,70 @@ object BoolAlgebraSpec extends ZIOBaseSpec {
 
   def spec = suite("BoolAlgebraSpec")(
     test("all returns conjunction of values") {
-      assert(BoolAlgebra.all(List(success1, failure1, failure2)), isSome(isFailure))
+      assert(BoolAlgebra.all(List(success1, failure1, failure2)))(isSome(isFailure))
     },
     testM("and distributes over or") {
       check(boolAlgebra, boolAlgebra, boolAlgebra) { (a, b, c) =>
-        assert(a && (b || c), equalTo((a && b) || (a && c)))
+        assert(a && (b || c))(equalTo((a && b) || (a && c)))
       }
     },
     testM("and is associative") {
       check(boolAlgebra, boolAlgebra, boolAlgebra) { (a, b, c) =>
-        assert((a && b) && c, equalTo(a && (b && c)))
+        assert((a && b) && c)(equalTo(a && (b && c)))
       }
     },
     testM("and is commutative") {
       check(boolAlgebra, boolAlgebra) { (a, b) =>
-        assert(a && b, equalTo(b && a))
+        assert(a && b)(equalTo(b && a))
       }
     },
     test("any returns disjunction of values") {
-      assert(BoolAlgebra.any(List(success1, failure1, failure2)), isSome(isSuccess))
+      assert(BoolAlgebra.any(List(success1, failure1, failure2)))(isSome(isSuccess))
     },
     test("as maps values to constant value") {
-      assert(
-        (success1 && success2).as("value"),
-        equalTo(BoolAlgebra.success("value") && BoolAlgebra.success("value"))
-      )
+      assert((success1 && success2).as("value"))(equalTo(BoolAlgebra.success("value") && BoolAlgebra.success("value")))
     },
     test("both returns conjunction of two values") {
-      assert(success1 && success2, isSuccess) &&
-      assert(success1 && failure1, isFailure) &&
-      assert(failure1 && success1, isFailure) &&
-      assert(failure1 && failure2, isFailure)
+      assert(success1 && success2)(isSuccess) &&
+      assert(success1 && failure1)(isFailure) &&
+      assert(failure1 && success1)(isFailure) &&
+      assert(failure1 && failure2)(isFailure)
     },
     test("collectAll combines multiple values") {
-      assert(
-        BoolAlgebra.collectAll(List(success1, failure1, failure2)),
+      assert(BoolAlgebra.collectAll(List(success1, failure1, failure2)))(
         isSome(equalTo(success1 && failure1 && failure2))
       )
     },
     testM("De Morgan's laws") {
       check(boolAlgebra, boolAlgebra) { (a, b) =>
-        assert(!(a && b), equalTo(!a || !b)) &&
-        assert(!a || !b, equalTo(!(a && b))) &&
-        assert(!(a || b), equalTo(!a && !b)) &&
-        assert(!a && !b, equalTo(!(a || b)))
+        assert(!(a && b))(equalTo(!a || !b)) &&
+        assert(!a || !b)(equalTo(!(a && b))) &&
+        assert(!(a || b))(equalTo(!a && !b)) &&
+        assert(!a && !b)(equalTo(!(a || b)))
       }
     },
     testM("double negative") {
       check(boolAlgebra) { a =>
-        assert(!(!a), equalTo(a)) &&
-        assert(a, equalTo(!(!a)))
+        assert(!(!a))(equalTo(a)) &&
+        assert(a)(equalTo(!(!a)))
       }
     },
     test("either returns disjunction of two values") {
-      assert(success1 || success2, isSuccess) &&
-      assert(success1 || failure1, isSuccess) &&
-      assert(failure1 || success1, isSuccess) &&
-      assert(failure1 || failure2, isFailure)
+      assert(success1 || success2)(isSuccess) &&
+      assert(success1 || failure1)(isSuccess) &&
+      assert(failure1 || success1)(isSuccess) &&
+      assert(failure1 || failure2)(isFailure)
     },
     testM("hashCode is consistent with equals") {
       checkN(10)(equalBoolAlgebraOfSize(4)) { pair =>
         val (a, b) = pair
-        assert(a.hashCode, equalTo(b.hashCode))
+        assert(a.hashCode)(equalTo(b.hashCode))
       }
     },
     test("failures collects failures") {
       val actual   = (success1 && success2 && failure1 && failure2).failures.get
       val expected = !failure1 && !failure2
-      assert(actual, equalTo(expected))
+      assert(actual)(equalTo(expected))
     },
     test("foreach combines multiple values") {
       def isEven(n: Int): BoolAlgebra[String] =
@@ -86,60 +82,60 @@ object BoolAlgebraSpec extends ZIOBaseSpec {
         BoolAlgebra.success("2 is even") &&
         BoolAlgebra.failure("3 is odd")
 
-      assert(actual, isSome(equalTo(expected)))
+      assert(actual)(isSome(equalTo(expected)))
     },
     test("implies returns implication of two values") {
-      assert(success1 ==> success2, isSuccess) &&
-      assert(success1 ==> failure1, isFailure) &&
-      assert(failure1 ==> success1, isSuccess) &&
-      assert(failure1 ==> failure2, isSuccess)
+      assert(success1 ==> success2)(isSuccess) &&
+      assert(success1 ==> failure1)(isFailure) &&
+      assert(failure1 ==> success1)(isSuccess) &&
+      assert(failure1 ==> failure2)(isSuccess)
     },
     test("isFailure returns whether result is failure") {
-      assert(!success1.isFailure && failure1.isFailure, isTrue)
+      assert(!success1.isFailure && failure1.isFailure)(isTrue)
     },
     test("isSuccess returns whether result is success") {
-      assert(success1.isSuccess && !failure1.isSuccess, isTrue)
+      assert(success1.isSuccess && !failure1.isSuccess)(isTrue)
     },
     test("map transforms values") {
       val actual   = (success1 && failure1 && failure2).map(_.split(" ").head)
       val expected = BoolAlgebra.success("first") && BoolAlgebra.failure("first") && BoolAlgebra.failure("second")
-      assert(actual, equalTo(expected))
+      assert(actual)(equalTo(expected))
     },
     testM("monad left identity") {
       check(boolAlgebra) { a =>
-        assert(a.flatMap(BoolAlgebra.success), equalTo(a))
+        assert(a.flatMap(BoolAlgebra.success))(equalTo(a))
       }
     },
     testM("monad right identity") {
       val genInt      = Gen.int(0, 9)
       val genFunction = Gen.function[Random with Sized, Int, BoolAlgebra[Int]](boolAlgebra)
       check(genInt, genFunction) { (a, f) =>
-        assert(BoolAlgebra.success(a).flatMap(f), equalTo(f(a)))
+        assert(BoolAlgebra.success(a).flatMap(f))(equalTo(f(a)))
       }
     },
     testM("monad associativity") {
       val genFunction = Gen.function[Random with Sized, Int, BoolAlgebra[Int]](boolAlgebra)
       check(boolAlgebra, genFunction, genFunction) { (a, f, g) =>
-        assert(a.flatMap(f).flatMap(g), equalTo(a.flatMap(n => f(n).flatMap(g))))
+        assert(a.flatMap(f).flatMap(g))(equalTo(a.flatMap(n => f(n).flatMap(g))))
       }
     },
     testM("or distributes over and") {
       check(boolAlgebra, boolAlgebra, boolAlgebra) { (a, b, c) =>
         val left  = a || (b && c)
         val right = (a || b) && (a || c)
-        assert(left, equalTo(right))
+        assert(left)(equalTo(right))
       }
     },
     testM("or is associative") {
       check(boolAlgebra, boolAlgebra, boolAlgebra) { (a, b, c) =>
         val left  = (a || b) || c
         val right = a || (b || c)
-        assert(left, equalTo(right))
+        assert(left)(equalTo(right))
       }
     },
     testM("or is commutative") {
       check(boolAlgebra, boolAlgebra) { (a, b) =>
-        assert(a || b, equalTo(b || a))
+        assert(a || b)(equalTo(b || a))
       }
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -12,14 +12,14 @@ object CheckSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.effect(())
           r <- random.nextInt(n)
-        } yield assert(r, isLessThan(n))
+        } yield assert(r)(isLessThan(n))
       }
     },
     testM("effectual properties can be tested") {
       checkM(Gen.int(1, 100)) { n =>
         for {
           r <- random.nextInt(n)
-        } yield assert(r, isLessThan(n))
+        } yield assert(r)(isLessThan(n))
       }
     },
     testM("error in checkM is test failure") {
@@ -27,12 +27,12 @@ object CheckSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.fail("fail")
           r <- random.nextInt(n)
-        } yield assert(r, isLessThan(n))
+        } yield assert(r)(isLessThan(n))
       }
     } @@ failure,
     testM("overloaded check methods work") {
       check(Gen.anyInt, Gen.anyInt, Gen.anyInt) { (x, y, z) =>
-        assert((x + y) + z, equalTo(x + (y + z)))
+        assert((x + y) + z)(equalTo(x + (y + z)))
       }
     },
     testM("max shrinks is respected") {
@@ -43,10 +43,10 @@ object CheckSpec extends ZIOBaseSpec {
               for {
                 _ <- ref.update(_ + 1)
                 p <- random.nextInt(10).map(_ != 0)
-              } yield assert(p, isTrue)
+              } yield assert(p)(isTrue)
             }
         result <- ref.get
-      } yield assert(result, isLessThan(1200))
+      } yield assert(result)(isLessThan(1200))
     },
     testM("tests can be written in property based style") {
       val chunkWithLength = for {
@@ -57,29 +57,29 @@ object CheckSpec extends ZIOBaseSpec {
       } yield (chunk, i)
       check(chunkWithLength) {
         case (chunk, i) =>
-          assert(chunk.apply(i), equalTo(chunk.toSeq.apply(i)))
+          assert(chunk.apply(i))(equalTo(chunk.toSeq.apply(i)))
       }
     },
     testM("tests with filtered generators terminate") {
       check(Gen.anyInt.filter(_ > 0), Gen.anyInt.filter(_ > 0)) { (a, b) =>
-        assert(a, equalTo(b))
+        assert(a)(equalTo(b))
       }
     } @@ failure,
     testM("failing tests contain gen failure details") {
       check(Gen.anyInt) { a =>
-        assert(a, isGreaterThan(0))
+        assert(a)(isGreaterThan(0))
       }.flatMap {
         _.run.map(_.failures match {
           case Some(BoolAlgebra.Value(details)) => details.gen.fold(false)(_.shrinkedInput == 0)
           case _                                => false
         })
-      }.map(assert(_, isTrue))
+      }.map(assert(_)(isTrue))
     },
     testM("implication works correctly") {
       check(Gen.listOf1(Gen.int(-10, 10))) { ns =>
         val nss      = ns.sorted
-        val nonEmpty = assert(nss, hasSize(isGreaterThan(0)))
-        val sorted   = assert(nss.zip(nss.tail).exists { case (a, b) => a > b }, isFalse)
+        val nonEmpty = assert(nss)(hasSize(isGreaterThan(0)))
+        val sorted   = assert(nss.zip(nss.tail).exists { case (a, b) => a > b })(isFalse)
         nonEmpty ==> sorted
       }
     },

--- a/test-tests/shared/src/test/scala/zio/test/CompileSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CompileSpec.scala
@@ -6,12 +6,12 @@ object CompileSpec extends ZIOBaseSpec {
 
   def spec = suite("CompileSpec")(
     testM("typeCheck must return Right if the specified string is valid Scala code") {
-      assertM(typeCheck("1 + 1"), isRight(anything))
+      assertM(typeCheck("1 + 1"))(isRight(anything))
     },
     testM("typeCheck must return Left with an error message otherwise") {
       val expected = "value ++ is not a member of Int"
-      if (TestVersion.isScala2) assertM(typeCheck("1 ++ 1"), isLeft(equalTo(expected)))
-      else assertM(typeCheck("1 ++ 1"), isLeft(anything))
+      if (TestVersion.isScala2) assertM(typeCheck("1 ++ 1"))(isLeft(equalTo(expected)))
+      else assertM(typeCheck("1 ++ 1"))(isLeft(anything))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -10,80 +10,47 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
 
   def spec = suite("DefaultTestReporterSpec")(
     testM("correctly reports a successful test") {
-      assertM(
-        runLog(test1),
-        equalTo(test1Expected.mkString + reportStats(1, 0, 0))
-      )
+      assertM(runLog(test1))(equalTo(test1Expected.mkString + reportStats(1, 0, 0)))
     },
     testM("correctly reports a failed test") {
-      assertM(
-        runLog(test3),
-        equalTo(test3Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test3))(equalTo(test3Expected.mkString + reportStats(0, 0, 1)))
     },
     testM("correctly reports an error in a test") {
-      assertM(
-        runLog(test4),
-        equalTo(test4Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test4))(equalTo(test4Expected.mkString + reportStats(0, 0, 1)))
     },
     testM("correctly reports successful test suite") {
-      assertM(
-        runLog(suite1),
-        equalTo(suite1Expected.mkString + reportStats(2, 0, 0))
-      )
+      assertM(runLog(suite1))(equalTo(suite1Expected.mkString + reportStats(2, 0, 0)))
     },
     testM("correctly reports failed test suite") {
-      assertM(
-        runLog(suite2),
-        equalTo(suite2Expected.mkString + reportStats(2, 0, 1))
-      )
+      assertM(runLog(suite2))(equalTo(suite2Expected.mkString + reportStats(2, 0, 1)))
     },
     testM("correctly reports multiple test suites") {
-      assertM(
-        runLog(suite3),
-        equalTo(suite3Expected.mkString + reportStats(2, 0, 1))
-      )
+      assertM(runLog(suite3))(equalTo(suite3Expected.mkString + reportStats(2, 0, 1)))
     },
     testM("correctly reports empty test suite") {
-      assertM(
-        runLog(suite4),
-        equalTo(suite4Expected.mkString + reportStats(2, 0, 1))
-      )
+      assertM(runLog(suite4))(equalTo(suite4Expected.mkString + reportStats(2, 0, 1)))
     },
     testM("correctly reports failure of simple assertion") {
-      assertM(
-        runLog(test5),
-        equalTo(test5Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test5))(equalTo(test5Expected.mkString + reportStats(0, 0, 1)))
     },
     testM("correctly reports multiple nested failures") {
-      assertM(
-        runLog(test6),
-        equalTo(test6Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test6))(equalTo(test6Expected.mkString + reportStats(0, 0, 1)))
     },
     testM("correctly reports labeled failures") {
-      assertM(
-        runLog(test7),
-        equalTo(test7Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test7))(equalTo(test7Expected.mkString + reportStats(0, 0, 1)))
     },
     testM("correctly reports negated failures") {
-      assertM(
-        runLog(test8),
-        equalTo(test8Expected.mkString + reportStats(0, 0, 1))
-      )
+      assertM(runLog(test8))(equalTo(test8Expected.mkString + reportStats(0, 0, 1)))
     }
   )
 
-  val test1         = zio.test.test("Addition works fine")(assert(1 + 1, equalTo(2)))
+  val test1         = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(2)))
   val test1Expected = expectedSuccess("Addition works fine")
 
-  val test2         = zio.test.test("Subtraction works fine")(assert(1 - 1, equalTo(0)))
+  val test2         = zio.test.test("Subtraction works fine")(assert(1 - 1)(equalTo(0)))
   val test2Expected = expectedSuccess("Subtraction works fine")
 
-  val test3 = zio.test.test("Value falls within range")(assert(52, equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
+  val test3 = zio.test.test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
   val test3Expected = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
@@ -105,13 +72,13 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
       withOffset(2)("No ZIO Trace available.\n")
   )
 
-  val test5 = zio.test.test("Addition works fine")(assert(1 + 1, equalTo(3)))
+  val test5 = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(3)))
   val test5Expected = Vector(
     expectedFailure("Addition works fine"),
     withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n")
   )
 
-  val test6 = zio.test.test("Multiple nested failures")(assert(Right(Some(3)), isRight(isSome(isGreaterThan(4)))))
+  val test6 = zio.test.test("Multiple nested failures")(assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4)))))
   val test6Expected = Vector(
     expectedFailure("Multiple nested failures"),
     withOffset(2)(s"${blue("3")} did not satisfy ${cyan("isGreaterThan(4)")}\n"),
@@ -129,10 +96,10 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
       b <- ZIO.effectTotal(Some(1))
       c <- ZIO.effectTotal(Some(0))
       d <- ZIO.effectTotal(Some(1))
-    } yield assert(a, isSome(equalTo(1)).label("first")) &&
-      assert(b, isSome(equalTo(1)).label("second")) &&
-      assert(c, isSome(equalTo(1)).label("third")) &&
-      assert(d, isSome(equalTo(1)).label("fourth"))
+    } yield assert(a)(isSome(equalTo(1)).label("first")) &&
+      assert(b)(isSome(equalTo(1)).label("second")) &&
+      assert(c)(isSome(equalTo(1)).label("third")) &&
+      assert(d)(isSome(equalTo(1)).label("fourth"))
   }
   val test7Expected = Vector(
     expectedFailure("labeled failures"),
@@ -143,7 +110,7 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
   )
 
   val test8 = zio.test.test("Not combinator") {
-    assert(100, not(equalTo(100)))
+    assert(100)(not(equalTo(100)))
   }
   val test8Expected = Vector(
     expectedFailure("Not combinator"),

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -12,7 +12,7 @@ object FunSpec extends ZIOBaseSpec {
       for {
         f <- Fun.make((n: Int) => random.nextInt(n))
         n <- random.nextInt.map(abs(_))
-      } yield assert(f(n), equalTo(f(n)))
+      } yield assert(f(n))(equalTo(f(n)))
     },
     testM("fun does not have race conditions") {
       for {
@@ -20,7 +20,7 @@ object FunSpec extends ZIOBaseSpec {
         results <- ZIO.foreachPar(List.range(0, 1000))(
                     n => ZIO.effectTotal((n % 6, f(n % 6)))
                   )
-      } yield assert(results.distinct.length, equalTo(6))
+      } yield assert(results.distinct.length)(equalTo(6))
     },
     testM("fun is showable") {
       for {
@@ -28,14 +28,14 @@ object FunSpec extends ZIOBaseSpec {
         p = f("Scala")
         q = f("Haskell")
       } yield {
-        assert(f.toString, equalTo(s"Fun(Scala -> $p, Haskell -> $q)")) ||
-        assert(f.toString, equalTo(s"Fun(Haskell -> $q, Scala -> $p)"))
+        assert(f.toString)(equalTo(s"Fun(Scala -> $p, Haskell -> $q)")) ||
+        assert(f.toString)(equalTo(s"Fun(Haskell -> $q, Scala -> $p)"))
       }
     },
     testM("fun is supported on Scala.js") {
       for {
         f <- Fun.make((_: Int) => ZIO.foreach(List.range(0, 100000))(ZIO.succeed))
-      } yield assert(f(1), anything)
+      } yield assert(f(1))(anything)
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenZIOSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenZIOSpec.scala
@@ -13,8 +13,8 @@ object GenZIOSpec extends ZIOBaseSpec {
         sample                <- sampleEffect(gen)
         (failures, successes) = partitionExit(sample)
       } yield {
-        assert(successes, isEmpty) &&
-        assert(failures, isNonEmpty && forall(dies(anything)))
+        assert(successes)(isEmpty) &&
+        assert(failures)(isNonEmpty && forall(dies(anything)))
       }
     },
     testM("failures generates failed effects") {
@@ -23,8 +23,8 @@ object GenZIOSpec extends ZIOBaseSpec {
         sample                <- sampleEffect(gen)
         (failures, successes) = partitionExit(sample)
       } yield {
-        assert(successes, isEmpty) &&
-        assert(failures, isNonEmpty && forall(fails(anything)))
+        assert(successes)(isEmpty) &&
+        assert(failures)(isNonEmpty && forall(fails(anything)))
       }
     },
     testM("successes generates successful effects") {
@@ -33,8 +33,8 @@ object GenZIOSpec extends ZIOBaseSpec {
         sample                <- sampleEffect(gen)
         (failures, successes) = partitionExit(sample)
       } yield {
-        assert(successes, isNonEmpty && forall(isWithin(-10, 10))) &&
-        assert(failures, isEmpty)
+        assert(successes)(isNonEmpty && forall(isWithin(-10, 10))) &&
+        assert(failures)(isEmpty)
       }
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -11,19 +11,19 @@ object ManagedSpec extends ZIOBaseSpec {
         for {
           _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
           result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result, equalTo(2))
+        } yield assert(result)(equalTo(2))
       },
       testM("second test") {
         for {
           _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
           result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result, equalTo(3))
+        } yield assert(result)(equalTo(3))
       },
       testM("third test") {
         for {
           _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
           result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result, equalTo(4))
+        } yield assert(result)(equalTo(4))
       }
     ).provideManagedShared(Ref.make(1).toManaged(_.set(-10))),
     suite("managed per test")(
@@ -31,13 +31,13 @@ object ManagedSpec extends ZIOBaseSpec {
         for {
           _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
           result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result, equalTo(2))
+        } yield assert(result)(equalTo(2))
       },
       testM("second test") {
         for {
           _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
           result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result, equalTo(2))
+        } yield assert(result)(equalTo(2))
       }
     ).provideManaged(Ref.make(1).toManaged(_.set(-10)))
   )

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -13,7 +13,7 @@ object SpecSpec extends ZIOBaseSpec {
         import zio.NeedsEnv.needsEnv
         val spec = suite("Suite1")(
           test("Test1") {
-            assert(true, isTrue)
+            assert(true)(isTrue)
           }
         ).provideManagedShared(ZManaged.dieMessage("everybody dies"))
         for {
@@ -23,10 +23,10 @@ object SpecSpec extends ZIOBaseSpec {
       testM("does not acquire the environment if the suite is ignored") {
         val spec = suite("Suite1")(
           testM("Test1") {
-            assertM(ZIO.accessM[Ref[Boolean]](_.get), isTrue)
+            assertM(ZIO.accessM[Ref[Boolean]](_.get))(isTrue)
           },
           testM("another test") {
-            assertM(ZIO.accessM[Ref[Boolean]](_.get), isTrue)
+            assertM(ZIO.accessM[Ref[Boolean]](_.get))(isTrue)
           }
         )
         for {
@@ -37,7 +37,7 @@ object SpecSpec extends ZIOBaseSpec {
                 } @@ ifEnvSet("foo")
               }
           result <- ref.get
-        } yield assert(result, isTrue)
+        } yield assert(result)(isTrue)
       }
     ),
     suite("only")(
@@ -46,7 +46,7 @@ object SpecSpec extends ZIOBaseSpec {
           for {
             passed1 <- isSuccess(spec.only(passingTest))
             passed2 <- isSuccess(spec.only(failingTest))
-          } yield assert(passed1, isTrue) && assert(passed2, isFalse)
+          } yield assert(passed1)(isTrue) && assert(passed2)(isFalse)
         }
       },
       testM("ignores all tests except ones in the suite matching the given label") {
@@ -54,14 +54,14 @@ object SpecSpec extends ZIOBaseSpec {
           for {
             passed1 <- isSuccess(spec.only(passingSuite))
             passed2 <- isSuccess(spec.only(failingSuite))
-          } yield assert(passed1, isTrue) && assert(passed2, isFalse)
+          } yield assert(passed1)(isTrue) && assert(passed2)(isFalse)
         }
       },
       testM("runs everything if root suite label given") {
         checkM(genSuite) { spec =>
           for {
             passed <- isSuccess(spec.only(rootSuite))
-          } yield assert(passed, isFalse)
+          } yield assert(passed)(isFalse)
         }
       }
     )
@@ -77,10 +77,10 @@ object SpecSpec extends ZIOBaseSpec {
   }
   def mixedSpec(prefix: String, suffix: String) = suite(prefix + rootSuite + suffix)(
     suite(prefix + failingSuite + suffix)(test(prefix + failingTest + suffix) {
-      assert(1, equalTo(2))
+      assert(1)(equalTo(2))
     }),
     suite(prefix + passingSuite + suffix)(test(prefix + passingTest + suffix) {
-      assert(1, equalTo(1))
+      assert(1)(equalTo(1))
     })
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestAnnotationMapSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAnnotationMapSpec.scala
@@ -7,8 +7,8 @@ object TestAnnotationMapSpec extends DefaultRunnableSpec {
   def spec = suite("TestAnnotationMapSpec")(
     test("get retrieves the annotation of the specified type") {
       val annotations = TestAnnotationMap.empty.annotate(TestAnnotation.ignored, 1)
-      assert(annotations.get(TestAnnotation.ignored), equalTo(1)) &&
-      assert(annotations.get(TestAnnotation.retried), equalTo(0))
+      assert(annotations.get(TestAnnotation.ignored))(equalTo(1)) &&
+      assert(annotations.get(TestAnnotation.retried))(equalTo(0))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -16,13 +16,13 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("test") {
-          assertM(ref.get, equalTo(1))
+          assertM(ref.get)(equalTo(1))
         } @@ around_(ref.set(1), ref.set(-1))
         result <- isSuccess(spec)
         after  <- ref.get
       } yield {
-        assert(result, isTrue) &&
-        assert(after, equalTo(-1))
+        assert(result)(isTrue) &&
+        assert(after)(equalTo(-1))
       }
     },
     testM("after evaluates in case if test IO fails") {
@@ -54,47 +54,47 @@ object TestAspectSpec extends ZIOBaseSpec {
     testM("dotty applies test aspect only on Dotty") {
       for {
         ref    <- Ref.make(false)
-        spec   = test("test")(assert(true, isTrue)) @@ dotty(after(ref.set(true)))
+        spec   = test("test")(assert(true)(isTrue)) @@ dotty(after(ref.set(true)))
         _      <- execute(spec)
         result <- ref.get
-      } yield if (TestVersion.isDotty) assert(result, isTrue) else assert(result, isFalse)
+      } yield if (TestVersion.isDotty) assert(result)(isTrue) else assert(result)(isFalse)
     },
     testM("dottyOnly runs tests only on Dotty") {
-      val spec   = test("Dotty-only")(assert(TestVersion.isDotty, isTrue)) @@ dottyOnly
+      val spec   = test("Dotty-only")(assert(TestVersion.isDotty)(isTrue)) @@ dottyOnly
       val result = if (TestVersion.isDotty) isSuccess(spec) else isIgnored(spec)
-      assertM(result, isTrue)
+      assertM(result)(isTrue)
     },
     test("exceptDotty runs tests on all versions except Dotty") {
-      assert(TestVersion.isDotty, isFalse)
+      assert(TestVersion.isDotty)(isFalse)
     } @@ exceptDotty,
     test("exceptJS runs tests on all platforms except ScalaJS") {
-      assert(TestPlatform.isJS, isFalse)
+      assert(TestPlatform.isJS)(isFalse)
     } @@ exceptJS,
     test("exceptJVM runs tests on all platforms except the JVM") {
-      assert(TestPlatform.isJVM, isFalse)
+      assert(TestPlatform.isJVM)(isFalse)
     } @@ exceptJVM,
     test("exceptScala2 runs tests on all versions except Scala 2") {
-      assert(TestVersion.isScala2, isFalse)
+      assert(TestVersion.isScala2)(isFalse)
     } @@ exceptScala2,
     test("failure makes a test pass if the result was a failure") {
-      assert(throw new java.lang.Exception("boom"), isFalse)
+      assert(throw new java.lang.Exception("boom"))(isFalse)
     } @@ failure,
     test("failure makes a test pass if it died with a specified failure") {
-      assert(throw new NullPointerException(), isFalse)
+      assert(throw new NullPointerException())(isFalse)
     } @@ failure(diesWithSubtypeOf[NullPointerException]),
     test("failure does not make a test pass if it failed with an unexpected exception") {
-      assert(throw new NullPointerException(), isFalse)
+      assert(throw new NullPointerException())(isFalse)
     } @@ failure(diesWithSubtypeOf[IllegalArgumentException])
       @@ failure,
     test("failure does not make a test pass if the specified failure does not match") {
-      assert(throw new RuntimeException(), isFalse)
+      assert(throw new RuntimeException())(isFalse)
     } @@ failure(diesWith(hasMessage("boom")))
       @@ failure,
     test("failure makes tests pass on any assertion failure") {
-      assert(true, equalTo(false))
+      assert(true)(equalTo(false))
     } @@ failure,
     test("failure makes tests pass on an expected assertion failure") {
-      assert(true, equalTo(false))
+      assert(true)(equalTo(false))
     } @@ failure(
       isCase[TestFailure[Any], Any](
         "Assertion",
@@ -106,105 +106,105 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("flaky test") {
-          assertM(ref.update(_ + 1), equalTo(100))
+          assertM(ref.update(_ + 1))(equalTo(100))
         } @@ flaky
         result <- isSuccess(spec)
         n      <- ref.get
-      } yield assert(result, isTrue) && assert(n, equalTo(100))
+      } yield assert(result)(isTrue) && assert(n)(equalTo(100))
     },
     testM("flaky retries a test that dies") {
       for {
         ref <- Ref.make(0)
         spec = testM("flaky test that dies") {
-          assertM(ref.update(_ + 1).filterOrDieMessage(_ >= 100)("die"), equalTo(100))
+          assertM(ref.update(_ + 1).filterOrDieMessage(_ >= 100)("die"))(equalTo(100))
         } @@ flaky
         result <- isSuccess(spec)
         n      <- ref.get
-      } yield assert(result, isTrue) && assert(n, equalTo(100))
+      } yield assert(result)(isTrue) && assert(n)(equalTo(100))
     },
     test("flaky retries a test with a limit") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ flaky @@ failure,
     test("ifEnv runs a test if environment variable satisfies assertion") {
-      assert(true, isTrue)
+      assert(true)(isTrue)
     } @@ ifEnv("PATH", containsString("bin")) @@ success @@ jvmOnly,
     test("ifEnv ignores a test if environment variable does not satisfy assertion") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifEnv("PATH", nothing) @@ jvmOnly,
     test("ifEnv ignores a test if environment variable does not exist") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifEnv("QWERTY", anything) @@ jvmOnly,
     test("ifEnvSet runs a test if environment variable is set") {
-      assert(true, isTrue)
+      assert(true)(isTrue)
     } @@ ifEnvSet("PATH") @@ success @@ jvmOnly,
     test("ifEnvSet ignores a test if environment variable is not set") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifEnvSet("QWERTY") @@ jvmOnly,
     test("ifProp runs a test if property satisfies assertion") {
-      assert(true, isTrue)
+      assert(true)(isTrue)
     } @@ ifProp("java.vm.name", containsString("VM")) @@ success @@ jvmOnly,
     test("ifProp ignores a test if property does not satisfy assertion") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifProp("java.vm.name", nothing) @@ jvmOnly,
     test("ifProp ignores a test if property does not exist") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifProp("qwerty", anything) @@ jvmOnly,
     test("ifPropSet runs a test if property is set") {
-      assert(true, isTrue)
+      assert(true)(isTrue)
     } @@ ifPropSet("java.vm.name") @@ success @@ jvmOnly,
     test("ifPropSet ignores a test if property is not set") {
-      assert(true, isFalse)
+      assert(true)(isFalse)
     } @@ ifPropSet("qwerty") @@ jvmOnly,
     testM("js applies test aspect only on ScalaJS") {
       for {
         ref    <- Ref.make(false)
-        spec   = test("test")(assert(true, isTrue)) @@ js(after(ref.set(true)))
+        spec   = test("test")(assert(true)(isTrue)) @@ js(after(ref.set(true)))
         _      <- execute(spec)
         result <- ref.get
-      } yield if (TestPlatform.isJS) assert(result, isTrue) else assert(result, isFalse)
+      } yield if (TestPlatform.isJS) assert(result)(isTrue) else assert(result)(isFalse)
     },
     testM("jsOnly runs tests only on ScalaJS") {
-      val spec   = test("Javascript-only")(assert(TestPlatform.isJS, isTrue)) @@ jsOnly
+      val spec   = test("Javascript-only")(assert(TestPlatform.isJS)(isTrue)) @@ jsOnly
       val result = if (TestPlatform.isJS) isSuccess(spec) else isIgnored(spec)
-      assertM(result, isTrue)
+      assertM(result)(isTrue)
     },
     testM("jvm applies test aspect only on jvm") {
       for {
         ref    <- Ref.make(false)
-        spec   = test("test")(assert(true, isTrue)) @@ jvm(after(ref.set(true)))
+        spec   = test("test")(assert(true)(isTrue)) @@ jvm(after(ref.set(true)))
         _      <- execute(spec)
         result <- ref.get
-      } yield assert(if (TestPlatform.isJVM) result else !result, isTrue)
+      } yield assert(if (TestPlatform.isJVM) result else !result)(isTrue)
     },
     testM("jvmOnly runs tests only on the JVM") {
-      val spec   = test("JVM-only")(assert(TestPlatform.isJVM, isTrue)) @@ jvmOnly
+      val spec   = test("JVM-only")(assert(TestPlatform.isJVM)(isTrue)) @@ jvmOnly
       val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
-      assertM(result, isTrue)
+      assertM(result)(isTrue)
     },
     testM("retry retries failed tests according to a schedule") {
       for {
         ref <- Ref.make(0)
         spec = testM("retry") {
-          assertM(ref.update(_ + 1), equalTo(2))
+          assertM(ref.update(_ + 1))(equalTo(2))
         } @@ retry(Schedule.recurs(1))
         result <- isSuccess(spec)
-      } yield assert(result, isTrue)
+      } yield assert(result)(isTrue)
     },
     testM("scala2 applies test aspect only on Scala 2") {
       for {
         ref    <- Ref.make(false)
-        spec   = test("test")(assert(true, isTrue)) @@ scala2(after(ref.set(true)))
+        spec   = test("test")(assert(true)(isTrue)) @@ scala2(after(ref.set(true)))
         _      <- execute(spec)
         result <- ref.get
-      } yield if (TestVersion.isScala2) assert(result, isTrue) else assert(result, isFalse)
+      } yield if (TestVersion.isScala2) assert(result)(isTrue) else assert(result)(isFalse)
     },
     testM("scala2Only runs tests only on Scala 2") {
-      val spec   = test("Scala2-only")(assert(TestVersion.isScala2, isTrue)) @@ scala2Only
+      val spec   = test("Scala2-only")(assert(TestVersion.isScala2)(isTrue)) @@ scala2Only
       val result = if (TestVersion.isScala2) isSuccess(spec) else isIgnored(spec)
-      assertM(result, isTrue)
+      assertM(result)(isTrue)
     },
     testM("timeout makes tests fail after given duration") {
-      assertM(ZIO.never *> ZIO.unit, equalTo(()))
+      assertM(ZIO.never *> ZIO.unit)(equalTo(()))
     } @@ timeout(1.nanos)
       @@ failure(diesWithSubtypeOf[TestTimeoutException]),
     testM("timeout reports problem with interruption") {
@@ -217,7 +217,7 @@ object TestAspectSpec extends ZIOBaseSpec {
           } yield assertCompletes
         } @@ timeout(10.milliseconds, 1.nanosecond) @@ failure(diesWith(equalTo(interruptionTimeoutFailure)))
         result <- isSuccess(spec.provide(liveClock))
-      } yield assert(result, isTrue)
+      } yield assert(result)(isTrue)
     }
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -10,19 +10,19 @@ object TestSpec extends ZIOBaseSpec {
 
   def spec = suite("TestSpec")(
     testM("assertM works correctly") {
-      assertM(nanoTime, equalTo(0L))
+      assertM(nanoTime)(equalTo(0L))
     },
     testM("testM error is test failure") {
       for {
         _      <- ZIO.fail("fail")
         result <- ZIO.succeed("succeed")
-      } yield assert(result, equalTo("succeed"))
+      } yield assert(result)(equalTo("succeed"))
     } @@ failure,
     testM("testM is polymorphic in error type") {
       for {
         _      <- ZIO.effect(())
         result <- ZIO.succeed("succeed")
-      } yield assert(result, equalTo("succeed"))
+      } yield assert(result)(equalTo("succeed"))
     },
     testM("testM suspends effects") {
       var n = 0
@@ -38,7 +38,7 @@ object TestSpec extends ZIOBaseSpec {
       ).filterLabels(_ == "test2").get
       for {
         _ <- execute(spec)
-      } yield assert(n, equalTo(1))
+      } yield assert(n)(equalTo(1))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -30,7 +30,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- (sleep(10.hours) *> ref.set(false)).fork
         _      <- adjust(9.hours)
         result <- ref.get
-      } yield assert(result, isTrue)
+      } yield assert(result)(isTrue)
     } @@ after(setTime(0.hours))
       @@ nonFlaky,
     testM("sleep correctly handles multiple sleeps") {
@@ -45,7 +45,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- adjust(2.hours)
         _      <- latch2.await
         result <- ref.get
-      } yield assert(result, equalTo("Hello, World!"))
+      } yield assert(result)(equalTo("Hello, World!"))
     } @@ after(setTime(0.hours))
       @@ nonFlaky,
     testM("sleep correctly handles new set time") {
@@ -69,63 +69,63 @@ object ClockSpec extends ZIOBaseSpec {
         time1 <- nanoTime
         _     <- adjust(1.millis)
         time2 <- nanoTime
-      } yield assert(fromNanos(time2 - time1), equalTo(1.millis))
+      } yield assert(fromNanos(time2 - time1))(equalTo(1.millis))
     },
     testM("adjust correctly advances currentTime") {
       for {
         time1 <- currentTime(TimeUnit.NANOSECONDS)
         _     <- adjust(1.millis)
         time2 <- currentTime(TimeUnit.NANOSECONDS)
-      } yield assert(time2 - time1, equalTo(1.millis.toNanos))
+      } yield assert(time2 - time1)(equalTo(1.millis.toNanos))
     },
     testM("adjust correctly advances currentDateTime") {
       for {
         time1 <- currentDateTime
         _     <- adjust(1.millis)
         time2 <- currentDateTime
-      } yield assert((time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli), equalTo(1L))
+      } yield assert((time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli))(equalTo(1L))
     },
     testM("adjust does not produce sleeps") {
-      adjust(1.millis) *> assertM(sleeps, isEmpty)
+      adjust(1.millis) *> assertM(sleeps)(isEmpty)
     },
     testM("setDateTime correctly sets currentDateTime") {
       for {
         expected <- UIO.effectTotal(OffsetDateTime.now(ZoneId.of("UTC+9")))
         _        <- setDateTime(expected)
         actual   <- clock.currentDateTime
-      } yield assert(actual.toInstant.toEpochMilli, equalTo(expected.toInstant.toEpochMilli))
+      } yield assert(actual.toInstant.toEpochMilli)(equalTo(expected.toInstant.toEpochMilli))
     },
     testM("setTime correctly sets nanotime") {
       for {
         _    <- setTime(1.millis)
         time <- clock.nanoTime
-      } yield assert(time, equalTo(1.millis.toNanos))
+      } yield assert(time)(equalTo(1.millis.toNanos))
     },
     testM("setTime correctly sets currentTime") {
       for {
         _    <- setTime(1.millis)
         time <- currentTime(TimeUnit.NANOSECONDS)
-      } yield assert(time, equalTo(1.millis.toNanos))
+      } yield assert(time)(equalTo(1.millis.toNanos))
     },
     testM("setTime correctly sets currentDateTime") {
       for {
         _    <- TestClock.setTime(1.millis)
         time <- currentDateTime
-      } yield assert(time.toInstant.toEpochMilli, equalTo(1.millis.toMillis))
+      } yield assert(time.toInstant.toEpochMilli)(equalTo(1.millis.toMillis))
     },
     testM("setTime does not produce sleeps") {
       for {
         _      <- setTime(1.millis)
         sleeps <- sleeps
-      } yield assert(sleeps, isEmpty)
+      } yield assert(sleeps)(isEmpty)
     },
     testM("setTimeZone correctly sets timeZone") {
       setTimeZone(ZoneId.of("UTC+10")) *>
-        assertM(timeZone, equalTo(ZoneId.of("UTC+10")))
+        assertM(timeZone)(equalTo(ZoneId.of("UTC+10")))
     },
     testM("setTimeZone does not produce sleeps") {
       setTimeZone(ZoneId.of("UTC+11")) *>
-        assertM(sleeps, isEmpty)
+        assertM(sleeps)(isEmpty)
     },
     testM("timeout example from TestClock documentation works correctly") {
       val example = for {
@@ -133,7 +133,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- TestClock.adjust(1.minute)
         result <- fiber.join
       } yield result == None
-      assertM(example, isTrue)
+      assertM(example)(isTrue)
     } @@ nonFlaky,
     testM("recurrence example from TestClock documentation works correctly") {
       val example = for {
@@ -147,7 +147,7 @@ object ClockSpec extends ZIOBaseSpec {
         d <- q.take.as(true)
         e <- q.poll.map(_.isEmpty)
       } yield a && b && c && d && e
-      assertM(example, isTrue)
+      assertM(example)(isTrue)
     },
     testM("fiber time is not subject to race conditions") {
       for {
@@ -155,7 +155,7 @@ object ClockSpec extends ZIOBaseSpec {
         _        <- sleep(2.millis).zipPar(sleep(1.millis))
         result   <- fiberTime
         expected <- clock.currentTime(TimeUnit.MILLISECONDS)
-      } yield assert(result.toMillis, equalTo(expected))
+      } yield assert(result.toMillis)(equalTo(expected))
     } @@ nonFlaky,
     testM("fiber time & clock time are always 0 at the start of a test that repeats with @@ nonFlaky")(
       for {
@@ -163,8 +163,8 @@ object ClockSpec extends ZIOBaseSpec {
         clockTime <- currentTime(TimeUnit.NANOSECONDS)
         _         <- adjust(3.nanos)
         _         <- sleep(2.nanos)
-      } yield assert(fiberTime, equalTo(0.millis)) &&
-        assert(clockTime, equalTo(0.millis.toNanos))
+      } yield assert(fiberTime)(equalTo(0.millis)) &&
+        assert(clockTime)(equalTo(0.millis.toNanos))
     ) @@ nonFlaky(3),
     testM("sleeps on forks that don't rejoin does not increase fiber time") {
       for {
@@ -176,7 +176,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- latch1.await
         _      <- latch2.await
         result <- fiberTime
-      } yield assert(result, equalTo(0.nanos))
+      } yield assert(result)(equalTo(0.nanos))
     } @@ nonFlaky
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -12,21 +12,21 @@ object ConsoleSpec extends ZIOBaseSpec {
     testM("outputs nothing") {
       for {
         output <- TestConsole.output
-      } yield assert(output, isEmpty)
+      } yield assert(output)(isEmpty)
     },
     testM("writes to output") {
       for {
         _      <- putStr("First line")
         _      <- putStr("Second line")
         output <- TestConsole.output
-      } yield assert(output, equalTo(Vector("First line", "Second line")))
+      } yield assert(output)(equalTo(Vector("First line", "Second line")))
     },
     testM("writes line to output") {
       for {
         _      <- putStrLn("First line")
         _      <- putStrLn("Second line")
         output <- TestConsole.output
-      } yield assert(output, equalTo(Vector("First line\n", "Second line\n")))
+      } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
     },
     testM("reads from input") {
       for {
@@ -34,8 +34,8 @@ object ConsoleSpec extends ZIOBaseSpec {
         input1      <- testConsole.getStrLn
         input2      <- testConsole.getStrLn
       } yield {
-        assert(input1, equalTo("Input 1")) &&
-        assert(input2, equalTo("Input 2"))
+        assert(input1)(equalTo("Input 1")) &&
+        assert(input2)(equalTo("Input 2"))
       }
     },
     testM("fails on empty input") {
@@ -43,8 +43,8 @@ object ConsoleSpec extends ZIOBaseSpec {
         failed  <- getStrLn.either
         message = failed.fold(_.getMessage, identity)
       } yield {
-        assert(failed.isLeft, isTrue) &&
-        assert(message, equalTo("There is no more input left to read"))
+        assert(failed.isLeft)(isTrue) &&
+        assert(message)(equalTo("There is no more input left to read"))
       }
     },
     testM("feeds lines to input") {
@@ -53,8 +53,8 @@ object ConsoleSpec extends ZIOBaseSpec {
         input1 <- getStrLn
         input2 <- getStrLn
       } yield {
-        assert(input1, equalTo("Input 1")) &&
-        assert(input2, equalTo("Input 2"))
+        assert(input1)(equalTo("Input 1")) &&
+        assert(input2)(equalTo("Input 2"))
       }
     },
     testM("clears lines from input") {
@@ -64,8 +64,8 @@ object ConsoleSpec extends ZIOBaseSpec {
         failed  <- getStrLn.either
         message = failed.fold(_.getMessage, identity)
       } yield {
-        assert(failed.isLeft, isTrue) &&
-        assert(message, equalTo("There is no more input left to read"))
+        assert(failed.isLeft)(isTrue) &&
+        assert(message)(equalTo("There is no more input left to read"))
       }
     },
     testM("clears lines from output") {
@@ -74,13 +74,13 @@ object ConsoleSpec extends ZIOBaseSpec {
         _      <- putStr("Second line")
         _      <- clearOutput
         output <- TestConsole.output
-      } yield assert(output, isEmpty)
+      } yield assert(output)(isEmpty)
     },
     testM("output is empty at the start of repeating tests") {
       for {
         output <- TestConsole.output
         _      <- putStrLn("Input")
-      } yield assert(output, isEmpty)
+      } yield assert(output)(isEmpty)
     } @@ nonFlaky
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -14,14 +14,14 @@ object EnvironmentSpec extends ZIOBaseSpec {
       for {
         _    <- TestClock.setTime(1.millis)
         time <- clock.currentTime(TimeUnit.MILLISECONDS)
-      } yield assert(time, equalTo(1L))
+      } yield assert(time)(equalTo(1L))
     },
     testM("Console writes line to output") {
       for {
         _      <- console.putStrLn("First line")
         _      <- console.putStrLn("Second line")
         output <- TestConsole.output
-      } yield assert(output, equalTo(Vector("First line\n", "Second line\n")))
+      } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
     },
     testM("Console reads line from input") {
       for {
@@ -29,15 +29,15 @@ object EnvironmentSpec extends ZIOBaseSpec {
         input1 <- console.getStrLn
         input2 <- console.getStrLn
       } yield {
-        assert(input1, equalTo("Input 1")) &&
-        assert(input2, equalTo("Input 2"))
+        assert(input1)(equalTo("Input 1")) &&
+        assert(input2)(equalTo("Input 2"))
       }
     },
     testM("Random returns next pseudorandom integer") {
       for {
         i <- random.nextInt
         j <- random.nextInt
-      } yield !assert(i, equalTo(j))
+      } yield !assert(i)(equalTo(j))
     },
     /*Live clock is used to seed random number generator;
             Node.js only has 1ms resolution so need to wait at least that long to avoid flakiness on ScalaJS*/
@@ -46,25 +46,25 @@ object EnvironmentSpec extends ZIOBaseSpec {
         i <- random.nextInt.provideManaged(TestEnvironment.Value)
         _ <- Live.live(clock.sleep(1.millisecond))
         j <- random.nextInt.provideManaged(TestEnvironment.Value)
-      } yield !assert(i, equalTo(j))
+      } yield !assert(i)(equalTo(j))
     },
     testM("System returns an environment variable when it is set") {
       for {
         _   <- TestSystem.putEnv("k1", "v1")
         env <- system.env("k1")
-      } yield assert(env, isSome(equalTo("v1")))
+      } yield assert(env)(isSome(equalTo("v1")))
     },
     testM("System returns a property when it is set") {
       for {
         _   <- TestSystem.putProperty("k1", "v1")
         env <- system.property("k1")
-      } yield assert(env, isSome(equalTo("v1")))
+      } yield assert(env)(isSome(equalTo("v1")))
     },
     testM("System returns the line separator when it is set") {
       for {
         _       <- TestSystem.setLineSeparator(",")
         lineSep <- system.lineSeparator
-      } yield assert(lineSep, equalTo(","))
+      } yield assert(lineSep)(equalTo(","))
     },
     testM("mapTestClock maps the `TestClock` implementation in the test environment") {
       TestClock.makeTest(TestClock.DefaultData).use { testClock =>
@@ -74,7 +74,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
           result <- clock
                      .currentTime(TimeUnit.MILLISECONDS)
                      .provide(testEnvironment.mapTestClock(_ => testClock))
-        } yield assert(result, equalTo(0L))
+        } yield assert(result)(equalTo(0L))
       }
     },
     testM("mapTestConsole maps the `TestConsole` implementation in the test environment") {
@@ -85,7 +85,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
         result <- console.getStrLn
                    .provide(testEnvironment.mapTestConsole(_ => testConsole))
                    .run
-      } yield assert(result, fails(anything))
+      } yield assert(result)(fails(anything))
     },
     testM("mapTestRandom maps the `TestRandom` implementation in the test environment") {
       for {
@@ -95,7 +95,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
         testRandom      <- TestRandom.makeTest(TestRandom.DefaultData)
         result <- random.nextInt
                    .provide(testEnvironment.mapTestRandom(_ => testRandom))
-      } yield assert(result, not(equalTo(n)))
+      } yield assert(result)(not(equalTo(n)))
     },
     testM("mapTestSystem maps the `TestSystem` implementation in the test environment") {
       for {
@@ -105,7 +105,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
         result <- system
                    .env("k1")
                    .provide(testEnvironment.mapTestSystem(_ => testSystem))
-      } yield assert(result, isNone)
+      } yield assert(result)(isNone)
     },
     testM("withLiveClock maps the `TestClock` implementation to one that uses the live environment") {
       for {
@@ -116,19 +116,19 @@ object EnvironmentSpec extends ZIOBaseSpec {
       for {
         _      <- console.putStr("")
         output <- TestConsole.output
-      } yield assert(output, isEmpty)
+      } yield assert(output)(isEmpty)
     }.provideSome[TestEnvironment](_.withLiveConsole),
     testM("withLiveRandom maps the `TestRandom` implementation to one that uses the live environment") {
       for {
         _ <- TestRandom.feedInts(0)
         n <- random.nextInt
-      } yield assert(n, not(equalTo(0)))
+      } yield assert(n)(not(equalTo(0)))
     }.provideSome[TestEnvironment](_.withLiveRandom),
     testM("withLiveSystem maps the `TestSystem` implementation to one that uses the live environment") {
       for {
         _   <- TestSystem.putEnv("k1", "v1")
         env <- system.env("k1")
-      } yield assert(env, isNone)
+      } yield assert(env)(isNone)
     }.provideSome[TestEnvironment](_.withLiveSystem)
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
@@ -14,13 +14,13 @@ object LiveSpec extends ZIOBaseSpec {
       for {
         test <- clock.currentTime(TimeUnit.MILLISECONDS)
         live <- Live.live(clock.currentTime(TimeUnit.MILLISECONDS))
-      } yield assert(test, equalTo(0L)) && assert(live, not(equalTo(0L)))
+      } yield assert(test)(equalTo(0L)) && assert(live)(not(equalTo(0L)))
     },
     testM("withLive provides real environment to single effect") {
       for {
         _      <- Live.withLive(console.putStr("woot"))(_.delay(1.nanosecond))
         result <- TestConsole.output
-      } yield assert(result, equalTo(Vector("woot")))
+      } yield assert(result)(equalTo(Vector("woot")))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -48,7 +48,7 @@ object RandomSpec extends ZIOBaseSpec {
         .map(rt => {
           val x = rt.unsafeRun(test.flatMap[Any, Nothing, Int](_.nextInt))
           val y = rt.unsafeRun(test.flatMap[Any, Nothing, Int](_.nextInt))
-          assert(x, equalTo(y))
+          assert(x)(equalTo(y))
         })
     },
     testM("check fed ints do not survive repeating tests") {
@@ -57,7 +57,7 @@ object RandomSpec extends ZIOBaseSpec {
         value  <- zio.random.nextInt
         value2 <- zio.random.nextInt
         _      <- ZIO.accessM[TestRandom](_.random.feedInts(1, 2))
-      } yield assert(value, equalTo(-1157408321)) && assert(value2, equalTo(758500184))
+      } yield assert(value)(equalTo(-1157408321)) && assert(value2)(equalTo(758500184))
     } @@ nonFlaky
   )
 
@@ -74,7 +74,7 @@ object RandomSpec extends ZIOBaseSpec {
         _          <- clear(testRandom)
         random     <- extract(testRandom)
         expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
-      } yield assert(random, equalTo(expected))
+      } yield assert(random)(equalTo(expected))
     }
 
   def checkFeed[A, B >: Random](generate: SRandom => A)(
@@ -91,8 +91,8 @@ object RandomSpec extends ZIOBaseSpec {
         random     <- extract(testRandom)
         expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
       } yield {
-        assert(results, equalTo(values)) &&
-        assert(random, equalTo(expected))
+        assert(results)(equalTo(values)) &&
+        assert(random)(equalTo(expected))
       }
     }
 
@@ -112,7 +112,7 @@ object RandomSpec extends ZIOBaseSpec {
         _          <- testRandom.setSeed(seed)
         actual     <- UIO.foreach(List.fill(100)(()))(_ => f(testRandom))
         expected   <- ZIO.effectTotal(List.fill(100)(g(sRandom)))
-      } yield assert(actual, equalTo(expected))
+      } yield assert(actual)(equalTo(expected))
     }
 
   def forAllEqualBytes: ZIO[Random, Nothing, TestResult] =
@@ -137,7 +137,7 @@ object RandomSpec extends ZIOBaseSpec {
         _          <- testRandom.setSeed(seed)
         actual     <- testRandom.nextGaussian
         expected   <- ZIO.effectTotal(sRandom.nextGaussian)
-      } yield assert(actual, approximatelyEquals(expected, 0.01))
+      } yield assert(actual)(approximatelyEquals(expected, 0.01))
     }
 
   def forAllEqualN[A](
@@ -150,7 +150,7 @@ object RandomSpec extends ZIOBaseSpec {
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, size)
         expected   <- ZIO.effectTotal(g(sRandom, size))
-      } yield assert(actual, equalTo(expected))
+      } yield assert(actual)(equalTo(expected))
     }
 
   def forAllEqualShuffle(
@@ -163,7 +163,7 @@ object RandomSpec extends ZIOBaseSpec {
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, testList)
         expected   <- ZIO.effectTotal(g(sRandom, testList))
-      } yield assert(actual, equalTo(expected))
+      } yield assert(actual)(equalTo(expected))
     }
 
   def forAllBounded[A: Numeric](gen: Gen[Random, A])(
@@ -175,7 +175,7 @@ object RandomSpec extends ZIOBaseSpec {
       for {
         testRandom <- ZIO.environment[Random].map(_.random)
         nextRandom <- next(testRandom, upper)
-      } yield assert(nextRandom, isWithin(zero, upper))
+      } yield assert(nextRandom)(isWithin(zero, upper))
     }
   }
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/SchedulerSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SchedulerSpec.scala
@@ -31,7 +31,7 @@ object SchedulerSpec extends ZIOBaseSpec {
         _         <- ZIO.effectTotal(runTask(scheduler, promise, 10.seconds + 1.nanosecond))
         _         <- adjust(10.seconds)
         executed  <- promise.poll.map(_.nonEmpty)
-      } yield assert(executed, isFalse)
+      } yield assert(executed)(isFalse)
     ),
     testM("scheduled tasks can be canceled")(
       for {
@@ -42,8 +42,8 @@ object SchedulerSpec extends ZIOBaseSpec {
         _         <- adjust(10.seconds)
         executed  <- promise.poll.map(_.nonEmpty)
       } yield {
-        assert(executed, isFalse) &&
-        assert(canceled, isTrue)
+        assert(executed)(isFalse) &&
+        assert(canceled)(isTrue)
       }
     ),
     testM("tasks that are cancelled after completion are not reported as interrupted")(
@@ -54,7 +54,7 @@ object SchedulerSpec extends ZIOBaseSpec {
         _         <- adjust(10.seconds + 1.nanos)
         _         <- promise.await
         canceled  <- ZIO.effectTotal(cancel())
-      } yield assert(canceled, isFalse)
+      } yield assert(canceled)(isFalse)
     ),
     testM("scheduled tasks get executed before shutdown")(
       for {
@@ -64,7 +64,7 @@ object SchedulerSpec extends ZIOBaseSpec {
         _         <- ZIO.effectTotal(scheduler.shutdown())
         _         <- promise.await
         time      <- clock.currentTime(NANOSECONDS)
-      } yield assert(fromNanos(time), equalTo(10.seconds))
+      } yield assert(fromNanos(time))(equalTo(10.seconds))
     )
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -13,67 +13,67 @@ object SystemSpec extends ZIOBaseSpec {
       for {
         env <- system.env("k1")
         _   <- putEnv("k1", "v1")
-      } yield assert(env, isNone)
+      } yield assert(env)(isNone)
     } @@ nonFlaky,
     testM("fetch an environment variable and check that if it exists, return a reasonable value") {
       for {
         _   <- putEnv("k1", "v1")
         env <- system.env("k1")
-      } yield assert(env, isSome(equalTo("v1")))
+      } yield assert(env)(isSome(equalTo("v1")))
     },
     testM("fetch an environment variable and check that if it does not exist, return None") {
       for {
         env <- system.env("k1")
-      } yield assert(env, isNone)
+      } yield assert(env)(isNone)
     },
     testM("fetch an environment variable and check that if it is set, return the set value") {
       for {
         _   <- putEnv("k1", "v1")
         env <- system.env("k1")
-      } yield assert(env, isSome(equalTo("v1")))
+      } yield assert(env)(isSome(equalTo("v1")))
     },
     testM("fetch an environment variable and check that if it is cleared, return None") {
       for {
         _   <- putEnv("k1", "v1")
         _   <- clearEnv("k1")
         env <- system.env("k1")
-      } yield assert(env, isNone)
+      } yield assert(env)(isNone)
     },
     testM("fetch a VM property and check that if it exists, return a reasonable value") {
       for {
         _    <- putProperty("k1", "v1")
         prop <- system.property("k1")
-      } yield assert(prop, isSome(equalTo("v1")))
+      } yield assert(prop)(isSome(equalTo("v1")))
     },
     testM("fetch a VM property and check that if it does not exist, return None") {
       for {
         prop <- system.property("k1")
-      } yield assert(prop, isNone)
+      } yield assert(prop)(isNone)
     },
     testM("fetch a VM property and check that if it is set, return the set value") {
       for {
         _    <- putProperty("k1", "v1")
         prop <- system.property("k1")
-      } yield assert(prop, isSome(equalTo("v1")))
+      } yield assert(prop)(isSome(equalTo("v1")))
     },
     testM("fetch a VM property and check that if it is cleared, return None") {
       for {
         _    <- putProperty("k1", "v1")
         _    <- clearProperty("k1")
         prop <- system.property(("k1"))
-      } yield assert(prop, isNone)
+      } yield assert(prop)(isNone)
     },
     testM("fetch the system's line separator and check that it is identical to Data.lineSeparator") {
       for {
         testSystem <- TestSystem.makeTest(Data(lineSeparator = ","))
         lineSep    <- testSystem.lineSeparator
-      } yield assert(lineSep, equalTo(","))
+      } yield assert(lineSep)(equalTo(","))
     },
     testM("fetch the system's line separator and check that if it is set, return the set value") {
       for {
         _       <- setLineSeparator(",")
         lineSep <- system.lineSeparator
-      } yield assert(lineSep, equalTo(","))
+      } yield assert(lineSep)(equalTo(","))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
@@ -29,7 +29,7 @@ object ExpectationSpecUtils {
     check: Assertion[A]
   ) = testM(name) {
     val result = mock.use[Any, E, A](app.provide _)
-    assertM(result, check)
+    assertM(result)(check)
   }
 
   private[mock] def testSpecTimeboxed[E, A](name: String)(duration: Duration)(
@@ -43,7 +43,7 @@ object ExpectationSpecUtils {
         .timeout(duration)
         .provide(Clock.Live)
 
-    assertM(result, check)
+    assertM(result)(check)
   }
 
   private[mock] def testSpecDied[E, A](name: String)(
@@ -58,7 +58,7 @@ object ExpectationSpecUtils {
         .absorb
         .flip
 
-    assertM(result, check)
+    assertM(result)(check)
   }
 
   val intTuple22 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)


### PR DESCRIPTION
Resolves #2520. I implemented a simple Scalafix rule to migrate all of our internal tests to use the new curried versions of `assert` and `assertM`. Do we have a place for this? We should publish a version of this when we do the next release so our users can upgrade their tests as well.

```scala
package fix

import scalafix.v1._
import scala.meta._

class CurriedAssert extends SemanticRule("CurriedAssert") {
  override def fix(implicit doc: SemanticDocument): Patch = {
    doc.tree.collect {
      case t @ Term.Apply(assert @ Term.Name("assert"), List(value, assertion)) =>
        Patch.replaceTree(t, assert + "(" + value + ")(" + assertion + ")")
      case t @ Term.Apply(assertM @ Term.Name("assertM"), List(value, assertion)) =>
        Patch.replaceTree(t, assertM + "(" + value + ")(" + assertion + ")")
      case t =>
        Patch.empty
    }.asPatch
  }
}
```
