### PR TITLE
Fix Compilation Issue on Hydra

### DIFF
--- a/test/js/src/main/scala/zio/test/environment/PlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/environment/PlatformSpecific.scala
@@ -20,7 +20,7 @@ import zio._
 import zio.test.Annotations
 import zio.test.Sized
 
-trait PlatformSpecific {
+private[environment] trait PlatformSpecific {
   type TestEnvironment =
     ZEnv with Annotations with TestClock with TestConsole with Live with TestRandom with Sized with TestSystem
 

--- a/test/jvm/src/main/scala/zio/test/environment/PlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/environment/PlatformSpecific.scala
@@ -21,7 +21,7 @@ import zio.test.Annotations
 import zio.test.Sized
 import zio.{ ZEnv, ZLayer }
 
-trait PlatformSpecific {
+private[environment] trait PlatformSpecific {
   type TestEnvironment =
     ZEnv with Annotations with TestClock with TestConsole with Live with TestRandom with Sized with TestSystem
 


### PR DESCRIPTION
Resolves #2664. If looks like the issue was related to the fact that the `PlatformSpecific` traits in ZIO Test weren't package private. With this change, the encoding for these traits is the same as the other platform specific traits in Core. I'm not sure if there is a broader issue we need to address where in all these cases we have a circularity where for example we have:

```scala
package object ZIO extends PlatformSpecific
```

```scala
package zio

private[zio] trait PlatformSpecific
```

But I think since the issue was only occurring with regard to ZIO Test this should at least resolve the immediate issue and then we can figure out if we want to make further changes.