### PR TITLE
Bugfix: complete foreachPar_ on empty input

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -481,6 +481,9 @@ object ZIOSpec extends ZIOBaseSpec {
           rs  <- ref.get
         } yield assert(rs)(hasSize(equalTo(as.length))) &&
           assert(rs.toSet)(equalTo(as.toSet))
+      },
+      testM("completes on empty input") {
+        ZIO.foreachPar_(Nil)(_ => ZIO.unit).as(assertCompletes)
       }
     ),
     suite("foreachParN")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2258,6 +2258,7 @@ object ZIO {
     for {
       parentId <- ZIO.fiberId
       result   <- Promise.make[E, Unit]
+      _        <- ZIO.when(as.isEmpty)(result.succeed(()))
       succeed  <- Ref.make(0)
       _ <- ZIO.traverse_(as) {
             f(_)


### PR DESCRIPTION
Promise was completed only when there were some elements inside passed
iterable.