### PR TITLE
Fix lazy constructors on streams

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1008,19 +1008,21 @@ object StreamSpec extends ZIOBaseSpec {
       import java.io.ByteArrayInputStream
       val chunkSize = ZStreamChunk.DefaultChunkSize
       val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
-      val is        = new ByteArrayInputStream(data)
+      def is        = new ByteArrayInputStream(data)
       ZStream.fromInputStream(is, chunkSize).run(Sink.collectAll[Chunk[Byte]]) map { chunks =>
         assert(chunks.flatMap(_.toArray[Byte]).toArray)(equalTo(data))
       }
     },
     testM("Stream.fromIterable")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
-      assertM(Stream.fromIterable(l).runCollect)(equalTo(l))
+      def lazyL = l
+      assertM(Stream.fromIterable(lazyL).runCollect)(equalTo(l))
     }),
     testM("Stream.fromIterableM")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
       assertM(Stream.fromIterableM(UIO.effectTotal(l)).runCollect)(equalTo(l))
     }),
     testM("Stream.fromIterator")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
-      assertM(Stream.fromIterator(UIO.effectTotal(l.iterator)).runCollect)(equalTo(l))
+      def lazyIt = l.iterator
+      assertM(Stream.fromIterator(UIO.effectTotal(lazyIt)).runCollect)(equalTo(l))
     }),
     testM("Stream.fromQueue")(checkM(smallChunks(Gen.anyInt)) { c =>
       for {

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -392,6 +392,8 @@ private[stream] object StreamEffect extends Serializable {
   def fromIterator[A](iterator: => Iterator[A]): StreamEffect[Any, Nothing, A] =
     StreamEffect {
       Managed.effectTotal(() => if (iterator.hasNext) iterator.next() else end)
+      val it = iterator
+      Managed.effectTotal(() => if (it.hasNext) it.next() else end)
     }
 
   def fromJavaIterator[A](iterator: ju.Iterator[A]): StreamEffect[Any, Nothing, A] = {
@@ -411,12 +413,13 @@ private[stream] object StreamEffect extends Serializable {
     StreamEffectChunk {
       StreamEffect {
         Managed.effectTotal {
-          var done = false
+          var done       = false
+          val capturedIs = is
 
           def pull(): Chunk[Byte] = {
             val buf = Array.ofDim[Byte](chunkSize)
             try {
-              val bytesRead = is.read(buf)
+              val bytesRead = capturedIs.read(buf)
               if (bytesRead < 0) {
                 done = true
                 end


### PR DESCRIPTION
being `ZStream.fromInputStream` lazy, it causes infinite loop (and heap exhaustion) when invoked with an inputstream coming from a `def`.
The same happens for `fromIterator`. Fixed by capturing their value in the inner expression. Also made tests passing `def` values rather than `val`