### PR TITLE
Publish Scalafix Migration Rule for Curried Assert

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,54 @@
+lazy val V = _root_.scalafix.sbt.BuildInfo
+inThisBuild(
+  List(
+    organization := "dev.zio",
+    homepage := Some(url("https://zio.dev")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "jdegoes",
+        "John De Goes",
+        "john@degoes.net",
+        url("http://degoes.net")
+      )
+    ),
+    scalaVersion := V.scala212,
+    addCompilerPlugin(scalafixSemanticdb),
+    scalacOptions ++= List(
+      "-Yrangepos",
+      "-P:semanticdb:synthetics:on"
+    )
+  )
+)
+
+skip in publish := true
+
+lazy val rules = project.settings(
+  moduleName := "scalafix",
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+)
+
+lazy val input = project.settings(
+  skip in publish := true,
+  libraryDependencies += "dev.zio" %% "zio-test" % "1.0.0-RC17"
+)
+
+lazy val output = project.settings(
+  skip in publish := true
+)
+
+lazy val tests = project
+  .settings(
+    skip in publish := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    compile.in(Compile) := 
+      compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
+    scalafixTestkitOutputSourceDirectories :=
+      sourceDirectories.in(output, Compile).value,
+    scalafixTestkitInputSourceDirectories :=
+      sourceDirectories.in(input, Compile).value,
+    scalafixTestkitInputClasspath :=
+      fullClasspath.in(input, Compile).value,
+  )
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix/input/src/main/scala/fix/CurriedAssert.scala
+++ b/scalafix/input/src/main/scala/fix/CurriedAssert.scala
@@ -1,0 +1,14 @@
+/*
+rule = CurriedAssert
+ */
+package fix
+
+import zio._
+import zio.clock._
+import zio.test._
+import zio.test.Assertion._
+
+object CurriedAssert {
+  assertM(nanoTime, equalTo(0))
+  assert(Right(Some(3)), isRight(isSome(isGreaterThan(4))))
+}

--- a/scalafix/output/src/main/scala/fix/CurriedAssert.scala
+++ b/scalafix/output/src/main/scala/fix/CurriedAssert.scala
@@ -1,0 +1,11 @@
+package fix
+
+import zio._
+import zio.clock._
+import zio.test._
+import zio.test.Assertion._
+
+object CurriedAssert {
+  assertM(nanoTime)(equalTo(0))
+  assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4))))
+}

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.8

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")

--- a/scalafix/readme.md
+++ b/scalafix/readme.md
@@ -1,0 +1,7 @@
+# Scalafix rules for zio
+
+To develop rule:
+```
+sbt ~tests/test
+# edit rules/src/main/scala/fix/CurriedAssert.scala
+```

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.CurriedAssert

--- a/scalafix/rules/src/main/scala/fix/CurriedAssert.scala
+++ b/scalafix/rules/src/main/scala/fix/CurriedAssert.scala
@@ -1,0 +1,20 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+class CurriedAssert extends SemanticRule("CurriedAssert") {
+
+  val assert = SymbolMatcher.normalized(
+    "zio.test.package.assert",
+    "zio.test.package.assertM"
+  )
+
+  override def fix(implicit doc: SemanticDocument): Patch =
+    doc.tree.collect {
+      case t @ assert(Term.Apply(name, List(value, assertion))) =>
+        Patch.replaceTree(t, name + "(" + value + ")(" + assertion + ")")
+      case _ =>
+        Patch.empty
+    }.asPatch
+}

--- a/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,7 @@
+package fix
+
+import scalafix.testkit.SemanticRuleSuite
+
+class RuleSuite extends SemanticRuleSuite() {
+  runAllTests()
+}


### PR DESCRIPTION
Following up on #2545 publishes a Scalafix rule for migrating tests to use the curried assert. Once we merge this I can submit a PR to Scala Steward and then tests will automatically be migrated when Scala Steward submits PRs to update ZIO to RC18.