### PR TITLE
Implement ZIO#retryUntil and ZIO#retryWhile

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1244,6 +1244,18 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   }
 
   /**
+   * Retries this effect until its error satisfies the specified predicate.
+   */
+  final def retryUntil(f: E => Boolean): ZIO[R, E, A] =
+    retry(Schedule.doUntil(f))
+
+  /**
+   * Retries this effect while its error satisfies the specified predicate.
+   */
+  final def retryWhile(f: E => Boolean): ZIO[R, E, A] =
+    retry(Schedule.doWhile(f))
+
+  /**
    * Returns an effect that semantically runs the effect on a fiber,
    * producing an [[zio.Exit]] for the completion value of the fiber.
    */


### PR DESCRIPTION
Following up on discussion on Discord, adds convenience methods `retryUntil` and `retryWhile` on `ZIO` symmetrical with the existing `doUntil` and `doWhile` combinators. These are easily implemented in terms of `retry` and `Schedule` but we get a decent number of questions about how to do this so I think nice to have.