### PR TITLE
Change laziness of when methods.

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -679,7 +679,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when[E](b: => Boolean)(io: IO[E, Any]): IO[E, Unit] =
+  def when[E](b: Boolean)(io: => IO[E, Any]): IO[E, Unit] =
     ZIO.when(b)(io)
 
   /**
@@ -697,7 +697,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  def whenM[E](b: IO[E, Boolean])(io: IO[E, Any]): IO[E, Unit] =
+  def whenM[E](b: IO[E, Boolean])(io: => IO[E, Any]): IO[E, Unit] =
     ZIO.whenM(b)(io)
 
   /**

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -362,7 +362,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.when]]
    */
-  def when[E](b: => Boolean)(managed: Managed[E, Any]): Managed[E, Unit] =
+  def when[E](b: Boolean)(managed: => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.when(b)(managed)
 
   /**
@@ -382,7 +382,7 @@ object Managed {
   /**
    * See [[zio.ZManaged.whenM]]
    */
-  def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, Any]): Managed[E, Unit] =
+  def whenM[E](b: Managed[E, Boolean])(managed: => Managed[E, Any]): Managed[E, Unit] =
     ZManaged.whenM(b)(managed)
 
   private[zio] def dieNow(t: Throwable): Managed[Nothing, Nothing] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -713,7 +713,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when[R](b: => Boolean)(rio: RIO[R, Any]): RIO[R, Unit] =
+  def when[R](b: Boolean)(rio: => RIO[R, Any]): RIO[R, Unit] =
     ZIO.when(b)(rio)
 
   /**
@@ -731,7 +731,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  def whenM[R](b: RIO[R, Boolean])(rio: RIO[R, Any]): RIO[R, Unit] =
+  def whenM[R](b: RIO[R, Boolean])(rio: => RIO[R, Any]): RIO[R, Unit] =
     ZIO.whenM(b)(rio)
 
   /**

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -650,7 +650,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when(b: => Boolean)(task: Task[Any]): Task[Unit] =
+  def when(b: Boolean)(task: => Task[Any]): Task[Unit] =
     ZIO.when(b)(task)
 
   /**
@@ -668,7 +668,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  def whenM(b: Task[Boolean])(task: Task[Any]): Task[Unit] =
+  def whenM(b: Task[Boolean])(task: => Task[Any]): Task[Unit] =
     ZIO.whenM(b)(task)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -564,7 +564,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when(b: => Boolean)(uio: UIO[Any]): UIO[Unit] =
+  def when(b: Boolean)(uio: => UIO[Any]): UIO[Unit] =
     ZIO.when(b)(uio)
 
   /**
@@ -582,7 +582,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.whenM]]
    */
-  def whenM(b: UIO[Boolean])(uio: UIO[Any]): UIO[Unit] =
+  def whenM(b: UIO[Boolean])(uio: => UIO[Any]): UIO[Unit] =
     ZIO.whenM(b)(uio)
 
   /**

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -629,7 +629,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.when]]
    */
-  def when[R](b: => Boolean)(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.when(b)(rio)
+  def when[R](b: Boolean)(rio: => URIO[R, Any]): URIO[R, Unit] = ZIO.when(b)(rio)
 
   /**
    * @see [[zio.ZIO.whenCase]]
@@ -645,7 +645,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.whenM]]
    */
-  def whenM[R](b: URIO[R, Boolean])(rio: URIO[R, Any]): URIO[R, Unit] = ZIO.whenM(b)(rio)
+  def whenM[R](b: URIO[R, Boolean])(rio: => URIO[R, Any]): URIO[R, Unit] = ZIO.whenM(b)(rio)
 
   /**
    * @see [[zio.ZIO.yieldNow]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1732,7 +1732,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * The moral equivalent of `if (p) exp`
    */
-  final def when(b: => Boolean): ZIO[R, E, Unit] =
+  final def when(b: Boolean): ZIO[R, E, Unit] =
     ZIO.when(b)(self)
 
   /**
@@ -3124,7 +3124,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * The moral equivalent of `if (p) exp`
    */
-  def when[R, E](b: => Boolean)(zio: ZIO[R, E, Any]): ZIO[R, E, Unit] =
+  def when[R, E](b: Boolean)(zio: => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     if (b) zio.unit else unit
 
   /**
@@ -3142,7 +3142,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  def whenM[R, E](b: ZIO[R, E, Boolean])(zio: ZIO[R, E, Any]): ZIO[R, E, Unit] =
+  def whenM[R, E](b: ZIO[R, E, Boolean])(zio: => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     b.flatMap(b => if (b) zio.unit else unit)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1986,7 +1986,7 @@ object ZManaged {
   /**
    * The moral equivalent of `if (p) exp`
    */
-  def when[R, E](b: => Boolean)(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def when[R, E](b: Boolean)(zManaged: => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     if (b) zManaged.unit else unit
 
   /**
@@ -2006,7 +2006,7 @@ object ZManaged {
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
-  def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
+  def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: => ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     b.flatMap(b => if (b) zManaged.unit else unit)
 
   private[zio] def dieNow(t: Throwable): ZManaged[Any, Nothing, Nothing] =


### PR DESCRIPTION
Two small changes to `ZIO.when` and `ZIO.whenM`.

The first is straight-forward: in most cases of `when`, the boolean parameter is strictly evaluated, so it should be passed by value.

The second is more debatable: changed the effect parameter to be lazy, so the effect value is only constructed when the test is true, as would be the case for the `if` equivalent. The current strict construction of the effect value can be surprising.

In my case, I was dealing with a non-typesafe API and I had the code constructing the effect value perform a cast that was only valid if the test was true. Took me a while to understand why I was getting `ClassCastException`. This can be fixed with `ZIO.effectSuspendTotal`, but it's not that obvious.
