### PR TITLE
Add ZIO#validateMPar and ZIO#validateFirstMPar

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -700,10 +700,22 @@ object IO {
     ZIO.validateM(in)(f)
 
   /**
+   * @see See [[zio.ZIO.validateMPar]]
+   */
+  def validateMPar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
+    ZIO.validateMPar(in)(f)
+
+  /**
    * @see See [[zio.ZIO.validateFirstM]]
    */
   def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
     ZIO.validateFirstM(in)(f)
+
+  /**
+   * @see See [[zio.ZIO.validateFirstMPar]]
+   */
+  def validateFirstMPar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
+    ZIO.validateFirstMPar(in)(f)
 
   /**
    * @see See [[zio.ZIO.when]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2855,6 +2855,21 @@ object ZIO {
     }
 
   /**
+   * Feeds elements of type A to f and accumulates, in parallel,
+   * all errors in error channel or successes in success channel.
+   *
+   * This combinator is lossy meaning that if there are errors all successes will be lost.
+   * To retain all information please use ZIO#partitionMPar
+   */
+  def validateMPar[R, E, A, B](
+    in: Iterable[A]
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, ::[E], List[B]] =
+    partitionMPar(in)(f).flatMap {
+      case (e :: es, _) => ZIO.fail(::(e, es))
+      case (_, bs)      => ZIO.succeed(bs)
+    }
+
+  /**
    * Feeds elements of type A to f until it succeeds. Returns first success or the accumulation of all errors.
    */
   def validateFirstM[R, E, A, B](
@@ -2866,6 +2881,16 @@ object ZIO {
           f(a).foldM(e => ZIO.succeed(e :: es), b => ZIO.fail(b))
       }
       .flip
+
+  /**
+   * Feeds elements of type A to f, in parallel, until it succeeds. Returns first success or the accumulation of all errors.
+   *
+   * In case of success all other running fibers are terminated.
+   */
+  def validateFirstMPar[R, E, A, B](
+    in: Iterable[A]
+  )(f: A => ZIO[R, E, B])(implicit ev: CanFail[E]): ZIO[R, List[E], B] =
+    ZIO.foreachPar(in)(f(_).flip).flip
 
   /**
    * The moral equivalent of `if (p) exp`


### PR DESCRIPTION
Most of the tests are already done by forEachPar in terms of termination of fibers and parallelism. 