### PR TITLE
ZIO Core: Delete ZIO#provideOne

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3276,16 +3276,6 @@ object ZIO {
       self.refineOrDie { case e: E1 => e }
   }
 
-  /**
-   * TODO: Document and pull out to top-level.
-   */
-  def provideOne[R1](r1: R1): ProvideOne[R1] = new ProvideOne[R1](r1)
-
-  class ProvideOne[R1](r1: R1) {
-    def apply[R2 <: Has[_], E, A](zio: ZIO[Has[R1] with R2, E, A])(implicit R1: Tagged[R1]): ZIO[R2, E, A] =
-      zio.provideSome[R2](r2 => r2.add(r1))
-  }
-
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]


### PR DESCRIPTION
This was a method from a previous iteration of the new environment encoding that is not documented and not used anywhere. Its functionality is subsumed by the new `provideSomeLayer`.