### PR TITLE
Add coding guidelines documentation.

### DIFF
--- a/docs/about/coding_guidelines.md
+++ b/docs/about/coding_guidelines.md
@@ -1,0 +1,65 @@
+---
+id: about_coding_guidelines
+title:  "ZIO Coding Guidelines"
+---
+
+These are coding guidelines strictly for ZIO contributors for ZIO projects and 
+not general conventions to be applied by the Scala community.
+
+Additionally, bear in mind that, although we try to enforce these rules to the 
+best of our ability, both via automated rules (scalafix) and strict reviewing 
+processes, it is both possible to find existing code that does not comply to 
+these rules. If that is the case, we would be extremely grateful if you could 
+make a contribution, by proving a fix to said issue.
+
+Last, but not least, these rules are continuously evolving and as such, 
+refer to them once in a while when in doubt.
+
+
+### Extensions:
+
+1. value classes must be final and extend AnyVal.
+2. method extension classes must be final and extend AnyVal
+3. Sealed traits that are ADTs should extend from Product with Serializable.
+4. Regular traits and sealed trait that do not form ADTS should extend from Serializable but not from Product.
+5. Multiple parameter classes that are ADT should be case class and not extend AnyVal
+6. Traits should always extends serializable
+
+### Final definitions
+
+1. All methods on classes / traits declared final, by default
+2. No methods on objects declared final
+3. No methods on final classes declared final
+4. All classes inside objects should be defined final
+5. All final classes have private constructors & constructor parameters
+6. All vals declared final, either in objects or final classes, if they are constant expressions and without type annotations.
+7. Private methods/vals not declared final since they are already final
+8. Package-private vals/methods declared final
+
+### Refactor
+
+1. If a class has all final members, class declared final & final member annotations removed
+2. use least powerful type alias
+
+### Naming of parameters
+
+1. partial function are called `pf`
+2. evidences are called `ev`
+3. promise are called `p` (unless in its own class methods, in that case it is called `that`)
+4. functions are called `fn`, `fn1`, unless they bear specific meaning: `use`, `release`, ..
+4. consider _ method having more meaningful names
+5. iterable are called `in`
+6. when a parameter type equals own (in a method of a trait) call it `that`
+7. please, PLEASE, only use  by name parameters if it makes sense. mind the Function[0] extra allocation and loss of clean syntax
+8. folds initial value are called `zero`
+
+### Misc
+
+1. GADTS should have type annotation.
+2. Type alias should have type annotation.
+3. Methods that lift pure values to effects are dangerous. Dangerous in the sense that they can potentially have dangerous side-effects. Such methods should have a default lazy variant and an eager variant for advanced users that are aware they absolutely do not have side-effects in their code, having slight gains in performance. The lazy variant should have a normal name (succeed, fail, lift, potato) and the eager variant should have a now suffix (succeedNow, liftNow, potatoNow) which makes it clear of its eager behaviour.      
+
+### Code structure
+
+1. Method alphabetization - add lazy vals to fix forward references.
+2. Sorting of imports                            

--- a/docs/about/coding_guidelines.md
+++ b/docs/about/coding_guidelines.md
@@ -16,50 +16,53 @@ Last, but not least, these rules are continuously evolving and as such,
 refer to them once in a while when in doubt.
 
 
-### Extensions:
+### Defining classes and traits
 
-1. value classes must be final and extend AnyVal.
-2. method extension classes must be final and extend AnyVal
-3. Sealed traits that are ADTs should extend from Product with Serializable.
-4. Regular traits and sealed trait that do not form ADTS should extend from Serializable but not from Product.
+1. Value classes must be final and extend AnyVal.
+2. Method extension classes must be final and extend `AnyVal`.
+3. Sealed traits that are ADTs should extend `Product` and `Serializable`.
+4. Regular traits and sealed trait that do not form ADTS should extend `Serializable` but not `Product`.
 5. Multiple parameter classes that are ADT should be case class and not extend AnyVal
-6. Traits should always extends serializable
+6. Traits should always extends `Serializable`. (i.e. `ZIO`)
 
-### Final definitions
+### Final and private modifiers 
 
