### PR TITLE
ZIO Core: Fix Exponential Schedule

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -197,14 +197,14 @@ object ScheduleSpec extends ZIOBaseSpec {
         assertM(
           TestClock
             .setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis) >>> testElapsed)(List.fill(5)(()))
-        )(equalTo(List(0, 2, 6, 14, 30).map(i => (i * 100).millis)))
+        )(equalTo(List(0, 1, 3, 7, 15).map(i => (i * 100).millis)))
       },
       testM("exponential delay with other factor") {
         assertM(
           TestClock.setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis, 3.0) >>> testElapsed)(
             List.fill(5)(())
           )
-        )(equalTo(List(0, 3, 12, 39, 120).map(i => (i * 100).millis)))
+        )(equalTo(List(0, 1, 4, 13, 40).map(i => (i * 100).millis)))
       }
     ),
     suite("Retry according to a provided strategy")(

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -745,7 +745,7 @@ object Schedule {
    * repetitions so far. Returns the current duration between recurrences.
    */
   def exponential(base: Duration, factor: Double = 2.0): Schedule[Clock, Any, Duration] =
-    delayed(forever.map(i => base * math.pow(factor, (i + 1).doubleValue)))
+    delayed(forever.map(i => base * math.pow(factor, i.doubleValue)))
 
   /**
    * A schedule that always recurs, increasing delays by summing the

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1054,7 +1054,7 @@ object StreamSpec extends ZIOBaseSpec {
       val schedule = Schedule.exponential(1.second) <* Schedule.recurs(5)
       val stream   = ZStream.fromSchedule(schedule)
       val zio      = TestClock.adjust(62.seconds) *> stream.runCollect
-      val expected = List(1.seconds, 2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds)
+      val expected = List(2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds, 64.seconds)
       assertM(zio)(equalTo(expected))
     },
     testM("Stream.fromTQueue") {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1054,7 +1054,7 @@ object StreamSpec extends ZIOBaseSpec {
       val schedule = Schedule.exponential(1.second) <* Schedule.recurs(5)
       val stream   = ZStream.fromSchedule(schedule)
       val zio      = TestClock.adjust(62.seconds) *> stream.runCollect
-      val expected = List(2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds, 64.seconds)
+      val expected = List(1.seconds, 2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds)
       assertM(zio)(equalTo(expected))
     },
     testM("Stream.fromTQueue") {


### PR DESCRIPTION
The first delay in `Schedule.exponential(10.milliseconds)` should be 10 milliseconds, not 20 milliseconds.