### PR TITLE
Migrate ZStream.die|fail|halt|empty|never|range|iterate and Stream#takeWhile

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -155,6 +155,22 @@ object ZStreamSpec extends ZIOBaseSpec {
           .use(nPulls(_, 3))
           .map(assert(_)(equalTo(List(Right(1), Left(Right(())), Left(Right(()))))))
       }
+      // suite("takeWhile")(
+      //   testM("happy path")(checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+      //     for {
+      //       streamTakeWhile <- s.takeWhile(p).runCollect.run
+      //       listTakeWhile   <- s.runCollect.map(_.takeWhile(p)).run
+      //     } yield assert(listTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(listTakeWhile))
+      //   }),
+      //   testM("short circuits")(
+      //     assertM(
+      //       (ZStream.succeedNow(1) ++ Stream.failNow("Ouch"))
+      //         .takeWhile(_ => false)
+      //         .runDrain
+      //         .either
+      //     )(isRight(isUnit))
+      //   )
+      // )
     ),
     suite("Constructors")(
       suite("bracket")(
@@ -233,9 +249,9 @@ object ZStreamSpec extends ZIOBaseSpec {
             .map(assert(_)(equalTo(List(Right(i), Left(Right(())), Left(Right(()))))))
         })
       ),
-      // testM("Stream.iterate")(
-      //   assertM(Stream.iterate(1)(_ + 1).take(10).runCollect)(equalTo((1 to 10).toList))
-      // ),
+      testM("iterate")(
+        assertM(ZStream.iterate(1)(_ + 1).take(10).runCollect)(equalTo((1 to 10).toList))
+      ),
       suite("managed")(
         testM("success") {
           for {

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -286,11 +286,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assert(fin)(isTrue) && assert(pulls)(
             equalTo(List(Left(Left("Ouch")), Left(Right(())), Left(Right(()))))
           )
-        },
-        testM("range") {
-          assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
         }
-      )
+      ),
+      testM("range") {
+        assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
+      }
       // suite("take")(
       // testM("take")(checkM(streamOfBytes, Gen.anyInt) { (s: Stream[String, Byte], n: Int) =>
       //   for {

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -148,9 +148,6 @@ object ZStreamSpec extends ZIOBaseSpec {
             .use(nPulls(_, 3))
             .map(assert(_)(equalTo(List(Left(Left("Ouch")), Left(Right(())), Left(Right(()))))))
         },
-        testM("range") {
-          assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
-        },
         testM("succeedNow")(checkM(Gen.anyInt) { i =>
           ZStream
             .succeedNow(i)
@@ -159,6 +156,9 @@ object ZStreamSpec extends ZIOBaseSpec {
             .map(assert(_)(equalTo(List(Right(i), Left(Right(())), Left(Right(()))))))
         })
       ),
+      // testM("Stream.iterate")(
+      //   assertM(Stream.iterate(1)(_ + 1).take(10).runCollect)(equalTo((1 to 10).toList))
+      // ),
       suite("managed")(
         testM("success") {
           for {
@@ -193,6 +193,9 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assert(fin)(isTrue) && assert(pulls)(
             equalTo(List(Left(Left("Ouch")), Left(Right(())), Left(Right(()))))
           )
+        },
+        testM("range") {
+          assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
         }
       )
     ),

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -148,6 +148,9 @@ object ZStreamSpec extends ZIOBaseSpec {
             .use(nPulls(_, 3))
             .map(assert(_)(equalTo(List(Left(Left("Ouch")), Left(Right(())), Left(Right(()))))))
         },
