### PR TITLE
ZIO Core: Add Platform Flags

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -99,6 +99,21 @@ private[internal] trait PlatformSpecific {
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ec))
 
   /**
+   * Returns whether the current platform is ScalaJS.
+   */
+  val isJS = true
+
+  /**
+   * Returns whether the currently platform is the JVM.
+   */
+  val isJVM = false
+
+  /**
+   * Returns whether the currently platform is Scala Native.
+   */
+  val isNative = false
+
+  /**
    * Makes a new default platform. This is a side-effecting method.
    */
   final def makeDefault(yieldOpCount: Int = defaultYieldOpCount): Platform =

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -106,6 +106,21 @@ private[internal] trait PlatformSpecific {
     fromExecutor(Executor.fromExecutionContext(defaultYieldOpCount)(ec))
 
   /**
+   * Returns whether the current platform is ScalaJS.
+   */
+  val isJS = false
+
+  /**
+   * Returns whether the currently platform is the JVM.
+   */
+  val isJVM = true
+
+  /**
+   * Returns whether the currently platform is Scala Native.
+   */
+  val isNative = false
+
+  /**
    * Makes a new default platform. This is a side-effecting method.
    */
   def makeDefault(yieldOpCount: Int = defaultYieldOpCount): Platform =

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -57,9 +57,9 @@ private[internal] trait PlatformSpecific {
   final val defaultYieldOpCount = 2048
 
   /**
-    * Returns the name of the thread group to which this thread belongs. This
-    * is a side-effecting method.
-    */
+   * Returns the name of the thread group to which this thread belongs. This
+   * is a side-effecting method.
+   */
   val getCurrentThreadGroup: String = ""
 
   /**
@@ -93,6 +93,21 @@ private[internal] trait PlatformSpecific {
    */
   final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ec))
+
+  /**
+   * Returns whether the current platform is ScalaJS.
+   */
+  val isJS = false
+
+  /**
+   * Returns whether the currently platform is the JVM.
+   */
+  val isJVM = false
+
+  /**
+   * Returns whether the currently platform is Scala Native.
+   */
+  val isNative = true
 
   /**
    * Makes a new default platform. This is a side-effecting method.


### PR DESCRIPTION
It can be useful to know at runtime what platform we are on, for example so we can implement details of the fiber supervision model to reflect the platform. This PR adds flags identifying the platform available internally to ZIO similar to the ones already exposed in ZIO Test. 