### PR TITLE
Runtime.unsafeRunTask that applies only for `E <: Throwable`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -202,7 +202,7 @@ object CauseSpec extends ZIOBaseSpec {
               )
               .map(new Throwable(msg1, _))
         }
-        val failOrDie = Gen.elements(Cause.fail[Throwable](_), Cause.die(_))
+        val failOrDie = Gen.elements[Throwable => Cause[Throwable]](Cause.fail, Cause.die)
         check(throwable, failOrDie) { (e, makeCause) =>
           val rootCause        = makeCause(e)
           val cause            = Cause.traced(rootCause, ZTrace(Fiber.Id(0L, 0L), Nil, Nil, None))

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -189,6 +189,40 @@ object CauseSpec extends ZIOBaseSpec {
           assert(result)(isTrue)
         }
       }
+    ),
+    suite("squashWithTrace")(
+      testM("converts Cause to original exception with ZTraces in root cause") {
+        val throwable = (Gen.alphaNumericString <*> Gen.alphaNumericString).flatMap {
+          case (msg1, msg2) =>
+            Gen
+              .elements(
+                new IllegalArgumentException(msg2),
+                // null cause can't be replaced using Throwable.initCause() on the JVM
+                new IllegalArgumentException(msg2, null)
+              )
+              .map(new Throwable(msg1, _))
+        }
+        val failOrDie = Gen.elements(Cause.fail[Throwable](_), Cause.die(_))
+        check(throwable, failOrDie) { (e, makeCause) =>
+          val rootCause        = makeCause(e)
+          val cause            = Cause.traced(rootCause, ZTrace(Fiber.Id(0L, 0L), Nil, Nil, None))
+          val causeMessage     = e.getCause.getMessage
+          val throwableMessage = e.getMessage
+          val renderedCause    = Cause.stackless(cause).prettyPrint
+          val squashed         = cause.squashWithTrace(identity)
+
+          assert(squashed)(
+            equalTo(e) &&
+              hasMessage(throwableMessage) &&
+              hasCause(
+                isSubtype[IllegalArgumentException](
+                  hasMessage(causeMessage) &&
+                    hasCause(hasMessage(renderedCause))
+                )
+              )
+          )
+        }
+      }
     )
   )
 

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -213,11 +213,11 @@ object CauseSpec extends ZIOBaseSpec {
 
           assert(squashed)(
             equalTo(e) &&
-              hasMessageEqualTo(throwableMessage) &&
+              hasMessage(equalTo(throwableMessage)) &&
               hasThrowableCause(
                 isSubtype[IllegalArgumentException](
-                  hasMessageEqualTo(causeMessage) &&
-                    hasThrowableCause(hasMessageEqualTo(renderedCause))
+                  hasMessage(equalTo(causeMessage)) &&
+                    hasThrowableCause(hasMessage(equalTo(renderedCause)))
                 )
               )
           )

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -213,11 +213,11 @@ object CauseSpec extends ZIOBaseSpec {
 
           assert(squashed)(
             equalTo(e) &&
-              hasMessage(throwableMessage) &&
-              hasCause(
+              hasMessageEqualTo(throwableMessage) &&
+              hasThrowableCause(
                 isSubtype[IllegalArgumentException](
-                  hasMessage(causeMessage) &&
-                    hasCause(hasMessage(renderedCause))
+                  hasMessageEqualTo(causeMessage) &&
+                    hasThrowableCause(hasMessageEqualTo(renderedCause))
                 )
               )
           )

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -105,7 +105,7 @@ object RefMSpec extends ZIOBaseSpec {
       for {
         refM  <- RefM.make[State](Active)
         value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
-      } yield assert(value)(dies(hasMessageEqualTo(fatalError)))
+      } yield assert(value)(dies(hasMessage(equalTo(fatalError))))
     },
     testM("interrupt parent fiber and update") {
       for {

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -105,7 +105,7 @@ object RefMSpec extends ZIOBaseSpec {
       for {
         refM  <- RefM.make[State](Active)
         value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
-      } yield assert(value)(dies(hasMessage(fatalError)))
+      } yield assert(value)(dies(hasMessageEqualTo(fatalError)))
     },
     testM("interrupt parent fiber and update") {
       for {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2616,6 +2616,14 @@ object ZIOSpec extends ZIOBaseSpec {
         val interrupted = io.sandbox.either.map(_.left.map(_.interrupted))
         assertM(interrupted)(isLeft(isTrue))
       }
+    ),
+    suite("toFuture")(
+      testM("should fail with ZTrace attached") {
+        for {
+          future <- ZIO.fail(new Throwable(new IllegalArgumentException)).toFuture
+          result <- ZIO.fromFuture(_ => future).either
+        } yield assert(result)(isLeft(hasCause(hasCause(hasMessage(containsString("Fiber:Id("))))))
+      }
     )
   )
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2622,7 +2622,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           future <- ZIO.fail(new Throwable(new IllegalArgumentException)).toFuture
           result <- ZIO.fromFuture(_ => future).either
-        } yield assert(result)(isLeft(hasCause(hasCause(hasMessage(containsString("Fiber:Id("))))))
+        } yield assert(result)(isLeft(hasThrowableCause(hasThrowableCause(hasMessage(containsString("Fiber:Id("))))))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1118,7 +1118,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ohNoes   = ";-0"
           managed  = Managed.make(ZIO.dieMessage(ohNoes))(_ => released.set(true))
           res1 <- managed.memoize.use { memoized =>
-                   assertM(memoized.use_(ZIO.unit).run)(dies(hasMessage(ohNoes)))
+                   assertM(memoized.use_(ZIO.unit).run)(dies(hasMessageEqualTo(ohNoes)))
                  }
           res2 <- assertM(released.get)(isFalse)
         } yield res1 && res2
