### PR TITLE
Implement orElse Variants

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1042,6 +1042,24 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(orElse)(equalTo(true))
       }
     ),
+    suite("orElseFail")(
+      testM("executes this effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        assertM(ZIO.succeedNow(true).orElseFail(false))(isTrue)
+      },
+      testM("otherwise fails with the specified error") {
+        assertM(ZIO.failNow(false).orElseFail(true).flip)(isTrue)
+      }
+    ),
+    suite("orElseSucceed")(
+      testM("executes this effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        assertM(ZIO.succeedNow(true).orElseSucceed(false))(isTrue)
+      },
+      testM("otherwise succeeds with the specified value") {
+        assertM(ZIO.failNow(false).orElseSucceed(true))(isTrue)
+      }
+    ),
     suite("parallelErrors")(
       testM("oneFailure") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -551,6 +551,28 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(finalizers)(equalTo(List("First", "Second"))) && assert(result)(isSome(succeeds(equalTo("42"))))
       }
     ),
+    suite("orElseFail")(
+      testM("executes this effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        val managed = ZManaged.succeedNow(true).orElseFail(false)
+        assertM(managed.use(ZIO.succeedNow))(isTrue)
+      },
+      testM("otherwise fails with the specified error") {
+        val managed = ZManaged.failNow(false).orElseFail(true).flip
+        assertM(managed.use(ZIO.succeedNow))(isTrue)
+      }
+    ),
+    suite("orElseSucceed")(
+      testM("executes this effect and returns its value if it succeeds") {
+        import zio.CanFail.canFail
+        val managed = ZManaged.succeedNow(true).orElseSucceed(false)
+        assertM(managed.use(ZIO.succeedNow))(isTrue)
+      },
+      testM("otherwise succeeds with the specified value") {
+        val managed = ZManaged.failNow(false).orElseSucceed(true)
+        assertM(managed.use(ZIO.succeedNow))(isTrue)
+      }
+    ),
     suite("preallocate")(
       testM("runs finalizer on interruption") {
         for {

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -437,6 +437,28 @@ object ZSTMSpec extends ZIOBaseSpec {
         } yield assert(result)(equalTo(2 -> 2))
       }
     ),
+    suite("orElseFail")(
+      testM("tries this effect first") {
+        import zio.CanFail.canFail
+        val transaction = ZSTM.succeedNow(true).orElseFail(false)
+        assertM(transaction.commit)(isTrue)
+      },
+      testM("if it fails, fails with the specified error") {
+        val transaction = ZSTM.failNow(false).orElseFail(true).fold(identity, _ => false)
+        assertM(transaction.commit)(isTrue)
+      }
+    ),
+    suite("orElseSucceed")(
+      testM("tries this effect first") {
+        import zio.CanFail.canFail
+        val transaction = ZSTM.succeedNow(true).orElseSucceed(false)
+        assertM(transaction.commit)(isTrue)
+      },
+      testM("if it succeeds, succeeds with the specified value") {
+        val transaction = ZSTM.failNow(false).orElseSucceed(true)
+        assertM(transaction.commit)(isTrue)
+      }
+    ),
     suite("when combinators")(
       testM("when true") {
         for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -880,6 +880,20 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     tryOrElse(that.map(Right(_)), ZIO.succeedLeft)
 
   /**
+   * Executes this effect and returns its value, if it succeeds, but
+   * otherwise fails with the specified error.
+   */
+  final def orElseFail[E1](e1: => E1)(implicit ev: CanFail[E]): ZIO[R, E1, A] =
+    orElse(ZIO.failNow(e1))
+
+  /**
+   * Executes this effect and returns its value, if it succeeds, but
+   * otherwise suceeds with the specified value.
+   */
+  final def orElseSucceed[A1 >: A](a1: => A1)(implicit ev: CanFail[E]): URIO[R, A1] =
+    orElse(ZIO.succeedNow(a1))
+
+  /**
    * Exposes all parallel errors in a single call
    *
    */

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -578,6 +578,20 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     foldM(_ => that.map(Right[A, B]), a => ZManaged.succeedNow(Left[A, B](a)))
 
   /**
+   * Executes this effect and returns its value, if it succeeds, but
+   * otherwise fails with the specified error.
+   */
+  final def orElseFail[E1](e1: => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
+    orElse(ZManaged.failNow(e1))
+
+  /**
+   * Executes this effect and returns its value, if it succeeds, but
+   * otherwise suceeds with the specified value.
+   */
+  final def orElseSucceed[A1 >: A](a1: => A1)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A1] =
+    orElse(ZManaged.succeedNow(a1))
+
+  /**
    * Preallocates the managed resource, resulting in a ZManaged that reserves and acquires immediately and cannot fail.
    * You should take care that you are not interrupted between running preallocate and actually acquiring the resource
    * as you might leak otherwise.


### PR DESCRIPTION
Resolves #2787. I think we can make the type signatures slightly more specific than originally specified, if I am understanding the semantics correctly. `orElseFail` will always replace the original failure with the new one, so `E1` does not have to be a super type of `E`. `orElseFail` will always replace the original failure with a success so the resulting effect cannot fail.