### PR TITLE
ZIO Test: Gracefully Handle Malformed Class Names in Assertion#isSubtype

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -252,6 +252,14 @@ object AssertionSpec extends ZIOBaseSpec {
     test("isSome must fail when supplied value is None") {
       assert(None)(isSome(equalTo("zio")))
     } @@ failure,
+    test("isSubtype gracefully handles malformed class names") {
+      sealed trait Exception
+      object Exception {
+        case class MyException() extends Exception
+      }
+      val exception = new Exception.MyException
+      assert(exception)(isSubtype[Exception.MyException](anything))
+    },
     test("isTrue must succeed when supplied value is true") {
       assert(true)(isTrue)
     },

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -111,6 +111,16 @@ object Assertion extends AssertionVariants {
     final case class Infix(left: RenderParam, op: String, right: RenderParam)    extends Render
 
     /**
+     * Creates a string representation of a class name.
+     */
+    def className[A](C: ClassTag[A]): String =
+      try {
+        C.runtimeClass.getSimpleName
+      } catch {
+        case _: Throwable => C.runtimeClass.getName
+      }
+
+    /**
      * Creates a string representation of a field accessor.
      */
     def field(name: String): String =
@@ -585,7 +595,7 @@ object Assertion extends AssertionVariants {
    * }}}
    */
   def isSubtype[A](assertion: Assertion[A])(implicit C: ClassTag[A]): Assertion[Any] =
-    Assertion.assertionRec("isSubtype")(param(C.runtimeClass.getSimpleName))(assertion) { actual =>
+    Assertion.assertionRec("isSubtype")(param(className(C)))(assertion) { actual =>
       if (C.runtimeClass.isAssignableFrom(actual.getClass())) Some(actual.asInstanceOf[A])
       else None
     }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -117,6 +117,7 @@ object Assertion extends AssertionVariants {
       try {
         C.runtimeClass.getSimpleName
       } catch {
+        // See https://github.com/scala/bug/issues/2034.
         case t: InternalError if t.getMessage == "Malformed class name" =>
           C.runtimeClass.getName
       }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -117,7 +117,8 @@ object Assertion extends AssertionVariants {
       try {
         C.runtimeClass.getSimpleName
       } catch {
-        case _: Throwable => C.runtimeClass.getName
+        case t: InternalError if t.getMessage == "Malformed class name" =>
+          C.runtimeClass.getName
       }
 
     /**


### PR DESCRIPTION
Resolves #2861. We try to call `simpleClassName`. If that fails we fall back to calling `getName`. This was the vast majority of users still get the more readable simple class name. If the user provides us with a class with a degenerate name they just get a longer class name.