### PR TITLE
ZIO Test: Implement Gen#crossAll and Gen#zipAll

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -443,6 +443,42 @@ object GenSpec extends ZIOBaseSpec {
     },
     testM("runHead") {
       assertM(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))
+    },
+    testM("crossAll") {
+      val gen = Gen.crossAll(
+        List(
+          Gen.fromIterable(List(1, 2)),
+          Gen.fromIterable(List(3)),
+          Gen.fromIterable(List(4, 5))
+        )
+      )
+      assertM(gen.runCollect)(
+        equalTo(
+          List(
+            List(1, 3, 4),
+            List(1, 3, 5),
+            List(2, 3, 4),
+            List(2, 3, 5)
+          )
+        )
+      )
+    },
+    testM("zipAll") {
+      val gen = Gen.zipAll(
+        List(
+          Gen.fromIterable(List(1, 2)),
+          Gen.fromIterable(List(3)),
+          Gen.fromIterable(List(4, 5))
+        )
+      )
+      assertM(gen.runCollect)(
+        equalTo(
+          List(
+            List(1, 3, 4),
+            List(2, 3, 5)
+          )
+        )
+      )
     }
   )
 

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -257,6 +257,13 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * Composes the specified generators to create a cartesian product of
    * elements with the specified function.
    */
+  def crossAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]] =
+    gens.foldRight[Gen[R, List[A]]](Gen.const(List.empty))(_.crossWith(_)(_ :: _))
+
+  /**
+   * Composes the specified generators to create a cartesian product of
+   * elements with the specified function.
+   */
   def crossN[R, A, B, C](gen1: Gen[R, A], gen2: Gen[R, B])(f: (A, B) => C): Gen[R, C] =
     gen1.crossWith(gen2)(f)
 
@@ -529,7 +536,15 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   /**
    * Zips the specified generators together pairwise. The new generator will
    * generate elements as long as any generator is generating elements, running
-   * the other generator multiple times if necessary.
+   * the other generators multiple times if necessary.
+   */
+  def zipAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]] =
+    gens.foldRight[Gen[R, List[A]]](Gen.const(List.empty))(_.zipWith(_)(_ :: _))
+
+  /**
+   * Zips the specified generators together pairwise. The new generator will
+   * generate elements as long as any generator is generating elements, running
+   * the other generators multiple times if necessary.
    */
   def zipN[R, A, B, C](gen1: Gen[R, A], gen2: Gen[R, B])(f: (A, B) => C): Gen[R, C] =
     gen1.zipWith(gen2)(f)
@@ -537,7 +552,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   /**
    * Zips the specified generators together pairwise. The new generator will
    * generate elements as long as any generator is generating elements, running
-   * the other generator multiple times if necessary.
+   * the other generators multiple times if necessary.
    */
   def zipN[R, A, B, C, D](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C])(f: (A, B, C) => D): Gen[R, D] =
     (gen1 <&> gen2 <&> gen3).map {
@@ -547,7 +562,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   /**
    * Zips the specified generators together pairwise. The new generator will
    * generate elements as long as any generator is generating elements, running
-   * the other generator multiple times if necessary.
+   * the other generators multiple times if necessary.
    */
   def zipN[R, A, B, C, D, F](gen1: Gen[R, A], gen2: Gen[R, B], gen3: Gen[R, C], gen4: Gen[R, D])(
     f: (A, B, C, D) => F


### PR DESCRIPTION
Resolves #2573. I thought that a stream analogy was more appropriate here and more consistent with our other combinators for `Gen`. The signatures are:

```scala
def crossAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]]
def zipAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]]
```

`crossAll` returns the cartesian product of an utterable of generators and could be thought of as a version of `crossN` that requires all the generators to be of the same type but allows the number of generators to vary. `zipAll` pulls elements pairwise from each generator and could be thought of as a variant on `ZipN` in the same way.

We should make sure we are comfortable with these names since we should probably align them with similar combinators on `ZStream` if they are added at some point. Open to other suggestions.