### PR TITLE
ZIO Core: Implement ***

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -17,6 +17,14 @@ import zio.test.environment.{ Live, TestClock }
 object ZIOSpec extends ZIOBaseSpec {
 
   def spec = suite("ZIOSpec")(
+    suite("***")(
+      testM("splits the environment") {
+        val zio1 = ZIO.fromFunction((n: Int) => n + 2)
+        val zio2 = ZIO.fromFunction((n: Int) => n * 3)
+        val zio3 = zio1 *** zio2
+        assertM(zio3.provide((4, 5)))(equalTo((6, 15)))
+      }
+    ),
     suite("absorbWith")(
       testM("on fail") {
         assertM(TaskExampleError.absorbWith(identity).run)(fails(equalTo(ExampleError)))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -574,19 +574,19 @@ object ZSTMSpec extends ZIOBaseSpec {
       ),
       suite("tupled environment")(
         testM("_1 should extract first") {
-          val tx  = ZSTM._1[(Int, String), Nothing, Int, String]
+          val tx  = ZSTM._1[Nothing, Int, String]
           val env = (42, "test")
 
           assertM(tx.provide(env).commit)(equalTo(env._1))
         },
         testM("_2 should extract second") {
-          val tx  = ZSTM._2[(Int, String), Nothing, Int, String]
+          val tx  = ZSTM._2[Nothing, Int, String]
           val env = (42, "test")
 
           assertM(tx.provide(env).commit)(equalTo(env._2))
         },
         testM("swap") {
-          val tx  = ZSTM.swap[(Int, String), Nothing, Int, String]
+          val tx  = ZSTM.swap[Nothing, Int, String]
           val env = (42, "test")
 
           assertM(tx.provide(env).commit)(equalTo(env.swap))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -574,13 +574,13 @@ object ZSTMSpec extends ZIOBaseSpec {
       ),
       suite("tupled environment")(
         testM("_1 should extract first") {
-          val tx  = ZSTM._1[Nothing, Int, String]
+          val tx  = ZSTM.first[Nothing, Int, String]
           val env = (42, "test")
 
           assertM(tx.provide(env).commit)(equalTo(env._1))
         },
         testM("_2 should extract second") {
-          val tx  = ZSTM._2[Nothing, Int, String]
+          val tx  = ZSTM.second[Nothing, Int, String]
           val env = (42, "test")
 
           assertM(tx.provide(env).commit)(equalTo(env._2))

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -262,6 +262,11 @@ object RIO {
     ZIO.filter(as)(f)
 
   /**
+   * @see See [[zio.ZIO.first]]
+   */
+  def first[A, B]: RIO[(A, B), A] = ZIO.first
+
+  /**
    * @see See [[zio.ZIO.firstSuccessOf]]
    */
   def firstSuccessOf[R, A](
@@ -637,6 +642,11 @@ object RIO {
   def runtime[R]: ZIO[R, Nothing, Runtime[R]] = ZIO.runtime
 
   /**
+   * @see See [[zio.ZIO.second]]
+   */
+  def second[A, B]: RIO[(A, B), B] = ZIO.second
+
+  /**
    * @see See [[zio.ZIO.sleep]]
    */
   def sleep(duration: => Duration): RIO[Clock, Unit] =
@@ -790,16 +800,6 @@ object RIO {
    * @see See [[zio.ZIO.yieldNow]]
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
-
-  /**
-   * @see See [[zio.ZIO._1]]
-   */
-  def _1[A, B]: RIO[(A, B), A] = ZIO._1
-
-  /**
-   * @see See [[zio.ZIO._2]]
-   */
-  def _2[A, B]: RIO[(A, B), B] = ZIO._2
 
   private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
 

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -676,7 +676,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.swap]]
    */
-  def swap[R, A, B](implicit ev: R <:< (A, B)): RIO[R, (B, A)] =
+  def swap[A, B]: RIO[(A, B), (B, A)] =
     ZIO.swap
 
   /**
@@ -794,12 +794,12 @@ object RIO {
   /**
    * @see See [[zio.ZIO._1]]
    */
-  def _1[R, A, B](implicit ev: R <:< (A, B)): RIO[R, A] = ZIO._1
+  def _1[A, B]: RIO[(A, B), A] = ZIO._1
 
   /**
    * @see See [[zio.ZIO._2]]
    */
-  def _2[R, A, B](implicit ev: R <:< (A, B)): RIO[R, B] = ZIO._2
+  def _2[A, B]: RIO[(A, B), B] = ZIO._2
 
   private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -594,7 +594,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.swap]]
    */
-  def swap[R, A, B](implicit ev: R <:< (A, B)): URIO[R, (B, A)] = ZIO.swap
+  def swap[A, B]: URIO[(A, B), (B, A)] = ZIO.swap
 
   /**
    * @see [[zio.ZIO.trace]]
@@ -699,12 +699,12 @@ object URIO {
   /**
    * @see [[zio.ZIO._1]]
    */
-  def _1[R, A, B](implicit ev: R <:< (A, B)): URIO[R, A] = ZIO._1
+  def _1[A, B]: URIO[(A, B), A] = ZIO._1
 
   /**
    * @see [[zio.ZIO._2]]
    */
-  def _2[R, A, B](implicit ev: R <:< (A, B)): URIO[R, B] = ZIO._2
+  def _2[A, B]: URIO[(A, B), B] = ZIO._2
 
   private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -234,6 +234,11 @@ object URIO {
     ZIO.filter(as)(f)
 
   /**
+   * @see [[zio.ZIO.first]]
+   */
+  def first[A, B]: URIO[(A, B), A] = ZIO.first
+
+  /**
    * @see [[zio.ZIO.firstSuccessOf]]
    */
   def firstSuccessOf[R, A](
@@ -559,6 +564,11 @@ object URIO {
   def runtime[R]: URIO[R, Runtime[R]] = ZIO.runtime
 
   /**
+   * @see [[zio.ZIO.second]]
+   */
+  def second[A, B]: URIO[(A, B), B] = ZIO.second
+
+  /**
    * @see [[zio.ZIO.sleep]]
    */
   def sleep(duration: => Duration): URIO[Clock, Unit] = ZIO.sleep(duration)
@@ -695,16 +705,6 @@ object URIO {
    * @see [[zio.ZIO.yieldNow]]
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
-
-  /**
-   * @see [[zio.ZIO._1]]
-   */
-  def _1[A, B]: URIO[(A, B), A] = ZIO._1
-
-  /**
-   * @see [[zio.ZIO._2]]
-   */
-  def _2[A, B]: URIO[(A, B), B] = ZIO._2
 
   private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -92,7 +92,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * second part to that effect.
    */
   final def ***[R1, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[(R, R1), E1, (A, B)] =
-    (ZIO._1[E1, R, R1] >>> self) &&& (ZIO._2[E1, R, R1] >>> that)
+    (ZIO.first[E1, R, R1] >>> self) &&& (ZIO.second[E1, R, R1] >>> that)
 
   /**
    * A variant of `flatMap` that ignores the value produced by this effect.
@@ -2303,6 +2303,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     }
 
   /**
+   * Returns an effectful function that extracts out the first element of a
+   * tuple.
+   */
+  def first[E, A, B]: ZIO[(A, B), E, A] = fromFunction[(A, B), A](_._1)
+
+  /**
    * Returns an effect that races this effect with all the specified effects,
    * yielding the value of the first effect to succeed with a value.
    * Losers of the race will be interrupted immediately
@@ -3054,6 +3060,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     } yield Runtime(environment, platform)
 
   /**
+   * Returns an effectful function that extracts out the second element of a
+   * tuple.
+   */
+  def second[E, A, B]: ZIO[(A, B), E, B] = fromFunction[(A, B), B](_._2)
+
+  /**
    *  Alias for [[ZIO.collectAll]]
    */
   @deprecated("use collectAll", "1.0.0")
@@ -3272,18 +3284,6 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * overhead.
    */
   val yieldNow: UIO[Unit] = ZIO.Yield
-
-  /**
-   * Returns an effectful function that extracts out the first element of a
-   * tuple.
-   */
-  def _1[E, A, B]: ZIO[(A, B), E, A] = fromFunction[(A, B), A](_._1)
-
-  /**
-   * Returns an effectful function that extracts out the second element of a
-   * tuple.
-   */
-  def _2[E, A, B]: ZIO[(A, B), E, B] = fromFunction[(A, B), B](_._2)
 
   def apply[A](a: => A): Task[A] = effect(a)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -73,6 +73,103 @@ import zio.{ TracingStatus => TracingS }
 sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E, A] { self =>
 
   /**
+   * Sequentially zips this effect with the specified effect, combining the
+   * results into a tuple.
+   */
+  final def &&&[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
+    self.zipWith(that)((a, b) => (a, b))
+
+  /**
+   * Returns an effect that executes both this effect and the specified effect,
+   * in parallel, returning result of provided effect. If either side fails,
+   * then the other side will be interrupted, interrupted the result.
+   */
+  final def &>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
+    self.zipWithPar(that)((_, b) => b)
+
+  /**
+   * Splits the environment, providing the first part to this effect and the
+   * second part to that effect.
+   */
+  final def ***[R1, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[(R, R1), E1, (A, B)] =
+    (ZIO._1[E1, R, R1] >>> self) &&& (ZIO._2[E1, R, R1] >>> that)
+
+  /**
+   * A variant of `flatMap` that ignores the value produced by this effect.
+   */
+  final def *>[R1 <: R, E1 >: E, B](that: => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
+    self.flatMap(new ZIO.ZipRightFn(() => that))
+
+  /**
+   * Depending on provided environment, returns either this one or the other
+   * effect lifted in `Left` or `Right`, respectively.
+   */
+  final def +++[R1, B, E1 >: E](that: ZIO[R1, E1, B]): ZIO[Either[R, R1], E1, Either[A, B]] =
+    ZIO.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
+
+  /**
+   * Returns an effect that executes both this effect and the specified effect,
+   * in parallel, this effect result returned. If either side fails,
+   * then the other side will be interrupted, interrupted the result.
+   */
+  final def <&[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, A] =
+    self.zipWithPar(that)((a, _) => a)
+
+  /**
+   * Returns an effect that executes both this effect and the specified effect,
+   * in parallel, combining their results into a tuple. If either side fails,
+   * then the other side will be interrupted, interrupted the result.
+   */
+  final def <&>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
+    self.zipWithPar(that)((a, b) => (a, b))
+
+  /**
+   * Sequences the specified effect after this effect, but ignores the
+   * value produced by the effect.
+   */
+  final def <*[R1 <: R, E1 >: E, B](that: => ZIO[R1, E1, B]): ZIO[R1, E1, A] =
+    self.flatMap(new ZIO.ZipLeftFn(() => that))
+
+  /**
+   * Alias for `&&&`.
+   */
+  final def <*>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
+    self &&& that
+
+  /**
+   * Operator alias for `compose`.
+   */
+  final def <<<[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] =
+    that >>> self
+
+  /**
+   * Operator alias for `orElse`.
+   */
+  final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
+    orElse(that)
+
+  /**
+   * Alias for `flatMap`.
+   *
+   * {{{
+   * val parsed = readFile("foo.txt") >>= parseFile
+   * }}}
+   */
+  final def >>=[R1 <: R, E1 >: E, B](k: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] = flatMap(k)
+
+  /**
+   * Operator alias for `andThen`.
+   */
+  final def >>>[R1 >: A, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R, E1, B] =
+    self.flatMap(that.provide)
+
+  /**
+   * Depending on provided environment returns either this one or the other effect.
+   */
+  final def |||[R1, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[Either[R, R1], E1, A1] =
+    ZIO.accessM(_.fold(self.provide, that.provide))
+
+  /**
    * Returns an effect that submerges the error case of an `Either` into the
    * `ZIO`. The inverse operation of `ZIO.either`.
    */
@@ -1032,25 +1129,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     r0.use(self.provide)
 
   /**
-   * Operator alias for `andThen`.
-   */
-  final def >>>[R1 >: A, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R, E1, B] =
-    self.flatMap(that.provide)
-
-  /**
-   * Depending on provided environment returns either this one or the other effect.
-   */
-  final def |||[R1, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[Either[R, R1], E1, A1] =
-    ZIO.accessM(_.fold(self.provide, that.provide))
-
-  /**
-   * Depending on provided environment, returns either this one or the other
-   * effect lifted in `Left` or `Right`, respectively.
-   */
-  final def +++[R1, B, E1 >: E](that: ZIO[R1, E1, B]): ZIO[Either[R, R1], E1, Either[A, B]] =
-    ZIO.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
-
-  /**
    * Returns a successful effect if the value is `Left`, or fails with the error `None`.
    */
   final def left[B, C](implicit ev: A <:< Either[B, C]): ZIO[R, Option[E], B] =
@@ -1764,77 +1842,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
       }
     )
   }
-
-  /**
-   * Alias for `flatMap`.
-   *
-   * {{{
-   * val parsed = readFile("foo.txt") >>= parseFile
-   * }}}
-   */
-  final def >>=[R1 <: R, E1 >: E, B](k: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] = flatMap(k)
-
-  /**
-   * Returns an effect that executes both this effect and the specified effect,
-   * in parallel, combining their results into a tuple. If either side fails,
-   * then the other side will be interrupted, interrupted the result.
-   */
-  final def <&>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
-    self.zipWithPar(that)((a, b) => (a, b))
-
-  /**
-   * Returns an effect that executes both this effect and the specified effect,
-   * in parallel, this effect result returned. If either side fails,
-   * then the other side will be interrupted, interrupted the result.
-   */
-  final def <&[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, A] =
-    self.zipWithPar(that)((a, _) => a)
-
-  /**
-   * Returns an effect that executes both this effect and the specified effect,
-   * in parallel, returning result of provided effect. If either side fails,
-   * then the other side will be interrupted, interrupted the result.
-   */
-  final def &>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    self.zipWithPar(that)((_, b) => b)
-
-  /**
-   * Operator alias for `orElse`.
-   */
-  final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
-    orElse(that)
-
-  /**
-   * Operator alias for `compose`.
-   */
-  final def <<<[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] =
-    that >>> self
-
-  /**
-   * A variant of `flatMap` that ignores the value produced by this effect.
-   */
-  final def *>[R1 <: R, E1 >: E, B](that: => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    self.flatMap(new ZIO.ZipRightFn(() => that))
-
-  /**
-   * Sequences the specified effect after this effect, but ignores the
-   * value produced by the effect.
-   */
-  final def <*[R1 <: R, E1 >: E, B](that: => ZIO[R1, E1, B]): ZIO[R1, E1, A] =
-    self.flatMap(new ZIO.ZipLeftFn(() => that))
-
-  /**
-   * Sequentially zips this effect with the specified effect, combining the
-   * results into a tuple.
-   */
-  final def &&&[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
-    self.zipWith(that)((a, b) => (a, b))
-
-  /**
-   * Alias for `&&&`.
-   */
-  final def <*>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, (A, B)] =
-    self &&& that
 }
 
 object ZIO extends ZIOCompanionPlatformSpecific {
@@ -3089,8 +3096,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  def swap[R, E, A, B](implicit ev: R <:< (A, B)): ZIO[R, E, (B, A)] =
-    fromFunction[R, (B, A)](_.swap)
+  def swap[E, A, B]: ZIO[(A, B), E, (B, A)] =
+    fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Capture ZIO trace at the current point
@@ -3270,13 +3277,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns an effectful function that extracts out the first element of a
    * tuple.
    */
-  def _1[R, E, A, B](implicit ev: R <:< (A, B)): ZIO[R, E, A] = fromFunction[R, A](_._1)
+  def _1[E, A, B]: ZIO[(A, B), E, A] = fromFunction[(A, B), A](_._1)
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  def _2[R, E, A, B](implicit ev: R <:< (A, B)): ZIO[R, E, B] = fromFunction[R, B](_._2)
+  def _2[E, A, B]: ZIO[(A, B), E, B] = fromFunction[(A, B), B](_._2)
 
   def apply[A](a: => A): Task[A] = effect(a)
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -59,7 +59,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * second part to that effect.
    */
   def ***[R1, E1 >: E, B](that: ZManaged[R1, E1, B]): ZManaged[(R, R1), E1, (A, B)] =
-    (ZManaged._1[E1, R, R1] >>> self) &&& (ZManaged._2[E1, R, R1] >>> that)
+    (ZManaged.first[E1, R, R1] >>> self) &&& (ZManaged.second[E1, R, R1] >>> that)
 
   /**
    * Symbolic alias for zipRight
@@ -1128,18 +1128,6 @@ object ZManaged {
   }
 
   /**
-   * Returns an effectful function that extracts out the first element of a
-   * tuple.
-   */
-  def _1[E, A, B]: ZManaged[(A, B), E, A] = fromFunction(_._1)
-
-  /**
-   * Returns an effectful function that extracts out the second element of a
-   * tuple.
-   */
-  def _2[E, A, B]: ZManaged[(A, B), E, B] = fromFunction(_._2)
-
-  /**
    * Submerges the error case of an `Either` into the `ZManaged`. The inverse
    * operation of `ZManaged.either`.
    */
@@ -1270,6 +1258,12 @@ object ZManaged {
         )
       } yield reservation
     }
+
+  /**
+   * Returns an effectful function that extracts out the first element of a
+   * tuple.
+   */
+  def first[E, A, B]: ZManaged[(A, B), E, A] = fromFunction(_._1)
 
   /**
    * Returns an effect that performs the outer effect first, followed by the
@@ -1829,6 +1823,12 @@ object ZManaged {
         )
       }
     }
+
+  /**
+   * Returns an effectful function that extracts out the second element of a
+   * tuple.
+   */
+  def second[E, A, B]: ZManaged[(A, B), E, B] = fromFunction(_._2)
 
   /**
    *  Alias for [[ZManaged.collectAll]]

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -77,17 +77,17 @@ final class ZSTM[-R, +E, +A] private[stm] (
   import ZSTM.internal.{ prepareResetJournal, TExit }
 
   /**
-   * Sequentially zips this value with the specified one.
+   * Alias for `<*>` and `zip`.
    */
-  def <*>[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, (A, B)] =
-    self zip that
+  def &&&[R1 <: R, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[R1, E1, (A, B)] =
+    self <*> that
 
   /**
-   * Sequentially zips this value with the specified one, discarding the
-   * second element of the tuple.
+   * Splits the environment, providing the first part to this effect and the
+   * second part to that effect.
    */
-  def <*[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, A] =
-    self zipLeft that
+  def ***[R1, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[(R, R1), E1, (A, B)] =
+    (ZSTM._1[E1, R, R1] >>> self) &&& (ZSTM._2[E1, R, R1] >>> that)
 
   /**
    * Sequentially zips this value with the specified one, discarding the
@@ -97,23 +97,24 @@ final class ZSTM[-R, +E, +A] private[stm] (
     self zipRight that
 
   /**
-   * Feeds the value produced by this effect to the specified function,
-   * and then runs the returned effect as well to produce its results.
+   * Depending on provided environment, returns either this one or the other
+   * effect lifted in `Left` or `Right`, respectively.
    */
-  def >>=[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
-    self flatMap f
+  def +++[R1, B, E1 >: E](that: ZSTM[R1, E1, B]): ZSTM[Either[R, R1], E1, Either[A, B]] =
+    ZSTM.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
 
   /**
-   * Tries this effect first, and if it fails, tries the other effect.
+   * Sequentially zips this value with the specified one, discarding the
+   * second element of the tuple.
    */
-  def <>[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1])(implicit ev: CanFail[E]): ZSTM[R1, E1, A1] =
-    orElse(that)
+  def <*[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, A] =
+    self zipLeft that
 
   /**
-   * Propagates the given environment to self.
+   * Sequentially zips this value with the specified one.
    */
-  def >>>[R1 >: A, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[R, E1, B] =
-    flatMap(that.provide)
+  def <*>[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, (A, B)] =
+    self zip that
 
   /**
    * Propagates self environment to that.
@@ -122,23 +123,29 @@ final class ZSTM[-R, +E, +A] private[stm] (
     that >>> self
 
   /**
+   * Tries this effect first, and if it fails, tries the other effect.
+   */
+  def <>[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1])(implicit ev: CanFail[E]): ZSTM[R1, E1, A1] =
+    orElse(that)
+
+  /**
+   * Feeds the value produced by this effect to the specified function,
+   * and then runs the returned effect as well to produce its results.
+   */
+  def >>=[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
+    self flatMap f
+
+  /**
+   * Propagates the given environment to self.
+   */
+  def >>>[R1 >: A, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[R, E1, B] =
+    flatMap(that.provide)
+
+  /**
    * Depending on provided environment returns either this one or the other effect.
    */
   def |||[R1, E1 >: E, A1 >: A](that: ZSTM[R1, E1, A1]): ZSTM[Either[R, R1], E1, A1] =
     ZSTM.accessM[Either[R, R1]](_.fold(self.provide, that.provide))
-
-  /**
-   * Depending on provided environment, returns either this one or the other
-   * effect lifted in `Left` or `Right`, respectively.
-   */
-  def +++[R1, B, E1 >: E](that: ZSTM[R1, E1, B]): ZSTM[Either[R, R1], E1, Either[A, B]] =
-    ZSTM.accessM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
-
-  /**
-   * Alias for `<*>` and `zip`.
-   */
-  def &&&[R1 <: R, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[R1, E1, (A, B)] =
-    self <*> that
 
   /**
    * Returns an effect that submerges the error case of an `Either` into the
@@ -1148,8 +1155,8 @@ object ZSTM {
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  def swap[R, E, A, B](implicit ev: R <:< (A, B)): ZSTM[R, E, (B, A)] =
-    fromFunction[R, (B, A)](_.swap)
+  def swap[E, A, B]: ZSTM[(A, B), E, (B, A)] =
+    fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Returns an `STM` effect that succeeds with `Unit`.
@@ -1172,15 +1179,15 @@ object ZSTM {
    * Returns an effectful function that extracts out the first element of a
    * tuple.
    */
-  def _1[R, E, A, B](implicit ev: R <:< (A, B)): ZSTM[R, E, A] =
-    fromFunction[R, A](_._1)
+  def _1[E, A, B]: ZSTM[(A, B), E, A] =
+    fromFunction[(A, B), A](_._1)
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  def _2[R, E, A, B](implicit ev: R <:< (A, B)): ZSTM[R, E, B] =
-    fromFunction[R, B](_._2)
+  def _2[E, A, B]: ZSTM[(A, B), E, B] =
+    fromFunction[(A, B), B](_._2)
 
   private[zio] def dieNow(t: Throwable): STM[Nothing, Nothing] =
     succeedNow(throw t)

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -87,7 +87,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * second part to that effect.
    */
   def ***[R1, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[(R, R1), E1, (A, B)] =
-    (ZSTM._1[E1, R, R1] >>> self) &&& (ZSTM._2[E1, R, R1] >>> that)
+    (ZSTM.first[E1, R, R1] >>> self) &&& (ZSTM.second[E1, R, R1] >>> that)
 
   /**
    * Sequentially zips this value with the specified one, discarding the
@@ -931,6 +931,13 @@ object ZSTM {
     }
 
   /**
+   * Returns an effectful function that extracts out the first element of a
+   * tuple.
+   */
+  def first[E, A, B]: ZSTM[(A, B), E, A] =
+    fromFunction[(A, B), A](_._1)
+
+  /**
    * Returns an effect that first executes the outer effect, and then executes
    * the inner effect, returning the value from the inner effect, and effectively
    * flattening a nested effect.
@@ -1135,6 +1142,13 @@ object ZSTM {
     succeed(Right(a))
 
   /**
+   * Returns an effectful function that extracts out the second element of a
+   * tuple.
+   */
+  def second[E, A, B]: ZSTM[(A, B), E, B] =
+    fromFunction[(A, B), B](_._2)
+
+  /**
    * Returns an effect with the optional value.
    */
   def some[A](a: => A): STM[Nothing, Option[A]] =
@@ -1174,20 +1188,6 @@ object ZSTM {
    */
   def whenM[R, E](b: ZSTM[R, E, Boolean])(stm: ZSTM[R, E, Any]): ZSTM[R, E, Unit] =
     b.flatMap(b => if (b) stm.unit else unit)
-
-  /**
-   * Returns an effectful function that extracts out the first element of a
-   * tuple.
-   */
-  def _1[E, A, B]: ZSTM[(A, B), E, A] =
-    fromFunction[(A, B), A](_._1)
-
-  /**
-   * Returns an effectful function that extracts out the second element of a
-   * tuple.
-   */
-  def _2[E, A, B]: ZSTM[(A, B), E, B] =
-    fromFunction[(A, B), B](_._2)
 
   private[zio] def dieNow(t: Throwable): STM[Nothing, Nothing] =
     succeedNow(throw t)


### PR DESCRIPTION
Implements `***` combinator for ZIO, ZManaged, and ZSTM analogous to existing method on `Schedule`. Simplifies type signatures for `_1`,`_2`, and `swap`. Alphabetizes symbolic operators. Should we rename `_1` and `_2` to `first` and `second`?