### PR TITLE
ZIO Test: Implement Forked Test Aspect

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,16 +1,13 @@
 package zio.test
 
 import scala.reflect.ClassTag
-import scala.reflect.ClassTag
 
-import zio.ZEnv
-import zio.ZLayer
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.{ Live, TestClock }
-import zio.{ Ref, Schedule, ZIO }
+import zio.{ Ref, Schedule, ZEnv, ZIO, ZLayer }
 
 object TestAspectSpec extends ZIOBaseSpec {
 
@@ -128,6 +125,12 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("flaky retries a test with a limit") {
       assert(true)(isFalse)
     } @@ flaky @@ failure,
+    testM("forked runs each test on its own separate fiber") {
+      for {
+        _        <- ZIO.never.fork
+        children <- ZIO.children
+      } yield assert(children)(hasSize(equalTo(1)))
+    } @@ forked @@ nonFlaky,
     test("ifEnv runs a test if environment variable satisfies assertion") {
       assert(true)(isTrue)
     } @@ ifEnv("PATH", containsString("bin")) @@ success @@ jvmOnly,

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -286,6 +286,15 @@ object TestAspect extends TimeoutVariants {
     retry(Schedule.recurs(n))
 
   /**
+   * An aspect that runs each test on its own separate fiber.
+   */
+  val forked: TestAspectPoly =
+    new PerTest.Poly {
+      def perTest[R, E](test: ZIO[R, TestFailure[E], TestSuccess]): ZIO[R, TestFailure[E], TestSuccess] =
+        test.fork.flatMap(_.join)
+    }
+
+  /**
    * An aspect that only runs a test if the specified environment variable
    * satisfies the specified assertion.
    */


### PR DESCRIPTION
We had discussed this but we hadn't actually implemented it, I think because we implemented the combinators to restore the test environment.