### PR TITLE
Implement ZSTM#commitEither

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -405,6 +405,15 @@ object ZSTMSpec extends ZIOBaseSpec {
         } yield assert(e)(equalTo(())) && assert(v)(equalTo(0))
       }
     ),
+    suite("commitEither")(
+      testM("commits this transaction whether it is a success or a failure") {
+        for {
+          tvar <- TRef.makeCommit(false)
+          e    <- (tvar.set(true) *> STM.failNow("Error!")).commitEither.flip
+          v    <- tvar.get.commit
+        } yield assert(e)(equalTo("Error!")) && assert(v)(isTrue)
+      }
+    ),
     suite("orElse must")(
       testM("rollback left retry") {
         import zio.CanFail.canFail

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -137,6 +137,13 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def commit: ZIO[R, E, A] = ZSTM.atomically(self)
 
   /**
+   * Commits this transaction atomically, regardless of whether the transaction
+   * is a success or a failure.
+   */
+  def commitEither: ZIO[R, E, A] =
+    either.commit.absolve
+
+  /**
    * Converts the failure channel into an `Either`.
    */
   def either(implicit ev: CanFail[E]): ZSTM[R, Nothing, Either[E, A]] =


### PR DESCRIPTION
To some of the recent discussions we have been having about errors in an STM transaction rolling it back, we can let the user control that by committing despite the error and handling the failure at the ZIO level.