-1. All methods on classes / traits declared final, by default
-2. No methods on objects declared final
-3. No methods on final classes declared final
-4. All classes inside objects should be defined final
-5. All final classes have private constructors & constructor parameters
-6. All vals declared final, either in objects or final classes, if they are constant expressions and without type annotations.
-7. Private methods/vals not declared final since they are already final
-8. Package-private vals/methods declared final
+1. All methods on classes / traits are declared `final`, by default.
+2. No methods on objects declared `final`.
+3. No methods on final classes declared `final`.
+4. All classes inside objects should be defined `final`.
+5. All final classes have private constructors & constructor parameters.
+6. All `vals` declared `final`, either in objects or `final classes`, if they are constant expressions and without type annotations.
+7. Private `methods` and `vals` are not declared `final` since they are already final.
+8. Package-private `vals` and `methods` declared `final`.
 
-### Refactor
+### Refactoring
 
-1. If a class has all final members, class declared final & final member annotations removed
-2. use least powerful type alias
+1. If a class has all `final` members, the class should be declared `final` and `final` member annotations should be removed except constant expressions.
+2. All type annotations should use the least powerful type alias. This means, that, let us say, a `ZIO` effect that has no dependencies but throws an arbitrary error, should be defined as `IO`.
 
-### Naming of parameters
+### Naming of parameters in methods and classes
 
-1. partial function are called `pf`
-2. evidences are called `ev`
-3. promise are called `p` (unless in its own class methods, in that case it is called `that`)
-4. functions are called `fn`, `fn1`, unless they bear specific meaning: `use`, `release`, ..
-4. consider _ method having more meaningful names
-5. iterable are called `in`
-6. when a parameter type equals own (in a method of a trait) call it `that`
-7. please, PLEASE, only use  by name parameters if it makes sense. mind the Function[0] extra allocation and loss of clean syntax
-8. folds initial value are called `zero`
+1. Partial functions are called `pf`
+2. Evidences are called `ev`
+3. Promise are called `p` (unless in its own class methods, in that case it is called `that`)
+4. Functions are called `fn`, `fn1`, unless they bear specific meaning: `use`, `release`, ..
+4. Consider _ method having more meaningful names
+5. Iterable are called `in`
+6. When a parameter type equals own (in a method of a trait) call it `that`
+7. Never use by-name parameter unless you really know what you are doing and it makes sense. Mind the `Function[0]` extra allocation and loss of clean syntax when invoking the method.
+8. Folds initial value are called `zero`
 
 ### Misc
 
-1. GADTS should have type annotation.
-2. Type alias should have type annotation.
-3. Methods that lift pure values to effects are dangerous. Dangerous in the sense that they can potentially have dangerous side-effects. Such methods should have a default lazy variant and an eager variant for advanced users that are aware they absolutely do not have side-effects in their code, having slight gains in performance. The lazy variant should have a normal name (succeed, fail, lift, potato) and the eager variant should have a now suffix (succeedNow, liftNow, potatoNow) which makes it clear of its eager behaviour.      
+1. GADTS should always have type annotation.
+2. Type alias should always have type annotation.
+3. Methods that lift pure values to effects are dangerous. Dangerous in the sense that they can potentially have dangerous side-effects. 
+Such methods should have a default lazy variant and an eager variant for advanced users that are aware they absolutely do not have side-effects in their code, 
+having slight gains in performance. The lazy variant should have a normal name (succeed, fail, lift, potato) and the eager variant should have a now suffix 
+(succeedNow, liftNow, potatoNow) which makes it clear of its eager behaviour.      
 
 ### Code structure
 
-1. Method alphabetization - add lazy vals to fix forward references.
+1. Method alphabetization - add lazy `vals` to fix forward references.
 2. Sorting of imports                            

--- a/docs/about/coding_guidelines.md
+++ b/docs/about/coding_guidelines.md
@@ -15,16 +15,15 @@ make a contribution, by proving a fix to said issue.
 Last, but not least, these rules are continuously evolving and as such, 
 refer to them once in a while when in doubt.
 
-
 ### Defining classes and traits
 
-1. Value classes must be final and extend AnyVal;
+1. Value classes must be final and extend `AnyVal`;
 
 2. Method extension classes must be final and extend `AnyVal`;
 
-3. Sealed traits that are ADTs should extend `Product` and `Serializable`;
+3. Sealed traits that are ADTs (Algebraic data types) should extend `Product` and `Serializable`;
 
-4. Regular traits and sealed trait that do not form ADTS should extend `Serializable` but not `Product`;
+4. Regular traits and sealed trait that do not form ADTs should extend `Serializable` but not `Product`;
 
 5. Traits should always extends `Serializable`. (i.e. `ZIO`).
 
@@ -56,8 +55,8 @@ refer to them once in a while when in doubt.
 
 ### Understanding naming of parameters or values
 
