### PR TITLE
refactor: simplify unit-related code

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2556,7 +2556,7 @@ object ZIOSpec extends ZIOBaseSpec {
         _ <- if (count != 1) {
               ZIO.fail("Accessed more than once")
             } else {
-              ZIO.succeed(())
+              ZIO.unit
             }
       } yield res
     }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -864,7 +864,7 @@ object Schedule {
    * A schedule that recurs forever, returning each input as the output.
    */
   def identity[A]: Schedule[Any, A, A] =
-    Schedule[Any, Unit, A, A](ZIO.succeed(()), (_, _) => ZIO.succeed(()), (a, _) => a)
+    Schedule[Any, Unit, A, A](ZIO.unit, (_, _) => ZIO.unit, (a, _) => a)
 
   /**
    * A schedule that always recurs, but will repeat on a linear time

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2808,7 +2808,7 @@ object ZIO {
   /**
    * Strictly-evaluated unit lifted into the `ZIO` monad.
    */
-  val unit: URIO[Any, Unit] = succeed(())
+  val unit: UIO[Unit] = succeed(())
 
   /**
    * Prefix form of `ZIO#uninterruptible`.

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -507,7 +507,7 @@ object SinkSpec extends ZIOBaseSpec {
         testM("step error") {
           val s = new ZSink[Any, String, Nothing, Any, Nothing] {
             type State = Unit
-            val initial                    = UIO.succeed(())
+            val initial                    = UIO.unit
             def step(state: State, a: Any) = IO.fail("Ouch")
             def extract(state: State)      = IO.fail("Ouch")
             def cont(state: State)         = true

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -15,7 +15,7 @@ trait SinkUtils {
 
   def stepErrorSink = new ZSink[Any, String, Int, Int, Int] {
     type State = Unit
-    val initial                    = UIO.succeed(())
+    val initial                    = UIO.unit
     def step(state: State, a: Int) = IO.fail("Ouch")
     def extract(state: State)      = IO.fail("Ouch")
     def cont(state: State)         = false
@@ -23,8 +23,8 @@ trait SinkUtils {
 
   def extractErrorSink = new ZSink[Any, String, Int, Int, Int] {
     type State = Unit
-    val initial                    = UIO.succeed(())
-    def step(state: State, a: Int) = UIO.succeed(())
+    val initial                    = UIO.unit
+    def step(state: State, a: Int) = UIO.unit
     def extract(state: State)      = IO.fail("Ouch")
     def cont(state: State)         = false
   }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -100,7 +100,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
                        inParallel {
                          k(IO.fail(None))
                        }(global)
-                       UIO.succeed(())
+                       UIO.unit
                      }
                      .runCollect
         } yield assert(result)(equalTo(Nil))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1534,8 +1534,8 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   def fromEffect[R, E, B](b: => ZIO[R, E, B]): ZSink[R, E, Nothing, Any, B] =
     new ZSink[R, E, Nothing, Any, B] {
       type State = Unit
-      val initial                    = IO.succeed(())
-      def step(state: State, a: Any) = IO.succeed(())
+      val initial                    = IO.unit
+      def step(state: State, a: Any) = IO.unit
       def extract(state: State)      = b.map((_, Chunk.empty))
       def cont(state: State)         = false
     }
@@ -1558,8 +1558,8 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   def halt[E](e: Cause[E]): ZSink[Any, E, Nothing, Any, Nothing] =
     new Sink[E, Nothing, Any, Nothing] {
       type State = Unit
-      val initial                    = UIO.succeed(())
-      def step(state: State, a: Any) = UIO.succeed(())
+      val initial                    = UIO.unit
+      def step(state: State, a: Any) = UIO.unit
       def extract(state: State)      = IO.halt(e)
       def cont(state: State)         = false
     }


### PR DESCRIPTION
1. Replace `succeed(())` with `unit`
2. Change `ZIO.unit` type ascription to `UIO`