### PR TITLE
ZIO Test: TestClock Improvements

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -156,13 +156,13 @@ object ScheduleSpec extends ZIOBaseSpec {
       },
       testM("for a given number of times with random jitter in (0, 1)") {
         val schedule  = Schedule.spaced(500.millis).jittered(0, 1)
-        val scheduled = TestClock.setTime(Duration.Infinity) *> run(schedule >>> testElapsed)(List.fill(5)(()))
+        val scheduled = TestClock.runAll *> run(schedule >>> testElapsed)(List.fill(5)(()))
         val expected  = List(0.millis, 250.millis, 500.millis, 750.millis, 1000.millis)
         assertM(TestRandom.feedDoubles(0.5, 0.5, 0.5, 0.5, 0.5) *> scheduled)(equalTo(expected))
       },
       testM("for a given number of times with random jitter in custom interval") {
         val schedule  = Schedule.spaced(500.millis).jittered(2, 4)
-        val scheduled = TestClock.setTime(Duration.Infinity) *> run(schedule >>> testElapsed)((List.fill(5)(())))
+        val scheduled = TestClock.runAll *> run(schedule >>> testElapsed)((List.fill(5)(())))
         val expected  = List(0, 1500, 3000, 5000, 7000).map(_.millis)
         assertM(TestRandom.feedDoubles(0.5, 0.5, 1, 1, 0.5) *> scheduled)(equalTo(expected))
       },
@@ -174,7 +174,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         val strategy = Schedule.spaced(200.millis).whileInput[String](_ == "KeepTryingError")
         val expected = (800.millis, "GiveUpError", 4)
         val result   = io.retryOrElseEither(strategy, (e: String, r: Int) => TestClock.fiberTime.map((_, e, r)))
-        assertM(TestClock.setTime(Duration.Infinity) *> result)(isLeft(equalTo(expected)))
+        assertM(TestClock.runAll *> result)(isLeft(equalTo(expected)))
       },
       testM("fibonacci delay") {
         assertM(
@@ -189,7 +189,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         )(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 100).millis)))
       },
       testM("modified linear delay") {
-        assertM(TestClock.setTime(Duration.Infinity) *> run(Schedule.linear(100.millis).modifyDelay {
+        assertM(TestClock.runAll *> run(Schedule.linear(100.millis).modifyDelay {
           case (_, d) => ZIO.succeedNow(d * 2)
         } >>> testElapsed)(List.fill(5)(())))(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 200).millis)))
       },
@@ -201,7 +201,7 @@ object ScheduleSpec extends ZIOBaseSpec {
       },
       testM("exponential delay with other factor") {
         assertM(
-          TestClock.setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis, 3.0) >>> testElapsed)(
+          TestClock.runAll *> run(Schedule.exponential(100.millis, 3.0) >>> testElapsed)(
             List.fill(5)(())
           )
         )(equalTo(List(0, 1, 4, 13, 40).map(i => (i * 100).millis)))

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -194,6 +194,12 @@ object ClockSpec extends ZIOBaseSpec {
         _         <- TestClock.adjust(5.seconds)
         _         <- latch.await
       } yield assertCompletes
+    },
+    testM("runAll runs all scheduled effects") {
+      for {
+        _ <- TestClock.runAll
+        _ <- ZIO.sleep(Duration.Infinity)
+      } yield assertCompletes
     }
   )
 }


### PR DESCRIPTION
A couple of incremental improvements to the TestClock:

1. Currently when the TestClock is restored as part of combinators like `nonFlaky` the flag of whether the warning that sleep is being used but the TestClock is not being adjusted gets restored as well. This can result in the warning being rendered multiple times if the clock is not being adjusted. This PR fixes this so the warning will only be rendered once per test.
2. Adds a method `runAll` that sets the clock time to infinity so all pending effects run and any new scheduled effects run immediately.
3. Some simplifications to the internal representation of TestClock.