### PR TITLE
LightTypeTag instead of scala-reflect, GraalVM/NativeImage support

### DIFF
--- a/core/js/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/PlatformSpecific.scala
@@ -34,22 +34,12 @@ private[zio] trait PlatformSpecific {
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }
 
-  type TaggedType[A] = Tag[A]
-  type TagType       = LightTypeTag
+  type TaggedType[A] = ScalaSpecific.TaggedType[A]
+  type TagType       = ScalaSpecific.TagType
 
-  private[zio] def taggedTagType[A](t: Tagged[A]): TagType = t.tag.tag
+  private[zio] def taggedTagType[A](t: Tagged[A]): TagType = ScalaSpecific.taggedTagType(t)
 
-  private[zio] def taggedIsSubtype(left: TagType, right: TagType): Boolean =
-    left <:< right
+  private[zio] def taggedIsSubtype(left: TagType, right: TagType): Boolean = ScalaSpecific.taggedIsSubtype(left, right)
 
-  private[zio] def taggedGetHasServices[A](t: TagType): Set[TagType] =
-    t.decompose.map { parent =>
-      parent.ref match {
-        case reference: LightTypeTagRef.AppliedNamedReference if reference.typeArgs.size == 1 =>
-          parent.typeArgs.head
-
-        case _ =>
-          parent
-      }
-    }
+  private[zio] def taggedGetHasServices[A](t: TagType): Set[TagType] = ScalaSpecific.taggedGetHasServices(t)
 }

--- a/core/js/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/PlatformSpecific.scala
@@ -16,9 +16,6 @@
 
 package zio
 
-import izumi.fundamentals.reflection.Tags.Tag
-import izumi.fundamentals.reflection.macrortti.{ LightTypeTag, LightTypeTagRef }
-
 import zio.clock.Clock
 import zio.console.Console
 import zio.random.Random

--- a/core/native/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/PlatformSpecific.scala
@@ -16,9 +16,6 @@
 
 package zio
 
-import izumi.fundamentals.reflection.Tags.Tag
-import izumi.fundamentals.reflection.macrortti.{ LightTypeTag, LightTypeTagRef }
-
 import zio.clock.Clock
 import zio.console.Console
 import zio.random.Random
@@ -34,22 +31,12 @@ private[zio] trait PlatformSpecific {
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }
 
-  type TaggedType[A] = Tag[A]
-  type TagType       = LightTypeTag
+  type TaggedType[A] = ScalaSpecific.TaggedType[A]
+  type TagType       = ScalaSpecific.TagType
 
-  private[zio] def taggedTagType[A](t: Tagged[A]): TagType = t.tag.tag
+  private[zio] def taggedTagType[A](t: Tagged[A]): TagType = ScalaSpecific.taggedTagType(t)
 
-  private[zio] def taggedIsSubtype(left: TagType, right: TagType): Boolean =
-    left <:< right
+  private[zio] def taggedIsSubtype(left: TagType, right: TagType): Boolean = ScalaSpecific.taggedIsSubtype(left, right)
 
-  private[zio] def taggedGetHasServices[A](t: TagType): Set[TagType] =
-    t.decompose.map { parent =>
-      parent.ref match {
-        case reference: LightTypeTagRef.AppliedNamedReference if reference.typeArgs.size == 1 =>
-          parent.typeArgs.head
-
-        case _ =>
-          parent
-      }
-    }
+  private[zio] def taggedGetHasServices[A](t: TagType): Set[TagType] = ScalaSpecific.taggedGetHasServices(t)
 }

--- a/core/shared/src/main/scala-2.x/zio/ScalaSpecific.scala
+++ b/core/shared/src/main/scala-2.x/zio/ScalaSpecific.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio
 
 import izumi.fundamentals.reflection.Tags.Tag

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -2,6 +2,7 @@ import sbt._
 import Keys._
 import explicitdeps.ExplicitDepsPlugin.autoImport._
 import sbtcrossproject.CrossPlugin.autoImport._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbtbuildinfo._
 import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
@@ -85,7 +86,10 @@ object BuildHelper {
   val scalaReflectSettings = Seq(
     libraryDependencies ++=
       (if (isDotty.value) Seq()
-       else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value))
+       else
+         Seq(
+           "io.7mind.izumi" %%% "fundamentals-reflection" % "0.10.2-M6"
+         ))
   )
 
   // Keep this consistent with the version in .core-tests/shared/src/test/scala/REPLSpec.scala


### PR DESCRIPTION
This is a preliminary P/R replacing `scala-reflect` with [`LightTypeTag`](https://blog.7mind.io/lightweight-reflection.html) from [izumi](https://github.com/7mind/izumi).

For now it depends on `"io.7mind.izumi" %%% "fundamentals-reflection" % "0.10.2-M6"`, it's a lightweight library and it does not pollute the classpath:

```
❯ coursier resolve --tree io.7mind.izumi:fundamentals-reflection_2.13:0.10.2-M6
  Result:
└─ io.7mind.izumi:fundamentals-reflection_2.13:0.10.2-M6
   ├─ io.7mind.izumi:fundamentals-functional_2.13:0.10.2-M6
   │  ├─ org.scala-lang:scala-library:2.13.1
   │  └─ org.scala-lang.modules:scala-collection-compat_2.13:2.1.3
   │     └─ org.scala-lang:scala-library:2.13.0 -> 2.13.1
   ├─ io.7mind.izumi:fundamentals-platform_2.13:0.10.2-M6
   │  ├─ io.7mind.izumi:fundamentals-collections_2.13:0.10.2-M6
   │  │  ├─ org.scala-lang:scala-library:2.13.1
   │  │  └─ org.scala-lang.modules:scala-collection-compat_2.13:2.1.3
   │  │     └─ org.scala-lang:scala-library:2.13.0 -> 2.13.1
   │  ├─ org.scala-lang:scala-library:2.13.1
   │  └─ org.scala-lang.modules:scala-collection-compat_2.13:2.1.3
   │     └─ org.scala-lang:scala-library:2.13.0 -> 2.13.1
   ├─ io.7mind.izumi:fundamentals-thirdparty-boopickle-shaded_2.13:0.10.2-M6
   │  ├─ org.scala-lang:scala-library:2.13.1
   │  └─ org.scala-lang.modules:scala-collection-compat_2.13:2.1.3
   │     └─ org.scala-lang:scala-library:2.13.0 -> 2.13.1
   ├─ org.scala-lang:scala-library:2.13.1
   └─ org.scala-lang.modules:scala-collection-compat_2.13:2.1.3
      └─ org.scala-lang:scala-library:2.13.0 -> 2.13.1
```

Next steps:

1. In case we consider this experiment successful I'll move (or copy) LTT into a separate repository within zio org.
2. All the tag-specific code can be unified across all the build targets except dotty
3. Dotty support is pending

