### PR TITLE
Remove string gens because they allocate too many short lived objects

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -4,5 +4,5 @@ import zio.duration._
 import zio.test._
 
 trait ZIOBaseSpec extends DefaultRunnableSpec {
-  override def aspects = List(TestAspect.timeout(600.seconds))
+  override def aspects = List(TestAspect.timeout(60.seconds))
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -38,7 +38,7 @@ object ChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("foldLeft") {
-      check(stringGen, Gen.function2(stringGen), smallChunks(intGen)) { (s0, f, c) =>
+      check(intGen, Gen.function2(intGen), smallChunks(intGen)) { (s0, f, c) =>
         assert(c.fold(s0)(f))(equalTo(c.toArray.foldLeft(s0)(f)))
       }
     },
@@ -54,13 +54,13 @@ object ChunkSpec extends ZIOBaseSpec {
       }
     ),
     testM("map") {
-      val fn = Gen.function[Random with Sized, Int, String](stringGen)
+      val fn = Gen.function[Random with Sized, Int, Int](intGen)
       check(smallChunks(intGen), fn) { (c, f) =>
         assert(c.map(f).toSeq)(equalTo(c.toSeq.map(f)))
       }
     },
     suite("mapM")(
-      testM("mapM happy path")(checkM(mediumChunks(stringGen), Gen.function(Gen.boolean)) { (chunk, f) =>
+      testM("mapM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, f) =>
         chunk.mapM(s => UIO.succeedNow(f(s))).map(assert(_)(equalTo(chunk.map(f))))
       }),
       testM("mapM error") {
@@ -84,37 +84,37 @@ object ChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("indexWhere") {
-      val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn, intGen) { (chunk, p, from) =>
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn, intGen) { (chunk, p, from) =>
         assert(chunk.indexWhere(p, from).getOrElse(-1))(equalTo(chunk.toSeq.indexWhere(p, from)))
       }
     } @@ exceptScala211,
     testM("exists") {
-      val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn) { (chunk, p) =>
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn) { (chunk, p) =>
         assert(chunk.exists(p))(equalTo(chunk.toSeq.exists(p)))
       }
     },
     testM("forall") {
-      val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn) { (chunk, p) =>
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn) { (chunk, p) =>
         assert(chunk.forall(p))(equalTo(chunk.toSeq.forall(p)))
       }
     },
     testM("find") {
-      val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn) { (chunk, p) =>
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn) { (chunk, p) =>
         assert(chunk.find(p))(equalTo(chunk.toSeq.find(p)))
       }
     },
     testM("filter") {
-      val fn = Gen.function[Random with Sized, String, Boolean](Gen.boolean)
-      check(mediumChunks(stringGen), fn) { (chunk, p) =>
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn) { (chunk, p) =>
         assert(chunk.filter(p).toSeq)(equalTo(chunk.toSeq.filter(p)))
       }
     },
     suite("filterM")(
-      testM("filterM happy path")(checkM(mediumChunks(stringGen), Gen.function(Gen.boolean)) { (chunk, p) =>
+      testM("filterM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
         chunk.filterM(s => UIO.succeedNow(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
       }),
       testM("filterM error") {
@@ -165,7 +165,7 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
     },
     testM("toArray with elements of type String") {
-      check(mediumChunks(stringGen)) { c =>
+      check(mediumChunks(intGen)) { c =>
         assert(c.toArray.toSeq)(equalTo(c.toSeq))
       }
     },
@@ -178,7 +178,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
       },
       testM("collect chunk") {
-        val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
+        val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
         check(mediumChunks(intGen), pfGen) { (c, pf) =>
           assert(c.collect(pf).toSeq)(equalTo(c.toSeq.collect(pf)))
         }
@@ -189,7 +189,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assertM(Chunk.empty.collectM { case _ => UIO.succeedNow(1) })(equalTo(Chunk.empty))
       },
       testM("collectM chunk") {
-        val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[String]](Gen.successes(stringGen))
+        val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))
         checkM(mediumChunks(intGen), pfGen) { (c, pf) =>
           for {
             result   <- c.collectM(pf).map(_.toList)
@@ -206,7 +206,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
       },
       testM("collectWhile chunk") {
-        val pfGen = Gen.partialFunction[Random with Sized, Int, String](stringGen)
+        val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
         check(mediumChunks(intGen), pfGen) { (c, pf) =>
           assert(c.collectWhile(pf).toSeq)(equalTo(c.toSeq.takeWhile(pf.isDefinedAt).map(pf.apply)))
         }
@@ -217,7 +217,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assertM(Chunk.empty.collectWhileM { case _ => UIO.succeedNow(1) })(equalTo(Chunk.empty))
       },
       testM("collectWhileM chunk") {
-        val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[String]](Gen.successes(stringGen))
+        val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))
         checkM(mediumChunks(intGen), pfGen) { (c, pf) =>
           for {
             result   <- c.collectWhileM(pf).map(_.toList)

--- a/streams-tests/jvm/src/test/scala/zio/stream/GenUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/GenUtils.scala
@@ -6,7 +6,5 @@ import zio.test.Gen
 trait GenUtils {
   def toBoolFn[R <: Random, A] = Gen.function[R, A, Boolean](Gen.boolean)
 
-  val stringGen = Gen.small(Gen.stringN(_)(Gen.alphaNumericChar))
-
   val intGen = Gen.int(-10, 10)
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -47,7 +47,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       s1.orElse(s2).flattenChunks.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
     },
     testM("StreamChunk.map") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, f) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, f) =>
         for {
           res1 <- slurp(s.map(f))
           res2 <- slurp(s).map(_.map(f))
@@ -55,7 +55,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.filter") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.filter(p))
           res2 <- slurp(s).map(_.filter(p))
@@ -63,7 +63,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     suite("StreamChunk.filterM")(
-      testM("filterM happy path")(checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      testM("filterM happy path")(checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.filterM(s => UIO.succeedNow(p(s))))
           res2 <- slurp(s).map(_.filter(p))
@@ -74,7 +74,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     ),
     testM("StreamChunk.filterNot") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.filterNot(p))
           res2 <- slurp(s).map(_.filterNot(p))
@@ -82,8 +82,8 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.mapConcat") {
-      val fn = Gen.function[Random with Sized, String, Iterable[Int]](Gen.small(Gen.listOfN(_)(intGen)))
-      checkM(pureStreamChunkGen(tinyChunks(stringGen)), fn) { (s, f) =>
+      val fn = Gen.function[Random with Sized, Int, Iterable[Int]](Gen.small(Gen.listOfN(_)(intGen)))
+      checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
         for {
           res1 <- slurp(s.mapConcat(f))
           res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
@@ -91,8 +91,8 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.mapConcatChunk") {
-      val fn = Gen.function[Random with Sized, String, Chunk[Int]](smallChunks(intGen))
-      checkM(pureStreamChunkGen(tinyChunks(stringGen)), fn) { (s, f) =>
+      val fn = Gen.function[Random with Sized, Int, Chunk[Int]](smallChunks(intGen))
+      checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
         for {
           res1 <- slurp(s.mapConcatChunk(f))
           res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
@@ -101,8 +101,8 @@ object StreamChunkSpec extends ZIOBaseSpec {
     },
     suite("StreamChunk.mapConcatChunkM")(
       testM("mapConcatChunkM happy path") {
-        val fn = Gen.function[Random with Sized, String, Chunk[Int]](smallChunks(intGen))
-        checkM(pureStreamChunkGen(tinyChunks(stringGen)), fn) { (s, f) =>
+        val fn = Gen.function[Random with Sized, Int, Chunk[Int]](smallChunks(intGen))
+        checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
             res1 <- slurp(s.mapConcatChunkM(s => UIO.succeedNow(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
@@ -120,8 +120,8 @@ object StreamChunkSpec extends ZIOBaseSpec {
     ),
     suite("StreamChunk.mapConcatM")(
       testM("mapConcatM happy path") {
-        val fn = Gen.function[Random with Sized, String, Iterable[Int]](Gen.listOf(intGen))
-        checkM(pureStreamChunkGen(tinyChunks(stringGen)), fn) { (s, f) =>
+        val fn = Gen.function[Random with Sized, Int, Iterable[Int]](Gen.listOf(intGen))
+        checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
             res1 <- slurp(s.mapConcatM(s => UIO.succeedNow(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
@@ -152,7 +152,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         .map(assert(_)(isLeft(equalTo(123))))
     },
     testM("StreamChunk.drop") {
-      checkM(chunksOfStrings, intGen) { (s, n) =>
+      checkM(chunksOfInts, intGen) { (s, n) =>
         for {
           res1 <- slurp(s.drop(n))
           res2 <- slurp(s).map(_.drop(n))
@@ -160,7 +160,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.take") {
-      checkM(chunksOfStrings, intGen) { (s, n) =>
+      checkM(chunksOfInts, intGen) { (s, n) =>
         for {
           res1 <- slurp(s.take(n))
           res2 <- slurp(s).map(_.take(n))
@@ -168,7 +168,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.dropUntil") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.dropUntil(p))
           res2 <- slurp(s).map(seq => StreamUtils.dropUntil(seq.toList)(p))
@@ -176,7 +176,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.dropWhile") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.dropWhile(p))
           res2 <- slurp(s).map(_.dropWhile(p))
@@ -184,7 +184,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.takeUntil") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.takeUntil(p))
           res2 <- slurp(s).map(seq => StreamUtils.takeUntil(seq.toList)(p))
@@ -192,7 +192,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.takeWhile") {
-      checkM(chunksOfStrings, toBoolFn[Random with Sized, String]) { (s, p) =>
+      checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
           res1 <- slurp(s.takeWhile(p))
           res2 <- slurp(s).map(_.takeWhile(p))
@@ -234,7 +234,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.++") {
-      checkM(chunksOfStrings, chunksOfStrings) { (s1, s2) =>
+      checkM(chunksOfInts, chunksOfInts) { (s1, s2) =>
         for {
           res1 <- slurp(s1).zipWith(slurp(s2))(_ ++ _)
           res2 <- slurp(s1 ++ s2)
@@ -242,7 +242,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.zipWithIndex") {
-      checkM(chunksOfStrings) { s =>
+      checkM(chunksOfInts) { s =>
         for {
           res1 <- slurp(s.zipWithIndex)
           res2 <- slurp(s).map(_.zipWithIndex.map(t => (t._1, t._2.toLong)))
@@ -305,9 +305,9 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("StreamChunk.tap") {
-      checkM(chunksOfStrings) { s =>
+      checkM(chunksOfInts) { s =>
         for {
-          acc           <- Ref.make(List.empty[String])
+          acc           <- Ref.make(List.empty[Int])
           withoutEffect <- slurp(s).run
           tap           <- slurp(s.tap(a => acc.update(a :: _).unit)).run
           list          <- acc.get.run
@@ -329,7 +329,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       }
     ),
     testM("StreamChunk.fold") {
-      checkM(chunksOfStrings, intGen, Gen.function2(intGen)) { (s, zero, f) =>
+      checkM(chunksOfInts, intGen, Gen.function2(intGen)) { (s, zero, f) =>
         for {
           res1 <- s.fold(zero)(f)
           res2 <- slurp(s).map(_.foldLeft(zero)(f))
@@ -338,29 +338,29 @@ object StreamChunkSpec extends ZIOBaseSpec {
     },
     testM("StreamChunk.foldWhileM") {
       checkM(
-        chunksOfStrings,
+        chunksOfInts,
         intGen,
         toBoolFn[Random, Int],
         Gen.function2(intGen)
       ) { (s, zero, cont, f) =>
         for {
-          res1 <- s.foldWhileM[Any, Nothing, String, Int](zero)(cont)((acc, a) => IO.succeedNow(f(acc, a)))
+          res1 <- s.foldWhileM[Any, Nothing, Int, Int](zero)(cont)((acc, a) => IO.succeedNow(f(acc, a)))
           res2 <- slurp(s).map(l => foldLazyList(l.toList, zero)(cont)(f))
         } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.flattenChunks") {
-      checkM(chunksOfStrings) { s =>
+      checkM(chunksOfInts) { s =>
         for {
-          res1 <- s.flattenChunks.fold[String, List[String]](Nil)((acc, a) => a :: acc).map(_.reverse)
+          res1 <- s.flattenChunks.fold[Int, List[Int]](Nil)((acc, a) => a :: acc).map(_.reverse)
           res2 <- slurp(s)
         } yield assert(res1)(equalTo(res2))
       }
     },
     testM("StreamChunk.collect") {
       checkM(
-        pureStreamChunkGen(smallChunks(stringGen)),
-        Gen.partialFunction[Random with Sized, String, String](Gen.anyString)
+        pureStreamChunkGen(smallChunks(intGen)),
+        Gen.partialFunction[Random with Sized, Int, String](Gen.anyString)
       ) { (s, p) =>
         for {
           res1 <- slurp(s.collect(p))
@@ -371,7 +371,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
     testM("StreamChunk.collectWhile") {
       checkM(
         pureStreamChunkGen(smallChunks(intGen)),
-        Gen.partialFunction[Random with Sized, Int, String](stringGen)
+        Gen.partialFunction[Random with Sized, Int, Int](intGen)
       ) { (s, pf) =>
         for {
           res1 <- slurp(s.collectWhile(pf))

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
@@ -38,6 +38,5 @@ object StreamChunkUtils extends StreamChunkUtils with GenUtils {
     loop(list, zero)
   }
 
-  val chunksOfInts    = pureStreamChunkGen(smallChunks(intGen))
-  val chunksOfStrings = pureStreamChunkGen(smallChunks(stringGen))
+  val chunksOfInts = pureStreamChunkGen(smallChunks(intGen))
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -65,13 +65,11 @@ trait StreamUtils extends ChunkUtils with GenZIO {
 }
 
 object StreamUtils extends StreamUtils with GenUtils {
-  val streamOfBytes   = Gen.small(streamGen(Gen.anyByte, _))
-  val streamOfInts    = Gen.small(streamGen(intGen, _))
-  val streamOfStrings = Gen.small(streamGen(stringGen, _))
+  val streamOfBytes = Gen.small(streamGen(Gen.anyByte, _))
+  val streamOfInts  = Gen.small(streamGen(intGen, _))
 
   val listOfInts = Gen.listOf(intGen)
 
-  val pureStreamOfBytes   = Gen.small(pureStreamGen(Gen.anyByte, _))
-  val pureStreamOfInts    = Gen.small(pureStreamGen(intGen, _))
-  val pureStreamOfStrings = Gen.small(pureStreamGen(stringGen, _))
+  val pureStreamOfBytes = Gen.small(pureStreamGen(Gen.anyByte, _))
+  val pureStreamOfInts  = Gen.small(pureStreamGen(intGen, _))
 }

--- a/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
@@ -3,5 +3,5 @@ package zio.test
 import zio.duration._
 
 trait ZIOBaseSpec extends DefaultRunnableSpec {
-  override def aspects = List(TestAspect.timeout(600.seconds))
+  override def aspects = List(TestAspect.timeout(60.seconds))
 }


### PR DESCRIPTION
This PR removes the string generators in streams tests.

I noticed that on a heap dump, we are allocating too many `:: (List cons)` objects and many strings as well. Our string generators seem to cause a lot of heap churn for now and we should look into improving them.

@adamgfraser and I observed the behavior of this PR on CI several times, and even added the `timed` test aspect to measure the running time of the tests. The worst offenders are now in the 10% of the allowed timeout (6-7 seconds). We have concluded that this change will at least shorten our CI time and we can get by with our old test timeouts.