### PR TITLE
ZIO Test: Improve Version Specific Support

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -88,7 +88,7 @@ object ChunkSpec extends ZIOBaseSpec {
       check(mediumChunks(stringGen), fn, intGen) { (chunk, p, from) =>
         assert(chunk.indexWhere(p, from).getOrElse(-1))(equalTo(chunk.toSeq.indexWhere(p, from)))
       }
-    } @@ exceptScala211, // TODO remove me when scala/bug#11852 is fixed
+    } @@ exceptScala211,
     testM("exists") {
       val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
       check(mediumChunks(stringGen), fn) { (chunk, p) =>

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -4,6 +4,7 @@ import ChunkUtils._
 
 import zio.random.Random
 import zio.test.Assertion.{ equalTo, isLeft }
+import zio.test.TestAspect.exceptScala211
 import zio.test._
 import zio.{ Chunk, IO, UIO, ZIOBaseSpec }
 
@@ -84,10 +85,10 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     testM("indexWhere") {
       val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn, Gen.int(0, Int.MaxValue)) { (chunk, p, from) => // TODO should test for all ints once it can be excluded from running against 2.11
+      check(mediumChunks(stringGen), fn, intGen) { (chunk, p, from) =>
         assert(chunk.indexWhere(p, from).getOrElse(-1))(equalTo(chunk.toSeq.indexWhere(p, from)))
       }
-    },
+    } @@ exceptScala211, // TODO remove me when scala/bug#11852 is fixed
     testM("exists") {
       val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
       check(mediumChunks(stringGen), fn) { (chunk, p) =>

--- a/test/shared/src/main/scala-2.11/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-2.11/zio/test/TestVersion.scala
@@ -25,17 +25,17 @@ object TestVersion {
   /**
    * Returns whether the current Scala version is Dotty.
    */
-  val isDotty: Boolean = true
+  val isDotty: Boolean = false
 
   /**
    * Returns whether the current Scala version is Scala 2.
    */
-  val isScala2: Boolean = false
+  val isScala2: Boolean = true
 
   /**
    * Returns whether the current Scala version is Scala 2.11.
    */
-  val isScala211: Boolean = false
+  val isScala211: Boolean = true
 
   /**
    * Returns whether the current Scala version is Scala 2.12.

--- a/test/shared/src/main/scala-2.12/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-2.12/zio/test/TestVersion.scala
@@ -25,12 +25,12 @@ object TestVersion {
   /**
    * Returns whether the current Scala version is Dotty.
    */
-  val isDotty: Boolean = true
+  val isDotty: Boolean = false
 
   /**
    * Returns whether the current Scala version is Scala 2.
    */
-  val isScala2: Boolean = false
+  val isScala2: Boolean = true
 
   /**
    * Returns whether the current Scala version is Scala 2.11.
@@ -40,7 +40,7 @@ object TestVersion {
   /**
    * Returns whether the current Scala version is Scala 2.12.
    */
-  val isScala212: Boolean = false
+  val isScala212: Boolean = true
 
   /**
    * Returns whether the current Scala version is Scala 2.13.

--- a/test/shared/src/main/scala-2.13/zio/test/TestVersion.scala
+++ b/test/shared/src/main/scala-2.13/zio/test/TestVersion.scala
@@ -31,4 +31,19 @@ object TestVersion {
    * Returns whether the current Scala version is Scala 2.
    */
   val isScala2: Boolean = true
+
+  /**
+   * Returns whether the current Scala version is Scala 2.11.
+   */
+  val isScala211: Boolean = false
+
+  /**
+   * Returns whether the current Scala version is Scala 2.12.
+   */
+  val isScala212: Boolean = false
+
+  /**
+   * Returns whether the current Scala version is Scala 2.13.
+   */
+  val isScala213: Boolean = true
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -229,10 +229,28 @@ object TestAspect extends TimeoutVariants {
     if (TestPlatform.isJVM) ignore else identity
 
   /**
-   * An aspect that runs tests on all versions except Scala2.
+   * An aspect that runs tests on all versions except Scala 2.
    */
   val exceptScala2: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isScala2) ignore else identity
+
+  /**
+   * An aspect that runs tests on all versions except Scala 2.11.
+   */
+  val exceptScala211: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala211) ignore else identity
+
+  /**
+   * An aspect that runs tests on all versions except Scala 2.12.
+   */
+  val exceptScala212: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala212) ignore else identity
+
+  /**
+   * An aspect that runs tests on all versions except Scala 2.13.
+   */
+  val exceptScala213: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala213) ignore else identity
 
   /**
    * An aspect that sets suites to the specified execution strategy, but only
@@ -495,10 +513,52 @@ object TestAspect extends TimeoutVariants {
     if (TestVersion.isScala2) that else identity
 
   /**
+   * An aspect that applies the specified aspect on Scala 2.11.
+   */
+  def scala211[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS](
+    that: TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS]
+  ): TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS] =
+    if (TestVersion.isScala211) that else identity
+
+  /**
+   * An aspect that applies the specified aspect on Scala 2.12.
+   */
+  def scala212[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS](
+    that: TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS]
+  ): TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS] =
+    if (TestVersion.isScala212) that else identity
+
+  /**
+   * An aspect that applies the specified aspect on Scala 2.13.
+   */
+  def scala213[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS](
+    that: TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS]
+  ): TestAspect[LowerR, UpperR, LowerE, UpperE, LowerS, UpperS] =
+    if (TestVersion.isScala213) that else identity
+
+  /**
    * An aspect that only runs tests on Scala 2.
    */
   val scala2Only: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isScala2) identity else ignore
+
+  /**
+   * An aspect that only runs tests on Scala 2.11.
+   */
+  val scala211Only: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala211) identity else ignore
+
+  /**
+   * An aspect that only runs tests on Scala 2.12.
+   */
+  val scala212Only: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala212) identity else ignore
+
+  /**
+   * An aspect that only runs tests on Scala 2.13.
+   */
+  val scala213Only: TestAspectAtLeastR[Annotations] =
+    if (TestVersion.isScala213) identity else ignore
 
   /**
    * An aspect that converts ignored tests into test failures.


### PR DESCRIPTION
Currently version specific support in ZIO Test is limited to Scala 2 and Dotty. However, sometimes it can be necessary to apply different testing logic based on the specific Scala version (e.g. Scala 2.11). This PR adds accessors and test aspects to be able to control the execution of tests based on the specific Scala version and uses this to resolve an issue we had with testing one of the methods on `Chunk` recently.