### PR TITLE
Implement Convenience Methods for Creating a Runtime with an Environment

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,6 +19,7 @@ package zio.internal
 import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 
 import scala.concurrent.ExecutionContext
+import scala.scalajs.js
 
 import com.github.ghik.silencer.silent
 
@@ -27,6 +28,14 @@ import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 
 private[internal] trait PlatformSpecific {
+
+  /**
+   * Adds a shutdown hook that executes the specified action on shutdown.
+   */
+  def addShutdownHook(action: () => Unit): Unit =
+    js.Dynamic.global.onunload = { (_: Any) =>
+      action()
+    }
 
   /**
    * A Runtime with settings suitable for benchmarks, specifically with Tracing

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -29,6 +29,16 @@ import zio.internal.tracing.TracingConfig
 private[internal] trait PlatformSpecific {
 
   /**
+   * Adds a shutdown hook that executes the specified action on shutdown.
+   */
+  def addShutdownHook(action: () => Unit): Unit =
+    java.lang.Runtime.getRuntime.addShutdownHook {
+      new Thread {
+        override def run() = action()
+      }
+    }
+
+  /**
    * A Runtime with settings suitable for benchmarks, specifically with Tracing
    * and auto-yielding disabled.
    *

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -28,6 +28,12 @@ import zio.internal.tracing.TracingConfig
 private[internal] trait PlatformSpecific {
 
   /**
+   * Adds a shutdown hook that executes the specified action on shutdown.
+   */
+  def addShutdownHook(action: () => Unit): Unit =
+    ()
+
+  /**
    * A Runtime with settings suitable for benchmarks, specifically with Tracing
    * and auto-yielding disabled.
    *


### PR DESCRIPTION
Implements `Runtime.unsafeMake` which builds a runtime from a `ZLayer` and uses it to implement `unsafeDefault` and `unsafeGlobal`, which build runtimes from a `ZLayer` using the default executor and Scala's global execution context, respectively.

I ended up not being happy with the `shutdownHook` solution. It is not consistent on the JVM (e.g. shutdown hooks are not invoked when using SBT until exiting the session) and doesn't provide a way to run finalizers across platforms in a consistent manner. Instead, I had these methods return a tuple of a runtime and an effect that can be run to return the finalizer. This way users can create a runtime at the top of their application, use it throughout, and then specify their own logic about running finalizers (or discard it entirely if there are no finalizers).