### PR TITLE
ZIO Test: Implement Tagged Annotation

### DIFF
--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -48,7 +48,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
             specs
               .flatMap(ZIO.foreach(_)(traverse(_, suiteDesc, path :+ label.toString)))
               .ignore
-        case TestCase(label, _) =>
+        case TestCase(label, _, _) =>
           effectTotal(description.addChild(testDescription(label.toString, path)))
       }
 
@@ -105,7 +105,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Defa
       )
     def loop(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
       specCase match {
-        case TestCase(label, test) => TestCase(label, instrumentTest(label, path, test))
+        case TestCase(label, test, annotations) => TestCase(label, instrumentTest(label, path, test), annotations)
         case SuiteCase(label, specs, es) =>
           @silent("inferred to be `Any`")
           val instrumented =

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -25,9 +25,9 @@ object ZTestEvent {
     executedSpec.mapLabel(_.toString).fold[UIO[Seq[ZTestEvent]]] {
       case Spec.SuiteCase(_, results, _) =>
         results.flatMap(UIO.collectAll(_).map(_.flatten))
-      case zio.test.Spec.TestCase(label, result) =>
+      case Spec.TestCase(label, result, _) =>
         result.map { result =>
-          Seq(ZTestEvent(fullyQualifiedName, new TestSelector(label), toStatus(result._1), None, 0, fingerprint))
+          Seq(ZTestEvent(fullyQualifiedName, new TestSelector(label), toStatus(result), None, 0, fingerprint))
         }
     }
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -90,7 +90,7 @@ object ReportingTestUtils {
     )
   )
 
-  val test4 = Spec.test("Failing test", failed(Cause.fail("Fail")))
+  val test4 = Spec.test("Failing test", failed(Cause.fail("Fail")), TestAnnotationMap.empty)
   val test4Expected = Vector(
     expectedFailure("Failing test"),
     withOffset(2)("Fiber failed.\n") +

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -53,8 +53,8 @@ object SpecSpec extends ZIOBaseSpec {
         ).provideManagedShared(UIO(43).toManaged_)
         for {
           executedSpec <- execute(spec)
-          successes    <- executedSpec.countTests(_._1.isRight)
-          failures     <- executedSpec.countTests(_._1.isLeft)
+          successes    <- executedSpec.countTests(_.isRight)
+          failures     <- executedSpec.countTests(_.isLeft)
         } yield assert(successes)(equalTo(1)) && assert(failures)(equalTo(2))
       }
     ),

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -12,7 +12,7 @@ object TestUtils {
     execSpec: UIO[ExecutedSpec[E, L, S]]
   )(f: Either[TestFailure[E], TestSuccess[S]] => Boolean): ZIO[Any, Nothing, Boolean] =
     execSpec.flatMap { results =>
-      results.forall { case Spec.TestCase(_, test) => test.map(r => f(r._1)); case _ => ZIO.succeedNow(true) }
+      results.forall { case Spec.TestCase(_, test, _) => test.map(r => f(r)); case _ => ZIO.succeedNow(true) }
     }
 
   def isIgnored[E, L, S](spec: ZSpec[environment.TestEnvironment, E, L, S]): ZIO[Any, Nothing, Boolean] = {

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -51,13 +51,13 @@ object DefaultTestReporter {
           for {
             specs <- executedSpecs
             failures <- UIO.foreach(specs)(_.exists {
-                         case Spec.TestCase(_, test) => test.map(_._1.isLeft);
-                         case _                      => UIO.succeedNow(false)
+                         case Spec.TestCase(_, test, _) => test.map(_.isLeft);
+                         case _                         => UIO.succeedNow(false)
                        })
             annotations <- Spec(c).fold[UIO[TestAnnotationMap]] {
                             case Spec.SuiteCase(_, specs, _) =>
                               specs.flatMap(UIO.collectAll(_).map(_.foldLeft(TestAnnotationMap.empty)(_ ++ _)))
-                            case Spec.TestCase(_, test) => test.map(_._2)
+                            case Spec.TestCase(_, _, annotations) => UIO.succeedNow(annotations)
                           }
             hasFailures = failures.exists(identity)
             status      = if (hasFailures) Failed else Passed
@@ -68,36 +68,35 @@ object DefaultTestReporter {
             rest                <- UIO.foreach(specs)(loop(_, depth + tabSize, annotations :: ancestors)).map(_.flatten)
           } yield rendered(Suite, label, status, depth, (renderedLabel): _*)
             .withAnnotations(renderedAnnotations) +: rest
-        case Spec.TestCase(label, result) =>
-          result.flatMap {
-            case (result, annotations) =>
-              val renderedAnnotations = testAnnotationRenderer.run(ancestors, annotations)
-              val renderedResult = result match {
-                case Right(TestSuccess.Succeeded(_)) =>
-                  UIO.succeedNow(rendered(Test, label, Passed, depth, withOffset(depth)(green("+") + " " + label)))
-                case Right(TestSuccess.Ignored) =>
-                  UIO.succeedNow(rendered(Test, label, Ignored, depth))
-                case Left(TestFailure.Assertion(result)) =>
-                  result.run.flatMap(result =>
-                    result
-                      .fold(details =>
-                        renderFailure(label, depth, details)
-                          .map(failures => rendered(Test, label, Failed, depth, failures: _*))
-                      )(_.zipWith(_)(_ && _), _.zipWith(_)(_ || _), _.map(!_))
+        case Spec.TestCase(label, result, annotations) =>
+          result.flatMap { result =>
+            val renderedAnnotations = testAnnotationRenderer.run(ancestors, annotations)
+            val renderedResult = result match {
+              case Right(TestSuccess.Succeeded(_)) =>
+                UIO.succeedNow(rendered(Test, label, Passed, depth, withOffset(depth)(green("+") + " " + label)))
+              case Right(TestSuccess.Ignored) =>
+                UIO.succeedNow(rendered(Test, label, Ignored, depth))
+              case Left(TestFailure.Assertion(result)) =>
+                result.run.flatMap(result =>
+                  result
+                    .fold(details =>
+                      renderFailure(label, depth, details)
+                        .map(failures => rendered(Test, label, Failed, depth, failures: _*))
+                    )(_.zipWith(_)(_ && _), _.zipWith(_)(_ || _), _.map(!_))
+                )
+              case Left(TestFailure.Runtime(cause)) =>
+                renderCause(cause, depth).map { string =>
+                  rendered(
+                    Test,
+                    label,
+                    Failed,
+                    depth,
+                    (Seq(renderFailureLabel(label, depth)) ++ Seq(string)): _*
                   )
-                case Left(TestFailure.Runtime(cause)) =>
-                  renderCause(cause, depth).map { string =>
-                    rendered(
-                      Test,
-                      label,
-                      Failed,
-                      depth,
-                      (Seq(renderFailureLabel(label, depth)) ++ Seq(string)): _*
-                    )
 
-                  }
-              }
-              renderedResult.map(result => Seq(result.withAnnotations(renderedAnnotations)))
+                }
+            }
+            renderedResult.map(result => Seq(result.withAnnotations(renderedAnnotations)))
           }
       }
     loop(executedSpec, 0, List.empty)
@@ -122,11 +121,11 @@ object DefaultTestReporter {
           } yield stats.foldLeft((0, 0, 0)) {
             case ((x1, x2, x3), (y1, y2, y3)) => (x1 + y1, x2 + y2, x3 + y3)
           }
-        case Spec.TestCase(_, result) =>
+        case Spec.TestCase(_, result, _) =>
           result.map {
-            case (Left(_), _)                         => (0, 0, 1)
-            case (Right(TestSuccess.Succeeded(_)), _) => (1, 0, 0)
-            case (Right(TestSuccess.Ignored), _)      => (0, 1, 0)
+            case Left(_)                         => (0, 0, 1)
+            case Right(TestSuccess.Succeeded(_)) => (1, 0, 0)
+            case Right(TestSuccess.Ignored)      => (0, 1, 0)
           }
       }
     for {

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -32,7 +32,7 @@ trait RunnableSpec[R, E, L, T, S] extends AbstractRunnableSpec {
 
   private val runSpec: URIO[TestLogger with Clock, Int] = for {
     results     <- run
-    hasFailures <- results.exists { case TestCase(_, test) => test.map(_._1.isLeft); case _ => UIO.succeedNow(false) }
+    hasFailures <- results.exists { case TestCase(_, test, _) => test.map(_.isLeft); case _ => UIO.succeedNow(false) }
     summary     <- SummaryBuilder.buildSummary(results)
     _           <- TestLogger.logLine(summary.summary)
   } yield if (hasFailures) 1 else 0

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -62,6 +62,12 @@ object TestAnnotation {
     TestAnnotation("retried", 0, _ + _)
 
   /**
+   * An annotation which tags tests with strings.
+   */
+  val tagged: TestAnnotation[Set[String]] =
+    TestAnnotation("tagged", Set.empty, _ union _)
+
+  /**
    * An annotation for timing.
    */
   val timing: TestAnnotation[Duration] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,7 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   lazy val default: TestAnnotationRenderer =
-    CompositeRenderer(Vector(ignored, repeated, retried, timed))
+    CompositeRenderer(Vector(ignored, repeated, retried, tagged, timed))
 
   /**
    * A test annotation renderer that renders the number of ignored tests.
@@ -104,6 +104,16 @@ object TestAnnotationRenderer {
       case (child :: _) =>
         if (child == 0) None
         else Some(s"retried: $child")
+    }
+
+  /**
+   * A test annotation renderer that renders string tags.
+   */
+  val tagged: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.tagged) {
+      case (child :: _) =>
+        if (child.isEmpty) None
+        else Some(s"tagged: ${child.map("\"" + _ + "\"").mkString(", ")}")
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -1,16 +1,17 @@
 package zio.test
 
-final case class TestArgs(testSearchTerms: List[String])
+final case class TestArgs(testSearchTerms: List[String], tagSearchTerms: List[String])
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(List.empty[String])
+  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String])
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term) => ("testSearchTerm", term)
+        case Array("-t", term)    => ("testSearchTerm", term)
+        case Array("-tags", term) => ("tagSearchTerm", term)
       }
       .toList
       .groupBy(_._1)
@@ -19,6 +20,6 @@ object TestArgs {
           (k, v.map(_._2))
       }
 
-    TestArgs(parsedArgs.getOrElse("testSearchTerm", Nil))
+    TestArgs(parsedArgs.getOrElse("testSearchTerm", Nil), parsedArgs.getOrElse("tagSearchTerm", Nil))
   }
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -576,6 +576,12 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
+   * Annotates tests with string tags.
+   */
+  def tag(tags: String*): TestAspectAtLeastR[Annotations] =
+    before(Annotations.annotate(TestAnnotation.tagged, tags.toSet))
+
+  /**
    * Annotates tests with their execution times.
    */
   val timed: TestAspect[Nothing, Live with Annotations, Nothing, Any, Nothing, Any] =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -578,8 +578,8 @@ object TestAspect extends TimeoutVariants {
   /**
    * Annotates tests with string tags.
    */
-  def tag(tags: String*): TestAspectAtLeastR[Annotations] =
-    before(Annotations.annotate(TestAnnotation.tagged, tags.toSet))
+  def tag(tag: String, tags: String*): TestAspectAtLeastR[Annotations] =
+    before(Annotations.annotate(TestAnnotation.tagged, Set(tag) union tags.toSet))
 
   /**
    * Annotates tests with their execution times.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -579,7 +579,13 @@ object TestAspect extends TimeoutVariants {
    * Annotates tests with string tags.
    */
   def tag(tag: String, tags: String*): TestAspectAtLeastR[Annotations] =
-    before(Annotations.annotate(TestAnnotation.tagged, Set(tag) union tags.toSet))
+    new TestAspect[Nothing, Annotations, Nothing, Any, Nothing, Any] {
+      def some[R >: Nothing <: Annotations, E >: Nothing <: Any, S >: Nothing <: Any, L](
+        predicate: L => Boolean,
+        spec: ZSpec[R, E, L, S]
+      ): ZSpec[R, E, L, S] =
+        spec.annotate(TestAnnotation.tagged, Set(tag) union tags.toSet)
+    }
 
   /**
    * Annotates tests with their execution times.
@@ -640,8 +646,8 @@ object TestAspect extends TimeoutVariants {
     ): ZSpec[R, E, L, S] =
       spec.transform[R, TestFailure[E], L, TestSuccess[S]] {
         case c @ Spec.SuiteCase(_, _, _) => c
-        case Spec.TestCase(label, test) =>
-          Spec.TestCase(label, if (predicate(label)) perTest(test) else test)
+        case Spec.TestCase(label, test, annotations) =>
+          Spec.TestCase(label, if (predicate(label)) perTest(test) else test, annotations)
       }
   }
   object PerTest {

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -44,6 +44,15 @@ object TestExecutor {
             case (success, annotations) => ZIO.succeedNow((Right(success), annotations))
           }
         )
+        .flatMap(_.fold[UIO[ExecutedSpec[E, L, S]]] {
+          case Spec.SuiteCase(label, specs, exec) =>
+            UIO.succeedNow(Spec.suite(label, specs.flatMap(UIO.collectAll).map(_.toVector), exec))
+          case Spec.TestCase(label, test, annotations) =>
+            test.map {
+              case (result, annotations1) =>
+                Spec.test(label, UIO.succeedNow(result), annotations ++ annotations1)
+            }
+        })
     val environment = env
   }
 }

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -39,8 +39,8 @@ trait TimeoutVariants {
           spec.caseValue match {
             case Spec.SuiteCase(label, specs, exec) =>
               Spec.suite(label, specs.map(_.map(loop(label :: labels, _))), exec)
-            case Spec.TestCase(label, test) =>
-              Spec.test(label, warn(labels, label, test, duration))
+            case Spec.TestCase(label, test, annotations) =>
+              Spec.test(label, warn(labels, label, test, duration), annotations)
           }
 
         loop(Nil, spec)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -110,7 +110,7 @@ package object test extends CompileVariants {
   /**
    * An `ExecutedSpec` is a spec that has been run to produce test results.
    */
-  type ExecutedSpec[+E, +L, +S] = Spec[Any, Nothing, L, Annotated[ExecutedResult[E, S]]]
+  type ExecutedSpec[+E, +L, +S] = Spec[Any, Nothing, L, ExecutedResult[E, S]]
 
   /**
    * An `Annotated[A]` contains a value of type `A` along with zero or more
@@ -374,7 +374,8 @@ package object test extends CompileVariants {
               case None           => ZIO.succeedNow(TestSuccess.Succeeded(BoolAlgebra.unit))
               case Some(failures) => ZIO.failNow(TestFailure.Assertion(BoolAlgebraM(ZIO.succeedNow(failures))))
             })
-        )
+        ),
+      TestAnnotationMap.empty
     )
 
   /**


### PR DESCRIPTION
Allows tagging tests with string tags. Example output:

```
[info]   + monad laws - tagged: "laws", "monad"
[info]     + monad left identity - tagged: "laws", "monad"
[info]     + monad right identity - tagged: "laws", "monad"
[info]     + monad associativity - tagged: "laws", "monad"
```