### PR TITLE
Implement ZIO#once

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -877,48 +877,13 @@ object ZIOSpec extends ZIOBaseSpec {
       }
     ),
     suite("once")(
-      testM("returns an effect that returns the result of this effet a single time") {
+      testM("returns an effect that will only be executed once") {
         for {
           ref    <- Ref.make(0)
-          zio    <- ref.update(_ + 1).once(())
+          zio    <- ref.update(_ + 1).once
           _      <- ZIO.collectAllPar(ZIO.replicate(100)(zio))
           result <- ref.get
         } yield assert(result)(equalTo(1))
-      },
-      testM("returns the specified fallback value if the result has already been returned") {
-        for {
-          ref    <- Ref.make(0)
-          zio    <- ref.updateAndGet(_ + 2).once(1)
-          result <- ZIO.collectAllPar(ZIO.replicate(100)(zio)).map(_.sum)
-        } yield assert(result)(equalTo(101))
-      }
-    ),
-    suite("onceM")(
-      testM("returns the result of the specified fallback effect if the result has already been returned") {
-        for {
-          ref    <- Ref.make(0)
-          zio    <- ref.update(_ + 2).onceM(ref.update(_ + 1))
-          _      <- ZIO.collectAllPar(ZIO.replicate(100)(zio))
-          result <- ref.get
-        } yield assert(result)(equalTo(101))
-      },
-      testM("subsequent evaluations retry the effect if the effect fails with an error") {
-        for {
-          ref    <- Ref.make(0)
-          zio    <- (ref.update(_ + 1) *> ZIO.fail("fail")).onceM(ref.update(_ - 1))
-          _      <- ZIO.collectAll(ZIO.replicate(100)(zio.ignore))
-          result <- ref.get
-        } yield assert(result)(equalTo(100))
-      }
-    ),
-    suite("onceWithM")(
-      testM("uses the specified function to determine whether to retry this effect") {
-        for {
-          ref    <- Ref.make(0)
-          zio    <- (ref.update(_ + 1) *> ZIO.fail("fail")).onceWithM(ref.update(_ - 1))(_ => false)
-          _      <- ZIO.collectAll(ZIO.replicate(100)(zio.ignore))
-          result <- ref.get
-        } yield assert(result)(equalTo(-98))
       }
     ),
     suite("onExit")(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -876,6 +876,16 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(task.run)(fails(isSome(equalTo(ex))))
       }
     ),
