### PR TITLE
Implement Deprecated DefaultRuntime

### DIFF
--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -9,11 +9,11 @@ import monix.eval.{ Task => MTask }
 
 import zio.internal._
 
-object IOBenchmarks extends DefaultRuntime {
+object IOBenchmarks extends BootstrapRuntime {
 
   override val platform: Platform = Platform.benchmark
 
-  val TracedRuntime = new DefaultRuntime {
+  val TracedRuntime = new BootstrapRuntime {
     override val platform = Platform.benchmark.withTracing(Tracing.enabled)
   }
 

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -97,7 +97,7 @@ object RTSSpec extends ZIOBaseSpec {
     testM("deadlock regression 1") {
       import java.util.concurrent.Executors
 
-      val rts = new DefaultRuntime {}
+      val rts = new BootstrapRuntime {}
       val e   = Executors.newSingleThreadExecutor()
 
       (0 until 10000).foreach { _ =>

--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -37,7 +37,7 @@ package zio
  * }
  * }}}
  */
-trait App extends DefaultRuntime {
+trait App extends BootstrapRuntime {
 
   /**
    * The main function of the application, which will be passed the command-line

--- a/core/native/src/main/scala/zio/App.scala
+++ b/core/native/src/main/scala/zio/App.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-trait App extends DefaultRuntime {
+trait App extends BootstrapRuntime {
 
   /**
    * The main function of the application, which will be passed the command-line

--- a/core/shared/src/main/scala/zio/BootstrapRuntime.scala
+++ b/core/shared/src/main/scala/zio/BootstrapRuntime.scala
@@ -16,17 +16,14 @@
 
 package zio
 
-trait App extends BootstrapRuntime {
+import zio.internal.Platform
+
+trait BootstrapRuntime extends Runtime[Unit] {
+  val environment: Unit = ()
 
   /**
-   * The main function of the application, which will be passed the command-line
-   * arguments to the program.
+   * The platform of the runtime, which provides the essential capabilities
+   * necessary to bootstrap execution of tasks.
    */
-  def run(args: List[String]): ZIO[ZEnv, Nothing, Int]
-
-  /**
-   * The Scala main function, intended to be called only by the Scala runtime.
-   */
-  final def main(args0: Array[String]): Unit =
-    unsafeRunAsync(run(args0.toList).provideLayer(ZEnv.live))(_ => ())
+  val platform: Platform = Platform.default
 }

--- a/core/shared/src/main/scala/zio/DefaultRuntime.scala
+++ b/core/shared/src/main/scala/zio/DefaultRuntime.scala
@@ -18,12 +18,16 @@ package zio
 
 import zio.internal.Platform
 
-trait DefaultRuntime extends Runtime[Unit] {
-  val environment: Unit = ()
-
-  /**
-   * The platform of the runtime, which provides the essential capabilities
-   * necessary to bootstrap execution of tasks.
-   */
-  val platform: Platform = Platform.default
+@deprecated(
+  "Use `Runtime.global` and provide the required environment directly using" +
+    "`ZIO#provideLayer`. In general, layers are managed resources that " +
+    "require allocation and deallocation and therefore scoping resources to" +
+    "an effect is highly recommended as a best practice. " +
+    "`Runtime.unsafefromLayer` can be used when this best practice is is too " +
+    "inconvenient.",
+  "1.0.0"
+)
+trait DefaultRuntime extends Runtime[ZEnv] {
+  override val platform: Platform = Platform.default
+  override val environment: ZEnv  = Runtime.unsafeFromLayer(ZEnv.live, platform).environment
 }

--- a/core/shared/src/main/scala/zio/DefaultRuntime.scala
+++ b/core/shared/src/main/scala/zio/DefaultRuntime.scala
@@ -19,7 +19,7 @@ package zio
 import zio.internal.Platform
 
 @deprecated(
-  "Use `Runtime.global` and provide the required environment directly using" +
+  "Use `Runtime.default` and provide the required environment directly using" +
     "`ZIO#provideLayer`. In general, layers are managed resources that " +
     "require allocation and deallocation and therefore scoping resources to" +
     "an effect is highly recommended as a best practice. " +

--- a/core/shared/src/main/scala/zio/ManagedApp.scala
+++ b/core/shared/src/main/scala/zio/ManagedApp.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-trait ManagedApp extends DefaultRuntime { ma =>
+trait ManagedApp extends BootstrapRuntime { ma =>
 
   /**
    * The main function of the application, which will be passed the command-line

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -67,8 +67,8 @@ import zio.{ TracingStatus => TracingS }
  * In order to integrate with Scala, `ZIO` values must be interpreted into the
  * Scala runtime. This process of interpretation executes the effects described
  * by a given immutable `ZIO` value. For more information on interpreting `ZIO`
- * values, see the default interpreter in `DefaultRuntime` or the safe main function in
- * `App`.
+ * values, see the default interpreter in `BootstrapRuntime` or the safe main
+ * function in `App`.
  */
 sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
 

--- a/docs/datatypes/fiber.md
+++ b/docs/datatypes/fiber.md
@@ -52,7 +52,7 @@ def fib(n: Int): UIO[Int] =
 
 The interrupt operation does not resume until the fiber has completed or has been interrupted and all its finalizers have been run. These precise semantics allow construction of programs that do not leak resources.
 
-A more powerful variant of `fork`, called `fork0`, allows specification of supervisor that will be passed any non-recoverable errors from the forked fiber, including all such errors that occur in finalizers. If this supervisor is not specified, then the supervisor of the parent fiber will be used, recursively, up to the root handler, which can be specified in `DefaultRuntime` (the default supervisor merely prints the stack trace).
+A more powerful variant of `fork`, called `fork0`, allows specification of supervisor that will be passed any non-recoverable errors from the forked fiber, including all such errors that occur in finalizers. If this supervisor is not specified, then the supervisor of the parent fiber will be used, recursively, up to the root handler, which can be specified in `Runtime` (the default supervisor merely prints the stack trace).
 
 ## Error Model
 
@@ -120,4 +120,4 @@ Fibers only ever shift onto the thread pool of the runtime system, which means t
 
 For performance reasons, fibers will attempt to execute on the same thread for a (configurable) minimum period, before yielding to other fibers. Fibers that resume from asynchronous callbacks will resume on the initiating thread, and continue for some time before yielding and resuming on the runtime thread pool.
 
-These defaults help guarantee stack safety and cooperative multitasking. They can be changed in `DefaultRuntime` if automatic thread shifting is not desired.
+These defaults help guarantee stack safety and cooperative multitasking. They can be changed in `Runtime` if automatic thread shifting is not desired.

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -23,7 +23,7 @@ import zio.test._
  * <br/><br/>
  * Scala.JS is not supported, as JUnit TestFramework for SBT under Scala.JS doesn't support custom runners.
  */
-class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with DefaultRuntime {
+class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with BootstrapRuntime {
   private val className = klass.getName.stripSuffix("$")
 
   private lazy val spec: AbstractRunnableSpec = {


### PR DESCRIPTION
Resolves #2873. I renamed the existing `DefaultRuntime` that has `Unit` for the environment type to `BootstrapRuntime`.