### PR TITLE
Fix Regression in Ergonomics of Working with Durations

### DIFF
--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -23,7 +23,7 @@ object DurationSpec extends ZIOBaseSpec {
         assert(Duration.fromNanos(1) * -1.0)(equalTo(Duration.Zero: Duration))
       },
       test("Its stdlib representation is correct and matches type") {
-        val duration: ScalaFiniteDuration = Duration.fromNanos(1234L).asScala
+        val duration: ScalaFiniteDuration = Duration.Finite(1234L).asScala
         val expected: ScalaFiniteDuration = ScalaFiniteDuration(1234L, TimeUnit.NANOSECONDS)
         assert(duration)(equalTo(expected))
       },
@@ -80,6 +80,10 @@ object DurationSpec extends ZIOBaseSpec {
       },
       test("Folding picks up the correct value") {
         assert(Duration.fromNanos(Long.MaxValue).fold("Infinity", _ => "Finite"))(equalTo("Finite"))
+      },
+      test("Durations can be accumulated") {
+        val durations = List(1.second, 2.seconds, 3.seconds)
+        assert(durations.foldLeft(Duration.Zero)(_ + _))(equalTo(6.seconds))
       }
     ),
     suite("Make a Duration from negative nanos and check that:")(

--- a/core/shared/src/main/scala/zio/duration/Duration.scala
+++ b/core/shared/src/main/scala/zio/duration/Duration.scala
@@ -73,7 +73,7 @@ object Duration {
 
     def apply(nanos: Long): Finite =
       if (nanos >= 0) new Finite(nanos)
-      else Zero
+      else Finite(0)
 
   }
 
@@ -159,12 +159,12 @@ object Duration {
     override def render: String = "Infinity"
   }
 
-  def apply(amount: Long, unit: TimeUnit): Finite = fromNanos(unit.toNanos(amount))
+  def apply(amount: Long, unit: TimeUnit): Duration = fromNanos(unit.toNanos(amount))
 
-  def fromInstant(instant: Instant): Finite =
+  def fromInstant(instant: Instant): Duration =
     Duration(instant.toEpochMilli, TimeUnit.MILLISECONDS)
 
-  def fromNanos(nanos: Long): Finite = Finite(nanos)
+  def fromNanos(nanos: Long): Duration = Finite(nanos)
 
   def fromScala(duration: ScalaDuration): Duration = duration match {
     case d: ScalaFiniteDuration => fromNanos(d.toNanos)
@@ -176,6 +176,6 @@ object Duration {
     else if (duration.compareTo(JavaDuration.ofNanos(Long.MaxValue)) >= 0) Infinity
     else fromNanos(duration.toNanos)
 
-  val Zero: Finite = Finite(0)
+  val Zero: Duration = Finite(0)
 
 }

--- a/core/shared/src/main/scala/zio/duration/DurationSyntax.scala
+++ b/core/shared/src/main/scala/zio/duration/DurationSyntax.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit._
 
 final class DurationSyntax(n: Long) {
 
-  private[this] def asDuration(unit: TimeUnit): Duration.Finite = Duration(n, unit)
+  private[this] def asDuration(unit: TimeUnit): Duration = Duration(n, unit)
 
   def nanoseconds = asDuration(NANOSECONDS)
   def nanos       = nanoseconds


### PR DESCRIPTION
#2567 caused a regression in the ergonomics of working with durations as reported in #3011.

My analysis of the situation is that we are currently suffering from being halfway between two different encoding.

Prior to #2567 the encoding was more like a traditional algebraic data type where we hid the underlying type (`Finite` or `Infinite`) as much as possible. This generally worked well but resulted in us not being able to honor the roundtrip property that converting a Scala finite duration to a ZIO duration and back would preserve type information.

#2567 fixed that but created an issue where most of our constructors return `Finite` but because of the possibility of overflow almost all operators return just `Duration`, which causes type inference problems when, for example, accumulating a collection of durations with a fold.

This PR addresses by implementing an approach that all constructors on `Duration` should return a `Duration`, while constructors on `Finite` can return a finite duration. Thus, for most users who want the better type inference doing something like `durations.foldLeft(Duration.Zero)(_ + _)` will work like it did on RC17. Users who want to construct durations returning the more specific subtype can use the `apply` method on `Finite`.