### PR TITLE
Port ZStream#ensuring,take,runDrain; ZStream.bracket,bracketExit; ZSi…

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -10,6 +10,30 @@ import zio.test._
 object ZStreamSpec extends ZIOBaseSpec {
   def spec = suite("ZStreamSpec")(
     suite("Combinators")(
+      suite("ensuring")(
+        testM("Stream.ensuring") {
+          for {
+            log <- Ref.make[List[String]](Nil)
+            _ <- (for {
+                  _ <- ZStream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
+                  _ <- ZStream.fromEffect(log.update("Use" :: _))
+                } yield ()).ensuring(log.update("Ensuring" :: _)).runDrain
+            execution <- log.get
+          } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+        }
+      ),
+      suite("ensuringFirst")(
+        testM("Stream.ensuringFirst") {
+          for {
+            log <- Ref.make[List[String]](Nil)
+            _ <- (for {
+                  _ <- ZStream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
+                  _ <- ZStream.fromEffect(log.update("Use" :: _))
+                } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
+            execution <- log.get
+          } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+        }
+      ),
       suite("flatMap")(
         testM("deep flatMap stack safety") {
           def fib(n: Int): UStream[Int] =
@@ -133,6 +157,59 @@ object ZStreamSpec extends ZIOBaseSpec {
       }
     ),
     suite("Constructors")(
+      suite("bracket")(
+        testM("bracket")(
+          for {
+            done           <- Ref.make(false)
+            iteratorStream = ZStream.bracket(UIO(0))(_ => done.set(true))
+            result         <- iteratorStream.runCollect
+            released       <- done.get
+          } yield assert(result)(equalTo(List(0))) && assert(released)(isTrue)
+        ),
+        testM("bracket short circuits")(
+          for {
+            done <- Ref.make(false)
+            stream = ZStream
+              .bracket(UIO(Chunk(0, 1, 2)))(_ => done.set(true))
+              .flatMap(ZStream.fromChunk(_))
+              .take(2)
+            result   <- stream.runCollect
+            released <- done.get
+          } yield assert(result)(equalTo(List(0, 1))) && assert(released)(isTrue)
+        ),
+        // testM("no acquisition when short circuiting")(
+        //   for {
+        //     acquired       <- Ref.make(false)
+        //     iteratorStream = (Stream(1) ++ Stream.bracket(acquired.set(true))(_ => UIO.unit)).take(0)
+        //     _              <- iteratorStream.run(Sink.drain)
+        //     result         <- acquired.get
+        //   } yield assert(result)(isFalse)
+        // ),
+        testM("releases when there are defects") {
+          for {
+            ref <- Ref.make(false)
+            _ <- ZStream
+                  .bracket(ZIO.unit)(_ => ref.set(true))
+                  .flatMap(_ => ZStream.fromEffect(ZIO.dieMessage("boom")))
+                  .runDrain
+                  .run
+            released <- ref.get
+          } yield assert(released)(isTrue)
+        },
+        testM("flatMap associativity doesn't affect bracket lifetime")(
+          for {
+            leftAssoc <- ZStream
+                          .bracket(Ref.make(true))(_.set(false))
+                          .flatMap(r => ZStream.fromEffect(UIO.succeedNow(r)))
+                          .flatMap(r => ZStream.fromEffect(r.get))
+                          .runCollect
+            rightAssoc <- ZStream
+                           .bracket(Ref.make(true))(_.set(false))
+                           .flatMap(r => ZStream.fromEffect(UIO(r)).flatMap(r => ZStream.fromEffect(r.get)))
+                           .runCollect
+          } yield assert(leftAssoc -> rightAssoc)(equalTo(List(true) -> List(true)))
+        )
+      ),
       suite("fromEffect")(
         testM("success") {
           ZStream
@@ -192,6 +269,32 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         }
       )
+      // suite("take")(
+      // testM("take")(checkM(streamOfBytes, Gen.anyInt) { (s: Stream[String, Byte], n: Int) =>
+      //   for {
+      //     takeStreamResult <- s.take(n.toLong).runCollect.run
+      //     takeListResult   <- s.runCollect.map(_.take(n)).run
+      //   } yield assert(takeListResult.succeeded)(isTrue) implies assert(takeStreamResult)(equalTo(takeListResult))
+      // }),
+      // testM("take short circuits")(
+      //   for {
+      //     ran    <- Ref.make(false)
+      //     stream = (ZStream(1) ++ Stream.fromEffect(ran.set(true)).drain).take(0)
+      //     _      <- stream.run(Sink.drain)
+      //     result <- ran.get
+      //   } yield assert(result)(isFalse)
+      // ),
+      //  testM("take(0) short circuits")(
+      //    for {
+      //      units <- Stream.never.take(0).run(Sink.collectAll[Unit])
+      //    } yield assert(units)(equalTo(Nil))
+      //  ),
+      //  testM("take(1) short circuits")(
+      //    for {
+      //      ints <- (Stream(1) ++ Stream.never).take(1).run(Sink.collectAll[Int])
+      //    } yield assert(ints)(equalTo(List(1)))
+      //  )
+      // )
     ),
     suite("Destructors")(
       testM("toQueue")(checkM(smallChunks(Gen.anyInt)) { (c: Chunk[Int]) =>

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -61,4 +61,10 @@ object ZSink extends Serializable {
         query = buf.get.map(_.reverse)
       } yield Control(push, query)
     }
+
+  /**
+   * A sink that ignores all incoming elements.
+   */
+  val drain: ZSink[Any, Nothing, Unit, Any, Unit] =
+    ZSink(ZManaged.succeed(Control(_ => UIO.unit, UIO.unit)))
 }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -36,6 +36,26 @@ class ZStream[-R, +E, -M, +B, +A](
     }
 
   /**
+   * Executes the provided finalizer after this stream's finalizers run.
+   *
+   * @tparam R1 the environment required by the finalizer
+   * @param fin the finalizer
+   * @return a stream that executes the provided finalizer in addition to the existing ones
+   */
+  final def ensuring[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, M, B, A] =
+    ZStream(self.process.ensuring(fin))
+
+  /**
+   * Executes the provided finalizer before this stream's finalizers run.
+   *
+   * @tparam R1 the environment required by the finalizer
+   * @param fin the finalizer
+   * @return a stream that executes the provided finalizer in addition to the existing ones
+   */
+  final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, M, B, A] =
+    ZStream(self.process.ensuringFirst(fin))
+
+  /**
    * Returns a stream made of the concatenation in strict order of all the streams
    * produced by passing each element of this stream to `f0`
    *
@@ -181,6 +201,40 @@ class ZStream[-R, +E, -M, +B, +A](
     } yield ()
 
   /**
+   * Runs the stream and collects all of its elements in a list.
+   *
+   * Equivalent to `run(Sink.collectAll[A])`.
+   *
+   * @return an action that yields the list of elements in the stream
+   */
+  final def runCollect: ZIO[R, E, List[A]] = runQuery(ZSink.collectAll[A])
+
+  /**
+   * Runs the stream and collects all of its elements in a list.
+   *
+   * Equivalent to `run(Sink.collectAll[A])`.
+   *
+   * @return an action that yields the list of elements in the stream
+   */
+  final def runCollectManaged: ZManaged[R, E, List[A]] = runQueryManaged(ZSink.collectAll[A])
+
+  /**
+   * Runs the stream purely for its effects. Any elements emitted by
+   * the stream are discarded.
+   *
+   * @return a managed effect that drains the stream
+   */
+  final def runDrainManaged: ZManaged[R, E, Unit] = runQueryManaged(ZSink.drain)
+
+  /**
+   * Runs the stream purely for its effects. Any elements emitted by
+   * the stream are discarded.
+   *
+   * @return an action that drains the stream
+   */
+  final def runDrain: ZIO[R, E, Unit] = runDrainManaged.use(UIO.succeedNow)
+
+  /**
    * Runs the sink on the stream to produce either the sink's internal state or an error.
    *
    * @tparam B the internal state of the sink
@@ -213,22 +267,21 @@ class ZStream[-R, +E, -M, +B, +A](
     } yield b
 
   /**
-   * Runs the stream and collects all of its elements in a list.
-   *
-   * Equivalent to `run(Sink.collectAll[A])`.
-   *
-   * @return an action that yields the list of elements in the stream
+   * Takes the specified number of elements from this stream.
+   * @param n the number of elements to retain
+   * @return a stream with `n` or less elements
    */
-  final def runCollect: ZIO[R, E, List[A]] = runQuery(ZSink.collectAll[A])
-
-  /**
-   * Runs the stream and collects all of its elements in a list.
-   *
-   * Equivalent to `run(Sink.collectAll[A])`.
-   *
-   * @return an action that yields the list of elements in the stream
-   */
-  final def runCollectManaged: ZManaged[R, E, List[A]] = runQueryManaged(ZSink.collectAll[A])
+  def take(n: Long): ZStream[R, E, M, Option[B], A] =
+    ZStream {
+      for {
+        as      <- self.process
+        counter <- Ref.make(0L).toManaged_
+        pull = counter.get.flatMap { c =>
+          if (c >= n) Pull.end(None)
+          else as.pull.mapError(_.map(Some(_))) <* counter.set(c + 1)
+        }
+      } yield Control(pull, as.command)
+    }
 
   /**
    * Converts the stream to a managed queue. After the managed queue is used,
@@ -293,6 +346,36 @@ object ZStream extends Serializable {
    */
   def apply[R, E, M, B, A](process: ZManaged[R, Nothing, Control[R, E, M, B, A]]): ZStream[R, E, M, B, A] =
     new ZStream(process)
+
+  /**
+   * Creates a stream from an effect and a finalizer. The finalizer will run
+   * once the stream consumption has ended.
+   *
+   * @tparam R the environment required by the effects
+   * @tparam E the error type yielded by the effect
+   * @tparam A the value type yielded by the effect
+   * @param acquire the effect
+   * @param release the finalizer
+   * @return a stream that emits the value yielded by the effect
+   */
+  def bracket[R, E, A](acquire: ZIO[R, E, A])(release: A => ZIO[R, Nothing, Any]): ZStream[R, E, Any, Unit, A] =
+    managed(ZManaged.make(acquire)(release))
+
+  /**
+   * Creates a stream from an effect and a finalizer. The finalizer will run
+   * once the stream consumption has ended.
+   *
+   * @tparam R the environment required by the effects
+   * @tparam E the error type yielded by the effect
+   * @tparam A the value type yielded by the effect
+   * @param acquire the effect
+   * @param release the finalizer
+   * @return a stream that emits the value yielded by the effect
+   */
+  def bracketExit[R, E, A](
+    acquire: ZIO[R, E, A]
+  )(release: (A, Exit[Any, Any]) => ZIO[R, Nothing, Any]): ZStream[R, E, Any, Unit, A] =
+    managed(ZManaged.makeExit(acquire)(release))
 
   /**
    * Creates a stream from a [[zio.Chunk]] of values


### PR DESCRIPTION
…nk.drain

More tests that are commented out. Deferred those so the branch doesn't get huge.

@vasilmkd @regiskuckaertz 