### PR TITLE
Fix small errors in `ZIO.sandbox` scaladocs

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1559,23 +1559,22 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Exposes the full cause of failure of this effect.
    *
    * {{{
-   * case class DomainError()
+   * final case class DomainError()
    *
    * val veryBadIO: IO[DomainError, Unit] =
    *   IO.effectTotal(5 / 0) *> IO.fail(DomainError())
    *
-   * val caught: UIO[Unit] =
-   *   veryBadIO.sandbox.catchAll {
+   * val caught: IO[DomainError, Unit] =
+   *   veryBadIO.sandbox.mapError(_.untraced).catchAll {
    *     case Cause.Die(_: ArithmeticException) =>
    *       // Caught defect: divided by zero!
-   *       IO.succeed(0)
-   *     case Cause.Fail(e) =>
+   *       IO.unit
+   *     case Cause.Fail(_) =>
    *       // Caught error: DomainError!
-   *       IO.succeed(0)
+   *       IO.unit
    *     case cause =>
    *       // Caught unknown defects, shouldn't recover!
    *       IO.halt(cause)
-   *    *
    *   }
    * }}}
    */


### PR DESCRIPTION
The old version of the scaladoc for `ZIO.sandbox` did not compile and if updated to compile, it didn't work because it matched on `Cause.Die` directly, but the cause is wrapped within a `Traced`. The following changes were made:

* Let `caught` return an `IO[DomainError, Unit]` instead of `UIO[Unit]`
* Map the error with `_.untraced` to remove the outer layer and make the pattern matching work.
* Change the `IO.succeed(0)` to `IO.unit`, because some folks will get an `discarded non-Unit value` warning otherwise.