### PR TITLE
Scalafix introduction with a naive configuration for sorting imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,16 @@ lint: &lint
     - <<: *clean_cache
     - <<: *save_cache
 
+fix: &fix
+  steps:
+    - checkout
+    - <<: *load_cache
+    - run:
+        name: Fix check code
+        command: ./sbt ++${SCALA_VERSION}! fixCheck
+    - <<: *clean_cache
+    - <<: *save_cache
+
 mdoc: &mdoc
   steps:
     - checkout
@@ -235,6 +245,13 @@ jobs:
       - <<: *scala_212
       - <<: *jdk_8
 
+  fix:
+    <<: *fix
+    <<: *machine_ubuntu
+    environment:
+      - <<: *scala_212
+      - <<: *jdk_8
+
   mdoc:
     <<: *mdoc
     <<: *machine_ubuntu
@@ -331,54 +348,70 @@ workflows:
       - lint:
           filters:
             <<: *filter_tags
+      - fix:
+          requires:
+            - lint
+          filters:
+            <<: *filter_tags
+
       - mdoc:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_211_jdk8_jvm:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_212_jdk8_jvm:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_213_jdk8_jvm:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_dotty_jdk8_jvm:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_212_jdk11_jvm:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_211_jdk8_js:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_212_jdk8_js:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_213_jdk8_js:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - test_211_jdk8_native:
           requires:
             - lint
+            - fix
           filters:
             <<: *filter_tags
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ lint: &lint
     - <<: *load_cache
     - run:
         name: Lint code
-        command: ./sbt ++${SCALA_VERSION}! check
+        command: ./sbt ++${SCALA_VERSION}! fmtCheck
     - <<: *clean_cache
     - <<: *save_cache
 

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,3 @@
--Xss2M
+-Xss8m
+-Xms1G
+-Xmx8G

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,14 @@
+rules = [
+  RemoveUnused
+  LeakingImplicitClassVal
+  ProcedureSyntax
+  NoValInForComprehension
+  SortImports
+]
+
+SortImports.blocks = [
+"java.",
+"scala.",
+"*",
+"zio."
+]

--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -1,11 +1,12 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.scalacheck
-import zio.test.Gen
+
+import java.util.concurrent.TimeUnit
+
 import zio.IOBenchmarks.unsafeRun
+import zio.test.Gen
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
 import org.openjdk.jmh.annotations._
 import org.scalacheck
-
-import java.util.concurrent.TimeUnit
 
 import zio.IOBenchmarks.unsafeRun
 import zio.test.Gen

--- a/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
@@ -1,8 +1,8 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 
 import scala.collection.immutable.Range
 

--- a/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.collection.immutable.Range
+
+import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
@@ -1,12 +1,11 @@
 package zio
 
-import IOBenchmarks.unsafeRun
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.collection.immutable.Range
+
+import IOBenchmarks.unsafeRun
+import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
@@ -1,12 +1,12 @@
 package zio
 
-import java.util.concurrent.TimeUnit
+import IOBenchmarks.unsafeRun
 
 import org.openjdk.jmh.annotations._
 
-import scala.collection.immutable.Range
+import java.util.concurrent.TimeUnit
 