@@ -1131,7 +1131,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           memoized.use_(ZIO.unit)
         }
 
-        assertM(program.run)(dies(hasMessage(myBad)))
+        assertM(program.run)(dies(hasMessageEqualTo(myBad)))
       },
       testM("behaves properly if use dies") {
         val darn = "darn"
@@ -1143,7 +1143,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                  memoized.use_(ZIO.dieMessage(darn))
                }.run
           v2 <- released.get
-        } yield assert(v1)(dies(hasMessage(darn))) && assert(v2)(isTrue)
+        } yield assert(v1)(dies(hasMessageEqualTo(darn))) && assert(v2)(isTrue)
       },
       testM("behaves properly if use is interrupted") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1118,7 +1118,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           ohNoes   = ";-0"
           managed  = Managed.make(ZIO.dieMessage(ohNoes))(_ => released.set(true))
           res1 <- managed.memoize.use { memoized =>
-                   assertM(memoized.use_(ZIO.unit).run)(dies(hasMessageEqualTo(ohNoes)))
+                   assertM(memoized.use_(ZIO.unit).run)(dies(hasMessage(equalTo(ohNoes))))
                  }
           res2 <- assertM(released.get)(isFalse)
         } yield res1 && res2
@@ -1131,7 +1131,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           memoized.use_(ZIO.unit)
         }
 
-        assertM(program.run)(dies(hasMessageEqualTo(myBad)))
+        assertM(program.run)(dies(hasMessage(equalTo(myBad))))
       },
       testM("behaves properly if use dies") {
         val darn = "darn"
@@ -1143,7 +1143,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                  memoized.use_(ZIO.dieMessage(darn))
                }.run
           v2 <- released.get
