### PR TITLE
ZIO Test: Fix Subtype Assertion

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -252,7 +252,19 @@ object AssertionSpec extends ZIOBaseSpec {
     test("isSome must fail when supplied value is None") {
       assert(None)(isSome(equalTo("zio")))
     } @@ failure,
-    test("isSubtype gracefully handles malformed class names") {
+    test("isSubtype must succeed when value is subtype of specified type") {
+      assert(dog)(isSubtype[Animal](anything))
+    },
+    test("isSubtype must fail when value is supertype of specified type") {
+      assert(animal)(isSubtype[Cat](anything))
+    } @@ failure,
+    test("isSubtype must fail when value is neither subtype nor supertype of specified type") {
+      assert(cat)(isSubtype[Dog](anything))
+    } @@ failure,
+    test("isSubtype must handle primitive types") {
+      assert(1)(isSubtype[Int](anything))
+    },
+    test("isSubtype must handle malformed class names") {
       sealed trait Exception
       object Exception {
         case class MyException() extends Exception
@@ -336,4 +348,12 @@ object AssertionSpec extends ZIOBaseSpec {
   val ageGreaterThan20: Assertion[SampleUser] = hasField("age", _.age, isGreaterThan(20))
 
   val someException = new RuntimeException("Boom!")
+
+  trait Animal
+  trait Dog extends Animal
+  trait Cat extends Animal
+
+  val animal = new Animal {}
+  val dog    = new Dog    {}
+  val cat    = new Cat    {}
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -597,10 +597,7 @@ object Assertion extends AssertionVariants {
    * }}}
    */
   def isSubtype[A](assertion: Assertion[A])(implicit C: ClassTag[A]): Assertion[Any] =
-    Assertion.assertionRec("isSubtype")(param(className(C)))(assertion) { actual =>
-      if (C.runtimeClass.isAssignableFrom(actual.getClass())) Some(actual.asInstanceOf[A])
-      else None
-    }
+    Assertion.assertionRec("isSubtype")(param(className(C)))(assertion)(C.unapply(_))
 
   /**
    * Makes a new assertion that requires a value be true.


### PR DESCRIPTION
Resolves #2970. Class tags have an unapply method that contains special logic for handling primitive types we can use.