### PR TITLE
ZIO Test: Fix Bug in TestClock

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -128,10 +128,13 @@ object ZIOSpec extends ZIOBaseSpec {
           cache <- incrementAndGet(ref).cached(60.minutes)
           a     <- cache
           _     <- TestClock.adjust(59.minutes)
+          _     <- clock.sleep(59.minutes)
           b     <- cache
           _     <- TestClock.adjust(1.minute)
+          _     <- clock.sleep(1.minutes)
           c     <- cache
           _     <- TestClock.adjust(59.minutes)
+          _     <- clock.sleep(1.minute)
           d     <- cache
         } yield assert(a)(equalTo(b)) && assert(b)(not(equalTo(c))) && assert(c)(equalTo(d))
       }

--- a/core/shared/src/main/scala/zio/duration/Duration.scala
+++ b/core/shared/src/main/scala/zio/duration/Duration.scala
@@ -16,7 +16,7 @@
 
 package zio.duration
 
-import java.time.{ Duration => JavaDuration }
+import java.time.{ Duration => JavaDuration, Instant }
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
@@ -160,6 +160,9 @@ object Duration {
   }
 
   def apply(amount: Long, unit: TimeUnit): Finite = fromNanos(unit.toNanos(amount))
+
+  def fromInstant(instant: Instant): Finite =
+    Duration(instant.toEpochMilli, TimeUnit.MILLISECONDS)
 
   def fromNanos(nanos: Long): Finite = Finite(nanos)
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1245,6 +1245,7 @@ object SinkSpec extends ZIOBaseSpec {
               res1  <- sink.extract(step1).map(_._1)
               init2 <- sink.initial
               _     <- TestClock.adjust(23.milliseconds)
+              _     <- clock.sleep(23.milliseconds)
               step2 <- sink.step(init2, 2)
               res2  <- sink.extract(step2).map(_._1)
               init3 <- sink.initial
@@ -1254,6 +1255,7 @@ object SinkSpec extends ZIOBaseSpec {
               step4 <- sink.step(init4, 4)
               res4  <- sink.extract(step4).map(_._1)
               _     <- TestClock.adjust(11.milliseconds)
+              _     <- clock.sleep(11.milliseconds)
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)
@@ -1270,6 +1272,7 @@ object SinkSpec extends ZIOBaseSpec {
               res1  <- sink.extract(step1).map(_._1)
               init2 <- sink.initial
               _     <- TestClock.adjust(23.milliseconds)
+              _     <- clock.sleep(23.milliseconds)
               step2 <- sink.step(init2, 2)
               res2  <- sink.extract(step2).map(_._1)
               init3 <- sink.initial
@@ -1279,6 +1282,7 @@ object SinkSpec extends ZIOBaseSpec {
               step4 <- sink.step(init4, 4)
               res4  <- sink.extract(step4).map(_._1)
               _     <- TestClock.adjust(11.milliseconds)
+              _     <- clock.sleep(11.milliseconds)
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -95,7 +95,7 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         expected <- UIO.effectTotal(OffsetDateTime.now(ZoneId.of("UTC+9")))
         _        <- setDateTime(expected)
-        _        <- sleep(Duration(expected.toInstant.toEpochMilli, TimeUnit.MILLISECONDS))
+        _        <- sleep(Duration.fromInstant(expected.toInstant))
         actual   <- clock.currentDateTime
       } yield assert(actual.toInstant.toEpochMilli)(equalTo(expected.toInstant.toEpochMilli))
     },

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -1,6 +1,6 @@
 package zio.test.environment
 
-import java.time._
+import java.time.{ OffsetDateTime, ZoneId }
 import java.util.concurrent.TimeUnit
 
 import zio._
@@ -68,6 +68,7 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         time1 <- nanoTime
         _     <- adjust(1.millis)
+        _     <- sleep(1.millis)
         time2 <- nanoTime
       } yield assert(fromNanos(time2 - time1))(equalTo(1.millis))
     },
@@ -75,6 +76,7 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         time1 <- currentTime(TimeUnit.NANOSECONDS)
         _     <- adjust(1.millis)
+        _     <- sleep(1.millis)
         time2 <- currentTime(TimeUnit.NANOSECONDS)
       } yield assert(time2 - time1)(equalTo(1.millis.toNanos))
     },
@@ -82,6 +84,7 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         time1 <- currentDateTime
         _     <- adjust(1.millis)
