### PR TITLE
ZIO Test: Implement TestAspect#verify

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -232,6 +232,16 @@ object TestAspectSpec extends ZIOBaseSpec {
         } @@ timeout(10.milliseconds, 1.nanosecond) @@ failure(diesWith(equalTo(interruptionTimeoutFailure)))
         result <- isSuccess(spec.provideLayer(liveClock))
       } yield assert(result)(isTrue)
+    },
+    testM("verify verifies the specified post-condition after each test is run") {
+      for {
+        ref <- Ref.make(false)
+        spec = suite("verify")(
+          testM("first test")(ZIO.succeedNow(assertCompletes)),
+          testM("second test")(ref.set(true).as(assertCompletes))
+        ) @@ sequential @@ verify(assertM(ref.get)(isTrue))
+        result <- isSuccess(spec)
+      } yield assert(result)(isFalse)
     }
   )
 

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -593,6 +593,15 @@ object TestAspect extends TimeoutVariants {
       }
     }
 
+  /**
+   * Verifies the specified post-condition after each test is run.
+   */
+  def verify[R0, E0](condition: => ZIO[R0, E0, TestResult]): TestAspect[Nothing, R0, E0, Any] =
+    new TestAspect.PerTest[Nothing, R0, E0, Any] {
+      def perTest[R <: R0, E >: E0](test: ZIO[R, TestFailure[E], TestSuccess]): ZIO[R, TestFailure[E], TestSuccess] =
+        test <* ZTest(condition)
+    }
+
   trait PerTest[+LowerR, -UpperR, +LowerE, -UpperE] extends TestAspect[LowerR, UpperR, LowerE, UpperE] {
 
     def perTest[R >: LowerR <: UpperR, E >: LowerE <: UpperE](


### PR DESCRIPTION
Resolves #2792.

The each variant of `verify` is implemented for now. There is some ambiguity of what we should do if both the test and the post-condition fail. Right now if the test fails we just fail immediately and don't evaluate the post condition. If the test passes we then evaluate the post-condition and fail the test if the post-condition fails.

The more serious issue I ran into is with the all variant. To implement this we want to implement a combinator like:

```scala
trait Spec[-R, +E, +T] {
  // Models running all the tests in this spec
  final def collectAll: URIO[R, Spec[Any, E, T]] =
    caseValue match {
      case Spec.SuiteCase(label, specs, exec) =>
        specs.foldCauseM(
          c => ZIO.succeedNow(Spec.suite(label, ZIO.halt(c), exec)),
          ZIO.foreach(_)(_.collectAll).map(_.toVector).map(specs => Spec.suite(label, ZIO.succeedNow(specs), exec))
        )
      case Spec.TestCase(label, test, annotations) =>
        test.run.map(exit => Spec.test(label, ZIO.done(exit), annotations))
    }
}
```

That way we could call `collectAll` on the spec, then evaluate the post-condition, and then if necessary fail the tests in the spec. However, this violates the sandboxing of resources we're trying to achieve. We now have a spec that depends on one `R` instead of each test and suite depending on its own `R`. I'm not sure how we model this with our current representation of specs.