### PR TITLE
ZIO Core: Move FinalizerRef to ZManaged

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect.nonFlaky
+import zio.test.TestAspect._
 import zio.test._
 import zio.test.environment._
 
@@ -197,7 +197,7 @@ object ZLayerSpec extends ZIOBaseSpec {
           actual <- ref.get
         } yield (assert(actual)(contains(acquire1)) ==> assert(actual)(contains(release1))) &&
           (assert(actual)(contains(acquire2)) ==> assert(actual)(contains(release2)))
-      } @@ nonFlaky,
+      } @@ flaky,
       testM("interruption with >>>") {
         for {
           ref    <- makeRef
@@ -223,7 +223,7 @@ object ZLayerSpec extends ZIOBaseSpec {
         } yield (assert(actual)(contains(acquire1)) ==> assert(actual)(contains(release1))) &&
           (assert(actual)(contains(acquire2)) ==> assert(actual)(contains(release2))) &&
           (assert(actual)(contains(acquire3)) ==> assert(actual)(contains(release3)))
-      } @@ nonFlaky,
+      } @@ flaky,
       testM("layers can be acquired in parallel") {
         for {
           promise <- Promise.make[Nothing, Unit]

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, nonFlaky }
+import zio.test.TestAspect.nonFlaky
 import zio.test._
 import zio.test.environment._
 
@@ -197,7 +197,7 @@ object ZLayerSpec extends ZIOBaseSpec {
           actual <- ref.get
         } yield (assert(actual)(contains(acquire1)) ==> assert(actual)(contains(release1))) &&
           (assert(actual)(contains(acquire2)) ==> assert(actual)(contains(release2)))
-      } @@ flaky,
+      } @@ nonFlaky,
       testM("interruption with >>>") {
         for {
           ref    <- makeRef
@@ -223,7 +223,7 @@ object ZLayerSpec extends ZIOBaseSpec {
         } yield (assert(actual)(contains(acquire1)) ==> assert(actual)(contains(release1))) &&
           (assert(actual)(contains(acquire2)) ==> assert(actual)(contains(release2))) &&
           (assert(actual)(contains(acquire3)) ==> assert(actual)(contains(release3)))
-      } @@ flaky,
+      } @@ nonFlaky,
       testM("layers can be acquired in parallel") {
         for {
           promise <- Promise.make[Nothing, Unit]

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect._
+import zio.test.TestAspect.{ flaky, nonFlaky }
 import zio.test._
 import zio.test.environment._
 

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -848,17 +848,12 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("scope")(
       testM("runs finalizer on interruption") {
         for {
-          ref <- Ref.make(0)
-          managed = ZManaged {
-            val reserve = ref.update(_ + 1)
-            val acquire = ref.update(_ + 1)
-            val release = ref.set(0)
-            reserve *> ZIO.succeedNow(Reservation(acquire, _ => release))
-          }
-          zio    = ZManaged.scope.use(scope => scope(managed).fork.flatMap(_.join))
-          fiber  <- zio.fork
-          _      <- fiber.interrupt
-          result <- ref.get
+          ref     <- Ref.make(0)
+          managed = makeTestManaged(ref)
+          zio     = ZManaged.scope.use(scope => scope(managed).fork.flatMap(_.join))
+          fiber   <- zio.fork
+          _       <- fiber.interrupt
+          result  <- ref.get
         } yield assert(result)(equalTo(0))
       } @@ nonFlaky,
       testM("runs finalizer when close is called") {
@@ -1168,20 +1163,17 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(count)(equalTo(1))
       },
       testM("Runs finalizers if it is interrupted") {
-        val acquire1 = "Acquiring Module 1"
-        val acquire2 = "Acquiring Module 2"
-        val release1 = "Releasing Module 1"
-        val release2 = "Releasing Module 2"
         for {
-          ref      <- Ref.make(Vector.empty[String])
-          managed1 = ZManaged.make(ref.update(_ :+ acquire1))(_ => ref.update(_ :+ release1))
-          managed2 = ZManaged.make(ref.update(_ :+ acquire2))(_ => ref.update(_ :+ release2))
+          ref1     <- Ref.make(0)
+          ref2     <- Ref.make(0)
+          managed1 = makeTestManaged(ref1)
+          managed2 = makeTestManaged(ref2)
           managed3 = managed1 <&> managed2
           fiber    <- managed3.use_(ZIO.unit).fork
           _        <- fiber.interrupt
-          actual   <- ref.get
-        } yield (assert(actual)(contains(acquire1)) ==> assert(actual)(contains(release1))) &&
-          (assert(actual)(contains(acquire2)) ==> assert(actual)(contains(release2)))
+          result1  <- ref1.get
+          result2  <- ref2.get
+        } yield assert(result1)(equalTo(0)) && assert(result2)(equalTo(0))
       } @@ nonFlaky
     ),
     suite("flatten")(
@@ -1424,6 +1416,14 @@ object ZManagedSpec extends ZIOBaseSpec {
       _                  <- reachedAcquisition.await
       interruption       <- Live.live(managedFiber.interruptAs(fiberId).timeout(5.seconds))
     } yield assert(interruption.map(_.untraced))(equalTo(expected(fiberId)))
+
+  def makeTestManaged(ref: Ref[Int]): Managed[Nothing, Unit] =
+    Managed {
+      val reserve = ref.update(_ + 1)
+      val acquire = ref.update(_ + 1)
+      val release = ref.set(0)
+      reserve *> ZIO.succeedNow(Reservation(acquire, _ => release))
+    }
 
   def testFinalizersPar[R, E](
     n: Int,

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1421,7 +1421,7 @@ object ZManagedSpec extends ZIOBaseSpec {
     Managed {
       val reserve = ref.update(_ + 1)
       val acquire = ref.update(_ + 1)
-      val release = ref.set(0)
+      val release = ref.update(n => if (n > 0) 0 else -1)
       reserve *> ZIO.succeedNow(Reservation(acquire, _ => release))
     }
 

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -293,5 +293,5 @@ object Exit extends Serializable {
 
   def succeed[A](a: A): Exit[Nothing, A] = Success(a)
 
-  def unit: Exit[Nothing, Unit] = succeed(())
+  val unit: Exit[Nothing, Unit] = succeed(())
 }

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -87,7 +87,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.finalizerRef]]
    */
-  def finalizerRef(initial: Exit[Any, Any] => UIO[Any]): Managed[Nothing, Ref[Exit[Any, Any] => UIO[Any]]] =
+  def finalizerRef(initial: Exit[Any, Any] => UIO[Any]): Managed[Nothing, ZManaged.FinalizerRef[Any]] =
     ZManaged.finalizerRef(initial)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1062,40 +1062,22 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    */
   def zipWithPar[R1 <: R, E1 >: E, A1, A2](that: ZManaged[R1, E1, A1])(f0: (A, A1) => A2): ZManaged[R1, E1, A2] =
     ZManaged[R1, E1, A2] {
-      Ref.make[Either[Exit[Any, Any], List[Exit[Any, Any] => ZIO[R1, Nothing, Any]]]](Right(Nil)).map { ref =>
+      ZManaged.FinalizerRef.make[R1](_ => UIO.unit).map { finalizers =>
         Reservation(
           acquire = {
             val left = ZIO.uninterruptibleMask { restore =>
-              self.reserve.flatMap { reservation =>
-                ref.updateSomeAndGet {
-                  case Right(finalizers) => Right(reservation.release :: finalizers)
-                }.flatMap {
-                  case Left(exit) => restore(reservation.acquire).ensuring(reservation.release(exit))
-                  case _          => restore(reservation.acquire)
-                }
-              }
+              reserve
+                .flatMap(res => finalizers.add(res.release).as(res))
+                .flatMap(res => restore(res.acquire))
             }
             val right = ZIO.uninterruptibleMask { restore =>
-              that.reserve.flatMap { reservation =>
-                ref.updateSomeAndGet {
-                  case Right(finalizers) => Right(reservation.release :: finalizers)
-                }.flatMap {
-                  case Left(exit) => restore(reservation.acquire).ensuring(reservation.release(exit))
-                  case _          => restore(reservation.acquire)
-                }
-              }
+              that.reserve
+                .flatMap(res => finalizers.add(res.release).as(res))
+                .flatMap(res => restore(res.acquire))
             }
             left.zipWithPar(right)(f0)
           },
-          release = exit =>
-            ref.getAndSet(Left(exit)).flatMap {
-              case Right(finalizers) =>
-                for {
-                  exits <- ZIO.foreach(finalizers)(_(exit).run)
-                  _     <- ZIO.doneNow(Exit.collectAllPar(exits).getOrElse(Exit.unit))
-                } yield ()
-              case _ => ZIO.unit
-            }
+          release = finalizers.run
         )
       }
     }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3256,8 +3256,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     ZStream {
       for {
         finalizerRef <- ZManaged.finalizerRef[R](_ => UIO.unit)
-        finalizer    <- finalizerRef.add(_ => finalizer).once.toManaged_
-        pull         = (finalizer *> Pull.end).uninterruptible
+        pull         = (finalizerRef.add(_ => finalizer) *> Pull.end).uninterruptible
       } yield pull
     }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3256,8 +3256,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     ZStream {
       for {
         finalizerRef <- ZManaged.finalizerRef[R](_ => UIO.unit)
-        once         <- Ref.make(true).map(ref => finalizerRef.add(_ => finalizer).whenM(ref.getAndSet(false))).toManaged_
-        pull         = (once *> Pull.end).uninterruptible
+        finalizer    <- finalizerRef.add(_ => finalizer).once.toManaged_
+        pull         = (finalizer *> Pull.end).uninterruptible
       } yield pull
     }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -880,17 +880,17 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
 
     ZStream {
       for {
-        finalizer <- ZManaged.finalizerRefInternal[R1](_ => UIO.unit)
-        selfPull  <- Ref.make[Pull[R, E, A]](Pull.end).toManaged_
-        otherPull <- Ref.make[Pull[R1, E2, A1]](Pull.end).toManaged_
-        stateRef  <- Ref.make[State](State.NotStarted).toManaged_
+        finalizers <- ZManaged.finalizerRef[R1](_ => UIO.unit)
+        selfPull   <- Ref.make[Pull[R, E, A]](Pull.end).toManaged_
+        otherPull  <- Ref.make[Pull[R1, E2, A1]](Pull.end).toManaged_
+        stateRef   <- Ref.make[State](State.NotStarted).toManaged_
         pull = {
           def switch(e: Cause[Option[E]]): Pull[R1, E2, A1] = {
             def next(e: Cause[E]) = ZIO.uninterruptibleMask { restore =>
               for {
-                _  <- finalizer.get.flatMap(_.apply(Exit.fail(e)))
+                _  <- finalizers.remove.flatMap(ZIO.foreach(_)(_(Exit.fail(e))))
                 r  <- f(e).process.reserve
-                _  <- finalizer.set(r.release)
+                _  <- finalizers.add(r.release)
                 as <- restore(r.acquire)
                 _  <- otherPull.set(as)
                 _  <- stateRef.set(State.Other)
@@ -909,7 +909,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
               ZIO.uninterruptibleMask { restore =>
                 for {
                   r  <- self.process.reserve
-                  _  <- finalizer.set(r.release)
+                  _  <- finalizers.add(r.release)
                   as <- restore(r.acquire)
                   _  <- selfPull.set(as)
                   _  <- stateRef.set(State.Self)
@@ -1301,7 +1301,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
   final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZStream[R1, E1, B]): ZStream[R1, E1, B] = {
     def go(
       as: Pull[R1, E1, A],
-      finalizer: Ref[Exit[_, _] => URIO[R1, _]],
+      finalizers: ZManaged.FinalizerRef[R1],
       currPull: Ref[Pull[R1, E1, B]]
     ): Pull[R1, E1, B] = {
       val pullOuter = ZIO.uninterruptibleMask { restore =>
@@ -1309,7 +1309,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
           (for {
             reservation <- f0(a).process.reserve
             bs          <- restore(reservation.acquire)
-            _           <- finalizer.set(reservation.release)
+            _           <- finalizers.add(reservation.release)
             _           <- currPull.set(bs)
           } yield ())
         }
@@ -1319,10 +1319,12 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
         Cause.sequenceCauseOption(c) match {
           case Some(e) => Pull.haltNow(e)
           case None =>
-            (finalizer.get.flatMap(_(Exit.succeed(()))) *>
-              finalizer.set(_ => UIO.unit)).uninterruptible *>
+            finalizers
+              .replace(_ => UIO.unit)
+              .flatMap(ZIO.foreach(_)(_(Exit.unit)))
+              .uninterruptible *>
               pullOuter *>
-              go(as, finalizer, currPull)
+              go(as, finalizers, currPull)
         }
       }
     }
@@ -1331,7 +1333,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
       for {
         currPull  <- Ref.make[Pull[R1, E1, B]](Pull.end).toManaged_
         as        <- self.process
-        finalizer <- ZManaged.finalizerRefInternal[R1](_ => UIO.unit)
+        finalizer <- ZManaged.finalizerRef[R1](_ => UIO.unit)
       } yield go(as, finalizer, currPull)
     }
   }


### PR DESCRIPTION
@iravid I confirmed that `scope` has the same issue as we have been seeing. I moved `FinalizerRef` to `ZManaged`, implemented `scope` and `zipWithPar` in terms of that, and moved several other combinators to using that.

There are a couple of combinators like `switchable` and `ZStream#catchAllCause` that use more complex patterns involving removing finalizers that can't easily be expressed in terms of this. I renamed the existing `finalizerRef` method to `finalizerRefInternal` and made it `private[zio]`. I think it is tricky to use correctly given that the finalizer may be run before child fibers have registered their finalizers but obviously open to feedback on that.