### PR TITLE
docs(testing) fix typo, should be ++

### DIFF
--- a/docs/usecases/testing.md
+++ b/docs/usecases/testing.md
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "dev.zio" %% "zio-test"     % zioVersion % "test",
   "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
 )
-testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+testFrameworks ++= new TestFramework("zio.test.sbt.ZTestFramework")
 ```
 
 From there the fastest way to start writing tests is to extend `DefaultRunnableSpec`, which creates a Spec that is also an executable program you can run from within SBT using `test:run` or by using `test` with the SBT test runner.


### PR DESCRIPTION
Copy pasting noticed a small typo which prevents sbt from building on _https://zio.dev/docs/usecases/usecases_testing_ . This a PR to fix it