### PR TITLE
ZStream: flatMap (and ZSink.collectAll)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -1,7 +1,8 @@
 package zio.stream.experimental
 
-import zio._
 import ZSinkUtils._
+
+import zio._
 import zio.test.Assertion.equalTo
 import zio.test._
 

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -1,0 +1,55 @@
+package zio.stream.experimental
+
+import zio._
+import ZSinkUtils._
+import zio.test.Assertion.equalTo
+import zio.test._
+
+object ZSinkSpec extends ZIOBaseSpec {
+  def spec = suite("ZSinkSpec")(
+    suite("Constructors")(
+      suite("collectAll")(
+        testM("happy path") {
+          val sink = ZSink.collectAll[Int]
+          assertM(sinkIteration(sink, 1))(equalTo(List(1)))
+        }
+        // TODO uncomment when combinators migrated
+        // testM("init error") {
+        //   val sink = initErrorSink.collectAll
+        //   assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
+        // },
+        // testM("step error") {
+        //   val sink = stepErrorSink.collectAll
+        //   assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
+        // },
+        // testM("extract error") {
+        //   val sink = extractErrorSink.collectAll
+        //   assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
+        // },
+        // testM("interaction with succeed") {
+        //   val sink = ZSink.succeed[Int, Int](5).collectAll
+        //   for {
+        //     init <- sink.initial
+        //     s <- sink
+        //           .step(init, 1)
+        //           .flatMap(sink.step(_, 2))
+        //           .flatMap(sink.step(_, 3))
+        //     result <- sink.extract(s)
+        //   } yield assert(result)(equalTo(List(5, 5, 5, 5) -> Chunk(1, 2, 3)))
+        // },
+        // testM("interaction with ignoreWhile") {
+        //   val sink = ZSink.ignoreWhile[Int](_ < 5).collectAll
+        //   for {
+        //     result <- sink.initial
+        //                .flatMap(sink.step(_, 1))
+        //                .flatMap(sink.step(_, 2))
+        //                .flatMap(sink.step(_, 3))
+        //                .flatMap(sink.step(_, 5))
+        //                .flatMap(sink.step(_, 6))
+        //                .flatMap(sink.extract)
+        //   } yield assert(result)(equalTo(List((), ()) -> Chunk(5, 6)))
+        // }
+      )
+    )
+  )
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkUtils.scala
@@ -1,0 +1,31 @@
+package zio.stream.experimental
+
+import zio._
+import ZSink.Control
+
+object ZSinkUtils {
+  val initErrorSink = ZSink[Any, String, Int, Int, Int] {
+    Managed.failNow("Ouch")
+  }
+
+  val stepErrorSink = ZSink[Any, String, Int, Int, Int] {
+    Managed.succeedNow {
+      Control(
+        _ => IO.failNow(Left("Ouch")),
+        IO.failNow("Ouch")
+      )
+    }
+  }
+
+  def extractErrorSink = ZSink[Any, String, Int, Int, Int] {
+    Managed.succeedNow {
+      Control(
+        _ => IO.unit,
+        IO.failNow("Ouch")
+      )
+    }
+  }
+
+  def sinkIteration[R, E, M, B, A](sink: ZSink[R, E, B, A, Any], a: A): ZIO[R, E, B] =
+    sink.process.use(control => control.push(a).catchAll(_.fold(IO.fail(_), _ => IO.unit)) *> control.query)
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkUtils.scala
@@ -1,7 +1,8 @@
 package zio.stream.experimental
 
-import zio._
 import ZSink.Control
+
+import zio._
 
 object ZSinkUtils {
   val initErrorSink = ZSink[Any, String, Int, Int, Int] {

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -147,7 +147,14 @@ object ZStreamSpec extends ZIOBaseSpec {
             .process
             .use(nPulls(_, 3))
             .map(assert(_)(equalTo(List(Left(Left("Ouch")), Left(Right(())), Left(Right(()))))))
-        }
+        },
+        testM("succeedNow")(checkM(Gen.anyInt) { i =>
+          ZStream
+            .succeedNow(i)
+            .process
+            .use(nPulls(_, 3))
+            .map(assert(_)(equalTo(List(Right(i), Left(Right(())), Left(Right(()))))))
+        })
       ),
       suite("managed")(
         testM("success") {

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -10,6 +10,95 @@ import zio.test._
 object ZStreamSpec extends ZIOBaseSpec {
   def spec = suite("ZStreamSpec")(
     suite("Combinators")(
+      suite("flatMap")(
+        testM("deep flatMap stack safety") {
+          def fib(n: Int): UStream[Int] =
+            if (n <= 1) ZStream.succeedNow(n)
+            else
+              fib(n - 1).flatMap { a =>
+                fib(n - 2).flatMap { b =>
+                  ZStream.succeedNow(a + b)
+                }
+              }
+
+          val stream   = fib(20)
+          val expected = 6765
+
+          assertM(stream.runCollect)(equalTo(List(expected)))
+        }
+        //   testM("left identity")(checkM(Gen.anyInt, Gen.function(pureStreamOfInts)) { (x, f) =>
+        //     for {
+        //       res1 <- ZStream(x).flatMap(f).runCollect
+        //       res2 <- f(x).runCollect
+        //     } yield assert(res1)(equalTo(res2))
+        //   }),
+        //   testM("right identity")(
+        //     checkM(pureStreamOfInts)(m =>
+        //       for {
+        //         res1 <- m.flatMap(i => ZStream(i)).runCollect
+        //         res2 <- m.runCollect
+        //       } yield assert(res1)(equalTo(res2))
+        //     )
+        //   ),
+        //   testM("associativity") {
+        //     val tinyStream = Gen.int(0, 2).flatMap(pureStreamGen(Gen.anyInt, _))
+        //     val fnGen      = Gen.function(tinyStream)
+        //     checkM(tinyStream, fnGen, fnGen) { (m, f, g) =>
+        //       for {
+        //         leftStream  <- m.flatMap(f).flatMap(g).runCollect
+        //         rightStream <- m.flatMap(x => f(x).flatMap(g)).runCollect
+        //       } yield assert(leftStream)(equalTo(rightStream))
+        //     }
+        //   },
+        // TODO uncomment when bracket*, tap, ensuring, etc. are migrated
+        // testM("inner finalizers") {
+        //   for {
+        //     effects <- Ref.make(List[Int]())
+        //     push    = (i: Int) => effects.update(i :: _)
+        //     latch   <- Promise.make[Nothing, Unit]
+        //     fiber <- ZStream(
+        //               ZStream.bracket(push(1))(_ => push(1)),
+        //               ZStream.fromEffect(push(2)),
+        //               ZStream.bracket(push(3))(_ => push(3)) *> Stream.fromEffect(
+        //                 latch.succeed(()) *> ZIO.never
+        //               )
+        //             ).flatMap(identity).runDrain.fork
+        //     _      <- latch.await
+        //     _      <- fiber.interrupt
+        //     result <- effects.get
+        //   } yield assert(result)(equalTo(List(3, 3, 2, 1, 1)))
+
+        // },
+        // testM("finalizer ordering") {
+        //   for {
+        //     effects <- Ref.make(List[Int]())
+        //     push    = (i: Int) => effects.update(i :: _)
+        //     stream = for {
+        //       _ <- ZStream.bracket(push(1))(_ => push(1))
+        //       _ <- ZStream((), ()).tap(_ => push(2)).ensuring(push(2))
+        //       _ <- ZStream.bracket(push(3))(_ => push(3))
+        //       _ <- ZStream((), ()).tap(_ => push(4)).ensuring(push(4))
+        //     } yield ()
+        //     _      <- stream.runDrain
+        //     result <- effects.get
+        //   } yield assert(result)(equalTo(List(1, 2, 3, 4, 4, 4, 3, 2, 3, 4, 4, 4, 3, 2, 1).reverse))
+        // },
+        // testM("exit signal") {
+        //   for {
+        //     ref <- Ref.make(false)
+        //     inner = ZStream
+        //       .bracketExit(UIO.unit)((_, e) =>
+        //         e match {
+        //           case Exit.Failure(_) => ref.set(true)
+        //           case Exit.Success(_) => UIO.unit
+        //         }
+        //       )
+        //       .flatMap(_ => ZStream.failNow("Ouch"))
+        //     _   <- ZStream.succeedNow(()).flatMap(_ => inner).runDrain.either.unit
+        //     fin <- ref.get
+        //   } yield assert(fin)(isTrue)
+        // }
+      ),
       testM("map") {
         ZStream
           .fromEffect(UIO.succeed(1))

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -48,11 +48,11 @@ object ZSink extends Serializable {
     new ZSink(process)
 
   /**
-    * Accumulates all incoming elements into a list.
-    *
-    * @tparam A the type of elements
-    * @return a sink accumulating (forever) incoming elements
-    */
+   * Accumulates all incoming elements into a list.
+   *
+   * @tparam A the type of elements
+   * @return a sink accumulating (forever) incoming elements
+   */
   def collectAll[A]: ZSink[Any, Nothing, List[A], A, Nothing] = {
     import scala.collection.mutable.ListBuffer
     ZSink[Any, Nothing, List[A], A, Nothing] {

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -53,14 +53,12 @@ object ZSink extends Serializable {
    * @tparam A the type of elements
    * @return a sink accumulating (forever) incoming elements
    */
-  def collectAll[A]: ZSink[Any, Nothing, List[A], A, Nothing] = {
-    import scala.collection.mutable.ListBuffer
+  def collectAll[A]: ZSink[Any, Nothing, List[A], A, Nothing] =
     ZSink[Any, Nothing, List[A], A, Nothing] {
       for {
-        buf   <- Ref.make(ListBuffer.empty[A]).toManaged_
-        push  = (a: A) => buf.update(_ :+ a)
-        query = buf.get.map(_.toList)
+        buf   <- Ref.make(List.empty[A]).toManaged_
+        push  = (a: A) => buf.update(a :: _)
+        query = buf.get.map(_.reverse)
       } yield Control(push, query)
     }
-  }
 }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -46,4 +46,21 @@ object ZSink extends Serializable {
    */
   def apply[R, E, M, A, B](process: ZManaged[R, E, ZSink.Control[R, E, M, A, B]]): ZSink[R, E, M, A, B] =
     new ZSink(process)
+
+  /**
+    * Accumulates all incoming elements into a list.
+    *
+    * @tparam A the type of elements
+    * @return a sink accumulating (forever) incoming elements
+    */
+  def collectAll[A]: ZSink[Any, Nothing, List[A], A, Nothing] = {
+    import scala.collection.mutable.ListBuffer
+    ZSink[Any, Nothing, List[A], A, Nothing] {
+      for {
+        buf   <- Ref.make(ListBuffer.empty[A]).toManaged_
+        push  = (a: A) => buf.update(_ :+ a)
+        query = buf.get.map(_.toList)
+      } yield Control(push, query)
+    }
+  }
 }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -303,7 +303,7 @@ object ZStream extends Serializable {
    * @param c a chunk of values
    * @return a finite stream of values
    */
-  def fromChunk[A](c: => Chunk[A]): ZStream[Any, Nothing, Any, Unit, A] =
+  def fromChunk[A](c: => Chunk[A]): UStream[A] =
     ZStream {
       Managed.fromEffect {
         Ref.make(0).map { iRef =>
@@ -372,4 +372,14 @@ object ZStream extends Serializable {
         }
       } yield Control(pull, Command.noop)
     }
+
+  /**
+   * Creates a single-valued pure stream
+   *
+   * @tparam A the value type
+   * @param a the only value of the stream
+   * @return a single-valued stream
+   */
+  def succeedNow[A](a: A): UStream[A] =
+    managed(Managed.succeedNow(a))
 }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -185,7 +185,7 @@ class ZStream[-R, +E, -M, +B, +A](
   /**
    * Runs the sink on the stream to produce either the sink's internal state or an error.
    */
-  def runQuery[R1 <: R, E1 >: E, A1 >: A, B](sink: ZSink[R1, E1, B, A1, Nothing]): ZIO[R1, E1, B] =
+  def runQuery[R1 <: R, E1 >: E, A1 >: A, B](sink: ZSink[R1, E1, B, A1, Any]): ZIO[R1, E1, B] =
     (self.process <*> sink.process).use {
       case (command, control) =>
         def pull: ZIO[R1, E1, B] =

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -204,14 +204,8 @@ class ZStream[-R, +E, -M, +B, +A](
       go = {
         def pull: ZIO[R1, E1, B] =
           command.pull.foldM(
-            {
-              case Left(e)  => ZIO.failNow(e)
-              case Right(_) => control.query
-            },
-            control.push(_).catchAll {
-              case Left(e)  => ZIO.failNow(e)
-              case Right(_) => ZIO.unit
-            } *> pull
+            _.fold(ZIO.failNow, _ => control.query),
+            control.push(_).catchAll(_.fold(ZIO.failNow, _ => ZIO.unit)) *> pull
           )
         pull
       }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -34,7 +34,7 @@ class ZStream[-R, +E, -M, +B, +A](
         }
       } yield Control(pull, Command.noop)
     }
-  
+
   /**
    * Returns a stream made of the concatenation in strict order of all the streams
    * produced by passing each element of this stream to `f0`
@@ -211,7 +211,7 @@ class ZStream[-R, +E, -M, +B, +A](
    * @return an action that yields the list of elements in the stream
    */
   final def runCollect: ZIO[R, E, List[A]] = runQuery(ZSink.collectAll[A])
-  
+
   /**
    * Converts the stream to a managed queue. After the managed queue is used,
    * the queue will never again produce values and should be discarded.

--- a/streams/shared/src/main/scala/zio/stream/experimental/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/package.scala
@@ -1,0 +1,7 @@
+package zio.stream
+
+package object experimental {
+  type Stream[+E, +A] = ZStream[Any, E, Any, Nothing, A]
+  type UStream[A]     = ZStream[Any, Nothing, Any, Nothing, A]
+  type URStream[R, A] = ZStream[R, Nothing, Any, Nothing, A]
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/package.scala
@@ -1,7 +1,7 @@
 package zio.stream
 
 package object experimental {
-  type Stream[+E, +A] = ZStream[Any, E, Any, Nothing, A]
-  type UStream[A]     = ZStream[Any, Nothing, Any, Nothing, A]
-  type URStream[R, A] = ZStream[R, Nothing, Any, Nothing, A]
+  type Stream[+E, +A] = ZStream[Any, E, Any, Unit, A]
+  type UStream[A]     = ZStream[Any, Nothing, Any, Unit, A]
+  type URStream[R, A] = ZStream[R, Nothing, Any, Unit, A]
 }


### PR DESCRIPTION
Had to add `ZSink.collectAll` as it is used in all the tests. Some tests will have to be commented out until more combinators have been migrated, but I don't think this is bad as I'm reusing most of the existing implementation.

cc @vasilmkd 