### PR TITLE
ZLayer Improvements

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -181,6 +181,44 @@ object ZLayerSpec extends ZIOBaseSpec {
         _      <- env.use_(ZIO.unit)
         actual <- ref.get
       } yield assert(actual)(equalTo(expected))
+    },
+    testM("map does not interfere with sharing") {
+      val expected = Vector(
+        "Acquiring Module 1",
+        "Acquiring Module 2",
+        "Acquiring Module 3",
+        "Releasing Module 3",
+        "Releasing Module 2",
+        "Releasing Module 1"
+      )
+      for {
+        ref    <- makeRef
+        layer1 = makeLayer1(ref)
+        layer2 = makeLayer2(ref)
+        layer3 = makeLayer3(ref)
+        env    = ((layer1.map(identity) >>> layer2) ++ (layer1 >>> layer3)).build
+        _      <- env.use_(ZIO.unit)
+        actual <- ref.get
+      } yield assert(actual)(equalTo(expected))
+    },
+    testM("mapError does not interfere with sharing") {
+      val expected = Vector(
+        "Acquiring Module 1",
+        "Acquiring Module 2",
+        "Acquiring Module 3",
+        "Releasing Module 3",
+        "Releasing Module 2",
+        "Releasing Module 1"
+      )
+      for {
+        ref    <- makeRef
+        layer1 = makeLayer1(ref)
+        layer2 = makeLayer2(ref)
+        layer3 = makeLayer3(ref)
+        env    = ((layer1.mapError(identity) >>> layer2) ++ (layer1 >>> layer3)).build
+        _      <- env.use_(ZIO.unit)
+        actual <- ref.get
+      } yield assert(actual)(equalTo(expected))
     }
   )
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -112,12 +112,12 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
     new ZLayer(scope.map(run => run(_).mapError(f)))
 
   /**
-   * Returns a new layer with some of the services output by this layer
-   * replaced by the implementations in the specified layer
+   * Overwrites the services output by this laywr with the services output by
+   * the specified layer.
    */
-  def overwrite[E1 >: E, A: Tagged](
-    that: ZLayer.NoDeps[E1, Has[A]]
-  )(implicit ev: ROut <:< Has[A]): ZLayer[RIn, E1, ROut] =
+  def overwrite[E1 >: E, RIn2, A: Tagged](
+    that: ZLayer[RIn2, E1, Has[A]]
+  )(implicit ev: ROut <:< Has[A]): ZLayer[RIn with RIn2, E1, ROut] =
     new ZLayer(
       Managed.finalizerRef(_ => UIO.unit).map { finalizerRef => memoMap =>
         for {

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -3,8 +3,11 @@ package zio.test.environment
 import java.util.concurrent.TimeUnit
 
 import zio._
+import zio.clock._
 import zio.duration._
+import zio.scheduler._
 import zio.test.Assertion._
+import zio.test.TestAspect._
 import zio.test._
 
 object EnvironmentSpec extends ZIOBaseSpec {
@@ -66,6 +69,11 @@ object EnvironmentSpec extends ZIOBaseSpec {
         _       <- TestSystem.setLineSeparator(",")
         lineSep <- system.lineSeparator
       } yield assert(lineSep)(equalTo(","))
-    }
+    },
+    testM("clock can be set") {
+      val testEnvironment = TestEnvironment.live.overwrite(Scheduler.live >>> Clock.live)
+      val zio             = clock.sleep(1.nanosecond).provideLayer(testEnvironment)
+      assertM(zio)(anything)
+    } @@ nonFlaky
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit
 import zio._
 import zio.clock._
 import zio.duration._
-import zio.scheduler._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
@@ -70,10 +69,10 @@ object EnvironmentSpec extends ZIOBaseSpec {
         lineSep <- system.lineSeparator
       } yield assert(lineSep)(equalTo(","))
     },
-    testM("clock can be set") {
-      val testEnvironment = TestEnvironment.live.overwrite(Scheduler.live >>> Clock.live)
-      val zio             = clock.sleep(1.nanosecond).provideLayer(testEnvironment)
-      assertM(zio)(anything)
+    testM("clock service can be overwritten") {
+      val withLiveClock = TestEnvironment.live.overwrite(Clock.live)
+      val time          = clock.nanoTime.provideLayer(withLiveClock)
+      assertM(time)(isGreaterThan(0L))
     } @@ nonFlaky
   )
 }