+        testM("range") {
+          assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
+        },
         testM("succeedNow")(checkM(Gen.anyInt) { i =>
           ZStream
             .succeedNow(i)

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -504,16 +504,13 @@ object ZStream extends Serializable {
    */
   def iterate[A](a: A)(f: A => A): UStream[A] =
     ZStream {
-      Managed.effectTotal {
-        var currA = a
-        Control(
-          ZIO.effectTotal {
-            val ret = currA
-            currA = f(currA)
-            ret
-          },
-          Command.noop
-        )
+      Managed.fromEffect {
+        Ref.make(a).map { currA =>
+          Control(
+            currA.modify(a => f(a) -> a),
+            Command.noop
+          )
+        }
       }
     }
 

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -507,7 +507,7 @@ object ZStream extends Serializable {
       Managed.fromEffect {
         Ref.make(a).map { currA =>
           Control(
-            currA.modify(a => f(a) -> a),
+            currA.modify(a => a -> f(a)),
             Command.noop
           )
         }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -402,7 +402,11 @@ object ZStream extends Serializable {
       Managed.effectTotal {
         var currA = a
         Control(
-          ZIO.succeedNow(currA) <* ZIO.effectTotal { currA = f(currA) },
+          ZIO.effectTotal { 
+            val ret = currA
+            currA = f(currA)
+            ret
+          },
           Command.noop
         )
       }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -141,11 +141,11 @@ class ZStream[-R, +E, -M, +B, +A](
     }
 
   /**
-   * Maps the elements of this stream using a ''pure'' function.
+   * Maps the end-of-stream marker using a ''pure'' function.
    *
-   * @tparam C the value type of the new stream
+   * @tparam C the value type of the new marker
    * @param f the ''pure'' transformation function
-   * @return a stream of transformed values
+   * @return a stream with a transformed marker
    */
   def mapMarker[C](f: B => C): ZStream[R, E, M, C, A] =
     ZStream {

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -296,7 +296,9 @@ class ZStream[-R, +E, -M, +B, +A](
           if (_)
             Pull.end(None)
           else
-            control.pull.mapError(_.map(Some(_))).flatMap(a => if (pred(a)) Pull.emit(a) else done.set(true) *> Pull.end(None))
+            control.pull
+              .mapError(_.map(Some(_)))
+              .flatMap(a => if (pred(a)) Pull.emit(a) else done.set(true) *> Pull.end(None))
         }
       } yield Control(pull, control.command)
     }
@@ -365,8 +367,8 @@ object ZStream extends Serializable {
   def apply[R, E, M, B, A](process: ZManaged[R, Nothing, Control[R, E, M, B, A]]): ZStream[R, E, M, B, A] =
     new ZStream(process)
 
-    /**
-     * Creates a stream from an effect and a finalizer. The finalizer will run
+  /**
+   * Creates a stream from an effect and a finalizer. The finalizer will run
    * once the stream consumption has ended.
    *
    * @tparam R the environment required by the effects
@@ -397,7 +399,7 @@ object ZStream extends Serializable {
 
   /**
    * The stream that always dies with the `ex`.
-   * 
+   *
    * @param ex The exception that kills the stream
    * @return a stream that dies with an exception
    */
@@ -406,7 +408,7 @@ object ZStream extends Serializable {
 
   /**
    * The stream that always dies with an exception described by `msg`.
-   * 
+   *
    * @param msg The message to feed the runtime exception
    * @return a stream that dies with a runtime exception
    */
@@ -469,7 +471,7 @@ object ZStream extends Serializable {
 
   /**
    * The stream that always halts with `cause`.
-   * 
+   *
    * @tparam The error type
    * @param the cause for halting the stream
    * @return a stream that is halted
@@ -485,7 +487,7 @@ object ZStream extends Serializable {
       Managed.effectTotal {
         var currA = a
         Control(
-          ZIO.effectTotal { 
+          ZIO.effectTotal {
             val ret = currA
             currA = f(currA)
             ret
@@ -532,7 +534,7 @@ object ZStream extends Serializable {
 
   /**
    * Constructs a stream from a range of integers (lower bound included, upper bound not included)
-   * 
+   *
    * @param min the lower bound
    * @param max the upper bound
    */


### PR DESCRIPTION
Refrained from doing `unit` as it builds on `concat` which is a beast that needs to be tackled on its own.

@vasilmkd 