### PR TITLE
ZStream#bufferDropping safe reimplementation

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
@@ -82,7 +82,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
                       }
         } yield assert(snapshots._1)(equalTo(0)) && assert(snapshots._2)(equalTo(List(8, 7, 6, 5, 4, 3, 2, 1))) &&
           assert(snapshots._3)(equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 8, 7, 6, 5, 4, 3, 2, 1)))
-      } @@ flaky
+      }
     ),
     suite("Stream.bufferSliding")(
       testM("buffer the Stream with Error") {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -6,7 +6,6 @@ import ZStream.Pull
 import zio._
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import zio.test._
-import zio.test.TestAspect.nonFlaky
 
 object StreamPullSafetySpec extends ZIOBaseSpec {
 
@@ -152,7 +151,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
           )
         )
       )
-    } @@ nonFlaky,
+    },
     testM("Stream.bufferUnbounded is safe to pull again") {
       assertM(
         Stream(1, 2, 3, 4, 5)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -6,6 +6,7 @@ import ZStream.Pull
 import zio._
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import zio.test._
+import zio.test.TestAspect.nonFlaky
 
 object StreamPullSafetySpec extends ZIOBaseSpec {
 
@@ -131,6 +132,27 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
         )
       )
     },
+    testM("Stream.bufferDropping is safe to pull again") {
+      assertM(
+        Stream(1, 2, 3, 4, 5)
+          .mapM(n => if (n % 2 == 0) IO.fail(s"Ouch $n") else UIO.succeed(n))
+          .bufferDropping(2)
+          .process
+          .use(nPulls(_, 7))
+      )(
+        equalTo(
+          List(
+            Right(1),
+            Left(Some("Ouch 2")),
+            Right(3),
+            Left(Some("Ouch 4")),
+            Right(5),
+            Left(None),
+            Left(None)
+          )
+        )
+      )
+    } @@ nonFlaky,
     testM("Stream.bufferUnbounded is safe to pull again") {
       assertM(
         Stream(1, 2, 3, 4, 5)


### PR DESCRIPTION
Reimplement ZStream#bufferDropping without racing effects and add tests for pull safety.