### PR TITLE
ZIO Mock: Less powerful expectation

### DIFF
--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -190,7 +190,7 @@ Next we create the live version of the service with the implementation of the ca
 ``` scala mdoc
 import zio.console.Console
 
-val accountObserverLive: ZLayer[Console, Nothing, Has[AccountObserver.Service]] = 
+val accountObserverLive: ZLayer[Console, Nothing, Has[AccountObserver.Service]] =
   ZLayer.fromService[Console.Service, Nothing, Has[AccountObserver.Service]] { console =>
     Has(new AccountObserver.Service {
       def processEvent(event: AccountEvent): UIO[Unit] =

--- a/examples/shared/src/test/scala/zio/examples/test/MockingExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockingExampleSpec.scala
@@ -89,6 +89,16 @@ object MockingExampleSpec extends DefaultRunnableSpec {
 
       val result = app.provideLayer(mockEnv)
       assertM(result)(equalTo(42))
+    },
+    testM("failure if unexpected calls") {
+      import MockRandom._
+
+      val app = random.nextInt *> random.nextLong
+      val mockEnv =
+        (nextInt._1 returns value(42))
+
+      val result = app.provideLayer(mockEnv)
+      assertM(result)(equalTo(42L))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -282,6 +282,14 @@ object ExpectationSpec extends ZIOBaseSpec {
         ),
         Module.>.singleParam(1) *> Module.>.static,
         equalTo("bar")
+      ),
+      testSpec("zipRight")(
+        (
+          (Module.singleParam(equalTo(1)) returns value("foo")) zipRight
+            (Module.static returns value("bar"))
+        ),
+        Module.>.singleParam(1) *> Module.>.static,
+        equalTo("bar")
       )
     ),
     suite("expectations failure")(
@@ -318,22 +326,6 @@ object ExpectationSpec extends ZIOBaseSpec {
         Module.>.singleParam(1) *> Module.>.manyParams(2, "3", 4L),
         equalTo(UnexpectedCallExpection(Module.manyParams, (2, "3", 4L)))
       )
-    ), {
-      val e1 = Module.command(equalTo(1)) returns unit
-      val e2 = Module.singleParam(equalTo(2)) returns value("foo")
-      val e3 = Module.command(equalTo(3)) returns unit
-      val app: zio.ZIO[zio.Has[Module], Any, String] =
-        for {
-          _ <- Module.>.command(1)
-          v <- Module.>.singleParam(2)
-          _ <- Module.>.command(3)
-        } yield v
-
-      suite("expectation building")(
-        testSpec("flatMap")(e1.flatMap(_ => e2).flatMap(_ => e3), app, equalTo("foo")),
-        testSpec("zipRight")(e1.zipRight(e2).zipRight(e3), app, equalTo("foo")),
-        testSpec("*>")(e1 *> e2 *> e3, app, equalTo("foo"))
-      )
-    }
+    )
   )
 }

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -18,10 +18,8 @@ package zio.test.mock
 
 import scala.language.implicitConversions
 
-import com.github.ghik.silencer.silent
-
 import zio.test.Assertion
-import zio.test.mock.Expectation.{ AnyCall, Call, Empty, FlatMap, Next, State }
+import zio.test.mock.Expectation.{ AnyCall, Call, Compose, Empty, Next, State }
 import zio.test.mock.MockException.UnmetExpectationsException
 import zio.test.mock.ReturnExpectation.{ Fail, Succeed }
 import zio.{ Has, IO, Managed, Ref, UIO, ZIO, ZLayer }
@@ -47,21 +45,14 @@ import zio.{ IO, Managed, Ref, UIO, ZIO }
 sealed trait Expectation[-M, +E, +A] { self =>
 
   /**
-   * A variant of `flatMap` that ignores the value returned by this expectation.
-   */
-  final def *>[M1 <: M, E1 >: E, B](that: Expectation[M1, E1, B]): Expectation[M1, E1, B] = flatMap(_ => that)
-
-  /**
-   * Returns an expectation that models the execution of this expectation,
-   * followed by passing of its value to the specified continuation function `k`,
-   * followed by the expectation that it returns.
+   * Compose two expectations, producing a new expectation to satisfying both sequentially.
    *
    * {{
-   * val mockClock = (MockClock.sleep(equalTo(1.second)) returns unit).flatMap(_ => MockClock.nanoTime returns value(5L))
+   * val mockClock = (MockClock.sleep(equalTo(1.second)) returns unit) *> (MockClock.nanoTime returns value(5L))
    * }}
    */
-  final def flatMap[M1 <: M, E1 >: E, B](k: A => Expectation[M1, E1, B]): Expectation[M1, E1, B] =
-    FlatMap(self, k)
+  final def *>[M1 <: M, E1 >: E, B](that: Expectation[M1, E1, B]): Expectation[M1, E1, B] =
+    Compose(self, that)
 
   /**
    * Converts this Expectation to ZManaged mock environment.
@@ -81,11 +72,11 @@ sealed trait Expectation[-M, +E, +A] { self =>
       UIO.succeed(expectation).flatMap {
         case Empty =>
           popNextExpectation.flatMap {
-            case Some(next) => extract(state, next(null))
+            case Some(next) => extract(state, next)
             case None       => UIO.succeed(Right(()))
           }
 
-        case FlatMap(current, next) =>
+        case Compose(current, next) =>
           for {
             _   <- state.nextRef.update(next.asInstanceOf[Next[M, E]] :: _)
             out <- extract(state, current)
@@ -95,7 +86,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
           for {
             _ <- state.callsRef.update(_ :+ call.asInstanceOf[AnyCall])
             out <- popNextExpectation.flatMap {
-                    case Some(next) => extract(state, next(null))
+                    case Some(next) => extract(state, next)
                     case None       => UIO.succeed(Right(()))
                   }
           } yield out
@@ -128,15 +119,6 @@ sealed trait Expectation[-M, +E, +A] { self =>
       env   <- Managed.fromEffect(makeEnvironment(state))
     } yield env)
   }
-
-  /**
-   * Returns empty expectation.
-   *
-   * This is required for the for-comprehension syntax.
-   */
-  @silent("parameter value f in method map is never used")
-  final def map[B](f: A => B): Expectation[M, E, Nothing] =
-    flatMap(_ => Empty)
 
   /**
    * A named alias for `*>`
@@ -192,14 +174,14 @@ object Expectation {
   def valueM[I, A](f: I => IO[Nothing, A]): Succeed[I, A] = Succeed(f)
 
   /**
-   * Implicitly converts Expectation to ZManaged mock environment.
+   * Implicitly converts Expectation to ZLayer mock environment.
    */
   implicit def toLayer[M: Mockable, E, A](
     expectation: Expectation[M, E, A]
   ): ZLayer.NoDeps[Nothing, Has[M]] = expectation.toLayer
 
   private[Expectation] type AnyCall      = Call[Any, Any, Any, Any]
-  private[Expectation] type Next[-M, +E] = Any => Expectation[M, E, Any]
+  private[Expectation] type Next[-M, +E] = Expectation[M, E, Any]
 
   private[Expectation] final case class State[M, E](
     callsRef: Ref[List[AnyCall]],
@@ -208,8 +190,6 @@ object Expectation {
 
   /**
    * Models expectation for no calls on module `M`.
-   *
-   * The the `unit` value for Expectation monad.
    */
   private[mock] case object Empty extends Expectation[Any, Nothing, Nothing]
 
@@ -225,12 +205,9 @@ object Expectation {
 
   /**
    * Models sequential expectations on module `M`.
-   *
-   * The `A` value in `next` is not used, it's only required to fit the flatMap signature,
-   * which we want to be able to use the for-comprehension syntax.
    */
-  private[mock] final case class FlatMap[-M, +E, A, +B](
+  private[mock] final case class Compose[-M, +E, A, +B](
     current: Expectation[M, E, A],
-    next: A => Expectation[M, E, B]
+    next: Expectation[M, E, B]
   ) extends Expectation[M, E, B]
 }


### PR DESCRIPTION
Following up on discussion in #2671 we're dropping `flatMap` and `map` here, as it was only needed for `for-comprehension` syntax. Instead, for larger expectations the following syntax is encouraged:

```scala
import MockConsole._

val mock =
    (putStrLn(equalTo("foo")) returns unit) *>
    (putStrLn(equalTo("bar")) returns unit) *>
    (putStrLn(equalTo("baz")) returns unit) *>
    (getStrLn returns value("acme")) *>
    (putStrLn(equalTo("foo2")) returns unit) *>
    (putStrLn(equalTo("bar2")) returns unit) *>
    (putStrLn(equalTo("baz2")) returns unit) *>
    (getStrLn returns value("acme2"))
```

@jdegoes @adamgfraser 