### PR TITLE
Add ZIO#doUntil, doWhile, retryUntil and retryWhile equals and effectful variants

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -272,10 +272,38 @@ object ZIOSpec extends ZIOBaseSpec {
           result <- out.get
         } yield assert(result)(equalTo(10))
       },
-      testM("doUntil always evaluates effect once") {
+      testM("doUntil always evaluates effect at least once") {
         for {
           ref    <- Ref.make(0)
           _      <- ref.update(_ + 1).doUntil(_ => true)
+          result <- ref.get
+        } yield assert(result)(equalTo(1))
+      }
+    ),
+    suite("doUntilEquals")(
+      testM("doUntilEquals repeats until result is equal to predicate") {
+        for {
+          q      <- Queue.unbounded[Int]
+          _      <- q.offerAll(List(1, 2, 3, 4, 5, 6))
+          acc    <- Ref.make(0)
+          _      <- (q.take <* acc.update(_ + 1)).doUntilEquals(5)
+          result <- acc.get
+        } yield assert(result)(equalTo(5))
+      }
+    ),
+    suite("doUntilM")(
+      testM("doUntilM repeat until effectful condition is true") {
+        for {
+          in     <- Ref.make(10)
+          out    <- Ref.make(0)
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doUntilM(v => UIO.succeedNow(v == 0))
+          result <- out.get
+        } yield assert(result)(equalTo(10))
+      },
+      testM("doUntilM always evaluates effect at least once") {
+        for {
+          ref    <- Ref.make(0)
+          _      <- ref.update(_ + 1).doUntilM(_ => UIO.succeedNow(true))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -289,10 +317,38 @@ object ZIOSpec extends ZIOBaseSpec {
           result <- out.get
         } yield assert(result)(equalTo(11))
       },
-      testM("doWhile always evaluates effect once") {
+      testM("doWhile always evaluates effect at least once") {
         for {
           ref    <- Ref.make(0)
           _      <- ref.update(_ + 1).doWhile(_ => false)
+          result <- ref.get
+        } yield assert(result)(equalTo(1))
+      }
+    ),
+    suite("doWhileEquals")(
+      testM("doWhileEquals repeats while result equals predicate") {
+        for {
+          q      <- Queue.unbounded[Int]
+          _      <- q.offerAll(List(0, 0, 0, 0, 1, 2))
+          acc    <- Ref.make(0)
+          _      <- (q.take <* acc.update(_ + 1)).doWhileEquals(0)
+          result <- acc.get
+        } yield assert(result)(equalTo(5))
+      }
+    ),
+    suite("doWhileM")(
+      testM("doWhileM repeats while condition is true") {
+        for {
+          in     <- Ref.make(10)
+          out    <- Ref.make(0)
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doWhileM(v => UIO.succeedNow(v >= 0))
+          result <- out.get
+        } yield assert(result)(equalTo(11))
+      },
+      testM("doWhileM always evaluates effect at least once") {
+        for {
+          ref    <- Ref.make(0)
+          _      <- ref.update(_ + 1).doWhileM(_ => UIO.succeedNow(false))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -1261,10 +1317,38 @@ object ZIOSpec extends ZIOBaseSpec {
           result <- out.get
         } yield assert(result)(equalTo(10))
       },
-      testM("retryUntil doesn't retry when condition is true") {
+      testM("retryUntil runs at least once") {
         for {
           ref    <- Ref.make(0)
-          _      <- ref.update(_ + 1).flipWith(_.doUntil(_ => true))
+          _      <- ref.update(_ + 1).flipWith(_.retryUntil(_ => true))
+          result <- ref.get
+        } yield assert(result)(equalTo(1))
+      }
+    ),
+    suite("retryUntilEquals")(
+      testM("retryUntilEquals retries until error equals predicate") {
+        for {
+          q      <- Queue.unbounded[Int]
+          _      <- q.offerAll(List(1, 2, 3, 4, 5, 6))
+          acc    <- Ref.make(0)
+          _      <- (q.take <* acc.update(_ + 1)).flipWith(_.retryUntilEquals(5))
+          result <- acc.get
+        } yield assert(result)(equalTo(5))
+      }
+    ),
+    suite("retryUntilM")(
+      testM("retryUntilM retries until condition is true") {
+        for {
+          in     <- Ref.make(10)
+          out    <- Ref.make(0)
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryUntilM(v => UIO.succeedNow(v == 0)))
+          result <- out.get
+        } yield assert(result)(equalTo(10))
+      },
+      testM("retryUntilM runs at least once") {
+        for {
+          ref    <- Ref.make(0)
+          _      <- ref.update(_ + 1).flipWith(_.retryUntilM(_ => UIO.succeedNow(true)))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -1278,10 +1362,38 @@ object ZIOSpec extends ZIOBaseSpec {
           result <- out.get
         } yield assert(result)(equalTo(11))
       },
-      testM("retryWhile doesn't retry when condition is false") {
+      testM("retryWhile runs at least once") {
         for {
           ref    <- Ref.make(0)
           _      <- ref.update(_ + 1).flipWith(_.retryWhile(_ => false))
+          result <- ref.get
+        } yield assert(result)(equalTo(1))
+      }
+    ),
+    suite("retryWhileEquals")(
+      testM("retryWhileEquals retries while error equals predicate") {
+        for {
+          q      <- Queue.unbounded[Int]
+          _      <- q.offerAll(List(0, 0, 0, 0, 1, 2))
+          acc    <- Ref.make(0)
+          _      <- (q.take <* acc.update(_ + 1)).flipWith(_.retryWhileEquals(0))
+          result <- acc.get
+        } yield assert(result)(equalTo(5))
+      }
+    ),
+    suite("retryWhileM")(
+      testM("retryWhileM retries while condition is true") {
+        for {
+          in     <- Ref.make(10)
+          out    <- Ref.make(0)
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryWhileM(v => UIO.succeedNow(v >= 0)))
+          result <- out.get
+        } yield assert(result)(equalTo(11))
+      },
+      testM("retryWhileM runs at least once") {
+        for {
+          ref    <- Ref.make(0)
+          _      <- ref.update(_ + 1).flipWith(_.retryWhileM(_ => UIO.succeedNow(false)))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -688,7 +688,7 @@ object Schedule {
   /**
    * A schedule that recurs for as long as the predicate is equal.
    */
-  def doWhileEquals[A](a: A): Schedule[Any, A, A] =
+  def doWhileEquals[A](a: => A): Schedule[Any, A, A] =
     identity[A].whileInput(_ == a)
 
   /**
@@ -706,7 +706,7 @@ object Schedule {
   /**
    * A schedule that recurs for until the predicate is equal.
    */
-  def doUntilEquals[A](a: A): Schedule[Any, A, A] =
+  def doUntilEquals[A](a: => A): Schedule[Any, A, A] =
     identity[A].untilInput(_ == a)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -378,10 +378,34 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     repeat(Schedule.doUntil(f))
 
   /**
+   * Repeats this effect until its result is equal to the predicate.
+   */
+  final def doUntilEquals[A1 >: A](a: => A1): ZIO[R, E, A1] =
+    repeat(Schedule.doUntilEquals(a))
+
+  /**
+   * Repeats this effect until its result satisfies the specified effectful predicate.
+   */
+  final def doUntilM(f: A => UIO[Boolean]): ZIO[R, E, A] =
+    repeat(Schedule.doUntilM(f))
+
+  /**
    * Repeats this effect while its result satisfies the specified predicate.
    */
   final def doWhile(f: A => Boolean): ZIO[R, E, A] =
     repeat(Schedule.doWhile(f))
+
+  /**
+   * Repeats this effect for as long as the predicate is equal to its result.
+   */
+  final def doWhileEquals[A1 >: A](a: => A1): ZIO[R, E, A1] =
+    repeat(Schedule.doWhileEquals(a))
+
+  /**
+   * Repeats this effect while its result satisfies the specified effectful predicate.
+   */
+  final def doWhileM(f: A => UIO[Boolean]): ZIO[R, E, A] =
+    repeat(Schedule.doWhileM(f))
 
   /**
    * Returns an effect whose failure and success have been lifted into an
@@ -1340,14 +1364,38 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Retries this effect until its error satisfies the specified predicate.
    */
-  final def retryUntil(f: E => Boolean): ZIO[R, E, A] =
+  final def retryUntil(f: E => Boolean)(implicit ev: CanFail[E]): ZIO[R, E, A] =
     retry(Schedule.doUntil(f))
+
+  /**
+   * Retries this effect until its error equals the predicate.
+   */
+  final def retryUntilEquals[E1 >: E](e: => E1)(implicit ev: CanFail[E1]): ZIO[R, E1, A] =
+    retry(Schedule.doUntilEquals(e))
+
+  /**
+   * Retries this effect until its error satisfies the specified effectful predicate.
+   */
+  final def retryUntilM(f: E => UIO[Boolean])(implicit ev: CanFail[E]): ZIO[R, E, A] =
+    retry(Schedule.doUntilM(f))
 
   /**
    * Retries this effect while its error satisfies the specified predicate.
    */
-  final def retryWhile(f: E => Boolean): ZIO[R, E, A] =
+  final def retryWhile(f: E => Boolean)(implicit ev: CanFail[E]): ZIO[R, E, A] =
     retry(Schedule.doWhile(f))
+
+  /**
+   * Repeats this effect for as long as the error equals the predicate.
+   */
+  final def retryWhileEquals[E1 >: E](e: => E1)(implicit ev: CanFail[E1]): ZIO[R, E1, A] =
+    retry(Schedule.doWhileEquals(e))
+
+  /**
+   * Retries this effect while its error satisfies the specified effectful predicate.
+   */
+  final def retryWhileM(f: E => UIO[Boolean])(implicit ev: CanFail[E]): ZIO[R, E, A] =
+    retry(Schedule.doWhileM(f))
 
   /**
    * Returns an effect that semantically runs the effect on a fiber,


### PR DESCRIPTION
A couple of combinators missing in ZIO that were present in scheduler that could be added for free.