+    suite("once")(
+      testM("returns an effect that will only be executed once") {
+        for {
+          ref    <- Ref.make(0)
+          zio    <- ref.update(_ + 1).once
+          _      <- ZIO.collectAllPar(ZIO.replicate(100)(zio))
+          result <- ref.get
+        } yield assert(result)(equalTo(1))
+      }
+    ),
     suite("onExit")(
       testM("executes that a cleanup function runs when effect succeeds") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -877,13 +877,48 @@ object ZIOSpec extends ZIOBaseSpec {
       }
     ),
     suite("once")(
-      testM("returns an effect that will only be executed once") {
+      testM("returns an effect that returns the result of this effet a single time") {
         for {
           ref    <- Ref.make(0)
-          zio    <- ref.update(_ + 1).once
+          zio    <- ref.update(_ + 1).once(())
           _      <- ZIO.collectAllPar(ZIO.replicate(100)(zio))
           result <- ref.get
         } yield assert(result)(equalTo(1))
+      },
+      testM("returns the specified fallback value if the result has already been returned") {
+        for {
+          ref    <- Ref.make(0)
+          zio    <- ref.updateAndGet(_ + 2).once(1)
+          result <- ZIO.collectAllPar(ZIO.replicate(100)(zio)).map(_.sum)
+        } yield assert(result)(equalTo(101))
+      }
+    ),
+    suite("onceM")(
+      testM("returns the result of the specified fallback effect if the result has already been returned") {
+        for {
+          ref    <- Ref.make(0)
+          zio    <- ref.update(_ + 2).onceM(ref.update(_ + 1))
+          _      <- ZIO.collectAllPar(ZIO.replicate(100)(zio))
+          result <- ref.get
+        } yield assert(result)(equalTo(101))
+      },
+      testM("subsequent evaluations retry the effect if the effect fails with an error") {
+        for {
+          ref    <- Ref.make(0)
+          zio    <- (ref.update(_ + 1) *> ZIO.fail("fail")).onceM(ref.update(_ - 1))
+          _      <- ZIO.collectAll(ZIO.replicate(100)(zio.ignore))
+          result <- ref.get
+        } yield assert(result)(equalTo(100))
+      }
+    ),
+    suite("onceWithM")(
+      testM("uses the specified function to determine whether to retry this effect") {
+        for {
+          ref    <- Ref.make(0)
+          zio    <- (ref.update(_ + 1) *> ZIO.fail("fail")).onceWithM(ref.update(_ - 1))(_ => false)
+          _      <- ZIO.collectAll(ZIO.replicate(100)(zio.ignore))
+          result <- ref.get
+        } yield assert(result)(equalTo(-98))
       }
     ),
     suite("onExit")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -776,6 +776,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self.lock(Executor.fromExecutionContext(Int.MaxValue)(ec))
 
   /**
+   * Returns an effect that will only be executed once, even if it is evalauted
+   * multiple times.
+   */
+  final def once: ZIO[Any, Nothing, ZIO[R, E, Unit]] =
+    Ref.make(true).map(ref => self.whenM(ref.getAndSet(false)))
+
+  /**
    * Runs the specified effect if this effect fails, providing the error to the
    * effect if it exists. The provided effect will not be interrupted.
    */

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -776,53 +776,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     self.lock(Executor.fromExecutionContext(Int.MaxValue)(ec))
 
   /**
-   * Returns an effect that, if evaluated, will return the result of this
-   * effect a single time. If the result of this effect has already been
-   * returned the specified fallback value will be returned. Uses the specified
-   * function to determine whether to retry this effect on subsequent
-   * evaluations if the effect fails with an error or is interrupted.
+   * Returns an effect that will be executed at most once, even if it is
+   * evaluated multiple times.
    */
-  final def once[A1 >: A](fallback: => A1): UIO[ZIO[R, E, A1]] =
-    onceWith(fallback)(_ => true)
-
-  /**
-   * Returns an effect that, if evaluated, will return the result of this
-   * effect a single time. If the result of this effect has already been
-   * returned the result of the specified fallback effect will be returned.
-   * If this effect fails with an error or is interrupted subsequent
-   * evaluations will retry the effect.
-   */
-  final def onceM[R1 <: R, E1 >: E, A1 >: A](fallback: ZIO[R1, E1, A1]): UIO[ZIO[R1, E1, A1]] =
-    onceWithM(fallback)(_ => true)
-
-  /**
-   * Returns an effect that, if evaluated, will return the result of this
-   * effect a single time. If the result of this effect has already been
-   * returned the specified fallback value will be returned. If this effect
-   * fails with an error or is interrupted subsequent evaluations will retry
-   * the effect.
-   */
-  final def onceWith[A1 >: A](fallback: => A1)(f: Cause[E] => Boolean): UIO[ZIO[R, E, A1]] =
-    onceWithM(ZIO.succeed(fallback))(f)
-
-  /**
-   * Returns an effect that, if evaluated, will return the result of this
-   * effect a single time. If the result of this effect has already been
-   * returned the result of the specified fallback effect will be returned.
-   * Uses the specified function to determine whether to retry this effect on
-   * subsequent evaluations if the effect fails with an error or is
-   * interrupted.
-   */
-  final def onceWithM[R1 <: R, E1 >: E, A1 >: A](
-    fallback: ZIO[R1, E1, A1]
-  )(f: Cause[E] => Boolean): UIO[ZIO[R1, E1, A1]] =
-    Ref.make(true).map { ref =>
-      ZIO
-        .bracketExit(ref.getAndSet(false))((_, exit: Exit[E, Option[A]]) =>
-          exit.fold(cause => ref.set(f(cause)), _ => ZIO.unit)
-        )(b => if (b) self.map(Some(_)) else ZIO.succeedNow(None))
-        .flatMap(_.fold(fallback)(ZIO.succeedNow))
-    }
+  final def once: UIO[ZIO[R, E, Unit]] =
+    Ref.make(true).map(ref => self.whenM(ref.getAndSet(false)))
 
   /**
    * Runs the specified effect if this effect fails, providing the error to the


### PR DESCRIPTION
Sometimes we want to know that an effect will only be evaluated a single time (e.g. a finalizer that could be subject to early release). `once` takes an effect and returns a new effect that will only be executed once, even if it is evaluated multiple times.