### PR TITLE
Reenable Test On Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJVMNoBenchmarks",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;examplesJVM/test:compile"
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
 )
 addCommandAlias(
   "testJVMDotty",


### PR DESCRIPTION
After this all tests on Scala 2.13 should be running normally.