### PR TITLE
Add a reference towards `foreach_` in `foreach` doc

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2301,6 +2301,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * returns the results in a new `List[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
+   * If you do not need the results, see `foreach_` for a more efficient implementation.
    */
   def foreach[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
     in.foldRight[ZIO[R, E, List[B]]](effectTotal(Nil))((a, io) => f(a).zipWith(io)((b, bs) => b :: bs))
@@ -2317,6 +2318,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * returns the results in a new `Chunk[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
+   * If you do not need the results, see `foreach_` for a more efficient implementation.
    */
   final def foreach[R, E, A, B](in: Chunk[A])(f: A => ZIO[R, E, B]): ZIO[R, E, Chunk[B]] =
     in.mapM(f)
@@ -2341,6 +2343,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * returns the results in a new `Chunk[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
+   * If you do not need the results, see `foreach_` for a more efficient implementation.
    */
   final def foreach_[R, E, A](as: Chunk[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     as.mapM_(f)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2343,7 +2343,6 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * returns the results in a new `Chunk[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
-   * If you do not need the results, see `foreach_` for a more efficient implementation.
    */
   final def foreach_[R, E, A](as: Chunk[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
     as.mapM_(f)

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1371,6 +1371,7 @@ object ZManaged {
    * returns the results in a new `List[B]`.
    *
    * For a parallel version of this method, see `foreachPar`.
+   * If you do not need the results, see `foreach_` for a more efficient implementation.
    */
   def foreach[R, E, A1, A2](as: Iterable[A1])(f: A1 => ZManaged[R, E, A2]): ZManaged[R, E, List[A2]] =
     as.foldRight[ZManaged[R, E, List[A2]]](succeedNow(Nil))((a, m) => f(a).zipWith(m)(_ :: _))


### PR DESCRIPTION
Add a comment similar to the one for `foreachPar` for `foreach_` in relevant `foreach` scala doc. 
The goal is to make `foreach_` more discoverable, its intent clear, and make it clear that the `_` doesn't mean that you should not use it. 

This is especially important since most people comming from an imperative background will likelly use patterns where their loops doesn't return anything usefull, and so they should default to `foreach_` for noticeable performance improvement.