### PR TITLE
Change Signature of Ref#update to Return UIO[Unit]

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -24,21 +24,30 @@ object FiberRefSpec extends ZIOBaseSpec {
           value    <- child.join
         } yield assert(value)(equalTo(initial))
       },
-      testM("`set` updates the current value") {
+      testM("`getAndUpdate` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          _        <- fiberRef.set(update)
-          value    <- fiberRef.get
-        } yield assert(value)(equalTo(update))
+          value1   <- fiberRef.getAndUpdate(_ => update)
+          value2   <- fiberRef.get
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(update))
       },
-      testM("`set` by a child doesn't update parent's value") {
+      testM("`getAndUpdateSome` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          promise  <- Promise.make[Nothing, Unit]
-          _        <- (fiberRef.set(update) *> promise.succeed(())).fork
-          _        <- promise.await
-          value    <- fiberRef.get
-        } yield assert(value)(equalTo(initial))
+          value1 <- fiberRef.getAndUpdateSome {
+                     case _ => update
+                   }
+          value2 <- fiberRef.get
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(update))
+      },
+      testM("`getAndUpdateSome` not changes value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          value1 <- fiberRef.getAndUpdateSome {
+                     case _ if false => update
+                   }
+          value2 <- fiberRef.get
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(initial))
       },
       testM("`locally` restores original value") {
         for {
@@ -64,55 +73,6 @@ object FiberRefSpec extends ZIOBaseSpec {
           value      <- fiberRef.get
         } yield assert(localValue)(equalTo(update)) && assert(value)(equalTo(initial))
       },
-      testM("its value is inherited on join") {
-        for {
-          fiberRef <- FiberRef.make(initial)
-          child    <- fiberRef.set(update).fork
-          _        <- child.join
-          value    <- fiberRef.get
-        } yield assert(value)(equalTo(update))
-      },
-      testM("initial value is always available") {
-        for {
-          child    <- FiberRef.make(initial).fork
-          fiberRef <- child.await.flatMap(ZIO.doneNow)
-          value    <- fiberRef.get
-        } yield assert(value)(equalTo(initial))
-      },
-      testM("`update` changes value") {
-        for {
-          fiberRef <- FiberRef.make(initial)
-          value1   <- fiberRef.updateAndGet(_ => update)
-          value2   <- fiberRef.get
-        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
-      },
-      testM("`updateSome` changes value") {
-        for {
-          fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateAndGetSome {
-                     case _ => update
-                   }
-          value2 <- fiberRef.get
-        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
-      },
-      testM("`updateSome` changes value") {
-        for {
-          fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateAndGetSome {
-                     case _ => update
-                   }
-          value2 <- fiberRef.get
-        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
-      },
-      testM("`updateSome` not changes value") {
-        for {
-          fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateAndGetSome {
-                     case _ if false => update
-                   }
-          value2 <- fiberRef.get
-        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(initial))
-      },
       testM("`modify` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
@@ -128,6 +88,62 @@ object FiberRefSpec extends ZIOBaseSpec {
                    }
           value2 <- fiberRef.get
         } yield assert(value1)(equalTo(2)) && assert(value2)(equalTo(initial))
+      },
+      testM("`set` updates the current value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          _        <- fiberRef.set(update)
+          value    <- fiberRef.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("`set` by a child doesn't update parent's value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          promise  <- Promise.make[Nothing, Unit]
+          _        <- (fiberRef.set(update) *> promise.succeed(())).fork
+          _        <- promise.await
+          value    <- fiberRef.get
+        } yield assert(value)(equalTo(initial))
+      },
+      testM("`updateAndGet` changes value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          value1   <- fiberRef.updateAndGet(_ => update)
+          value2   <- fiberRef.get
+        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
+      },
+      testM("`updateAndGetSome` changes value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          value1 <- fiberRef.updateAndGetSome {
+                     case _ => update
+                   }
+          value2 <- fiberRef.get
+        } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
+      },
+      testM("`updateAndGetSome` not changes value") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          value1 <- fiberRef.updateAndGetSome {
+                     case _ if false => update
+                   }
+          value2 <- fiberRef.get
+        } yield assert(value1)(equalTo(initial)) && assert(value2)(equalTo(initial))
+      },
+      testM("its value is inherited on join") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          child    <- fiberRef.set(update).fork
+          _        <- child.join
+          value    <- fiberRef.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("initial value is always available") {
+        for {
+          child    <- FiberRef.make(initial).fork
+          fiberRef <- child.await.flatMap(ZIO.doneNow)
+          value    <- fiberRef.get
+        } yield assert(value)(equalTo(initial))
       },
       testM("its value is inherited after simple race") {
         for {

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -112,19 +112,19 @@ object FiberRefSpec extends ZIOBaseSpec {
           value2   <- fiberRef.get
         } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
-      testM("`updateAndGetSome` changes value") {
+      testM("`updateSomeAndGet` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateAndGetSome {
+          value1 <- fiberRef.updateSomeAndGet {
                      case _ => update
                    }
           value2 <- fiberRef.get
         } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
-      testM("`updateAndGetSome` not changes value") {
+      testM("`updateSomeAndGet` not changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateAndGetSome {
+          value1 <- fiberRef.updateSomeAndGet {
                      case _ if false => update
                    }
           value2 <- fiberRef.get

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -82,14 +82,14 @@ object FiberRefSpec extends ZIOBaseSpec {
       testM("`update` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1   <- fiberRef.update(_ => update)
+          value1   <- fiberRef.updateAndGet(_ => update)
           value2   <- fiberRef.get
         } yield assert(value1)(equalTo(update)) && assert(value2)(equalTo(update))
       },
       testM("`updateSome` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateSome {
+          value1 <- fiberRef.updateAndGetSome {
                      case _ => update
                    }
           value2 <- fiberRef.get
@@ -98,7 +98,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       testM("`updateSome` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateSome {
+          value1 <- fiberRef.updateAndGetSome {
                      case _ => update
                    }
           value2 <- fiberRef.get
@@ -107,7 +107,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       testM("`updateSome` not changes value") {
         for {
           fiberRef <- FiberRef.make(initial)
-          value1 <- fiberRef.updateSome {
+          value1 <- fiberRef.updateAndGetSome {
                      case _ if false => update
                    }
           value2 <- fiberRef.get

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -17,7 +17,7 @@ object PromiseSpec extends ZIOBaseSpec {
       for {
         p  <- Promise.make[Nothing, Int]
         r  <- Ref.make(13)
-        s  <- p.complete(r.update(_ + 1))
+        s  <- p.complete(r.updateAndGet(_ + 1))
         v1 <- p.await
         v2 <- p.await
       } yield assert(s)(isTrue) &&
@@ -28,7 +28,7 @@ object PromiseSpec extends ZIOBaseSpec {
       for {
         p  <- Promise.make[Nothing, Int]
         r  <- Ref.make(13)
-        s  <- p.completeWith(r.update(_ + 1))
+        s  <- p.completeWith(r.updateAndGet(_ + 1))
         v1 <- p.await
         v2 <- p.await
       } yield assert(s)(isTrue) &&

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -22,7 +22,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("update") {
       for {
         refM  <- RefM.make(current)
-        value <- refM.update(_ => IO.effectTotal(update))
+        value <- refM.updateAndGet(_ => IO.effectTotal(update))
       } yield assert(value)(equalTo(update))
     },
     testM("update with failure") {
@@ -34,14 +34,14 @@ object RefMSpec extends ZIOBaseSpec {
     testM("updateSome") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateSome { case Closed => IO.succeedNow(Active) }
+        value <- refM.updateAndGetSome { case Closed => IO.succeedNow(Active) }
       } yield assert(value)(equalTo(Active))
     },
     testM("updateSome twice") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.updateSome { case Active => IO.succeedNow(Changed) }
-        value2 <- refM.updateSome {
+        value1 <- refM.updateAndGetSome { case Active => IO.succeedNow(Changed) }
+        value2 <- refM.updateAndGetSome {
                    case Active  => IO.succeedNow(Changed)
                    case Changed => IO.succeedNow(Closed)
                  }
@@ -115,7 +115,7 @@ object RefMSpec extends ZIOBaseSpec {
         fiber       <- makeAndWait.fork
         refM        <- promise.await
         _           <- fiber.interrupt
-        value       <- refM.update(_ => ZIO.succeedNow(Closed))
+        value       <- refM.updateAndGet(_ => ZIO.succeedNow(Closed))
       } yield assert(value)(equalTo(Closed))
     }
   )

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -133,26 +133,26 @@ object RefMSpec extends ZIOBaseSpec {
         value <- refM.updateAndGet(_ => IO.failNow(failure)).run
       } yield assert(value)(fails(equalTo(failure)))
     },
-    testM("updateAndGetSome") {
+    testM("updateSomeAndGet") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateAndGetSome { case Closed => IO.succeedNow(Active) }
+        value <- refM.updateSomeAndGet { case Closed => IO.succeedNow(Active) }
       } yield assert(value)(equalTo(Active))
     },
-    testM("updateAndGetSome twice") {
+    testM("updateSomeAndGet twice") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.updateAndGetSome { case Active => IO.succeedNow(Changed) }
-        value2 <- refM.updateAndGetSome {
+        value1 <- refM.updateSomeAndGet { case Active => IO.succeedNow(Changed) }
+        value2 <- refM.updateSomeAndGet {
                    case Active  => IO.succeedNow(Changed)
                    case Changed => IO.succeedNow(Closed)
                  }
       } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
     },
-    testM("updateAndGetSome with failure") {
+    testM("updateSomeAndGet with failure") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateAndGetSome { case Active => IO.failNow(failure) }.run
+        value <- refM.updateSomeAndGet { case Active => IO.failNow(failure) }.run
       } yield assert(value)(fails(equalTo(failure)))
     }
   )

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -12,46 +12,53 @@ object RefMSpec extends ZIOBaseSpec {
         value <- refM.get
       } yield assert(value)(equalTo(current))
     },
-    testM("set") {
+    testM("getAndUpdate") {
       for {
-        refM  <- RefM.make(current)
-        _     <- refM.set(update)
-        value <- refM.get
-      } yield assert(value)(equalTo(update))
+        refM   <- RefM.make(current)
+        value1 <- refM.getAndUpdate(_ => IO.effectTotal(update))
+        value2 <- refM.get
+      } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
     },
-    testM("update") {
-      for {
-        refM  <- RefM.make(current)
-        value <- refM.updateAndGet(_ => IO.effectTotal(update))
-      } yield assert(value)(equalTo(update))
-    },
-    testM("update with failure") {
+    testM("getAndUpdate with failure") {
       for {
         refM  <- RefM.make[String](current)
-        value <- refM.update(_ => IO.failNow(failure)).run
+        value <- refM.getAndUpdate(_ => IO.failNow(failure)).run
       } yield assert(value)(fails(equalTo(failure)))
     },
-    testM("updateSome") {
-      for {
-        refM  <- RefM.make[State](Active)
-        value <- refM.updateAndGetSome { case Closed => IO.succeedNow(Active) }
-      } yield assert(value)(equalTo(Active))
-    },
-    testM("updateSome twice") {
+    testM("getAndUpdateSome") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.updateAndGetSome { case Active => IO.succeedNow(Changed) }
-        value2 <- refM.updateAndGetSome {
+        value1 <- refM.getAndUpdateSome { case Closed => IO.succeedNow(Active) }
+        value2 <- refM.get
+      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
+    },
+    testM("getAndUpdateSome twice") {
+      for {
+        refM   <- RefM.make[State](Active)
+        value1 <- refM.getAndUpdateSome { case Active => IO.succeedNow(Changed) }
+        value2 <- refM.getAndUpdateSome {
                    case Active  => IO.succeedNow(Changed)
                    case Changed => IO.succeedNow(Closed)
                  }
-      } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+        value3 <- refM.get
+      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
     },
-    testM("updateSome with failure") {
+    testM("getAndUpdateSome with failure") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateSome { case Active => IO.failNow(failure) }.run
+        value <- refM.getAndUpdateSome { case Active => IO.failNow(failure) }.run
       } yield assert(value)(fails(equalTo(failure)))
+    },
+    testM("interrupt parent fiber and update") {
+      for {
+        promise     <- Promise.make[Nothing, RefM[State]]
+        latch       <- Promise.make[Nothing, Unit]
+        makeAndWait = promise.complete(RefM.make[State](Active)) *> latch.await
+        fiber       <- makeAndWait.fork
+        refM        <- promise.await
+        _           <- fiber.interrupt
+        value       <- refM.updateAndGet(_ => ZIO.succeedNow(Closed))
+      } yield assert(value)(equalTo(Closed))
     },
     testM("modify") {
       for {
@@ -107,16 +114,46 @@ object RefMSpec extends ZIOBaseSpec {
         value <- refM.modifySome("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
       } yield assert(value)(dies(hasMessage(equalTo(fatalError))))
     },
-    testM("interrupt parent fiber and update") {
+    testM("set") {
       for {
-        promise     <- Promise.make[Nothing, RefM[State]]
-        latch       <- Promise.make[Nothing, Unit]
-        makeAndWait = promise.complete(RefM.make[State](Active)) *> latch.await
-        fiber       <- makeAndWait.fork
-        refM        <- promise.await
-        _           <- fiber.interrupt
-        value       <- refM.updateAndGet(_ => ZIO.succeedNow(Closed))
-      } yield assert(value)(equalTo(Closed))
+        refM  <- RefM.make(current)
+        _     <- refM.set(update)
+        value <- refM.get
+      } yield assert(value)(equalTo(update))
+    },
+    testM("updateAndGet") {
+      for {
+        refM  <- RefM.make(current)
+        value <- refM.updateAndGet(_ => IO.effectTotal(update))
+      } yield assert(value)(equalTo(update))
+    },
+    testM("updateAndGet with failure") {
+      for {
+        refM  <- RefM.make[String](current)
+        value <- refM.updateAndGet(_ => IO.failNow(failure)).run
+      } yield assert(value)(fails(equalTo(failure)))
+    },
+    testM("updateAndGetSome") {
+      for {
+        refM  <- RefM.make[State](Active)
+        value <- refM.updateAndGetSome { case Closed => IO.succeedNow(Active) }
+      } yield assert(value)(equalTo(Active))
+    },
+    testM("updateAndGetSome twice") {
+      for {
+        refM   <- RefM.make[State](Active)
+        value1 <- refM.updateAndGetSome { case Active => IO.succeedNow(Changed) }
+        value2 <- refM.updateAndGetSome {
+                   case Active  => IO.succeedNow(Changed)
+                   case Changed => IO.succeedNow(Closed)
+                 }
+      } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+    },
+    testM("updateAndGetSome with failure") {
+      for {
+        refM  <- RefM.make[State](Active)
+        value <- refM.updateAndGetSome { case Active => IO.failNow(failure) }.run
+      } yield assert(value)(fails(equalTo(failure)))
     }
   )
 

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -73,17 +73,17 @@ object RefSpec extends ZIOBaseSpec {
         value <- ref.updateAndGet(_ => update)
       } yield assert(value)(equalTo(update))
     },
-    testM("updateAndGetSome") {
+    testM("updateSomeAndGet") {
       for {
         ref   <- Ref.make[State](Active)
-        value <- ref.updateAndGetSome { case Closed => Changed }
+        value <- ref.updateSomeAndGet { case Closed => Changed }
       } yield assert(value)(equalTo(Active))
     },
-    testM("updateAndGetSome twice") {
+    testM("updateSomeAndGet twice") {
       for {
         ref    <- Ref.make[State](Active)
-        value1 <- ref.updateAndGetSome { case Active => Changed }
-        value2 <- ref.updateAndGetSome {
+        value1 <- ref.updateSomeAndGet { case Active => Changed }
+        value2 <- ref.updateSomeAndGet {
                    case Active  => Changed
                    case Changed => Closed
                  }

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -22,20 +22,20 @@ object RefSpec extends ZIOBaseSpec {
     testM("update") {
       for {
         ref   <- Ref.make(current)
-        value <- ref.update(_ => update)
+        value <- ref.updateAndGet(_ => update)
       } yield assert(value)(equalTo(update))
     },
     testM("updateSome") {
       for {
         ref   <- Ref.make[State](Active)
-        value <- ref.updateSome { case Closed => Changed }
+        value <- ref.updateAndGetSome { case Closed => Changed }
       } yield assert(value)(equalTo(Active))
     },
     testM("updateSome twice") {
       for {
         ref    <- Ref.make[State](Active)
-        value1 <- ref.updateSome { case Active => Changed }
-        value2 <- ref.updateSome {
+        value1 <- ref.updateAndGetSome { case Active => Changed }
+        value2 <- ref.updateAndGetSome {
                    case Active  => Changed
                    case Changed => Closed
                  }

--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -12,34 +12,30 @@ object RefSpec extends ZIOBaseSpec {
         value <- ref.get
       } yield assert(value)(equalTo(current))
     },
-    testM("set") {
+    testM("getAndUpdate") {
       for {
-        ref   <- Ref.make(current)
-        _     <- ref.set(update)
-        value <- ref.get
-      } yield assert(value)(equalTo(update))
+        ref    <- Ref.make(current)
+        value1 <- ref.getAndUpdate(_ => update)
+        value2 <- ref.get
+      } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
     },
-    testM("update") {
-      for {
-        ref   <- Ref.make(current)
-        value <- ref.updateAndGet(_ => update)
-      } yield assert(value)(equalTo(update))
-    },
-    testM("updateSome") {
-      for {
-        ref   <- Ref.make[State](Active)
-        value <- ref.updateAndGetSome { case Closed => Changed }
-      } yield assert(value)(equalTo(Active))
-    },
-    testM("updateSome twice") {
+    testM("getAndUpdateSome") {
       for {
         ref    <- Ref.make[State](Active)
-        value1 <- ref.updateAndGetSome { case Active => Changed }
-        value2 <- ref.updateAndGetSome {
+        value1 <- ref.getAndUpdateSome { case Closed => Changed }
+        value2 <- ref.get
+      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
+    },
+    testM("getAndUpdateSome twice") {
+      for {
+        ref    <- Ref.make[State](Active)
+        value1 <- ref.getAndUpdateSome { case Active => Changed }
+        value2 <- ref.getAndUpdateSome {
                    case Active  => Changed
                    case Changed => Closed
                  }
-      } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+        value3 <- ref.get
+      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
     },
     testM("modify") {
       for {
@@ -63,6 +59,35 @@ object RefSpec extends ZIOBaseSpec {
                    case Changed => ("closed", Closed)
                  }
       } yield assert(value1)(equalTo("changed")) && assert(value2)(equalTo("closed"))
+    },
+    testM("set") {
+      for {
+        ref   <- Ref.make(current)
+        _     <- ref.set(update)
+        value <- ref.get
+      } yield assert(value)(equalTo(update))
+    },
+    testM("updateAndGet") {
+      for {
+        ref   <- Ref.make(current)
+        value <- ref.updateAndGet(_ => update)
+      } yield assert(value)(equalTo(update))
+    },
+    testM("updateAndGetSome") {
+      for {
+        ref   <- Ref.make[State](Active)
+        value <- ref.updateAndGetSome { case Closed => Changed }
+      } yield assert(value)(equalTo(Active))
+    },
+    testM("updateAndGetSome twice") {
+      for {
+        ref    <- Ref.make[State](Active)
+        value1 <- ref.updateAndGetSome { case Active => Changed }
+        value2 <- ref.updateAndGetSome {
+                   case Active  => Changed
+                   case Changed => Closed
+                 }
+      } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
     }
   )
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -318,7 +318,7 @@ object ScheduleSpec extends ZIOBaseSpec {
   def repeat[B](schedule: Schedule[Any, Int, B]): ZIO[Any with Clock, Nothing, B] =
     for {
       ref <- Ref.make(0)
-      res <- ref.update(_ + 1).repeat(schedule)
+      res <- ref.updateAndGet(_ + 1).repeat(schedule)
     } yield res
 
   /**
@@ -349,7 +349,7 @@ object ScheduleSpec extends ZIOBaseSpec {
    */
   def alwaysFail(ref: Ref[Int]): IO[String, Int] =
     for {
-      i <- ref.update(_ + 1)
+      i <- ref.updateAndGet(_ + 1)
       x <- IO.failNow(s"Error: $i")
     } yield x
 
@@ -360,7 +360,7 @@ object ScheduleSpec extends ZIOBaseSpec {
    */
   def failOn0(ref: Ref[Int]): IO[String, Int] =
     for {
-      i <- ref.update(_ + 1)
+      i <- ref.updateAndGet(_ + 1)
       x <- if (i <= 1) IO.failNow(s"Error: $i") else IO.succeedNow(i)
     } yield x
 

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -132,21 +132,21 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
 
   /**
    * Atomically modifies the `FiberRef` with the specified partial function.
-   * If the function is undefined on the current value it returns the old value
-   * without changing it.
-   */
-  def updateAndGetSome(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
-    val result = pf.applyOrElse[A, A](v, identity)
-    (result, result)
-  }
-
-  /**
-   * Atomically modifies the `FiberRef` with the specified partial function.
    * If the function is undefined on the current value it doesn't change it.
    */
   def updateSome(pf: PartialFunction[A, A]): UIO[Unit] = modify { v =>
     val result = pf.applyOrElse[A, A](v, identity)
     ((), result)
+  }
+
+  /**
+   * Atomically modifies the `FiberRef` with the specified partial function.
+   * If the function is undefined on the current value it returns the old value
+   * without changing it.
+   */
+  def updateSomeAndGet(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
+    val result = pf.applyOrElse[A, A](v, identity)
+    (result, result)
   }
 
   /**

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -55,6 +55,13 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
   val get: UIO[A] = modify(v => (v, v))
 
   /**
+   * Atomically sets the value associated with the current fiber and returns
+   * the old value.
+   */
+  def getAndSet(a: A): UIO[A] =
+    modify(v => (v, a))
+
+  /**
    * Atomically modifies the `FiberRef` with the specified function and returns
    * the old value.
    */

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -90,18 +90,37 @@ final class FiberRef[A] private[zio] (private[zio] val initial: A, private[zio] 
   /**
    * Atomically modifies the `FiberRef` with the specified function.
    */
-  def update(f: A => A): UIO[A] = modify { v =>
+  def update(f: A => A): UIO[Unit] = modify { v =>
+    val result = f(v)
+    ((), result)
+  }
+
+  /**
+   * Atomically modifies the `FiberRef` with the specified function and returns
+   * the result.
+   */
+  def updateAndGet(f: A => A): UIO[A] = modify { v =>
     val result = f(v)
     (result, result)
   }
 
   /**
    * Atomically modifies the `FiberRef` with the specified partial function.
-   * if the function is undefined in the current value it returns the old value without changing it.
+   * if the function is undefined in the current value it returns the old value
+   * without changing it.
    */
-  def updateSome(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
+  def updateAndGetSome(pf: PartialFunction[A, A]): UIO[A] = modify { v =>
     val result = pf.applyOrElse[A, A](v, identity)
     (result, result)
+  }
+
+  /**
+   * Atomically modifies the `FiberRef` with the specified partial function.
+   * if the function is undefined in the current value it doesn't change it.
+   */
+  def updateSome(pf: PartialFunction[A, A]): UIO[Unit] = modify { v =>
+    val result = pf.applyOrElse[A, A](v, identity)
+    ((), result)
   }
 
   /**

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -226,29 +226,6 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
 
   /**
    * Atomically modifies the `Ref` with the specified partial function.
-   * If the function is undefined on the current value it returns the old value
-   * without changing it.
-   *
-   * @param pf partial function to atomically modify the `Ref`
-   * @return `UIO[A]` modified value of the `Ref`
-   */
-  def updateAndGetSome(pf: PartialFunction[A, A]): UIO[A] = IO.effectTotal {
-    var loop    = true
-    var next: A = null.asInstanceOf[A]
-
-    while (loop) {
-      val current = value.get
-
-      next = pf.applyOrElse(current, (_: A) => current)
-
-      loop = !value.compareAndSet(current, next)
-    }
-
-    next
-  }
-
-  /**
-   * Atomically modifies the `Ref` with the specified partial function.
    * If the function is undefined on the current value it doesn't change it.
    *
    * @param pf partial function to atomically modify the `Ref`
@@ -267,6 +244,29 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
     }
 
     ()
+  }
+
+  /**
+   * Atomically modifies the `Ref` with the specified partial function.
+   * If the function is undefined on the current value it returns the old value
+   * without changing it.
+   *
+   * @param pf partial function to atomically modify the `Ref`
+   * @return `UIO[A]` modified value of the `Ref`
+   */
+  def updateSomeAndGet(pf: PartialFunction[A, A]): UIO[A] = IO.effectTotal {
+    var loop    = true
+    var next: A = null.asInstanceOf[A]
+
+    while (loop) {
+      val current = value.get
+
+      next = pf.applyOrElse(current, (_: A) => current)
+
+      loop = !value.compareAndSet(current, next)
+    }
+
+    next
   }
 }
 

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -41,6 +41,27 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
   def get: UIO[A] = IO.effectTotal(value.get)
 
   /**
+   * Atomically writes the specified value to the `Ref`, returning the value
+   * immediately before modification. This is not implemented in terms of
+   * `modify` purely for performance reasons.
+   *
+   * @param a value to be written to the `Ref`
+   * @return `UIO[A]` value of the `Ref` immediately before modification
+   */
+  def getAndSet(a: A): UIO[A] = IO.effectTotal {
+    var loop       = true
+    var current: A = null.asInstanceOf[A]
+
+    while (loop) {
+      current = value.get
+
+      loop = !value.compareAndSet(current, a)
+    }
+
+    current
+  }
+
+  /**
    * Atomically modifies the `Ref` with the specified function, returning the
    * value immediately before modification. This is not implemented in terms of
    * `modify` purely for performance reasons.

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -54,6 +54,16 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
     modify(a => f(a).map((a, _)))
 
   /**
+   * Writes a new value to the `RefM`, returning the value immediately before
+   * modification.
+   *
+   * @param a value to be written to the `RefM`
+   * @return `UIO[A]` value of the `RefM` immediately before modification
+   */
+  def getAndSet(a: A): UIO[A] =
+    value.getAndSet(a)
+
+  /**
    * Atomically modifies the `RefM` with the specified partial function,
    * returning the value immediately before modification.
    * If the function is undefined on the current value it doesn't change it.
@@ -119,7 +129,7 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
     } yield b
 
   /**
-   * Writes a new value to the `Ref`, with a guarantee of immediate
+   * Writes a new value to the `RefM`, with a guarantee of immediate
    * consistency (at some cost to performance).
    *
    * @param a value to be written to the `RefM`

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -171,19 +171,6 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
 
   /**
    * Atomically modifies the `RefM` with the specified partial function.
-   * If the function is undefined on the current value it returns the old value
-   * without changing it.
-   *
-   * @param pf partial function to atomically modify the `RefM`
-   * @tparam R environment of the effect
-   * @tparam E error type
-   * @return `ZIO[R, E, A]` modified value of the `RefM`
-   */
-  def updateAndGetSome[R, E](pf: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, A] =
-    modify(a => pf.applyOrElse(a, (_: A) => IO.succeedNow(a)).map(a => (a, a)))
-
-  /**
-   * Atomically modifies the `RefM` with the specified partial function.
    * If the function is undefined on the current value it doesn't change it.
    *
    * @param pf partial function to atomically modify the `RefM`
@@ -193,6 +180,19 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[_, A, _]]) 
    */
   def updateSome[R, E](pf: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, Unit] =
     modify(a => pf.applyOrElse(a, (_: A) => IO.succeedNow(a)).map(a => ((), a)))
+
+  /**
+   * Atomically modifies the `RefM` with the specified partial function.
+   * If the function is undefined on the current value it returns the old value
+   * without changing it.
+   *
+   * @param pf partial function to atomically modify the `RefM`
+   * @tparam R environment of the effect
+   * @tparam E error type
+   * @return `ZIO[R, E, A]` modified value of the `RefM`
+   */
+  def updateSomeAndGet[R, E](pf: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, A] =
+    modify(a => pf.applyOrElse(a, (_: A) => IO.succeedNow(a)).map(a => (a, a)))
 }
 
 object RefM extends Serializable {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -247,7 +247,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     def get(cache: RefM[Option[(Long, Promise[E, A])]]): ZIO[R with Clock, E, A] =
       ZIO.uninterruptibleMask { restore =>
         clock.nanoTime.flatMap { time =>
-          cache.updateSome {
+          cache.updateAndGetSome {
             case None                          => compute(time)
             case Some((end, _)) if time >= end => compute(time)
           }.flatMap(a => restore(a.get._2.await))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -247,7 +247,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     def get(cache: RefM[Option[(Long, Promise[E, A])]]): ZIO[R with Clock, E, A] =
       ZIO.uninterruptibleMask { restore =>
         clock.nanoTime.flatMap { time =>
-          cache.updateAndGetSome {
+          cache.updateSomeAndGet {
             case None                          => compute(time)
             case Some((end, _)) if time >= end => compute(time)
           }.flatMap(a => restore(a.get._2.await))

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -277,20 +277,20 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Updates element in the array with given function.
    */
-  def update(index: Int, fn: A => A): STM[Nothing, A] =
+  def update(index: Int, fn: A => A): STM[Nothing, Unit] =
     if (0 <= index && index < array.length) array(index).update(fn)
     else STM.dieNow(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Atomically updates element in the array with given transactional effect.
    */
-  def updateM[E](index: Int, fn: A => STM[E, A]): STM[E, A] =
+  def updateM[E](index: Int, fn: A => STM[E, A]): STM[E, Unit] =
     if (0 <= index && index < array.length)
       for {
         currentVal <- array(index).get
         newVal     <- fn(currentVal)
         _          <- array(index).set(newVal)
-      } yield newVal
+      } yield ()
     else STM.dieNow(new ArrayIndexOutOfBoundsException(index))
 }
 

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -41,6 +41,20 @@ final class TRef[A] private (
     })
 
   /**
+   * Sets the value of the `TRef` and returns the old value.
+   */
+  def getAndSet(a: A): STM[Nothing, A] =
+    new ZSTM((journal, _, _, _) => {
+      val entry = getOrMakeEntry(journal)
+
+      val oldValue = entry.unsafeGet[A]
+
+      entry.unsafeSet(a)
+
+      TExit.Succeed(oldValue)
+    })
+
+  /**
    * Updates the value of the variable and returns the old value.
    */
   def getAndUpdate(f: A => A): STM[Nothing, A] =

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -141,17 +141,17 @@ final class TRef[A] private (
     })
 
   /**
-   * Updates some values of the variable but leaves others alone, returning the
-   * new value.
-   */
-  def updateAndGetSome(f: PartialFunction[A, A]): STM[Nothing, A] =
-    updateAndGet(f orElse { case a => a })
-
-  /**
    * Updates some values of the variable but leaves others alone.
    */
   def updateSome(f: PartialFunction[A, A]): STM[Nothing, Unit] =
     update(f orElse { case a => a })
+
+  /**
+   * Updates some values of the variable but leaves others alone, returning the
+   * new value.
+   */
+  def updateSomeAndGet(f: PartialFunction[A, A]): STM[Nothing, A] =
+    updateAndGet(f orElse { case a => a })
 
   private def getOrMakeEntry(journal: Journal): Entry =
     if (journal.containsKey(self)) journal.get(self)

--- a/docs/datatypes/tref.md
+++ b/docs/datatypes/tref.md
@@ -94,7 +94,7 @@ import zio.stm._
 
 val updateSingle: UIO[Int] = (for {
   tRef <- TRef.make(10)
-  nValue <- tRef.update(_ + 20)
+  nValue <- tRef.updateAndGet(_ + 20)
 } yield nValue).commit
 ```
 
@@ -106,7 +106,7 @@ import zio.stm._
 
 val updateMultiple: UIO[Int] = for {
   tRef <- TRef.makeCommit(10)
-  nValue <- tRef.update(_ + 20).commit
+  nValue <- tRef.updateAndGet(_ + 20).commit
 } yield nValue
 ```
 
@@ -154,7 +154,7 @@ def transfer(tSender: TRef[Int],
     for {
       _ <- tSender.get.filter(_ >= amount)
       _ <- tSender.update(_ - amount)
-      nAmount <- tReceiver.update(_ + amount)
+      nAmount <- tReceiver.updateAndGet(_ + amount)
     } yield nAmount
   }
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -258,7 +258,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
                      acc.update(a :: _) *> IO.succeedNow(true)
                    else
                      IO.succeedNow(false)
-                 }.flatMap(_ => acc.update(_.reverse))
+                 }.flatMap(_ => acc.updateAndGet(_.reverse))
           res2 <- slurp(s.takeWhile(cont)).map(_.toList)
         } yield assert(res1)(equalTo(res2))
       }
@@ -267,7 +267,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       checkM(chunksOfInts) { s =>
         for {
           acc  <- Ref.make[List[Int]](Nil)
-          res1 <- s.foreach(a => acc.update(a :: _).unit).flatMap(_ => acc.update(_.reverse))
+          res1 <- s.foreach(a => acc.update(a :: _).unit).flatMap(_ => acc.updateAndGet(_.reverse))
           res2 <- slurp(s).map(_.toList)
         } yield assert(res1)(equalTo(res2))
       }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamPullSafetySpec.scala
@@ -817,7 +817,7 @@ object StreamPullSafetySpec extends ZIOBaseSpec {
     testM("Stream.repeatEffectWith is safe to pull again") {
       def effect(ref: Ref[Int]): IO[String, Int] =
         for {
-          cnt <- ref.update(_ + 1)
+          cnt <- ref.updateAndGet(_ + 1)
           res <- if (cnt == 2) IO.failNow("Ouch") else UIO.succeedNow(cnt)
         } yield res
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1351,7 +1351,7 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           ref <- Ref.make(0)
           fa = for {
-            newCount <- ref.update(_ + 1)
+            newCount <- ref.updateAndGet(_ + 1)
             res      <- if (newCount >= 5) ZIO.failNow(None) else ZIO.succeedNow(newCount)
           } yield res
           res <- Stream

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -109,7 +109,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("flaky test") {
-          assertM(ref.update(_ + 1))(equalTo(100))
+          assertM(ref.updateAndGet(_ + 1))(equalTo(100))
         } @@ flaky
         result <- isSuccess(spec)
         n      <- ref.get
@@ -119,7 +119,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("flaky test that dies") {
-          assertM(ref.update(_ + 1).filterOrDieMessage(_ >= 100)("die"))(equalTo(100))
+          assertM(ref.updateAndGet(_ + 1).filterOrDieMessage(_ >= 100)("die"))(equalTo(100))
         } @@ flaky
         result <- isSuccess(spec)
         n      <- ref.get
@@ -199,7 +199,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("retry") {
-          assertM(ref.update(_ + 1))(equalTo(2))
+          assertM(ref.updateAndGet(_ + 1))(equalTo(2))
         } @@ retry(Schedule.recurs(1))
         result <- isSuccess(spec)
       } yield assert(result)(isTrue)

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -189,7 +189,7 @@ object ClockSpec extends ZIOBaseSpec {
       for {
         latch     <- Promise.make[Nothing, Unit]
         ref       <- Ref.make(3)
-        countdown = ref.update(_ - 1).flatMap(n => latch.succeed(()).when(n == 0))
+        countdown = ref.updateAndGet(_ - 1).flatMap(n => latch.succeed(()).when(n == 0))
         _         <- countdown.repeat(Schedule.fixed(2.seconds)).delay(1.second).fork
         _         <- TestClock.adjust(5.seconds)
         _         <- latch.await

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -373,7 +373,7 @@ package object environment extends PlatformSpecific {
        * scheduled effects will be run as a result of this method.
        */
       def setTimeZone(zone: ZoneId): UIO[Unit] =
-        fiberState.update(_.copy(timeZone = zone)).unit
+        fiberState.update(_.copy(timeZone = zone))
 
       /**
        * Semantically blocks the current fiber until the wall clock time is
@@ -415,12 +415,10 @@ package object environment extends PlatformSpecific {
         UIO.forkAll_(wakes.sortBy(_._1).map(_._2.succeed(()))).fork.unit
 
       private[TestClock] val warningDone: UIO[Unit] =
-        warningState
-          .updateSome[Any, Nothing] {
-            case WarningData.Start          => ZIO.succeedNow(WarningData.done)
-            case WarningData.Pending(fiber) => fiber.interrupt.as(WarningData.done)
-          }
-          .unit
+        warningState.updateSome[Any, Nothing] {
+          case WarningData.Start          => ZIO.succeedNow(WarningData.done)
+          case WarningData.Pending(fiber) => fiber.interrupt.as(WarningData.done)
+        }
 
       private val warningStart: UIO[Unit] =
         warningState.updateSome {
@@ -428,7 +426,7 @@ package object environment extends PlatformSpecific {
             for {
               fiber <- live.provide(console.putStrLn(warning).delay(5.seconds)).interruptible.fork
             } yield WarningData.pending(fiber)
-        }.unit
+        }
 
     }
 
@@ -603,13 +601,13 @@ package object environment extends PlatformSpecific {
        * Clears the contents of the input buffer.
        */
       val clearInput: UIO[Unit] =
-        consoleState.update(data => data.copy(input = List.empty)).unit
+        consoleState.update(data => data.copy(input = List.empty))
 
       /**
        * Clears the contents of the output buffer.
        */
       val clearOutput: UIO[Unit] =
-        consoleState.update(data => data.copy(output = Vector.empty)).unit
+        consoleState.update(data => data.copy(output = Vector.empty))
 
       /**
        * Writes the specified sequence of strings to the input buffer. The
@@ -618,7 +616,7 @@ package object environment extends PlatformSpecific {
        * input buffer.
        */
       def feedLines(lines: String*): UIO[Unit] =
-        consoleState.update(data => data.copy(input = lines.toList ::: data.input)).unit
+        consoleState.update(data => data.copy(input = lines.toList ::: data.input))
 
       /**
        * Takes the first value from the input buffer, if one exists, or else
@@ -649,7 +647,7 @@ package object environment extends PlatformSpecific {
       override def putStr(line: String): UIO[Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ line)
-        }.unit
+        }
 
       /**
        * Writes the specified string to the output buffer followed by a newline
@@ -658,7 +656,7 @@ package object environment extends PlatformSpecific {
       override def putStrLn(line: String): ZIO[Any, Nothing, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ s"$line\n")
-        }.unit
+        }
 
       /**
        * Saves the `TestConsole`'s current state in an effect which, when run, will restore the `TestConsole`
@@ -801,49 +799,49 @@ package object environment extends PlatformSpecific {
        * Clears the buffer of booleans.
        */
       val clearBooleans: UIO[Unit] =
-        bufferState.update(_.copy(booleans = List.empty)).unit
+        bufferState.update(_.copy(booleans = List.empty))
 
       /**
        * Clears the buffer of bytes.
        */
       val clearBytes: UIO[Unit] =
-        bufferState.update(_.copy(bytes = List.empty)).unit
+        bufferState.update(_.copy(bytes = List.empty))
 
       /**
        * Clears the buffer of characters.
        */
       val clearChars: UIO[Unit] =
-        bufferState.update(_.copy(chars = List.empty)).unit
+        bufferState.update(_.copy(chars = List.empty))
 
       /**
        * Clears the buffer of doubles.
        */
       val clearDoubles: UIO[Unit] =
-        bufferState.update(_.copy(doubles = List.empty)).unit
+        bufferState.update(_.copy(doubles = List.empty))
 
       /**
        * Clears the buffer of floats.
        */
       val clearFloats: UIO[Unit] =
-        bufferState.update(_.copy(floats = List.empty)).unit
+        bufferState.update(_.copy(floats = List.empty))
 
       /**
        * Clears the buffer of integers.
        */
       val clearInts: UIO[Unit] =
-        bufferState.update(_.copy(integers = List.empty)).unit
+        bufferState.update(_.copy(integers = List.empty))
 
       /**
        * Clears the buffer of longs.
        */
       val clearLongs: UIO[Unit] =
-        bufferState.update(_.copy(longs = List.empty)).unit
+        bufferState.update(_.copy(longs = List.empty))
 
       /**
        * Clears the buffer of strings.
        */
       val clearStrings: UIO[Unit] =
-        bufferState.update(_.copy(strings = List.empty)).unit
+        bufferState.update(_.copy(strings = List.empty))
 
       /**
        * Feeds the buffer with specified sequence of booleans. The first value in
@@ -851,7 +849,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedBooleans(booleans: Boolean*): UIO[Unit] =
-        bufferState.update(data => data.copy(booleans = booleans.toList ::: data.booleans)).unit
+        bufferState.update(data => data.copy(booleans = booleans.toList ::: data.booleans))
 
       /**
        * Feeds the buffer with specified sequence of chunks of bytes. The first
@@ -859,7 +857,7 @@ package object environment extends PlatformSpecific {
        * be taken before any values that were previously in the buffer.
        */
       def feedBytes(bytes: Chunk[Byte]*): UIO[Unit] =
-        bufferState.update(data => data.copy(bytes = bytes.toList ::: data.bytes)).unit
+        bufferState.update(data => data.copy(bytes = bytes.toList ::: data.bytes))
 
       /**
        * Feeds the buffer with specified sequence of characters. The first value
@@ -867,7 +865,7 @@ package object environment extends PlatformSpecific {
        * taken before any values that were previously in the buffer.
        */
       def feedChars(chars: Char*): UIO[Unit] =
-        bufferState.update(data => data.copy(chars = chars.toList ::: data.chars)).unit
+        bufferState.update(data => data.copy(chars = chars.toList ::: data.chars))
 
       /**
        * Feeds the buffer with specified sequence of doubles. The first value in
@@ -875,7 +873,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedDoubles(doubles: Double*): UIO[Unit] =
-        bufferState.update(data => data.copy(doubles = doubles.toList ::: data.doubles)).unit
+        bufferState.update(data => data.copy(doubles = doubles.toList ::: data.doubles))
 
       /**
        * Feeds the buffer with specified sequence of floats. The first value in
@@ -883,7 +881,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedFloats(floats: Float*): UIO[Unit] =
-        bufferState.update(data => data.copy(floats = floats.toList ::: data.floats)).unit
+        bufferState.update(data => data.copy(floats = floats.toList ::: data.floats))
 
       /**
        * Feeds the buffer with specified sequence of integers. The first value in
@@ -891,7 +889,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedInts(ints: Int*): UIO[Unit] =
-        bufferState.update(data => data.copy(integers = ints.toList ::: data.integers)).unit
+        bufferState.update(data => data.copy(integers = ints.toList ::: data.integers))
 
       /**
        * Feeds the buffer with specified sequence of longs. The first value in
@@ -899,7 +897,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedLongs(longs: Long*): UIO[Unit] =
-        bufferState.update(data => data.copy(longs = longs.toList ::: data.longs)).unit
+        bufferState.update(data => data.copy(longs = longs.toList ::: data.longs))
 
       /**
        * Feeds the buffer with specified sequence of strings. The first value in
@@ -907,7 +905,7 @@ package object environment extends PlatformSpecific {
        * before any values that were previously in the buffer.
        */
       def feedStrings(strings: String*): UIO[Unit] =
-        bufferState.update(data => data.copy(strings = strings.toList ::: data.strings)).unit
+        bufferState.update(data => data.copy(strings = strings.toList ::: data.strings))
 
       private val randomBoolean: UIO[Boolean] =
         randomBits(1).map(_ != 0)
@@ -1435,33 +1433,33 @@ package object environment extends PlatformSpecific {
        * variables maintained by this `TestSystem`.
        */
       def putEnv(name: String, value: String): UIO[Unit] =
-        systemState.update(data => data.copy(envs = data.envs.updated(name, value))).unit
+        systemState.update(data => data.copy(envs = data.envs.updated(name, value)))
 
       /**
        * Adds the specified name and value to the mapping of system properties
        * maintained by this `TestSystem`.
        */
       def putProperty(name: String, value: String): UIO[Unit] =
-        systemState.update(data => data.copy(properties = data.properties.updated(name, value))).unit
+        systemState.update(data => data.copy(properties = data.properties.updated(name, value)))
 
       /**
        * Sets the system line separator maintained by this `TestSystem` to the
        * specified value.
        */
       def setLineSeparator(lineSep: String): UIO[Unit] =
-        systemState.update(_.copy(lineSeparator = lineSep)).unit
+        systemState.update(_.copy(lineSeparator = lineSep))
 
       /**
        * Clears the mapping of environment variables.
        */
       def clearEnv(variable: String): UIO[Unit] =
-        systemState.update(data => data.copy(envs = data.envs - variable)).unit
+        systemState.update(data => data.copy(envs = data.envs - variable))
 
       /**
        * Clears the mapping of system properties.
        */
       def clearProperty(prop: String): UIO[Unit] =
-        systemState.update(data => data.copy(properties = data.properties - prop)).unit
+        systemState.update(data => data.copy(properties = data.properties - prop))
 
       /**
        * Saves the `TestSystem``'s current state in an effect which, when run, will restore the `TestSystem`

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -424,7 +424,7 @@ package object test extends CompileVariants {
       ZLayer.fromEffect(FiberRef.make(TestAnnotationMap.empty).map { fiberRef =>
         Has(new Annotations.Service {
           def annotate[V](key: TestAnnotation[V], value: V): UIO[Unit] =
-            fiberRef.update(_.annotate(key, value)).unit
+            fiberRef.update(_.annotate(key, value))
           def get[V](key: TestAnnotation[V]): UIO[V] =
             fiberRef.get.map(_.get(key))
           def withAnnotation[R, E, A](zio: ZIO[R, E, A]): ZIO[R, Annotated[E], Annotated[A]] =


### PR DESCRIPTION
Resolves #2754. `update` goes to returning `UIO[Unit]` and `updateAndGet` is implemented for returning `UIO[A]`. Makes conforming changes to `Ref`, `RefM`, `FiberRef`, and `TRef` includes `update` and `updateSome` variants.