### PR TITLE
Add ZStream filter combinator

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -1,8 +1,7 @@
 package zio.stream.experimental
 
-import ZStreamUtils.nPulls
-
 import zio._
+import zio.stream.experimental.ZStreamUtils.nPulls
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import zio.test._
 
@@ -16,6 +15,22 @@ object ZStreamSpec extends ZIOBaseSpec {
           .process
           .use(nPulls(_, 3))
           .map(assert(_)(equalTo(List(Right("1"), Left(Right(())), Left(Right(()))))))
+      },
+      testM("filter - keep elements that satisfy the predicate") {
+        ZStream
+          .fromEffect(UIO.succeed(1))
+          .filter(_ > 0)
+          .process
+          .use(nPulls(_, 3))
+          .map(assert(_)(equalTo(List(Right(1), Left(Right(())), Left(Right(()))))))
+      },
+      testM("filter - filter out elements that do not satisfy the predicate") {
+        ZStream
+          .fromEffect(UIO.succeed(1))
+          .filter(_ < 0)
+          .process
+          .use(nPulls(_, 3))
+          .map(assert(_)(equalTo(List(Left(Right(())), Left(Right(())), Left(Right(()))))))
       }
     ),
     suite("Constructors")(

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -28,6 +28,8 @@ class ZStream[-R, +E, -M, +B, +A](
   /**
    * Filters this stream by the specified predicate, retaining all elements for
    * which the predicate evaluates to true.
+   * @param pred predicate used for deciding whether element should be retained
+   * @return a stream containing only elements from the original stream that satisfy given `pred`
    */
   def filter(pred: A => Boolean): ZStream[R, E, M, B, A] =
     ZStream {

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -24,6 +24,23 @@ class ZStream[-R, +E, -M, +B, +A](
         )
       }
     }
+
+  /**
+   * Filters this stream by the specified predicate, retaining all elements for
+   * which the predicate evaluates to true.
+   */
+  def filter(pred: A => Boolean): ZStream[R, E, M, B, A] =
+    ZStream {
+      self.process.map { control =>
+        Control(
+          control.pull.flatMap { a =>
+            if (pred(a)) UIO.succeedNow(a)
+            else control.pull
+          },
+          control.command
+        )
+      }
+    }
 }
 
 object ZStream extends Serializable {


### PR DESCRIPTION
Tests cover only one-element Stream. Will change once `fromIterable()` is implemented