### PR TITLE
Implement ZSTM#tap

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -528,7 +528,21 @@ object ZSTMSpec extends ZIOBaseSpec {
         ans <- ZSTM.collectAll(List(tq.take, tq.take, tq.take))
       } yield ans
       assertM(tx.commit)(equalTo(List(1, 2, 3)))
-    }
+    },
+    suite("taps")(
+      testM("tap should apply the transactional function to the effect result while keeping the effect itself") {
+        val tx =
+          for {
+            refA <- TRef.make(10)
+            refB <- TRef.make(0)
+            _    <- refA.update(_ * 2)
+            a    <- refA.get.tap(v => refB.set(v + 1))
+            b    <- refB.get
+          } yield (a, b)
+
+        assertM(tx.commit)(equalTo((20, 21)))
+      }
+    )
   )
 
   trait STMEnv {

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -535,12 +535,11 @@ object ZSTMSpec extends ZIOBaseSpec {
           for {
             refA <- TRef.make(10)
             refB <- TRef.make(0)
-            _    <- refA.update(_ * 2)
             a    <- refA.get.tap(v => refB.set(v + 1))
             b    <- refB.get
           } yield (a, b)
 
-        assertM(tx.commit)(equalTo((20, 21)))
+        assertM(tx.commit)(equalTo((10, 11)))
       }
     )
   )

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -315,7 +315,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * "Peeks" at the success of transactional effect.
    */
   def tap[R1 <: R, E1 >: E](f: A => ZSTM[R1, E1, Any]): ZSTM[R1, E1, A] =
-    flatMap(f) *> self
+    flatMap(a => f(a).as(a))
 
   /**
    * Maps the success value of this effect to unit.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -312,6 +312,12 @@ final class ZSTM[-R, +E, +A] private[stm] (
     )
 
   /**
+   * "Peeks" at the success of transactional effect.
+   */
+  def tap[R1 <: R, E1 >: E](f: A => ZSTM[R1, E1, Any]): ZSTM[R1, E1, A] =
+    flatMap(f) *> self
+
+  /**
    * Maps the success value of this effect to unit.
    */
   def unit: ZSTM[R, E, Unit] = as(())


### PR DESCRIPTION
`tapError` and `tapBoth` to follow in subsequent PRs.