### PR TITLE
Fix `catchSome` docstring

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -324,7 +324,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    *
    * {{{
    * openFile("data.json").catchSome {
-   *   case FileNotFoundException(_) => openFile("backup.json")
+   *   case _: FileNotFoundException => openFile("backup.json")
    * }
    * }}}
    */


### PR DESCRIPTION
The current example throws a compile error: `class FileNotFoundException is not a case class, nor does it have a valid unapply/unapplySeq member`. For Java classes like the `FileNotFoundException`, the syntax shown in https://zio.dev/docs/overview/overview_handling_errors#catching-some-errors should be used.