### PR TITLE
ztest: single entrypoint

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -50,9 +50,21 @@ final class ZTestRunner(val args: Array[String], val remoteArgs: Array[String], 
         .mkString("", "", "Done")
   }
 
-  def tasks(defs: Array[TaskDef]): Array[Task] =
-    defs.map(new ZTestTask(_, testClassLoader, sendSummary, TestArgs.parse(args)))
+  def tasks(defs: Array[TaskDef]): Array[Task] = {
+    val tasks = defs.map(new ZTestTask(_, testClassLoader, sendSummary, TestArgs.parse(args)))
+    Array(new ZTestRootTask(tasks))
+  }
 }
 
 final class ZTestTask(taskDef: TaskDef, testClassLoader: ClassLoader, sendSummary: SendSummary, testArgs: TestArgs)
     extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs)
+
+class ZTestRootTask(val zioTasks: Array[ZTestTask]) extends Task {
+  override def tags(): Array[String] = Array.empty
+
+  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+    zioTasks.toArray
+  }
+
+  override def taskDef(): TaskDef = new TaskDef("zio core", new Fingerprint {}, true, Array())
+}

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -51,8 +51,15 @@ final class ZTestRunner(val args: Array[String], val remoteArgs: Array[String], 
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] = {
-    val tasks = defs.map(new ZTestTask(_, testClassLoader, sendSummary, TestArgs.parse(args)))
-    Array(new ZTestRootTask(tasks))
+    val testArgs        = TestArgs.parse(args)
+    val tasks           = defs.map(new ZTestTask(_, testClassLoader, sendSummary, testArgs))
+    val entrypointClass = testArgs.rootTask.getOrElse(classOf[ZTestRootTask].getName)
+    val rootTask = getClass.getClassLoader
+      .loadClass(entrypointClass)
+      .getConstructor(classOf[Array[ZTestTask]])
+      .newInstance(tasks)
+      .asInstanceOf[Task]
+    Array(rootTask)
   }
 }
 

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -62,9 +62,8 @@ final class ZTestTask(taskDef: TaskDef, testClassLoader: ClassLoader, sendSummar
 class ZTestRootTask(val zioTasks: Array[ZTestTask]) extends Task {
   override def tags(): Array[String] = Array.empty
 
-  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] =
     zioTasks.toArray
-  }
 
   override def taskDef(): TaskDef = new TaskDef("zio core", new Fingerprint {}, true, Array())
 }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -122,7 +122,7 @@ object ZTestFrameworkSpec {
     val runner  = new ZTestFramework().runner(Array(), Array(), getClass.getClassLoader)
     val task = runner
       .tasks(Array(taskDef))
-      .flatMap(task => task.asInstanceOf[ZTestRootTask].zioTasks)
+      .map(task => task.asInstanceOf[ZTestTask])
       .map { zTestTask =>
         new ZTestTask(
           zTestTask.taskDef,
@@ -143,7 +143,7 @@ object ZTestFrameworkSpec {
     val runner  = new ZTestFramework().runner(Array(), Array(), getClass.getClassLoader)
     val task = runner
       .tasks(Array(taskDef))
-      .flatMap(task => task.asInstanceOf[ZTestRootTask].zioTasks)
+      .map(task => task.asInstanceOf[ZTestTask])
       .map { zTestTask =>
         new ZTestTask(
           zTestTask.taskDef,

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -122,8 +122,8 @@ object ZTestFrameworkSpec {
     val runner  = new ZTestFramework().runner(Array(), Array(), getClass.getClassLoader)
     val task = runner
       .tasks(Array(taskDef))
-      .map { task =>
-        val zTestTask = task.asInstanceOf[BaseTestTask]
+      .flatMap(task => task.asInstanceOf[ZTestRootTask].zioTasks)
+      .map { zTestTask =>
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
@@ -143,8 +143,8 @@ object ZTestFrameworkSpec {
     val runner  = new ZTestFramework().runner(Array(), Array(), getClass.getClassLoader)
     val task = runner
       .tasks(Array(taskDef))
-      .map { task =>
-        val zTestTask = task.asInstanceOf[BaseTestTask]
+      .flatMap(task => task.asInstanceOf[ZTestRootTask].zioTasks)
+      .map { zTestTask =>
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
@@ -171,7 +171,14 @@ object ZTestFrameworkSpec {
       .tasks(Array(taskDef))
       .head
 
-    task.execute(eventHandler, loggers.toArray)
+    @scala.annotation.tailrec
+    def doRun(tasks: Iterable[Task]): Unit = {
+      val more = tasks.flatMap(_.execute(eventHandler, loggers.toArray))
+      if (more.nonEmpty) {
+        doRun(more)
+      }
+    }
+    doRun(Iterable(task))
   }
 
   lazy val failingSpecFQN = SimpleFailingSpec.getClass.getName

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -1,17 +1,18 @@
 package zio.test
 
-final case class TestArgs(testSearchTerms: List[String], tagSearchTerms: List[String])
+final case class TestArgs(testSearchTerms: List[String], tagSearchTerms: List[String], testTaskPolicy: Option[String])
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String])
+  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String], None)
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term)    => ("testSearchTerm", term)
-        case Array("-tags", term) => ("tagSearchTerm", term)
+        case Array("-t", term)      => ("testSearchTerm", term)
+        case Array("-tags", term)   => ("tagSearchTerm", term)
+        case Array("-policy", name) => ("policy", name)
       }
       .toList
       .groupBy(_._1)
@@ -20,6 +21,9 @@ object TestArgs {
           (k, v.map(_._2))
       }
 
-    TestArgs(parsedArgs.getOrElse("testSearchTerm", Nil), parsedArgs.getOrElse("tagSearchTerm", Nil))
+    val terms          = parsedArgs.getOrElse("testSearchTerm", Nil)
+    val tags           = parsedArgs.getOrElse("tagSearchTerm", Nil)
+    val testTaskPolicy = parsedArgs.getOrElse("policy", Nil).headOption
+    TestArgs(terms, tags, testTaskPolicy)
   }
 }


### PR DESCRIPTION
Trying to address the issues explained in https://github.com/zio/zio/issues/1208#issuecomment-513761904

So, essentially in our case each test is a function PLUS its signature, introspectable in runtime (a sequence of typetags to be precise).
For our workflow we need to collect all the individual tests from all the classes, then decide which components can be reused between the tests (for example, there is no need to re-instantiate a database driver for every test) and  build a "test plan" - a project network for shared components plus individual project networks for every individual test. Then we execute them and report progress along the way.

There are several problems in current zio-test design preventing us from implementing our flow:

1) Every BaseTestTask is independent. It loads an individual class and executes it in an isolated environment. For our workflow we need just ONE Task which loads all the tests and delegates the work to our engine
2) Though ZTestRunner is hardwired with ZTestTask and there is no way to supply custom loading and execution strategies

These are the blockers. There is one more thing which is not critical but kinda annoying:
3) Label is an abstract type and there is no typeclass nor base class for it. So you use .toString instead of a typeclass: searchTerms.exists(term => label.toString.contains(term)). We need to use labels to carry additional test metadata, the best thing we can do is something like 

```
case class IzumiLabel[L](roots: Set[LightTypeTag], label: L) {
def toString = label.toString
}
```

Which I consider to be a very ugly solution

A summary: in order to meet our goal we need
1) An ability to collect *all* the tests from *all* the testclasses at one point (BaseTestTask probably)
2) An ability to set custom execution logic for BaseTestTask (an SBT key would be perfect,  Java SPI may be fine too). Also it would be great to have an ability to use custom test discovery logic in BaseTestTask - this way we may be able to create custom DSLs with ease
3) A typeclass for Labels (not critical but very good to have)