### PR TITLE
use ZIO.infinity in ZManaged.useForever to avoid GC related problems

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -921,7 +921,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Use the resource until interruption.
    * Useful for resources that you want to acquire and use as long as the application is running, like a HTTP server.
    */
-  val useForever: ZIO[R, E, Nothing] = use(_ => ZIO.never)
+  val useForever: ZIO[R with Clock, E, Nothing] = use(_ => ZIO.infinity)
 
   /**
    * The moral equivalent of `if (p) exp`


### PR DESCRIPTION
According to the [release notes](https://github.com/zio/zio/releases/tag/v1.0.0-RC18) there might be some problems when using `ZIO.never`.

The typical patter we have in our apps is:
```
    managedApp.useForever.catchAll(e =>
      UIO(defectLogger.error(s"Error in application lifecycle: $e")).as(1),
    )
```
One way to interpret this would be that in some cases useForever with never will be garbage collected and any code following it won't be executed.

Excerpt from release notes:
> When ZIO.never is forked, it will be garbage collected, so ZIO.never.onInterrupt(putStrLn("Bye")) will never execute the finalizer. This can be inconvenient for testing, so ZIO.infinity is added which is like never, but won't be garbage collected.

I am not sure about if "forked" here means `ZIO.never.fork` or something else. And if "testing" here means that it shouldn't happen in production. In case I got it all wrong feel free to close this MR. Otherwise happy to learn and hear your explanations.