### PR TITLE
Services refactor

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -215,7 +215,7 @@ object SerializableSpec extends ZIOBaseSpec {
     },
     testM("TracingStatus.Untraced is serializable") {
       Live.live(for {
-        system <- ZIO.accessM[System](has => serializeAndBack(has.get[System.Service]))
+        system <- ZIO.accessM[System](has => serializeAndBack(has.get[system.Service]))
         result <- system.property("notpresent")
       } yield assert(result)(equalTo(Option.empty[String])))
     }

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -19,8 +19,8 @@ package zio
 /**
  * The trait `Has[A]` is used with ZIO environment to express an effect's
  * dependency on a service of type `A`. For example,
- * `RIO[Has[Console.Service], Unit]` is an effect that requires a
- * `Console.Service` service. Inside the ZIO library, type aliases are provided
+ * `RIO[Has[console.Service], Unit]` is an effect that requires a
+ * `console.Service` service. Inside the ZIO library, type aliases are provided
  * as shorthands for common services, e.g.:
  *
  * {{{

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -278,7 +278,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
   final def delayedM[R1 <: R](
     f: Duration => ZIO[R1, Nothing, Duration]
   )(implicit ev1: Has.IsHas[R1], ev2: R1 <:< Clock): Schedule[R1, A, B] = {
-    def proxy(clock0: Clock.Service, r1: R1): Clock.Service = new Clock.Service {
+    def proxy(clock0: clock.Service, r1: R1): clock.Service = new clock.Service {
       def currentTime(unit: TimeUnit) = clock0.currentTime(unit)
       def currentDateTime             = clock0.currentDateTime
       val nanoTime                    = clock0.nanoTime
@@ -289,7 +289,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
       val initial =
         for {
           oldEnv <- ZIO.environment[R1]
-          env    = ev1.update[R1, Clock.Service](oldEnv, proxy(_, oldEnv))
+          env    = ev1.update[R1, clock.Service](oldEnv, proxy(_, oldEnv))
           init   <- self.initial.provide(env)
         } yield (init, env)
       val extract = (a: A, s: State) => self.extract(a, s._1)
@@ -427,7 +427,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
   final def modifyDelay[R1 <: R](
     f: (B, Duration) => ZIO[R1, Nothing, Duration]
   )(implicit ev1: Has.IsHas[R1], ev2: R1 <:< Clock): Schedule[R1, A, B] = {
-    def proxy(clock0: Clock.Service, env: R1, current: B): Clock.Service = new Clock.Service {
+    def proxy(clock0: clock.Service, env: R1, current: B): clock.Service = new clock.Service {
       def currentTime(unit: TimeUnit) = clock0.currentTime(unit)
       def currentDateTime             = clock0.currentDateTime
       val nanoTime                    = clock0.nanoTime
@@ -438,7 +438,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
       val initial = self.initial
       val extract = (a: A, s: self.State) => self.extract(a, s)
       val update = (a: A, s: self.State) =>
-        self.update(a, s).provideSome[R1](env => ev1.update[R1, Clock.Service](env, proxy(_, env, self.extract(a, s))))
+        self.update(a, s).provideSome[R1](env => ev1.update[R1, clock.Service](env, proxy(_, env, self.extract(a, s))))
     }
   }
 

--- a/core/shared/src/main/scala/zio/clock/Clock.scala
+++ b/core/shared/src/main/scala/zio/clock/Clock.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.clock
+
+import java.time.{ Instant, OffsetDateTime, ZoneId }
+import java.util.concurrent.TimeUnit
+
+import zio._
+import zio.duration._
+
+object Clock extends PlatformSpecific with Serializable {
+
+  val any: ZLayer[Clock, Nothing, Clock] =
+    ZLayer.requires[Clock]
+
+  val live: ZLayer.NoDeps[Nothing, Clock] = ZLayer.succeed {
+    new Service {
+      def currentTime(unit: TimeUnit): UIO[Long] =
+        IO.effectTotal(System.currentTimeMillis).map(l => unit.convert(l, TimeUnit.MILLISECONDS))
+
+      val nanoTime: UIO[Long] = IO.effectTotal(System.nanoTime)
+
+      def sleep(duration: Duration): UIO[Unit] =
+        UIO.effectAsyncInterrupt { cb =>
+          val canceler = globalScheduler.schedule(() => cb(UIO.unit), duration)
+          Left(UIO.effectTotal(canceler()))
+        }
+
+      def currentDateTime: ZIO[Any, Nothing, OffsetDateTime] =
+        for {
+          millis <- currentTime(TimeUnit.MILLISECONDS)
+          zone   <- ZIO.effectTotal(ZoneId.systemDefault)
+        } yield OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), zone)
+    }
+  }
+}

--- a/core/shared/src/main/scala/zio/clock/Service.scala
+++ b/core/shared/src/main/scala/zio/clock/Service.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.clock
+
+import java.time.OffsetDateTime
+import java.util.concurrent.TimeUnit
+
+import zio._
+import zio.duration._
+
+trait Service {
+  def currentTime(unit: TimeUnit): UIO[Long]
+  def currentDateTime: UIO[OffsetDateTime]
+  def nanoTime: UIO[Long]
+  def sleep(duration: Duration): UIO[Unit]
+}

--- a/core/shared/src/main/scala/zio/console/Console.scala
+++ b/core/shared/src/main/scala/zio/console/Console.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.console
+
+import java.io.{ EOFException, IOException, PrintStream, Reader }
+
+import scala.io.StdIn
+import scala.{ Console => SConsole }
+
+import zio._
+
+object Console extends Serializable {
+
+  val any: ZLayer[Console, Nothing, Console] =
+    ZLayer.requires[Console]
+
+  val live: ZLayer.NoDeps[Nothing, Console] = ZLayer.succeed {
+    new Service {
+
+      /**
+       * Prints text to the console.
+       */
+      final def putStr(line: String): UIO[Unit] =
+        putStr(SConsole.out)(line)
+
+      final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream) {
+          SConsole.print(line)
+        })
+
+      /**
+       * Prints a line of text to the console, including a newline character.
+       */
+      final def putStrLn(line: String): UIO[Unit] =
+        putStrLn(SConsole.out)(line)
+
+      final def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream) {
+          SConsole.println(line)
+        })
+
+      /**
+       * Retrieves a line of input from the console.
+       */
+      final val getStrLn: ZIO[Any, IOException, String] =
+        getStrLn(SConsole.in)
+
+      /**
+       * Retrieves a line of input from the console.
+       * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
+       * returns null.
+       */
+      final def getStrLn(reader: Reader): IO[IOException, String] =
+        IO.effect(SConsole.withIn(reader) {
+            val line = StdIn.readLine()
+            if (line == null) {
+              throw new EOFException("There is no more input left to read")
+            } else line
+          })
+          .refineToOrDie[IOException]
+    }
+  }
+}

