### PR TITLE
Re-implement ignore using unitFn

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3239,6 +3239,7 @@ object ZIO {
   def apply[A](a: => A): Task[A] = effect(a)
 
   private val _IdentityFn: Any => Any = (a: Any) => a
+  private val _UnitFn: Any => Unit = (_: Any) => ()
 
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]
 
@@ -3250,6 +3251,8 @@ object ZIO {
           b => (es, b :: bs)
         )
     }
+
+  private[zio] def unitFn[A]: A => Unit = _UnitFn.asInstanceOf[A => Unit]
 
   implicit final class ZIOAutocloseableOps[R, E, A <: AutoCloseable](private val io: ZIO[R, E, A]) extends AnyVal {
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -670,7 +670,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  final def ignore: URIO[R, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
+  final def ignore: URIO[R, Unit] = self.foldCause(ZIO.unitFn, ZIO.unitFn)
 
   /**
    * Performs this effect interruptibly. Because this is the default, this

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -670,7 +670,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  final def ignore: URIO[R, Unit] = self.foldCause(ZIO.unitFn, ZIO.unitFn)
+  final def ignore: URIO[R, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
 
   /**
    * Performs this effect interruptibly. Because this is the default, this

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -670,7 +670,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  final def ignore: URIO[R, Unit] = self.foldM(_ => ZIO.unit, _ => ZIO.unit)
+  final def ignore: URIO[R, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
 
   /**
    * Performs this effect interruptibly. Because this is the default, this

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3239,6 +3239,7 @@ object ZIO {
   def apply[A](a: => A): Task[A] = effect(a)
 
   private val _IdentityFn: Any => Any = (a: Any) => a
+
   private val _UnitFn: Any => Unit = (_: Any) => ()
 
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3240,8 +3240,6 @@ object ZIO {
 
   private val _IdentityFn: Any => Any = (a: Any) => a
 
-  private val _UnitFn: Any => Unit = (_: Any) => ()
-
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]
 
   private[zio] def partitionMap[A, A1, A2](iterable: Iterable[A])(f: A => Either[A1, A2]): (List[A1], List[A2]) =
@@ -3253,7 +3251,7 @@ object ZIO {
         )
     }
 
-  private[zio] def unitFn[A]: A => Unit = _UnitFn.asInstanceOf[A => Unit]
+  private[zio] val unitFn: Any => Unit = (_: Any) => ()
 
   implicit final class ZIOAutocloseableOps[R, E, A <: AutoCloseable](private val io: ZIO[R, E, A]) extends AnyVal {
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -312,7 +312,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  def ignore: ZSTM[R, Nothing, Unit] = self.fold(_ => (), _ => ())
+  def ignore: ZSTM[R, Nothing, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
 
   /**
    * Returns a successful effect if the value is `Left`, or fails with the error `None`.


### PR DESCRIPTION
Dropped lambdas in favor of constant cast as suggested in [this comment](https://github.com/zio/zio/pull/2808#issuecomment-582370210).