+        _     <- sleep(1.millis)
         time2 <- currentDateTime
       } yield assert((time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli))(equalTo(1L))
     },
@@ -92,24 +95,28 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         expected <- UIO.effectTotal(OffsetDateTime.now(ZoneId.of("UTC+9")))
         _        <- setDateTime(expected)
+        _        <- sleep(Duration(expected.toInstant.toEpochMilli, TimeUnit.MILLISECONDS))
         actual   <- clock.currentDateTime
       } yield assert(actual.toInstant.toEpochMilli)(equalTo(expected.toInstant.toEpochMilli))
     },
     testM("setTime correctly sets nanotime") {
       for {
         _    <- setTime(1.millis)
+        _    <- sleep(1.millis)
         time <- clock.nanoTime
       } yield assert(time)(equalTo(1.millis.toNanos))
     },
     testM("setTime correctly sets currentTime") {
       for {
         _    <- setTime(1.millis)
+        _    <- sleep(1.millis)
         time <- currentTime(TimeUnit.NANOSECONDS)
       } yield assert(time)(equalTo(1.millis.toNanos))
     },
     testM("setTime correctly sets currentDateTime") {
       for {
         _    <- TestClock.setTime(1.millis)
+        _    <- sleep(1.millis)
         time <- currentDateTime
       } yield assert(time.toInstant.toEpochMilli)(equalTo(1.millis.toMillis))
     },
@@ -177,6 +184,16 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- latch2.await
         result <- fiberTime
       } yield assert(result)(equalTo(0.nanos))
