### PR TITLE
Implement TQueue#peekOption

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -36,7 +36,7 @@ class QueueBackPressureBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](queueSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](queueSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue.make(queueSize).commit)
+    zioTQ = unsafeRun(TQueue.bounded(queueSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](queueSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -36,7 +36,7 @@ class QueueParallelBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.bounded(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.bounded[MTask, Int](totalSize).runSyncUnsafe()
   }
 

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -38,7 +38,7 @@ class QueueSequentialBenchmark {
   def createQueues(): Unit = {
     zioQ = unsafeRun(Queue.bounded[Int](totalSize))
     fs2Q = fs2.concurrent.Queue.bounded[CIO, Int](totalSize).unsafeRunSync()
-    zioTQ = unsafeRun(TQueue.make(totalSize).commit)
+    zioTQ = unsafeRun(TQueue.bounded(totalSize).commit)
     monixQ = monix.catnap.ConcurrentQueue.withConfig[MTask, Int](Bounded(totalSize), SPSC).runSyncUnsafe()
   }
 

--- a/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
@@ -64,6 +64,14 @@ object TQueueSpec extends ZIOBaseSpec {
         } yield ans
         assertM(tx.commit)(equalTo(List(1, 2, 3, 4, 5)))
       },
+      testM("offerMax") {
+        val tx = for {
+          tq        <- TQueue.bounded[Int](3)
+          remaining <- tq.offerMax(List(1, 2, 3, 4, 5))
+          ans       <- tq.takeAll
+        } yield (ans, remaining)
+        assertM(tx.commit)(equalTo((List(1, 2, 3), List(4, 5))))
+      },
       testM("takeUpTo") {
         val tx = for {
           tq   <- TQueue.bounded[Int](5)

--- a/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
@@ -64,10 +64,10 @@ object TQueueSpec extends ZIOBaseSpec {
         } yield ans
         assertM(tx.commit)(equalTo(List(1, 2, 3, 4, 5)))
       },
-      testM("offerMax") {
+      testM("offerAll respects capacity") {
         val tx = for {
           tq        <- TQueue.bounded[Int](3)
-          remaining <- tq.offerMax(List(1, 2, 3, 4, 5))
+          remaining <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans       <- tq.takeAll
         } yield (ans, remaining)
         assertM(tx.commit)(equalTo((List(1, 2, 3), List(4, 5))))

--- a/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TQueueSpec.scala
@@ -24,9 +24,9 @@ object TQueueSpec extends ZIOBaseSpec {
 
   def spec = suite("TQueue")(
     suite("factories")(
-      testM("make") {
+      testM("bounded") {
         val capacity = 5
-        val tq       = TQueue.make[Int](capacity).map(_.capacity)
+        val tq       = TQueue.bounded[Int](capacity).map(_.capacity)
         assertM(tq.commit)(equalTo(capacity))
       },
       testM("unbounded") {
@@ -37,7 +37,7 @@ object TQueueSpec extends ZIOBaseSpec {
     suite("insertion and removal")(
       testM("offer & take") {
         val tx = for {
-          tq    <- TQueue.make[Int](5)
+          tq    <- TQueue.bounded[Int](5)
           _     <- tq.offer(1)
           _     <- tq.offer(2)
           _     <- tq.offer(3)
@@ -49,7 +49,7 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("takeUpTo") {
         val tx = for {
-          tq   <- TQueue.make[Int](5)
+          tq   <- TQueue.bounded[Int](5)
           _    <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans  <- tq.takeUpTo(3)
           size <- tq.size
@@ -58,7 +58,7 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("offerAll & takeAll") {
         val tx = for {
-          tq  <- TQueue.make[Int](5)
+          tq  <- TQueue.bounded[Int](5)
           _   <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans <- tq.takeAll
         } yield ans
@@ -66,7 +66,7 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("takeUpTo") {
         val tx = for {
-          tq   <- TQueue.make[Int](5)
+          tq   <- TQueue.bounded[Int](5)
           _    <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans  <- tq.takeUpTo(3)
           size <- tq.size
@@ -75,7 +75,7 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("takeUpTo larger than container") {
         val tx = for {
-          tq   <- TQueue.make[Int](5)
+          tq   <- TQueue.bounded[Int](5)
           _    <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans  <- tq.takeUpTo(7)
           size <- tq.size
@@ -84,7 +84,7 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("poll value") {
         val tx = for {
-          tq  <- TQueue.make[Int](5)
+          tq  <- TQueue.bounded[Int](5)
           _   <- tq.offerAll(List(1, 2, 3))
           ans <- tq.poll
         } yield ans
@@ -92,14 +92,14 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("poll empty queue") {
         val tx = for {
-          tq  <- TQueue.make[Int](5)
+          tq  <- TQueue.bounded[Int](5)
           ans <- tq.poll
         } yield ans
         assertM(tx.commit)(isNone)
       },
       testM("seek element") {
         val tx = for {
-          tq   <- TQueue.make[Int](5)
+          tq   <- TQueue.bounded[Int](5)
           _    <- tq.offerAll(List(1, 2, 3, 4, 5))
           ans  <- tq.seek(_ == 3)
           size <- tq.size
@@ -125,6 +125,22 @@ object TQueueSpec extends ZIOBaseSpec {
         } yield (next, size)
         assertM(tx.commit)(equalTo((1, 5)))
       },
+      testM("peekOption value") {
+        val tx = for {
+          tq   <- TQueue.unbounded[Int]
+          _    <- tq.offerAll(List(1, 2, 3, 4, 5))
+          next <- tq.peekOption
+          size <- tq.size
+        } yield (next, size)
+        assertM(tx.commit)(equalTo((Some(1), 5)))
+      },
+      testM("peekOption empty queue") {
+        val tx = for {
+          tq   <- TQueue.bounded[Int](5)
+          next <- tq.peekOption
+        } yield next
+        assertM(tx.commit)(isNone)
+      },
       testM("view the last value") {
         val tx = for {
           tq   <- TQueue.unbounded[Int]
@@ -146,8 +162,8 @@ object TQueueSpec extends ZIOBaseSpec {
       },
       testM("check isFull") {
         val tx = for {
-          tq1 <- TQueue.make[Int](5)
-          tq2 <- TQueue.make[Int](5)
+          tq1 <- TQueue.bounded[Int](5)
+          tq2 <- TQueue.bounded[Int](5)
           _   <- tq1.offerAll(List(1, 2, 3, 4, 5))
           qb1 <- tq1.isFull
           qb2 <- tq2.isFull

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -519,7 +519,17 @@ object ZSTMSpec extends ZIOBaseSpec {
             assertM(env.ref.get.commit)(equalTo(1))
         }
       }
-    )
+    ),
+    testM("STM collectAll ordering") {
+      val tx = for {
+        tq  <- TQueue.bounded[Int](3)
+        _   <- tq.offer(1)
+        _   <- tq.offer(2)
+        _   <- tq.offer(3)
+        ans <- ZSTM.collectAll(List(tq.take, tq.take, tq.take))
+      } yield ans
+      assertM(tx.commit)(equalTo(List(1, 2, 3)))
+    }
   )
 
   trait STMEnv {

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -55,11 +55,11 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     }
 
   /**
-    * Offers each of the elements in the specified collection to the queue up to
-    * the maximum capacity of the queue, retrying if there is not capacity in
-    * the queue for all of these elements. Returns any remaining elements in the
-    * specified collection.
-    */
+   * Offers each of the elements in the specified collection to the queue up to
+   * the maximum capacity of the queue, retrying if there is not capacity in
+   * the queue for all of these elements. Returns any remaining elements in the
+   * specified collection.
+   */
   def offerAll(as: Iterable[A]): STM[Nothing, Iterable[A]] = {
     val (forQueue, remaining) = as.splitAt(capacity)
     ref.get.flatMap { q =>

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -55,28 +55,17 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     }
 
   /**
-   * Offers each of the elements in the specified collection to the queue,
-   * retrying if there is not capacity in the queue for all of the elements in
-   * the collection.
-   */
-  def offerAll(as: Iterable[A]): STM[Nothing, Unit] =
-    if (as.size > capacity)
-      STM.dieMessage("collection size greater than queue capacity")
-    else
-      ref.get.flatMap { q =>
-        if (as.size <= capacity - q.length) ref.update(_.enqueue(as.toList)).unit
-        else STM.retry
-      }
-
-  /**
-   * Offers each of the elements in the specified collection to the queue up to
-   * the maximum capacity of the queue, retrying if there is not capacity in
-   * the queue for all of these elements. Returns any remaining elements in the
-   * specified collection.
-   */
-  def offerMax(as: Iterable[A]): STM[Nothing, Iterable[A]] = {
+    * Offers each of the elements in the specified collection to the queue up to
+    * the maximum capacity of the queue, retrying if there is not capacity in
+    * the queue for all of these elements. Returns any remaining elements in the
+    * specified collection.
+    */
+  def offerAll(as: Iterable[A]): STM[Nothing, Iterable[A]] = {
     val (forQueue, remaining) = as.splitAt(capacity)
-    offerAll(forQueue) *> STM.succeed(remaining)
+    ref.get.flatMap { q =>
+      if (forQueue.size <= capacity - q.length) ref.update(_.enqueue(forQueue.toList))
+      else STM.retry
+    } *> STM.succeed(remaining)
   }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -18,56 +18,23 @@ package zio.stm
 
 import scala.collection.immutable.{ Queue => ScalaQueue }
 
-import com.github.ghik.silencer.silent
-
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
-  def offer(a: A): STM[Nothing, Unit] =
-    for {
-      q <- ref.get
-      _ <- STM.check(q.length < capacity)
-      _ <- ref.update(_.enqueue(a))
-    } yield ()
-
-  // TODO: Scala doesn't allow Iterable???
-  @silent("enqueueAll")
-  def offerAll(as: List[A]): STM[Nothing, Unit] =
-    ref.update(_.enqueue(as)).unit
-
-  def poll: STM[Nothing, Option[A]] = takeUpTo(1).map(_.headOption)
-
-  def size: STM[Nothing, Int] = ref.get.map(_.length)
-
-  def take: STM[Nothing, A] =
-    ref.get.flatMap { q =>
-      q.dequeueOption match {
-        case Some((a, as)) =>
-          ref.set(as) *> STM.succeed(a)
-        case _ => STM.retry
-      }
-    }
-
-  def takeAll: STM[Nothing, List[A]] =
-    ref.modify(q => (q.toList, ScalaQueue.empty[A]))
-
-  def takeUpTo(max: Int): STM[Nothing, List[A]] =
-    ref.get
-      .map(_.splitAt(max))
-      .flatMap(split => ref.set(split._2) *> STM.succeed(split._1))
-      .map(_.toList)
 
   /**
-   * View the next element in the queue without removing it. retries if the queue is empty.
+   * Checks if the queue is empty.
    */
-  def peek: STM[Nothing, A] =
-    ref.get.flatMap(
-      _.headOption match {
-        case Some(a) => STM.succeed(a)
-        case None    => STM.retry
-      }
-    )
+  def isEmpty: STM[Nothing, Boolean] =
+    ref.get.map(_.isEmpty)
 
   /**
-   * View the last element inserted into the queue. retries if the queue is empty
+   * Checks if the queue is at capacity.
+   */
+  def isFull: STM[Nothing, Boolean] =
+    ref.get.map(_.size == capacity)
+
+  /**
+   * Views the last element inserted into the queue, retrying if the queue is
+   * empty.
    */
   def last: STM[Nothing, A] =
     ref.get.flatMap(
@@ -78,17 +45,56 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     )
 
   /**
-   * Checks if the Queue is empty
+   * Offers the specified value to the queue, retrying if the queue is at
+   * capacity.
    */
-  def isEmpty: STM[Nothing, Boolean] = ref.get.map(_.isEmpty)
+  def offer(a: A): STM[Nothing, Unit] =
+    ref.get.flatMap { q =>
+      if (q.length < capacity) ref.update(_.enqueue(a)).unit
+      else STM.retry
+    }
 
   /**
-   * Checks if the Queue is at capacity
+   * Offers each of the elements in the specified collection to the queue,
+   * retrying if there is not capacity in the queue for all of the elements in
+   * the collection.
    */
-  def isFull: STM[Nothing, Boolean] = ref.get.map(_.size == capacity)
+  def offerAll(as: Iterable[A]): STM[Nothing, Unit] =
+    ref.get.flatMap { q =>
+      if (as.size <= capacity - q.length) ref.update(_.enqueue(as.toList)).unit
+      else STM.retry
+    }
 
   /**
-   * Drops elements from the queue while they dont satisfy the predicate until it does and takes it.
+   * Views the next element in the queue without removing it, retrying if the
+   * queue is empty.
+   */
+  def peek: STM[Nothing, A] =
+    ref.get.flatMap(
+      _.headOption match {
+        case Some(a) => STM.succeed(a)
+        case None    => STM.retry
+      }
+    )
+
+  /**
+   * Views the next element in the queue without removing it, returning `None`
+   * if the queue is empty.
+   */
+  def peekOption: STM[Nothing, Option[A]] =
+    ref.get.map(_.headOption)
+
+  /**
+   * Takes a single element from the queue, returning `None` if the queue is
+   * empty.
+   */
+  def poll: STM[Nothing, Option[A]] =
+    takeUpTo(1).map(_.headOption)
+
+  /**
+   * Drops elements from the queue while they do not satisfy the predicate,
+   * taking and returning the first element that does satisfy the predicate.
+   * Retries if no elements satisfy the predicate.
    */
   def seek(f: A => Boolean): STM[Nothing, A] = {
     @annotation.tailrec
@@ -102,11 +108,52 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
     ref.get.flatMap(go)
   }
+
+  /**
+   * Returns the number of elements currently in the queue.
+   */
+  def size: STM[Nothing, Int] =
+    ref.get.map(_.length)
+
+  /**
+   * Takes a single element from the queue, retrying if the queue is empty.
+   */
+  def take: STM[Nothing, A] =
+    ref.get.flatMap { q =>
+      q.dequeueOption match {
+        case Some((a, as)) =>
+          ref.set(as) *> STM.succeed(a)
+        case _ => STM.retry
+      }
+    }
+
+  /**
+   * Takes all elements from the queue.
+   */
+  def takeAll: STM[Nothing, List[A]] =
+    ref.modify(q => (q.toList, ScalaQueue.empty[A]))
+
+  /**
+   * Takes up to the specified maximum number of elements from the queue.
+   */
+  def takeUpTo(max: Int): STM[Nothing, List[A]] =
+    ref.get
+      .map(_.splitAt(max))
+      .flatMap(split => ref.set(split._2) *> STM.succeed(split._1))
+      .map(_.toList)
 }
 
 object TQueue {
-  def make[A](capacity: Int): STM[Nothing, TQueue[A]] =
+
+  /**
+   * Constructs a new bounded queue with the specified capacity.
+   */
+  def bounded[A](capacity: Int): STM[Nothing, TQueue[A]] =
     TRef.make(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
 
-  def unbounded[A]: STM[Nothing, TQueue[A]] = make(Int.MaxValue)
+  /**
+   * Constructs a new unbounded queue.
+   */
+  def unbounded[A]: STM[Nothing, TQueue[A]] =
+    bounded(Int.MaxValue)
 }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -845,10 +845,7 @@ object ZSTM {
    * transactional effect that produces a list of values.
    */
   def collectAll[E, A](i: Iterable[STM[E, A]]): STM[E, List[A]] =
-    i.foldRight[STM[E, List[A]]](STM.succeed(Nil)) {
-      case (stm, acc) =>
-        acc.zipWith(stm)((xs, x) => x :: xs)
-    }
+    i.foldRight[STM[E, List[A]]](STM.succeed(Nil))(_.zipWith(_)(_ :: _))
 
   /**
    * Kills the fiber running the effect.

--- a/docs/datatypes/tqueue.md
+++ b/docs/datatypes/tqueue.md
@@ -7,16 +7,25 @@ A `TQueue[A]` is a mutable queue that can participate in transactions in STM.
 
 ## Create a TQueue
 
-Creating an empty `TQueue` with specified capacity:
+Creating an empty bounded `TQueue` with specified capacity:
 
 ```scala mdoc:silent
 import zio._
 import zio.stm._
 
-val tQueue: STM[Nothing, TQueue[Int]] = TQueue.make[Int](5)
+val tQueueBounded: STM[Nothing, TQueue[Int]] = TQueue.bounded[Int](5)
 ```
 
-## Put element(s) to a TQueue
+Creating an empty unbounded `TQueue`:
+
+```scala mdoc:silent
+import zio._
+import zio.stm._
+
+val tQueueUnbounded: STM[Nothing, TQueue[Int]] = TQueue.unbounded[Int]
+```
+
+## Put element(s) in a TQueue
 
 In order to put an element to a `TQueue`:
 
@@ -25,7 +34,7 @@ import zio._
 import zio.stm._
 
 val tQueueOffer: UIO[TQueue[Int]] = (for {
-  tQueue <- TQueue.make[Int](3)
+  tQueue <- TQueue.bounded[Int](3)
   _      <- tQueue.offer(1)
 } yield tQueue).commit
 ```
@@ -40,7 +49,7 @@ import zio._
 import zio.stm._
 
 val tQueueOfferAll: UIO[TQueue[Int]] = (for {
-  tQueue <- TQueue.make[Int](3)
+  tQueue <- TQueue.bounded[Int](3)
   _      <- tQueue.offerAll(List(1, 2))
 } yield tQueue).commit
 ```
@@ -54,7 +63,7 @@ import zio._
 import zio.stm._
 
 val tQueueTake: UIO[Int] = (for {
-  tQueue <- TQueue.make[Int](3)
+  tQueue <- TQueue.bounded[Int](3)
   _      <- tQueue.offerAll(List(1, 2))
   res    <- tQueue.take
 } yield res).commit
@@ -69,7 +78,7 @@ import zio._
 import zio.stm._
 
 val tQueuePoll: UIO[Option[Int]] = (for {
-  tQueue <- TQueue.make[Int](3)
+  tQueue <- TQueue.bounded[Int](3)
   res    <- tQueue.poll
 } yield res).commit
 ```
@@ -81,7 +90,7 @@ import zio._
 import zio.stm._
 
 val tQueueTakeUpTo: UIO[List[Int]] = (for {
-  tQueue <- TQueue.make[Int](4)
+  tQueue <- TQueue.bounded[Int](4)
   _      <- tQueue.offerAll(List(1, 2))
   res    <- tQueue.takeUpTo(3)
 } yield res).commit
@@ -94,7 +103,7 @@ import zio._
 import zio.stm._
 
 val tQueueTakeAll: UIO[List[Int]] = (for {
-  tQueue <- TQueue.make[Int](4)
+  tQueue <- TQueue.bounded[Int](4)
   _      <- tQueue.offerAll(List(1, 2))
   res    <- tQueue.takeAll
 } yield res).commit
@@ -109,7 +118,7 @@ import zio._
 import zio.stm._
 
 val tQueueSize: UIO[Int] = (for {
-  tQueue <- TQueue.make[Int](3)
+  tQueue <- TQueue.bounded[Int](3)
   _      <- tQueue.offerAll(List(1, 2))
   size   <- tQueue.size
 } yield size).commit


### PR DESCRIPTION
We previously added `peek` which looks at the first value in the queue without taking it and retries if the queue is empty. It can also be helpful to just look at the first value without retrying, so implements `peekOption` that returns `None` instead of retrying if the queue is empty.

Also alphabetizes methods, renames `make` to `bounded`, and adds Scaladoc.

I noticed that `offerAll` did not seem to respect the capacity of the queue. I changed it to retry if there is not sufficient capacity in the queue for all the elements in the collection, which seemed to be the only sensible way to do it transactionally, but let me know if you have a different thought.