### PR TITLE
Update welcome tasks and command alias

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+addCommandAlias("build", "clean; fix; fmt; testJVM")
 addCommandAlias("fix", "all compile:scalafix test:scalafix")
 addCommandAlias(
   "fixCheck",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
-addCommandAlias("build", "clean; fix; fmt; testJVM")
+addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("fix", "all compile:scalafix test:scalafix")
 addCommandAlias(
   "fixCheck",

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+addCommandAlias("build", "prepare; testJVM")
 addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("fix", "all compile:scalafix test:scalafix")
 addCommandAlias(

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -155,6 +155,14 @@ If all the tests are passing, then you can prepare your code to be shipped:
 sbt prepare
 ```
 
+For simplicity, there is a command that does everything. Prepares code, compiles it and runs tests:
+
+```bash
+# If you are already in a SBT session you can type only 'build'
+
+sbt build
+```
+
 If your changes altered an API, then you may need to rebuild the microsite to make sure none of the (compiled) documentation breaks:
 
 ```bash

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -147,12 +147,12 @@ At this point, you should re-run all tests to make sure everything is passing:
 sbt test
 ```
 
-If all the tests are passing, then you can format your code:
+If all the tests are passing, then you can prepare your code to be shipped:
 
 ```bash
-# If you are already in a SBT session you can type only 'fmt'
+# If you are already in a SBT session you can type only 'prepare'
 
-sbt fmt
+sbt prepare
 ```
 
 If your changes altered an API, then you may need to rebuild the microsite to make sure none of the (compiled) documentation breaks:

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -265,6 +265,7 @@ object BuildHelper {
         |${header(s"/____|___\\___/   ${version.value}")}
         |
         |Useful sbt tasks:
+        |${item("build")} - Prepares sources, compiles and runs tests.
         |${item("prepare")} - Prepares sources by applying both scalafix and scalafmt
         |${item("fix")} - Fixes sources files using scalafix
         |${item("fmt")} - Formats source files using scalafmt

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -265,7 +265,7 @@ object BuildHelper {
         |${header(s"/____|___\\___/   ${version.value}")}
         |
         |Useful sbt tasks:
-        |${item("build")} - Prepares code to be shipped by running clean fix fmt and testJVM
+        |${item("prepare")} - Prepares sources by applying both scalafix and scalafmt
         |${item("fix")} - Fixes sources files using scalafix
         |${item("fmt")} - Formats source files using scalafmt
         |${item("~compileJVM")} - Compiles all JVM modules (file-watch enabled)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -265,6 +265,8 @@ object BuildHelper {
         |${header(s"/____|___\\___/   ${version.value}")}
         |
         |Useful sbt tasks:
+        |${item("build")} - Prepares code to be shipped by running clean fix fmt and testJVM
+        |${item("fix")} - Fixes sources files using scalafix
         |${item("fmt")} - Formats source files using scalafmt
         |${item("~compileJVM")} - Compiles all JVM modules (file-watch enabled)
         |${item("testJVM")} - Runs all JVM tests


### PR DESCRIPTION
Continuation of #2560

After some thought about this. What about, instead of merging fmt and fix, provide a very useful task that is intuitive that would be run before shipping code? (creating a PR)

To be honest, I could also not come up with a intuitive name to merge fix and fmt.

