### PR TITLE
Promise#succeed deadlock bug

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -110,6 +110,17 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
           .map(assert(_)(equalTo(List(Left(Some("Ouch")), Left(None), Left(None)))))
       }
     ),
+    testM("Stream.bufferDropping is safe to pull again") {
+      assertM(
+        Stream(1, 2, 3, 4, 5)
+          .mapM(n => if (n % 2 == 0) IO.fail(s"Ouch $n") else UIO.succeed(n))
+          .bufferDropping(3)
+          .process
+          .use(nPulls(_, 6))
+      )(
+        equalTo(Nil)
+      )
+    },
     testM("Stream.drop is safe to pull again") {
       assertM(
         Stream(1, 2, 3, 4, 5, 6, 7)

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -61,7 +61,12 @@ object Take {
   case object End                            extends Take[Nothing, Nothing]
 
   def fromPull[R, E, A](pull: Pull[R, E, A]): ZIO[R, Nothing, Take[E, A]] =
-    pull.fold(_.fold[Take[E, A]](Take.End)(e => Take.Fail(Cause.fail(e))), Take.Value(_))
+    pull.foldCause(
+      Cause
+        .sequenceCauseOption(_)
+        .fold[Take[E, A]](Take.End)(Take.Fail(_)),
+      Take.Value(_)
+    )
 
   def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
     io.flatMap {


### PR DESCRIPTION
If anyone is interested to take a look, I really need help. I'm dealing with a strange deadlock. The promise that I send over a queue to another fiber, running `succeed` on it doesn't complete the promise, instead it hangs. The code can be checked out and run, it happens on the test that I have added. The message `s"unblocked $p"` never gets printed to the console.