### PR TITLE
Implement ZIO#tapCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2537,6 +2537,16 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       }
     ),
+    suite("tapCause")(
+      testM("does not lose infomrmation") {
+        val causes = Gen.causes(Gen.anyString, Gen.throwable)
+        checkM(causes, causes) { (c1, c2) =>
+          for {
+            exit <- ZIO.halt(c1).tapCause(_ => ZIO.halt(c2)).run
+          } yield assert(exit)(failsCause(equalTo(Cause.Then(c1, c2))))
+        }
+      }
+    ),
     suite("timeoutFork")(
       testM("returns `Right` with the produced value if the effect completes before the timeout elapses") {
         assertM(ZIO.unit.timeoutFork(100.millis))(isRight(isUnit))

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -827,6 +827,16 @@ object ZManagedSpec extends ZIOBaseSpec {
         ).use(ZIO.succeed)
       }
     ),
+    suite("tapCause")(
+      testM("does not lose infomrmation") {
+        val causes = Gen.causes(Gen.anyString, Gen.throwable)
+        checkM(causes, causes) { (c1, c2) =>
+          for {
+            exit <- ZManaged.halt(c1).tapCause(_ => ZManaged.halt(c2)).use(ZIO.succeed).run
+          } yield assert(exit)(failsCause(equalTo(Cause.Then(c1, c2))))
+        }
+      }
+    ),
     suite("tapError")(
       testM("Doesn't change the managed resource") {
         ZManaged

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1427,6 +1427,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self.foldCauseM(new ZIO.TapErrorRefailFn(f), new ZIO.TapFn(g))
 
   /**
+   * Returns an effect that effectually "peeks" at the cause of the failure of
+   * this effect.
+   * {{{
+   * readFile("data.json").tapCause(logCause(_))
+   * }}}
+   */
+  final def tapCause[R1 <: R, E1 >: E](f: Cause[E] => ZIO[R1, E1, Any]): ZIO[R1, E1, A] =
+    self.foldCauseM(new ZIO.TapCauseRefailFn(f), ZIO.succeed)
+
+  /**
    * Returns an effect that effectfully "peeks" at the failure of this effect.
    * {{{
    * readFile("data.json").tapError(logError(_))
@@ -3277,10 +3287,25 @@ object ZIO {
       c.failureOrCause.fold(underlying, ZIO.halt)
   }
 
+  final class TapCauseRefailFn[R, E, E1 >: E, A](override val underlying: Cause[E] => ZIO[R, E1, Any])
+      extends ZIOFn1[Cause[E], ZIO[R, E1, Nothing]] {
+    def apply(c1: Cause[E]): ZIO[R, E1, Nothing] =
+      underlying(c1).foldCauseM(
+        c2 => ZIO.halt(Cause.Then(c1, c2)),
+        _ => ZIO.halt(c1)
+      )
+  }
+
   final class TapErrorRefailFn[R, E, E1 >: E, A](override val underlying: E => ZIO[R, E1, Any])
       extends ZIOFn1[Cause[E], ZIO[R, E1, Nothing]] {
-    def apply(c: Cause[E]): ZIO[R, E1, Nothing] =
-      c.failureOrCause.fold(underlying(_) *> ZIO.halt(c), _ => ZIO.halt(c))
+    def apply(c1: Cause[E]): ZIO[R, E1, Nothing] =
+      c1.failureOrCause.fold(
+        underlying(_).foldCauseM(
+          c2 => ZIO.halt(Cause.Then(c1, c2)),
+          _ => ZIO.halt(c1)
+        ),
+        _ => ZIO.halt(c1)
+      )
   }
 
   private[zio] object Tags {


### PR DESCRIPTION
Like `tapError` but gives access to the full cause.

I noticed in working on this that there is a risk of information loss in the existing implementation of the `tapError` combinator. For example, if we have `ZIO.fail("foo).tapError(_ => ZIO.fail("bar"))` we will get back `ZIO.fail("bar")` with the original failure being silently dropped. This is particularly problematic with `tapError` because there is a risk of dropping an unchecked exception and returning a checked exception instead.

This PR addresses this by using `Cause.Then` to retain information about both errors if both the original effect and the tap effect fail.