### PR TITLE
Add a note to disambiguate the `foreach` method's name

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2484,6 +2484,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * returns the results in a new `List[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
+   *
+   * NOTICE: this has a different meaning than the `foreach` method one would find elsewhere
+   * in Scala's standard library. On standard collections, `foreach` applies a side-effecting
+   * function on the elements of the collection and returns `Unit`. Here, the `foreach` method
+   * applies the `f` function to every elements of `in` and aggregates the results in a single
+   * `ZIO` context. In other libraries, this behaviour is most often called `traverse`.
    */
   def foreach[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
     in.foldRight[ZIO[R, E, List[B]]](effectTotal(Nil))((a, io) => f(a).zipWith(io)((b, bs) => b :: bs))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2489,7 +2489,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * in Scala's standard library. On standard collections, `foreach` applies a side-effecting
    * function on the elements of the collection and returns `Unit`. Here, the `foreach` method
    * applies the `f` function to every elements of `in` and aggregates the results in a single
-   * `ZIO` context. In other libraries, this behaviour is most often called `traverse`.
+   * `ZIO` context. 
+   * ADVANCED: In other typeclass-based FP libraries, this behaviour is most often called `traverse`.
    */
   def foreach[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
     in.foldRight[ZIO[R, E, List[B]]](effectTotal(Nil))((a, io) => f(a).zipWith(io)((b, bs) => b :: bs))


### PR DESCRIPTION
Since the name `foreach` is already widely used in Scala's standard library with a slightly different meaning, I thought it would be valuable (especially for the people whose first contact with Scala will be the ZIO library) to add a comment stressing out that fact.