### PR TITLE
Exclude PGP Upgrades

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "com.jsuereth", artifactId = "sbt-pgp" } ]


### PR DESCRIPTION
Following up on recommendation from @mijicd on Discord, adds setting to ignore PGP upgrades so we don't have this weird situation where in general Scala Steward upgrades should be merged as a matter of course but contributors have to remember to close pull requests for this one particular upgrade.