### PR TITLE
Implement ZIO#provideSomeLayer

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1152,6 +1152,15 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
+    suite("provideSomeLayer")(
+      testM("can split environment into two parts") {
+        lazy val clockLayer: ZLayer[Any, Nothing, Clock]    = ???
+        lazy val zio: ZIO[Clock with Random, Nothing, Unit] = ???
+        lazy val zio2: ZIO[Random, Nothing, Unit]           = zio.provideSomeLayer[Random](clockLayer)
+        lazy val _                                          = zio2
+        ZIO.succeed(assertCompletes)
+      }
+    ),
     suite("raceAll")(
       testM("returns first success") {
         assertM(ZIO.failNow("Fail").raceAll(List(IO.succeedNow(24))))(equalTo(24))

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1154,11 +1154,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("provideSomeLayer")(
       testM("can split environment into two parts") {
-        lazy val clockLayer: ZLayer[Any, Nothing, Clock]    = ???
-        lazy val zio: ZIO[Clock with Random, Nothing, Unit] = ???
-        lazy val zio2: ZIO[Random, Nothing, Unit]           = zio.provideSomeLayer[Random](clockLayer)
-        lazy val _                                          = zio2
-        ZIO.succeed(assertCompletes)
+        val clockLayer: ZLayer[Any, Nothing, Clock]    = Scheduler.live >>> Clock.live
+        val zio: ZIO[Clock with Random, Nothing, Unit] = ZIO.unit
+        val zio2: ZIO[Random, Nothing, Unit]           = zio.provideSomeLayer[Random](clockLayer)
+        assertM(zio2)(anything)
       }
     ),
     suite("raceAll")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3289,7 +3289,7 @@ object ZIO {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): ZIO[R0, E1, A] =
-      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+      self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
   implicit final class ZIOWithFilterOps[R, E, A](private val self: ZIO[R, E, A]) extends AnyVal {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -952,6 +952,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): ZIO[R0, E, A] =
     ZIO.accessM(r0 => self.provide(f(r0)))
 
+  final def provideSomeLayer[R0 <: Has[_]]: ZIO.ProvideSomeLayer[R0, R, E, A] =
+    new ZIO.ProvideSomeLayer[R0, R, E, A](self)
+
   /**
    * An effectful version of `provideSome`, useful when the act of partial
    * provision requires an effect.
@@ -3230,6 +3233,11 @@ object ZIO {
   final class IfM[R, E](private val b: ZIO[R, E, Boolean]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, A](onTrue: ZIO[R1, E1, A], onFalse: ZIO[R1, E1, A]): ZIO[R1, E1, A] =
       b.flatMap(b => if (b) onTrue else onFalse)
+  }
+
+  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](layer: ZLayer[R0, E1, R1])(implicit ev: R0 with R1 <:< R, tagged: Tagged[R0]): ZIO[R0, E1, A] =
+      self.provideSome[R0 with R1](ev).provideLayer(layer ++ ZLayer.identity[R0])
   }
 
   final class TimeoutTo[R, E, A, B](self: ZIO[R, E, A], b: B) {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3202,6 +3202,13 @@ object ZIO {
       zio.provideSome[R2](r2 => r2.add(r1))
   }
 
+  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: ZLayer[R0, E1, R1]
+    )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R0]): ZIO[R0, E1, A] =
+      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](layer ++ ZLayer.identity[R0])
+  }
+
   implicit final class ZIOWithFilterOps[R, E, A](private val self: ZIO[R, E, A]) extends AnyVal {
 
     /**
@@ -3233,13 +3240,6 @@ object ZIO {
   final class IfM[R, E](private val b: ZIO[R, E, Boolean]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, A](onTrue: ZIO[R1, E1, A], onFalse: ZIO[R1, E1, A]): ZIO[R1, E1, A] =
       b.flatMap(b => if (b) onTrue else onFalse)
-  }
-
-  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
-    def apply[E1 >: E, R1 <: Has[_]](
-      layer: ZLayer[R0, E1, R1]
-    )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R0]): ZIO[R0, E1, A] =
-      self.provideSome[R0 with R1](ev).provideLayer(layer ++ ZLayer.identity[R0])
   }
 
   final class TimeoutTo[R, E, A, B](self: ZIO[R, E, A], b: B) {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3236,7 +3236,9 @@ object ZIO {
   }
 
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
-    def apply[E1 >: E, R1 <: Has[_]](layer: ZLayer[R0, E1, R1])(implicit ev: R0 with R1 <:< R, tagged: Tagged[R0]): ZIO[R0, E1, A] =
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: ZLayer[R0, E1, R1]
+    )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R0]): ZIO[R0, E1, A] =
       self.provideSome[R0 with R1](ev).provideLayer(layer ++ ZLayer.identity[R0])
   }
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1092,7 +1092,7 @@ object ZManaged {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): ZManaged[R0, E1, A] =
-      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+      self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
   trait Scope {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3555,7 +3555,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): ZStream[R0, E1, A] =
-      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+      self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
   private[zio] def dieNow(ex: Throwable): Stream[Nothing, Nothing] =

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -560,13 +560,13 @@ object Spec {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): Spec[R0, E1, T] =
-      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+      self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
   final class ProvideSomeLayerShared[R0 <: Has[_], -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): Spec[R0, E1, T] =
-      self.provideSomeShared[R0 with R1](ev).provideLayerShared[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+      self.provideLayerShared[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 }

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -358,6 +358,37 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
     provideSomeM(ZIO.fromFunction(f))
 
   /**
+   * Splits the environment into two parts, providing each test with one part
+   * using the specified layer and leaving the remainder `R0`.
+   *
+   * {{{
+   * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
+   *
+   * val spec: ZSpec[Clock with Random, Nothing] = ???
+   *
+   * val spec2 = spec.provideSomeLayer[Random](clockLayer)
+   * }}}
+   */
+  final def provideSomeLayer[R0 <: Has[_]]: Spec.ProvideSomeLayer[R0, R, E, T] =
+    new Spec.ProvideSomeLayer[R0, R, E, T](self)
+
+  /**
+   * Splits the environment into two parts, providing all tests with a shared
+   * version of one part using the specified layer and leaving the remainder
+   * `R0`.
+   *
+   * {{{
+   * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
+   *
+   * val spec: ZIO[Clock with Random, Nothing, Unit] = ???
+   *
+   * val zio2 = zio.provideSomeLayer[Random](clockLayer)
+   * }}}
+   */
+  final def provideSomeLayerShared[R0 <: Has[_]]: Spec.ProvideSomeLayerShared[R0, R, E, T] =
+    new Spec.ProvideSomeLayerShared[R0, R, E, T](self)
+
+  /**
    * Uses the specified effect to provide each test in this spec with part of
    * its required environment.
    */
@@ -524,4 +555,18 @@ object Spec {
 
   final def test[R, E, T](label: String, test: ZIO[R, E, T], annotations: TestAnnotationMap): Spec[R, E, T] =
     Spec(TestCase(label, test, annotations))
+
+  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: ZLayer[R0, E1, R1]
+    )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): Spec[R0, E1, T] =
+      self.provideSome[R0 with R1](ev).provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+  }
+
+  final class ProvideSomeLayerShared[R0 <: Has[_], -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: ZLayer[R0, E1, R1]
+    )(implicit ev: R0 with R1 <:< R, tagged: Tagged[R1]): Spec[R0, E1, T] =
+      self.provideSomeShared[R0 with R1](ev).provideLayerShared[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+  }
 }


### PR DESCRIPTION
Initial work to resolve #2794. Right now we need evidence that the remaining environment type `R0` is a subtype of `Has[_]` and that there is a type tag available for `R0`. Not sure if we can get rid of the type tag requirement, though it still seems to work okay. Needs documentation, tests, and implementation for other effect types.