--- a/core/shared/src/main/scala/zio/console/Service.scala
+++ b/core/shared/src/main/scala/zio/console/Service.scala
@@ -14,28 +14,14 @@
  * limitations under the License.
  */
 
-package zio
+package zio.console
 
 import java.io.IOException
 
-package object console {
-  type Console = Has[Service]
+import zio._
 
-  /**
-   * Prints text to the console.
-   */
-  def putStr(line: => String): ZIO[Console, Nothing, Unit] =
-    ZIO.accessM(_.get putStr line)
-
-  /**
-   * Prints a line of text to the console, including a newline character.
-   */
-  def putStrLn(line: => String): ZIO[Console, Nothing, Unit] =
-    ZIO.accessM(_.get putStrLn line)
-
-  /**
-   * Retrieves a line of input from the console.
-   */
-  val getStrLn: ZIO[Console, IOException, String] =
-    ZIO.accessM(_.get.getStrLn)
+trait Service extends Serializable {
+  def putStr(line: String): UIO[Unit]
+  def putStrLn(line: String): UIO[Unit]
+  def getStrLn: IO[IOException, String]
 }

--- a/core/shared/src/main/scala/zio/random/Random.scala
+++ b/core/shared/src/main/scala/zio/random/Random.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.random
+
+import zio._
+
+object Random extends Serializable {
+
+  val any: ZLayer[Random, Nothing, Random] =
+    ZLayer.requires[Random]
+
+  val live: ZLayer.NoDeps[Nothing, Random] = ZLayer.succeed {
+    new Service {
+      import scala.util.{ Random => SRandom }
+
+      val nextBoolean: UIO[Boolean] = ZIO.effectTotal(SRandom.nextBoolean())
+      def nextBytes(length: Int): UIO[Chunk[Byte]] =
+        ZIO.effectTotal {
+          val array = Array.ofDim[Byte](length)
+
+          SRandom.nextBytes(array)
+
+          Chunk.fromArray(array)
+        }
+      val nextDouble: UIO[Double]                 = ZIO.effectTotal(SRandom.nextDouble())
+      val nextFloat: UIO[Float]                   = ZIO.effectTotal(SRandom.nextFloat())
+      val nextGaussian: UIO[Double]               = ZIO.effectTotal(SRandom.nextGaussian())
+      def nextInt(n: Int): UIO[Int]               = ZIO.effectTotal(SRandom.nextInt(n))
+      val nextInt: UIO[Int]                       = ZIO.effectTotal(SRandom.nextInt())
+      val nextLong: UIO[Long]                     = ZIO.effectTotal(SRandom.nextLong())
+      def nextLong(n: Long): UIO[Long]            = Random.nextLongWith(nextLong, n)
+      val nextPrintableChar: UIO[Char]            = ZIO.effectTotal(SRandom.nextPrintableChar())
+      def nextString(length: Int): UIO[String]    = ZIO.effectTotal(SRandom.nextString(length))
+      def shuffle[A](list: List[A]): UIO[List[A]] = Random.shuffleWith(nextInt(_), list)
+    }
+  }
+
+  protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =
+    for {
+      bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
+      _         <- bufferRef.update(_ ++= list)
+      swap = (i1: Int, i2: Int) =>
+        bufferRef.update {
+          case buffer =>
+            val tmp = buffer(i1)
+            buffer(i1) = buffer(i2)
+            buffer(i2) = tmp
+            buffer
+        }
+      _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextInt(n).flatMap(k => swap(n - 1, k)))
+      buffer <- bufferRef.get
+    } yield buffer.toList
+
+  protected[zio] def nextLongWith(nextLong: UIO[Long], n: Long): UIO[Long] =
+    if (n <= 0)
+      UIO.dieNow(new IllegalArgumentException("n must be positive"))
+    else {
+      nextLong.flatMap { r =>
+        val m = n - 1
+        if ((n & m) == 0L)
+          UIO.succeedNow(r & m)
+        else {
+          def loop(u: Long): UIO[Long] =
+            if (u + m - u % m < 0L) nextLong.flatMap(r => loop(r >>> 1))
+            else UIO.succeedNow(u % n)
+          loop(r >>> 1)
+        }
+      }
+    }
+}