-ZIO often but does not always uses the following naming conventions. This guide can help you understand where the names come from. 
-Naming expectations can be helpful in understanding the role of certain parameters without even glancing at its type when reading code, class or method signatures.
+ZIO code often uses the following naming conventions and you might be asked to change method parameters to follow this conventions. This guide can help you understand where the names come from. 
+Naming expectations can be helpful in understanding the role of certain parameters without even glancing at its type signature when reading code or class/method signatures.
 
 1. Partial functions have a shortened name `pf`;
 
@@ -84,12 +83,12 @@ Naming expectations can be helpful in understanding the role of certain paramete
 
 ### Understanding naming of methods
 
-ZIO goes to great lengths to define method names that are intuitive to the library user. Naming is hard. 
+ZIO goes to great lengths to define method names that are intuitive to the library user. Naming is hard!!! 
 This section will attempt to provide some guidelines and examples to document, guide and explain naming of methods in ZIO.
 
 1. Methods that lift pure values to effects are dangerous. Dangerous in the sense that they can potentially have dangerous side-effects. 
    Such methods should have a default lazy variant and an eager variant for advanced users that are aware they absolutely do not have side-effects in their code, 
-   having slight gains in performance. The lazy variant should have a normal name (succeed, fail, die, lift) and the eager variant should have a now suffix 
+   having slight gains in performance. The lazy variant should have a normal name (succeed, fail, die, lift) and the eager variant should have a `now` suffix 
    (succeedNow, failNow, dieNow, liftNow) which makes it clear of its eager behaviour;
 
 2. Methods that have the form of `List#zip` are called `zip`, and have an alias called `<*>`. The parallel version, if applicable, has the name `zipPar`, with an alias called `<&>`;
@@ -106,7 +105,6 @@ This section will attempt to provide some guidelines and examples to document, g
 
 7. `Foreach` should be used as the default traverse operation, with `traverse` retained as an alias for programmers with an FP background. For example, `ZIO.foreach`.
    
-
 ### Type annotations
 
 ZIO goes to great lengths to take advantage of the scala compiler in varied ways. Type variance is one of them. 
@@ -120,7 +118,8 @@ The following rules are good to have in mind when adding new `types`, `traits` o
 
 ### Method alphabetization
 
-In general the following rules should be applied regarding method alphabetization. To fix forward references we recommend values to be made lazy (`lazy val`).
+In general the following rules should be applied regarding method alphabetization. To fix forward references of values we recommend the programmer to make them lazy (`lazy val`).
+Operators are any methods that only have non-letter characters (i.e. `<*>` , `<>`, `*>`).
 
 1. Public abstract defs / vals listed first, and alphabetized, with operators appearing before names.
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -17,7 +17,7 @@ To begin contributing, please follow these steps:
 
 ### Get The Project
 
-If you don't already have one, sign up for a free [GitHub Account](https://github.com/join?source=header-home).
+If you don not  already have one, sign up for a free [GitHub Account](https://github.com/join?source=header-home).
 
 After you [log into](https://github.com/login) GitHub using your account, go to the [ZIO Project Page](https://github.com/zio/zio), and click on [Fork](https://github.com/zio/zio/fork) to fork the ZIO repository into your own account.
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -17,7 +17,7 @@ To begin contributing, please follow these steps:
 
 ### Get The Project
 
-If you don not  already have one, sign up for a free [GitHub Account](https://github.com/join?source=header-home).
+If you do not already have one, sign up for a free [GitHub Account](https://github.com/join?source=header-home).
 
 After you [log into](https://github.com/login) GitHub using your account, go to the [ZIO Project Page](https://github.com/zio/zio), and click on [Fork](https://github.com/zio/zio/fork) to fork the ZIO repository into your own account.
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -85,6 +85,7 @@
   "about-sidebar": {
       "About": [
           "about/about_index",
+          "about/about_coding_guidelines",
           "about/about_contributing",
           "about/about_coc"
       ]


### PR DESCRIPTION
#2549 Draft. Let me know what you think guys. I need a lot more stuff!!! I love this

The plan was never to create strictness on contributors but to help them. For instance, for naming variables, something that I struggle with, if someone is not sure, they could either check the rest of the codebase or check the coding guidelines, which are just that, guidelines.

Additionally, this would serve as a base to get inspiration to produce scalafix rules so that these process could be automated.

The idea, is to improve the codebase, the contribution experience and the ZIO library as a whole.

**The only thing to be automated would be rules based on the scala lang docs (when to use modifiers, extends of certain things, etc) itself removing the need for the contributor to know its details. Improving speed, reducing review iterations and improving code quality.**