### PR TITLE
Don't Attempt to Add Shutdown Hook on ScalaJS

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,7 +19,6 @@ package zio.internal
 import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 
 import scala.concurrent.ExecutionContext
-import scala.scalajs.js
 
 import com.github.ghik.silencer.silent
 
@@ -32,8 +31,9 @@ private[internal] trait PlatformSpecific {
   /**
    * Adds a shutdown hook that executes the specified action on shutdown.
    */
-  def addShutdownHook(action: () => Unit): Unit =
-    js.Dynamic.global.onunload = { (_: Any) => action() }
+  def addShutdownHook(action: () => Unit): Unit = {
+    val _ = action
+  }
 
   /**
    * A Runtime with settings suitable for benchmarks, specifically with Tracing


### PR DESCRIPTION
Resolves #3021. There doesn't seem to be a way to safely add a global shutdown hook on ScalaJS on a consistent basis so removing that functionality, similar to the current implementation on Scala Native. Users can call `shutdown` to release resources at the end of their application in a mixed code base.