--- a/core/shared/src/main/scala/zio/random/Service.scala
+++ b/core/shared/src/main/scala/zio/random/Service.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.random
+
+import zio._
+
+trait Service extends Serializable {
+  def nextBoolean: UIO[Boolean]
+  def nextBytes(length: Int): UIO[Chunk[Byte]]
+  def nextDouble: UIO[Double]
+  def nextFloat: UIO[Float]
+  def nextGaussian: UIO[Double]
+  def nextInt(n: Int): UIO[Int]
+  def nextInt: UIO[Int]
+  def nextLong: UIO[Long]
+  def nextLong(n: Long): UIO[Long]
+  def nextPrintableChar: UIO[Char]
+  def nextString(length: Int): UIO[String]
+  def shuffle[A](list: List[A]): UIO[List[A]]
+}

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -1,87 +1,23 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio
 
 package object random {
-  type Random = Has[Random.Service]
-
-  object Random extends Serializable {
-    trait Service extends Serializable {
-
-      def nextBoolean: UIO[Boolean]
-      def nextBytes(length: Int): UIO[Chunk[Byte]]
-      def nextDouble: UIO[Double]
-      def nextFloat: UIO[Float]
-      def nextGaussian: UIO[Double]
-      def nextInt(n: Int): UIO[Int]
-      def nextInt: UIO[Int]
-      def nextLong: UIO[Long]
-      def nextLong(n: Long): UIO[Long]
-      def nextPrintableChar: UIO[Char]
-      def nextString(length: Int): UIO[String]
-      def shuffle[A](list: List[A]): UIO[List[A]]
-    }
-
-    val any: ZLayer[Random, Nothing, Random] =
-      ZLayer.requires[Random]
-
-    val live: ZLayer.NoDeps[Nothing, Random] = ZLayer.succeed {
-      new Service {
-        import scala.util.{ Random => SRandom }
-
-        val nextBoolean: UIO[Boolean] = ZIO.effectTotal(SRandom.nextBoolean())
-        def nextBytes(length: Int): UIO[Chunk[Byte]] =
-          ZIO.effectTotal {
-            val array = Array.ofDim[Byte](length)
-
-            SRandom.nextBytes(array)
-
-            Chunk.fromArray(array)
-          }
-        val nextDouble: UIO[Double]                 = ZIO.effectTotal(SRandom.nextDouble())
-        val nextFloat: UIO[Float]                   = ZIO.effectTotal(SRandom.nextFloat())
-        val nextGaussian: UIO[Double]               = ZIO.effectTotal(SRandom.nextGaussian())
-        def nextInt(n: Int): UIO[Int]               = ZIO.effectTotal(SRandom.nextInt(n))
-        val nextInt: UIO[Int]                       = ZIO.effectTotal(SRandom.nextInt())
-        val nextLong: UIO[Long]                     = ZIO.effectTotal(SRandom.nextLong())
-        def nextLong(n: Long): UIO[Long]            = Random.nextLongWith(nextLong, n)
-        val nextPrintableChar: UIO[Char]            = ZIO.effectTotal(SRandom.nextPrintableChar())
-        def nextString(length: Int): UIO[String]    = ZIO.effectTotal(SRandom.nextString(length))
-        def shuffle[A](list: List[A]): UIO[List[A]] = Random.shuffleWith(nextInt(_), list)
-      }
-    }
-
-    protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =
-      for {
-        bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
-        _         <- bufferRef.update(_ ++= list)
-        swap = (i1: Int, i2: Int) =>
-          bufferRef.update {
-            case buffer =>
-              val tmp = buffer(i1)
-              buffer(i1) = buffer(i2)
-              buffer(i2) = tmp
-              buffer
-          }
-        _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextInt(n).flatMap(k => swap(n - 1, k)))
-        buffer <- bufferRef.get
-      } yield buffer.toList
-
-    protected[zio] def nextLongWith(nextLong: UIO[Long], n: Long): UIO[Long] =
-      if (n <= 0)
-        UIO.dieNow(new IllegalArgumentException("n must be positive"))
-      else {
-        nextLong.flatMap { r =>
-          val m = n - 1
-          if ((n & m) == 0L)
-            UIO.succeedNow(r & m)
-          else {
-            def loop(u: Long): UIO[Long] =
-              if (u + m - u % m < 0L) nextLong.flatMap(r => loop(r >>> 1))
-              else UIO.succeedNow(u % n)
-            loop(r >>> 1)
-          }
-        }
-      }
-  }
+  type Random = Has[Service]
 
   val nextBoolean: ZIO[Random, Nothing, Boolean]                   = ZIO.accessM(_.get.nextBoolean)
   def nextBytes(length: => Int): ZIO[Random, Nothing, Chunk[Byte]] = ZIO.accessM(_.get.nextBytes(length))
