### PR TITLE
ZIO Core: Improve Ergonomics of ZIO#summarized

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -4,8 +4,6 @@ import scala.annotation.tailrec
 import scala.util.{ Failure, Success }
 
 import zio.Cause._
-import zio.Cause._
-import zio.LatchOps._
 import zio.LatchOps._
 import zio.clock.Clock
 import zio.duration._
@@ -2631,7 +2629,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           counter   <- Ref.make(0)
           increment = counter.updateAndGet(_ + 1)
-          result    <- increment.summarized((a: Int, b: Int) => (a, b))(increment)
+          result    <- increment.summarized(increment)((_, _))
         } yield {
           val ((start, end), value) = result
           assert(start)(equalTo(1)) &&

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1396,7 +1396,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * then combining the values to produce a summary, together with the result of
    * execution.
    */
-  final def summarized[R1 <: R, E1 >: E, B, C](f: (B, B) => C)(summary: ZIO[R1, E1, B]): ZIO[R1, E1, (C, A)] =
+  final def summarized[R1 <: R, E1 >: E, B, C](summary: ZIO[R1, E1, B])(f: (B, B) => C): ZIO[R1, E1, (C, A)] =
     for {
       start <- summary
       value <- self
@@ -1458,7 +1458,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * A more powerful variation of `timed` that allows specifying the clock.
    */
   final def timedWith[R1 <: R, E1 >: E](nanoTime: ZIO[R1, E1, Long]): ZIO[R1, E1, (Duration, A)] =
-    summarized[R1, E1, Long, Duration]((start, end) => Duration.fromNanos(end - start))(nanoTime)
+    summarized(nanoTime)((start, end) => Duration.fromNanos(end - start))
 
   /**
    * Returns an effect that will timeout this effect, returning `None` if the


### PR DESCRIPTION
Working with ZIO#summarized is kind of annoying right now. Because the `B` parameter comes first and is in input position it can't be inferred, so we either have to specify all four type parameters of `summarized` or annotate the types of the inputs to `f`, which often otherwise could be very concise. By switching the order of the arguments we get the `B` type inferred from the result type of `summary`. I think this is also more logical conceptually, as first we are specifying the summary effect we want to use, and then we specify how we want to combine its values.

```scala
final def summarized[R1 <: R, E1 >: E, B, C](f: (B, B) => C)(summary: ZIO[R1, E1, B]): ZIO[R1, E1, (C, A)]
```