-        } yield assert(v1)(dies(hasMessageEqualTo(darn))) && assert(v2)(isTrue)
+        } yield assert(v1)(dies(hasMessage(equalTo(darn)))) && assert(v2)(isTrue)
       },
       testM("behaves properly if use is interrupted") {
         for {

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -21,6 +21,7 @@ import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 import scala.concurrent.ExecutionContext
 
 import com.github.ghik.silencer.silent
+
 import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -90,4 +90,6 @@ private[internal] trait PlatformSpecific {
   final def newConcurrentSet[A](): JSet[A] = new HashSet[A]()
 
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
+
+  final def forceThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -20,6 +20,7 @@ import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 
 import scala.concurrent.ExecutionContext
 
+import com.github.ghik.silencer.silent
 import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
@@ -91,5 +92,6 @@ private[internal] trait PlatformSpecific {
 
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
 
+  @silent("is never used")
   final def forceThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -98,4 +98,18 @@ private[internal] trait PlatformSpecific {
     Collections.synchronizedMap(new WeakHashMap[A, B]())
 
   final def newConcurrentSet[A](): JSet[A] = ConcurrentHashMap.newKeySet[A]()
+
+  /**
+   * calling [[Throwable.initCause]] may will on the JVM if `newCause != this`,
+   * which may happen if the cause is setto null.
+   * This works around this with reflection.
+   */
+  def forceThrowableCause(throwable: Throwable, newCause: Throwable): Unit = {
+    import scala.util.control.Exception._
+    ignoring(classOf[Throwable]) {
+      val causeField = classOf[Throwable].getDeclaredField("cause")
+      causeField.setAccessible(true)
+      causeField.set(throwable, newCause)
+    }
+  }
 }

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -101,7 +101,7 @@ private[internal] trait PlatformSpecific {
 
   /**
    * calling `initCause()` on [[java.lang.Throwable]] may fail on the JVM if `newCause != this`,
-   * which may happen if the cause is setto null.
+   * which may happen if the cause is set to null.
    * This works around this with reflection.
    */
   def forceThrowableCause(throwable: Throwable, newCause: Throwable): Unit = {

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -100,7 +100,7 @@ private[internal] trait PlatformSpecific {
   final def newConcurrentSet[A](): JSet[A] = ConcurrentHashMap.newKeySet[A]()
 
   /**
-   * calling [[Throwable.initCause]] may will on the JVM if `newCause != this`,
+   * calling `initCause()` on [[java.lang.Throwable]] may fail on the JVM if `newCause != this`,
    * which may happen if the cause is setto null.
    * This works around this with reflection.
    */

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -20,6 +20,7 @@ import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 
 import scala.concurrent.ExecutionContext
 
+import com.github.ghik.silencer.silent
 import zio.Cause
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
@@ -91,5 +92,6 @@ private[internal] trait PlatformSpecific {
 
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
 
+  @silent("is never used")
   final def forThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -93,5 +93,5 @@ private[internal] trait PlatformSpecific {
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
 
   @silent("is never used")
-  final def forThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
+  final def forceThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -90,4 +90,6 @@ private[internal] trait PlatformSpecific {
   final def newConcurrentSet[A](): JSet[A] = new HashSet[A]()
 
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
+
+  final def forThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -347,7 +347,6 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
       (if (interrupted) Some(new InterruptedException) else None) orElse
       defects.headOption getOrElse (new InterruptedException)
 
-
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
@@ -365,7 +364,6 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
    */
   final def squashWithTrace(f: E => Throwable): Throwable =
     attachTrace(squashWith(f))
-
 
   /**
    * Remove all `Fail` and `Interrupt` nodes from this `Cause`,

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -341,7 +341,7 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
-   * In addition, appends a new element the `Throwable`s "caused by" chain,
+   * In addition, appends a new element the to `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    */
   final def squashWithTrace(f: E => Throwable): Throwable =

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -341,7 +341,7 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
-   * In addition, appends a new element the `Thrwoable`s "caused by" chain,
+   * In addition, appends a new element the `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    */
   final def squashWithTrace(f: E => Throwable): Throwable =

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -341,20 +341,31 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
+   */
+  final def squashWith(f: E => Throwable): Throwable =
+    failureOption.map(f) orElse
+      (if (interrupted) Some(new InterruptedException) else None) orElse
+      defects.headOption getOrElse (new InterruptedException)
+
+
+  /**
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
+   * "most important" `Throwable`.
+   * In addition, appends a new element the to `Throwable`s "caused by" chain,
+   * with this `Cause` "pretty printed" (in stackless mode) as the message.
+   */
+  final def squashTrace(implicit ev: E <:< Throwable): Throwable =
+    squashWithTrace(ev)
+
+  /**
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
+   * "most important" `Throwable`.
    * In addition, appends a new element the to `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    */
   final def squashWithTrace(f: E => Throwable): Throwable =
     attachTrace(squashWith(f))
 
-  /**
-   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
-   * "most important" `Throwable`.
-   */
-  final def squashWith(f: E => Throwable): Throwable =
-    failureOption.map(f) orElse
-      (if (interrupted) Some(new InterruptedException) else None) orElse
-      defects.headOption getOrElse (new InterruptedException)
 
   /**
    * Remove all `Fail` and `Interrupt` nodes from this `Cause`,

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -17,6 +17,9 @@
 package zio
 
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
+import zio.internal.Platform
 
 sealed trait Cause[+E] extends Product with Serializable { self =>
   import Cause.Internal._
@@ -338,6 +341,15 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
+   * In addition, appends a new element the `Thrwoable`s "caused by" chain,
+   * with this `Cause` "pretty printed" (in stackless mode) as the message.
+   */
+  final def squashWithTrace(f: E => Throwable): Throwable =
+    attachTrace(squashWith(f))
+
+  /**
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
+   * "most important" `Throwable`.
    */
   final def squashWith(f: E => Throwable): Throwable =
     failureOption.map(f) orElse
@@ -421,6 +433,25 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
           }
       }
     loop(z, self, Nil)
+  }
+
+  private def attachTrace(e: Throwable): Throwable = {
+    val rootCause = rootCauseOf(e)
+    val trace     = Cause.FiberTrace(Cause.stackless(this).prettyPrint)
+    try {
+      // this may fail on JVM (if cause was null and not this), but shouldn't fail on JS/Native
+      rootCause.initCause(trace)
+    } catch {
+      case NonFatal(_) => Platform.forceThrowableCause(rootCause, trace)
+    }
+    e
+  }
+
+  @tailrec
+  private def rootCauseOf(e: Throwable): Throwable = {
+    val cause = e.getCause
+    if (cause == null || cause.eq(e)) e
+    else rootCauseOf(cause)
   }
 }
 
@@ -776,5 +807,9 @@ object Cause extends Serializable {
 
       loop(c, List.empty, Set.empty, List.empty)
     }
+  }
+
+  private case class FiberTrace(trace: String) extends Throwable(null, null, true, false) {
+    override final def getMessage: String = trace
   }
 }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -286,7 +286,7 @@ trait Fiber[+E, +A] { self =>
   /**
    * Converts this fiber into a [[scala.concurrent.Future]], translating
    * any errors to [[java.lang.Throwable]] with the specified conversion function,
-   * using [[Cause.squashWithTrace()]]
+   * using [[Cause.squashWithTrace]]
    *
    * @param f function to the error into a Throwable
    * @return `UIO[Future[A]]`

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -285,7 +285,8 @@ trait Fiber[+E, +A] { self =>
 
   /**
    * Converts this fiber into a [[scala.concurrent.Future]], translating
-   * any errors to [[java.lang.Throwable]] with the specified conversion function.
+   * any errors to [[java.lang.Throwable]] with the specified conversion function,
+   * using [[Cause.squashWithTrace()]]
    *
    * @param f function to the error into a Throwable
    * @return `UIO[Future[A]]`
@@ -294,7 +295,7 @@ trait Fiber[+E, +A] { self =>
     UIO.effectTotal {
       val p: concurrent.Promise[A] = scala.concurrent.Promise[A]()
 
-      def failure(cause: Cause[E]): UIO[p.type] = UIO(p.failure(cause.squashWith(f)))
+      def failure(cause: Cause[E]): UIO[p.type] = UIO(p.failure(cause.squashWithTrace(f)))
       def success(value: A): UIO[p.type]        = UIO(p.success(value))
 
       ZIO.runtime[Any].map { runtime =>

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -57,6 +57,18 @@ trait Runtime[+R] {
     unsafeRunSync(zio).getOrElse(c => throw FiberFailure(c))
 
   /**
+   * Executes the Task/RIO effect synchronously, failing
+   * with with a the original throwable on both [[Cause.Fail]] and [[Cause.Die]].
+   * In addition, appends a new element the `Thrwoable`s "caused by" chain,
+   * with this `Cause` "pretty printed" (in stackless mode) as the message.
+   * May fail on Scala.js if the effect cannot be entirely run synchronously.
+   *
+   * This method is effectful and should only be done at the edges of your program.
+   */
+  final def unsafeRunTask[A](task: => ZIO[R, Throwable, A]): A =
+    unsafeRunSync(task).fold(cause => throw cause.squashWithTrace(identity), identity)
+
+  /**
    * Executes the effect synchronously. May
    * fail on Scala.js if the effect cannot be entirely run synchronously.
    *

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -59,7 +59,7 @@ trait Runtime[+R] {
   /**
    * Executes the Task/RIO effect synchronously, failing
    * with the original `Throwable` on both [[Cause.Fail]] and [[Cause.Die]].
-   * In addition, appends a new element the `Throwable`s "caused by" chain,
+   * In addition, appends a new element to the `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    * May fail on Scala.js if the effect cannot be entirely run synchronously.
    *

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -66,7 +66,7 @@ trait Runtime[+R] {
    * This method is effectful and should only be done at the edges of your program.
    */
   final def unsafeRunTask[A](task: => ZIO[R, Throwable, A]): A =
-    unsafeRunSync(task).fold(cause => throw cause.squashWithTrace(identity), identity)
+    unsafeRunSync(task).fold(cause => throw cause.squashTrace, identity)
 
   /**
    * Executes the effect synchronously. May

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -59,7 +59,7 @@ trait Runtime[+R] {
   /**
    * Executes the Task/RIO effect synchronously, failing
    * with with a the original throwable on both [[Cause.Fail]] and [[Cause.Die]].
-   * In addition, appends a new element the `Thrwoable`s "caused by" chain,
+   * In addition, appends a new element the `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    * May fail on Scala.js if the effect cannot be entirely run synchronously.
    *

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -58,7 +58,7 @@ trait Runtime[+R] {
 
   /**
    * Executes the Task/RIO effect synchronously, failing
-   * with with a the original throwable on both [[Cause.Fail]] and [[Cause.Die]].
+   * with the original `Throwable` on both [[Cause.Fail]] and [[Cause.Die]].
    * In addition, appends a new element the `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    * May fail on Scala.js if the effect cannot be entirely run synchronously.

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -91,7 +91,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       @@ failure,
     test("failure does not make a test pass if the specified failure does not match") {
       assert(throw new RuntimeException())(isFalse)
-    } @@ failure(diesWith(hasMessage("boom")))
+    } @@ failure(diesWith(hasMessageEqualTo("boom")))
       @@ failure,
     test("failure makes tests pass on any assertion failure") {
       assert(true)(equalTo(false))

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -91,7 +91,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       @@ failure,
     test("failure does not make a test pass if the specified failure does not match") {
       assert(throw new RuntimeException())(isFalse)
-    } @@ failure(diesWith(hasMessageEqualTo("boom")))
+    } @@ failure(diesWith(hasMessage(equalTo("boom"))))
       @@ failure,
     test("failure makes tests pass on any assertion failure") {
       assert(true)(equalTo(false))

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -297,7 +297,19 @@ object Assertion extends AssertionVariants {
    * Makes a new assertion that requires an exception to have a certain message.
    */
   def hasMessage(message: String): Assertion[Throwable] =
-    assertion[Throwable]("hasMessage")(param(message))(th => th.getMessage == message)
+    hasMessage(equalTo(message))
+
+  /**
+   * Makes a new assertion that requires an exception to have a certain message.
+   */
+  def hasMessage(message: Assertion[String]): Assertion[Throwable] =
+    Assertion.assertionRec("hasMessage")(param(message))(message)(th => Some(th.getMessage))
+
+  /**
+   * Makes a new assertion that requires an exception to have a certain cause.
+   */
+  def hasCause(cause: Assertion[Throwable]): Assertion[Throwable] =
+    Assertion.assertionRec("hasCause")(param(cause))(cause)(th => Some(th.getCause))
 
   /**
    * Makes a new assertion that requires a given string to end with the specified suffix.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -296,12 +296,6 @@ object Assertion extends AssertionVariants {
   /**
    * Makes a new assertion that requires an exception to have a certain message.
    */
-  def hasMessageEqualTo(message: String): Assertion[Throwable] =
-    hasMessage(equalTo(message))
-
-  /**
-   * Makes a new assertion that requires an exception to have a certain message.
-   */
   def hasMessage(message: Assertion[String]): Assertion[Throwable] =
     Assertion.assertionRec("hasMessage")(param(message))(message)(th => Some(th.getMessage))
 

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -296,7 +296,7 @@ object Assertion extends AssertionVariants {
   /**
    * Makes a new assertion that requires an exception to have a certain message.
    */
-  def hasMessage(message: String): Assertion[Throwable] =
+  def hasMessageEqualTo(message: String): Assertion[Throwable] =
     hasMessage(equalTo(message))
 
   /**
@@ -308,8 +308,8 @@ object Assertion extends AssertionVariants {
   /**
    * Makes a new assertion that requires an exception to have a certain cause.
    */
-  def hasCause(cause: Assertion[Throwable]): Assertion[Throwable] =
-    Assertion.assertionRec("hasCause")(param(cause))(cause)(th => Some(th.getCause))
+  def hasThrowableCause(cause: Assertion[Throwable]): Assertion[Throwable] =
+    Assertion.assertionRec("hasThrowableCause")(param(cause))(cause)(th => Some(th.getCause))
 
   /**
    * Makes a new assertion that requires a given string to end with the specified suffix.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.duration._
 import zio.system
-import zio.test.Assertion.{ hasMessage, isCase, isSubtype }
+import zio.test.Assertion.{ equalTo, hasMessage, isCase, isSubtype }
 import zio.test.environment.{ Live, Restorable, TestClock, TestConsole, TestRandom, TestSystem }
 import zio.{ Cause, Schedule, ZIO, ZManaged }
 
@@ -405,7 +405,7 @@ object TestAspect extends TimeoutVariants {
             case TestFailure.Runtime(cause) => cause.dieOption
             case _                          => None
           },
-          isSubtype[TestTimeoutException](hasMessage(s"Timeout of ${duration.render} exceeded."))
+          isSubtype[TestTimeoutException](hasMessage(equalTo(s"Timeout of ${duration.render} exceeded.")))
         )
       )
 


### PR DESCRIPTION
* on failure throws the result of new method `Cause.squashWithTrace` that attaches fiber traces to the exception as a new root cause, containing pretty printed (stackless) `zio.Cause`.
* changed `ZIO.toFuture` (and thus Runtime.unsafeRunToFuture) to use `Cause.squashWithTrace` as well
#2546 