### PR TITLE
ZIO Core: Add Convenience Methods for Fiber Dumps

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -594,13 +594,15 @@ object Fiber extends FiberPlatformSpecific {
    * TODO: Switch to "streaming lazy" version.
    */
   val dumpAll: UIO[Iterable[Dump]] =
-    dump((_rootFibers.asScala: @silent("JavaConverters")).toList: _*)
+    UIO.effectSuspendTotal {
+      dump((_rootFibers.asScala: @silent("JavaConverters")).toList: _*)
+    }
 
   /**
    * Collects a complete dump of the specified fibers and all children of the
    * fibers.
    */
-  def dump(fibers: Fiber.Runtime[_, _]*): UIO[Iterable[Dump]] = UIO.effectSuspendTotal {
+  def dump(fibers: Fiber.Runtime[_, _]*): UIO[Iterable[Dump]] = {
     import internal.FiberContext
 
     def loop(fibers: Iterable[Fiber.Runtime[_, _]], acc: UIO[Vector[Dump]]): UIO[Vector[Dump]] =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -179,12 +179,7 @@ object TestAspect extends TimeoutVariants {
             )
           }
         def dump[E, A](label: String, fiber: Fiber.Runtime[E, A]): ZIO[Live, Nothing, Unit] =
-          for {
-            dumps    <- Fiber.dump(Set(fiber))
-            dumpStrs <- ZIO.foreach(dumps)(_.prettyPrintM)
-            dumpStr  = s"$label: ${dumpStrs.mkString("\n")}"
-            _        <- Live.live(console.putStrLn(dumpStr))
-          } yield ()
+          Live.live(Fiber.putDumpStr(label, fiber))
         spec.transform[R, TestFailure[E], TestSuccess] {
           case c @ Spec.SuiteCase(_, _, _) => c
           case Spec.TestCase(label, test, annotations) =>


### PR DESCRIPTION
Typically when we do a fiber dump we want to see a fiber and its children and there can be a little work right now in collecting all those and rendering them. Adds convenience methods `dumpStr` to collect a fiber dump for specified fibers and render it to a string and `putDumpStr` to collect the fiber dump and render it to standard output.