### PR TITLE
Update Schedule Documentation

### DIFF
--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -100,8 +100,7 @@ val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.seco
 Stops retrying after a specified amount of time has elapsed:
 
 ```scala mdoc:silent
-val action = clock.nanoTime.flatMap(n => console.putStrLn(n.toString)) *> ZIO.fail("fail")
-action.retry(expCapped).timeout(30.seconds)
+val expMaxElapsed = (Schedule.exponential(10.milliseconds) >>> Schedule.elapsed).whileOutput(_ < 30.seconds)
 ```
 
 Retry only when a specific exception occurs:

--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -100,7 +100,8 @@ val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.seco
 Stops retrying after a specified amount of time has elapsed:
 
 ```scala mdoc:silent
-val expMaxElapsed = Schedule.exponential(10.milliseconds) && Schedule.elapsed.whileOutput(_ < 30.seconds)
+val action = clock.nanoTime.flatMap(n => console.putStrLn(n.toString)) *> ZIO.fail("fail")
+action.retry(expCapped).timeout(30.seconds)
 ```
 
 Retry only when a specific exception occurs:


### PR DESCRIPTION
`schedule && Schedule.elapsed.whileOut(_ < time)` is not a great way to place an overall time limit on a schedule with the new encoding because `elapsed` will return immediately with the current elapsed time versus the elapsed time after the other schedule that has done sleeping, so you generally end up with an additional repetition of the schedule versus what you want. Updates the documentation to not use this example and instead put an overall timeout on the effect.