### PR TITLE
ZIO Test: TestConsole Improvements

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -75,7 +75,7 @@ object ZLayerSpec extends ZIOBaseSpec {
       testM("Size of Test layers") {
         for {
           r1 <- testSize(Annotations.live, 1, "Annotations.live")
-          r2 <- testSize(TestConsole.default, 2, "TestConsole.default")
+          r2 <- testSize(ZEnv.live >>> Live.default >>> TestConsole.default, 2, "TestConsole.default")
           r3 <- testSize(ZEnv.live >>> Live.default, 1, "Live.default")
           r4 <- testSize(ZEnv.live >>> TestRandom.deterministic, 2, "TestRandom.live")
           r5 <- testSize(Sized.live(100), 1, "Sized.live(100)")
@@ -84,8 +84,9 @@ object ZLayerSpec extends ZIOBaseSpec {
       },
       testM("Size of >>> (9)") {
         val layer = (ZEnv.live >>>
-          (Annotations.live ++ TestConsole.default ++ Live.default ++ TestRandom.deterministic ++ Sized
-            .live(100) ++ TestSystem.default))
+          (Annotations.live ++ (Live.default >>> TestConsole.default) ++
+            Live.default ++ TestRandom.deterministic ++ Sized.live(100)
+            ++ TestSystem.default))
 
         testSize(layer, 9)
       },

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -75,7 +75,7 @@ object ZLayerSpec extends ZIOBaseSpec {
       testM("Size of Test layers") {
         for {
           r1 <- testSize(Annotations.live, 1, "Annotations.live")
-          r2 <- testSize(ZEnv.live >>> Live.default >>> TestConsole.default, 2, "TestConsole.default")
+          r2 <- testSize(ZEnv.live >>> Live.default >>> TestConsole.debug, 2, "TestConsole.default")
           r3 <- testSize(ZEnv.live >>> Live.default, 1, "Live.default")
           r4 <- testSize(ZEnv.live >>> TestRandom.deterministic, 2, "TestRandom.live")
           r5 <- testSize(Sized.live(100), 1, "Sized.live(100)")
@@ -84,7 +84,7 @@ object ZLayerSpec extends ZIOBaseSpec {
       },
       testM("Size of >>> (9)") {
         val layer = (ZEnv.live >>>
-          (Annotations.live ++ (Live.default >>> TestConsole.default) ++
+          (Annotations.live ++ (Live.default >>> TestConsole.debug) ++
             Live.default ++ TestRandom.deterministic ++ Sized.live(100)
             ++ TestSystem.default))
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -296,7 +296,7 @@ object ChunkSpec extends ZIOBaseSpec {
     test("filterConstFalseResultsInEmptyChunk") {
       assert(Chunk.fromArray(Array(1, 2, 3)).filter(_ => false))(equalTo(Chunk.empty))
     },
-    test("def testzipAllWith") {
+    test("zipAllWith") {
       assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 4))) &&
       assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0))) &&
       assert(Chunk(1, 2).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0)))

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -2,54 +2,56 @@ package zio.test
 
 import zio.test.Assertion._
 import zio.test.ReportingTestUtils._
+import zio.test.TestAspect.silent
 
 object DefaultTestReporterSpec extends ZIOBaseSpec {
 
-  def spec = suite("DefaultTestReporterSpec")(
-    testM("correctly reports a successful test") {
-      assertM(runLog(test1))(equalTo(test1Expected.mkString + reportStats(1, 0, 0)))
-    },
-    testM("correctly reports a failed test") {
-      assertM(runLog(test3))(equalTo(test3Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports an error in a test") {
-      assertM(runLog(test4))(equalTo(test4Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports successful test suite") {
-      assertM(runLog(suite1))(equalTo(suite1Expected.mkString + reportStats(2, 0, 0)))
-    },
-    testM("correctly reports failed test suite") {
-      assertM(runLog(suite2))(equalTo(suite2Expected.mkString + reportStats(2, 0, 1)))
-    },
-    testM("correctly reports multiple test suites") {
-      assertM(runLog(suite3))(equalTo(suite3Expected.mkString + reportStats(4, 0, 2)))
-    },
-    testM("correctly reports empty test suite") {
-      assertM(runLog(suite4))(equalTo(suite4Expected.mkString + reportStats(2, 0, 1)))
-    },
-    testM("correctly reports failure of simple assertion") {
-      assertM(runLog(test5))(equalTo(test5Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports multiple nested failures") {
-      assertM(runLog(test6))(equalTo(test6Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports labeled failures") {
-      assertM(runLog(test7))(equalTo(test7Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports negated failures") {
-      assertM(runLog(test8))(equalTo(test8Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports mock failure of invalid argument") {
-      assertM(runLog(mock1))(equalTo(mock1Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports mock failure of invalid method") {
-      assertM(runLog(mock2))(equalTo(mock2Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports mock failure of unmet expectations") {
-      assertM(runLog(mock3))(equalTo(mock3Expected.mkString + reportStats(0, 0, 1)))
-    },
-    testM("correctly reports mock failure of unexpected call") {
-      assertM(runLog(mock4))(equalTo(mock4Expected.mkString + reportStats(0, 0, 1)))
-    }
-  )
+  def spec =
+    suite("DefaultTestReporterSpec")(
+      testM("correctly reports a successful test") {
+        assertM(runLog(test1))(equalTo(test1Expected.mkString + reportStats(1, 0, 0)))
+      },
+      testM("correctly reports a failed test") {
+        assertM(runLog(test3))(equalTo(test3Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports an error in a test") {
+        assertM(runLog(test4))(equalTo(test4Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports successful test suite") {
+        assertM(runLog(suite1))(equalTo(suite1Expected.mkString + reportStats(2, 0, 0)))
+      },
+      testM("correctly reports failed test suite") {
+        assertM(runLog(suite2))(equalTo(suite2Expected.mkString + reportStats(2, 0, 1)))
+      },
+      testM("correctly reports multiple test suites") {
+        assertM(runLog(suite3))(equalTo(suite3Expected.mkString + reportStats(4, 0, 2)))
+      },
+      testM("correctly reports empty test suite") {
+        assertM(runLog(suite4))(equalTo(suite4Expected.mkString + reportStats(2, 0, 1)))
+      },
+      testM("correctly reports failure of simple assertion") {
+        assertM(runLog(test5))(equalTo(test5Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports multiple nested failures") {
+        assertM(runLog(test6))(equalTo(test6Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports labeled failures") {
+        assertM(runLog(test7))(equalTo(test7Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports negated failures") {
+        assertM(runLog(test8))(equalTo(test8Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports mock failure of invalid argument") {
+        assertM(runLog(mock1))(equalTo(mock1Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports mock failure of invalid method") {
+        assertM(runLog(mock2))(equalTo(mock2Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports mock failure of unmet expectations") {
+        assertM(runLog(mock3))(equalTo(mock3Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports mock failure of unexpected call") {
+        assertM(runLog(mock4))(equalTo(mock4Expected.mkString + reportStats(0, 0, 1)))
+      }
+    ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -2,7 +2,6 @@ package zio.test
 
 import scala.{ Console => SConsole }
 
-import zio.clock.Clock
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan, isRight, isSome, not }
 import zio.test.environment.{ testEnvironment, TestClock, TestConsole, TestEnvironment }
 import zio.test.mock.ExpectationSpecUtils.Module
@@ -51,7 +50,7 @@ object ReportingTestUtils {
     for {
       _ <- TestTestRunner(testEnvironment)
             .run(spec)
-            .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](TestLogger.fromConsole ++ TestClock.default)
+            .provideLayer(TestLogger.fromConsole ++ TestClock.default)
       output <- TestConsole.output
     } yield output.mkString
 
@@ -59,9 +58,7 @@ object ReportingTestUtils {
     for {
       results <- TestTestRunner(testEnvironment)
                   .run(spec)
-                  .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](
-                    TestLogger.fromConsole ++ TestClock.default
-                  )
+                  .provideLayer(TestLogger.fromConsole ++ TestClock.default)
       actualSummary <- SummaryBuilder.buildSummary(results)
     } yield actualSummary.summary
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -50,7 +50,7 @@ object ReportingTestUtils {
     for {
       _ <- TestTestRunner(testEnvironment)
             .run(spec)
-            .provideLayer(TestLogger.fromConsole ++ TestClock.default)
+            .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](TestLogger.fromConsole ++ TestClock.default)
       output <- TestConsole.output
     } yield output.mkString
 
@@ -58,7 +58,9 @@ object ReportingTestUtils {
     for {
       results <- TestTestRunner(testEnvironment)
                   .run(spec)
-                  .provideLayer(TestLogger.fromConsole ++ TestClock.default)
+                  .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](
+                     TestLogger.fromConsole ++ TestClock.default
+                   )
       actualSummary <- SummaryBuilder.buildSummary(results)
     } yield actualSummary.summary
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -2,6 +2,7 @@ package zio.test
 
 import scala.{ Console => SConsole }
 
+import zio.clock.Clock
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan, isRight, isSome, not }
 import zio.test.environment.{ testEnvironment, TestClock, TestConsole, TestEnvironment }
 import zio.test.mock.ExpectationSpecUtils.Module
@@ -59,8 +60,8 @@ object ReportingTestUtils {
       results <- TestTestRunner(testEnvironment)
                   .run(spec)
                   .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](
-                     TestLogger.fromConsole ++ TestClock.default
-                   )
+                    TestLogger.fromConsole ++ TestClock.default
+                  )
       actualSummary <- SummaryBuilder.buildSummary(results)
     } yield actualSummary.summary
 

--- a/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
@@ -2,33 +2,35 @@ package zio.test
 
 import zio.test.Assertion._
 import zio.test.ReportingTestUtils._
+import zio.test.TestAspect.silent
 
 object SummaryBuilderSpec extends ZIOBaseSpec {
 
   def summarize(log: Vector[String]): String =
     log.filter(!_.contains("+")).mkString.stripLineEnd
 
-  def spec = suite("SummaryBuilderSpec")(
-    testM("doesn't generate summary for a successful test") {
-      assertM(runSummary(test1))(equalTo(""))
-    },
-    testM("includes a failed test") {
-      assertM(runSummary(test3))(equalTo(summarize(test3Expected)))
-    },
-    testM("correctly reports an error in a test") {
-      assertM(runSummary(test4))(equalTo(summarize(test4Expected)))
-    },
-    testM("doesn't generate summary for a successful test suite") {
-      assertM(runSummary(suite1))(equalTo(""))
-    },
-    testM("correctly reports failed test suite") {
-      assertM(runSummary(suite2))(equalTo(summarize(suite2Expected)))
-    },
-    testM("correctly reports multiple test suites") {
-      assertM(runSummary(suite3))(equalTo(summarize(suite3Expected)))
-    },
-    testM("correctly reports failure of simple assertion") {
-      assertM(runSummary(test5))(equalTo(summarize(test5Expected)))
-    }
-  )
+  def spec =
+    suite("SummaryBuilderSpec")(
+      testM("doesn't generate summary for a successful test") {
+        assertM(runSummary(test1))(equalTo(""))
+      },
+      testM("includes a failed test") {
+        assertM(runSummary(test3))(equalTo(summarize(test3Expected)))
+      },
+      testM("correctly reports an error in a test") {
+        assertM(runSummary(test4))(equalTo(summarize(test4Expected)))
+      },
+      testM("doesn't generate summary for a successful test suite") {
+        assertM(runSummary(suite1))(equalTo(""))
+      },
+      testM("correctly reports failed test suite") {
+        assertM(runSummary(suite2))(equalTo(summarize(suite2Expected)))
+      },
+      testM("correctly reports multiple test suites") {
+        assertM(runSummary(suite3))(equalTo(summarize(suite3Expected)))
+      },
+      testM("correctly reports failure of simple assertion") {
+        assertM(runSummary(test5))(equalTo(summarize(test5Expected)))
+      }
+    ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -187,6 +187,9 @@ object TestAspectSpec extends ZIOBaseSpec {
       val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
       assertM(result)(isTrue)
     },
+    testM("noDelay causes sleep effects to be executed immediately") {
+      assertM(ZIO.sleep(Duration.Infinity))(anything)
+    } @@ noDelay,
     suite("nonTermination")(
       testM("makes a test pass if it does not terminate within the specified time") {
         assertM(ZIO.never)(anything)

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -3,87 +3,88 @@ package zio.test.environment
 import zio.ZIO
 import zio.console._
 import zio.test.Assertion._
-import zio.test.TestAspect.nonFlaky
+import zio.test.TestAspect.{ nonFlaky, silent }
 import zio.test._
 import zio.test.environment.TestConsole._
 
 object ConsoleSpec extends ZIOBaseSpec {
 
-  def spec = suite("ConsoleSpec")(
-    testM("outputs nothing") {
-      for {
-        output <- TestConsole.output
-      } yield assert(output)(isEmpty)
-    },
-    testM("writes to output") {
-      for {
-        _      <- putStr("First line")
-        _      <- putStr("Second line")
-        output <- TestConsole.output
-      } yield assert(output)(equalTo(Vector("First line", "Second line")))
-    },
-    testM("writes line to output") {
-      for {
-        _      <- putStrLn("First line")
-        _      <- putStrLn("Second line")
-        output <- TestConsole.output
-      } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
-    },
-    testM("reads from input") {
-      {
+  def spec =
+    suite("ConsoleSpec")(
+      testM("outputs nothing") {
         for {
-          testConsole <- ZIO.environment[Console].map(_.get)
-          input1      <- testConsole.getStrLn
-          input2      <- testConsole.getStrLn
+          output <- TestConsole.output
+        } yield assert(output)(isEmpty)
+      },
+      testM("writes to output") {
+        for {
+          _      <- putStr("First line")
+          _      <- putStr("Second line")
+          output <- TestConsole.output
+        } yield assert(output)(equalTo(Vector("First line", "Second line")))
+      },
+      testM("writes line to output") {
+        for {
+          _      <- putStrLn("First line")
+          _      <- putStrLn("Second line")
+          output <- TestConsole.output
+        } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
+      },
+      testM("reads from input") {
+        {
+          for {
+            testConsole <- ZIO.environment[Console].map(_.get)
+            input1      <- testConsole.getStrLn
+            input2      <- testConsole.getStrLn
+          } yield {
+            assert(input1)(equalTo("Input 1")) &&
+            assert(input2)(equalTo("Input 2"))
+          }
+        }.provideLayer(TestConsole.live(Data(List("Input 1", "Input 2"), Vector.empty)))
+      },
+      testM("fails on empty input") {
+        for {
+          failed  <- getStrLn.either
+          message = failed.fold(_.getMessage, identity)
+        } yield {
+          assert(failed.isLeft)(isTrue) &&
+          assert(message)(equalTo("There is no more input left to read"))
+        }
+      },
+      testM("feeds lines to input") {
+        for {
+          _      <- feedLines("Input 1", "Input 2")
+          input1 <- getStrLn
+          input2 <- getStrLn
         } yield {
           assert(input1)(equalTo("Input 1")) &&
           assert(input2)(equalTo("Input 2"))
         }
-      }.provideLayer(TestConsole.live(Data(List("Input 1", "Input 2"), Vector.empty)))
-    },
-    testM("fails on empty input") {
-      for {
-        failed  <- getStrLn.either
-        message = failed.fold(_.getMessage, identity)
-      } yield {
-        assert(failed.isLeft)(isTrue) &&
-        assert(message)(equalTo("There is no more input left to read"))
-      }
-    },
-    testM("feeds lines to input") {
-      for {
-        _      <- feedLines("Input 1", "Input 2")
-        input1 <- getStrLn
-        input2 <- getStrLn
-      } yield {
-        assert(input1)(equalTo("Input 1")) &&
-        assert(input2)(equalTo("Input 2"))
-      }
-    },
-    testM("clears lines from input") {
-      for {
-        _       <- feedLines("Input 1", "Input 2")
-        _       <- clearInput
-        failed  <- getStrLn.either
-        message = failed.fold(_.getMessage, identity)
-      } yield {
-        assert(failed.isLeft)(isTrue) &&
-        assert(message)(equalTo("There is no more input left to read"))
-      }
-    },
-    testM("clears lines from output") {
-      for {
-        _      <- putStr("First line")
-        _      <- putStr("Second line")
-        _      <- clearOutput
-        output <- TestConsole.output
-      } yield assert(output)(isEmpty)
-    },
-    testM("output is empty at the start of repeating tests") {
-      for {
-        output <- TestConsole.output
-        _      <- putStrLn("Input")
-      } yield assert(output)(isEmpty)
-    } @@ nonFlaky
-  )
+      },
+      testM("clears lines from input") {
+        for {
+          _       <- feedLines("Input 1", "Input 2")
+          _       <- clearInput
+          failed  <- getStrLn.either
+          message = failed.fold(_.getMessage, identity)
+        } yield {
+          assert(failed.isLeft)(isTrue) &&
+          assert(message)(equalTo("There is no more input left to read"))
+        }
+      },
+      testM("clears lines from output") {
+        for {
+          _      <- putStr("First line")
+          _      <- putStr("Second line")
+          _      <- clearOutput
+          output <- TestConsole.output
+        } yield assert(output)(isEmpty)
+      },
+      testM("output is empty at the start of repeating tests") {
+        for {
+          output <- TestConsole.output
+          _      <- putStrLn("Input")
+        } yield assert(output)(isEmpty)
+      } @@ nonFlaky
+    ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -40,7 +40,7 @@ object ConsoleSpec extends ZIOBaseSpec {
             assert(input1)(equalTo("Input 1")) &&
             assert(input2)(equalTo("Input 2"))
           }
-        }.provideLayer(TestConsole.live(Data(List("Input 1", "Input 2"), Vector.empty)))
+        }.provideLayer(TestConsole.make(Data(List("Input 1", "Input 2"), Vector.empty)))
       },
       testM("fails on empty input") {
         for {

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -25,7 +25,7 @@ object EnvironmentSpec extends ZIOBaseSpec {
         _      <- console.putStrLn("Second line")
         output <- TestConsole.output
       } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
-    },
+    } @@ silent,
     testM("Console reads line from input") {
       for {
         _      <- TestConsole.feedLines("Input 1", "Input 2")

--- a/test/js/src/main/scala/zio/test/PlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/PlatformSpecific.scala
@@ -29,7 +29,7 @@ private[test] trait PlatformSpecific {
     val live: ZLayer[ZEnv, Nothing, TestEnvironment] =
       Annotations.live ++
         (Live.default >>> TestClock.default) ++
-        (Live.default >>> TestConsole.default) ++
+        (Live.default >>> TestConsole.debug) ++
         Live.default ++
         TestRandom.random ++
         Sized.live(100) ++

--- a/test/js/src/main/scala/zio/test/PlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/PlatformSpecific.scala
@@ -29,7 +29,7 @@ private[test] trait PlatformSpecific {
     val live: ZLayer[ZEnv, Nothing, TestEnvironment] =
       Annotations.live ++
         (Live.default >>> TestClock.default) ++
-        TestConsole.default ++
+        (Live.default >>> TestConsole.default) ++
         Live.default ++
         TestRandom.random ++
         Sized.live(100) ++

--- a/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
@@ -31,7 +31,7 @@ private[test] trait PlatformSpecific {
       Annotations.live ++
         Blocking.live ++
         (Live.default >>> TestClock.default) ++
-        (Live.default >>> TestConsole.default) ++
+        (Live.default >>> TestConsole.debug) ++
         Live.default ++
         TestRandom.random ++
         Sized.live(100) ++

--- a/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
@@ -31,7 +31,7 @@ private[test] trait PlatformSpecific {
       Annotations.live ++
         Blocking.live ++
         (Live.default >>> TestClock.default) ++
-        TestConsole.default ++
+        (Live.default >>> TestConsole.default) ++
         Live.default ++
         TestRandom.random ++
         Sized.live(100) ++

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -194,12 +194,15 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
-   * An aspect that sets the `TestConsole` instance in the environment to
-   * debug mode before each test so that console output is rendered to
+   * An aspect that runs each test with the `TestConsole` instance in the
+   * environment set to debug mode so that console output is rendered to
    * standard output in addition to being written to the output buffer.
    */
   val debug: TestAspectAtLeastR[TestConsole] =
-    before(TestConsole.debug)
+    new PerTest.AtLeastR[TestConsole] {
+      def perTest[R <: TestConsole, E](test: ZIO[R, TestFailure[E], TestSuccess]): ZIO[R, TestFailure[E], TestSuccess] =
+        TestConsole.debug(test)
+    }
 
   /**
    * An aspect that applies the specified aspect on Dotty.
@@ -590,12 +593,15 @@ object TestAspect extends TimeoutVariants {
     if (TestVersion.isScala213) identity else ignore
 
   /**
-   * An aspect that sets the `TestConsole` instance in the environment to
-   * silent mode before each test so that console output is only written to
+   * An aspect that runs each test with the `TestConsole` instance in the
+   * environment set to silent mode so that console output is only written to
    * the output buffer and not rendered to standard output.
    */
   val silent: TestAspectAtLeastR[TestConsole] =
-    before(TestConsole.silent)
+    new PerTest.AtLeastR[TestConsole] {
+      def perTest[R <: TestConsole, E](test: ZIO[R, TestFailure[E], TestSuccess]): ZIO[R, TestFailure[E], TestSuccess] =
+        TestConsole.silent(test)
+    }
 
   /**
    * An aspect that converts ignored tests into test failures.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -194,6 +194,14 @@ object TestAspect extends TimeoutVariants {
     }
 
   /**
+   * An aspect that sets the `TestConsole` instance in the environment to
+   * debug mode before each test so that console output is rendered to
+   * standard output in addition to being written to the output buffer.
+   */
+  val debug: TestAspectAtLeastR[TestConsole] =
+    before(TestConsole.debug)
+
+  /**
    * An aspect that applies the specified aspect on Dotty.
    */
   def dotty[LowerR, UpperR, LowerE, UpperE](
@@ -387,6 +395,14 @@ object TestAspect extends TimeoutVariants {
     if (TestPlatform.isJVM) identity else ignore
 
   /**
+   * An aspect that causes calls to `sleep` and methods implemented in terms
+   * of it to be executed immediately instead of requiring the `TestClock` to
+   * be adjusted.
+   */
+  val noDelay: TestAspectAtLeastR[TestClock] =
+    before(TestClock.runAll)
+
+  /**
    * An aspect that repeats the test a default number of times, ensuring it is
    * stable ("non-flaky"). Stops at the first failure.
    */
@@ -572,6 +588,14 @@ object TestAspect extends TimeoutVariants {
    */
   val scala213Only: TestAspectAtLeastR[Annotations] =
     if (TestVersion.isScala213) identity else ignore
+
+  /**
+   * An aspect that sets the `TestConsole` instance in the environment to
+   * silent mode before each test so that console output is only written to
+   * the output buffer and not rendered to standard output.
+   */
+  val silent: TestAspectAtLeastR[TestConsole] =
+    before(TestConsole.silent)
 
   /**
    * An aspect that converts ignored tests into test failures.

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -613,7 +613,7 @@ package object environment extends PlatformSpecific {
        * being written to the output buffer.
        */
       def debug[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
-        debugState.locally(false)(zio)
+        debugState.locally(true)(zio)
 
       /**
        * Writes the specified sequence of strings to the input buffer. The

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -546,19 +546,23 @@ package object environment extends PlatformSpecific {
   /**
    * `TestConsole` provides a testable interface for programs interacting with
    * the console by modeling input and output as reading from and writing to
-   * input and output buffers maintained by `TestConsole` and backed by a `Ref`.
+   * input and output buffers maintained by `TestConsole` and backed by a
+   * `Ref`.
    *
-   * All calls to `putStr` and `putStrLn` using the `TestConsole` will write the
-   * string to the output buffer and all calls to `getStrLn` will take a string
-   * from the input buffer. No actual printing or reading from the console will
-   * occur. `TestConsole` has several methods to access and manipulate the
-   * content of these buffers including `feedLines` to feed strings to the input
-   * buffer that will then be returned by calls to `getStrLn`, `output` to get
-   * the content of the output buffer from calls to `putStr` and `putStrLn`, and
+   * All calls to `putStr` and `putStrLn` using the `TestConsole` will write
+   * the string to the output buffer and all calls to `getStrLn` will take a
+   * string from the input buffer. To facilitate debugging, by default output
+   * will also be rendered to standard output. You can enable or disable this
+   * for a scope using `debug`, `silent`, or the corresponding test aspects.
+   *
+   * `TestConsole` has several methods to access and manipulate the content of
+   * these buffers including `feedLines` to feed strings to the input  buffer
+   * that will then be returned by calls to `getStrLn`, `output` to get the
+   * content of the output buffer from calls to `putStr` and `putStrLn`, and
    * `clearInput` and `clearOutput` to clear the respective buffers.
    *
-   * Together, these functions make it easy to test programs interacting with the
-   * console.
+   * Together, these functions make it easy to test programs interacting with
+   * the console.
    *
    * {{{
    * import zio.console._


### PR DESCRIPTION
One of the pain points of working with ZIO Test is that console output created using `console.putStrLn` is not displayed to the console so for debugging purposes users have to resort to `UIO(println(line))` which is not normally best practice and not what they would be using in their code. This PR changes the TestConsole to by default display console output to standard output in addition to writing it to the buffer. For most applications that are not console applications this should be strictly an improvement. For cases where the console output clutters the display test aspects `debug` and `silent` can be used to turn this on and off. Also adds test aspect `noDelay` for setting the TestClock so all effects run without delay.