### PR TITLE
Fix Build Failure On Master

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -543,7 +543,7 @@ object ZIOSpec extends ZIOBaseSpec {
           .foreachPar_(1 to 3)(IO.fail(_).uninterruptible)
           .foldCause(_.failures.toSet, _ => Set.empty)
         assertM(failures)(equalTo(Set(1, 2, 3)))
-      },
+      } @@ flaky,
       testM("runs all effects") {
         val as = Seq(1, 2, 3, 4, 5)
         for {


### PR DESCRIPTION
Issue already created for flaky test in #2642. Marking as flaky now to fix build failure on `master`.