### PR TITLE
Build failed on master due to flaky test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2000,7 +2000,7 @@ object ZIOSpec extends ZIOBaseSpec {
           } yield ()
 
         assertM(io.timeoutTo(42)(_ => 0)(1.second))(equalTo(0)).provide(Clock.Live)
-      },
+      } @@ flaky,
       testM("bracketForkExit release called on interrupt in separate fiber") {
         for {
           done <- Promise.make[Nothing, Unit]


### PR DESCRIPTION
bracketFork release called on interrupt in separate fiber

Build failed is [48168](https://circleci.com/gh/zio/zio/48168?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).