-import IOBenchmarks.unsafeRun
+import scala.collection.immutable.Range
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -46,9 +46,9 @@ class BubbleSortBenchmarks {
   }
   @Benchmark
   def monixBubbleSort() = {
+    import IOBenchmarks.monixScheduler
     import MonixIOArray._
     import monix.eval.Task
-    import IOBenchmarks.monixScheduler
 
     (for {
       array <- Task.eval(createTestArray)

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -1,5 +1,7 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -11,8 +13,6 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Threads
 import org.openjdk.jmh.annotations.Warmup
-
-import java.util.concurrent.TimeUnit
 
 import zio.IOBenchmarks.verify
 

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -13,6 +11,9 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Threads
 import org.openjdk.jmh.annotations.Warmup
+
+import java.util.concurrent.TimeUnit
+
 import zio.IOBenchmarks.verify
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -1,11 +1,11 @@
 package zio
 
+import scala.concurrent.ExecutionContext
+
 import cats._
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.effect.{ Fiber => CFiber }
 import monix.eval.{ Task => MTask }
-
-import scala.concurrent.ExecutionContext
 
 import zio.internal._
 

--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -1,11 +1,12 @@
 package zio
 
 import cats._
+import cats.effect.{ ContextShift, IO => CIO }
 import cats.effect.{ Fiber => CFiber }
+import monix.eval.{ Task => MTask }
 
 import scala.concurrent.ExecutionContext
-import cats.effect.{ ContextShift, IO => CIO }
-import monix.eval.{ Task => MTask }
+
 import zio.internal._
 
 object IOBenchmarks extends DefaultRuntime {

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -1,12 +1,11 @@
 package zio
 
-import IOBenchmarks._
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
+
+import IOBenchmarks._
+import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
-import java.util.concurrent.TimeUnit
+import IOBenchmarks._
 
 import org.openjdk.jmh.annotations._
-import scala.concurrent.Await
 
-import IOBenchmarks._
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-
 import scala.concurrent.Await
+
+import zio.IOBenchmarks._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -1,8 +1,8 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -1,8 +1,9 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -1,8 +1,8 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -1,8 +1,9 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -1,9 +1,11 @@
 package zio
 
+import cats.effect.concurrent.Deferred
+
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import cats.effect.concurrent.Deferred
-import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import cats.effect.concurrent.Deferred
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import cats.effect.concurrent.Deferred
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-
 import scala.concurrent.Await
+
+import zio.IOBenchmarks._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-
 import scala.annotation.tailrec
+
+import zio.IOBenchmarks._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -26,8 +27,8 @@ class IOMapBenchmark {
 
   @Benchmark
   def futureMap(): BigInt = {
-    import scala.concurrent.{ Await, Future }
     import scala.concurrent.duration.Duration.Inf
+    import scala.concurrent.{ Await, Future }
 
     @tailrec
     def sumTo(t: Future[BigInt], n: Int): Future[BigInt] =

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.annotation.tailrec
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-
 import scala.concurrent.Await
+
+import zio.IOBenchmarks._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -1,11 +1,12 @@
 package zio
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-
 import scala.concurrent.Await
+
+import zio.IOBenchmarks._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -1,16 +1,18 @@
 package zio
 
+import IOBenchmarks.monixScheduler
+import IOBenchmarks.unsafeRun
+import cats.effect.implicits._
+import cats.effect.{ ContextShift, IO => CIO }
+import cats.implicits._
+import monix.eval.{ Task => MTask }
+
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
-import IOBenchmarks.monixScheduler
-import monix.eval.{ Task => MTask }
-import cats.effect.{ ContextShift, IO => CIO }
-import org.openjdk.jmh.annotations._
-import cats.effect.implicits._
-import cats.implicits._
-import IOBenchmarks.unsafeRun
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -1,18 +1,17 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future }
+
 import IOBenchmarks.monixScheduler
 import IOBenchmarks.unsafeRun
 import cats.effect.implicits._
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
-
 import org.openjdk.jmh.annotations._
-
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future }
 
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -1,10 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
-import scala.collection.Iterable
-import scala.util.Random
-
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -17,6 +12,11 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
+
+import java.util.concurrent.TimeUnit
+
+import scala.collection.Iterable
+import scala.util.Random
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -1,5 +1,10 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
+import scala.collection.Iterable
+import scala.util.Random
+
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -12,11 +17,6 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
-
-import java.util.concurrent.TimeUnit
-
-import scala.collection.Iterable
-import scala.util.Random
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -1,13 +1,12 @@
 package zio
 
-import cats.effect.{ ContextShift, IO => CIO }
-import monix.eval.{ Task => MTask }
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
+
+import cats.effect.{ ContextShift, IO => CIO }
+import monix.eval.{ Task => MTask }
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 import zio.stm._

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -1,12 +1,16 @@
 package zio
 
-import zio.stm._
-import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 import cats.effect.{ ContextShift, IO => CIO }
 import monix.eval.{ Task => MTask }
+
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+
 import zio.IOBenchmarks._
+import zio.stm._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -1,10 +1,14 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 import cats.effect.{ ContextShift, IO => CIO }
-import org.openjdk.jmh.annotations._
 import monix.eval.{ Task => MTask }
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+
 import zio.IOBenchmarks._
 import zio.stm._
 

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -1,13 +1,12 @@
 package zio
 
-import cats.effect.{ ContextShift, IO => CIO }
-import monix.eval.{ Task => MTask }
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
+
+import cats.effect.{ ContextShift, IO => CIO }
+import monix.eval.{ Task => MTask }
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 import zio.stm._

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -1,17 +1,19 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.SPSC
+
 import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks._
-import zio.stm._
+
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
+
+import zio.IOBenchmarks._
+import zio.stm._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -1,16 +1,15 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.SPSC
-
 import org.openjdk.jmh.annotations._
-
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.ExecutionContext
 
 import zio.IOBenchmarks._
 import zio.stm._

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -1,18 +1,20 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
-import zio.stream._
+import IOBenchmarks._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Source => AkkaSource, Sink => AkkaSink, Keep }
 import cats.effect.{ IO => CatsIO }
 import fs2.{ Stream => FS2Stream, Chunk => FS2Chunk }
+
 import org.openjdk.jmh.annotations._
 
-import IOBenchmarks._
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+
+import zio.stream._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -1,18 +1,17 @@
 package zio
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 import IOBenchmarks._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Source => AkkaSource, Sink => AkkaSink, Keep }
 import cats.effect.{ IO => CatsIO }
 import fs2.{ Stream => FS2Stream, Chunk => FS2Chunk }
-
 import org.openjdk.jmh.annotations._
-
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 import zio.stream._
 

--- a/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
@@ -1,10 +1,9 @@
 package zio.internal
 
-import BenchUtils._
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import BenchUtils._
+import org.openjdk.jmh.annotations._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
@@ -1,12 +1,13 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
+import java.util.concurrent.TimeUnit
+
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
-import BenchUtils._
 
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
@@ -1,11 +1,10 @@
 package zio.internal
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
+import BenchUtils._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
-import java.util.concurrent.TimeUnit
 
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
 

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
@@ -1,7 +1,8 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 
 import zio.internal.impls._
 

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio.internal.impls._
 

--- a/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.{ Blackhole, Control }
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
@@ -1,11 +1,10 @@
 package zio.internal
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
+import BenchUtils._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.{ Blackhole, Control }
-
-import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
@@ -1,10 +1,9 @@
 package zio.internal
 
-import BenchUtils._
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import BenchUtils._
+import org.openjdk.jmh.annotations._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
@@ -1,12 +1,13 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
+import java.util.concurrent.TimeUnit
+
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
-import BenchUtils._
 
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
@@ -1,11 +1,10 @@
 package zio.internal
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
+import BenchUtils._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
-import java.util.concurrent.TimeUnit
 
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
 

--- a/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 
 /*
  * Main purposes of this set of benchmarks are:

--- a/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 /*
  * Main purposes of this set of benchmarks are:

--- a/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
@@ -1,10 +1,9 @@
 package zio.internal
 
-import BenchUtils._
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import BenchUtils._
+import org.openjdk.jmh.annotations._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
+import BenchUtils._
 
 import org.openjdk.jmh.annotations._
 
-import BenchUtils._
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
@@ -1,8 +1,9 @@
 package zio.stacktracer
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio.internal.stacktracer.impl.{ AkkaLineNumbers, AkkaLineNumbersTracer }
 import zio.stacktracer.TracersBenchmark.{ akkaTracer, asmTracer }
 import zio.stacktracer.impls.AsmTracer

--- a/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.stacktracer
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio.internal.stacktracer.impl.{ AkkaLineNumbers, AkkaLineNumbersTracer }
 import zio.stacktracer.TracersBenchmark.{ akkaTracer, asmTracer }

--- a/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
@@ -16,14 +16,15 @@
 
 package zio.stacktracer.impls
 
+import org.objectweb.asm._
+
 import java.lang.invoke.SerializedLambda
 
-import org.objectweb.asm._
+import scala.util.{ Failure, Success, Try }
+
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.ZTraceElement.SourceLocation
 import zio.stacktracer.impls.AsmTracer.MethodSearchVisitor
-
-import scala.util.{ Failure, Success, Try }
 
 /**
  * Java 8+ only

--- a/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
@@ -16,11 +16,11 @@
 
 package zio.stacktracer.impls
 
-import org.objectweb.asm._
-
 import java.lang.invoke.SerializedLambda
 
 import scala.util.{ Failure, Success, Try }
+
+import org.objectweb.asm._
 
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.ZTraceElement.SourceLocation

--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.stm
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio._
 

--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -1,8 +1,9 @@
 package zio.stm
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -1,13 +1,15 @@
 package zio.stm
 
-import zio._
-
-import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 import cats.effect.{ ContextShift, IO => CIO }
+
 import org.openjdk.jmh.annotations._
 
-import IOBenchmarks._
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+
+import zio.IOBenchmarks._
+import zio._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -37,8 +39,8 @@ class SemaphoreBenchmark {
 
   @Benchmark
   def semaphoreCatsContention() = {
-    import cats.effect.concurrent.Semaphore
     import cats.effect.Concurrent
+    import cats.effect.concurrent.Semaphore
     implicit val contextShift: ContextShift[CIO] = CIO.contextShift(ExecutionContext.global)
 
     (for {

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -1,12 +1,11 @@
 package zio.stm
 
-import cats.effect.{ ContextShift, IO => CIO }
-
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
+
+import cats.effect.{ ContextShift, IO => CIO }
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 import zio._

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.stm
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio.IOBenchmarks._
 import zio._

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -1,12 +1,11 @@
 package zio.stm
 
-import zio._
+import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
-
-import IOBenchmarks._
+import zio.IOBenchmarks._
+import zio._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -1,8 +1,8 @@
 package zio.stm
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio._
 

--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -1,8 +1,9 @@
 package zio.stm
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -1,8 +1,8 @@
 package zio.stm
 
-import org.openjdk.jmh.annotations._
-
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
 
 import zio._
 

--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -1,8 +1,9 @@
 package zio.stm
 
+import org.openjdk.jmh.annotations._
+
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
 import zio._
 
 @State(Scope.Thread)

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,10 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+addCommandAlias(
+  "fixCheck",
+  "; compile:scalafix --check ; test:scalafix --check"
+)
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("check", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -29,12 +29,13 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+addCommandAlias("fix", "all compile:scalafix test:scalafix")
 addCommandAlias(
   "fixCheck",
   "; compile:scalafix --check ; test:scalafix --check"
 )
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
-addCommandAlias("check", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
+addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile"

--- a/build.sbt
+++ b/build.sbt
@@ -330,3 +330,5 @@ lazy val docs = project.module
     coreTestsJVM
   )
   .enablePlugins(MdocPlugin, DocusaurusPlugin)
+
+scalafixDependencies in ThisBuild += "com.nequissimus" %% "sort-imports" % "0.3.1"

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -1,9 +1,9 @@
 package zio
 
+import zio.blocking.Blocking
 import zio.duration._
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
-import zio.blocking.Blocking
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -5,9 +5,9 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import zio.clock.Clock
 import zio.duration._
-import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ flaky, jvm, nonFlaky }
+import zio.test._
 
 object RTSSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -6,8 +6,8 @@ import zio.SerializableSpecHelpers._
 import zio.internal.stacktracer.ZTraceElement
 import zio.random.Random
 import zio.test.Assertion._
-import zio.test.{ test => testSync, _ }
 import zio.test.TestAspect.scala2Only
+import zio.test.{ test => testSync, _ }
 
 object SerializableSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/platform/PlatformSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/platform/PlatformSpec.scala
@@ -1,9 +1,9 @@
 package zio.platform
 
-import zio.internal.PlatformLive
-import zio.test._
-import zio.test.Assertion._
 import zio.ZIOBaseSpec
+import zio.internal.PlatformLive
+import zio.test.Assertion._
+import zio.test._
 
 object PlatformSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
@@ -1,11 +1,11 @@
 package zio
 package system
 
+import scala.reflect.io.File
+
+import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.live
-import zio.test.Assertion._
-
-import scala.reflect.io.File
 
 object SystemSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/CanFailSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CanFailSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object CanFailSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -2,8 +2,8 @@ package zio
 
 import zio.Cause.{ Both, Then }
 import zio.random.Random
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object CauseSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -1,8 +1,9 @@
 package zio
 
-import zio.test._
-import zio.test.Assertion.equalTo
 import java.nio._
+
+import zio.test.Assertion.equalTo
+import zio.test._
 
 object ChunkBufferSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
-import zio.test.{ assert, suite }
 import zio.test.Assertion.equalTo
+import zio.test.{ assert, suite }
 
 object ChunkSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -1,9 +1,9 @@
 package zio
 
-import zio.test._
+import zio.LatchOps._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.LatchOps._
+import zio.test._
 
 object FiberSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FunctionIOSpec.scala
@@ -1,8 +1,8 @@
 package zio
 
 import zio.FunctionIO._
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object FunctionIOSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object NeedsEnvSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object PromiseSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -1,9 +1,9 @@
 package zio
 
-import zio.test._
-import zio.test.Assertion._
 import zio.clock.Clock
 import zio.duration.durationInt
+import zio.test.Assertion._
+import zio.test._
 
 object RefMSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object RefSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,12 +1,12 @@
 package zio
 
+import scala.concurrent.Future
+
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.{ assert, assertM, suite, testM, TestResult }
-
-import scala.concurrent.Future
 import zio.test.environment.{ TestClock, TestRandom }
+import zio.test.{ assert, assertM, suite, testM, TestResult }
 
 object ScheduleSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3,15 +3,15 @@ package zio
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success }
 
+import zio.Cause._
+import zio.LatchOps._
 import zio.clock.Clock
 import zio.duration._
 import zio.random.Random
-import zio.test._
-import zio.test.environment._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ flaky, jvm, nonFlaky, scala2Only }
-import zio.Cause._
-import zio.LatchOps._
+import zio.test._
+import zio.test.environment._
 
 object ZIOSpec extends ZIOBaseSpec {
 
@@ -571,6 +571,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("fromFutureInterrupt")(
       testM("running Future can be interrupted") {
         import java.util.concurrent.atomic.AtomicInteger
+
         import scala.concurrent.{ ExecutionContext, Future }
         def infiniteFuture(ref: AtomicInteger)(implicit ec: ExecutionContext): Future[Nothing] =
           Future(ref.getAndIncrement()).flatMap(_ => infiniteFuture(ref))

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1,11 +1,11 @@
 package zio
 
 import zio.Cause.Interrupt
-import zio.duration._
 import zio.Exit.Failure
+import zio.duration._
 import zio.test.Assertion._
-import zio.test.environment._
 import zio.test._
+import zio.test.environment._
 
 object ZManagedSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -1,12 +1,13 @@
 package zio
 
 import scala.collection.immutable.Range
+
+import zio.ZQueueSpecUtil.waitForSize
 import zio.clock.Clock
 import zio.duration._
-import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ jvm, nonFlaky }
-import zio.ZQueueSpecUtil.waitForSize
+import zio.test._
 
 object ZQueueSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -3,11 +3,11 @@ package zio.duration
 import java.time.{ Duration => JavaDuration }
 import java.util.concurrent.TimeUnit
 
-import zio.ZIOBaseSpec
-import zio.test._
-import zio.test.Assertion._
-
 import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
+
+import zio.ZIOBaseSpec
+import zio.test.Assertion._
+import zio.test._
 
 object DurationSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
@@ -1,11 +1,11 @@
 package zio.internal
 import java.util.concurrent.RejectedExecutionException
 
+import scala.concurrent.ExecutionContext
+
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
-
-import scala.concurrent.ExecutionContext
 
 final class TestExecutor(val submitResult: Boolean) extends Executor {
   val here: Boolean                       = true

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
+import scala.util.Random.nextInt
+
 import zio.ZIOBaseSpec
 import zio.random.Random
 import zio.test.Assertion.equalTo
 import zio.test.{ assert, checkAll, suite, test, testM, Gen }
-
-import scala.util.Random.nextInt
 
 object StackBoolSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMSpec.scala
@@ -2,9 +2,9 @@ package zio
 package stm
 
 import zio.duration._
-import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
+import zio.test._
 
 object STMSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
+import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
-import zio.ZIOBaseSpec
 
 object TMapSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
@@ -16,11 +16,11 @@
 
 package zio.stm
 
-import zio.{ Exit, Promise, Ref, Schedule, ZIO }
 import zio.duration._
-import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.timeout
+import zio.test._
+import zio.{ Exit, Promise, Ref, Schedule, ZIO }
 
 object TReentrantLockSpec extends DefaultRunnableSpec {
   def pollSchedule[E, A] =

--- a/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
+import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
-import zio.ZIOBaseSpec
 
 object TSetSpec extends ZIOBaseSpec {
 

--- a/core/js/src/main/scala/zio/DefaultRuntime.scala
+++ b/core/js/src/main/scala/zio/DefaultRuntime.scala
@@ -18,9 +18,9 @@ package zio
 
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
-import zio.random.Random
 import zio.internal.{ Platform, PlatformLive }
+import zio.random.Random
+import zio.system.System
 
 trait DefaultRuntime extends Runtime[ZEnv] {
   override val platform: Platform = PlatformLive.Default

--- a/core/js/src/main/scala/zio/ZEnv.scala
+++ b/core/js/src/main/scala/zio/ZEnv.scala
@@ -17,8 +17,8 @@ package zio
 
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
 import zio.random.Random
+import zio.system.System
 
 object ZEnv {
 

--- a/core/js/src/main/scala/zio/ZEnvDefinition.scala
+++ b/core/js/src/main/scala/zio/ZEnvDefinition.scala
@@ -17,8 +17,8 @@ package zio
 
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
 import zio.random.Random
+import zio.system.System
 
 trait ZEnvDefinition {
   type ZEnv = Clock with Console with System with Random

--- a/core/js/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformLive.scala
@@ -18,6 +18,7 @@ package zio.internal
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
+
 import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig

--- a/core/js/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
+++ b/core/js/src/main/scala/zio/internal/impls/OneElementConcurrentQueue.scala
@@ -17,7 +17,6 @@
 package zio.internal.impls
 
 import java.io.Serializable
-
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
 
 import zio.internal.MutableConcurrentQueue

--- a/core/js/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/js/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -16,11 +16,11 @@
 
 package zio.scheduler
 
+import scala.scalajs.js
+
 import zio.ZIO
 import zio.duration.Duration
 import zio.internal.{ Scheduler => IScheduler }
-
-import scala.scalajs.js
 
 private[scheduler] object internal {
   private[scheduler] val GlobalScheduler = new IScheduler {

--- a/core/jvm/src/main/scala/zio/DefaultRuntime.scala
+++ b/core/jvm/src/main/scala/zio/DefaultRuntime.scala
@@ -16,12 +16,12 @@
 
 package zio
 
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
-import zio.random.Random
-import zio.blocking.Blocking
 import zio.internal.{ Platform, PlatformLive }
+import zio.random.Random
+import zio.system.System
 
 trait DefaultRuntime extends Runtime[ZEnv] {
   override val platform: Platform = PlatformLive.Default

--- a/core/jvm/src/main/scala/zio/ZEnv.scala
+++ b/core/jvm/src/main/scala/zio/ZEnv.scala
@@ -15,11 +15,11 @@
  */
 package zio
 
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
 import zio.random.Random
-import zio.blocking.Blocking
+import zio.system.System
 
 object ZEnv {
 

--- a/core/jvm/src/main/scala/zio/ZEnvDefinition.scala
+++ b/core/jvm/src/main/scala/zio/ZEnvDefinition.scala
@@ -15,11 +15,11 @@
  */
 package zio
 
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console.Console
-import zio.system.System
 import zio.random.Random
-import zio.blocking.Blocking
+import zio.system.System
 
 trait ZEnvDefinition {
   type ZEnv = Clock with Console with System with Random with Blocking

--- a/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformLive.scala
@@ -16,12 +16,12 @@
 
 package zio.internal
 
+import scala.concurrent.ExecutionContext
+
 import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig
-
-import scala.concurrent.ExecutionContext
 
 object PlatformLive {
   lazy val Default = makeDefault()

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,8 +16,8 @@
 
 package zio.internal
 
-import java.util.{ Collections, WeakHashMap, Map => JMap, Set => JSet }
 import java.util.concurrent.ConcurrentHashMap
+import java.util.{ Collections, WeakHashMap, Map => JMap, Set => JSet }
 
 trait PlatformSpecific {
   final def newWeakHashMap[A, B](): JMap[A, B] =

--- a/core/jvm/src/main/scala/zio/internal/impls/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/impls/RingBuffer.scala
@@ -17,6 +17,7 @@
 package zio.internal.impls
 
 import java.util.concurrent.atomic.AtomicLongArray
+
 import zio.internal.impls.padding.MutableQueueFieldsPadding
 import zio.internal.impls.padding.MutableQueueFieldsPadding.{ headUpdater, tailUpdater }
 

--- a/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
+++ b/core/jvm/src/main/scala/zio/scheduler/SchedulerLive.scala
@@ -16,12 +16,12 @@
 
 package zio.scheduler
 
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+
 import zio.ZIO
 import zio.duration.Duration
 import zio.internal.{ NamedThreadFactory, Scheduler => IScheduler }
-
-import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicInteger
 
 private[scheduler] object internal {
   private[scheduler] val GlobalScheduler = new IScheduler {

--- a/core/shared/src/main/scala-2.12+/zio/clock.scala
+++ b/core/shared/src/main/scala-2.12+/zio/clock.scala
@@ -16,10 +16,10 @@
 
 package zio
 
-import zio.duration.Duration
-
-import java.util.concurrent.TimeUnit
 import java.time.OffsetDateTime
+import java.util.concurrent.TimeUnit
+
+import zio.duration.Duration
 
 package object clock extends Clock.Service[Clock] {
   val clockService: ZIO[Clock, Nothing, Clock.Service[Any]] =

--- a/core/shared/src/main/scala/zio/CancelableFuture.scala
+++ b/core/shared/src/main/scala/zio/CancelableFuture.scala
@@ -16,8 +16,8 @@
 
 package zio
 
-import scala.concurrent.{ CanAwait, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ CanAwait, ExecutionContext, Future }
 import scala.util.Try
 
 abstract class CancelableFuture[+E, +A](val future: Future[A]) extends Future[A] with FutureTransformCompat[A] {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -16,9 +16,10 @@
 
 package zio
 
+import java.nio._
+
 import scala.collection.mutable.Builder
 import scala.reflect.{ classTag, ClassTag }
-import java.nio._
 
 /**
  * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,10 +16,10 @@
 
 package zio
 
-import com.github.ghik.silencer.silent
-
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+
+import com.github.ghik.silencer.silent
 
 import zio.internal.Executor
 import zio.internal.stacktracer.ZTraceElement

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,11 +16,12 @@
 
 package zio
 
-import zio.internal.Executor
-
-import scala.concurrent.Future
-import scala.collection.JavaConverters._
 import com.github.ghik.silencer.silent
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+import zio.internal.Executor
 import zio.internal.stacktracer.ZTraceElement
 
 /**

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1,8 +1,8 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
-
 import scala.concurrent.ExecutionContext
+
+import zio.internal.{ Executor, Platform }
 
 object IO {
 

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import Promise.internal._
-
 import java.util.concurrent.atomic.AtomicReference
+
+import Promise.internal._
 
 /**
  * A promise represents an asynchronous variable, of [[zio.IO]] type, that can

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -16,8 +16,9 @@
 
 package zio
 
-import java.util.concurrent.atomic.AtomicReference
 import Promise.internal._
+
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A promise represents an asynchronous variable, of [[zio.IO]] type, that can

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -1,10 +1,10 @@
 package zio
 
+import scala.concurrent.ExecutionContext
+
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
-
-import scala.concurrent.ExecutionContext
 
 object RIO {
 

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -16,10 +16,11 @@
 
 package zio
 
+import java.util.concurrent.TimeUnit
+
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.random.Random
-import java.util.concurrent.TimeUnit
 
 /**
  * Defines a stateful, possibly effectful, recurring schedule of actions.

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -20,10 +20,10 @@
 
 package zio
 
-import internals._
-
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Queue => IQueue }
+
+import internals._
 
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1,8 +1,8 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
-
 import scala.concurrent.ExecutionContext
+
+import zio.internal.{ Executor, Platform }
 
 object Task {
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -24,8 +24,8 @@ import zio.clock.Clock
 import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
 import zio.internal.{ Executor, Platform }
-import zio.{ InterruptStatus => InterruptS }
 import zio.{ DaemonStatus => DaemonS }
+import zio.{ InterruptStatus => InterruptS }
 import zio.{ TracingStatus => TracingS }
 
 /**
@@ -2038,8 +2038,9 @@ object ZIO {
     register: (ZIO[R, E, A] => Unit) => Either[Canceler[R], ZIO[R, E, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): ZIO[R, E, A] = {
-    import java.util.concurrent.atomic.AtomicBoolean
     import internal.OneShot
+
+    import java.util.concurrent.atomic.AtomicBoolean
 
     effectTotal((new AtomicBoolean(false), OneShot.make[Canceler[R]])).flatMap {
       case (started, cancel) =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2038,9 +2038,9 @@ object ZIO {
     register: (ZIO[R, E, A] => Unit) => Either[Canceler[R], ZIO[R, E, A]],
     blockingOn: List[Fiber.Id] = Nil
   ): ZIO[R, E, A] = {
-    import internal.OneShot
-
     import java.util.concurrent.atomic.AtomicBoolean
+
+    import internal.OneShot
 
     effectTotal((new AtomicBoolean(false), OneShot.make[Canceler[R]])).flatMap {
       case (started, cancel) =>

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -17,6 +17,7 @@
 package zio
 
 import scala.reflect.ClassTag
+
 import zio.clock.Clock
 import zio.duration.Duration
 

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -17,8 +17,9 @@
 package zio
 
 import scala.annotation.tailrec
-import zio.internal.MutableConcurrentQueue
+
 import zio.ZQueue.internal._
+import zio.internal.MutableConcurrentQueue
 
 /**
  * A `ZQueue[RA, EA, RB, EB, A, B]` is a lightweight, asynchronous queue into which values of

--- a/core/shared/src/main/scala/zio/ZTrace.scala
+++ b/core/shared/src/main/scala/zio/ZTrace.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import zio.internal.stacktracer.ZTraceElement
-
 import scala.annotation.tailrec
+
+import zio.internal.stacktracer.ZTraceElement
 
 final case class ZTrace(
   fiberId: Fiber.Id,

--- a/core/shared/src/main/scala/zio/clock/Clock.scala
+++ b/core/shared/src/main/scala/zio/clock/Clock.scala
@@ -16,12 +16,12 @@
 
 package zio.clock
 
+import java.time.{ Instant, OffsetDateTime, ZoneId }
 import java.util.concurrent.TimeUnit
 
 import zio.duration.Duration
 import zio.scheduler.SchedulerLive
 import zio.{ IO, UIO, ZIO }
-import java.time.{ Instant, OffsetDateTime, ZoneId }
 
 trait Clock extends Serializable {
   def clock: Clock.Service[Any]

--- a/core/shared/src/main/scala/zio/console/Console.scala
+++ b/core/shared/src/main/scala/zio/console/Console.scala
@@ -18,10 +18,10 @@ package zio.console
 
 import java.io.{ EOFException, IOException, PrintStream, Reader }
 
-import zio.{ IO, UIO, ZIO }
-
 import scala.io.StdIn
 import scala.{ Console => SConsole }
+
+import zio.{ IO, UIO, ZIO }
 
 trait Console extends Serializable {
   def console: Console.Service[Any]

--- a/core/shared/src/main/scala/zio/duration/Duration.scala
+++ b/core/shared/src/main/scala/zio/duration/Duration.scala
@@ -18,6 +18,7 @@ package zio.duration
 
 import java.time.{ Duration => JavaDuration }
 import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
 import scala.math.Ordered
 

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -17,9 +17,10 @@
 package zio.internal
 
 import java.util.concurrent._
+import java.{ util => ju }
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
-import java.{ util => ju }
 
 /**
  * An executor is responsible for executing actions. Each action is guaranteed

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,17 +16,17 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
-
-import com.github.ghik.silencer.silent
-
-import zio._
 import FiberContext.FiberRefLocals
+import com.github.ghik.silencer.silent
 import stacktracer.ZTraceElement
 import tracing.ZIOFn
 
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
+
+import zio._
 
 /**
  * An implementation of Fiber that maintains context necessary for evaluation.

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,15 +16,15 @@
 
 package zio.internal
 
-import FiberContext.FiberRefLocals
-import com.github.ghik.silencer.silent
-import stacktracer.ZTraceElement
-import tracing.ZIOFn
-
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
+
+import FiberContext.FiberRefLocals
+import com.github.ghik.silencer.silent
+import stacktracer.ZTraceElement
+import tracing.ZIOFn
 
 import zio._
 

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -17,8 +17,9 @@
 package zio.internal.impls
 
 import java.util.concurrent.ConcurrentLinkedQueue
-import zio.internal.MutableConcurrentQueue
 import java.util.concurrent.atomic.AtomicLong
+
+import zio.internal.MutableConcurrentQueue
 
 private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   override final val capacity = Int.MaxValue

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -16,13 +16,13 @@
 
 package zio.stm
 
-import com.github.ghik.silencer.silent
-
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 import java.util.{ HashMap => MutableMap }
 
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success, Try }
+
+import com.github.ghik.silencer.silent
 
 import zio.internal.{ Platform, Stack, Sync }
 import zio.{ CanFail, Fiber, IO, UIO }

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -16,15 +16,16 @@
 
 package zio.stm
 
-import java.util.{ HashMap => MutableMap }
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
-
 import com.github.ghik.silencer.silent
-import zio.{ CanFail, Fiber, IO, UIO }
-import zio.internal.{ Platform, Stack, Sync }
 
-import scala.util.{ Failure, Success, Try }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
+import java.util.{ HashMap => MutableMap }
+
 import scala.annotation.tailrec
+import scala.util.{ Failure, Success, Try }
+
+import zio.internal.{ Platform, Stack, Sync }
+import zio.{ CanFail, Fiber, IO, UIO }
 
 /**
  * `STM[E, A]` represents an effect that can be performed transactionally,

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
-import com.github.ghik.silencer.silent
-
 import scala.collection.immutable.{ Queue => ScalaQueue }
+
+import com.github.ghik.silencer.silent
 
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
   def offer(a: A): STM[Nothing, Unit] =

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
-import zio.{ Fiber, Managed }
-
 import TReentrantLock._
+
+import zio.{ Fiber, Managed }
 
 /**
  * A `TReentrantLock` is a reentrant read/write lock. Multiple readers may all

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -1,12 +1,11 @@
 import sbt._
 import Keys._
-
 import explicitdeps.ExplicitDepsPlugin.autoImport._
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
-
 import sbtbuildinfo._
 import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
+import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 
 object BuildHelper {
   val testDeps = Seq("org.scalacheck" %% "scalacheck" % "1.14.3" % "test")
@@ -176,6 +175,7 @@ object BuildHelper {
           compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full)
         )
     },
+    addCompilerPlugin(scalafixSemanticdb),
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings := true,

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -172,10 +172,10 @@ object BuildHelper {
       else
         Seq(
           "com.github.ghik" % "silencer-lib" % "1.4.4" % Provided cross CrossVersion.full,
-          compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full)
+          compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full),
+          compilerPlugin(scalafixSemanticdb)
         )
     },
-    addCompilerPlugin(scalafixSemanticdb),
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,4 @@ addSbtPlugin("com.jsuereth"                      % "sbt-pgp"                    
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"                  % "3.8.1")
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.0-M2")
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "0.6.1")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.9.11")

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
@@ -16,9 +16,9 @@
 
 package zio.internal.stacktracer.impl
 
-import AkkaLineNumbersTracer.lambdaNamePattern
-
 import scala.util.matching.Regex
+
+import AkkaLineNumbersTracer.lambdaNamePattern
 
 import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
 import zio.internal.stacktracer.{ Tracer, ZTraceElement }

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
@@ -16,11 +16,12 @@
 
 package zio.internal.stacktracer.impl
 
-import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
-import zio.internal.stacktracer.{ Tracer, ZTraceElement }
 import AkkaLineNumbersTracer.lambdaNamePattern
 
 import scala.util.matching.Regex
+
+import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
+import zio.internal.stacktracer.{ Tracer, ZTraceElement }
 
 /**
  * A [[Tracer]] implementation powered by Akka's `LineNumbers` bytecode parser (shipped with ZIO, no dependency on Akka)

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -1,10 +1,11 @@
 package zio.stream
 
-import zio.{ Chunk, IO, UIO, ZIOBaseSpec }
-import zio.random.Random
-import zio.test._
-import zio.test.Assertion.{ equalTo, isLeft }
 import ChunkUtils._
+
+import zio.random.Random
+import zio.test.Assertion.{ equalTo, isLeft }
+import zio.test._
+import zio.{ Chunk, IO, UIO, ZIOBaseSpec }
 
 case class Value(i: Int) extends AnyVal
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkUtils.scala
@@ -1,6 +1,7 @@
 package zio.stream
 
 import scala.reflect.ClassTag
+
 import zio.Chunk
 import zio.random.Random
 import zio.test.{ Gen, Sized }

--- a/streams-tests/jvm/src/test/scala/zio/stream/GenUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/GenUtils.scala
@@ -1,7 +1,7 @@
 package zio.stream
 
-import zio.test.Gen
 import zio.random.Random
+import zio.test.Gen
 
 trait GenUtils {
   def toBoolFn[R <: Random, A] = Gen.function[R, A, Boolean](Gen.boolean)

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1,14 +1,17 @@
 package zio.stream
 
 import java.util.concurrent.TimeUnit
+
 import scala.{ Stream => _ }
+
+import SinkUtils._
+
 import zio._
 import zio.clock.Clock
 import zio.duration._
-import zio.test._
 import zio.test.Assertion.{ equalTo, fails, isFalse, isLeft, isSome, isTrue, succeeds }
+import zio.test._
 import zio.test.environment.TestClock
-import SinkUtils._
 
 object SinkSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
-import zio.{ Chunk, IO, UIO }
-import zio.test.{ assert, Gen, GenZIO, TestResult }
 import zio.test.Assertion.{ equalTo, isRight, isTrue }
+import zio.test.{ assert, Gen, GenZIO, TestResult }
+import zio.{ Chunk, IO, UIO }
 
 trait SinkUtils {
   def initErrorSink = new ZSink[Any, String, Int, Int, Int] {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
@@ -1,10 +1,11 @@
 package zio.stream
 
 import scala.{ Stream => _ }
+
 import zio._
-import zio.test._
 import zio.test.Assertion.{ equalTo, fails }
 import zio.test.TestAspect.flaky
+import zio.test._
 
 object StreamBufferSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -1,13 +1,14 @@
 package zio.stream
 
+import scala.{ Stream => _ }
+
 import com.github.ghik.silencer.silent
+
+import zio._
 import zio.random.Random
 import zio.stream.StreamChunkUtils._
 import zio.test.Assertion.{ equalTo, isFalse, isLeft, succeeds }
 import zio.test._
-import zio._
-
-import scala.{ Stream => _ }
 
 object StreamChunkSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
@@ -2,6 +2,7 @@ package zio.stream
 
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
+
 import zio.random.Random
 import zio.test.{ Gen, Sized }
 import zio.{ Chunk, IO }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
 import zio._
-import zio.test._
 import zio.test.Assertion.{ dies, equalTo, fails, isTrue }
+import zio.test._
 
 object StreamDrainForkSpec extends ZIOBaseSpec {
   def spec = suite("ZStream.drainFork")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -1,12 +1,14 @@
 package zio.stream
 
 import scala.concurrent.ExecutionContext.global
-import zio._
-import zio.ZQueueSpecUtil.waitForValue
-import zio.{ IO, Promise, Ref, Task, UIO, ZIO }
-import zio.test._
-import zio.test.Assertion._
+
 import StreamUtils.inParallel
+
+import zio.ZQueueSpecUtil.waitForValue
+import zio._
+import zio.test.Assertion._
+import zio.test._
+import zio.{ IO, Promise, Ref, Task, UIO, ZIO }
 
 object StreamEffectAsyncSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamHaltWhenSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamHaltWhenSpec.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
 import zio._
-import zio.test._
 import zio.test.Assertion.{ equalTo, isFalse, isLeft }
+import zio.test._
 
 object StreamHaltWhenSpec extends ZIOBaseSpec {
   def spec = suite("ZStream.haltWhen")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamInterruptWhenSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamInterruptWhenSpec.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
 import zio._
-import zio.test._
 import zio.test.Assertion.{ equalTo, isLeft, isTrue }
+import zio.test._
 
 object StreamInterruptWhenSpec extends ZIOBaseSpec {
   def spec = suite("ZStream.interruptWhen")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -1,10 +1,11 @@
 package zio.stream
 
-import zio._
-import zio.test._
-import zio.test.Assertion.{ equalTo, isFalse, isTrue }
-import ZStream.Pull
 import StreamUtils.nPulls
+import ZStream.Pull
+
+import zio._
+import zio.test.Assertion.{ equalTo, isFalse, isTrue }
+import zio.test._
 
 object StreamPullSafetySpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1,10 +1,14 @@
 package zio.stream
 
-import zio._
+import scala.{ Stream => _ }
+
+import StreamUtils._
+
+import zio.Exit.Success
 import zio.ZQueueSpecUtil.waitForSize
+import zio._
 import zio.clock.Clock
 import zio.duration._
-import zio.test._
 import zio.test.Assertion.{
   dies,
   equalTo,
@@ -20,10 +24,7 @@ import zio.test.Assertion.{
   startsWith
 }
 import zio.test.TestAspect.flaky
-
-import scala.{ Stream => _ }
-import Exit.Success
-import StreamUtils._
+import zio.test._
 
 object StreamSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -1,10 +1,12 @@
 package zio.stream
 
-import zio.test.{ Gen, GenZIO, Sized }
-import zio.random.Random
-import zio._
-import ZStream.Pull
 import scala.concurrent.ExecutionContext
+
+import ZStream.Pull
+
+import zio._
+import zio.random.Random
+import zio.test.{ Gen, GenZIO, Sized }
 
 trait StreamUtils extends ChunkUtils with GenZIO {
   def streamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, Stream[String, A]] =

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -19,9 +19,9 @@ package zio.stream
 import java.io.{ IOException, InputStream }
 import java.{ util => ju }
 
+import zio.Cause
 import zio._
 import zio.clock.Clock
-import zio.Cause
 
 object Stream extends Serializable {
   import ZStream.Pull

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -16,8 +16,8 @@
 
 package zio.stream
 
-import zio.{ Cause, IO, ZIO }
 import zio.stream.ZStream.Pull
+import zio.{ Cause, IO, ZIO }
 
 /**
  * A `Take[E, A]` represents a single `take` from a queue modeling a stream of

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -16,11 +16,11 @@
 
 package zio.stream
 
+import scala.collection.mutable
+
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
-
-import scala.collection.mutable
 
 /**
  * A `Sink[E, A0, A, B]` consumes values of type `A`, ultimately producing
@@ -1060,7 +1060,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       widen untilOutput f
   }
 
-  implicit final class InvariantOps[R, E, A0, A, B](val sink: ZSink[R, E, A0, A, B]) extends AnyVal { self =>
+  implicit final class InvariantOps[R, E, A0, A, B](private val sink: ZSink[R, E, A0, A, B]) extends AnyVal { self =>
 
     /**
      * Drops the first `n`` elements from the sink.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -16,10 +16,10 @@
 
 package zio.stream
 
-import com.github.ghik.silencer.silent
-
 import java.io.{ IOException, InputStream }
 import java.{ util => ju }
+
+import com.github.ghik.silencer.silent
 
 import zio._
 import zio.clock.Clock

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -16,15 +16,16 @@
 
 package zio.stream
 
+import com.github.ghik.silencer.silent
+
 import java.io.{ IOException, InputStream }
 import java.{ util => ju }
 
-import com.github.ghik.silencer.silent
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
-import zio.stream.ZStream.Pull
 import zio.internal.UniqueKey
+import zio.stream.ZStream.Pull
 
 /**
  * A `Stream[E, A]` represents an effectful stream that can produce values of

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -17,6 +17,7 @@
 package zio.stream
 
 import com.github.ghik.silencer.silent
+
 import zio._
 
 /**

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -17,10 +17,11 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.test.{ Summary, TestArgs }
-import zio.{ Exit, Runtime }
 
 import scala.collection.mutable
+
+import zio.test.{ Summary, TestArgs }
+import zio.{ Exit, Runtime }
 
 sealed abstract class ZTestRunner(
   val args: Array[String],

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -16,9 +16,9 @@
 
 package zio.test.sbt
 
-import sbt.testing._
-
 import scala.collection.mutable
+
+import sbt.testing._
 
 import zio.test.{ Summary, TestArgs }
 import zio.{ Exit, Runtime }

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -16,9 +16,9 @@
 
 package zio.test.sbt
 
-import sbt.testing._
-
 import java.util.concurrent.atomic.AtomicReference
+
+import sbt.testing._
 
 import zio.ZIO
 import zio.test.{ Summary, TestArgs }

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -16,9 +16,10 @@
 
 package zio.test.sbt
 
+import sbt.testing._
+
 import java.util.concurrent.atomic.AtomicReference
 
-import sbt.testing._
 import zio.ZIO
 import zio.test.{ Summary, TestArgs }
 

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.test.sbt
 
+import scala.collection.mutable.ArrayBuffer
+
 import sbt.testing._
+
 import zio.FunctionIO
 import zio.test.sbt.TestingSupport._
 import zio.test.{ Assertion, DefaultRunnableSpec, Summary, TestArgs, TestAspect }
-
-import scala.collection.mutable.ArrayBuffer
 
 object ZTestFrameworkSpec {
 

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -1,6 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing.{ EventHandler, Logger, Task, TaskDef }
+
 import zio.clock.Clock
 import zio.test.{ AbstractRunnableSpec, SummaryBuilder, TestArgs, TestLogger }
 import zio.{ Runtime, ZIO }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/RunnableSpecFingerprint.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/RunnableSpecFingerprint.scala
@@ -1,6 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing.SubclassFingerprint
+
 import zio.test.AbstractRunnableSpec
 
 object RunnableSpecFingerprint extends SubclassFingerprint {

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -2,8 +2,8 @@ package zio.test.sbt
 
 import sbt.testing._
 
-import zio.test.{ ExecutedSpec, Spec, TestFailure, TestSuccess }
 import zio.UIO
+import zio.test.{ ExecutedSpec, Spec, TestFailure, TestSuccess }
 
 final case class ZTestEvent(
   fullyQualifiedName: String,

--- a/test-tests/jvm/src/main/scala/zio/test/ExitUtils.scala
+++ b/test-tests/jvm/src/main/scala/zio/test/ExitUtils.scala
@@ -1,7 +1,7 @@
 package zio.test
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 private[test] object ExitUtils {
 

--- a/test-tests/shared/src/main/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/main/scala/zio/test/GenUtils.scala
@@ -1,11 +1,11 @@
 package zio.test
 
+import scala.concurrent.Future
+
 import zio.Exit.{ Failure, Success }
+import zio._
 import zio.random.Random
 import zio.test.environment.TestRandom
-import zio._
-
-import scala.concurrent.Future
 
 object GenUtils extends DefaultRuntime {
 

--- a/test-tests/shared/src/main/scala/zio/test/SampleSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SampleSpec.scala
@@ -2,9 +2,9 @@ package zio.test
 
 import scala.concurrent.Future
 
-import zio.{ UIO, ZIO }
 import zio.stream.ZStream
 import zio.test.TestUtils.label
+import zio.{ UIO, ZIO }
 
 object SampleSpec extends AsyncBaseSpec {
 

--- a/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/main/scala/zio/test/SummaryBuilderSpec.scala
@@ -1,13 +1,13 @@
 package zio.test
 
+import scala.concurrent.Future
+
 import zio.clock.Clock
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan }
 import zio.test.ReportingTestUtils._
 import zio.test.TestUtils.label
 import zio.test.environment._
 import zio.{ Cause, IO, Managed }
-
-import scala.concurrent.Future
 
 object SummaryBuilderSpec extends AsyncBaseSpec {
   val run: List[Async[(Boolean, String)]] = List(

--- a/test-tests/shared/src/main/scala/zio/test/TestMain.scala
+++ b/test-tests/shared/src/main/scala/zio/test/TestMain.scala
@@ -1,8 +1,8 @@
 package zio.test
 
-import zio.test.TestUtils.{ report, scope }
-
 import scala.concurrent.ExecutionContext.Implicits.global
+
+import zio.test.TestUtils.{ report, scope }
 
 object TestMain {
 

--- a/test-tests/shared/src/main/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/main/scala/zio/test/TestUtils.scala
@@ -2,8 +2,8 @@ package zio.test
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-import zio.{ UIO, ZIO }
 import zio.test.environment.TestEnvironment
+import zio.{ UIO, ZIO }
 
 object TestUtils {
 

--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
-import zio.test.Assertion._
 import zio.ZIO
+import zio.test.Assertion._
 
 object AnnotationsSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -1,9 +1,9 @@
 package zio.test
 
+import scala.math.abs
+
 import zio.test.Assertion._
 import zio.{ random, ZIO }
-
-import scala.math.abs
 
 object FunSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -2,13 +2,13 @@ package zio.test
 
 import scala.math.Numeric.DoubleIsFractional
 
-import zio.{ Managed, UIO, ZIO }
 import zio.random.Random
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.test.{ check => Check, checkN => CheckN }
-import zio.test.environment.TestRandom
 import zio.test.TestAspect.scala2Only
+import zio.test.environment.TestRandom
+import zio.test.{ check => Check, checkN => CheckN }
+import zio.{ Managed, UIO, ZIO }
 
 object GenSpec extends ZIOBaseSpec {
   def spec = suite("GenSpec")(

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -1,9 +1,9 @@
 package zio.test
 
-import zio.{ Ref, ZIO, ZManaged }
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import zio.test.TestAspect.ifEnvSet
 import zio.test.TestUtils._
+import zio.{ Ref, ZIO, ZManaged }
 
 object SpecSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,13 +1,13 @@
 package zio.test
 
+import scala.reflect.ClassTag
+
 import zio.duration._
-import zio.test.environment.{ Live, TestClock }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
+import zio.test.environment.{ Live, TestClock }
 import zio.{ Ref, Schedule, ZIO }
-
-import scala.reflect.ClassTag
 
 object TestAspectSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -1,13 +1,13 @@
 package zio.test.environment
 
+import scala.util.{ Random => SRandom }
+
 import zio._
 import zio.random.Random
 import zio.test.Assertion._
-import zio.test.environment.TestRandom.{ DefaultData, Test => ZRandom }
-import zio.test._
 import zio.test.TestAspect._
-
-import scala.util.{ Random => SRandom }
+import zio.test._
+import zio.test.environment.TestRandom.{ DefaultData, Test => ZRandom }
 
 object RandomSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/SchedulerSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SchedulerSpec.scala
@@ -5,12 +5,12 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import zio.duration.Duration._
 import zio.duration._
 import zio.internal.Scheduler.CancelToken
+import zio.internal.{ Scheduler => IScheduler }
 import zio.scheduler.scheduler
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock._
 import zio.{ clock, DefaultRuntime, Promise, ZIO }
-import zio.internal.{ Scheduler => IScheduler }
 
 object SchedulerSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -2,9 +2,9 @@ package zio.test.environment
 
 import zio.system
 import zio.test.Assertion._
+import zio.test.TestAspect.nonFlaky
 import zio.test._
 import zio.test.environment.TestSystem._
-import zio.test.TestAspect.nonFlaky
 
 object SystemSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -1,13 +1,13 @@
 package zio.test.mock
 
-import zio.{ IO, UIO }
+import ExpectationSpecUtils._
+
 import zio.duration._
-import zio.test.{ suite, ZIOBaseSpec }
 import zio.test.Assertion.{ equalTo, isNone, isUnit, isWithin }
 import zio.test.mock.Expectation.{ failure, failureF, failureM, never, unit, value, valueF, valueM }
 import zio.test.mock.MockException.{ InvalidArgumentsException, InvalidMethodException, UnmetExpectationsException }
-
-import ExpectationSpecUtils._
+import zio.test.{ suite, ZIOBaseSpec }
+import zio.{ IO, UIO }
 
 object ExpectationSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
@@ -16,10 +16,10 @@
 
 package zio.test.mock
 
-import zio.{ IO, Managed, UIO, ZIO }
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.test.{ assertM, testM, Assertion }
+import zio.{ IO, Managed, UIO, ZIO }
 
 object ExpectationSpecUtils {
 

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -16,10 +16,10 @@
 
 package zio.test
 
-import zio.UIO
-
-import scala.reflect.macros.blackbox.Context
 import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.blackbox.Context
+
+import zio.UIO
 
 private[test] object Macros {
 

--- a/test/shared/src/main/scala/zio/test/BoolAlgebraM.scala
+++ b/test/shared/src/main/scala/zio/test/BoolAlgebraM.scala
@@ -1,7 +1,7 @@
 package zio.test
 
-import zio.test.BoolAlgebraM._
 import zio.ZIO
+import zio.test.BoolAlgebraM._
 
 final case class BoolAlgebraM[-R, +E, +A](run: ZIO[R, E, BoolAlgebra[A]]) { self =>
 

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -16,8 +16,8 @@
 
 package zio.test
 
-import zio.{ Runtime, ZIO }
 import zio.internal.Executor
+import zio.{ Runtime, ZIO }
 
 /**
  * A `Fun[A, B]` is a referentially transparent version of a potentially

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,9 +19,9 @@ package zio.test
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
 
-import zio.{ UIO, ZIO }
 import zio.random._
 import zio.stream.{ Stream, ZStream }
+import zio.{ UIO, ZIO }
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -16,8 +16,8 @@
 
 package zio.test
 
-import zio.{ Cause, ZIO }
 import zio.stream.{ Take, ZStream }
+import zio.{ Cause, ZIO }
 
 /**
  * A sample is a single observation from a random variable, together with a

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -16,9 +16,9 @@
 
 package zio.test
 
-import zio._
-
 import Spec._
+
+import zio._
 
 /**
  * A `Spec[R, E, L, T]` is the backbone of _ZIO Test_. Every spec is either a

--- a/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
+++ b/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
@@ -1,7 +1,7 @@
 package zio.test
 
-import zio.{ UIO, ZIO }
 import zio.test.Spec._
+import zio.{ UIO, ZIO }
 
 object SummaryBuilder {
   def buildSummary[E, L, S](executedSpec: ExecutedSpec[E, L, S]): UIO[Summary] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -16,9 +16,9 @@
 
 package zio.test
 
-import zio.duration._
-
 import scala.reflect.ClassTag
+
+import zio.duration._
 
 /**
  * A type of annotation.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -16,12 +16,12 @@
 
 package zio.test
 
-import zio.{ Cause, Schedule, ZIO, ZManaged }
-import zio.duration._
 import zio.clock.Clock
+import zio.duration._
 import zio.system
 import zio.system.System
 import zio.test.environment.{ Live, Restorable, TestClock, TestConsole, TestRandom, TestSystem }
+import zio.{ Cause, Schedule, ZIO, ZManaged }
 
 /**
  * A `TestAspect` is an aspect that can be weaved into specs. You can think of

--- a/test/shared/src/main/scala/zio/test/TestLogger.scala
+++ b/test/shared/src/main/scala/zio/test/TestLogger.scala
@@ -16,8 +16,8 @@
 
 package zio.test
 
-import zio.{ UIO, URIO, ZIO }
 import zio.console.Console
+import zio.{ UIO, URIO, ZIO }
 
 trait TestLogger {
   def testLogger: TestLogger.Service

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -16,12 +16,12 @@
 
 package zio.test
 
+import zio.ZIO
 import zio.clock.Clock
 import zio.console
 import zio.console.Console
 import zio.duration._
 import zio.test.environment.Live
-import zio.ZIO
 
 trait TimeoutVariants {
 

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -23,8 +23,8 @@ import zio._
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
-import zio.internal.{ Scheduler => IScheduler }
 import zio.internal.Scheduler.CancelToken
+import zio.internal.{ Scheduler => IScheduler }
 import zio.scheduler.Scheduler
 
 /**

--- a/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
@@ -16,11 +16,11 @@
 
 package zio.test.environment
 
-import java.io.IOException
 import java.io.EOFException
+import java.io.IOException
 
-import zio.console._
 import zio._
+import zio.console._
 
 /**
  * `TestConsole` provides a testable interface for programs interacting with

--- a/test/shared/src/main/scala/zio/test/environment/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestRandom.scala
@@ -20,8 +20,8 @@ package zio.test.environment
 import scala.collection.immutable.Queue
 import scala.math.{ log, sqrt }
 
-import zio.{ Chunk, Ref, UIO, ZIO }
 import zio.random.Random
+import zio.{ Chunk, Ref, UIO, ZIO }
 
 /**
  * `TestRandom` allows for deterministically testing effects involving

--- a/test/shared/src/main/scala/zio/test/environment/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestSystem.scala
@@ -16,8 +16,8 @@
 
 package zio.test.environment
 
-import zio.{ Ref, UIO, ZIO }
 import zio.system.System
+import zio.{ Ref, UIO, ZIO }
 
 /**
  * `TestSystem` supports deterministic testing of effects involving system

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -16,9 +16,8 @@
 
 package zio.test
 
-import zio.{ IO, NeedsEnv, ZIO }
-
 import zio.Managed
+import zio.{ IO, NeedsEnv, ZIO }
 
 /**
  * The `environment` package contains testable versions of all the standard ZIO

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -16,14 +16,15 @@
 
 package zio.test.mock
 
+import com.github.ghik.silencer.silent
+
 import scala.language.implicitConversions
 
-import com.github.ghik.silencer.silent
-import zio.{ IO, Managed, Ref, UIO, ZIO }
 import zio.test.Assertion
 import zio.test.mock.Expectation.{ AnyCall, Call, Empty, FlatMap, Next, State }
-import zio.test.mock.ReturnExpectation.{ Fail, Succeed }
 import zio.test.mock.MockException.UnmetExpectationsException
+import zio.test.mock.ReturnExpectation.{ Fail, Succeed }
+import zio.{ IO, Managed, Ref, UIO, ZIO }
 
 /**
  * An `Expectation[-M, +E, +A]` is an immutable data structure that represents

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -16,9 +16,9 @@
 
 package zio.test.mock
 
-import com.github.ghik.silencer.silent
-
 import scala.language.implicitConversions
+
+import com.github.ghik.silencer.silent
 
 import zio.test.Assertion
 import zio.test.mock.Expectation.{ AnyCall, Call, Empty, FlatMap, Next, State }

--- a/test/shared/src/main/scala/zio/test/mock/Method.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Method.scala
@@ -17,6 +17,7 @@
 package zio.test.mock
 
 import com.github.ghik.silencer.silent
+
 import zio.=!=
 import zio.test.Assertion
 

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -16,9 +16,9 @@
 
 package zio.test.mock
 
-import zio.{ IO, Promise, Ref, ZIO }
 import zio.test.mock.Expectation.Call
 import zio.test.mock.MockException.{ InvalidArgumentsException, InvalidMethodException }
+import zio.{ IO, Promise, Ref, ZIO }
 
 trait Mock {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -18,8 +18,8 @@ package zio.test.mock
 
 import java.io.IOException
 
-import zio.{ IO, UIO }
 import zio.console.Console
+import zio.{ IO, UIO }
 
 trait MockConsole extends Console {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -16,8 +16,8 @@
 
 package zio.test.mock
 
-import zio.{ Chunk, UIO }
 import zio.random.Random
+import zio.{ Chunk, UIO }
 
 trait MockRandom extends Random {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
@@ -16,8 +16,8 @@
 
 package zio.test.mock
 
-import zio.{ IO, UIO }
 import zio.system.System
+import zio.{ IO, UIO }
 
 trait MockSystem extends System {
 


### PR DESCRIPTION
Closes #2512 

In context of #2549 

I need some feedback on the configuration to use. This could be a first step towards introducing scalafix. Next steps would be to add custom rules to tailor our needs.

Adds scalafix
Adds scalafix standard rules + sorting imports
Adds scalafix to CI

Adds commandAlias fix