### PR TITLE
Optimize ZIO.reduceAllPar #1182

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
@@ -1,0 +1,33 @@
+package zio.internal
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.IOBenchmarks._
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+private[this] class ReduceAllParBenchmark {
+
+  private val a  = ZIO.unit
+  private val as = List.fill(10000)(ZIO.unit)
+
+  @Benchmark
+  def reduceAllPar(): Unit =
+    unsafeRun(ZIO.reduceAllPar(a, as)((_, _) => ()))
+
+  @Benchmark
+  def naiveReduceAllPar(): Unit =
+    unsafeRun(naiveReduceAllPar(a, as)((_, _) => ()))
+
+  def naiveReduceAllPar[R, R1 <: R, E, A](a: ZIO[R, E, A], as: Iterable[ZIO[R1, E, A]])(
+    f: (A, A) => A
+  ): ZIO[R1, E, A] =
+    as.foldLeft[ZIO[R1, E, A]](a) { (l, r) =>
+      l.zipPar(r).map(f.tupled)
+    }
+}

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2731,22 +2731,9 @@ object ZIO {
   def reduceAllPar[R, R1 <: R, E, A](a: ZIO[R, E, A], as: Iterable[ZIO[R1, E, A]])(
     f: (A, A) => A
   ): ZIO[R1, E, A] = {
-    def prepend(a: ZIO[R, E, A], as: Iterable[ZIO[R1, E, A]]): Iterable[ZIO[R1, E, A]] =
-      new Iterable[ZIO[R1, E, A]] {
-        override def iterator: Iterator[ZIO[R1, E, A]] = new Iterator[ZIO[R1, E, A]] {
-          private var started    = false
-          private val asIterator = as.iterator
-
-          override def hasNext: Boolean = !started || asIterator.hasNext
-
-          override def next(): ZIO[R1, E, A] =
-            if (!started) {
-              started = true
-              a
-            } else {
-              asIterator.next()
-            }
-        }
+    def prepend[Z](z: Z, zs: Iterable[Z]): Iterable[Z] =
+      new Iterable[Z] {
+        override def iterator: Iterator[Z] = Iterator(z) ++ zs.iterator
       }
 
     val all = prepend(a, as)


### PR DESCRIPTION
Parallelize effects using `foreachPar_` via `mergeAllPar` instead of
building a tree of effects with `zipPar`.

Benchmark results on input data with 10000 elements:

```
[info] Benchmark                                 Mode  Cnt   Score    Error  Units
[info] ReduceAllParBenchmark.naiveReduceAllPar  thrpt    5   0.047 ±  0.034  ops/s
[info] ReduceAllParBenchmark.reduceAllPar       thrpt    5  28.159 ± 13.505  ops/s
```