### PR TITLE
Add retryUntil and retryWhile to ZSTM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -158,7 +158,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         ) {
           for {
             tvar <- TRef.makeCommit(42)
-            join <- tvar.get.filter(_ == 42).commit
+            join <- tvar.get.retryUntil(_ == 42).commit
             _    <- tvar.set(9).commit
             v    <- tvar.get.commit
           } yield assert(v)(equalTo(9)) && assert(join)(equalTo(42))
@@ -194,7 +194,7 @@ object ZSTMSpec extends ZIOBaseSpec {
               receiver  <- TRef.makeCommit(0)
               _         <- transfer(receiver, sender, 150).fork
               _         <- sender.update(_ + 100).commit
-              _         <- sender.get.filter(_ == 50).commit
+              _         <- sender.get.retryUntil(_ == 50).commit
               senderV   <- sender.get.commit
               receiverV <- receiver.get.commit
             } yield assert(senderV)(equalTo(50)) && assert(receiverV)(equalTo(150))

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -171,24 +171,6 @@ final class ZSTM[-R, +E, +A] private[stm] (
     fold(_ => a, identity)
 
   /**
-   * Filters the value produced by this effect, retrying the transaction until
-   * the predicate returns true for the value.
-   */
-  def retryUntil(f: A => Boolean): ZSTM[R, E, A] =
-    collect {
-      case a if f(a) => a
-    }
-
-  /**
-   * Filters the value produced by this effect, retrying the transaction while
-   * the predicate returns true for the value.
-   */
-  def retryWhile(f: A => Boolean): ZSTM[R, E, A] =
-    collect {
-      case a if !f(a) => a
-    }
-
-  /**
    * Feeds the value produced by this effect to the specified function,
    * and then runs the returned effect as well to produce its results.
    */
@@ -353,6 +335,24 @@ final class ZSTM[-R, +E, +A] private[stm] (
         }
       }
     )
+
+  /**
+   * Filters the value produced by this effect, retrying the transaction until
+   * the predicate returns true for the value.
+   */
+  def retryUntil(f: A => Boolean): ZSTM[R, E, A] =
+    collect {
+      case a if f(a) => a
+    }
+
+  /**
+   * Filters the value produced by this effect, retrying the transaction while
+   * the predicate returns true for the value.
+   */
+  def retryWhile(f: A => Boolean): ZSTM[R, E, A] =
+    collect {
+      case a if !f(a) => a
+    }
 
   /**
    * "Peeks" at the success of transactional effect.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -174,15 +174,6 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Filters the value produced by this effect, retrying the transaction until
    * the predicate returns true for the value.
    */
-  def filter(f: A => Boolean): ZSTM[R, E, A] =
-    collect {
-      case a if f(a) => a
-    }
-
-  /**
-   * Filters the value produced by this effect, retrying the transaction until
-   * the predicate returns true for the value.
-   */
   def retryUntil(f: A => Boolean): ZSTM[R, E, A] =
     collect {
       case a if f(a) => a
@@ -373,11 +364,6 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Maps the success value of this effect to unit.
    */
   def unit: ZSTM[R, E, Unit] = as(())
-
-  /**
-   * Same as [[filter]]
-   */
-  def withFilter(f: A => Boolean): ZSTM[R, E, A] = filter(f)
 
   /**
    * The moral equivalent of `if (p) exp`

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -376,6 +376,11 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def whenM[R1 <: R, E1 >: E](b: ZSTM[R1, E1, Boolean]): ZSTM[R1, E1, Unit] = ZSTM.whenM(b)(self)
 
   /**
+   * Same as [[retryUntil]].
+   */
+  def withFilter(f: A => Boolean): ZSTM[R, E, A] = retryUntil(f)
+
+  /**
    * Named alias for `<*>`.
    */
   def zip[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, (A, B)] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -180,6 +180,24 @@ final class ZSTM[-R, +E, +A] private[stm] (
     }
 
   /**
+   * Filters the value produced by this effect, retrying the transaction until
+   * the predicate returns true for the value.
+   */
+  def retryUntil(f: A => Boolean): ZSTM[R, E, A] =
+    collect {
+      case a if f(a) => a
+    }
+
+  /**
+   * Filters the value produced by this effect, retrying the transaction while
+   * the predicate returns true for the value.
+   */
+  def retryWhile(f: A => Boolean): ZSTM[R, E, A] =
+    collect {
+      case a if !f(a) => a
+    }
+
+  /**
    * Feeds the value produced by this effect to the specified function,
    * and then runs the returned effect as well to produce its results.
    */


### PR DESCRIPTION
The reason for adding these 2 combinators is misleading semantics of `filter` and `withFilter` in the current implementation as discussed [here](https://github.com/zio/zio/issues/2802).

### Summary

- `filter` has been renamed to `retryUntil`.
- `withFilter` is dropped.
- `retryWhile` has been added.