### PR TITLE
Remove .sbtopts as it overwrites .jvmopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,0 @@
--J-Xmx2G
--J-XX:MaxMetaspaceSize=1024m


### PR DESCRIPTION
https://discuss.lightbend.com/t/proposal-environment-variables-java-opts-sbt-opts-and-how-to-pass-jvm-arguments/5385

Removing .sbtopts allows the JVM to properly set the heap as in .jvmopts, which leaves headroom for the garbage collector to do its job. I'm seeing proper GC after repeated runs of all tests in ZIO.

@adamgfraser 

Before (after failing to run the tests for the second time):
<img width="1512" alt="Screen_Shot_2020-01-30_at_22 03 25" src="https://user-images.githubusercontent.com/7115459/73492400-e72ccf00-43b0-11ea-8ff4-2b4329efb452.png">

After (after successfully running the tests 3 times):
<img width="1552" alt="Screen Shot 2020-01-30 at 22 24 39" src="https://user-images.githubusercontent.com/7115459/73492461-04fa3400-43b1-11ea-94b6-d09ba1639ce2.png">
