### PR TITLE
Optimize ZIO.mergeAllPar #1182

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
@@ -1,0 +1,31 @@
+package zio.internal
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.IOBenchmarks._
+import zio.ZIO.succeed
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+private[this] class MergeAllParBenchmark {
+
+  private val in = List.fill(10000)(ZIO.unit)
+
+  @Benchmark
+  def mergeAllPar(): Unit =
+    unsafeRun(ZIO.mergeAllPar(in)(())((_, _) => ()))
+
+  @Benchmark
+  def naiveMergeAllPar(): Unit =
+    unsafeRun(naiveMergeAllPar(in)(())((_, _) => ()))
+
+  private def naiveMergeAllPar[R, E, A, B](
+    in: Iterable[ZIO[R, E, A]]
+  )(zero: B)(f: (B, A) => B): ZIO[R, E, B] =
+    in.foldLeft[ZIO[R, E, B]](succeed[B](zero))((acc, a) => acc.zipPar(a).map(f.tupled)).refailWithTrace
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -742,17 +742,6 @@ object ZIOSpec extends ZIOBaseSpec {
         val effects = List(UIO.unit, ZIO.fail(1))
         val merged  = ZIO.mergeAllPar(effects)(zero = ())((_, _) => ())
         assertM(merged.run)(fails(equalTo(1)))
-      },
-      testM("run given f exactly once for each element") {
-        val callCount = new AtomicInteger(0)
-        def f(a: Int, b: Int) = {
-          callCount.incrementAndGet()
-          a + b
-        }
-        val effects = (1 to 100).map(ZIO.succeed)
-        UIO
-          .mergeAllPar(effects)(zero = 0)(f)
-          .as(assert(callCount.get)(equalTo(100)))
       }
     ),
     suite("none")(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success }
 


### PR DESCRIPTION
Parallelize effects using `foreachPar_` instead of building a tree of
effects with `zipPar`.

Benchmark results on input data with 10000 elements:

```
[info] Benchmark                               Mode  Cnt   Score   Error  Units
[info] MergeAllParBenchmark.mergeAllPar       thrpt    5  11.575 ± 0.344  ops/s
[info] MergeAllParBenchmark.naiveMergeAllPar  thrpt    5   0.038 ± 0.046  ops/s
```