### PR TITLE
ZIO Core: Improve Ergonomics of Layers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
@@ -12,7 +12,7 @@ object NeedsEnvSpec extends ZIOBaseSpec {
             import zio._
             import zio.console._
             val sayHello = console.putStrLn("Hello, World!")
-            sayHello.provideManaged(Console.live.build)
+            sayHello.provideLayer(Console.live)
             """
       }
       assertM(result)(isRight(isUnit))
@@ -23,7 +23,7 @@ object NeedsEnvSpec extends ZIOBaseSpec {
             import zio._
             import zio.console._
             val uio = UIO.succeed("Hello, World!")
-            uio.provideManaged(Console.live.value)
+            uio.provideLayer(Console.live)
             """
       }
       assertM(result)(isLeft(anything))

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2769,19 +2769,6 @@ object ZIOSpec extends ZIOBaseSpec {
 
         assertM(zio.provide(4))(equalTo((4, 2, 4)))
       },
-      testM("provideManaged is modular") {
-        def managed(v: Int): ZManaged[Any, Nothing, Int] =
-          ZManaged.make(IO.succeedNow(v))(_ => IO.effectTotal(()))
-
-        val zio =
-          for {
-            v1 <- ZIO.environment[Int]
-            v2 <- ZIO.environment[Int].provideManaged(managed(2))
-            v3 <- ZIO.environment[Int]
-          } yield (v1, v2, v3)
-
-        assertM(zio.provideManaged(managed(4)))(equalTo((4, 2, 4)))
-      },
       testM("effectAsync can use environment") {
         val zio = ZIO.effectAsync[Int, Nothing, Int](cb => cb(ZIO.environment[Int]))
         assertM(zio.provide(10))(equalTo(10))

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -189,8 +189,8 @@ object ZLayerSpec extends ZIOBaseSpec {
       testM("layers can be acquired in parallel") {
         for {
           promise <- Promise.make[Nothing, Unit]
-          layer1  = ZLayer.fromManaged(Managed.make(ZIO.never)(_ => ZIO.unit))
-          layer2  = ZLayer.fromManaged(Managed.make(promise.succeed(()).map(Has(_)))(_ => ZIO.unit))
+          layer1  = ZLayer.fromManagedMany(Managed.make(ZIO.never)(_ => ZIO.unit))
+          layer2  = ZLayer.fromManagedMany(Managed.make(promise.succeed(()).map(Has(_)))(_ => ZIO.unit))
           env     = (layer1 ++ layer2).build
           _       <- env.use_(ZIO.unit).fork
           _       <- promise.await

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -61,14 +61,14 @@ object ZLayerSpec extends ZIOBaseSpec {
   def spec =
     suite("ZLayerSpec")(
       testM("Size of >>> (1)") {
-        val layer = ZLayer.succeed(1) >>> ZLayer.fromService((i: Int) => Has(i.toString))
+        val layer = ZLayer.succeed(1) >>> ZLayer.fromServiceMany((i: Int) => Has(i.toString))
 
         testSize(layer, 1)
       },
       testM("Size of >>> (2)") {
         val layer = ZLayer.succeed(1) >>>
-          (ZLayer.fromService((i: Int) => Has(i.toString)) ++
-            ZLayer.fromService((i: Int) => Has(i % 2 == 0)))
+          (ZLayer.fromServiceMany((i: Int) => Has(i.toString)) ++
+            ZLayer.fromServiceMany((i: Int) => Has(i % 2 == 0)))
 
         testSize(layer, 2)
       },

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -61,14 +61,14 @@ object ZLayerSpec extends ZIOBaseSpec {
   def spec =
     suite("ZLayerSpec")(
       testM("Size of >>> (1)") {
-        val layer = ZLayer.succeed(1) >>> ZLayer.fromServiceMany((i: Int) => Has(i.toString))
+        val layer = ZLayer.succeed(1) >>> ZLayer.fromService((i: Int) => i.toString)
 
         testSize(layer, 1)
       },
       testM("Size of >>> (2)") {
         val layer = ZLayer.succeed(1) >>>
-          (ZLayer.fromServiceMany((i: Int) => Has(i.toString)) ++
-            ZLayer.fromServiceMany((i: Int) => Has(i % 2 == 0)))
+          (ZLayer.fromService((i: Int) => i.toString) ++
+            ZLayer.fromService((i: Int) => i % 2 == 0))
 
         testSize(layer, 2)
       },

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1066,6 +1066,15 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(res)(isNone)
       }
     ),
+    suite("toLayer")(
+      testM("converts a managed effect to a layer") {
+        val managed = ZEnv.live.build
+        val layer   = managed.toLayer
+        val zio1    = ZIO.environment[ZEnv]
+        val zio2    = zio1.provideLayer(layer)
+        assertM(zio2)(anything)
+      }
+    ),
     suite("withEarlyRelease")(
       testM("Provides a canceler that can be used to eagerly evaluate the finalizer") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1066,10 +1066,10 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(res)(isNone)
       }
     ),
-    suite("toLayer")(
+    suite("toLayerMany")(
       testM("converts a managed effect to a layer") {
         val managed = ZEnv.live.build
-        val layer   = managed.toLayer
+        val layer   = managed.toLayerMany
         val zio1    = ZIO.environment[ZEnv]
         val zio2    = zio1.provideLayer(layer)
         assertM(zio2)(anything)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1080,7 +1080,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def provideLayer[E1 >: E, R0, R1 <: Has[_]](
     layer: ZLayer[R0, E1, R1]
   )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZIO[R0, E1, A] =
-    provideSomeManaged(layer.build.map(ev1))
+    layer.build.map(ev1).use(self.provide)
 
   /**
    * An effectual version of `provide`, useful when the act of provision
@@ -1093,6 +1093,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Uses the given Managed[E1, R] to the environment required to run this effect,
    * leaving no outstanding environments and returning IO[E1, A]
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideManaged[E1 >: E](r0: Managed[E1, R])(implicit ev: NeedsEnv[R]): IO[E1, A] = provideSomeManaged(r0)
 
   /**
@@ -1149,6 +1150,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Uses the given ZManaged[R0, E1, R] to provide some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeManaged[R0, E1 >: E](r0: ZManaged[R0, E1, R])(implicit ev: NeedsEnv[R]): ZIO[R0, E1, A] =
     r0.use(self.provide)
 
@@ -1722,6 +1724,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def toFutureWith(f: E => Throwable): URIO[R, CancelableFuture[E, A]] =
     self.fork >>= (_.toFutureWith(f))
+
+  /**
+   * Constructs a layer from this effect, which must produce one or more
+   * services.
+   */
+  final def toLayer[A1 <: Has[_]](implicit ev: A <:< A1): ZLayer[R, E, A1] =
+    ZLayer(ZManaged.fromEffect(self.map(ev)))
 
   /**
    * Converts this ZIO to [[zio.Managed]]. This ZIO and the provided release action

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1150,7 +1150,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * effect.provideSomeM(r0)
    * }}}
    */
-  @deprecated("use contramapM", "1.0.0")
+  @deprecated("use provideLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](r0: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZIO[R0, E1, A] =
     r0.flatMap(self.provide)
 
@@ -1158,7 +1158,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Uses the given ZManaged[R0, E1, R] to provide some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  @deprecated("use provideSomeLayer", "1.0.0")
+  @deprecated("use provideLayer", "1.0.0")
   final def provideSomeManaged[R0, E1 >: E](r0: ZManaged[R0, E1, R])(implicit ev: NeedsEnv[R]): ZIO[R0, E1, A] =
     r0.use(self.provide)
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -148,6 +148,13 @@ object ZLayer {
     new ZLayer(Managed.succeed(_ => managed))
 
   /**
+   * Constructs a layer from acquire and release actions. The acquire and
+   * release actions will be performed uninterruptibly.
+   */
+  def fromAcquireRelease[E, A <: Has[_]](acquire: IO[E, A])(release: A => UIO[Any]): ZLayer.NoDeps[E, A] =
+    fromManaged(Managed.make(acquire)(release))
+
+  /**
    * Constructs a layer from the specified effect, which must produce one or
    * more services.
    */

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -743,7 +743,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * managed.provideSomeM(r0)
    * }}}
    */
-  @deprecated("use provideLayer", "1.0.0")
+  @deprecated("use provideSomeLayer", "1.0.0")
   def provideSomeM[R0, E1 >: E](
     r0: ZIO[R0, E1, R]
   )(implicit ev: NeedsEnv[R]): ZManaged[R0, E1, A] =

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -191,15 +191,15 @@ Next we create the live version of the service with the implementation of the ca
 import zio.console.Console
 
 val accountObserverLive: ZLayer[Console, Nothing, Has[AccountObserver.Service]] =
-  ZLayer.fromService[Console.Service, Has[AccountObserver.Service]] { console =>
-    Has(new AccountObserver.Service {
+  ZLayer.fromService { (console: Console.Service) =>
+    new AccountObserver.Service {
       def processEvent(event: AccountEvent): UIO[Unit] =
         for {
         _    <- console.putStrLn(s"Got $event")
         line <- console.getStrLn.orDie
         _    <- console.putStrLn(s"You entered: $line")
         } yield ()
-    })
+    }
   }
 ```
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2100,6 +2100,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * An effectual version of `provide`, useful when the act of provision
    * requires an effect.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideM[E1 >: E](r: ZIO[Any, E1, R])(implicit ev: NeedsEnv[R]): Stream[E1, A] =
     provideSomeM(r)
 
@@ -2160,13 +2161,9 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStream[R0, E1, A] =
-    ZStream.managed {
-      for {
-        r  <- env.toManaged_
-        as <- self.process.provide(r)
-      } yield as.provide(r)
-    }.flatMap(ZStream.repeatEffectOption)
+    provideSomeManaged(env.toManaged_)
 
   /**
    * Uses the given [[ZManaged]] to provide some of the environment required to run

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2161,7 +2161,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  @deprecated("use provideLayer", "1.0.0")
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStream[R0, E1, A] =
     provideSomeManaged(env.toManaged_)
 

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -508,6 +508,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Uses the given [[Managed]] to provide the environment required to run this stream,
    * leaving no outstanding environments.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideManaged[E1 >: E](m: Managed[E1, R])(implicit ev: NeedsEnv[R]): StreamChunk[E1, A] =
     provideSomeManaged(m)
 
@@ -529,6 +530,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Uses the given [[Managed]] to provide some of the environment required to run
    * this stream, leaving the remainder `R0`.
    */
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeManaged[R0, E1 >: E](
     env: ZManaged[R0, E1, R]
   )(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E1, A] =

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -501,6 +501,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * An effectful version of `provide`, useful when the act of provision
    * requires an effect.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideM[E1 >: E](r: IO[E1, R])(implicit ev: NeedsEnv[R]): StreamChunk[E1, A] =
     provideSomeM(r)
 
@@ -523,6 +524,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Effectfully provides some of the environment required to run this effect
    * leaving the remainder `R0`.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E1, A] =
     ZStreamChunk(chunks.provideSomeM(env))
 

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -524,7 +524,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Effectfully provides some of the environment required to run this effect
    * leaving the remainder `R0`.
    */
-  @deprecated("use provideLayer", "1.0.0")
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](env: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): ZStreamChunk[R0, E1, A] =
     ZStreamChunk(chunks.provideSomeM(env))
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -54,7 +54,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Boot
 
     unsafeRun(
       traverse(filteredSpec, description)
-        .provideManaged(spec.runner.executor.environment)
+        .provideLayer(spec.runner.executor.environment)
     )
     description
   }
@@ -62,7 +62,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Boot
   override def run(notifier: RunNotifier): Unit =
     zio.Runtime((), spec.runner.platform).unsafeRun {
       val instrumented = instrumentSpec(filteredSpec, new JUnitNotifier(notifier))
-      spec.runner.run(instrumented).unit.provideManaged(spec.runner.bootstrap)
+      spec.runner.run(instrumented).unit.provideLayer(spec.runner.bootstrap)
     }
 
   private def reportRuntimeFailure[E](notifier: JUnitNotifier, path: Vector[String], label: String, cause: Cause[E]) =

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -5,40 +5,46 @@ import zio.test.Assertion.equalTo
 
 object ManagedSpec extends ZIOBaseSpec {
 
+  type Counter = Has[Counter.Service]
+
+  object Counter {
+
+    trait Service {
+      def incrementAndGet: UIO[Int]
+    }
+
+    val live: ZLayer.NoDeps[Nothing, Counter] =
+      ZLayer.fromManaged {
+        Ref.make(1).toManaged(_.set(-10)).map { ref =>
+          Has(new Counter.Service {
+            val incrementAndGet: UIO[Int] = ref.updateAndGet(_ + 1)
+          })
+        }
+      }
+
+    val incrementAndGet: ZIO[Counter, Nothing, Int] =
+      ZIO.accessM[Counter](_.get[Counter.Service].incrementAndGet)
+  }
+
   def spec = suite("ManagedSpec")(
     suite("managed shared")(
       testM("first test") {
-        for {
-          _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
-          result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result)(equalTo(2))
+        assertM(Counter.incrementAndGet)(equalTo(2))
       },
       testM("second test") {
-        for {
-          _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
-          result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result)(equalTo(3))
+        assertM(Counter.incrementAndGet)(equalTo(3))
       },
       testM("third test") {
-        for {
-          _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
-          result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result)(equalTo(4))
+        assertM(Counter.incrementAndGet)(equalTo(4))
       }
-    ).provideManagedShared(Ref.make(1).toManaged(_.set(-10))),
+    ).provideLayerShared(Counter.live),
     suite("managed per test")(
       testM("first test") {
-        for {
-          _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
-          result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result)(equalTo(2))
+        assertM(Counter.incrementAndGet)(equalTo(2))
       },
       testM("second test") {
-        for {
-          _      <- ZIO.accessM[Ref[Int]](_.update(_ + 1))
-          result <- ZIO.accessM[Ref[Int]](_.get)
-        } yield assert(result)(equalTo(2))
+        assertM(Counter.incrementAndGet)(equalTo(2))
       }
-    ).provideManaged(Ref.make(1).toManaged(_.set(-10)))
+    ).provideLayer(Counter.live)
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -16,9 +16,9 @@ object ManagedSpec extends ZIOBaseSpec {
     val live: ZLayer.NoDeps[Nothing, Counter] =
       ZLayer.fromManaged {
         Ref.make(1).toManaged(_.set(-10)).map { ref =>
-          Has(new Counter.Service {
+          new Counter.Service {
             val incrementAndGet: UIO[Int] = ref.updateAndGet(_ + 1)
-          })
+          }
         }
       }
 

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion.{ equalTo, isFalse, isTrue }
 import zio.test.TestAspect.ifEnvSet
 import zio.test.TestUtils._
 import zio.test.environment.TestEnvironment
-import zio.{ Has, Ref, UIO, ZIO, ZLayer, ZManaged }
+import zio.{ Has, Ref, ZIO, ZLayer }
 
 object SpecSpec extends ZIOBaseSpec {
 
@@ -17,14 +17,14 @@ object SpecSpec extends ZIOBaseSpec {
   val layer = ZLayer.succeed(new Module.Service {})
 
   def spec = suite("SpecSpec")(
-    suite("provideManagedShared")(
+    suite("provideLayerShared")(
       testM("gracefully handles fiber death") {
         import zio.NeedsEnv.needsEnv
         val spec = suite("Suite1")(
           test("Test1") {
             assert(true)(isTrue)
           }
-        ).provideManagedShared(ZManaged.dieMessage("everybody dies"))
+        ).provideLayerShared(ZLayer.fromEffect(ZIO.dieMessage("everybody dies")))
         for {
           _ <- execute(spec)
         } yield assertCompletes
@@ -32,19 +32,16 @@ object SpecSpec extends ZIOBaseSpec {
       testM("does not acquire the environment if the suite is ignored") {
         val spec = suite("Suite1")(
           testM("Test1") {
-            assertM(ZIO.accessM[Ref[Boolean]](_.get))(isTrue)
+            assertM(ZIO.accessM[Has[Ref[Boolean]]](_.get[Ref[Boolean]].get))(isTrue)
           },
           testM("another test") {
-            assertM(ZIO.accessM[Ref[Boolean]](_.get))(isTrue)
+            assertM(ZIO.accessM[Has[Ref[Boolean]]](_.get[Ref[Boolean]].get))(isTrue)
           }
         )
         for {
-          ref <- Ref.make(true)
-          _ <- execute {
-                spec.provideManagedShared {
-                  ZManaged.make(ref.set(false).as(ref))(_ => ZIO.unit)
-                } @@ ifEnvSet("foo")
-              }
+          ref    <- Ref.make(true)
+          layer  = ZLayer.fromEffect(ref.set(false).as(Has(ref)))
+          _      <- execute(spec.provideCustomLayerShared(layer) @@ ifEnvSet("foo"))
           result <- ref.get
         } yield assert(result)(isTrue)
       },
@@ -57,9 +54,9 @@ object SpecSpec extends ZIOBaseSpec {
             assert(1)(Assertion.equalTo(1))
           },
           testM("test requires env") {
-            assertM(ZIO.environment[Int])(Assertion.equalTo(42))
+            assertM(ZIO.access[Has[Int]](_.get[Int]))(Assertion.equalTo(42))
           }
-        ).provideManagedShared(UIO(43).toManaged_)
+        ).provideLayerShared(ZLayer.succeed(43))
         for {
           executedSpec <- execute(spec)
           successes    <- executedSpec.countTests(_.isRight)

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -24,7 +24,7 @@ object SpecSpec extends ZIOBaseSpec {
           test("Test1") {
             assert(true)(isTrue)
           }
-        ).provideLayerShared(ZLayer.fromEffect(ZIO.dieMessage("everybody dies")))
+        ).provideLayerShared(ZLayer.fromEffectMany(ZIO.dieMessage("everybody dies")))
         for {
           _ <- execute(spec)
         } yield assertCompletes
@@ -40,7 +40,7 @@ object SpecSpec extends ZIOBaseSpec {
         )
         for {
           ref    <- Ref.make(true)
-          layer  = ZLayer.fromEffect(ref.set(false).as(Has(ref)))
+          layer  = ZLayer.fromEffect(ref.set(false).as(ref))
           _      <- execute(spec.provideCustomLayerShared(layer) @@ ifEnvSet("foo"))
           result <- ref.get
         } yield assert(result)(isTrue)

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -6,7 +6,7 @@ import zio.{ UIO, ZIO }
 object TestUtils {
 
   def execute[E](spec: ZSpec[TestEnvironment, E]): UIO[ExecutedSpec[E]] =
-    TestExecutor.managed(environment.testEnvironmentManaged).run(spec, ExecutionStrategy.Sequential)
+    TestExecutor.default(environment.testEnvironment).run(spec, ExecutionStrategy.Sequential)
 
   def forAllTests[E](
     execSpec: UIO[ExecutedSpec[E]]

--- a/test-tests/shared/src/test/scala/zio/test/mock/SpySpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/SpySpec.scala
@@ -25,7 +25,7 @@ object SpySpec extends DefaultRunnableSpec {
     }
 
     val live: ZLayer.NoDeps[Nothing, Counter] =
-      ZLayer.fromEffect(Ref.make(0).map(ref => Has(Live(ref))))
+      ZLayer.fromEffect(Ref.make(0).map(ref => Live(ref)))
   }
 
   sealed trait Command[A] extends Method[Counter.Service, Unit, A]

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -16,14 +16,14 @@
 
 package zio.test
 
-import zio.URIO
 import zio.clock.Clock
 import zio.test.reflect.Reflect.EnableReflectiveInstantiation
+import zio.{ Has, URIO }
 
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {
 
-  type Environment
+  type Environment <: Has[_]
   type Failure
 
   def aspects: List[TestAspect[Nothing, Environment, Nothing, Any]]

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -18,12 +18,12 @@ package zio.test
 
 import zio.clock.Clock
 import zio.test.Spec.TestCase
-import zio.{ UIO, URIO }
+import zio.{ Has, UIO, URIO }
 
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
  */
-trait RunnableSpec[R, E] extends AbstractRunnableSpec {
+trait RunnableSpec[R <: Has[_], E] extends AbstractRunnableSpec {
   override type Environment = R
   override type Failure     = E
 
@@ -43,10 +43,10 @@ trait RunnableSpec[R, E] extends AbstractRunnableSpec {
   final def main(args: Array[String]): Unit = {
     val runtime = runner.runtime
     if (TestPlatform.isJVM) {
-      val exitCode = runtime.unsafeRun(runSpec.provideManaged(runner.bootstrap))
+      val exitCode = runtime.unsafeRun(runSpec.provideLayer(runner.bootstrap))
       doExit(exitCode)
     } else if (TestPlatform.isJS) {
-      runtime.unsafeRunAsync[Nothing, Int](runSpec.provideManaged(runner.bootstrap)) { exit =>
+      runtime.unsafeRunAsync[Nothing, Int](runSpec.provideLayer(runner.bootstrap)) { exit =>
         val exitCode = exit.getOrElse(_ => 1)
         doExit(exitCode)
       }

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -447,7 +447,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified effect to provide each test in this spec with part of
    * its required environment.
    */
-  @deprecated("use provideLayer", "1.0.0")
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](zio: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     provideSomeManaged(zio.toManaged_)
 
@@ -455,7 +455,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified effect once to provide all tests in this spec with a
    * shared version of part of their required environment.
    */
-  @deprecated("use provideLayerShared", "1.0.0")
+  @deprecated("use provideSomeLayerShared", "1.0.0")
   final def provideSomeMShared[R0, E1 >: E](zio: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     provideSomeManagedShared(zio.toManaged_)
 

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -370,6 +370,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified `Managed` to provide each test in this spec with its
    * required environment.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideManaged[E1 >: E](managed: Managed[E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
     provideSomeManaged(managed)
 
@@ -377,6 +378,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified `Managed` once to provide all tests in this spec with
    * a shared version of their required environment.
    */
+  @deprecated("use provideLayerShared", "1.0.0")
   final def provideManagedShared[E1 >: E](managed: Managed[E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
     provideSomeManagedShared(managed)
 
@@ -436,6 +438,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified `ZManaged` to provide each test in this spec with part
    * of its required environment.
    */
+  @deprecated("use provideSomeLayer", "1.0.0")
   final def provideSomeManaged[R0, E1 >: E](
     managed: ZManaged[R0, E1, R]
   )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
@@ -448,6 +451,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified `ZManaged` once to provide all tests in this spec with
    * a shared version of part of their required environment.
    */
+  @deprecated("use provideSomeLayerShared", "1.0.0")
   final def provideSomeManagedShared[R0, E1 >: E](
     managed: ZManaged[R0, E1, R]
   )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] = {

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -298,7 +298,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Provides each test in this spec with its required environment
    */
   final def provide(r: R)(implicit ev: NeedsEnv[R]): Spec[Any, E, T] =
-    provideM(ZIO.succeedNow(r))
+    provideSome(_ => r)
 
   /**
    * Provides each test with the part of the environment that is not part of
@@ -374,15 +374,17 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified effect to provide each test in this spec with its
    * required environment.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideM[E1 >: E](zio: ZIO[Any, E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
-    provideSomeM(zio)
+    provideManaged(zio.toManaged_)
 
   /**
    * Uses the specified effect once to provide all tests in this spec with a
    * shared version of their required environment.
    */
+  @deprecated("use provideLayerShared", "1.0.0")
   final def provideMShared[E1 >: E](zio: ZIO[Any, E1, R])(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
-    provideSomeMShared(zio)
+    provideManagedShared(zio.toManaged_)
 
   /**
    * Uses the specified `Managed` to provide each test in this spec with its
@@ -405,7 +407,10 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * its required environment.
    */
   final def provideSome[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): Spec[R0, E, T] =
-    provideSomeM(ZIO.fromFunction(f))
+    transform[R0, E, T] {
+      case SuiteCase(label, specs, exec)      => SuiteCase(label, specs.provideSome(f), exec)
+      case TestCase(label, test, annotations) => TestCase(label, test.provideSome(f), annotations)
+    }
 
   /**
    * Splits the environment into two parts, providing each test with one part
@@ -442,33 +447,17 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * Uses the specified effect to provide each test in this spec with part of
    * its required environment.
    */
+  @deprecated("use provideLayer", "1.0.0")
   final def provideSomeM[R0, E1 >: E](zio: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
-    transform[R0, E1, T] {
-      case SuiteCase(label, specs, exec)      => SuiteCase(label, specs.provideSomeM(zio), exec)
-      case TestCase(label, test, annotations) => TestCase(label, test.provideSomeM(zio), annotations)
-    }
+    provideSomeManaged(zio.toManaged_)
 
   /**
    * Uses the specified effect once to provide all tests in this spec with a
    * shared version of part of their required environment.
    */
-  final def provideSomeMShared[R0, E1 >: E](zio: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] = {
-    def loop(r: R)(spec: Spec[R, E, T]): UIO[Spec[Any, E, T]] =
-      spec.caseValue match {
-        case SuiteCase(label, specs, exec) =>
-          specs.provide(r).run.map { result =>
-            Spec.suite(label, ZIO.doneNow(result).flatMap(ZIO.foreach(_)(loop(r))).map(_.toVector), exec)
-          }
-        case TestCase(label, test, annotations) =>
-          test.provide(r).run.map(result => Spec.test(label, ZIO.doneNow(result), annotations))
-      }
-    caseValue match {
-      case SuiteCase(label, specs, exec) =>
-        Spec.suite(label, zio.flatMap(r => specs.flatMap(ZIO.foreach(_)(loop(r))).map(_.toVector).provide(r)), exec)
-      case TestCase(label, test, annotations) =>
-        Spec.test(label, test.provideSomeM(zio), annotations)
-    }
-  }
+  @deprecated("use provideLayerShared", "1.0.0")
+  final def provideSomeMShared[R0, E1 >: E](zio: ZIO[R0, E1, R])(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
+    provideSomeManagedShared(zio.toManaged_)
 
   /**
    * Uses the specified `ZManaged` to provide each test in this spec with part
@@ -507,13 +496,6 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
         Spec.test(label, test.provideSomeManaged(managed), annotations)
     }
   }
-
-  /**
-   * Uses the specified function once to provide all tests in this spec with a
-   * shared version of part of their required environment.
-   */
-  final def provideSomeShared[R0](f: R0 => R)(implicit ev: NeedsEnv[R]): Spec[R0, E, T] =
-    provideSomeMShared(ZIO.fromFunction(f))
 
   /**
    * Computes the size of the spec, i.e. the number of tests in the spec.

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -437,7 +437,7 @@ package object environment extends PlatformSpecific {
      * This can be useful for mixing in with implementations of other interfaces.
      */
     def live(data: Data): ZLayer[Live, Nothing, Clock with TestClock] =
-      ZLayer.fromServiceManaged { (live: Live.Service) =>
+      ZLayer.fromServiceManyManaged { (live: Live.Service) =>
         for {
           ref      <- Ref.make(data).toManaged_
           fiberRef <- FiberRef.make(FiberData(0, 0, ZoneId.of("UTC")), FiberData.combine).toManaged_
@@ -1318,7 +1318,7 @@ package object environment extends PlatformSpecific {
 
     val random: ZLayer[Clock, Nothing, Random with TestRandom] =
       (ZLayer.service[Clock.Service] ++ deterministic) >>>
-        (ZLayer.fromFunctionM { (env: Clock with Random with TestRandom) =>
+        (ZLayer.fromFunctionManyM { (env: Clock with Random with TestRandom) =>
           val random     = env.get[Random.Service]
           val testRandom = env.get[TestRandom.Service]
 

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -660,7 +660,7 @@ package object environment extends PlatformSpecific {
      * interfaces.
      */
     def live(data: Data): ZLayer.NoDeps[Nothing, Console with TestConsole] =
-      ZLayer.fromEffect(
+      ZLayer.fromEffectMany(
         Ref.make(data).map(ref => Has.allOf[Console.Service, TestConsole.Service](Test(ref), Test(ref)))
       )
 
@@ -1304,7 +1304,7 @@ package object environment extends PlatformSpecific {
      * requires a `Random`, such as with `ZIO#provide`.
      */
     def make(data: Data): ZLayer.NoDeps[Nothing, Random with TestRandom] =
-      ZLayer.fromEffect(for {
+      ZLayer.fromEffectMany(for {
         data   <- Ref.make(data)
         buffer <- Ref.make(Buffer())
         test   = Test(data, buffer)
@@ -1318,7 +1318,7 @@ package object environment extends PlatformSpecific {
 
     val random: ZLayer[Clock, Nothing, Random with TestRandom] =
       (ZLayer.service[Clock.Service] ++ deterministic) >>>
-        (ZLayer.fromEnvironmentM { (env: Clock with Random with TestRandom) =>
+        (ZLayer.fromFunctionM { (env: Clock with Random with TestRandom) =>
           val random     = env.get[Random.Service]
           val testRandom = env.get[TestRandom.Service]
 
@@ -1470,7 +1470,9 @@ package object environment extends PlatformSpecific {
      * requires a `Console`, such as with `ZIO#provide`.
      */
     def live(data: Data): ZLayer.NoDeps[Nothing, System with TestSystem] =
-      ZLayer.fromEffect(Ref.make(data).map(ref => Has.allOf[System.Service, TestSystem.Service](Test(ref), Test(ref))))
+      ZLayer.fromEffectMany(
+        Ref.make(data).map(ref => Has.allOf[System.Service, TestSystem.Service](Test(ref), Test(ref)))
+      )
 
     val any: ZLayer[System with TestSystem, Nothing, System with TestSystem] =
       ZLayer.requires[System with TestSystem]

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -44,7 +44,7 @@ import zio.{ PlatformSpecific => _, _ }
  * {{{
  * import zio.test.environment._
  *
- * myProgram.provideManaged(testEnvironmentManaged)
+ * myProgram.provideLayer(testEnvironment)
  * }}}
  *
  * Then all environmental effects, such as printing to the console or
@@ -89,8 +89,8 @@ package object environment extends PlatformSpecific {
 
   val liveEnvironment: ZLayer.NoDeps[Nothing, ZEnv] = ZEnv.live
 
-  val testEnvironmentManaged: Managed[Nothing, TestEnvironment] =
-    (ZEnv.live >>> TestEnvironment.live).build
+  val testEnvironment: ZLayer.NoDeps[Nothing, TestEnvironment] =
+    ZEnv.live >>> TestEnvironment.live
 
   /**
    * Provides an effect with the "real" environment as opposed to the test

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -114,7 +114,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
           mock = Mock.make(state.callsRef)
         } yield mockable.environment(mock)
 
-    ZLayer.fromManaged(for {
+    ZLayer.fromManagedMany(for {
       state <- Managed.make(makeState)(checkUnmetExpectations)
       env   <- Managed.fromEffect(makeEnvironment(state))
     } yield env)

--- a/test/shared/src/main/scala/zio/test/mock/Spyable.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Spyable.scala
@@ -66,7 +66,7 @@ object Spyable {
     layer: ZLayer[R, E, Has[A]]
   )(implicit spyable: Spyable[A]): UIO[(Ref[Vector[Invocation[A, _, _]]], ZLayer[R, E, Has[A]])] =
     Ref.make(Vector.empty[Invocation[A, _, _]]).map { ref =>
-      val spy = ZLayer.fromService { (environment: A) =>
+      val spy = ZLayer.fromServiceMany { (environment: A) =>
         spyable.spy(Has(environment)) {
           case invocation => ref.update(_ :+ invocation)
         }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -21,7 +21,7 @@ import scala.deprecated
 import zio.console.Console
 import zio.duration.Duration
 import zio.stream.{ ZSink, ZStream }
-import zio.test.environment.{ testEnvironmentManaged, TestClock, TestConsole, TestEnvironment, TestRandom, TestSystem }
+import zio.test.environment.{ testEnvironment, TestClock, TestConsole, TestEnvironment, TestRandom, TestSystem }
 
 /**
  * _ZIO Test_ is a featherweight testing library for effectful programs.
@@ -337,7 +337,7 @@ package object test extends CompileVariants {
    * A `Runner` that provides a default testable environment.
    */
   val defaultTestRunner: TestRunner[TestEnvironment, Any] =
-    TestRunner(TestExecutor.managed(testEnvironmentManaged))
+    TestRunner(TestExecutor.default(testEnvironment))
 
   /**
    * Creates a failed test result with the specified runtime cause.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -424,7 +424,7 @@ package object test extends CompileVariants {
      */
     def live: ZLayer.NoDeps[Nothing, Annotations] =
       ZLayer.fromEffect(FiberRef.make(TestAnnotationMap.empty).map { fiberRef =>
-        Has(new Annotations.Service {
+        new Annotations.Service {
           def annotate[V](key: TestAnnotation[V], value: V): UIO[Unit] =
             fiberRef.update(_.annotate(key, value))
           def get[V](key: TestAnnotation[V]): UIO[V] =
@@ -433,7 +433,7 @@ package object test extends CompileVariants {
             fiberRef.locally(TestAnnotationMap.empty) {
               zio.foldM(e => fiberRef.get.map((e, _)).flip, a => fiberRef.get.map((a, _)))
             }
-        })
+        }
       })
 
     /**
@@ -453,12 +453,12 @@ package object test extends CompileVariants {
 
     def live(size: Int): ZLayer.NoDeps[Nothing, Sized] =
       ZLayer.fromEffect(FiberRef.make(size).map { fiberRef =>
-        Has(new Sized.Service {
+        new Sized.Service {
           val size: UIO[Int] =
             fiberRef.get
           def withSize[R, E, A](size: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
             fiberRef.locally(size)(zio)
-        })
+        }
       })
 
     def size: ZIO[Sized, Nothing, Int] =

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -475,9 +475,9 @@ package object test extends CompileVariants {
 
     def fromConsole: ZLayer[Console, Nothing, TestLogger] =
       ZLayer.fromService { (console: Console.Service) =>
-        Has(new Service {
+        new Service {
           def logLine(line: String): UIO[Unit] = console.putStrLn(line)
-        })
+        }
       }
 
     def logLine(line: String): URIO[TestLogger, Unit] =


### PR DESCRIPTION
Adds `toLayer` methods on `ZIO` and `ZManaged`. Adds `fromAcquireRelease` constructor on `ZLayer`. Deprecates `provideManaged` and `provideSomeManaged`.

Open items:
- Should we deprecate more `provide` variants?
- Should we rename `provideSome` to `contramap`?
- Other methods that would be helpful?
- I noticed some of the `ZLayer` constructors require an effect that doesn't have an environmental dependency. I think we could relax that unless we think think it adds clarity.
- Should we rename `fromEnvironment` to `fromFunction`? It basically lifts a function into a Layer "arrow". I found that a bit more intuitive.
- When should constructors take `Tagged` instead of `Has`. `fromAcquireRelease` for example seems like it would be significantly more ergonomic for the common case if it took `Tagged` but there is a risk of inconsistency and proliferation of methods here.