### PR TITLE
Return More Specific Type from Methods on Managed Runtime

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -202,7 +202,7 @@ object Runtime {
     override final def withTracing(t: Tracing): Runtime.Managed[R] =
       mapPlatform(_.withTracing(t))
 
-    override final def withTracingConfig(config: TracingConfig): Runtime[R] =
+    override final def withTracingConfig(config: TracingConfig): Runtime.Managed[R] =
       mapPlatform(_.withTracingConfig(config))
   }
 


### PR DESCRIPTION
Minor follow up on #2751. Makes methods on a managed runtime return a managed runtime instead of just a runtime. This way you can call methods on the managed runtime and retain the ability to shut it down early.