### PR TITLE
Make Lock Heritable

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -15,20 +15,35 @@ object BlockingSpec extends ZIOBaseSpec {
       testM("effectBlocking completes successfully") {
         assertM(effectBlocking(()))(isUnit)
       },
+      testM("effectBlocking runs on the blocking thread pool") {
+        for {
+          name <- effectBlocking(Thread.currentThread.getName)
+        } yield assert(name)(containsString("zio-default-blocking"))
+      },
       testM("effectBlockingCancelable completes successfully") {
         assertM(effectBlockingCancelable(())(UIO.unit))(isUnit)
       },
-      testM("effectBlockingInterrupt completes successfully") {
-        assertM(effectBlockingInterrupt(()))(isUnit)
+      testM("effectBlockingCancelable runs on the blocking thread pool") {
+        for {
+          name <- effectBlockingCancelable(Thread.currentThread.getName)(UIO.unit)
+        } yield assert(name)(containsString("zio-default-blocking"))
       },
-      testM("effectBlockingInterrupt can be interrupted") {
-        assertM(effectBlockingInterrupt(Thread.sleep(50000)).timeout(Duration.Zero))(isNone)
-      } @@ ignore,
       testM("effectBlockingCancelable can be interrupted") {
         val release = new AtomicBoolean(false)
         val cancel  = UIO.effectTotal(release.set(true))
         assertM(effectBlockingCancelable(blockingAtomic(release))(cancel).timeout(Duration.Zero))(isNone)
-      }
+      },
+      testM("effectBlockingInterrupt completes successfully") {
+        assertM(effectBlockingInterrupt(()))(isUnit)
+      },
+      testM("effectBlockingInterrupt runs on the blocking thread pool") {
+        for {
+          name <- effectBlockingInterrupt(Thread.currentThread.getName)
+        } yield assert(name)(containsString("zio-default-blocking"))
+      },
+      testM("effectBlockingInterrupt can be interrupted") {
+        assertM(effectBlockingInterrupt(Thread.sleep(50000)).timeout(Duration.Zero))(isNone)
+      } @@ ignore
     )
   )
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -10,7 +10,7 @@ import zio.duration._
 import zio.random.Random
 import zio.scheduler.Scheduler
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, jvm, nonFlaky, scala2Only }
+import zio.test.TestAspect.{ flaky, jvm, jvmOnly, nonFlaky, scala2Only }
 import zio.test._
 import zio.test.environment.{ Live, TestClock }
 
@@ -2648,7 +2648,7 @@ object ZIOSpec extends ZIOBaseSpec {
           childPool  <- pool.fork.flatMap(_.join)
         } yield assert(parentPool)(equalTo(childPool))
         io.lock(executor)
-      } @@ jvm(nonFlaky(100))
+      } @@ nonFlaky @@ jvmOnly
     ),
     suite("someOrFail")(
       testM("extracts the optional value") {

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -61,6 +61,12 @@ private[internal] trait PlatformSpecific {
   final val defaultYieldOpCount = 2048
 
   /**
+   * Returns the name of the thread group to which this thread belongs. This
+   * is a side-effecting method.
+   */
+  val getCurrentThreadGroup: String = ""
+
+  /**
    * A `Platform` created from Scala's global execution context.
    */
   lazy val global = fromExecutionContext(ExecutionContext.global)

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -62,6 +62,13 @@ private[internal] trait PlatformSpecific {
   final val defaultYieldOpCount = 2048
 
   /**
+   * Returns the name of the thread group to which this thread belongs. This
+   * is a side-effecting method.
+   */
+  final def getCurrentThreadGroup: String =
+    Thread.currentThread.getThreadGroup.getName
+
+  /**
    * A `Platform` created from Scala's global execution context.
    */
   lazy val global = fromExecutionContext(ExecutionContext.global)

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -57,6 +57,12 @@ private[internal] trait PlatformSpecific {
   final val defaultYieldOpCount = 2048
 
   /**
+    * Returns the name of the thread group to which this thread belongs. This
+    * is a side-effecting method.
+    */
+  val getCurrentThreadGroup: String = ""
+
+  /**
    * A `Platform` created from Scala's global execution context.
    */
   lazy val global = fromExecutionContext(ExecutionContext.global)

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -666,7 +666,7 @@ private[zio] final class FiberContext[E, A](
       Fiber.track(childContext)
     }
 
-    platform.executor.submitOrThrow(() => childContext.evaluateNow(zio))
+    executor.submitOrThrow(() => childContext.evaluateNow(zio))
 
     childContext
   }


### PR DESCRIPTION
Fixes a bug in `FiberContext` where when a fiber was forked it was forked on the platform's default executor instead of the current active executor. We had a test for this but the test was based on the  fiber's descriptor which said it was running on a certain executor even though it wasn't actually running there.

Resolves #2859.