### PR TITLE
ZIO Core: Align ZLayer Constructors

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3165,6 +3165,6 @@ object ZIOSpec extends ZIOBaseSpec {
 
   object Logging {
     trait Service
-    val live: ZLayer[Any, Nothing, Logging] = ZLayer.succeed(new Logging.Service {})
+    val live: ZLayer[Any, Nothing, Logging] = ZLayer.succeed(Has(new Logging.Service {}))
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -61,12 +61,12 @@ object ZLayerSpec extends ZIOBaseSpec {
   def spec =
     suite("ZLayerSpec")(
       testM("Size of >>> (1)") {
-        val layer = ZLayer.succeed(1) >>> ZLayer.fromService((i: Int) => Has(i.toString))
+        val layer = ZLayer.succeed(Has(1)) >>> ZLayer.fromService((i: Int) => Has(i.toString))
 
         testSize(layer, 1)
       },
       testM("Size of >>> (2)") {
-        val layer = ZLayer.succeed(1) >>>
+        val layer = ZLayer.succeed(Has(1)) >>>
           (ZLayer.fromService((i: Int) => Has(i.toString)) ++
             ZLayer.fromService((i: Int) => Has(i % 2 == 0)))
 

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -142,9 +142,9 @@ package object blocking {
       ZLayer.requires[Blocking]
 
     val live: ZLayer.NoDeps[Nothing, Blocking] = ZLayer.succeed {
-      new Service {
+      Has(new Service {
         override val blockingExecutor: Executor = internal.blockingExecutor0
-      }
+      })
     }
   }
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -403,7 +403,7 @@ object ZLayer {
   /**
    * Constructs a layer from the specified value.
    */
-  def succeed[A: Tagged](a: => A): ZLayer.NoDeps[Nothing, Has[A]] = ZLayer(ZManaged.succeed(Has(a)))
+  def succeed[A <: Has[_]](a: => A): ZLayer.NoDeps[Nothing, A] = ZLayer(ZManaged.succeed(a))
 
   /**
    * A `MemoMap` memoizes dependencies.

--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -36,7 +36,7 @@ package object clock {
       ZLayer.requires[Clock]
 
     val live: ZLayer.NoDeps[Nothing, Clock] = ZLayer.succeed {
-      new Service {
+      Has(new Service {
         def currentTime(unit: TimeUnit): UIO[Long] =
           IO.effectTotal(System.currentTimeMillis).map(l => unit.convert(l, TimeUnit.MILLISECONDS))
 
@@ -54,7 +54,7 @@ package object clock {
             zone   <- ZIO.effectTotal(ZoneId.systemDefault)
           } yield OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), zone)
 
-      }
+      })
     }
   }
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -37,7 +37,7 @@ package object console {
       ZLayer.requires[Console]
 
     val live: ZLayer.NoDeps[Nothing, Console] = ZLayer.succeed {
-      new Service {
+      Has(new Service {
 
         /**
          * Prints text to the console.
@@ -81,7 +81,7 @@ package object console {
             })
             .refineToOrDie[IOException]
 
-      }
+      })
     }
   }
 

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -24,7 +24,7 @@ package object random {
       ZLayer.requires[Random]
 
     val live: ZLayer.NoDeps[Nothing, Random] = ZLayer.succeed {
-      new Service {
+      Has(new Service {
         import scala.util.{ Random => SRandom }
 
         val nextBoolean: UIO[Boolean] = ZIO.effectTotal(SRandom.nextBoolean())
@@ -46,7 +46,7 @@ package object random {
         val nextPrintableChar: UIO[Char]            = ZIO.effectTotal(SRandom.nextPrintableChar())
         def nextString(length: Int): UIO[String]    = ZIO.effectTotal(SRandom.nextString(length))
         def shuffle[A](list: List[A]): UIO[List[A]] = Random.shuffleWith(nextInt(_), list)
-      }
+      })
     }
 
     protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -35,7 +35,7 @@ package object system {
       ZLayer.requires[System]
 
     val live: ZLayer.NoDeps[Nothing, System] = ZLayer.succeed(
-      new Service {
+      Has(new Service {
 
         def env(variable: String): IO[SecurityException, Option[String]] =
           IO.effect(Option(JSystem.getenv(variable))).refineToOrDie[SecurityException]
@@ -44,7 +44,7 @@ package object system {
           IO.effect(Option(JSystem.getProperty(prop)))
 
         val lineSeparator: UIO[String] = IO.effectTotal(JSystem.lineSeparator)
-      }
+      })
     )
   }
 

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -14,7 +14,7 @@ object SpecSpec extends ZIOBaseSpec {
     trait Service
   }
 
-  val layer = ZLayer.succeed(new Module.Service {})
+  val layer = ZLayer.succeed(Has(new Module.Service {}))
 
   def spec = suite("SpecSpec")(
     suite("provideManagedShared")(

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -3,14 +3,12 @@ package zio.test
 import scala.reflect.ClassTag
 import scala.reflect.ClassTag
 
-import zio.ZEnv
-import zio.ZLayer
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.{ Live, TestClock }
-import zio.{ Ref, Schedule, ZIO }
+import zio.{ Has, Ref, Schedule, ZEnv, ZIO, ZLayer }
 
 object TestAspectSpec extends ZIOBaseSpec {
 
@@ -224,7 +222,7 @@ object TestAspectSpec extends ZIOBaseSpec {
     testM("timeout reports problem with interruption") {
       for {
         testClock <- ZIO.environment[TestClock].map(_.get[TestClock.Service])
-        liveClock = (ZEnv.live >>> Live.default) ++ ZLayer.succeed(testClock)
+        liveClock = (ZEnv.live >>> Live.default) ++ ZLayer.succeed(Has(testClock))
         spec = testM("uninterruptible test") {
           for {
             _ <- (TestClock.adjust(11.milliseconds) *> ZIO.never).uninterruptible


### PR DESCRIPTION
First step at resolves #2929. Changes `succeed` to lift an `A <: Has[_]` into a layer.

As is this is a victory for consistency but not concision. It would be nice to have versions of `succeed`, `fromEffect`, and `fromManaged` that lift a `A` with implicit evidence `Tagged[A]` into a layer for the simple case where we have an existing single service and just want to construct layer from it. `fromService`, `fromServiceM`, and `fromServiceManaged` seem most logical for that but overlap with existing `fromServices` methods.

Does anyone else have ideas for naming, or renaming the existing methods?