### PR TITLE
Rename ZIO#ensuringExit to ZIO#onExit

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -297,45 +297,6 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(test)(equalTo(10))
       }
     ),
-    suite("ensuringExit")(
-      testM("executes finalizer on success") {
-        for {
-          ref <- Ref.make(false)
-          _ <- ZIO.unit.ensuringExit {
-                case Exit.Success(_) => ref.set(true)
-                case _               => UIO.unit
-              }
-          p <- ref.get
-        } yield assert(p)(isTrue)
-      },
-      testM("executes finalizer on failure") {
-        for {
-          ref <- Ref.make(false)
-          _ <- ZIO
-                .die(new RuntimeException)
-                .ensuringExit {
-                  case Exit.Failure(c) if c.died => ref.set(true)
-                  case _                         => UIO.unit
-                }
-                .sandbox
-                .ignore
-          p <- ref.get
-        } yield assert(p)(isTrue)
-      },
-      testM("executes finalizer on interruption") {
-        for {
-          latch1 <- Promise.make[Nothing, Unit]
-          latch2 <- Promise.make[Nothing, Unit]
-          fiber <- (latch1.succeed(()) *> ZIO.never).ensuringExit {
-                    case Exit.Failure(c) if c.interrupted => latch2.succeed(())
-                    case _                                => UIO.unit
-                  }.fork
-          _ <- latch1.await
-          _ <- fiber.interrupt
-          _ <- latch2.await
-        } yield assertCompletes
-      }
-    ),
     suite("fallback")(
       testM("executes an effect and returns its value if it succeeds") {
         import zio.CanFail.canFail
@@ -887,6 +848,45 @@ object ZIOSpec extends ZIOBaseSpec {
         val ex                                = new RuntimeException("Failed Task")
         val task: IO[Option[Throwable], Unit] = Task.fail(ex).none
         assertM(task.run)(fails(isSome(equalTo(ex))))
+      }
+    ),
+    suite("onExit")(
+      testM("executes that a cleanup function runs when effect succeeds") {
+        for {
+          ref <- Ref.make(false)
+          _ <- ZIO.unit.onExit {
+                case Exit.Success(_) => ref.set(true)
+                case _               => UIO.unit
+              }
+          p <- ref.get
+        } yield assert(p)(isTrue)
+      },
+      testM("ensures that a cleanup function runs when an effect fails") {
+        for {
+          ref <- Ref.make(false)
+          _ <- ZIO
+                .die(new RuntimeException)
+                .onExit {
+                  case Exit.Failure(c) if c.died => ref.set(true)
+                  case _                         => UIO.unit
+                }
+                .sandbox
+                .ignore
+          p <- ref.get
+        } yield assert(p)(isTrue)
+      },
+      testM("ensures that a cleanup function runs when an effect is interrupted") {
+        for {
+          latch1 <- Promise.make[Nothing, Unit]
+          latch2 <- Promise.make[Nothing, Unit]
+          fiber <- (latch1.succeed(()) *> ZIO.never).onExit {
+                    case Exit.Failure(c) if c.interrupted => latch2.succeed(())
+                    case _                                => UIO.unit
+                  }.fork
+          _ <- latch1.await
+          _ <- fiber.interrupt
+          _ <- latch2.await
+        } yield assertCompletes
       }
     ),
     suite("option")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -792,8 +792,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     )(_ => self)
 
   /**
-   * Ensures that a clean functions runs, whether this effect succeeds, fails,
-   * or is interrupted.
+   * Ensures that a cleanup functions runs, whether this effect succeeds,
+   * fails, or is interrupted.
    */
   final def onExit[R1 <: R](cleanup: Exit[E, A] => URIO[R1, Any]): ZIO[R1, E, A] =
     ZIO.bracketExit(ZIO.unit)((_, exit: Exit[E, A]) => cleanup(exit))(_ => self)


### PR DESCRIPTION
Minor follow up to confirm name to name of existing combinator with same functionality on `ZManaged`.