### PR TITLE
add get to STM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -150,6 +150,22 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertM(STM.failNow(None).flattenErrorOption("default error").commit.run)(fails(equalTo("default error")))
         }
       ),
+      suite("get")(
+        testM("extracts the value from Some") {
+          assertM(STM.succeedNow(Some(1)).get.commit)(equalTo(1))
+        },
+        testM("fails with Unit on None") {
+          assertM(STM.succeedNow(None).get.commit.run)(fails(isUnit))
+        },
+        testM("fails when given an error") {
+          val tx = for {
+            _ <- STM.failNow(ExampleError)
+            n <- STM.succeedNow(1)
+          } yield n
+
+          assertM(tx.get.commit.run)(fails(equalTo(ExampleError)))
+        }
+      ),
       suite("left")(
         testM("on Left value") {
           assertM(ZSTM.succeedNow(Left("Left")).left.commit)(equalTo("Left"))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -156,14 +156,6 @@ object ZSTMSpec extends ZIOBaseSpec {
         },
         testM("fails with Unit on None") {
           assertM(STM.succeedNow(None).get.commit.run)(fails(isUnit))
-        },
-        testM("fails when given an error") {
-          val tx = for {
-            _ <- STM.failNow(ExampleError)
-            n <- STM.succeedNow(1)
-          } yield n
-
-          assertM(tx.get.commit.run)(fails(equalTo(ExampleError)))
         }
       ),
       suite("left")(

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -332,6 +332,15 @@ final class ZSTM[-R, +E, +A] private[stm] (
     }
 
   /**
+   * Unwraps the optional success of this effect, but can fail with unit value.
+   */
+  def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): ZSTM[R, Unit, B] =
+    foldM(
+      ev1,
+      ev2(_).fold[ZSTM[R, Unit, B]](ZSTM.failNow(()))(ZSTM.succeedNow(_))
+    )
+
+  /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
   def ignore: ZSTM[R, Nothing, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)


### PR DESCRIPTION
https://github.com/zio/zio/issues/2802

I have one question here.

The current code is failing to compile and im wondering if this is the behavior that we want:

` def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): ZSTM[R, Unit, B]`

is from the `ZIO` class. If i understand this correctly this is saying that the effect we are doing this call should have signature `ZSTM[R, Nothing, Option[B]]` Im curious why it needs to be Nothing on the error channel. there is a very similar method to this called `someOrFail(e: E)` instead of implementing this call i tried to just call `someOrFail(())` but it seems i get problems on the Error channel. Also, the implementation here is my own and different from ZIO#get since that seems to convert to either first and do more complicated stuff. anyway. any feedback would be greatly appreciated