### PR TITLE
Implement ifM for Other Effect Types

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -416,6 +416,28 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(result)(equalTo(List("Closed")))
       }
     ),
+    suite("ifM")(
+      testM("runs `onTrue` if result of `b` is `true`") {
+        val managed = ZManaged.ifM(ZManaged.succeedNow(true))(ZManaged.succeedNow(true), ZManaged.succeedNow(false))
+        assertM(managed.use(ZIO.succeedNow))(isTrue)
+      },
+      testM("runs `onFalse` if result of `b` is `false`") {
+        val managed = ZManaged.ifM(ZManaged.succeedNow(false))(ZManaged.succeedNow(true), ZManaged.succeedNow(false))
+        assertM(managed.use(ZIO.succeedNow))(isFalse)
+      },
+      testM("infers correctly") {
+        trait R
+        trait R1 extends R
+        trait E1
+        trait E extends E1
+        trait A
+        val b: ZManaged[R, E, Boolean]   = ZManaged.succeedNow(true)
+        val onTrue: ZManaged[R1, E1, A]  = ZManaged.succeedNow(new A {})
+        val onFalse: ZManaged[R1, E1, A] = ZManaged.succeedNow(new A {})
+        val _                            = ZManaged.ifM(b)(onTrue, onFalse)
+        ZIO.succeed(assertCompletes)
+      }
+    ),
     suite("mergeAll")(
       testM("Merges elements in the correct order") {
         def res(int: Int) =

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -413,6 +413,12 @@ object IO {
   def identity: IO[Nothing, Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifM]]
+   */
+  def ifM[E](b: IO[E, Boolean]): ZIO.IfM[Any, E] =
+    new ZIO.IfM(b)
+
+  /**
    * @see See See [[zio.ZIO.interrupt]]
    */
   val interrupt: UIO[Nothing] = ZIO.interrupt

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -151,6 +151,12 @@ object Managed {
     ZManaged.halt(cause)
 
   /**
+   * See [[zio.ZManaged.ifM]]
+   */
+  def ifM[E](b: Managed[E, Boolean]): ZManaged.IfM[Any, E] =
+    new ZManaged.IfM(b)
+
+  /**
    * See [[zio.ZManaged.interrupt]]
    */
   val interrupt: Managed[Nothing, Nothing] = ZManaged.interrupt

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -405,7 +405,13 @@ object RIO {
   /**
    * @see See [[zio.ZIO.identity]]
    */
-  def identity[R]: RIO[Nothing, R] = ZIO.identity
+  def identity[R]: RIO[R, R] = ZIO.identity
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
+  def ifM[R](b: RIO[R, Boolean]): ZIO.IfM[R, Throwable] =
+    new ZIO.IfM(b)
 
   /**
    * @see See [[zio.ZIO.interrupt]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -408,6 +408,12 @@ object Task {
   def identity: Task[Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifM]]
+   */
+  def ifM(b: Task[Boolean]): ZIO.IfM[Any, Throwable] =
+    new ZIO.IfM(b)
+
+  /**
    * @see See [[zio.ZIO.interrupt]]
    */
   val interrupt: UIO[Nothing] = ZIO.interrupt

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -325,6 +325,12 @@ object UIO {
   def identity: UIO[Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifM]]
+   */
+  def ifM(b: UIO[Boolean]): ZIO.IfM[Any, Nothing] =
+    new ZIO.IfM(b)
+
+  /**
    * @see See [[zio.ZIO.interrupt]]
    */
   val interrupt: UIO[Nothing] = ZIO.interrupt

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -354,6 +354,12 @@ object URIO {
   def identity[R]: URIO[R, R] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifM]]
+   */
+  def ifM[R](b: URIO[R, Boolean]): ZIO.IfM[R, Nothing] =
+    new ZIO.IfM(b)
+
+  /**
    * @see [[zio.ZIO.interrupt]]
    */
   val interrupt: UIO[Nothing] = ZIO.interrupt

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1038,6 +1038,11 @@ object ZManaged {
       ZManaged.environment.flatMap(f)
   }
 
+  final class IfM[R, E](private val b: ZManaged[R, E, Boolean]) extends AnyVal {
+    def apply[R1 <: R, E1 >: E, A](onTrue: ZManaged[R1, E1, A], onFalse: ZManaged[R1, E1, A]): ZManaged[R1, E1, A] =
+      b.flatMap(b => if (b) onTrue else onFalse)
+  }
+
   trait PreallocationScope {
     def apply[R, E, A](managed: ZManaged[R, E, A]): ZIO[R, E, Managed[Nothing, A]]
   }
@@ -1334,6 +1339,12 @@ object ZManaged {
    * Returns the identity effectful function, which performs no effects
    */
   def identity[R]: ZManaged[R, Nothing, R] = fromFunction(scala.Predef.identity)
+
+  /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
+  def ifM[R, E](b: ZManaged[R, E, Boolean]): ZManaged.IfM[R, E] =
+    new ZManaged.IfM(b)
 
   /**
    * Returns an effect that is interrupted as if by the fiber calling this

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -107,6 +107,12 @@ object STM {
     ZSTM.fromTry(a)
 
   /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
+  def ifM[E](b: STM[E, Boolean]): ZSTM.IfM[Any, E] =
+    new ZSTM.IfM(b)
+
+  /**
    * Creates an `STM` value from a partial (but pure) function.
    */
   def partial[A](a: => A): STM[Throwable, A] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -425,6 +425,11 @@ object ZSTM {
       ZSTM.environment.flatMap(f)
   }
 
+  final class IfM[R, E](private val b: ZSTM[R, E, Boolean]) {
+    def apply[R1 <: R, E1 >: E, A](onTrue: ZSTM[R1, E1, A], onFalse: ZSTM[R1, E1, A]): ZSTM[R1, E1, A] =
+      b.flatMap(b => if (b) onTrue else onFalse)
+  }
+
   private final class Resumable[E, E1, A, B](
     val stm: STM[E, A],
     val ks: Stack[internal.TExit[E, A] => STM[E1, B]]
@@ -931,6 +936,12 @@ object ZSTM {
         case Success(a) => STM.succeedNow(a)
       }
     }
+
+  /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
+  def ifM[R, E](b: ZSTM[R, E, Boolean]): ZSTM.IfM[R, E] =
+    new ZSTM.IfM(b)
 
   /**
    * Creates an `STM` value from a partial (but pure) function.


### PR DESCRIPTION
People seemed to like `ifM`, so implements it for managed and STM and various type alias companion objects.