### PR TITLE
Fix Bugs in ZIO#partitionM and ZIO#validateFirstM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -980,66 +980,75 @@ object ZIOSpec extends ZIOBaseSpec {
         )
       } @@ nonFlaky
     ),
-    suite("partitionM")(
+    suite("partition")(
       testM("collects only successes") {
         import zio.CanFail.canFail
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionM(in)(a => ZIO.succeed(a))
+          res <- ZIO.partition(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects only failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionM(in)(a => ZIO.fail(a))
+          res <- ZIO.partition(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionM(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
+          res <- ZIO.partition(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
+      },
+      testM("evaluates effects in correct order") {
+        import zio.CanFail.canFail
+        val as = List(2, 4, 6, 3, 5, 6)
+        for {
+          ref     <- Ref.make(List.empty[Int])
+          _       <- ZIO.partition(as)(a => ref.update(a :: _))
+          effects <- ref.get.map(_.reverse)
+        } yield assert(effects)(equalTo(List(2, 4, 6, 3, 5, 6)))
       }
     ),
-    suite("partitionMPar")(
+    suite("partitionPar")(
       testM("collects a lot of successes") {
         import zio.CanFail.canFail
         val in = List.range(0, 1000)
         for {
-          res <- ZIO.partitionMPar(in)(a => ZIO.succeed(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionMPar(in)(a => ZIO.fail(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionMPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
+          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
-    suite("partitionMParN")(
+    suite("partitionParN")(
       testM("collects a lot of successes") {
         import zio.CanFail.canFail
         val in = List.range(0, 1000)
         for {
-          res <- ZIO.partitionMParN(3)(in)(a => ZIO.succeed(a))
+          res <- ZIO.partitionParN(3)(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionMParN(3)(in)(a => ZIO.fail(a))
+          res <- ZIO.partitionParN(3)(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionMParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
+          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
@@ -2573,48 +2582,48 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       }
     ),
-    suite("validateM")(
+    suite("validate")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
-        val res = IO.validateM(in)(a => ZIO.fail(a)).flip
+        val res = IO.validate(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = ZIO.validateM(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
+        val res = ZIO.validate(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = IO.validateM(in)(a => ZIO.succeed(a))
+        val res = IO.validate(in)(a => ZIO.succeed(a))
         assertM(res)(equalTo(in))
       }
     ),
-    suite("validateMPar")(
+    suite("validatePar")(
       testM("returns all errors if never valid") {
         val in  = List.fill(1000)(0)
-        val res = IO.validateMPar(in)(a => ZIO.fail(a)).flip
+        val res = IO.validatePar(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = ZIO.validateMPar(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
+        val res = ZIO.validatePar(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = IO.validateMPar(in)(a => ZIO.succeed(a))
+        val res = IO.validatePar(in)(a => ZIO.succeed(a))
         assertM(res)(equalTo(in))
       }
     ),
-    suite("validateFirstM")(
+    suite("validateFirst")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
-        val res = IO.validateFirstM(in)(a => ZIO.fail(a)).flip
+        val res = IO.validateFirst(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("runs sequentially and short circuits on first success validation") {
@@ -2624,22 +2633,28 @@ object ZIOSpec extends ZIOBaseSpec {
 
         for {
           counter    <- Ref.make(0)
-          res        <- ZIO.validateFirstM(in)(a => counter.update(_ + 1) *> f(a))
+          res        <- ZIO.validateFirst(in)(a => counter.update(_ + 1) *> f(a))
           assertions <- assertM(ZIO.succeed(res))(equalTo(6)) && assertM(counter.get)(equalTo(6))
         } yield assertions
+      },
+      testM("returns errors in correct order") {
+        val as = List(2, 4, 6, 3, 5, 6)
+        for {
+          results <- ZIO.validateFirst(as)(ZIO.fail).flip
+        } yield assert(results)(equalTo(List(2, 4, 6, 3, 5, 6)))
       }
     ),
-    suite("validateFirstMPar")(
+    suite("validateFirstPar")(
       testM("returns all errors if never valid") {
         val in  = List.fill(1000)(0)
-        val res = IO.validateFirstMPar(in)(a => ZIO.fail(a)).flip
+        val res = IO.validateFirstPar(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("returns success if valid") {
         import zio.CanFail.canFail
         val in  = List.range(1, 10)
         val f   = (a: Int) => if (a == 6) ZIO.succeed(a) else ZIO.fail(a)
-        val res = ZIO.validateFirstMPar(in)(f(_))
+        val res = ZIO.validateFirstPar(in)(f(_))
         assertM(res)(equalTo(6))
       }
     ),

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -520,28 +520,28 @@ object IO {
   val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
-   * @see See [[zio.ZIO.partitionM]]
+   * @see See [[zio.ZIO.partition]]
    */
-  def partitionM[E, A, B](
+  def partition[E, A, B](
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
-    ZIO.partitionM(in)(f)
+    ZIO.partition(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMPar]]
+   * @see See [[zio.ZIO.partitionPar]]
    */
-  def partitionMPar[E, A, B](
+  def partitionPar[E, A, B](
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
-    ZIO.partitionMPar(in)(f)
+    ZIO.partitionPar(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMParN]]
+   * @see See [[zio.ZIO.partitionParN]]
    */
-  def partitionMParN[E, A, B](n: Int)(
+  def partitionParN[E, A, B](n: Int)(
     in: Iterable[A]
   )(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[Nothing, (List[E], List[B])] =
-    ZIO.partitionMParN(n)(in)(f)
+    ZIO.partitionParN(n)(in)(f)
 
   /**
    * @see See [[zio.ZIO.raceAll]]
@@ -694,28 +694,28 @@ object IO {
   def untraced[E, A](zio: IO[E, A]): IO[E, A] = ZIO.untraced(zio)
 
   /**
-   * @see See [[zio.ZIO.validateM]]
+   * @see See [[zio.ZIO.validate]]
    */
-  def validateM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
-    ZIO.validateM(in)(f)
+  def validate[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
+    ZIO.validate(in)(f)
 
   /**
-   * @see See [[zio.ZIO.validateMPar]]
+   * @see See [[zio.ZIO.validatePar]]
    */
-  def validateMPar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
-    ZIO.validateMPar(in)(f)
+  def validatePar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[::[E], List[B]] =
+    ZIO.validatePar(in)(f)
 
   /**
-   * @see See [[zio.ZIO.validateFirstM]]
+   * @see See [[zio.ZIO.validateFirst]]
    */
-  def validateFirstM[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
-    ZIO.validateFirstM(in)(f)
+  def validateFirst[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
+    ZIO.validateFirst(in)(f)
 
   /**
-   * @see See [[zio.ZIO.validateFirstMPar]]
+   * @see See [[zio.ZIO.validateFirstPar]]
    */
-  def validateFirstMPar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
-    ZIO.validateFirstMPar(in)(f)
+  def validateFirstPar[E, A, B](in: Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): IO[List[E], B] =
+    ZIO.validateFirstPar(in)(f)
 
   /**
    * @see See [[zio.ZIO.when]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -505,24 +505,24 @@ object RIO {
   val none: UIO[Option[Nothing]] = ZIO.none
 
   /**
-   * @see See [[zio.ZIO.partitionM]]
+   * @see See [[zio.ZIO.partition]]
    */
-  def partitionM[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
-    ZIO.partitionM(in)(f)
+  def partition[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+    ZIO.partition(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMPar]]
+   * @see See [[zio.ZIO.partitionPar]]
    */
-  def partitionMPar[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
-    ZIO.partitionMPar(in)(f)
+  def partitionPar[R, A, B](in: Iterable[A])(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
+    ZIO.partitionPar(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMParN]]
+   * @see See [[zio.ZIO.partitionParN]]
    */
-  def partitionMParN[R, A, B](n: Int)(
+  def partitionParN[R, A, B](n: Int)(
     in: Iterable[A]
   )(f: A => RIO[R, B]): RIO[Nothing, (List[Throwable], List[B])] =
-    ZIO.partitionMParN(n)(in)(f)
+    ZIO.partitionParN(n)(in)(f)
 
   /**
    * @see See [[zio.ZIO.provide]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -515,22 +515,22 @@ object Task {
   val none: Task[Option[Nothing]] = ZIO.none
 
   /**
-   * @see See [[zio.ZIO.partitionM]]
+   * @see See [[zio.ZIO.partition]]
    */
-  def partitionM[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
-    ZIO.partitionM(in)(f)
+  def partition[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+    ZIO.partition(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMPar]]
+   * @see See [[zio.ZIO.partitionPar]]
    */
-  def partitionMPar[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
-    ZIO.partitionMPar(in)(f)
+  def partitionPar[A, B](in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+    ZIO.partitionPar(in)(f)
 
   /**
-   * @see See [[zio.ZIO.partitionMParN]]
+   * @see See [[zio.ZIO.partitionParN]]
    */
-  def partitionMParN[A, B](n: Int)(in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
-    ZIO.partitionMParN(n)(in)(f)
+  def partitionParN[A, B](n: Int)(in: Iterable[A])(f: A => Task[B]): Task[(List[Throwable], List[B])] =
+    ZIO.partitionParN(n)(in)(f)
 
   /**
    * @see See [[zio.ZIO.raceAll]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2685,8 +2685,7 @@ object ZIO {
   val none: UIO[Option[Nothing]] = succeed(None)
 
   /**
-   * Feeds elements of type `A` to a function f that returns an effect.
-   *
+   * Feeds elements of type `A` to a function `f` that returns an effect.
    * Collects all successes and failures in a tupled fashion.
    */
   def partition[R, E, A, B](
@@ -2696,8 +2695,8 @@ object ZIO {
 
   /**
    * Feeds elements of type `A` to a function `f` that returns an effect.
-   * Collects all successes and failures in parallel and returns the result as a tuple.
-   *
+   * Collects all successes and failures in parallel and returns the result as
+   * a tuple.
    */
   def partitionPar[R, E, A, B](
     in: Iterable[A]
@@ -2706,9 +2705,10 @@ object ZIO {
 
   /**
    * Feeds elements of type `A` to a function `f` that returns an effect.
-   * Collects all successes and failures in parallel and returns the result as a tuple.
+   * Collects all successes and failures in parallel and returns the result as
+   * a tuple.
    *
-   * Unlike `partitionMPar`, this method will use at most up to `n` fibers.
+   * Unlike [[partitionPar]], this method will use at most up to `n` fibers.
    */
   def partitionParN[R, E, A, B](n: Int)(
     in: Iterable[A]
@@ -2938,10 +2938,11 @@ object ZIO {
     zio.untraced
 
   /**
-   * Feeds elements of type A to f and accumulates all errors in error channel or successes in success channel.
+   * Feeds elements of type `A` to `f` and accumulates all errors in error
+   * channel or successes in success channel.
    *
-   * This combinator is lossy meaning that if there are errors all successes will be lost.
-   * To retain all information please use ZIO#partitionM
+   * This combinator is lossy meaning that if there are errors all successes
+   * will be lost. To retain all information please use [[partition]].
    */
   def validate[R, E, A, B](
     in: Iterable[A]
@@ -2952,11 +2953,11 @@ object ZIO {
     }
 
   /**
-   * Feeds elements of type A to f and accumulates, in parallel,
-   * all errors in error channel or successes in success channel.
+   * Feeds elements of type `A` to `f `and accumulates, in parallel, all errors
+   * in error channel or successes in success channel.
    *
-   * This combinator is lossy meaning that if there are errors all successes will be lost.
-   * To retain all information please use ZIO#partitionMPar
+   * This combinator is lossy meaning that if there are errors all successes
+   * will be lost. To retain all information please use [[partitionPar]].
    */
   def validatePar[R, E, A, B](
     in: Iterable[A]
@@ -2967,7 +2968,8 @@ object ZIO {
     }
 
   /**
-   * Feeds elements of type A to f until it succeeds. Returns first success or the accumulation of all errors.
+   * Feeds elements of type `A` to `f` until it succeeds. Returns first success
+   * or the accumulation of all errors.
    */
   def validateFirst[R, E, A, B](
     in: Iterable[A]
@@ -2975,7 +2977,8 @@ object ZIO {
     ZIO.foreach(in)(f(_).flip).flip
 
   /**
-   * Feeds elements of type A to f, in parallel, until it succeeds. Returns first success or the accumulation of all errors.
+   * Feeds elements of type `A` to `f`, in parallel, until it succeeds. Returns
+   * first success or the accumulation of all errors.
    *
    * In case of success all other running fibers are terminated.
    */


### PR DESCRIPTION
`partitionM` evaluated effects in the wrong order. `validateFirstM` accumulated errors in the wrong order. Fixes both and adds regression tests. Also renames combinators to remove `M` suffix` for consistency with other combinators.