### PR TITLE
ZIO Mock: Make sure zipRight and input ignoring flatMap are equivalent

### DIFF
--- a/examples/shared/src/test/scala/zio/examples/test/MockingExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockingExampleSpec.scala
@@ -10,7 +10,6 @@ import zio.test.{ assertM, suite, testM, DefaultRunnableSpec }
 import zio.{ clock, console, random }
 
 object MockingExampleSpec extends DefaultRunnableSpec {
-  
 
   def spec = suite("suite with mocks")(
     testM("expect call returning output") {
@@ -30,7 +29,7 @@ object MockingExampleSpec extends DefaultRunnableSpec {
       assertM(result)(isUnit)
     },
     testM("expect call with input satisfying assertion and transforming it into output") {
-      import MockRandom._ 
+      import MockRandom._
 
       val app     = random.nextInt(1)
       val mockEnv = nextInt._0(equalTo(1)) returns valueF(_ + 41)
@@ -38,7 +37,7 @@ object MockingExampleSpec extends DefaultRunnableSpec {
       assertM(result)(equalTo(42))
     },
     testM("expect call with input satisfying assertion and returning output") {
-      import MockRandom._ 
+      import MockRandom._
 
       val app     = random.nextInt(1)
       val mockEnv = nextInt._0(equalTo(1)) returns value(42)
@@ -46,7 +45,7 @@ object MockingExampleSpec extends DefaultRunnableSpec {
       assertM(result)(equalTo(42))
     },
     testM("expect call for overloaded method") {
-      import MockRandom._ 
+      import MockRandom._
 
       val app     = random.nextInt
       val mockEnv = nextInt._1 returns value(42)
@@ -55,8 +54,8 @@ object MockingExampleSpec extends DefaultRunnableSpec {
     },
     testM("expect calls from multiple modules") {
       import MockConsole._
-       import MockRandom._
-      
+      import MockRandom._
+
       val app        = random.nextInt.map(_.toString) >>= console.putStrLn
       val randomEnv  = nextInt._1 returns value(42)
       val consoleEnv = putStrLn(equalTo("42")) returns unit
@@ -81,7 +80,7 @@ object MockingExampleSpec extends DefaultRunnableSpec {
       assertM(result)(isUnit)
     },
     testM("failure if unmet expectations") {
-      import MockRandom._ 
+      import MockRandom._
 
       val app = random.nextInt
       val mockEnv =

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -318,6 +318,22 @@ object ExpectationSpec extends ZIOBaseSpec {
         Module.>.singleParam(1) *> Module.>.manyParams(2, "3", 4L),
         equalTo(UnexpectedCallExpection(Module.manyParams, (2, "3", 4L)))
       )
-    )
+    ), {
+      val e1 = Module.command(equalTo(1)) returns unit
+      val e2 = Module.singleParam(equalTo(2)) returns value("foo")
+      val e3 = Module.command(equalTo(3)) returns unit
+      val app: zio.ZIO[zio.Has[Module], Any, String] =
+        for {
+          _ <- Module.>.command(1)
+          v <- Module.>.singleParam(2)
+          _ <- Module.>.command(3)
+        } yield v
+
+      suite("expectation building")(
+        testSpec("flatMap")(e1.flatMap(_ => e2).flatMap(_ => e3), app, equalTo("foo")),
+        testSpec("zipRight")(e1.zipRight(e2).zipRight(e3), app, equalTo("foo")),
+        testSpec("*>")(e1 *> e2 *> e3, app, equalTo("foo"))
+      )
+    }
   )
 }

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -81,7 +81,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
       UIO.succeed(expectation).flatMap {
         case Empty =>
           popNextExpectation.flatMap {
-            case Some(next) => extract(state, next(()))
+            case Some(next) => extract(state, next(null))
             case None       => UIO.succeed(Right(()))
           }
 
@@ -95,7 +95,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
           for {
             _ <- state.callsRef.update(_ :+ call.asInstanceOf[AnyCall])
             out <- popNextExpectation.flatMap {
-                    case Some(next) => extract(state, next(()))
+                    case Some(next) => extract(state, next(null))
                     case None       => UIO.succeed(Right(()))
                   }
           } yield out


### PR DESCRIPTION
Fixes #2671 