-    } @@ nonFlaky
+    } @@ nonFlaky,
+    testM("TestClock interacts correctly with Scheduled.fixed") {
+      for {
+        latch     <- Promise.make[Nothing, Unit]
+        ref       <- Ref.make(3)
+        countdown = ref.update(_ - 1).flatMap(n => latch.succeed(()).when(n == 0))
+        _         <- countdown.repeat(Schedule.fixed(2.seconds)).delay(1.second).fork
+        _         <- TestClock.adjust(5.seconds)
+        _         <- latch.await
+      } yield assertCompletes
+    }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -13,6 +13,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
     testM("Clock returns time when it is set") {
       for {
         _    <- TestClock.setTime(1.millis)
+        _    <- clock.sleep(1.millis)
         time <- clock.currentTime(TimeUnit.MILLISECONDS)
       } yield assert(time)(equalTo(1L))
     },

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -180,10 +180,10 @@ package object environment extends PlatformSpecific {
    * involving the passage of time.
    *
    * Instead of waiting for actual time to pass, `sleep` and methods implemented
-   * in terms of it schedule effects to take place at a given clock time. Users
-   * can adjust the clock time using the `adjust` and `setTime` methods, and all
-   * effects scheduled to take place on or before that time will automically be
-   * run.
+   * in terms of it schedule effects to take place at a given wall clock time.
+   * Users can adjust the wall clock time using the `adjust` and `setTime`
+   * methods, and all effects scheduled to take place on or before that wall
+   * clock time will automically be run.
    *
    * For example, here is how we can test [[ZIO.timeout]] using `TestClock:
    *
@@ -200,12 +200,13 @@ package object environment extends PlatformSpecific {
    * }}}
    *
    * Note how we forked the fiber that `sleep` was invoked on. Calls to `sleep`
-   * and methods derived from it will semantically block until the time is
-   * set to on or after the time they are scheduled to run. If we didn't fork the
-   * fiber on which we called sleep we would never get to set the the time on the
-   * line below. Thus, a useful pattern when using `TestClock` is to fork the
-   * effect being tested, then adjust the clock to the desired time, and finally
-   * verify that the expected effects have been performed.
+   * and methods derived from it will semantically block until the wall clock
+   * time is set to on or after the time they are scheduled to run. If we
+   * didn't fork the fiber on which we called sleep we would never get to set
+   * the the wall clock time on the line below. Thus, a useful pattern when
+   * using `TestClock` is to fork the effect being tested, then adjust the wall
+   * clock time, and finally verify that the expected effects have been
+   * performed.
    *
    * Sleep and related combinators schedule events to occur at a specified
    * duration in the future relative to the current fiber time (e.g. 10 seconds
@@ -239,9 +240,9 @@ package object environment extends PlatformSpecific {
    * that an effect is performed after the recurrence period, and that the effect
    * is performed exactly once. The key thing to note here is that after each
    * recurrence the next recurrence is scheduled to occur at the appropriate time
-   * in the future, so when we adjust the clock by 60 minutes exactly one value
-   * is placed in the queue, and when we adjust the clock by another 60 minutes
-   * exactly one more value is placed in the queue.
+   * in the future, so when we adjust the wall clock time by 60 minutes exactly
+   * one value is placed in the queue, and when we adjust the wall clock time
+   * by another 60 minutes exactly one more value is placed in the queue.
    */
   object TestClock extends Serializable {
 
@@ -264,34 +265,32 @@ package object environment extends PlatformSpecific {
         with TestClock.Service {
 
       /**
-       * Increments the current clock time by the specified duration. Any effects
-       * that were scheduled to occur on or before the new time will immediately
-       * be run.
+       * Increments the wall clock time by the specified duration. Any effects
+       * that were scheduled to occur on or before the new wall clock time will
+       * immediately be run.
        */
       def adjust(duration: Duration): UIO[Unit] =
         warningDone *> clockState.modify { data =>
-          val nanoTime          = data.nanoTime + duration.toNanos
-          val currentTimeMillis = data.currentTimeMillis + duration.toMillis
-          val (wakes, sleeps)   = data.sleeps.partition(_._1 <= Duration.fromNanos(nanoTime))
+          val nanoTime        = data.nanoTime + duration.toNanos
+          val (wakes, sleeps) = data.sleeps.partition(_._1 <= Duration.fromNanos(nanoTime))
           val updated = data.copy(
             nanoTime = nanoTime,
-            currentTimeMillis = currentTimeMillis,
             sleeps = sleeps
           )
           (wakes, updated)
         }.flatMap(run)
 
       /**
-       * Returns the current clock time as an `OffsetDateTime`.
+       * Returns the current fiber time as an `OffsetDateTime`.
        */
       def currentDateTime: UIO[OffsetDateTime] =
-        clockState.get.map(data => toDateTime(data.currentTimeMillis, data.timeZone))
+        fiberState.get.map(data => toDateTime(data.currentTimeMillis, data.timeZone))
 
       /**
-       * Returns the current clock time in the specified time unit.
+       * Returns the current fiber time in the specified time unit.
        */
       def currentTime(unit: TimeUnit): UIO[Long] =
-        clockState.get.map(data => unit.convert(data.currentTimeMillis, TimeUnit.MILLISECONDS))
+        fiberState.get.map(data => unit.convert(data.currentTimeMillis, TimeUnit.MILLISECONDS))
 
       /**
        * Returns the current fiber time for this fiber. The fiber time is backed
@@ -313,14 +312,14 @@ package object environment extends PlatformSpecific {
         fiberState.get.map(_.nanoTime.nanos)
 
       /**
-       * Returns the current clock time in nanoseconds.
+       * Returns the current fiber time in nanoseconds.
        */
       val nanoTime: UIO[Long] =
-        clockState.get.map(_.nanoTime)
+        fiberState.get.map(_.nanoTime)
 
       /**
-       * Saves the `TestClock`'s current state in an effect which, when run, will restore the `TestClock`
-       * state to the saved state
+       * Saves the `TestClock`'s current state in an effect which, when run,
+       * will restore the `TestClock` state to the saved state
        */
       val save: UIO[UIO[Unit]] =
         for {
@@ -346,7 +345,7 @@ package object environment extends PlatformSpecific {
         }
 
       /**
-       * Sets the current clock time to the specified `OffsetDateTime`. Any
+       * Sets the wall clock time to the specified `OffsetDateTime`. Any
        * effects that were scheduled to occur on or before the new time will
        * immediately be run.
        */
@@ -354,7 +353,7 @@ package object environment extends PlatformSpecific {
         setTime(fromDateTime(dateTime))
 
       /**
-       * Sets the current clock time to the specified time in terms of duration
+       * Sets the wall clock time to the specified time in terms of duration
        * since the epoch. Any effects that were scheduled to occur on or before
        * the new time will immediately be run.
        */
@@ -363,30 +362,32 @@ package object environment extends PlatformSpecific {
           val (wakes, sleeps) = data.sleeps.partition(_._1 <= duration)
           val updated = data.copy(
             nanoTime = duration.toNanos,
-            currentTimeMillis = duration.toMillis,
             sleeps = sleeps
           )
           (wakes, updated)
         }.flatMap(run)
 
       /**
-       * Sets the time zone to the specified time zone. The clock time in terms
-       * of nanoseconds since the epoch will not be adjusted and no scheduled
-       * effects will be run as a result of this method.
+       * Sets the time zone to the specified time zone. The wall clock time in
+       * terms of nanoseconds since the epoch will not be adjusted and no
+       * scheduled effects will be run as a result of this method.
        */
       def setTimeZone(zone: ZoneId): UIO[Unit] =
-        clockState.update(_.copy(timeZone = zone)).unit
+        fiberState.update(_.copy(timeZone = zone)).unit
 
       /**
-       * Semantically blocks the current fiber until the clock time is equal to
-       * or greater than the specified duration. Once the clock time is adjusted
-       * to on or after the duration, the fiber will automatically be resumed.
+       * Semantically blocks the current fiber until the wall clock time is
+       * equal to or greater than the specified duration. Once the wall clock
+       * time is adjusted to on or after the duration, the fiber will
+       * automatically be resumed.
        */
       def sleep(duration: Duration): UIO[Unit] =
         for {
           latch <- Promise.make[Nothing, Unit]
           start <- fiberState.modify { data =>
-                    (data.nanoTime, data.copy(nanoTime = data.nanoTime + duration.toNanos))
+                    val nanoTime          = data.nanoTime + duration.toNanos
+                    val currentTimeMillis = data.currentTimeMillis + duration.toMillis
+                    (data.nanoTime, FiberData(nanoTime, currentTimeMillis, data.timeZone))
                   }
           await <- clockState.modify { data =>
                     val end = Duration.fromNanos(start) + duration
@@ -399,8 +400,8 @@ package object environment extends PlatformSpecific {
         } yield ()
 
       /**
-       * Returns a list of the times at which all queued effects are scheduled to
-       * resume.
+       * Returns a list of the wall clock times at which all queued effects are
+       * scheduled to resume.
        */
       val sleeps: UIO[List[Duration]] = clockState.get.map(_.sleeps.map(_._1))
 
@@ -408,7 +409,7 @@ package object environment extends PlatformSpecific {
        * Returns the time zone.
        */
       val timeZone: UIO[ZoneId] =
-        clockState.get.map(_.timeZone)
+        fiberState.get.map(_.timeZone)
 
       private def run(wakes: List[(Duration, Promise[Nothing, Unit])]): UIO[Unit] =
         UIO.forkAll_(wakes.sortBy(_._1).map(_._2.succeed(()))).fork.unit
@@ -432,9 +433,9 @@ package object environment extends PlatformSpecific {
     }
 
     /**
-     * Accesses a `TestClock` instance in the environment and increments the time
-     * by the specified duration, running any actions scheduled for on or before
-     * the new time.
+     * Accesses a `TestClock` instance in the environment and increments the
+     * wall clock time by the specified duration, running any actions scheduled
+     * for on or before the new time.
      */
     def adjust(duration: Duration): ZIO[TestClock, Nothing, Unit] =
       ZIO.accessM(_.get.adjust(duration))
@@ -454,7 +455,7 @@ package object environment extends PlatformSpecific {
       ZLayer.fromServiceManaged { (live: Live.Service) =>
         for {
           ref       <- Ref.make(data).toManaged_
-          fiberRef  <- FiberRef.make(FiberData(data.nanoTime), FiberData.combine).toManaged_
+          fiberRef  <- FiberRef.make(FiberData(0, 0, ZoneId.of("UTC")), FiberData.combine).toManaged_
           refM      <- RefM.make(WarningData.start).toManaged_
           test      <- Managed.make(UIO(Test(ref, fiberRef, live, refM)))(_.warningDone)
           scheduler <- test.scheduler.toManaged_
@@ -462,42 +463,43 @@ package object environment extends PlatformSpecific {
       }
 
     val default: ZLayer[Live, Nothing, Clock with TestClock with Scheduler] =
-      live(Data(0, 0, Nil, ZoneId.of("UTC")))
+      live(Data(0, Nil))
 
     /**
-     * Accesses a `TestClock` instance in the environment and saves the clock state in an effect which, when run,
-     * will restore the `TestClock` to the saved state
+     * Accesses a `TestClock` instance in the environment and saves the clock
+     * state in an effect which, when run, will restore the `TestClock` to the
+     * saved state
      */
     val save: ZIO[TestClock, Nothing, UIO[Unit]] = ZIO.accessM[TestClock](_.get.save)
 
     /**
-     * Accesses a `TestClock` instance in the environment and sets the clock time
-     * to the specified `OffsetDateTime`, running any actions scheduled for on or
-     * before the new time.
+     * Accesses a `TestClock` instance in the environment and sets the wall
+     * clock time to the specified `OffsetDateTime`, running any actions
+     * scheduled for on or before the new time.
      */
     def setDateTime(dateTime: OffsetDateTime): ZIO[TestClock, Nothing, Unit] =
       ZIO.accessM(_.get.setDateTime(dateTime))
 
     /**
-     * Accesses a `TestClock` instance in the environment and sets the clock time
-     * to the specified time in terms of duration since the epoch, running any
-     * actions scheduled for on or before the new time.
+     * Accesses a `TestClock` instance in the environment and sets the wall
+     * clock time to the specified time in terms of duration since the epoch,
+     * running any actions scheduled for on or before the new time.
      */
     def setTime(duration: Duration): ZIO[TestClock, Nothing, Unit] =
       ZIO.accessM(_.get.setTime(duration))
 
     /**
      * Accesses a `TestClock` instance in the environment, setting the time zone
-     * to the specified time zone. The clock time in terms of nanoseconds since
-     * the epoch will not be altered and no scheduled actions will be run as a
-     * result of this effect.
+     * to the specified time zone. The wall clock time in terms of nanoseconds
+     * since the epoch will not be altered and no scheduled actions will be run
+     * as a result of this effect.
      */
     def setTimeZone(zone: ZoneId): ZIO[TestClock, Nothing, Unit] =
       ZIO.accessM(_.get.setTimeZone(zone))
 
     /**
      * Accesses a `TestClock` instance in the environment and returns a list of
-     * times that effects are scheduled to run.
+     * wall clock times that effects are scheduled to run.
      */
     val sleeps: ZIO[TestClock, Nothing, List[Duration]] =
       ZIO.accessM(_.get.sleeps)
@@ -512,18 +514,17 @@ package object environment extends PlatformSpecific {
     /**
      * The state of the `TestClock`.
      */
-    final case class Data(
-      nanoTime: Long,
-      currentTimeMillis: Long,
-      sleeps: List[(Duration, Promise[Nothing, Unit])],
-      timeZone: ZoneId
-    )
+    final case class Data(nanoTime: Long, sleeps: List[(Duration, Promise[Nothing, Unit])])
 
-    final case class FiberData(nanoTime: Long)
+    final case class FiberData(nanoTime: Long, currentTimeMillis: Long, timeZone: ZoneId)
 
     object FiberData {
       def combine(first: FiberData, last: FiberData): FiberData =
-        FiberData(first.nanoTime max last.nanoTime)
+        FiberData(
+          first.nanoTime max last.nanoTime,
+          first.currentTimeMillis max last.currentTimeMillis,
+          last.timeZone
+        )
     }
 
     sealed trait WarningData


### PR DESCRIPTION
Following up on discussion on Discord, `TestClock` does not currently handle the following case correctly:

```scala
testM("TestClock interacts correctly with Scheduled.fixed") {
  for {
    latch     <- Promise.make[Nothing, Unit]
    ref       <- Ref.make(3)
    countdown = ref.update(_ - 1).flatMap(n => latch.succeed(()).when(n == 0))
    _         <- countdown.repeat(Schedule.fixed(2.seconds)).delay(1.second).fork
    _         <- TestClock.adjust(5.seconds)
    _         <- latch.await
  } yield assertCompletes
}
```

This test will timeout instead of passing. The issue is that `Schedule.fixed` calls `nanoTime` internally and uses that as an input to determine how long to sleep for. Since `nanoTime` is already set to 5 seconds by the `TestClock.adjust` call, that leads to corruption internal state in the schedule.

To fix this, we need to slightly change the contract of the `TestClock`. Methods such as `nanoTime` return the fiber time instead of the wall clock time, assuring that calls to `nanoTime` and other methods return a correct time that reflects how much time has actually passed on that fiber. Methods like `setTime` and `adjust` then are solely responsible for modifying the "wall clock time", which determines when pending sleep effects run.