@@ -95,5 +31,4 @@ package object random {
   val nextPrintableChar: ZIO[Random, Nothing, Char]                = ZIO.accessM(_.get.nextPrintableChar)
   def nextString(length: => Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.get.nextString(length))
   def shuffle[A](list: => List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.get.shuffle(list))
-
 }

--- a/core/shared/src/main/scala/zio/system/Service.scala
+++ b/core/shared/src/main/scala/zio/system/Service.scala
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-package zio
+package zio.system
 
-package object system {
-  type System = Has[Service]
+import zio._
 
-  /** Retrieve the value of an environment variable **/
-  def env(variable: => String): ZIO[System, SecurityException, Option[String]] =
-    ZIO.accessM(_.get env variable)
-
-  /** Retrieve the value of a system property **/
-  def property(prop: => String): ZIO[System, Throwable, Option[String]] =
-    ZIO.accessM(_.get property prop)
-
-  /** System-specific line separator **/
-  val lineSeparator: ZIO[System, Nothing, String] =
-    ZIO.accessM(_.get.lineSeparator)
+trait Service extends Serializable {
+  def env(variable: String): IO[SecurityException, Option[String]]
+  def property(prop: String): IO[Throwable, Option[String]]
+  def lineSeparator: UIO[String]
 }

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -191,7 +191,7 @@ Next we create the live version of the service with the implementation of the ca
 import zio.console.Console
 
 val accountObserverLive: ZLayer[Console, Nothing, Has[AccountObserver.Service]] =
-  ZLayer.fromService { (console: Console.Service) =>
+  ZLayer.fromService { (console: console.Service) =>
     new AccountObserver.Service {
       def processEvent(event: AccountEvent): UIO[Unit] =
         for {

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -179,13 +179,13 @@ object RandomSpec extends ZIOBaseSpec {
     }
 
   def forAllBounded[A: Numeric](gen: Gen[Random, A])(
-    next: (Random.Service, A) => UIO[A]
+    next: (random.Service, A) => UIO[A]
   ): ZIO[Random, Nothing, TestResult] = {
     val num = implicitly[Numeric[A]]
     import num._
     checkM(gen.map(num.abs(_))) { upper =>
       for {
-        testRandom <- ZIO.environment[Random].map(_.get[Random.Service])
+        testRandom <- ZIO.environment[Random].map(_.get[random.Service])
         nextRandom <- next(testRandom, upper)
       } yield assert(nextRandom)(isWithin(zero, upper))
     }

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -64,7 +64,7 @@ object SystemSpec extends ZIOBaseSpec {
       } yield assert(prop)(isNone)
     },
     testM("fetch the system's line separator and check that it is identical to Data.lineSeparator") {
-      TestSystem.live(Data(lineSeparator = ",")).build.map(_.get[zio.system.System.Service]).use { testSystem =>
+      TestSystem.live(Data(lineSeparator = ",")).build.map(_.get[zio.system.Service]).use { testSystem =>
         assertM(testSystem.lineSeparator)(equalTo(","))
       }
     },

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
 
+import zio.random
 import zio.random._
 import zio.stream.{ Stream, ZStream }
 import zio.{ UIO, ZIO }
@@ -381,14 +382,14 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * Constructs a generator from a function that uses randomness. The returned
    * generator will not have any shrinking.
    */
-  final def fromRandom[A](f: Random.Service => UIO[A]): Gen[Random, A] =
+  final def fromRandom[A](f: random.Service => UIO[A]): Gen[Random, A] =
     Gen(ZStream.fromEffect(ZIO.accessM[Random](r => f(r.get)).map(Sample.noShrink)))
 
   /**
    * Constructs a generator from a function that uses randomness to produce a
    * sample.
    */
-  final def fromRandomSample[R <: Random, A](f: Random.Service => UIO[Sample[R, A]]): Gen[R, A] =
+  final def fromRandomSample[R <: Random, A](f: random.Service => UIO[Sample[R, A]]): Gen[R, A] =
     Gen(ZStream.fromEffect(ZIO.accessM[Random](r => f(r.get))))
 
   /**

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -21,10 +21,9 @@ import java.util.UUID
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
 
-import zio.random
 import zio.random._
 import zio.stream.{ Stream, ZStream }
-import zio.{ UIO, ZIO }
+import zio.{ random, UIO, ZIO }
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -26,10 +26,9 @@ import scala.math.{ log, sqrt }
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
-import zio.{ random => zrandom }
 import zio.random.Random
 import zio.system.System
-import zio.{ PlatformSpecific => _, _ }
+import zio.{ PlatformSpecific => _, random => zrandom, _ }
 
 /**
  * The `environment` package contains testable versions of all the standard ZIO
@@ -1467,7 +1466,7 @@ package object environment extends PlatformSpecific {
       def clearProperty(prop: String): UIO[Unit]
     }
 
-    final case class Test(systemState: Ref[TestSystem.Data]) extends System.Service with TestSystem.Service {
+    final case class Test(systemState: Ref[TestSystem.Data]) extends system.Service with TestSystem.Service {
 
       /**
        * Returns the specified environment variable if it exists.
@@ -1544,7 +1543,7 @@ package object environment extends PlatformSpecific {
      */
     def live(data: Data): ZLayer.NoDeps[Nothing, System with TestSystem] =
       ZLayer.fromEffectMany(
-        Ref.make(data).map(ref => Has.allOf[System.Service, TestSystem.Service](Test(ref), Test(ref)))
+        Ref.make(data).map(ref => Has.allOf[system.Service, TestSystem.Service](Test(ref), Test(ref)))
       )
 
     val any: ZLayer[System with TestSystem, Nothing, System with TestSystem] =

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -261,7 +261,7 @@ package object environment extends PlatformSpecific {
       fiberState: FiberRef[TestClock.FiberData],
       live: Live.Service,
       warningState: RefM[TestClock.WarningData]
-    ) extends Clock.Service
+    ) extends clock.Service
         with TestClock.Service {
 
       /**
@@ -440,7 +440,7 @@ package object environment extends PlatformSpecific {
           fiberRef <- FiberRef.make(FiberData(Duration.Zero, ZoneId.of("UTC")), FiberData.combine).toManaged_
           refM     <- RefM.make(WarningData.start).toManaged_
           test     <- Managed.make(UIO(Test(ref, fiberRef, live, refM)))(_.warningDone)
-        } yield Has.allOf[Clock.Service, TestClock.Service](test, test)
+        } yield Has.allOf[clock.Service, TestClock.Service](test, test)
       }
 
     val any: ZLayer[Clock with TestClock, Nothing, Clock with TestClock] =
@@ -1387,13 +1387,13 @@ package object environment extends PlatformSpecific {
       make(DefaultData)
 
     val random: ZLayer[Clock, Nothing, Random with TestRandom] =
-      (ZLayer.service[Clock.Service] ++ deterministic) >>>
+      (ZLayer.service[clock.Service] ++ deterministic) >>>
         (ZLayer.fromFunctionManyM { (env: Clock with Random with TestRandom) =>
           val random     = env.get[Random.Service]
           val testRandom = env.get[TestRandom.Service]
 
           for {
-            time <- env.get[Clock.Service].nanoTime
+            time <- env.get[clock.Service].nanoTime
             _    <- env.get[TestRandom.Service].setSeed(time)
           } yield Has.allOf[Random.Service, TestRandom.Service](random, testRandom)
         })

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -596,7 +596,7 @@ package object environment extends PlatformSpecific {
       consoleState: Ref[TestConsole.Data],
       live: Live.Service,
       debugState: FiberRef[Boolean]
-    ) extends Console.Service
+    ) extends console.Service
         with TestConsole.Service {
 
       /**
@@ -695,7 +695,7 @@ package object environment extends PlatformSpecific {
           ref      <- Ref.make(data)
           debugRef <- FiberRef.make(debug)
           test     = Test(ref, live, debugRef)
-        } yield Has.allOf[Console.Service, TestConsole.Service](test, test)
+        } yield Has.allOf[console.Service, TestConsole.Service](test, test)
       }
 
     val any: ZLayer[Console with TestConsole, Nothing, Console with TestConsole] =

--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -19,19 +19,19 @@ package zio.test.mock
 import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
 
-import zio.clock.Clock
+import zio.clock
 import zio.duration.Duration
 import zio.{ Has, UIO }
 
 object MockClock {
 
-  object currentTime     extends Method[Clock.Service, TimeUnit, Long]
-  object currentDateTime extends Method[Clock.Service, Unit, OffsetDateTime]
-  object nanoTime        extends Method[Clock.Service, Unit, Long]
-  object sleep           extends Method[Clock.Service, Duration, Unit]
+  object currentTime     extends Method[clock.Service, TimeUnit, Long]
+  object currentDateTime extends Method[clock.Service, Unit, OffsetDateTime]
+  object nanoTime        extends Method[clock.Service, Unit, Long]
+  object sleep           extends Method[clock.Service, Duration, Unit]
 
-  implicit val mockableClock: Mockable[Clock.Service] = (mock: Mock) =>
-    Has(new Clock.Service {
+  implicit val mockableClock: Mockable[clock.Service] = (mock: Mock) =>
+    Has(new clock.Service {
       def currentTime(unit: TimeUnit): UIO[Long] = mock(MockClock.currentTime, unit)
       def currentDateTime: UIO[OffsetDateTime]   = mock(MockClock.currentDateTime)
       val nanoTime: UIO[Long]                    = mock(MockClock.nanoTime)

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -18,18 +18,18 @@ package zio.test.mock
 
 import java.io.IOException
 
-import zio.console.Console
+import zio.console
 import zio.{ Has, IO, UIO }
 import zio.{ IO, UIO }
 
 object MockConsole {
 
-  object putStr   extends Method[Console.Service, String, Unit]
-  object putStrLn extends Method[Console.Service, String, Unit]
-  object getStrLn extends Method[Console.Service, Unit, String]
+  object putStr   extends Method[console.Service, String, Unit]
+  object putStrLn extends Method[console.Service, String, Unit]
+  object getStrLn extends Method[console.Service, Unit, String]
 
-  implicit val mockableConsole: Mockable[Console.Service] = (mock: Mock) =>
-    Has(new Console.Service {
+  implicit val mockableConsole: Mockable[console.Service] = (mock: Mock) =>
+    Has(new console.Service {
       def putStr(line: String): UIO[Unit]   = mock(MockConsole.putStr, line)
       def putStrLn(line: String): UIO[Unit] = mock(MockConsole.putStrLn, line)
       val getStrLn: IO[IOException, String] = mock(MockConsole.getStrLn)

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -16,31 +16,31 @@
 
 package zio.test.mock
 
-import zio.random.Random
+import zio.random
 import zio.{ Chunk, Has, UIO }
 import zio.{ Chunk, UIO }
 
 object MockRandom {
 
-  object nextBoolean  extends Method[Random.Service, Unit, Boolean]
-  object nextBytes    extends Method[Random.Service, Int, Chunk[Byte]]
-  object nextDouble   extends Method[Random.Service, Unit, Double]
-  object nextFloat    extends Method[Random.Service, Unit, Float]
-  object nextGaussian extends Method[Random.Service, Unit, Double]
+  object nextBoolean  extends Method[random.Service, Unit, Boolean]
+  object nextBytes    extends Method[random.Service, Int, Chunk[Byte]]
+  object nextDouble   extends Method[random.Service, Unit, Double]
+  object nextFloat    extends Method[random.Service, Unit, Float]
+  object nextGaussian extends Method[random.Service, Unit, Double]
   object nextInt {
-    object _0 extends Method[Random.Service, Int, Int]
-    object _1 extends Method[Random.Service, Unit, Int]
+    object _0 extends Method[random.Service, Int, Int]
+    object _1 extends Method[random.Service, Unit, Int]
   }
   object nextLong {
-    object _0 extends Method[Random.Service, Unit, Long]
-    object _1 extends Method[Random.Service, Long, Long]
+    object _0 extends Method[random.Service, Unit, Long]
+    object _1 extends Method[random.Service, Long, Long]
   }
-  object nextPrintableChar extends Method[Random.Service, Unit, Char]
-  object nextString        extends Method[Random.Service, Int, String]
-  object shuffle           extends Method[Random.Service, List[Any], List[Any]]
+  object nextPrintableChar extends Method[random.Service, Unit, Char]
+  object nextString        extends Method[random.Service, Int, String]
+  object shuffle           extends Method[random.Service, List[Any], List[Any]]
 
-  implicit val mockableRandom: Mockable[Random.Service] = (mock: Mock) =>
-    Has(new Random.Service {
+  implicit val mockableRandom: Mockable[random.Service] = (mock: Mock) =>
+    Has(new random.Service {
       val nextBoolean: UIO[Boolean]                = mock(MockRandom.nextBoolean)
       def nextBytes(length: Int): UIO[Chunk[Byte]] = mock(MockRandom.nextBytes, length)
       val nextDouble: UIO[Double]                  = mock(MockRandom.nextDouble)

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -16,9 +16,8 @@
 
 package zio.test.mock
 
-import zio.random
 import zio.{ Chunk, Has, UIO }
-import zio.{ Chunk, UIO }
+import zio.{ random, Chunk, UIO }
 
 object MockRandom {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
@@ -16,18 +16,18 @@
 
 package zio.test.mock
 
-import zio.system.System
+import zio.system
 import zio.{ Has, IO, UIO }
 import zio.{ IO, UIO }
 
 object MockSystem {
 
-  object env           extends Method[System.Service, String, Option[String]]
-  object property      extends Method[System.Service, String, Option[String]]
-  object lineSeparator extends Method[System.Service, Unit, String]
+  object env           extends Method[system.Service, String, Option[String]]
+  object property      extends Method[system.Service, String, Option[String]]
+  object lineSeparator extends Method[system.Service, Unit, String]
 
-  implicit val mockableSystem: Mockable[System.Service] = (mock: Mock) =>
-    Has(new System.Service {
+  implicit val mockableSystem: Mockable[system.Service] = (mock: Mock) =>
+    Has(new system.Service {
       def env(variable: String): IO[SecurityException, Option[String]] = mock(MockSystem.env, variable)
       def property(prop: String): IO[Throwable, Option[String]]        = mock(MockSystem.property, prop)
       val lineSeparator: UIO[String]                                   = mock(MockSystem.lineSeparator)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -578,9 +578,9 @@ package object test extends CompileVariants {
     }
 
     def fromConsole: ZLayer[Console, Nothing, TestLogger] =
-      ZLayer.fromService { (console: Console.Service) =>
+      ZLayer.fromService { (cons: console.Service) =>
         new Service {
-          def logLine(line: String): UIO[Unit] = console.putStrLn(line)
+          def logLine(line: String): UIO[Unit] = cons.putStrLn(line)
         }
       }
 


### PR DESCRIPTION
@adamgfraser @jdegoes Do you think this is a useful change for code organization purposes? I feel like the further nesting of the `Service` is not beneficial and the package itself provides enough disambiguation.