### PR TITLE
Use `def` instead of `val` in Service Definitions

### DIFF
--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -52,7 +52,7 @@ private[blocking] object internal {
  * and continuously create new threads as necessary.
  */
 trait Blocking extends Serializable {
-  val blocking: Blocking.Service[Any]
+  def blocking: Blocking.Service[Any]
 }
 object Blocking extends Serializable {
   trait Service[R] extends Serializable {

--- a/core/shared/src/main/scala/zio/clock/Clock.scala
+++ b/core/shared/src/main/scala/zio/clock/Clock.scala
@@ -24,7 +24,7 @@ import zio.{ IO, UIO, ZIO }
 import java.time.{ Instant, OffsetDateTime, ZoneId }
 
 trait Clock extends Serializable {
-  val clock: Clock.Service[Any]
+  def clock: Clock.Service[Any]
 }
 
 object Clock extends Serializable {

--- a/core/shared/src/main/scala/zio/console/Console.scala
+++ b/core/shared/src/main/scala/zio/console/Console.scala
@@ -24,7 +24,7 @@ import scala.io.StdIn
 import scala.{ Console => SConsole }
 
 trait Console extends Serializable {
-  val console: Console.Service[Any]
+  def console: Console.Service[Any]
 }
 object Console extends Serializable {
   trait Service[R] {

--- a/core/shared/src/main/scala/zio/random/Random.scala
+++ b/core/shared/src/main/scala/zio/random/Random.scala
@@ -19,7 +19,7 @@ package zio.random
 import zio.{ Chunk, Ref, UIO, ZIO }
 
 trait Random extends Serializable {
-  val random: Random.Service[Any]
+  def random: Random.Service[Any]
 }
 object Random extends Serializable {
   trait Service[R] extends Serializable {

--- a/core/shared/src/main/scala/zio/scheduler/Scheduler.scala
+++ b/core/shared/src/main/scala/zio/scheduler/Scheduler.scala
@@ -20,7 +20,7 @@ import zio.ZIO
 import zio.internal.{ Scheduler => IScheduler }
 
 trait Scheduler extends Serializable {
-  val scheduler: Scheduler.Service[Any]
+  def scheduler: Scheduler.Service[Any]
 }
 
 object Scheduler extends Serializable {

--- a/core/shared/src/main/scala/zio/system/System.scala
+++ b/core/shared/src/main/scala/zio/system/System.scala
@@ -19,7 +19,7 @@ package zio.system
 import zio.{ UIO, ZIO }
 
 trait System extends Serializable {
-  val system: System.Service[Any]
+  def system: System.Service[Any]
 }
 object System extends Serializable {
   trait Service[R] extends Serializable {

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -94,7 +94,7 @@ trait AccountEvent
 import zio.test.mock._
 
 trait AccountObserver {
-  val accountObserver: AccountObserver.Service[Any]
+  def accountObserver: AccountObserver.Service[Any]
 }
 
 object AccountObserver {
@@ -124,7 +124,7 @@ We model input arguments according to following scheme:
 
 ```scala mdoc:silent
 trait ExampleService {
-  val exampleService: ExampleService.Service[Any]
+  def exampleService: ExampleService.Service[Any]
 }
 
 object ExampleService {
@@ -183,7 +183,7 @@ import zio.console.Console
 @accessible(">")
 @mockable
 trait AccountObserver {
-  val accountObserver: AccountObserver.Service[Any]
+  def accountObserver: AccountObserver.Service[Any]
 }
 
 object AccountObserver {

--- a/docs/howto/use_module_pattern.md
+++ b/docs/howto/use_module_pattern.md
@@ -101,7 +101,7 @@ trait Email
 
 ```scala mdoc:silent
 trait Postman {
-  val postman: Postman.Service[Any]
+  def postman: Postman.Service[Any]
 }
 
 object Postman {
@@ -141,7 +141,7 @@ trait EmailAddress
 trait TemplateId
 
 trait EmailRenderer {
-  val emailRenderer: EmailRenderer.Service[Any]
+  def emailRenderer: EmailRenderer.Service[Any]
 }
 
 object EmailRenderer {
@@ -153,7 +153,7 @@ object EmailRenderer {
 
 ```scala mdoc:silent
 trait Newsletter {
-  val newsletter: Newsletter.Service[Any]
+  def newsletter: Newsletter.Service[Any]
 }
 
 object Newsletter {

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
@@ -64,7 +64,7 @@ object ExpectationSpecUtils {
   val intTuple22 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
 
   trait Module {
-    val module: Module.Service[Any]
+    def module: Module.Service[Any]
   }
 
   object Module {

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -27,7 +27,7 @@ import zio.{ FiberRef, UIO, ZIO }
  * monad effect.
  */
 trait Annotations {
-  val annotations: Annotations.Service[Any]
+  def annotations: Annotations.Service[Any]
 }
 
 object Annotations {

--- a/test/shared/src/main/scala/zio/test/Sized.scala
+++ b/test/shared/src/main/scala/zio/test/Sized.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.{ FiberRef, UIO, ZIO }
 
 trait Sized {
-  val sized: Sized.Service[Any]
+  def sized: Sized.Service[Any]
 }
 
 object Sized {

--- a/test/shared/src/main/scala/zio/test/environment/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestClock.scala
@@ -96,8 +96,8 @@ import zio.scheduler.Scheduler
  * exactly one more value is placed in the queue.
  */
 trait TestClock extends Clock with Scheduler {
-  val clock: TestClock.Service[Any]
-  val scheduler: TestClock.Service[Any]
+  def clock: TestClock.Service[Any]
+  def scheduler: TestClock.Service[Any]
 }
 
 object TestClock extends Serializable {

--- a/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
@@ -57,7 +57,7 @@ import zio._
  * }}}
  */
 trait TestConsole extends Console {
-  val console: TestConsole.Service[Any]
+  def console: TestConsole.Service[Any]
 }
 
 object TestConsole extends Serializable {

--- a/test/shared/src/main/scala/zio/test/environment/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestRandom.scala
@@ -66,7 +66,7 @@ import zio.random.Random
  * number generation.
  */
 trait TestRandom extends Random {
-  val random: TestRandom.Service[Any]
+  def random: TestRandom.Service[Any]
 }
 
 object TestRandom extends Serializable {

--- a/test/shared/src/main/scala/zio/test/environment/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestSystem.scala
@@ -38,7 +38,7 @@ import zio.system.System
 
  */
 trait TestSystem extends System {
-  val system: TestSystem.Service[Any]
+  def system: TestSystem.Service[Any]
 }
 
 object TestSystem extends Serializable {

--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -25,7 +25,7 @@ import zio.duration.Duration
 
 trait MockClock extends Clock {
 
-  val clock: MockClock.Service[Any]
+  def clock: MockClock.Service[Any]
 }
 
 object MockClock {

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -23,7 +23,7 @@ import zio.console.Console
 
 trait MockConsole extends Console {
 
-  val console: MockConsole.Service[Any]
+  def console: MockConsole.Service[Any]
 }
 
 object MockConsole {

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -21,7 +21,7 @@ import zio.random.Random
 
 trait MockRandom extends Random {
 
-  val random: MockRandom.Service[Any]
+  def random: MockRandom.Service[Any]
 }
 
 object MockRandom {

--- a/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
@@ -21,7 +21,7 @@ import zio.system.System
 
 trait MockSystem extends System {
 
-  val system: MockSystem.Service[Any]
+  def system: MockSystem.Service[Any]
 }
 
 object MockSystem {


### PR DESCRIPTION
Resolves #2559.