--- a/test/shared/src/main/scala/zio/test/TestFailure.scala
+++ b/test/shared/src/main/scala/zio/test/TestFailure.scala
@@ -23,4 +23,22 @@ sealed trait TestFailure[+E]
 object TestFailure {
   final case class Assertion(result: TestResult) extends TestFailure[Nothing]
   final case class Runtime[+E](cause: Cause[E])  extends TestFailure[E]
+
+  /**
+   * Constructs a new assertion failure with the specified result.
+   */
+  def assertion(result: TestResult): TestFailure[Nothing] =
+    Assertion(result)
+
+  /**
+   * Constructs a new runtime failure with the specified cause.
+   */
+  def die[E](cause: Cause[E]): TestFailure[E] =
+    Runtime(cause)
+
+  /**
+   * Constructs a new runtime failure with the specified error.
+   */
+  def fail[E](e: E): TestFailure[E] =
+    Runtime(Cause.fail(e))
 }

--- a/test/shared/src/main/scala/zio/test/TestFailure.scala
+++ b/test/shared/src/main/scala/zio/test/TestFailure.scala
@@ -25,20 +25,26 @@ object TestFailure {
   final case class Runtime[+E](cause: Cause[E])  extends TestFailure[E]
 
   /**
-   * Constructs a new assertion failure with the specified result.
+   * Constructs an assertion failure with the specified result.
    */
   def assertion(result: TestResult): TestFailure[Nothing] =
     Assertion(result)
 
   /**
-   * Constructs a new runtime failure with the specified cause.
+   * Constructs a runtime failure that dies with the specified `Throwable`.
    */
-  def die[E](cause: Cause[E]): TestFailure[E] =
-    Runtime(cause)
+  def die(t: Throwable): TestFailure[Nothing] =
+    halt(Cause.die(t))
 
   /**
-   * Constructs a new runtime failure with the specified error.
+   * Constructs a runtime failure that fails with the specified error.
    */
   def fail[E](e: E): TestFailure[E] =
-    Runtime(Cause.fail(e))
+    halt(Cause.fail(e))
+
+  /**
+   * Constructs a runtime failure with the specified cause.
+   */
+  def halt[E](cause: Cause[E]): TestFailure[E] =
+    Runtime(cause)
 }


### PR DESCRIPTION
Makes a couple of improvements to the usability of `ZLayer`:

- Adds `map` and `mapError` methods on `ZLayer`
- Adds constructors for `TestFailure` to make it easier to lift the error type into a `TestFailure` for providing environments to specs in ZIO Test
- Implements `set` which is like `update` but just lets you set a service to a specified implementation
- Implements a new method `overwrite` on `ZLayer` that lets you overwrite the services output by a layer with the services from the specified layer. For example, you can do `TestEnvironment.live.overwrite(Scheduler.live >>> Clock.live)` to create a version of the test environment that uses the live clock.

I'm having some issues with the last one. I would have thought that I could implement it in terms of some combination of `++` and `+!+` with different orderings of the layers but I wasn't able to get that to work deterministically so right now it is implemented directly similar to other combinators on `ZLayer` such as `++` and `>>>`. Also, right now I have a restriction that the layer being used to overwrite has to have no environmental requirements. I found that when I didn't do that I wasn't able to consistently override the environment. It would be nice to be able to relax that restriction so we could just to `TestEnvironment.live.overwrite(Clock.live)` for example.