### PR TITLE
fix Schedule.recurs incorrect comment

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -924,8 +924,8 @@ object Schedule {
    * A schedule that recurs the specified number of times. Returns the number
    * of repetitions so far.
    *
-   * If 0 or negative numbers are given, the operation is not done at all so
-   * that in `(op: IO[E, A]).repeat(Schedule.recurs(0)) `, op is not done at all.
+   * If 0 or negative numbers are given, the operation is not repeated at all so
+   * that in `(op: IO[E, A]).repeat(Schedule.recurs(0)) `, op is only done once and repeated 0 times.
    */
   def recurs(n: Int): Schedule[Any, Any, Int] =
     forever.whileOutput(_ < n)


### PR DESCRIPTION
`op.repeat(Schedule.recurs(0))` will result on op being executed once and repeated zero times. the comment indicates that op is not executed at all which is incorrect. 