### PR TITLE
#1499 Make foreachPar_ stack-safe

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2232,14 +2232,8 @@ object ZIO {
    * For a sequential version of this method, see `foreach_`.
    */
   def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
-    ZIO
-      .effectTotal(as.iterator)
-      .flatMap { i =>
-        def loop(a: A): ZIO[R, E, Unit] =
-          if (i.hasNext) f(a).zipWithPar(loop(i.next))((_, _) => ())
-          else f(a).unit
-        if (i.hasNext) loop(i.next)
-        else ZIO.unit
+    as.foldLeft(unit: ZIO[R, E, Unit]) { (acc, a) =>
+        acc.zipParLeft(f(a))
       }
       .refailWithTrace
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1182,11 +1182,8 @@ object ZManaged {
    * For a sequential version of this method, see `foreach_`.
    */
   def foreachPar_[R, E, A](as: Iterable[A])(f: A => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
-    ZManaged.succeed(as.iterator).flatMap { i =>
-      def loop: ZManaged[R, E, Unit] =
-        if (i.hasNext) f(i.next).zipWithPar(loop)((_, _) => ())
-        else ZManaged.unit
-      loop
+    as.foldLeft(unit: ZManaged[R, E, Unit]) { (acc, a) =>
+      acc.zipParLeft(f(a))
     }
 
   /**


### PR DESCRIPTION
After this change we can pass large collections to `foreachPar_` methods
without crashing the whole application. Though, traversing through large
collections is very slow because of the issue #1182. For example, this
effect runs for more than a minute:

```scala
UIO.foreachParN_(n = 10)(0 to 10000)(ZIO.succeed)
```

So, now it seems impossible to write regression test which doesn't
exceed 1 minute timeout.

`ZIO.foreachParN_` also become stack-safe, as it calls `foreachPar_`.