### PR TITLE
Add onLeft and onRight to ZSTM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -183,6 +183,22 @@ object ZSTMSpec extends ZIOBaseSpec {
       testM("`mapError` to map from one error to another") {
         assertM(STM.failNow(-1).mapError(_ => "oh no!").commit.run)(fails(equalTo("oh no!")))
       },
+      suite("`onLeft`")(
+        testM("returns result when environment is on the left") {
+          val tx = ZSTM.access[String](_.length)
+            .onLeft[String, Int]
+            .provide(Left("test"))
+
+          assertM(tx.commit)(isLeft(equalTo(4)))
+        },
+        testM("returns whatever is provided on the right unmodified") {
+          val tx = ZSTM.access[String](_.length)
+            .onLeft[String, Int]
+            .provide(Right(42))
+
+          assertM(tx.commit)(isRight(equalTo(42)))
+        }
+      ),
       suite("`orDie`")(
         testM("when failure should die") {
           import zio.CanFail.canFail

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -187,7 +187,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         testM("returns result when environment is on the left") {
           val tx = ZSTM
             .access[String](_.length)
-            .onLeft[String, Int]
+            .onLeft[Int]
             .provide(Left("test"))
 
           assertM(tx.commit)(isLeft(equalTo(4)))
@@ -195,7 +195,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         testM("returns whatever is provided on the right unmodified") {
           val tx = ZSTM
             .access[String](_.length)
-            .onLeft[String, Int]
+            .onLeft[Int]
             .provide(Right(42))
 
           assertM(tx.commit)(isRight(equalTo(42)))
@@ -205,7 +205,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         testM("returns result when environment is on the right") {
           val tx = ZSTM
             .access[String](_.length)
-            .onRight[String, Int]
+            .onRight[Int]
             .provide(Right("test"))
 
           assertM(tx.commit)(isRight(equalTo(4)))
@@ -213,7 +213,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         testM("returns whatever is provided on the left unmodified") {
           val tx = ZSTM
             .access[String](_.length)
-            .onRight[String, Int]
+            .onRight[Int]
             .provide(Left(42))
 
           assertM(tx.commit)(isLeft(equalTo(42)))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -185,14 +185,16 @@ object ZSTMSpec extends ZIOBaseSpec {
       },
       suite("`onLeft`")(
         testM("returns result when environment is on the left") {
-          val tx = ZSTM.access[String](_.length)
+          val tx = ZSTM
+            .access[String](_.length)
             .onLeft[String, Int]
             .provide(Left("test"))
 
           assertM(tx.commit)(isLeft(equalTo(4)))
         },
         testM("returns whatever is provided on the right unmodified") {
-          val tx = ZSTM.access[String](_.length)
+          val tx = ZSTM
+            .access[String](_.length)
             .onLeft[String, Int]
             .provide(Right(42))
 
@@ -201,14 +203,16 @@ object ZSTMSpec extends ZIOBaseSpec {
       ),
       suite("`onRight`")(
         testM("returns result when environment is on the right") {
-          val tx = ZSTM.access[String](_.length)
+          val tx = ZSTM
+            .access[String](_.length)
             .onRight[String, Int]
             .provide(Right("test"))
 
           assertM(tx.commit)(isRight(equalTo(4)))
         },
         testM("returns whatever is provided on the left unmodified") {
-          val tx = ZSTM.access[String](_.length)
+          val tx = ZSTM
+            .access[String](_.length)
             .onRight[String, Int]
             .provide(Left(42))
 

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -199,6 +199,22 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertM(tx.commit)(isRight(equalTo(42)))
         }
       ),
+      suite("`onRight`")(
+        testM("returns result when environment is on the right") {
+          val tx = ZSTM.access[String](_.length)
+            .onRight[String, Int]
+            .provide(Right("test"))
+
+          assertM(tx.commit)(isRight(equalTo(4)))
+        },
+        testM("returns whatever is provided on the left unmodified") {
+          val tx = ZSTM.access[String](_.length)
+            .onRight[String, Int]
+            .provide(Left(42))
+
+          assertM(tx.commit)(isLeft(equalTo(42)))
+        }
+      ),
       suite("`orDie`")(
         testM("when failure should die") {
           import zio.CanFail.canFail

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -823,9 +823,19 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       ZIO.descriptorWith(descriptor => if (descriptor.interruptors.nonEmpty) cleanup else ZIO.unit)
     )
 
+  /**
+   * Returns this effect if environment is on the left, otherwise returns
+   * whatever is on the right unmodified. Note that the result is lifted
+   * in either.
+   */
   final def onLeft[R1 <: R, C]: ZIO[Either[R1, C], E, Either[A, C]] =
     self +++ ZIO.identity[C]
 
+  /**
+   * Returns this effect if environment is on the right, otherwise returns
+   * whatever is on the left unmodified. Note that the result is lifted
+   * in either.
+   */
   final def onRight[R1 <: R, C]: ZIO[Either[C, R1], E, Either[C, A]] =
     ZIO.identity[C] +++ self
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1002,12 +1002,22 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def provideSomeManaged[R0, E1 >: E](r0: ZManaged[R0, E1, R])(implicit ev: NeedsEnv[R]): ZIO[R0, E1, A] =
     r0.use(self.provide)
 
+  /**
+   * Operator alias for `andThen`.
+   */
   final def >>>[R1 >: A, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R, E1, B] =
     self.flatMap(that.provide)
 
+  /**
+   * Depending on provided environment returns either this one or the other effect.
+   */
   final def |||[R1, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[Either[R, R1], E1, A1] =
     ZIO.accessM(_.fold(self.provide, that.provide))
 
+  /**
+   * Depending on provided environment, returns either this one or the other
+   * effect lifted in `Left` or `Right`, respectively.
+   */
   final def +++[R1, B, E1 >: E](that: ZIO[R1, E1, B]): ZIO[Either[R, R1], E1, Either[A, B]] =
     ZIO.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
 
@@ -1765,6 +1775,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
     orElse(that)
 
+  /**
+   * Operator alias for `compose`.
+   */
   final def <<<[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] =
     that >>> self
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -828,7 +828,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * whatever is on the right unmodified. Note that the result is lifted
    * in either.
    */
-  final def onLeft[R1 <: R, C]: ZIO[Either[R1, C], E, Either[A, C]] =
+  final def onLeft[C]: ZIO[Either[R, C], E, Either[A, C]] =
     self +++ ZIO.identity[C]
 
   /**
@@ -836,7 +836,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * whatever is on the left unmodified. Note that the result is lifted
    * in either.
    */
-  final def onRight[R1 <: R, C]: ZIO[Either[C, R1], E, Either[C, A]] =
+  final def onRight[C]: ZIO[Either[C, R], E, Either[C, A]] =
     ZIO.identity[C] +++ self
 
   /**

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -118,6 +118,11 @@ object STM {
     ZSTM.fromTry(a)
 
   /**
+   * @see See [[zio.stm.ZSTM.identity]]
+   */
+  def identity: STM[Nothing, Any] = ZSTM.identity
+
+  /**
    * @see See [[zio.stm.ZSTM.ifM]]
    */
   def ifM[E](b: STM[E, Boolean]): ZSTM.IfM[Any, E] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -381,6 +381,9 @@ final class ZSTM[-R, +E, +A] private[stm] (
       case TExit.Retry      => ZSTM.retry
     }
 
+  def onLeft[R1 <: R, C]: ZSTM[Either[R1, C], E, Either[A, C]] =
+    self +++ ZSTM.identity[C]
+
   /**
    * Converts the failure channel into an `Option`.
    */

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -384,6 +384,9 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def onLeft[R1 <: R, C]: ZSTM[Either[R1, C], E, Either[A, C]] =
     self +++ ZSTM.identity[C]
 
+  def onRight[R1 <: R, C]: ZSTM[Either[C, R1], E, Either[C, A]] =
+    ZSTM.identity[C] +++ self
+
   /**
    * Converts the failure channel into an `Option`.
    */

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -122,6 +122,12 @@ final class ZSTM[-R, +E, +A] private[stm] (
     that >>> self
 
   /**
+   * Depending on provided environment, lift result of self to `Left` or that to `Right`.
+   */
+  def +++[R1, B, E1 >: E](that: ZSTM[R1, E1, B]): ZSTM[Either[R, R1], E1, Either[A, B]] =
+    ZSTM.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
+
+  /**
    * Returns an effect that submerges the error case of an `Either` into the
    * `STM`. The inverse operation of `STM.either`.
    */

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -110,13 +110,13 @@ final class ZSTM[-R, +E, +A] private[stm] (
     orElse(that)
 
   /**
-   * Propagates the given environment to self
+   * Propagates the given environment to self.
    */
   def >>>[R1 >: A, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[R, E1, B] =
     flatMap(that.provide)
 
   /**
-   * Propagates self environment to that
+   * Propagates self environment to that.
    */
   def <<<[R1, E1 >: E](that: ZSTM[R1, E1, R]): ZSTM[R1, E1, A] =
     that >>> self

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -860,6 +860,11 @@ object ZSTM {
     }
 
   /**
+   * Returns the identity effectful function, which performs no effects
+   */
+  def identity[R]: ZSTM[R, Nothing, R] = fromFunction[R, R](ZIO.identityFn)
+
+  /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
   def ifM[R, E](b: ZSTM[R, E, Boolean]): ZSTM.IfM[R, E] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -386,7 +386,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * whatever is on the right unmodified. Note that the result is lifted
    * in either.
    */
-  def onLeft[R1 <: R, C]: ZSTM[Either[R1, C], E, Either[A, C]] =
+  def onLeft[C]: ZSTM[Either[R, C], E, Either[A, C]] =
     self +++ ZSTM.identity[C]
 
   /**
@@ -394,7 +394,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * whatever is on the left unmodified. Note that the result is lifted
    * in either.
    */
-  def onRight[R1 <: R, C]: ZSTM[Either[C, R1], E, Either[C, A]] =
+  def onRight[C]: ZSTM[Either[C, R], E, Either[C, A]] =
     ZSTM.identity[C] +++ self
 
   /**
@@ -613,18 +613,6 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def tapError[R1 <: R, E1 >: E](f: E => ZSTM[R1, E1, Any])(implicit ev: CanFail[E]): ZSTM[R1, E1, A] =
     foldM(e => f(e) *> ZSTM.failNow(e), ZSTM.succeedNow)
-
-  /**
-   * Summarizes a `STM` effect by computing a provided value before and after
-   * execution, and then combining the values to produce a summary, together
-   * with the result of execution.
-   */
-  def summarized[R1 <: R, E1 >: E, B, C](summary: ZSTM[R1, E1, B])(f: (B, B) => C): ZSTM[R1, E1, (C, A)] =
-    for {
-      start <- summary
-      value <- self
-      end   <- summary
-    } yield (f(start, end), value)
 
   /**
    * Maps the success value of this effect to unit.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -381,9 +381,19 @@ final class ZSTM[-R, +E, +A] private[stm] (
       case TExit.Retry      => ZSTM.retry
     }
 
+  /**
+   * Returns this effect if environment is on the left, otherwise returns
+   * whatever is on the right unmodified. Note that the result is lifted
+   * in either.
+   */
   def onLeft[R1 <: R, C]: ZSTM[Either[R1, C], E, Either[A, C]] =
     self +++ ZSTM.identity[C]
 
+  /**
+   * Returns this effect if environment is on the right, otherwise returns
+   * whatever is on the left unmodified. Note that the result is lifted
+   * in either.
+   */
   def onRight[R1 <: R, C]: ZSTM[Either[C, R1], E, Either[C, A]] =
     ZSTM.identity[C] +++ self
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -201,8 +201,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
     }
 
   /**
-    * Named alias for `<<<`.
-    */
+   * Named alias for `<<<`.
+   */
   def compose[R1, E1 >: E](that: ZSTM[R1, E1, R]): ZSTM[R1, E1, A] =
     self <<< that
 
@@ -350,7 +350,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Returns a successful effect if the value is `Left`, or fails with
-    * a [[java.util.NoSuchElementException]].
+   * a [[java.util.NoSuchElementException]].
    */
   def leftOrFailException[B, C, E1 >: NoSuchElementException](
     implicit ev: A <:< Either[B, C],
@@ -396,8 +396,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Keeps none of the errors, and terminates the fiber running the `STM`
-    * effect with them, using the specified function to convert the `E`
-    * into a `Throwable`.
+   * effect with them, using the specified function to convert the `E`
+   * into a `Throwable`.
    */
   def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZSTM[R, Nothing, A] =
     mapError(f).catchAll(ZSTM.dieNow)
@@ -437,8 +437,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Returns a transactional effect that will produce the value of this effect
-    * in left side, unless it fails, in which case, it will produce the value
-    * of the specified effect in right side.
+   * in left side, unless it fails, in which case, it will produce the value
+   * of the specified effect in right side.
    */
   def orElseEither[R1 <: R, E1 >: E, B](
     that: => ZSTM[R1, E1, B]
@@ -518,7 +518,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Returns a successful effect if the value is `Right`, or fails with the
-    * given error 'e'.
+   * given error 'e'.
    */
   def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A <:< Either[B, C]): ZSTM[R, E1, C] =
     self.flatMap(ev(_) match {
@@ -528,7 +528,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Returns a successful effect if the value is `Right`, or fails with
-    * a [[java.util.NoSuchElementException]].
+   * a [[java.util.NoSuchElementException]].
    */
   def rightOrFailException[B, C, E1 >: NoSuchElementException](
     implicit ev: A <:< Either[B, C],
@@ -600,8 +600,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
 
   /**
    * Summarizes a `STM` effect by computing a provided value before and after
-    * execution, and then combining the values to produce a summary, together
-    * with the result of execution.
+   * execution, and then combining the values to produce a summary, together
+   * with the result of execution.
    */
   def summarized[R1 <: R, E1 >: E, B, C](summary: ZSTM[R1, E1, B])(f: (B, B) => C): ZSTM[R1, E1, (C, A)] =
     for {


### PR DESCRIPTION
Part of #2802

### Summary

- Added `identity`, `|||` and `+++`.
- Added `onLeft` and `onRight`.
- Document undocumented (related) ZIO combinators.