### PR TITLE
Fix Signature of ZLayer#map

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -100,7 +100,7 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
   /**
    * Returns a new layer whose output is mapped by the specified function.
    */
-  def map[ROut1 >: ROut <: Has[_]](f: ROut => ROut1): ZLayer[RIn, E, ROut1] =
+  def map[ROut1 <: Has[_]](f: ROut => ROut1): ZLayer[RIn, E, ROut1] =
     self >>> ZLayer.fromFunctionMany(f)
 
   /**


### PR DESCRIPTION
The type signature of `ZLayer#map` was overly constrained. The new output type does not need to be a super type of the original output type but can be unrelated as long as it is a subtype of `Has[_]`.