### PR TITLE
ZIO Test: Implement TestAspect#nonTermination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ project/.sbt
 test-output/
 .bloop
 .metals
+project/metals.sbt
 .idea
 coursier
 .DS_Store

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -51,6 +51,17 @@ object TestAspectSpec extends ZIOBaseSpec {
         assert(after)(equalTo(-1))
       }
     },
+    suite("doesNotTerminate")(
+      testM("makes a test pass if it does not terminate within the specified time") {
+        assertM(ZIO.never)(anything)
+      } @@ doesNotTerminate(10.milliseconds),
+      testM("makes a test fail if it succeeds within the specified time") {
+        assertM(ZIO.unit)(anything)
+      } @@ doesNotTerminate(1.minute) @@ failure,
+      testM("makes a test fail if it fails within the specified time") {
+        assertM(ZIO.fail("fail"))(anything)
+      } @@ doesNotTerminate(1.minute) @@ failure
+    ),
     testM("dotty applies test aspect only on Dotty") {
       for {
         ref    <- Ref.make(false)

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -51,17 +51,6 @@ object TestAspectSpec extends ZIOBaseSpec {
         assert(after)(equalTo(-1))
       }
     },
-    suite("nonTermination")(
-      testM("makes a test pass if it does not terminate within the specified time") {
-        assertM(ZIO.never)(anything)
-      } @@ nonTermination(10.milliseconds),
-      testM("makes a test fail if it succeeds within the specified time") {
-        assertM(ZIO.unit)(anything)
-      } @@ nonTermination(1.minute) @@ failure,
-      testM("makes a test fail if it fails within the specified time") {
-        assertM(ZIO.fail("fail"))(anything)
-      } @@ nonTermination(1.minute) @@ failure
-    ),
     testM("dotty applies test aspect only on Dotty") {
       for {
         ref    <- Ref.make(false)
@@ -192,6 +181,17 @@ object TestAspectSpec extends ZIOBaseSpec {
       val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
       assertM(result)(isTrue)
     },
+    suite("nonTermination")(
+      testM("makes a test pass if it does not terminate within the specified time") {
+        assertM(ZIO.never)(anything)
+      } @@ nonTermination(10.milliseconds),
+      testM("makes a test fail if it succeeds within the specified time") {
+        assertM(ZIO.unit)(anything)
+      } @@ nonTermination(1.minute) @@ failure,
+      testM("makes a test fail if it fails within the specified time") {
+        assertM(ZIO.fail("fail"))(anything)
+      } @@ nonTermination(1.minute) @@ failure
+    ),
     testM("retry retries failed tests according to a schedule") {
       for {
         ref <- Ref.make(0)

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -51,16 +51,16 @@ object TestAspectSpec extends ZIOBaseSpec {
         assert(after)(equalTo(-1))
       }
     },
-    suite("doesNotTerminate")(
+    suite("nonTermination")(
       testM("makes a test pass if it does not terminate within the specified time") {
         assertM(ZIO.never)(anything)
-      } @@ doesNotTerminate(10.milliseconds),
+      } @@ nonTermination(10.milliseconds),
       testM("makes a test fail if it succeeds within the specified time") {
         assertM(ZIO.unit)(anything)
-      } @@ doesNotTerminate(1.minute) @@ failure,
+      } @@ nonTermination(1.minute) @@ failure,
       testM("makes a test fail if it fails within the specified time") {
         assertM(ZIO.fail("fail"))(anything)
-      } @@ doesNotTerminate(1.minute) @@ failure
+      } @@ nonTermination(1.minute) @@ failure
     ),
     testM("dotty applies test aspect only on Dotty") {
       for {

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -189,7 +189,7 @@ object TestAspect extends TimeoutVariants {
    * Constructs an aspect that requires a test to not terminate within the
    * specified time.
    */
-  def doesNotTerminate(duration: Duration): TestAspect[Nothing, Live[Clock], Nothing, Any, Unit, Unit] =
+  def nonTermination(duration: Duration): TestAspect[Nothing, Live[Clock], Nothing, Any, Unit, Unit] =
     timeout(duration) >>>
       failure(
         isCase[TestFailure[Any], Throwable](

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -20,6 +20,7 @@ import zio.clock.Clock
 import zio.duration._
 import zio.system
 import zio.system.System
+import zio.test.Assertion.{ hasMessage, isCase, isSubtype }
 import zio.test.environment.{ Live, Restorable, TestClock, TestConsole, TestRandom, TestSystem }
 import zio.{ Cause, Schedule, ZIO, ZManaged }
 
@@ -183,6 +184,22 @@ object TestAspect extends TimeoutVariants {
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         effect *> test
     }
+
+  /**
+   * Constructs an aspect that requires a test to not terminate within the
+   * specified time.
+   */
+  def doesNotTerminate(duration: Duration): TestAspect[Nothing, Live[Clock], Nothing, Any, Unit, Unit] =
+    timeout(duration) >>>
+      failure(
+        isCase[TestFailure[Any], Throwable](
+          "Runtime", {
+            case TestFailure.Runtime(cause) => cause.dieOption
+            case _                          => None
+          },
+          isSubtype[TestTimeoutException](hasMessage(s"Timeout of ${duration.render} exceeded."))
+        )
+      )
 
   /**
    * An aspect that applies the specified aspect on Dotty.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -186,22 +186,6 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
-   * Constructs an aspect that requires a test to not terminate within the
-   * specified time.
-   */
-  def nonTermination(duration: Duration): TestAspect[Nothing, Live[Clock], Nothing, Any, Unit, Unit] =
-    timeout(duration) >>>
-      failure(
-        isCase[TestFailure[Any], Throwable](
-          "Runtime", {
-            case TestFailure.Runtime(cause) => cause.dieOption
-            case _                          => None
-          },
-          isSubtype[TestTimeoutException](hasMessage(s"Timeout of ${duration.render} exceeded."))
-        )
-      )
-
-  /**
    * An aspect that applies the specified aspect on Dotty.
    */
   def dotty[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS](
@@ -410,6 +394,22 @@ object TestAspect extends TimeoutVariants {
 
     restoreTestEnvironment >>> nonFlaky
   }
+
+  /**
+   * Constructs an aspect that requires a test to not terminate within the
+   * specified time.
+   */
+  def nonTermination(duration: Duration): TestAspect[Nothing, Live[Clock], Nothing, Any, Unit, Unit] =
+    timeout(duration) >>>
+      failure(
+        isCase[TestFailure[Any], Throwable](
+          "Runtime", {
+            case TestFailure.Runtime(cause) => cause.dieOption
+            case _                          => None
+          },
+          isSubtype[TestTimeoutException](hasMessage(s"Timeout of ${duration.render} exceeded."))
+        )
+      )
 
   /**
    * An aspect that executes the members of a suite in parallel.


### PR DESCRIPTION
Following up on a question I got, this provides an easy way to require that a test does not terminate within a specified time.