### PR TITLE
Adds ZManaged missing provide methods

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -908,7 +908,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Provides a layer to the ZIO effect, which translates it to another level.
    */
   final def provideLayer[E1 >: E, R0, R1 <: Has[_]](layer: ZLayer[R0, E1, R1])(implicit ev: R1 <:< R): ZIO[R0, E1, A] =
-    layer.translate.value.use(self.provide(_))
+    provideSomeManaged(layer.value.map(ev))
 
   /**
    * An effectual version of `provide`, useful when the act of provision
@@ -2270,7 +2270,7 @@ object ZIO {
    *
    * For a sequential version of this method, see `foreach`.
    */
-  final def foreachPar[R, E, A, B](as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] = {
+  def foreachPar[R, E, A, B](as: Iterable[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, List[B]] = {
     val size      = as.size
     val resultArr = new AtomicReferenceArray[B](size)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -908,10 +908,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Provides a layer to the ZIO effect, which translates it to another level.
    */
   final def provideLayer[E1 >: E, R0, R1 <: Has[_]](layer: ZLayer[R0, E1, R1])(implicit ev: R1 <:< R): ZIO[R0, E1, A] =
-    (for {
-      r0 <- ZManaged.environment[R0]
-      r1 <- layer.value.provide(r0)
-    } yield ev(r1)).use(self.provide(_))
+    layer.translate.value.use(self.provide(_))
 
   /**
    * An effectual version of `provide`, useful when the act of provision

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -77,10 +77,20 @@ final case class ZLayer[-RIn, +E, +ROut <: Has[_]](value: ZManaged[RIn, E, ROut]
     build.map(Runtime(_, p))
 
   /**
+   * I am not sure if this makes sense...
+   */
+  def translate[ROut1 <: Has[_]](implicit ev: ROut <:< ROut1): ZLayer[RIn, E, ROut1] =
+    ZLayer(for {
+      rin  <- ZManaged.environment[RIn]
+      rout <- value.provide(rin)
+    } yield ev(rout))
+
+  /**
    * Updates one of the services output by this layer.
    */
   def update[A: Tagged](f: A => A)(implicit ev: ROut <:< Has[A]): ZLayer[RIn, E, ROut] =
     ZLayer(value.map(env => env.update[A](f)))
+
 }
 object ZLayer {
   type NoDeps[+E, +B <: Has[_]] = ZLayer[Any, E, B]

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -77,20 +77,10 @@ final case class ZLayer[-RIn, +E, +ROut <: Has[_]](value: ZManaged[RIn, E, ROut]
     build.map(Runtime(_, p))
 
   /**
-   * I am not sure if this makes sense...
-   */
-  def translate[ROut1 <: Has[_]](implicit ev: ROut <:< ROut1): ZLayer[RIn, E, ROut1] =
-    ZLayer(for {
-      rin  <- ZManaged.environment[RIn]
-      rout <- value.provide(rin)
-    } yield ev(rout))
-
-  /**
    * Updates one of the services output by this layer.
    */
   def update[A: Tagged](f: A => A)(implicit ev: ROut <:< Has[A]): ZLayer[RIn, E, ROut] =
     ZLayer(value.map(env => env.update[A](f)))
-
 }
 object ZLayer {
   type NoDeps[+E, +B <: Has[_]] = ZLayer[Any, E, B]

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -635,7 +635,6 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): ZManaged[R0, E, A] =
     ZManaged(reserve.provideSome(f).map(r => Reservation(r.acquire.provideSome(f), e => r.release(e).provideSome(f))))
 
-
   /**
    * An effectful version of `provideSome`, useful when the act of partial
    * provision requires an effect.
@@ -648,8 +647,12 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * effect.provideSomeM(r0)
    * }}}
    */
-  def provideSomeM[R0, E1 >: E](f: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZManaged[R0, E1, A] =
-    ZManaged(reserve.provideSomeM(f).map(r => Reservation(r.acquire.provideSomeM(f), e => r.release(e).provideSomeM(f))))
+  def provideSomeM[R0, E1 >: E](
+    f: ZIO[R0, E1, R]
+  )(implicit ev1: NeedsEnv[R], ev2: E1 <:< Throwable): ZManaged[R0, E1, A] =
+    ZManaged(
+      reserve.provideSomeM(f).map(r => Reservation(r.acquire.provideSomeM(f), e => r.release(e).provideSomeM(f.orDie)))
+    )
 
   /**
    * Gives access to wrapped [[Reservation]].


### PR DESCRIPTION
Using ManagedApp and kinda feel it would be a nice addition. Updated the documentation to be similar to ZIO methods. 

Adds `provideLayer`, `provideManaged`, `provideManagedSome` and `provideSomeM` to `ZManaged`