### PR TITLE
Don't Shift To Blocking Executor If Already There

### DIFF
--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -66,7 +66,11 @@ object Blocking extends Serializable {
      * Locks the specified effect to the blocking thread pool.
      */
     def blocking[R1 <: R, E, A](zio: ZIO[R1, E, A]): ZIO[R1, E, A] =
-      blockingExecutor.flatMap(exec => zio.lock(exec))
+      for {
+        executor <- blockingExecutor
+        here     <- ZIO.effectTotal(executor.here)
+        a        <- if (here) zio else zio.lock(executor)
+      } yield a
 
     /**
      * Imports a synchronous effect that does blocking IO into a pure value.

--- a/core/jvm/src/main/scala/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/blocking/Blocking.scala
@@ -66,11 +66,7 @@ object Blocking extends Serializable {
      * Locks the specified effect to the blocking thread pool.
      */
     def blocking[R1 <: R, E, A](zio: ZIO[R1, E, A]): ZIO[R1, E, A] =
-      for {
-        executor <- blockingExecutor
-        here     <- ZIO.effectTotal(executor.here)
-        a        <- if (here) zio else zio.lock(executor)
-      } yield a
+      blockingExecutor.flatMap(exec => zio.lock(exec))
 
     /**
      * Imports a synchronous effect that does blocking IO into a pure value.

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -509,7 +509,9 @@ private[zio] final class FiberContext[E, A](
                   case ZIO.Tags.Lock =>
                     val zio = curZio.asInstanceOf[ZIO.Lock[Any, E, Any]]
 
-                    curZio = lock(zio.executor).bracket_(unlock, zio.zio)
+                    curZio =
+                      if (zio.executor eq executors.peek()) zio.zio
+                      else lock(zio.executor).bracket_(unlock, zio.zio)
 
                   case ZIO.Tags.Yield =>
                     evaluateLater(ZIO.unit)


### PR DESCRIPTION
Following up on a suggestion from @jdegoes on Discord, adds logic to `blocking` to avoid shifting to the blocking executor if the effect is already run there.

Could we push this logic higher up into `lock` so we always check if we are already running on the executor we are being asked to lock to and if so don't do anything? I think if `lock` is the exclusive way effects are shifted between executors in ZIO and inner locks take priority then this is safe to do.