### PR TITLE
Command-line args support for running the standalone specs

### DIFF
--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -88,7 +88,7 @@ final class ZTestTask(
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs) {
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
-    Runtime((), spec.platform)
+    Runtime((), specInstance.platform)
       .unsafeRunAsync((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged_).use_(ZIO.unit)) { exit =>
         exit match {
           case Exit.Failure(cause) => Console.err.println(s"$runnerType failed: " + cause.prettyPrint)

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -26,7 +26,7 @@ abstract class BaseTestTask(
 
   protected def run(eventHandler: EventHandler) =
     for {
-      spec    <- specInstance.runner.run(FilteredSpec(specInstance.spec, args))
+      spec    <- specInstance.runSpec(FilteredSpec(specInstance.spec, args))
       summary <- SummaryBuilder.buildSummary(spec)
       _       <- sendSummary.provide(summary)
       events  <- ZTestEvent.from(spec, taskDef.fullyQualifiedName, taskDef.fingerprint)

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -34,6 +34,14 @@ abstract class AbstractRunnableSpec {
    * Returns an effect that executes the spec, producing the results of the execution.
    */
   final def run: URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
+    runSpec(spec)
+
+  /**
+   * Returns an effect that executes a given spec, producing the results of the execution.
+   */
+  private[zio] final def runSpec(
+    spec: ZSpec[Environment, Failure]
+  ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
     runner.run(aspects.foldLeft(spec)(_ @@ _))
 
   /**

--- a/test/shared/src/main/scala/zio/test/FilteredSpec.scala
+++ b/test/shared/src/main/scala/zio/test/FilteredSpec.scala
@@ -1,0 +1,30 @@
+package zio.test
+
+/**
+ * Filters a given `ZSpec` based on the command-line arguments.
+ * If no arguments were specified, the spec returns unchanged.
+ */
+private[zio] object FilteredSpec {
+  def apply[R, E](spec: ZSpec[R, E], args: TestArgs): ZSpec[R, E] = {
+    def filtered: Option[ZSpec[R, E]] =
+      (args.testSearchTerms, args.tagSearchTerms) match {
+        case (Nil, Nil) => None
+        case (testSearchTerms, Nil) =>
+          spec.filterLabels { label =>
+            testSearchTerms.exists(term => label.contains(term))
+          }
+        case (Nil, tagSearchTerms) =>
+          spec.filterTags { tag =>
+            tagSearchTerms.contains(tag)
+          }
+        case (testSearchTerms, tagSearchTerms) =>
+          spec.filterTags { tag =>
+            testSearchTerms.contains(tag)
+          }.flatMap(_.filterLabels { label =>
+            tagSearchTerms.exists(term => label.contains(term))
+          })
+      }
+
+    filtered.getOrElse(spec)
+  }
+}


### PR DESCRIPTION
By default, the spec is a command-line application that can be executed directly. It currently does not perform any filtering and runs the entire spec.
This PR considers the arguments that may be passed and applies the filtering, similar to the sbt runner.

```
> java .... MySpec -t myTest -t myTest2 ...
```

This is a required step to improve the UX from tests runners such as IntelliJ (via the zio-intellij plugin), allowing running individual tests.