### PR TITLE
Fix flaky test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -763,8 +763,11 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           fiber  <- ZIO.forkAll(List(ZIO.dieNow(boom)))
           result <- fiber.join.sandbox.flip
-        } yield assert(result)(equalTo(Cause.die(boom)))
-      } @@ flaky
+        } yield {
+          assert(result)(equalTo(Cause.die(boom))) ||
+          (assert(result.dieOption)(isSome(equalTo(boom))) && assert(result.interrupted)(isTrue))
+        }
+      }
     ),
     suite("forkDaemon")(
       testM("child is unsupervised by parent") {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -759,13 +759,24 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)(equalTo(boom))
       },
       testM("propagates defects") {
-        val boom = new Exception("boom")
+        val boom                                 = new Exception("boom")
+        val die                                  = ZIO.dieNow(boom)
+        def joinDefect(fiber: Fiber[Nothing, _]) = fiber.join.sandbox.flip
         for {
-          fiber  <- ZIO.forkAll(List(ZIO.dieNow(boom)))
-          result <- fiber.join.sandbox.flip
+          fiber1 <- ZIO.forkAll(List(die))
+          fiber2 <- ZIO.forkAll(List(die, ZIO.succeed(42)))
+          fiber3 <- ZIO.forkAll(List(die, ZIO.succeed(42), ZIO.never))
+
+          result1 <- joinDefect(fiber1)
+          result2 <- joinDefect(fiber2)
+          result3 <- joinDefect(fiber3)
         } yield {
-          assert(result)(equalTo(Cause.die(boom))) ||
-          (assert(result.dieOption)(isSome(equalTo(boom))) && assert(result.interrupted)(isTrue))
+          assert(result1)(equalTo(Cause.die(boom))) && {
+            assert(result2)(equalTo(Cause.die(boom))) ||
+            (assert(result2.dieOption)(isSome(equalTo(boom))) && assert(result2.interrupted)(isTrue))
+          } && {
+            assert(result3.dieOption)(isSome(equalTo(boom))) && assert(result3.interrupted)(isTrue)
+          }
         }
       }
     ),

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -360,7 +360,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  def forkAll[E, A](as: Iterable[IO[E, A]]): UIO[Fiber.Synthetic[E, List[A]]] =
+  def forkAll[E, A](as: Iterable[IO[E, A]]): UIO[Fiber[E, List[A]]] =
     ZIO.forkAll(as)
 
   /**

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -361,7 +361,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  def forkAll[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Fiber.Synthetic[Throwable, List[A]]] =
+  def forkAll[R, A](as: Iterable[RIO[R, A]]): ZIO[R, Nothing, Fiber[Throwable, List[A]]] =
     ZIO.forkAll(as)
 
   /**

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -360,7 +360,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  def forkAll[A](as: Iterable[Task[A]]): UIO[Fiber.Synthetic[Throwable, List[A]]] =
+  def forkAll[A](as: Iterable[Task[A]]): UIO[Fiber[Throwable, List[A]]] =
     ZIO.forkAll(as)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -236,7 +236,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.forkAll]]
    */
-  def forkAll[A](as: Iterable[UIO[A]]): UIO[Fiber.Synthetic[Nothing, List[A]]] =
+  def forkAll[A](as: Iterable[UIO[A]]): UIO[Fiber[Nothing, List[A]]] =
     ZIO.forkAll(as)
 
   /**

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -333,7 +333,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.forkAll]]
    */
-  def forkAll[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Fiber.Synthetic[Nothing, List[A]]] =
+  def forkAll[R, A](as: Iterable[URIO[R, A]]): ZIO[R, Nothing, Fiber[Nothing, List[A]]] =
     ZIO.forkAll(as)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2603,23 +2603,11 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns an effect that forks all of the specified values, and returns a
    * composite fiber that produces a list of their results, in order.
    */
-  def forkAll[R, E, A](as: Iterable[ZIO[R, E, A]]): URIO[R, Fiber.Synthetic[E, List[A]]] =
-    as.toList match {
-      case Nil => succeedNow(Fiber.succeed(Nil))
-
-      case a :: Nil => a.fork.map(_.map(List(_)))
-
-      case as =>
-        // Note that we could handle all cases with this code. However, then we would effectively
-        // fork two fibers even for iterables with a single element. If this single ZIO resulted
-        // in an error, the existence of the second fiber could then in rare cases be observed
-        // by callers in the form of an interruption. See issue #2096.
-        as.foldRight[URIO[R, Fiber.Synthetic[E, List[A]]]](succeedNow(Fiber.succeed(Nil))) { (aIO, asFiberIO) =>
-          asFiberIO.zipWith(aIO.fork) {
-            case (asFiber, aFiber) =>
-              asFiber.zipWith(aFiber)((as, a) => a :: as)
-          }
-        }
+  def forkAll[R, E, A](as: Iterable[ZIO[R, E, A]]): URIO[R, Fiber[E, List[A]]] =
+    ZIO.foreach(as)(_.map(List(_)).fork).map { fibers =>
+      fibers
+        .reduceRightOption[Fiber[E, List[A]]]((a, as) => a.zipWith(as)((a, as) => a ::: as))
+        .getOrElse(Fiber.succeed(Nil))
     }
 
   /**


### PR DESCRIPTION
`ZIO.forkAll`, when being executed with `List(ZIO.dieNow(boom))` will
internally execute `nilIO.zipWithPar(boomIO)((as, a) => a :: as)`, where
`nilIO` is a simple ZIO value that results in `Nil`, and `boomIO` a
simple ZIO value that results in `ZIO.dieNow(boom)`. In rare cases,
`boomIO` completes before `nilIO` and then interrupts `nilIO`. The
result of the test is then not just a `Die`, but also an interruption.

Fixes #2096