### PR TITLE
ZIO Stream: Lift A Runnable Schedule Into A Stream

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1050,6 +1050,13 @@ object StreamSpec extends ZIOBaseSpec {
         items <- fiber.join
       } yield assert(items)(equalTo(c.toSeq.toList))
     }),
+    testM("Stream.fromSchedule") {
+      val schedule = Schedule.exponential(1.second) <* Schedule.recurs(5)
+      val stream   = ZStream.fromSchedule(schedule)
+      val zio      = TestClock.adjust(62.seconds) *> stream.runCollect
+      val expected = List(2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds, 64.seconds)
+      assertM(zio)(equalTo(expected))
+    },
     testM("Stream.fromTQueue") {
       TQueue.bounded[Int](5).commit.flatMap {
         tqueue =>

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -270,6 +270,12 @@ object Stream extends Serializable {
     ZStream.fromQueueWithShutdown(queue)
 
   /**
+   * See [[Ztream.fromSchedule]]
+   */
+  def fromSchedule[A](schedule: Schedule[Any, Any, A]): Stream[Nothing, A] =
+    ZStream.fromSchedule(schedule)
+
+  /**
    * See [[ZStream.fromTQueue]]
    */
   def fromTQueue[A](queue: TQueue[A]): Stream[Nothing, A] =

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -270,7 +270,7 @@ object Stream extends Serializable {
     ZStream.fromQueueWithShutdown(queue)
 
   /**
-   * See [[Ztream.fromSchedule]]
+   * See [[ZStream.fromSchedule]]
    */
   def fromSchedule[A](schedule: Schedule[Any, Any, A]): Stream[Nothing, A] =
     ZStream.fromSchedule(schedule)


### PR DESCRIPTION
Sometimes we want to work with schedules independent of the idea of repeating or retrying. If a `Schedule` has any for its input type we can think of it as "runnable" and generate a stream that repeatedly extracts and updates the state of the schedules. This could be useful for example if we want an exponential schedule but want to retain the durations output by the schedule.