### PR TITLE
Delete Now Variants

### DIFF
--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -30,7 +30,7 @@ object IOBenchmarks extends BootstrapRuntime {
     else zio *> repeat(n - 1)(zio)
 
   def verify(cond: Boolean)(message: => String): IO[AssertionError, Unit] =
-    ZIO.when(!cond)(IO.failNow(new AssertionError(message)))
+    ZIO.when(!cond)(IO.fail(new AssertionError(message)))
 
   def catsForkAll[A](as: Iterable[CIO[A]]): CIO[CFiber[CIO, List[A]]] = {
     type Fiber[A] = CFiber[CIO, A]

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -119,7 +119,7 @@ class IODeepAttemptBenchmark {
   @Benchmark
   def zioDeepAttampt(): BigInt = {
     def descend(n: Int): IO[ZIOError, BigInt] =
-      if (n == depth) IO.failNow(ZIOError("Oh noes!"))
+      if (n == depth) IO.fail(ZIOError("Oh noes!"))
       else if (n == halfway) descend(n + 1).fold[BigInt](_ => 50, identity)
       else descend(n + 1).map(_ + n)
 
@@ -129,7 +129,7 @@ class IODeepAttemptBenchmark {
   @Benchmark
   def zioDeepAttemptBaseline(): BigInt = {
     def descend(n: Int): IO[Error, BigInt] =
-      if (n == depth) IO.failNow(new Error("Oh noes!"))
+      if (n == depth) IO.fail(new Error("Oh noes!"))
       else if (n == halfway) descend(n + 1).fold[BigInt](_ => 50, identity)
       else descend(n + 1).map(_ + n)
 

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -134,7 +134,7 @@ class IOShallowAttemptBenchmark {
     def throwup(n: Int): IO[ZIOError, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
       else if (n == depth) IO.effectTotal(1)
-      else throwup(n + 1).foldM[Any, ZIOError, BigInt](_ => IO.succeedNow(0), _ => IO.failNow(ZIOError("Oh noes!")))
+      else throwup(n + 1).foldM[Any, ZIOError, BigInt](_ => IO.succeedNow(0), _ => IO.fail(ZIOError("Oh noes!")))
 
     unsafeRun(throwup(0))
   }
@@ -144,7 +144,7 @@ class IOShallowAttemptBenchmark {
     def throwup(n: Int): IO[Error, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
       else if (n == depth) IO.effectTotal(1)
-      else throwup(n + 1).foldM[Any, Error, BigInt](_ => IO.succeedNow(0), _ => IO.failNow(new Error("Oh noes!")))
+      else throwup(n + 1).foldM[Any, Error, BigInt](_ => IO.succeedNow(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafeRun(throwup(0))
   }

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -334,7 +334,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
       t1 <- ZIO
              .foreach_(1 to 10) { i =>
                if (i == 7)
-                 ZIO.unit *> ZIO.failNow("Dummy error!")
+                 ZIO.unit *> ZIO.fail("Dummy error!")
                else
                  ZIO.unit *> ZIO.trace
              }
@@ -465,7 +465,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
       _ <- ZIO.effect(traceThis()).traced.traced.traced
       _ <- ZIO.unit
       _ <- ZIO.unit
-      _ <- ZIO.failNow("end")
+      _ <- ZIO.fail("end")
     } yield ()).untraced
   }
 
@@ -527,7 +527,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
       t <- Task(fail())
             .flatMap(badMethod)
             .catchSome {
-              case _: ArithmeticException => ZIO.failNow("impossible match!")
+              case _: ArithmeticException => ZIO.fail("impossible match!")
             }
     } yield t
   }
@@ -550,7 +550,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
   object catchAllWithOptimizedEffectFixture {
     val succ               = ZIO.succeedNow(_: ZTrace)
     val fail               = () => throw new Exception("error!")
-    val refailAndLoseTrace = (_: Any) => ZIO.failNow("bad!")
+    val refailAndLoseTrace = (_: Any) => ZIO.fail("bad!")
   }
 
   def foldMWithOptimizedEffect = {

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -82,7 +82,7 @@ object RTSSpec extends ZIOBaseSpec {
             .succeed(21)
             .bracketExit((r: Int, exit: Exit[Any, Any]) =>
               if (exit.interrupted) exitLatch.succeed(r)
-              else IO.dieNow(new Error("Unexpected case"))
+              else IO.die(new Error("Unexpected case"))
             )(a => startLatch.succeed(a) *> IO.never *> IO.succeedNow(1))
           fiber      <- bracketed.fork
           startValue <- startLatch.await

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -38,7 +38,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
         p1 <- Promise.make[Nothing, Unit]
         p2 <- Promise.make[Nothing, Unit]
         f1 <- (ZIO.succeedNow(42) <* p1.succeed(())).toFuture
-        f2 <- ZIO.failNow(t).onError(_ => p2.succeed(())).toFuture
+        f2 <- ZIO.fail(t).onError(_ => p2.succeed(())).toFuture
         _  <- p1.await *> p2.await
         e1 <- ZIO.fromFuture(_ => f1.cancel())
         e2 <- ZIO.fromFuture(_ => f2.cancel())

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -89,7 +89,7 @@ object FiberSpec extends ZIOBaseSpec {
         for {
           queue  <- Queue.unbounded[Int]
           _      <- queue.offerAll(1 to 100)
-          worker = (n: Int) => if (n == 100) ZIO.failNow("fail") else queue.offer(n).unit
+          worker = (n: Int) => if (n == 100) ZIO.fail("fail") else queue.offer(n).unit
           exit   <- shard(queue, 4, worker).run
           _      <- queue.shutdown
         } yield assert(exit)(fails(equalTo("fail")))

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -22,7 +22,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("getAndUpdate with failure") {
       for {
         refM  <- RefM.make[String](current)
-        value <- refM.getAndUpdate(_ => IO.failNow(failure)).run
+        value <- refM.getAndUpdate(_ => IO.fail(failure)).run
       } yield assert(value)(fails(equalTo(failure)))
     },
     testM("getAndUpdateSome") {
@@ -46,7 +46,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("getAndUpdateSome with failure") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.getAndUpdateSome { case Active => IO.failNow(failure) }.run
+        value <- refM.getAndUpdateSome { case Active => IO.fail(failure) }.run
       } yield assert(value)(fails(equalTo(failure)))
     },
     testM("interrupt parent fiber and update") {
@@ -70,7 +70,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("modify with failure") {
       for {
         refM <- RefM.make[String](current)
-        r    <- refM.modify(_ => IO.failNow(failure)).run
+        r    <- refM.modify(_ => IO.fail(failure)).run
       } yield assert(r)(fails(equalTo(failure)))
     },
     testM("modify twice") {
@@ -98,14 +98,14 @@ object RefMSpec extends ZIOBaseSpec {
     testM("modifySome with failure not triggered") {
       for {
         refM  <- RefM.make[State](Active)
-        r     <- refM.modifySome("State doesn't change") { case Closed => IO.failNow(failure) }.orDieWith(new Exception(_))
+        r     <- refM.modifySome("State doesn't change") { case Closed => IO.fail(failure) }.orDieWith(new Exception(_))
         value <- refM.get
       } yield assert(r)(equalTo("State doesn't change")) && assert(value)(equalTo(Active))
     },
     testM("modifySome with failure") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.modifySome("State doesn't change") { case Active => IO.failNow(failure) }.run
+        value <- refM.modifySome("State doesn't change") { case Active => IO.fail(failure) }.run
       } yield assert(value)(fails(equalTo(failure)))
     },
     testM("modifySome with fatal error") {
@@ -130,7 +130,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("updateAndGet with failure") {
       for {
         refM  <- RefM.make[String](current)
-        value <- refM.updateAndGet(_ => IO.failNow(failure)).run
+        value <- refM.updateAndGet(_ => IO.fail(failure)).run
       } yield assert(value)(fails(equalTo(failure)))
     },
     testM("updateSomeAndGet") {
@@ -152,7 +152,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("updateSomeAndGet with failure") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateSomeAndGet { case Active => IO.failNow(failure) }.run
+        value <- refM.updateSomeAndGet { case Active => IO.fail(failure) }.run
       } yield assert(value)(fails(equalTo(failure)))
     }
   )

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -42,7 +42,7 @@ object SemaphoreSpec extends ZIOBaseSpec {
         val n = 1L
         for {
           s       <- Semaphore.make(n)
-          _       <- s.withPermit(IO.failNow("fail")).either
+          _       <- s.withPermit(IO.fail("fail")).either
           permits <- s.available
         } yield assert(permits)(equalTo(1L))
       },

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -39,7 +39,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("bimap")(
       testM("maps over both error and value channels") {
         checkM(Gen.anyInt) { i =>
-          val res = IO.failNow(i).bimap(_.toString, identity).either
+          val res = IO.fail(i).bimap(_.toString, identity).either
           assertM(res)(isLeft(equalTo(i.toString)))
         }
       }
@@ -76,11 +76,11 @@ object ZIOSpec extends ZIOBaseSpec {
           exit <- ZIO
                    .bracketExit[Any, String, Int, Int](
                      ZIO.succeedNow(42),
-                     (_, _) => ZIO.dieNow(releaseDied),
-                     _ => ZIO.failNow("use failed")
+                     (_, _) => ZIO.die(releaseDied),
+                     _ => ZIO.fail("use failed")
                    )
                    .run
-          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.failNow("effect should have failed"))
+          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.fail("effect should have failed"))
         } yield assert(cause.failures)(equalTo(List("use failed"))) &&
           assert(cause.defects)(equalTo(List(releaseDied)))
       }
@@ -121,12 +121,12 @@ object ZIOSpec extends ZIOBaseSpec {
           exit <- ZIO
                    .bracketExit[Any, String, Int, Int](
                      ZIO.succeedNow(42),
-                     (_, _) => ZIO.dieNow(releaseDied),
-                     _ => ZIO.failNow("use failed")
+                     (_, _) => ZIO.die(releaseDied),
+                     _ => ZIO.fail("use failed")
                    )
                    .disconnect
                    .run
-          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.failNow("effect should have failed"))
+          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.fail("effect should have failed"))
         } yield assert(cause.failures)(equalTo(List("use failed"))) &&
           assert(cause.defects)(equalTo(List(releaseDied)))
       }
@@ -211,7 +211,7 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(0)(_.collectM[Any, String, Int]("Predicate failed!")({ case v @ 0 => ZIO.succeedNow(v) })).sandbox.either
 
         val partialBadCase =
-          exactlyOnce(0)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.failNow("Partial failed!") })).sandbox.either
+          exactlyOnce(0)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.fail("Partial failed!") })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         val badCase =
@@ -268,10 +268,10 @@ object ZIOSpec extends ZIOBaseSpec {
         val terminated: Exit[Error, Int]  = Exit.die(error)
         val failed: Exit[Error, Int]      = Exit.fail(error)
 
-        assertM(IO.doneNow(completed))(equalTo(1)) &&
-        assertM(IO.doneNow(interrupted).run)(isInterrupted) &&
-        assertM(IO.doneNow(terminated).run)(dies(equalTo(error))) &&
-        assertM(IO.doneNow(failed).run)(fails(equalTo(error)))
+        assertM(IO.done(completed))(equalTo(1)) &&
+        assertM(IO.done(interrupted).run)(isInterrupted) &&
+        assertM(IO.done(terminated).run)(dies(equalTo(error))) &&
+        assertM(IO.done(failed).run)(fails(equalTo(error)))
       }
     ),
     suite("doUntil")(
@@ -367,7 +367,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("eventually")(
       testM("succeeds eventually") {
         def effect(ref: Ref[Int]) =
-          ref.get.flatMap(n => if (n < 10) ref.update(_ + 1) *> IO.failNow("Ouch") else UIO.succeedNow(n))
+          ref.get.flatMap(n => if (n < 10) ref.update(_ + 1) *> IO.fail("Ouch") else UIO.succeedNow(n))
 
         val test = for {
           ref <- Ref.make(0)
@@ -391,10 +391,10 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("filterOrElse")(
       testM("returns checked failure from held value") {
         val goodCase =
-          exactlyOnce(0)(_.filterOrElse[Any, String, Int](_ == 0)(a => ZIO.failNow(s"$a was not 0"))).sandbox.either
+          exactlyOnce(0)(_.filterOrElse[Any, String, Int](_ == 0)(a => ZIO.fail(s"$a was not 0"))).sandbox.either
 
         val badCase =
-          exactlyOnce(1)(_.filterOrElse[Any, String, Int](_ == 0)(a => ZIO.failNow(s"$a was not 0"))).sandbox.either
+          exactlyOnce(1)(_.filterOrElse[Any, String, Int](_ == 0)(a => ZIO.fail(s"$a was not 0"))).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         assertM(goodCase)(isRight(equalTo(0))) &&
@@ -404,10 +404,10 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("filterOrElse_")(
       testM("returns checked failure ignoring value") {
         val goodCase =
-          exactlyOnce(0)(_.filterOrElse_[Any, String, Int](_ == 0)(ZIO.failNow(s"Predicate failed!"))).sandbox.either
+          exactlyOnce(0)(_.filterOrElse_[Any, String, Int](_ == 0)(ZIO.fail(s"Predicate failed!"))).sandbox.either
 
         val badCase =
-          exactlyOnce(1)(_.filterOrElse_[Any, String, Int](_ == 0)(ZIO.failNow(s"Predicate failed!"))).sandbox.either
+          exactlyOnce(1)(_.filterOrElse_[Any, String, Int](_ == 0)(ZIO.fail(s"Predicate failed!"))).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         assertM(goodCase)(isRight(equalTo(0))) &&
@@ -429,11 +429,11 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("flattenErrorOption")(
       testM("fails when given Some error") {
-        val task: IO[String, Int] = IO.failNow(Some("Error")).flattenErrorOption("Default")
+        val task: IO[String, Int] = IO.fail(Some("Error")).flattenErrorOption("Default")
         assertM(task.run)(fails(equalTo("Error")))
       },
       testM("fails with Default when given None error") {
-        val task: IO[String, Int] = IO.failNow(None).flattenErrorOption("Default")
+        val task: IO[String, Int] = IO.fail(None).flattenErrorOption("Default")
         assertM(task.run)(fails(equalTo("Default")))
       },
       testM("succeeds when given a value") {
@@ -450,7 +450,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("`with a failing step function returns a failed IO") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
-          val res = IO.foldLeft(l)(0)((_, _) => IO.failNow("fail"))
+          val res = IO.foldLeft(l)(0)((_, _) => IO.fail("fail"))
           assertM(res.run)(fails(equalTo("fail")))
         }
       },
@@ -470,7 +470,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("`with a failing step function returns a failed IO") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
-          val res = IO.foldRight(l)(0)((_, _) => IO.failNow("fail"))
+          val res = IO.foldRight(l)(0)((_, _) => IO.fail("fail"))
           assertM(res.run)(fails(equalTo("fail")))
         }
       },
@@ -558,7 +558,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val as = (1 to 10)
         val results = IO
           .foreachPar(as) {
-            case 5 => IO.failNow("Boom!")
+            case 5 => IO.fail("Boom!")
             case a => IO.succeedNow(2 * a)
           }
           .flip
@@ -568,8 +568,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val as = (1 to 10)
         val results = IO
           .foreachPar(as) {
-            case 5 => IO.failNow("Boom1!")
-            case 8 => IO.failNow("Boom2!")
+            case 5 => IO.fail("Boom1!")
+            case 8 => IO.fail("Boom2!")
             case a => IO.succeedNow(2 * a)
           }
           .flip
@@ -621,7 +621,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
-        val odds = ZIO.foreachPar(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.failNow("not odd"))
+        val odds = ZIO.foreachPar(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.fail("not odd"))
         assertM(odds.flip)(equalTo("not odd"))
       },
       testM("interrupts effects on first failure") {
@@ -631,7 +631,7 @@ object ZIOSpec extends ZIOBaseSpec {
           actions = List(
             ZIO.never,
             ZIO.succeedNow(1),
-            ZIO.failNow("C"),
+            ZIO.fail("C"),
             promise.await *> ref.set(true)
           )
           e <- ZIO.foreachPar(actions)(a => a).flip
@@ -643,7 +643,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("accumulates errors") {
         def task(started: Ref[Int], trigger: Promise[Nothing, Unit])(i: Int): IO[Int, Unit] =
           started.updateAndGet(_ + 1) >>= { count =>
-            IO.when(count == 3)(trigger.succeed(())) *> trigger.await *> IO.failNow(i)
+            IO.when(count == 3)(trigger.succeed(())) *> trigger.await *> IO.fail(i)
           }
 
         for {
@@ -699,14 +699,14 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
-        val odds = ZIO.foreachParN(4)(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.failNow("not odd"))
+        val odds = ZIO.foreachParN(4)(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.fail("not odd"))
         assertM(odds.either)(isLeft(equalTo("not odd")))
       },
       testM("interrupts effects on first failure") {
         val actions = List(
           ZIO.never,
           ZIO.succeedNow(1),
-          ZIO.failNow("C")
+          ZIO.fail("C")
         )
         val io = ZIO.foreachParN(4)(actions)(a => a)
         assertM(io.either)(isLeft(equalTo("C")))
@@ -739,13 +739,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("propagate failures") {
         val boom = new Exception
         for {
-          fiber  <- ZIO.forkAll(List(ZIO.failNow(boom)))
+          fiber  <- ZIO.forkAll(List(ZIO.fail(boom)))
           result <- fiber.join.flip
         } yield assert(result)(equalTo(boom))
       },
       testM("propagates defects") {
         val boom                                 = new Exception("boom")
-        val die                                  = ZIO.dieNow(boom)
+        val die                                  = ZIO.die(boom)
         def joinDefect(fiber: Fiber[Nothing, _]) = fiber.join.sandbox.flip
         for {
           fiber1 <- ZIO.forkAll(List(die))
@@ -787,7 +787,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("calls provided function when task fails") {
         for {
           p <- Promise.make[Nothing, Unit]
-          _ <- ZIO.failNow(()).forkWithErrorHandler(p.succeed(_).unit)
+          _ <- ZIO.fail(()).forkWithErrorHandler(p.succeed(_).unit)
           _ <- p.await
         } yield assertCompletes
       }
@@ -826,7 +826,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(List.empty).head.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.failNow("Fail").head.either)(isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").head.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("ifM")(
@@ -856,10 +856,10 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(11).ignore)(equalTo(()))
       },
       testM("return failure as Unit") {
-        assertM(ZIO.failNow(123).ignore)(equalTo(()))
+        assertM(ZIO.fail(123).ignore)(equalTo(()))
       },
       testM("not catch throwable") {
-        assertM(ZIO.dieNow(ExampleError).ignore.run)(dies(equalTo(ExampleError)))
+        assertM(ZIO.die(ExampleError).ignore.run)(dies(equalTo(ExampleError)))
       }
     ),
     suite("iterate")(
@@ -877,7 +877,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(Right("Right")).left.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.failNow("Fail").left.either)(isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").left.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("leftOrFail")(
@@ -1013,7 +1013,7 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("return error if it exists in list") {
-        val effects = List(UIO.unit, ZIO.failNow(1))
+        val effects = List(UIO.unit, ZIO.fail(1))
         val merged  = ZIO.mergeAll(effects)(zero = ())((_, _) => ())
         assertM(merged.run)(fails(equalTo(1)))
       }
@@ -1033,7 +1033,7 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("return error if it exists in list") {
-        val effects = List(UIO.unit, ZIO.failNow(1))
+        val effects = List(UIO.unit, ZIO.fail(1))
         val merged  = ZIO.mergeAllPar(effects)(zero = ())((_, _) => ())
         assertM(merged.run)(fails(equalTo(1)))
       }
@@ -1049,7 +1049,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("fails with Some(ex) when effect fails with ex") {
         val ex                                = new RuntimeException("Failed Task")
-        val task: IO[Option[Throwable], Unit] = Task.failNow(ex).none
+        val task: IO[Option[Throwable], Unit] = Task.fail(ex).none
         assertM(task.run)(fails(isSome(equalTo(ex))))
       }
     ),
@@ -1078,7 +1078,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           ref <- Ref.make(false)
           _ <- ZIO
-                .dieNow(new RuntimeException)
+                .die(new RuntimeException)
                 .onExit {
                   case Exit.Failure(c) if c.died => ref.set(true)
                   case _                         => UIO.unit
@@ -1108,23 +1108,23 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(11).option)(equalTo(Some(11)))
       },
       testM("return failure as None") {
-        assertM(ZIO.failNow(123).option)(equalTo(None))
+        assertM(ZIO.fail(123).option)(equalTo(None))
       },
       testM("not catch throwable") {
         import zio.CanFail.canFail
-        assertM(ZIO.dieNow(ExampleError).option.run)(dies(equalTo(ExampleError)))
+        assertM(ZIO.die(ExampleError).option.run)(dies(equalTo(ExampleError)))
       },
       testM("catch throwable after sandboxing") {
-        assertM(ZIO.dieNow(ExampleError).sandbox.option)(equalTo(None))
+        assertM(ZIO.die(ExampleError).sandbox.option)(equalTo(None))
       }
     ),
     suite("optional")(
       testM("fails when given Some error") {
-        val task: IO[String, Option[Int]] = IO.failNow(Some("Error")).optional
+        val task: IO[String, Option[Int]] = IO.fail(Some("Error")).optional
         assertM(task.run)(fails(equalTo("Error")))
       },
       testM("succeeds with None given None error") {
-        val task: IO[String, Option[Int]] = IO.failNow(None).optional
+        val task: IO[String, Option[Int]] = IO.fail(None).optional
         assertM(task)(isNone)
       },
       testM("ucceeds with Some given a value") {
@@ -1138,18 +1138,18 @@ object ZIOSpec extends ZIOBaseSpec {
         val fiberId = Fiber.Id(0L, 123L)
         import zio.CanFail.canFail
         for {
-          plain <- (ZIO.dieNow(ex) <> IO.unit).run
-          both  <- (ZIO.haltNow(Cause.Both(interrupt(fiberId), die(ex))) <> IO.unit).run
-          thn   <- (ZIO.haltNow(Cause.Then(interrupt(fiberId), die(ex))) <> IO.unit).run
-          fail  <- (ZIO.failNow(ex) <> IO.unit).run
+          plain <- (ZIO.die(ex) <> IO.unit).run
+          both  <- (ZIO.halt(Cause.Both(interrupt(fiberId), die(ex))) <> IO.unit).run
+          thn   <- (ZIO.halt(Cause.Then(interrupt(fiberId), die(ex))) <> IO.unit).run
+          fail  <- (ZIO.fail(ex) <> IO.unit).run
         } yield assert(plain)(dies(equalTo(ex))) &&
           assert(both)(dies(equalTo(ex))) &&
           assert(thn)(dies(equalTo(ex))) &&
           assert(fail)(succeeds(isUnit))
       },
       testM("left failed and right died with kept cause") {
-        val z1                = Task.failNow(new Throwable("1"))
-        val z2: Task[Nothing] = Task.dieNow(new Throwable("2"))
+        val z1                = Task.fail(new Throwable("1"))
+        val z2: Task[Nothing] = Task.die(new Throwable("2"))
         val orElse: Task[Boolean] = z1.orElse(z2).catchAllCause {
           case Then(Die(FiberFailure(Traced(Fail(a: Throwable), _))), Traced(Die(b: Throwable), _)) =>
             Task(a.getMessage == "1" && b.getMessage == "2")
@@ -1159,8 +1159,8 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(orElse)(equalTo(true))
       },
       testM("left failed and right failed with kept cause") {
-        val z1                = Task.failNow(new Throwable("1"))
-        val z2: Task[Nothing] = Task.failNow(new Throwable("2"))
+        val z1                = Task.fail(new Throwable("1"))
+        val z2: Task[Nothing] = Task.fail(new Throwable("2"))
         val orElse: Task[Boolean] = z1.orElse(z2).catchAllCause {
           case Then(Die(FiberFailure(Traced(Fail(a: Throwable), _))), Traced(Fail(b: Throwable), _)) =>
             Task(a.getMessage == "1" && b.getMessage == "2")
@@ -1176,7 +1176,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(true).orElseFail(false))(isTrue)
       },
       testM("otherwise fails with the specified error") {
-        assertM(ZIO.failNow(false).orElseFail(true).flip)(isTrue)
+        assertM(ZIO.fail(false).orElseFail(true).flip)(isTrue)
       }
     ),
     suite("orElseSucceed")(
@@ -1185,21 +1185,21 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(true).orElseSucceed(false))(isTrue)
       },
       testM("otherwise succeeds with the specified value") {
-        assertM(ZIO.failNow(false).orElseSucceed(true))(isTrue)
+        assertM(ZIO.fail(false).orElseSucceed(true))(isTrue)
       }
     ),
     suite("parallelErrors")(
       testM("oneFailure") {
         for {
-          f1     <- IO.failNow("error1").fork
+          f1     <- IO.fail("error1").fork
           f2     <- IO.succeedNow("success1").fork
           errors <- f1.zip(f2).join.parallelErrors[String].flip
         } yield assert(errors)(equalTo(List("error1")))
       },
       testM("allFailures") {
         for {
-          f1     <- IO.failNow("error1").fork
-          f2     <- IO.failNow("error2").fork
+          f1     <- IO.fail("error1").fork
+          f2     <- IO.fail("error2").fork
           errors <- f1.zip(f2).join.parallelErrors[String].flip
         } yield assert(errors)(
           equalTo(List("error1", "error2")) ||
@@ -1219,13 +1219,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects only failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partition(in)(a => ZIO.failNow(a))
+          res <- ZIO.partition(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partition(in)(a => if (a % 2 == 0) ZIO.failNow(a) else ZIO.succeedNow(a))
+          res <- ZIO.partition(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("evaluates effects in correct order") {
@@ -1249,13 +1249,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionPar(in)(a => ZIO.failNow(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.failNow(a) else ZIO.succeedNow(a))
+          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
@@ -1270,13 +1270,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => ZIO.failNow(a))
+          res <- ZIO.partitionParN(3)(in)(a => ZIO.fail(a))
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       },
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.failNow(a) else ZIO.succeedNow(a))
+          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       }
     ),
@@ -1298,13 +1298,13 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("raceAll")(
       testM("returns first success") {
-        assertM(ZIO.failNow("Fail").raceAll(List(IO.succeedNow(24))))(equalTo(24))
+        assertM(ZIO.fail("Fail").raceAll(List(IO.succeedNow(24))))(equalTo(24))
       },
       testM("returns last failure") {
-        assertM(Live.live(ZIO.sleep(100.millis) *> ZIO.failNow(24)).raceAll(List(ZIO.failNow(25))).flip)(equalTo(24))
+        assertM(Live.live(ZIO.sleep(100.millis) *> ZIO.fail(24)).raceAll(List(ZIO.fail(25))).flip)(equalTo(24))
       } @@ flaky,
       testM("returns success when it happens after failure") {
-        assertM(ZIO.failNow(42).raceAll(List(IO.succeedNow(24) <* Live.live(ZIO.sleep(100.millis)))))(equalTo(24))
+        assertM(ZIO.fail(42).raceAll(List(IO.succeedNow(24) <* Live.live(ZIO.sleep(100.millis)))))(equalTo(24))
       }
     ),
     suite("reduceAllPar")(
@@ -1323,14 +1323,14 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("return error if zero is an error") {
-        val zeroElement  = ZIO.failNow(1)
+        val zeroElement  = ZIO.fail(1)
         val otherEffects = List(UIO.unit, UIO.unit)
         val reduced      = ZIO.reduceAllPar(zeroElement, otherEffects)((_, _) => ())
         assertM(reduced.run)(fails(equalTo(1)))
       },
       testM("return error if it exists in list") {
         val zeroElement = UIO.unit
-        val effects     = List(UIO.unit, ZIO.failNow(1))
+        val effects     = List(UIO.unit, ZIO.fail(1))
         val reduced     = ZIO.reduceAllPar(zeroElement, effects)((_, _) => ())
         assertM(reduced.run)(fails(equalTo(1)))
       }
@@ -1447,7 +1447,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeedNow(Left("Left")).right.either)(isLeft(isNone))
       },
       testM("on failure") {
-        assertM(ZIO.failNow("Fail").right.either)(isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").right.either)(isLeft(isSome(equalTo("Fail"))))
       }
     ),
     suite("refineToOrDie")(
@@ -1497,7 +1497,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("fails when given an exception") {
         val ex                               = new RuntimeException("Failed Task")
-        val task: IO[Option[Throwable], Int] = Task.failNow(ex).some
+        val task: IO[Option[Throwable], Int] = Task.fail(ex).some
         assertM(task.run)(fails(isSome(equalTo(ex))))
       }
     ),
@@ -1547,11 +1547,11 @@ object ZIOSpec extends ZIOBaseSpec {
           exactlyOnce(0)(_.rejectM[Any, String]({ case v if v != 0 => ZIO.succeedNow("Partial failed!") })).sandbox.either
 
         val partialBadCase =
-          exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.failNow("Partial failed!") })).sandbox.either
+          exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.fail("Partial failed!") })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         val badCase =
-          exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.failNow("Partial failed!") })).sandbox.either
+          exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.fail("Partial failed!") })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         assertM(goodCase)(isRight(equalTo(0))) &&
@@ -1667,7 +1667,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(l.zipWith(r)(_ && _))(isTrue)
       },
       testM("flip must make error into value") {
-        val io = IO.failNow(ExampleError).flip
+        val io = IO.fail(ExampleError).flip
         assertM(io)(equalTo(ExampleError))
       },
       testM("flip must make value into error") {
@@ -1723,7 +1723,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("catch failing finalizers with fail") {
         val io = IO
-          .failNow(ExampleError)
+          .fail(ExampleError)
           .ensuring(IO.effectTotal(throw InterruptCause1))
           .ensuring(IO.effectTotal(throw InterruptCause2))
           .ensuring(IO.effectTotal(throw InterruptCause3))
@@ -1737,7 +1737,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("catch failing finalizers with terminate") {
         val io = IO
-          .dieNow(ExampleError)
+          .die(ExampleError)
           .ensuring(IO.effectTotal(throw InterruptCause1))
           .ensuring(IO.effectTotal(throw InterruptCause2))
           .ensuring(IO.effectTotal(throw InterruptCause3))
@@ -1773,7 +1773,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val io =
           for {
             _ <- ZIO.succeedNow(42)
-            f <- ZIO.failNow("Uh oh!")
+            f <- ZIO.fail("Uh oh!")
           } yield f
 
         assertM(io.catchAllCause(ZIO.succeedNow))(equalTo(Cause.fail("Uh oh!")))
@@ -1787,7 +1787,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("fail ensuring") {
         var finalized = false
 
-        val io = Task.failNow(ExampleError).ensuring(IO.effectTotal { finalized = true; () })
+        val io = Task.fail(ExampleError).ensuring(IO.effectTotal { finalized = true; () })
 
         for {
           a1 <- assertM(io.run)(fails(equalTo(ExampleError)))
@@ -1800,7 +1800,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val cleanup: Cause[Throwable] => UIO[Unit] =
           _ => IO.effectTotal[Unit] { finalized = true; () }
 
-        val io = Task.failNow(ExampleError).onError(cleanup)
+        val io = Task.fail(ExampleError).onError(cleanup)
 
         for {
           a1 <- assertM(io.run)(fails(equalTo(ExampleError)))
@@ -1811,7 +1811,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val e2 = new Error("e2")
         val e3 = new Error("e3")
 
-        val io = TaskExampleError.ensuring(IO.dieNow(e2)).ensuring(IO.dieNow(e3))
+        val io = TaskExampleError.ensuring(IO.die(e2)).ensuring(IO.die(e3))
 
         val expectedCause: Cause[Throwable] =
           Cause.Then(Cause.fail(ExampleError), Cause.Then(Cause.die(e2), Cause.die(e3)))
@@ -1823,7 +1823,7 @@ object ZIOSpec extends ZIOBaseSpec {
 
         val io = IO
           .succeed[Int](42)
-          .ensuring(IO.dieNow(ExampleError))
+          .ensuring(IO.die(ExampleError))
           .fork
           .flatMap(_.await.flatMap[Any, Nothing, Any](e => UIO.effectTotal { reported = e }))
 
@@ -1841,11 +1841,11 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io.run)(fails(equalTo(ExampleError)))
       },
       testM("error in just release") {
-        val io = IO.bracket(IO.unit)(_ => IO.dieNow(ExampleError))(_ => IO.unit)
+        val io = IO.bracket(IO.unit)(_ => IO.die(ExampleError))(_ => IO.unit)
         assertM(io.run)(dies(equalTo(ExampleError)))
       },
       testM("error in just usage") {
-        val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.failNow(ExampleError))
+        val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.fail(ExampleError))
         assertM(io.run)(fails(equalTo(ExampleError)))
       },
       testM("rethrown caught error in acquisition") {
@@ -1853,7 +1853,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io.flip)(equalTo(ExampleError))
       },
       testM("rethrown caught error in release") {
-        val io = IO.bracket(IO.unit)(_ => IO.dieNow(ExampleError))(_ => IO.unit)
+        val io = IO.bracket(IO.unit)(_ => IO.die(ExampleError))(_ => IO.unit)
         assertM(io.run)(dies(equalTo(ExampleError)))
       },
       testM("rethrown caught error in usage") {
@@ -2060,7 +2060,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("effectAsyncM can fail before registering") {
         val zio = ZIO
-          .effectAsyncM[Any, String, Nothing](_ => ZIO.failNow("Ouch"))
+          .effectAsyncM[Any, String, Nothing](_ => ZIO.fail("Ouch"))
           .flip
 
         assertM(zio)(equalTo("Ouch"))
@@ -2108,7 +2108,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _ <- IO.effectAsync[Throwable, Unit] { k =>
                 latch.future.onComplete {
                   case Success(a) => k(IO.succeedNow(a))
-                  case Failure(t) => k(IO.failNow(t))
+                  case Failure(t) => k(IO.fail(t))
                 }(scala.concurrent.ExecutionContext.global)
               }
           _      <- fiber.interrupt
@@ -2170,15 +2170,15 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(Live.live(io))(equalTo(2))
       } @@ forked @@ flaky, // Due to weak supervision, this test is expected to fail sometimes
       testM("race of fail with success") {
-        val io = IO.failNow(42).race(IO.succeedNow(24)).either
+        val io = IO.fail(42).race(IO.succeedNow(24)).either
         assertM(io)(isRight(equalTo(24)))
       },
       testM("race of terminate with success") {
-        val io = IO.dieNow(new Throwable {}).race(IO.succeedNow(24))
+        val io = IO.die(new Throwable {}).race(IO.succeedNow(24))
         assertM(io)(equalTo(24))
       },
       testM("race of fail with fail") {
-        val io = IO.failNow(42).race(IO.failNow(42)).either
+        val io = IO.fail(42).race(IO.fail(42)).either
         assertM(io)(isLeft(equalTo(42)))
       },
       testM("race of value & never") {
@@ -2186,15 +2186,15 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io)(equalTo(42))
       },
       testM("firstSuccessOf of values") {
-        val io = IO.firstSuccessOf(IO.failNow(0), List(IO.succeedNow(100))).either
+        val io = IO.firstSuccessOf(IO.fail(0), List(IO.succeedNow(100))).either
         assertM(io)(isRight(equalTo(100)))
       },
       testM("firstSuccessOf of failures") {
-        val io = ZIO.firstSuccessOf(IO.failNow(0).delay(10.millis), List(IO.failNow(101))).either
+        val io = ZIO.firstSuccessOf(IO.fail(0).delay(10.millis), List(IO.fail(101))).either
         assertM(Live.live(io))(isLeft(equalTo(101)))
       },
       testM("firstSuccessOF of failures & 1 success") {
-        val io = ZIO.firstSuccessOf(IO.failNow(0), List(IO.succeedNow(102).delay(1.millis))).either
+        val io = ZIO.firstSuccessOf(IO.fail(0), List(IO.succeedNow(102).delay(1.millis))).either
         assertM(Live.live(io))(isRight(equalTo(102)))
       },
       testM("raceFirst interrupts loser on success") {
@@ -2250,11 +2250,11 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io)(equalTo(1))
       },
       testM("timeout of failure") {
-        val io = IO.failNow("Uh oh").timeout(1.hour)
+        val io = IO.fail("Uh oh").timeout(1.hour)
         assertM(Live.live(io).run)(fails(equalTo("Uh oh")))
       },
       testM("timeout of terminate") {
-        val io: ZIO[Clock, Nothing, Option[Int]] = IO.dieNow(ExampleError).timeout(1.hour)
+        val io: ZIO[Clock, Nothing, Option[Int]] = IO.die(ExampleError).timeout(1.hour)
         assertM(Live.live(io).run)(dies(equalTo(ExampleError)))
       }
     ),
@@ -2447,7 +2447,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           cont <- Promise.make[Nothing, Unit]
           p1   <- Promise.make[Nothing, Boolean]
-          f1   <- (cont.succeed(()) *> IO.never).catchAll(IO.failNow).ensuring(p1.succeed(true)).fork
+          f1   <- (cont.succeed(()) *> IO.never).catchAll(IO.fail).ensuring(p1.succeed(true)).fork
           _    <- cont.await
           _    <- f1.interrupt
           res  <- p1.await
@@ -2483,7 +2483,7 @@ object ZIOSpec extends ZIOBaseSpec {
           fiber <- withLatch { release =>
                     (release *> ZIO.never)
                       .ensuring(
-                        (ZIO.unit *> ZIO.failNow("Uh oh")).catchAll(_ => recovered.set(true))
+                        (ZIO.unit *> ZIO.fail("Uh oh")).catchAll(_ => recovered.set(true))
                       )
                       .fork
                   }
@@ -2603,7 +2603,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val io =
           for {
             finished <- Ref.make(false)
-            fiber    <- withLatch(release => (release *> ZIO.failNow("foo")).catchAll(_ => finished.set(true)).fork)
+            fiber    <- withLatch(release => (release *> ZIO.fail("foo")).catchAll(_ => finished.set(true)).fork)
             exit     <- fiber.interrupt
             finished <- finished.get
           } yield exit.interrupted == true || finished == true
@@ -2749,7 +2749,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("unsandbox")(
       testM("unwraps exception") {
-        val failure: IO[Cause[Exception], String] = IO.failNow(fail(new Exception("fail")))
+        val failure: IO[Cause[Exception], String] = IO.fail(fail(new Exception("fail")))
         val success: IO[Cause[Any], Int]          = IO.succeedNow(100)
         for {
           message <- failure.unsandbox.foldM(e => IO.succeedNow(e.getMessage), _ => IO.succeedNow("unexpected"))
@@ -2759,10 +2759,10 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("no information is lost during composition") {
         val causes = Gen.causes(Gen.anyString, Gen.throwable)
         def cause[R, E](zio: ZIO[R, E, Nothing]): ZIO[R, Nothing, Cause[E]] =
-          zio.foldCauseM(ZIO.succeedNow, ZIO.failNow)
+          zio.foldCauseM(ZIO.succeedNow, ZIO.fail)
         checkM(causes) { c =>
           for {
-            result <- cause(ZIO.haltNow(c).sandbox.mapErrorCause(e => e.untraced).unsandbox)
+            result <- cause(ZIO.halt(c).sandbox.mapErrorCause(e => e.untraced).unsandbox)
           } yield assert(result)(equalTo(c)) &&
             assert(result.prettyPrint)(equalTo(c.prettyPrint))
         }
@@ -2771,13 +2771,13 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("validate")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
-        val res = IO.validate(in)(a => ZIO.failNow(a)).flip
+        val res = IO.validate(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = ZIO.validate(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.failNow(a))
+        val res = ZIO.validate(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
@@ -2790,13 +2790,13 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("validatePar")(
       testM("returns all errors if never valid") {
         val in  = List.fill(1000)(0)
-        val res = IO.validatePar(in)(a => ZIO.failNow(a)).flip
+        val res = IO.validatePar(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("accumulate errors and ignore successes") {
         import zio.CanFail.canFail
         val in  = List.range(0, 10)
-        val res = ZIO.validatePar(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.failNow(a))
+        val res = ZIO.validatePar(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       },
       testM("accumulate successes") {
@@ -2809,13 +2809,13 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("validateFirst")(
       testM("returns all errors if never valid") {
         val in  = List.fill(10)(0)
-        val res = IO.validateFirst(in)(a => ZIO.failNow(a)).flip
+        val res = IO.validateFirst(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("runs sequentially and short circuits on first success validation") {
         import zio.CanFail.canFail
         val in = List.range(1, 10)
-        val f  = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.failNow(a)
+        val f  = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.fail(a)
 
         for {
           counter    <- Ref.make(0)
@@ -2826,20 +2826,20 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns errors in correct order") {
         val as = List(2, 4, 6, 3, 5, 6)
         for {
-          results <- ZIO.validateFirst(as)(ZIO.failNow).flip
+          results <- ZIO.validateFirst(as)(ZIO.fail(_)).flip
         } yield assert(results)(equalTo(List(2, 4, 6, 3, 5, 6)))
       }
     ),
     suite("validateFirstPar")(
       testM("returns all errors if never valid") {
         val in  = List.fill(1000)(0)
-        val res = IO.validateFirstPar(in)(a => ZIO.failNow(a)).flip
+        val res = IO.validateFirstPar(in)(a => ZIO.fail(a)).flip
         assertM(res)(equalTo(in))
       },
       testM("returns success if valid") {
         import zio.CanFail.canFail
         val in  = List.range(1, 10)
-        val f   = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.failNow(a)
+        val f   = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.fail(a)
         val res = ZIO.validateFirstPar(in)(f(_))
         assertM(res)(equalTo(6))
       }
@@ -2853,8 +2853,8 @@ object ZIOSpec extends ZIOBaseSpec {
           _         <- effectRef.set(2).when(true)
           val2      <- effectRef.get
           failure   = new Exception("expected")
-          _         <- IO.failNow(failure).when(false)
-          failed    <- IO.failNow(failure).when(true).either
+          _         <- IO.fail(failure).when(false)
+          failed    <- IO.fail(failure).when(true).either
         } yield {
           assert(val1)(equalTo(0)) &&
           assert(val2)(equalTo(2)) &&
@@ -2902,8 +2902,8 @@ object ZIOSpec extends ZIOBaseSpec {
           val2           <- effectRef.get
           conditionVal2  <- conditionRef.get
           failure        = new Exception("expected")
-          _              <- IO.failNow(failure).whenM(conditionFalse)
-          failed         <- IO.failNow(failure).whenM(conditionTrue).either
+          _              <- IO.fail(failure).whenM(conditionFalse)
+          failed         <- IO.fail(failure).whenM(conditionTrue).either
         } yield {
           assert(val1)(equalTo(0)) &&
           assert(conditionVal1)(equalTo(1)) &&
@@ -2962,7 +2962,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("toFuture")(
       testM("should fail with ZTrace attached") {
         for {
-          future <- ZIO.failNow(new Throwable(new IllegalArgumentException)).toFuture
+          future <- ZIO.fail(new Throwable(new IllegalArgumentException)).toFuture
           result <- ZIO.fromFuture(_ => future).either
         } yield assert(result)(isLeft(hasThrowableCause(hasThrowableCause(hasMessage(containsString("Fiber:Id("))))))
       }
@@ -2983,7 +2983,7 @@ object ZIOSpec extends ZIOBaseSpec {
         res   <- func(ref.update(_ + 1) *> ZIO.succeedNow(value))
         count <- ref.get
         _ <- if (count != 1) {
-              ZIO.failNow("Accessed more than once")
+              ZIO.fail("Accessed more than once")
             } else {
               ZIO.unit
             }
@@ -3001,12 +3001,12 @@ object ZIOSpec extends ZIOBaseSpec {
   val InterruptCause2 = new Throwable("Oh noes 2!")
   val InterruptCause3 = new Throwable("Oh noes 3!")
 
-  val TaskExampleError: Task[Int] = IO.failNow[Throwable](ExampleError)
+  val TaskExampleError: Task[Int] = IO.fail[Throwable](ExampleError)
 
   val TaskExampleDie: Task[Int] = IO.effectTotal(throw ExampleError)
 
   def asyncExampleError[A]: Task[A] =
-    IO.effectAsync[Throwable, A](_(IO.failNow(ExampleError)))
+    IO.effectAsync[Throwable, A](_(IO.fail(ExampleError)))
 
   def sum(n: Int): Int =
     if (n <= 0) 0
@@ -3035,7 +3035,7 @@ object ZIOSpec extends ZIOBaseSpec {
     else IO.unit *> deepErrorEffect(n - 1)
 
   def deepErrorFail(n: Int): Task[Unit] =
-    if (n == 0) IO.failNow(ExampleError)
+    if (n == 0) IO.fail(ExampleError)
     else IO.unit *> deepErrorFail(n - 1)
 
   def fib(n: Int): BigInt =

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -677,7 +677,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     testM("queue mapM with failure") {
       for {
         q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
-        _ <- q.offer(IO.failNow("Ouch"))
+        _ <- q.offer(IO.fail("Ouch"))
         v <- q.take.run
       } yield assert(v)(fails(equalTo("Ouch")))
     },

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -15,9 +15,9 @@
  */
 package zio.stm
 
+import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
-import zio.{ ZIO, ZIOBaseSpec }
 
 object TArraySpec extends ZIOBaseSpec {
 
@@ -33,8 +33,8 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
-          result <- ZIO.effect(tArray(-1)).run
-        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
+          result <- tArray(-1).commit.run
+        } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       }
     ),
     suite("collectFirst")(
@@ -746,8 +746,8 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
-          result <- ZIO.effect(tArray.update(-1, identity)).run
-        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
+          result <- tArray.update(-1, identity).commit.run
+        } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       }
     ),
     suite("updateM")(
@@ -760,8 +760,8 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(10)(0).commit
-          result <- ZIO.effect(tArray.updateM(10, STM.succeedNow)).run
-        } yield assert(result)(fails(isArrayIndexOutOfBoundsException))
+          result <- tArray.updateM(10, STM.succeedNow).commit.run
+        } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       },
       testM("updateM failure") {
         for {

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -113,7 +113,7 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
                      case Some(i) if i > 2 => STM.succeedNow(i.toString)
-                     case _                => STM.failNow(boom)
+                     case _                => STM.fail(boom)
                    }.commit.flip
         } yield assert(result)(equalTo(boom))
       },
@@ -122,7 +122,7 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
                      case Some(i) if i > 2 => STM.succeedNow(i.toString)
-                     case Some(7)          => STM.failNow(boom)
+                     case Some(7)          => STM.fail(boom)
                    }.commit
         } yield assert(result)(isSome(equalTo("4")))
       }
@@ -229,13 +229,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails for errors before witness") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => if (i == 4) STM.failNow(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.existsM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       },
       testM("fails for errors after witness") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => if (i == 6) STM.failNow(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.existsM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       }
     ),
@@ -325,13 +325,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("succeeds on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => if (i == 4) STM.failNow(boom) else STM.succeedNow(i % 7 == 0)).commit
+          result <- tArray.findLastM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 7 == 0)).commit
         } yield assert(result)(isSome(equalTo(7)))
       },
       testM("fails on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => if (i == 8) STM.failNow(boom) else STM.succeedNow(i % 7 == 0)).commit.flip
+          result <- tArray.findLastM(i => if (i == 8) STM.fail(boom) else STM.succeedNow(i % 7 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       }
     ),
@@ -365,13 +365,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => if (i == 4) STM.failNow(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
+          result <- tArray.findM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       },
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => if (i == 6) STM.failNow(boom) else STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.findM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit
         } yield assert(result)(isSome(equalTo(5)))
       }
     ),
@@ -410,7 +410,7 @@ object TArraySpec extends ZIOBaseSpec {
       },
       testM("returns effect failure") {
         def failInTheMiddle(acc: Int, a: Int): STM[Exception, Int] =
-          if (acc == N / 2) STM.failNow(boom) else STM.succeedNow(acc + a)
+          if (acc == N / 2) STM.fail(boom) else STM.succeedNow(acc + a)
 
         for {
           tArray <- makeTArray(N)(1).commit
@@ -460,13 +460,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails for errors before counterexample") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => if (i == 4) STM.failNow(boom) else STM.succeedNow(i != 5)).commit.flip
+          result <- tArray.forallM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i != 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       },
       testM("fails for errors after counterexample") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => if (i == 6) STM.failNow(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.forallM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       }
     ),
@@ -630,19 +630,19 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 4) STM.failNow(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
+          result <- tArray.indexWhereM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       },
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 6) STM.failNow(boom) else STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.indexWhereM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit
         } yield assert(result)(equalTo(4))
       },
       testM("succeeds when error excluded by offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 1) STM.failNow(boom) else STM.succeedNow(i % 5 == 0), 2).commit
+          result <- tArray.indexWhereM(i => if (i == 1) STM.fail(boom) else STM.succeedNow(i % 5 == 0), 2).commit
         } yield assert(result)(equalTo(4))
       }
     ),
@@ -731,7 +731,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray(N)(0).commit
           _      <- tArray.update(N / 2, _ => 1).commit
-          result <- tArray.transformM(a => if (a == 0) STM.succeedNow(42) else STM.failNow(boom)).commit.either
+          result <- tArray.transformM(a => if (a == 0) STM.succeedNow(42) else STM.fail(boom)).commit.either
           first  <- tArray(0).commit
         } yield assert(result.left.map(r => (first, r)))(isLeft(equalTo((0, boom))))
       }
@@ -766,7 +766,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("updateM failure") {
         for {
           tArray <- makeTArray(n)(0).commit
-          result <- tArray.updateM(0, _ => STM.failNow(boom)).commit.either
+          result <- tArray.updateM(0, _ => STM.fail(boom)).commit.either
         } yield assert(result)(isLeft(equalTo(boom)))
       }
     ),
@@ -856,7 +856,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails on errors") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.failNow(boom) else STM.succeedNow(a + b)).commit.flip
+          result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.fail(boom) else STM.succeedNow(a + b)).commit.flip
         } yield assert(result)(equalTo(boom))
       }
     )

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -131,7 +131,7 @@ package object blocking {
                                 Thread.interrupted // Clear interrupt status
                                 ZIO.interrupt
                               case t: Throwable =>
-                                ZIO.failNow(t)
+                                ZIO.fail(t)
                             } finally {
                               withMutex { thread.set(None); end.set(()) }
                             }

--- a/core/shared/src/main/scala/zio/Example.scala
+++ b/core/shared/src/main/scala/zio/Example.scala
@@ -1,0 +1,24 @@
+import java.time.{ LocalDateTime }
+
+import zio.clock.Clock
+import zio.console.{ putStrLn, Console }
+import zio.duration._
+import zio.{ Schedule, Task, ZIO }
+
+object BrokenUnsafeRunToFutureReproducer extends zio.App {
+  override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] = {
+    val effect = ZIO
+      .effectSuspendTotal(putStrLn(s"Current time is ${LocalDateTime.now}"))
+      .delay(1.second)
+
+    val toFutureAndBackToEffect = for {
+      rt <- ZIO.runtime[Console with Clock]
+      _  <- Task.fromFuture(_ => rt.unsafeRunToFuture(effect))
+    } yield ()
+
+    toFutureAndBackToEffect
+      .repeat(Schedule.fixed(1.second))
+      .orDie
+      .as(0)
+  }
+}

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -723,13 +723,5 @@ object IO {
       ZIO.bracket(acquire, release, use)
   }
 
-  private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
-
-  private[zio] def doneNow[E, A](r: Exit[E, A]): IO[E, A] = ZIO.doneNow(r)
-
-  private[zio] def failNow[E](error: E): IO[E, Nothing] = ZIO.failNow(error)
-
-  private[zio] def haltNow[E](cause: Cause[E]): IO[E, Nothing] = ZIO.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): UIO[A] = ZIO.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -385,18 +385,6 @@ object Managed {
   def whenM[E](b: Managed[E, Boolean])(managed: Managed[E, Any]): Managed[E, Unit] =
     ZManaged.whenM(b)(managed)
 
-  private[zio] def dieNow(t: Throwable): Managed[Nothing, Nothing] =
-    ZManaged.dieNow(t)
-
-  private[zio] def failNow[E](error: E): Managed[E, Nothing] =
-    ZManaged.failNow(error)
-
-  private[zio] def haltNow[E](cause: Cause[E]): Managed[E, Nothing] =
-    ZManaged.haltNow(cause)
-
-  private[zio] def doneNow[E, A](r: Exit[E, A]): Managed[E, A] =
-    ZManaged.doneNow(r)
-
   private[zio] def succeedNow[A](r: A): Managed[Nothing, A] =
     ZManaged.succeedNow(r)
 }

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -76,13 +76,13 @@ final class Promise[E, A] private (private val state: AtomicReference[State[E, A
    * Kills the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
-  def die(e: Throwable): UIO[Boolean] = completeWith(IO.dieNow(e))
+  def die(e: Throwable): UIO[Boolean] = completeWith(IO.die(e))
 
   /**
    * Exits the promise with the specified exit, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
-  def done(e: Exit[E, A]): UIO[Boolean] = completeWith(IO.doneNow(e))
+  def done(e: Exit[E, A]): UIO[Boolean] = completeWith(IO.done(e))
 
   /**
    * Completes the promise with the result of the specified effect. If the
@@ -137,13 +137,13 @@ final class Promise[E, A] private (private val state: AtomicReference[State[E, A
    * Fails the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
-  def fail(e: E): UIO[Boolean] = completeWith(IO.failNow(e))
+  def fail(e: E): UIO[Boolean] = completeWith(IO.fail(e))
 
   /**
    * Halts the promise with the specified cause, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
-  def halt(e: Cause[E]): UIO[Boolean] = completeWith(IO.haltNow(e))
+  def halt(e: Cause[E]): UIO[Boolean] = completeWith(IO.halt(e))
 
   /**
    * Completes the promise with interruption. This will interrupt all fibers

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -739,13 +739,5 @@ object RIO {
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
 
-  private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
-
-  private[zio] def doneNow[A](r: Exit[Throwable, A]): Task[A] = ZIO.doneNow(r)
-
-  private[zio] def failNow(error: Throwable): Task[Nothing] = ZIO.failNow(error)
-
-  private[zio] def haltNow(cause: Cause[Throwable]): Task[Nothing] = ZIO.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): UIO[A] = ZIO.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -235,7 +235,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     updated(update =>
       (a, s) =>
         test(a, self.extract(a, s)).flatMap {
-          case false => ZIO.failNow(())
+          case false => ZIO.fail(())
           case true  => update(a, s)
         }
     )
@@ -553,7 +553,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     updated(update =>
       (a, s) =>
         f(a).flatMap {
-          case true  => ZIO.failNow(())
+          case true  => ZIO.fail(())
           case false => update(a, s)
         }
     )
@@ -572,7 +572,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     updated(update =>
       (a, s) =>
         f(self.extract(a, s)).flatMap {
-          case true  => ZIO.failNow(())
+          case true  => ZIO.fail(())
           case false => update(a, s)
         }
     )
@@ -718,7 +718,7 @@ object Schedule {
       type State = Unit
       val initial = ZIO.unit
       val extract = (a: A, _: Unit) => pf.lift(a)
-      val update  = (a: A, _: Unit) => pf.lift(a).fold[IO[Unit, Unit]](ZIO.succeedNow(()))(_ => ZIO.failNow(()))
+      val update  = (a: A, _: Unit) => pf.lift(a).fold[IO[Unit, Unit]](ZIO.succeedNow(()))(_ => ZIO.fail(()))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -137,7 +137,7 @@ private object internals {
 
   def assertNonNegative(n: Long): UIO[Unit] =
     if (n < 0)
-      IO.dieNow(new NegativeArgument(s"Unexpected negative value `$n` passed to acquireN or releaseN."))
+      IO.die(new NegativeArgument(s"Unexpected negative value `$n` passed to acquireN or releaseN."))
     else IO.unit
 
   final class NegativeArgument(message: String) extends IllegalArgumentException(message)

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -676,13 +676,5 @@ object Task extends TaskPlatformSpecific {
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
 
-  private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
-
-  private[zio] def doneNow[A](r: Exit[Throwable, A]): Task[A] = ZIO.doneNow(r)
-
-  private[zio] def failNow(error: Throwable): Task[Nothing] = ZIO.failNow(error)
-
-  private[zio] def haltNow(cause: Cause[Throwable]): Task[Nothing] = ZIO.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): UIO[A] = ZIO.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -590,11 +590,5 @@ object UIO {
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
 
-  private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
-
-  private[zio] def doneNow[A](r: Exit[Nothing, A]): UIO[A] = ZIO.doneNow(r)
-
-  private[zio] def haltNow(cause: Cause[Nothing]): UIO[Nothing] = ZIO.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): UIO[A] = ZIO.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -652,11 +652,5 @@ object URIO {
    */
   val yieldNow: UIO[Unit] = ZIO.yieldNow
 
-  private[zio] def dieNow(t: Throwable): UIO[Nothing] = ZIO.dieNow(t)
-
-  private[zio] def doneNow[A](r: Exit[Nothing, A]): UIO[A] = ZIO.doneNow(r)
-
-  private[zio] def haltNow(cause: Cause[Nothing]): UIO[Nothing] = ZIO.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): UIO[A] = ZIO.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -45,7 +45,7 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
    * outputs of the specified layer.
    */
   def >>>[E1 >: E, ROut2 <: Has[_]](that: ZLayer[ROut, E1, ROut2]): ZLayer[RIn, E1, ROut2] =
-    fold(ZLayer.fromFunctionManyM(ZIO.failNow), that)
+    fold(ZLayer.fromFunctionManyM(ZIO.fail(_)), that)
 
   /**
    * Combines this layer with the specified layer, producing a new layer that
@@ -108,7 +108,7 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
    * function.
    */
   def mapError[E1](f: E => E1): ZLayer[RIn, E1, ROut] =
-    fold(ZLayer.fromFunctionManyM(f andThen ZIO.failNow), ZLayer.identity)
+    fold(ZLayer.fromFunctionManyM(e => ZIO.fail(f(e))), ZLayer.identity)
 
   /**
    * Converts a layer that requires no services into a managed runtime, which

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -160,7 +160,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   def absorbWith(f: E => Throwable): ZManaged[R, Throwable, A] =
     self.sandbox
       .foldM(
-        cause => ZManaged.failNow(cause.squashWith(f)),
+        cause => ZManaged.fail(cause.squashWith(f)),
         ZManaged.succeedNow
       )
 
@@ -227,7 +227,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   def catchSome[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[E, ZManaged[R1, E1, A1]]
   )(implicit ev: CanFail[E]): ZManaged[R1, E1, A1] =
-    foldM(pf.applyOrElse[E, ZManaged[R1, E1, A1]](_, ZManaged.failNow), ZManaged.succeedNow)
+    foldM(pf.applyOrElse[E, ZManaged[R1, E1, A1]](_, ZManaged.fail(_)), ZManaged.succeedNow)
 
   /**
    * Recovers from some or all of the error Causes.
@@ -235,7 +235,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   def catchSomeCause[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[Cause[E], ZManaged[R1, E1, A1]]
   ): ZManaged[R1, E1, A1] =
-    foldCauseM(pf.applyOrElse[Cause[E], ZManaged[R1, E1, A1]](_, ZManaged.haltNow), ZManaged.succeedNow)
+    foldCauseM(pf.applyOrElse[Cause[E], ZManaged[R1, E1, A1]](_, ZManaged.halt(_)), ZManaged.succeedNow)
 
   /**
    * Fail with `e` if the supplied `PartialFunction` does not match, otherwise
@@ -249,7 +249,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * continue with the returned value.
    */
   def collectM[R1 <: R, E1 >: E, B](e: => E1)(pf: PartialFunction[A, ZManaged[R1, E1, B]]): ZManaged[R1, E1, B] =
-    self.flatMap(v => pf.applyOrElse[A, ZManaged[R1, E1, B]](v, _ => ZManaged.failNow(e)))
+    self.flatMap(v => pf.applyOrElse[A, ZManaged[R1, E1, B]](v, _ => ZManaged.fail(e)))
 
   /**
    * Executes the second effect and then provides its output as an environment to this effect
@@ -319,7 +319,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
             for {
               fs    <- finalizers.get
               exits <- ZIO.foreach(fs)(_(exitU).run)
-              _     <- ZIO.doneNow(Exit.collectAll(exits).getOrElse(Exit.unit))
+              _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
             } yield ()
         )
       }
@@ -344,7 +344,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Flip the error and result
     **/
   def flip: ZManaged[R, A, E] =
-    foldM(ZManaged.succeedNow, ZManaged.failNow)
+    foldM(ZManaged.succeedNow, ZManaged.fail(_))
 
   /**
    * Flip the error and result, then apply an effectful function to the effect
@@ -411,7 +411,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
             for {
               fs    <- finalizers.get
               exits <- ZIO.foreach(fs)(_(exitU).run)
-              _     <- ZIO.doneNow(Exit.collectAll(exits).getOrElse(Exit.unit))
+              _     <- ZIO.done(Exit.collectAll(exits).getOrElse(Exit.unit))
             } yield ()
         )
       }
@@ -490,7 +490,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
                 ZIO.uninterruptibleMask { restore =>
                   self.provide(r).reserve.flatMap(res => restore(res.acquire).run.map(e => e -> Some(res -> e)))
                 }
-            }.flatMap(ZIO.doneNow)
+            }.flatMap(ZIO.done(_))
 
           val acquire2: ZIO[R, Nothing, ZManaged[Any, E, A]] =
             ZIO.succeedNow(acquire1.toManaged_)
@@ -562,7 +562,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * the specified function to convert the `E` into a `Throwable`.
    */
   def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, Nothing, A] =
-    mapError(f).catchAll(ZManaged.dieNow)
+    mapError(f).catchAll(ZManaged.die(_))
 
   /**
    * Executes this effect and returns its value, if it succeeds, but
@@ -585,7 +585,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * otherwise fails with the specified error.
    */
   final def orElseFail[E1](e1: => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
-    orElse(ZManaged.failNow(e1))
+    orElse(ZManaged.fail(e1))
 
   /**
    * Executes this effect and returns its value, if it succeeds, but
@@ -716,7 +716,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   def refineOrDieWith[E1](
     pf: PartialFunction[E, E1]
   )(f: E => Throwable)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
-    catchAll(e => pf.lift(e).fold[ZManaged[R, E1, A]](ZManaged.dieNow(f(e)))(ZManaged.failNow))
+    catchAll(e => pf.lift(e).fold[ZManaged[R, E1, A]](ZManaged.die(f(e)))(ZManaged.fail(_)))
 
   /**
    * Retries with the specified retry policy.
@@ -731,7 +731,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
           policy
             .update(err, state)
             .foldM(
-              _ => ZIO.failNow(err),
+              _ => ZIO.fail(err),
               loop(zio, _)
             ),
         succ => ZIO.succeedNow((state, succ))
@@ -849,7 +849,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
               case (leftDone, rightFiber) =>
                 rightFiber.interrupt.flatMap(_ =>
                   leftDone.foldM(
-                    ZIO.haltNow,
+                    ZIO.halt(_),
                     succ => clock.nanoTime.map(end => Some((Duration.fromNanos(end - start), succ)))
                   )
                 )
@@ -1190,7 +1190,7 @@ object ZManaged {
               case Running(finalizers) =>
                 for {
                   exits <- f(finalizers.map(_(exit)))
-                  _     <- ZIO.doneNow(Exit.collectAllPar(exits).getOrElse(Exit.unit))
+                  _     <- ZIO.done(Exit.collectAllPar(exits).getOrElse(Exit.unit))
                 } yield ()
               case _ => UIO.unit
             }
@@ -1479,7 +1479,7 @@ object ZManaged {
    * Lifts an `Either` into a `ZManaged` value.
    */
   def fromEither[E, A](v: => Either[E, A]): ZManaged[Any, E, A] =
-    effectTotal(v).flatMap(_.fold(failNow, succeedNow))
+    effectTotal(v).flatMap(_.fold(fail(_), succeedNow))
 
   /**
    * Lifts a function `R => A` into a `ZManaged[R, Nothing, A]`.
@@ -1514,7 +1514,7 @@ object ZManaged {
    * method.
    */
   val interrupt: ZManaged[Any, Nothing, Nothing] =
-    ZManaged.fromEffect(ZIO.descriptor).flatMap(d => haltNow(Cause.interrupt(d.id)))
+    ZManaged.fromEffect(ZIO.descriptor).flatMap(d => halt(Cause.interrupt(d.id)))
 
   /**
    * Returns an effect that is interrupted as if by the specified fiber.
@@ -1856,7 +1856,7 @@ object ZManaged {
    * value, then the specified error will be raised.
    */
   def require[R, E, A](error: => E): ZManaged[R, E, Option[A]] => ZManaged[R, E, A] =
-    (zManaged: ZManaged[R, E, Option[A]]) => zManaged.flatMap(_.fold[ZManaged[R, E, A]](failNow(error))(succeedNow))
+    (zManaged: ZManaged[R, E, Option[A]]) => zManaged.flatMap(_.fold[ZManaged[R, E, A]](fail(error))(succeedNow))
 
   /**
    * Lifts a pure `Reservation[R, E, A]` into `ZManaged[R, E, A]`
@@ -2008,18 +2008,6 @@ object ZManaged {
    */
   def whenM[R, E](b: ZManaged[R, E, Boolean])(zManaged: ZManaged[R, E, Any]): ZManaged[R, E, Unit] =
     b.flatMap(b => if (b) zManaged.unit else unit)
-
-  private[zio] def dieNow(t: Throwable): ZManaged[Any, Nothing, Nothing] =
-    halt(Cause.die(t))
-
-  private[zio] def doneNow[E, A](r: Exit[E, A]): ZManaged[Any, E, A] =
-    ZManaged.fromEffect(ZIO.doneNow(r))
-
-  private[zio] def failNow[E](error: E): ZManaged[Any, E, Nothing] =
-    haltNow(Cause.fail(error))
-
-  private[zio] def haltNow[E](cause: Cause[E]): ZManaged[Any, E, Nothing] =
-    ZManaged.fromEffect(ZIO.haltNow(cause))
 
   private[zio] def succeedNow[R, A](r: A): ZManaged[R, Nothing, A] =
     ZManaged(IO.succeedNow(Reservation(IO.succeedNow(r), _ => IO.unit)))

--- a/core/shared/src/main/scala/zio/internal/package.scala
+++ b/core/shared/src/main/scala/zio/internal/package.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import zio.stm.ZSTM
+
+package object internal {
+
+  /**
+   * Returns an effect that models success with the specified value.
+   */
+  def ZIOSucceedNow[A](a: A): ZIO[Any, Nothing, A] =
+    ZIO.succeedNow(a)
+
+  /**
+   * Lifts an eager, pure value into a Managed.
+   */
+  def ZManagedSucceedNow[A](r: A): ZManaged[Any, Nothing, A] =
+    ZManaged(IO.succeedNow(Reservation(IO.succeedNow(r), _ => IO.unit)))
+
+  /**
+   * Returns an `STM` effect that succeeds with the specified value.
+   */
+  def ZSTMSucceedNow[A](a: A): ZSTM[Any, Nothing, A] =
+    ZSTM.succeedNow(a)
+}

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -67,7 +67,7 @@ package object random {
 
     protected[zio] def nextLongWith(nextLong: UIO[Long], n: Long): UIO[Long] =
       if (n <= 0)
-        UIO.dieNow(new IllegalArgumentException("n must be positive"))
+        UIO.die(new IllegalArgumentException("n must be positive"))
       else {
         nextLong.flatMap { r =>
           val m = n - 1

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -317,15 +317,6 @@ object STM {
    */
   def whenM[E](b: STM[E, Boolean])(stm: STM[E, Any]): STM[E, Unit] = ZSTM.whenM(b)(stm)
 
-  private[zio] def dieNow(t: Throwable): STM[Nothing, Nothing] =
-    ZSTM.dieNow(t)
-
-  private[zio] def doneNow[E, A](exit: => ZSTM.internal.TExit[E, A]): STM[E, A] =
-    ZSTM.doneNow(exit)
-
-  private[zio] def failNow[E](e: E): STM[E, Nothing] =
-    ZSTM.failNow(e)
-
   private[zio] def succeedNow[A](a: A): STM[Nothing, A] =
     ZSTM.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -26,7 +26,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    */
   def apply(index: Int): STM[Nothing, A] =
     if (0 <= index && index < array.length) array(index).get
-    else STM.dieNow(new ArrayIndexOutOfBoundsException(index))
+    else STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Finds the result of applying a partial function to the first value in its domain.
@@ -277,7 +277,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    */
   def update(index: Int, fn: A => A): STM[Nothing, Unit] =
     if (0 <= index && index < array.length) array(index).update(fn)
-    else STM.dieNow(new ArrayIndexOutOfBoundsException(index))
+    else STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Atomically updates element in the array with given transactional effect.
@@ -289,7 +289,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         newVal     <- fn(currentVal)
         _          <- array(index).set(newVal)
       } yield ()
-    else STM.dieNow(new ArrayIndexOutOfBoundsException(index))
+    else STM.die(new ArrayIndexOutOfBoundsException(index))
 }
 
 object TArray {

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -39,7 +39,7 @@ final class TSemaphore private (val permits: TRef[Long]) extends AnyVal {
 
   private def assertNonNegative(n: Long): STM[Nothing, Unit] =
     if (n < 0)
-      STM.dieNow(new RuntimeException(s"Unexpected negative value `$n` passed to acquireN or releaseN."))
+      STM.die(new RuntimeException(s"Unexpected negative value `$n` passed to acquireN or releaseN."))
     else STM.unit
 }
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -182,7 +182,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * the specified pair of functions, `f` and `g`.
    */
   def bimap[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZSTM[R, E2, B] =
-    foldM(e => ZSTM.failNow(f(e)), a => ZSTM.succeedNow(g(a)))
+    foldM(e => ZSTM.fail(f(e)), a => ZSTM.succeedNow(g(a)))
 
   /**
    * Recovers from all errors.
@@ -196,7 +196,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def catchSome[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[E, ZSTM[R1, E1, A1]]
   )(implicit ev: CanFail[E]): ZSTM[R1, E1, A1] =
-    catchAll(pf.applyOrElse(_, (e: E) => ZSTM.failNow(e)))
+    catchAll(pf.applyOrElse(_, (e: E) => ZSTM.fail(e)))
 
   /**
    * Simultaneously filters and maps the value produced by this effect.
@@ -210,7 +210,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def collectM[R1 <: R, E1 >: E, B](pf: PartialFunction[A, ZSTM[R1, E1, B]]): ZSTM[R1, E1, B] =
     self.continueWithM {
-      case TExit.Fail(e)    => ZSTM.failNow(e)
+      case TExit.Fail(e)    => ZSTM.fail(e)
       case TExit.Succeed(a) => if (pf.isDefinedAt(a)) pf(a) else ZSTM.retry
       case TExit.Retry      => ZSTM.retry
     }
@@ -257,7 +257,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * if the full transaction fails, everything will be rolled back.
    */
   def ensuring[R1 <: R](finalizer: ZSTM[R1, Nothing, Any]): ZSTM[R1, E, A] =
-    foldM(e => finalizer *> ZSTM.failNow(e), a => finalizer *> ZSTM.succeedNow(a))
+    foldM(e => finalizer *> ZSTM.fail(e), a => finalizer *> ZSTM.succeedNow(a))
 
   /**
    * Returns an effect that ignores errors and runs repeatedly until it eventually succeeds.
@@ -269,7 +269,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Dies with specified `Throwable` if the predicate fails.
    */
   def filterOrDie(p: A => Boolean)(t: => Throwable): ZSTM[R, E, A] =
-    filterOrElse_(p)(ZSTM.dieNow(t))
+    filterOrElse_(p)(ZSTM.die(t))
 
   /**
    * Dies with a [[java.lang.RuntimeException]] having the specified text message
@@ -294,7 +294,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Fails with `e` if the predicate fails.
    */
   def filterOrFail[E1 >: E](p: A => Boolean)(e: => E1): ZSTM[R, E1, A] =
-    filterOrElse_[R, E1, A](p)(ZSTM.failNow(e))
+    filterOrElse_[R, E1, A](p)(ZSTM.fail(e))
 
   /**
    * Feeds the value produced by this effect to the specified function,
@@ -303,7 +303,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def flatMap[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
     self.continueWithM {
       case TExit.Succeed(a) => f(a)
-      case TExit.Fail(e)    => ZSTM.failNow(e)
+      case TExit.Fail(e)    => ZSTM.fail(e)
       case TExit.Retry      => ZSTM.retry
     }
 
@@ -332,7 +332,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * flipping back.
    */
   def flip(implicit ev: CanFail[E]): ZSTM[R, A, E] =
-    foldM(ZSTM.succeedNow, ZSTM.failNow)
+    foldM(ZSTM.succeedNow, ZSTM.fail(_))
 
   /**
    *  Swaps the error/value parameters, applies the function `f` and flips the parameters back
@@ -375,7 +375,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): ZSTM[R, Unit, B] =
     foldM(
       ev1,
-      ev2(_).fold[ZSTM[R, Unit, B]](ZSTM.failNow(()))(ZSTM.succeedNow(_))
+      ev2(_).fold[ZSTM[R, Unit, B]](ZSTM.fail(()))(ZSTM.succeedNow(_))
     )
 
   /**
@@ -384,8 +384,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def head[B](implicit ev: A <:< List[B]): ZSTM[R, Option[E], B] =
     foldM(
-      e => ZSTM.failNow(Some(e)),
-      ev(_).headOption.fold[ZSTM[R, Option[E], B]](ZSTM.failNow(None))(ZSTM.succeedNow)
+      e => ZSTM.fail(Some(e)),
+      ev(_).headOption.fold[ZSTM[R, Option[E], B]](ZSTM.fail(None))(ZSTM.succeedNow)
     )
 
   /**
@@ -398,8 +398,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def left[B, C](implicit ev: A <:< Either[B, C]): ZSTM[R, Option[E], B] =
     foldM(
-      e => ZSTM.failNow(Some(e)),
-      a => ev(a).fold(ZSTM.succeedNow, _ => ZSTM.failNow(None))
+      e => ZSTM.fail(Some(e)),
+      a => ev(a).fold(ZSTM.succeedNow, _ => ZSTM.fail(None))
     )
 
   /**
@@ -407,7 +407,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def leftOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A <:< Either[B, C]): ZSTM[R, E1, B] =
     flatMap(ev(_) match {
-      case Right(_)    => ZSTM.failNow(e)
+      case Right(_)    => ZSTM.fail(e)
       case Left(value) => ZSTM.succeedNow(value)
     })
 
@@ -420,8 +420,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
     ev2: E <:< E1
   ): ZSTM[R, E1, B] =
     foldM(
-      e => ZSTM.failNow(ev2(e)),
-      a => ev(a).fold(ZSTM.succeedNow(_), _ => ZSTM.failNow(new NoSuchElementException("Either.left.get on Right")))
+      e => ZSTM.fail(ev2(e)),
+      a => ev(a).fold(ZSTM.succeedNow(_), _ => ZSTM.fail(new NoSuchElementException("Either.left.get on Right")))
     )
 
   /**
@@ -430,7 +430,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def map[B](f: A => B): ZSTM[R, E, B] =
     self.continueWithM {
       case TExit.Succeed(a) => ZSTM.succeedNow(f(a))
-      case TExit.Fail(e)    => ZSTM.failNow(e)
+      case TExit.Fail(e)    => ZSTM.fail(e)
       case TExit.Retry      => ZSTM.retry
     }
 
@@ -440,7 +440,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZSTM[R, E1, A] =
     self.continueWithM {
       case TExit.Succeed(a) => ZSTM.succeedNow(a)
-      case TExit.Fail(e)    => ZSTM.failNow(f(e))
+      case TExit.Fail(e)    => ZSTM.fail(f(e))
       case TExit.Retry      => ZSTM.retry
     }
 
@@ -456,8 +456,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def none[B](implicit ev: A <:< Option[B]): ZSTM[R, Option[E], Unit] =
     self.foldM(
-      e => ZSTM.failNow(Some(e)),
-      _.fold[ZSTM[R, Option[E], Unit]](ZSTM.unit)(_ => ZSTM.failNow(None))
+      e => ZSTM.fail(Some(e)),
+      _.fold[ZSTM[R, Option[E], Unit]](ZSTM.unit)(_ => ZSTM.fail(None))
     )
 
   /**
@@ -503,7 +503,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def optional[E1](implicit ev: E <:< Option[E1]): ZSTM[R, E1, Option[A]] =
     foldM(
-      _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.failNow(_)),
+      _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.fail(_)),
       a => ZSTM.succeedNow(Some(a))
     )
 
@@ -520,7 +520,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * into a `Throwable`.
    */
   def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZSTM[R, Nothing, A] =
-    mapError(f).catchAll(ZSTM.dieNow)
+    mapError(f).catchAll(ZSTM.die(_))
 
   /**
    * Named alias for `<>`.
@@ -567,7 +567,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Tries this effect first, and if it fails, fails with the specified error.
    */
   def orElseFail[E1](e1: => E1)(implicit ev: CanFail[E]): ZSTM[R, E1, A] =
-    orElse(ZSTM.failNow(e1))
+    orElse(ZSTM.fail(e1))
 
   /**
    * Tries this effect first, and if it fails, succeeds with the specified
@@ -616,14 +616,14 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * the specified function to convert the `E` into a `Throwable`.
    */
   def refineOrDieWith[E1](pf: PartialFunction[E, E1])(f: E => Throwable)(implicit ev: CanFail[E]): ZSTM[R, E1, A] =
-    self.catchAll(err => (pf.lift(err)).fold[ZSTM[R, E1, A]](ZSTM.dieNow(f(err)))(ZSTM.failNow(_)))
+    self.catchAll(err => (pf.lift(err)).fold[ZSTM[R, E1, A]](ZSTM.die(f(err)))(ZSTM.fail(_)))
 
   /**
    * Fail with the returned value if the `PartialFunction` matches, otherwise
    * continue with our held value.
    */
   def reject[R1 <: R, E1 >: E](pf: PartialFunction[A, E1]): ZSTM[R1, E1, A] =
-    rejectM(pf.andThen(ZSTM.failNow(_)))
+    rejectM(pf.andThen(ZSTM.fail(_)))
 
   /**
    * Continue with the returned computation if the `PartialFunction` matches,
@@ -632,7 +632,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def rejectM[R1 <: R, E1 >: E](pf: PartialFunction[A, ZSTM[R1, E1, E1]]): ZSTM[R1, E1, A] =
     self.flatMap { v =>
-      pf.andThen[ZSTM[R1, E1, A]](_.flatMap(ZSTM.failNow))
+      pf.andThen[ZSTM[R1, E1, A]](_.flatMap(ZSTM.fail(_)))
         .applyOrElse[A, ZSTM[R1, E1, A]](v, ZSTM.succeedNow)
     }
 
@@ -659,8 +659,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def right[B, C](implicit ev: A <:< Either[B, C]): ZSTM[R, Option[E], C] =
     self.foldM(
-      e => ZSTM.failNow(Some(e)),
-      a => ev(a).fold(_ => ZSTM.failNow(None), ZSTM.succeedNow)
+      e => ZSTM.fail(Some(e)),
+      a => ev(a).fold(_ => ZSTM.fail(None), ZSTM.succeedNow)
     )
 
   /**
@@ -670,7 +670,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A <:< Either[B, C]): ZSTM[R, E1, C] =
     self.flatMap(ev(_) match {
       case Right(value) => ZSTM.succeedNow(value)
-      case Left(_)      => ZSTM.failNow(e)
+      case Left(_)      => ZSTM.fail(e)
     })
 
   /**
@@ -682,8 +682,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
     ev2: E <:< E1
   ): ZSTM[R, E1, C] =
     self.foldM(
-      e => ZSTM.failNow(ev2(e)),
-      a => ev(a).fold(_ => ZSTM.failNow(new NoSuchElementException("Either.right.get on Left")), ZSTM.succeedNow(_))
+      e => ZSTM.fail(ev2(e)),
+      a => ev(a).fold(_ => ZSTM.fail(new NoSuchElementException("Either.right.get on Left")), ZSTM.succeedNow(_))
     )
 
   /**
@@ -691,15 +691,15 @@ final class ZSTM[-R, +E, +A] private[stm] (
    */
   def some[B](implicit ev: A <:< Option[B]): ZSTM[R, Option[E], B] =
     self.foldM(
-      e => ZSTM.failNow(Some(e)),
-      _.fold[ZSTM[R, Option[E], B]](ZSTM.failNow(Option.empty[E]))(ZSTM.succeedNow)
+      e => ZSTM.fail(Some(e)),
+      _.fold[ZSTM[R, Option[E], B]](ZSTM.fail(Option.empty[E]))(ZSTM.succeedNow)
     )
 
   /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZSTM[R, E1, B] =
-    flatMap(_.fold[ZSTM[R, E1, B]](ZSTM.failNow(e))(ZSTM.succeedNow))
+    flatMap(_.fold[ZSTM[R, E1, B]](ZSTM.fail(e))(ZSTM.succeedNow))
 
   /**
    * Extracts the optional value, or fails with a [[java.util.NoSuchElementException]]
@@ -709,8 +709,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
     ev2: NoSuchElementException <:< E1
   ): ZSTM[R, E1, B] =
     foldM(
-      ZSTM.failNow,
-      _.fold[ZSTM[R, E1, B]](ZSTM.failNow(ev2(new NoSuchElementException("None.get"))))(ZSTM.succeedNow)
+      ZSTM.fail(_),
+      _.fold[ZSTM[R, E1, B]](ZSTM.fail(ev2(new NoSuchElementException("None.get"))))(ZSTM.succeedNow)
     )
 
   /**
@@ -737,13 +737,13 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def tapBoth[R1 <: R, E1 >: E](f: E => ZSTM[R1, E1, Any], g: A => ZSTM[R1, E1, Any])(
     implicit ev: CanFail[E]
   ): ZSTM[R1, E1, A] =
-    foldM(e => f(e) *> ZSTM.failNow(e), a => g(a) as a)
+    foldM(e => f(e) *> ZSTM.fail(e), a => g(a) as a)
 
   /**
    * "Peeks" at the error of the transactional effect.
    */
   def tapError[R1 <: R, E1 >: E](f: E => ZSTM[R1, E1, Any])(implicit ev: CanFail[E]): ZSTM[R1, E1, A] =
-    foldM(e => f(e) *> ZSTM.failNow(e), ZSTM.succeedNow)
+    foldM(e => f(e) *> ZSTM.fail(e), ZSTM.succeedNow)
 
   /**
    * Maps the success value of this effect to unit.
@@ -910,7 +910,7 @@ object ZSTM {
    * Returns a value modelled on provided exit status.
    */
   def done[R, E, A](exit: => TExit[E, A]): ZSTM[R, E, A] =
-    suspend(doneNow(exit))
+    suspend(done(exit))
 
   /**
    * Retrieves the environment inside an stm.
@@ -996,7 +996,7 @@ object ZSTM {
   def fromEither[E, A](e: => Either[E, A]): STM[E, A] =
     STM.suspend {
       e match {
-        case Left(t)  => STM.failNow(t)
+        case Left(t)  => STM.fail(t)
         case Right(a) => STM.succeedNow(a)
       }
     }
@@ -1018,7 +1018,7 @@ object ZSTM {
    * Lifts an `Option` into a `STM`.
    */
   def fromOption[A](v: => Option[A]): STM[Unit, A] =
-    STM.suspend(v.fold[STM[Unit, A]](STM.failNow(()))(STM.succeedNow))
+    STM.suspend(v.fold[STM[Unit, A]](STM.fail(()))(STM.succeedNow))
 
   /**
    * Lifts a `Try` into a `STM`.
@@ -1026,7 +1026,7 @@ object ZSTM {
   def fromTry[A](a: => Try[A]): STM[Throwable, A] =
     STM.suspend {
       a match {
-        case Failure(t) => STM.failNow(t)
+        case Failure(t) => STM.fail(t)
         case Success(a) => STM.succeedNow(a)
       }
     }
@@ -1188,7 +1188,7 @@ object ZSTM {
    * value, then the specified error will be raised.
    */
   def require[R, E, A](error: => E): ZSTM[R, E, Option[A]] => ZSTM[R, E, A] =
-    _.flatMap(_.fold[ZSTM[R, E, A]](failNow(error))(succeedNow))
+    _.flatMap(_.fold[ZSTM[R, E, A]](fail(error))(succeedNow))
 
   /**
    * Abort and retry the whole transaction when any of the underlying
@@ -1249,7 +1249,7 @@ object ZSTM {
     in: Iterable[A]
   )(f: A => ZSTM[R, E, B])(implicit ev: CanFail[E]): ZSTM[R, ::[E], List[B]] =
     partition(in)(f).flatMap {
-      case (e :: es, _) => failNow(::(e, es))
+      case (e :: es, _) => fail(::(e, es))
       case (_, bs)      => succeedNow(bs)
     }
 
@@ -1285,19 +1285,6 @@ object ZSTM {
    */
   def whenM[R, E](b: ZSTM[R, E, Boolean])(stm: ZSTM[R, E, Any]): ZSTM[R, E, Unit] =
     b.flatMap(b => if (b) stm.unit else unit)
-
-  private[zio] def dieNow(t: Throwable): STM[Nothing, Nothing] =
-    succeedNow(throw t)
-
-  private[zio] def doneNow[E, A](exit: TExit[E, A]): STM[E, A] =
-    exit match {
-      case TExit.Retry      => STM.retry
-      case TExit.Fail(e)    => STM.failNow(e)
-      case TExit.Succeed(a) => STM.succeedNow(a)
-    }
-
-  private[zio] def failNow[E](e: E): STM[E, Nothing] =
-    fail(e)
 
   private[zio] def succeedNow[A](a: A): STM[Nothing, A] =
     succeed(a)
@@ -1587,7 +1574,7 @@ object ZSTM {
 
       value match {
         case TExit.Succeed(a) => completeTodos(IO.succeedNow(a), journal, platform)
-        case TExit.Fail(e)    => completeTodos(IO.failNow(e), journal, platform)
+        case TExit.Fail(e)    => completeTodos(IO.fail(e), journal, platform)
         case TExit.Retry      => TryCommit.Suspend(journal)
       }
     }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -46,7 +46,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assertM(Chunk(1, 1, 1).mapAccumM(0)((s, el) => UIO.succeedNow((s + el, s + el))))(equalTo((3, Chunk(1, 2, 3))))
       },
       testM("mapAccumM error") {
-        Chunk(1, 1, 1).mapAccumM(0)((_, _) => IO.failNow("Ouch")).either.map(assert(_)(isLeft(equalTo("Ouch"))))
+        Chunk(1, 1, 1).mapAccumM(0)((_, _) => IO.fail("Ouch")).either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("map") {
@@ -58,7 +58,7 @@ object ChunkSpec extends ZIOBaseSpec {
         chunk.mapM(s => UIO.succeedNow(f(s))).map(assert(_)(equalTo(chunk.map(f))))
       }),
       testM("mapM error") {
-        Chunk(1, 2, 3).mapM(_ => IO.failNow("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
+        Chunk(1, 2, 3).mapM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
       }
     ),
     testM("flatMap") {
@@ -100,7 +100,7 @@ object ChunkSpec extends ZIOBaseSpec {
         chunk.filterM(s => UIO.succeedNow(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
       }),
       testM("filterM error") {
-        Chunk(1, 2, 3).filterM(_ => IO.failNow("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
+        Chunk(1, 2, 3).filterM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
       }
     ),
     testM("drop chunk") {
@@ -172,7 +172,7 @@ object ChunkSpec extends ZIOBaseSpec {
         }
       },
       testM("collectM chunk that fails") {
-        Chunk(1, 2).collectM { case 2 => IO.failNow("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
+        Chunk(1, 2).collectM { case 2 => IO.fail("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     suite("collectWhile")(
@@ -200,7 +200,7 @@ object ChunkSpec extends ZIOBaseSpec {
         }
       },
       testM("collectWhileM chunk that fails") {
-        Chunk(1, 2).collectWhileM { case _ => IO.failNow("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
+        Chunk(1, 2).collectWhileM { case _ => IO.fail("Ouch") }.either.map(assert(_)(isLeft(equalTo("Ouch"))))
       }
     ),
     testM("foreach") {

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -509,8 +509,8 @@ object SinkSpec extends ZIOBaseSpec {
           val s = new ZSink[Any, String, Nothing, Any, Nothing] {
             type State = Unit
             val initial                    = UIO.unit
-            def step(state: State, a: Any) = IO.failNow("Ouch")
-            def extract(state: State)      = IO.failNow("Ouch")
+            def step(state: State, a: Any) = IO.fail("Ouch")
+            def extract(state: State)      = IO.fail("Ouch")
             def cont(state: State)         = true
           }
           assertM(sinkIteration(s.optional, 1))(equalTo((None, Chunk.single(1))))
@@ -526,11 +526,11 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("orElse")(
         testM("left") {
-          val sink = ZSink.identity[Int] orElse ZSink.failNow("Ouch")
+          val sink = ZSink.identity[Int] orElse ZSink.fail("Ouch")
           assertM(sinkIteration(sink, 1))(equalTo((Left(1), Chunk.empty)))
         },
         testM("right") {
-          val sink = ZSink.failNow("Ouch") orElse ZSink.identity[Int]
+          val sink = ZSink.fail("Ouch") orElse ZSink.identity[Int]
           assertM(sinkIteration(sink, 1))(equalTo((Right(1), Chunk.empty)))
         },
         testM("init error left") {
@@ -590,7 +590,7 @@ object SinkSpec extends ZIOBaseSpec {
           } yield assert(result)(equalTo((Left(List(1, 2, 3, 4)), Chunk.empty)))
         },
         testM("left long fail right short") {
-          val sink = (ZSink.collectAll[Int] <* ZSink.failNow("Ouch")) orElse ZSink.collectAllN[Int](2)
+          val sink = (ZSink.collectAll[Int] <* ZSink.fail("Ouch")) orElse ZSink.collectAllN[Int](2)
           for {
             init   <- sink.initial
             step1  <- sink.step(init, 1)
@@ -914,7 +914,7 @@ object SinkSpec extends ZIOBaseSpec {
           val empty: Stream[Nothing, Int]     = ZStream.empty
           val single: Stream[Nothing, Int]    = ZStream.succeedNow(1)
           val double: Stream[Nothing, Int]    = ZStream(1, 2)
-          val failed: Stream[String, Nothing] = ZStream.failNow("Ouch")
+          val failed: Stream[String, Nothing] = ZStream.fail("Ouch")
 
           def run[E](stream: Stream[E, Int]) =
             for {
@@ -956,7 +956,7 @@ object SinkSpec extends ZIOBaseSpec {
           val empty: Stream[Nothing, Int]     = ZStream.empty
           val single: Stream[Nothing, Int]    = ZStream.succeedNow(1)
           val double: Stream[Nothing, Int]    = ZStream(1, 2)
-          val failed: Stream[String, Nothing] = ZStream.failNow("Ouch")
+          val failed: Stream[String, Nothing] = ZStream.fail("Ouch")
 
           def run[E](stream: Stream[E, Int]) =
             (for {
@@ -1466,7 +1466,7 @@ object SinkSpec extends ZIOBaseSpec {
                     a match {
                       case a if a.isWhitespace => UIO.succeedNow(((ParserState.Start, acc, true), Chunk.empty))
                       case '['                 => UIO.succeedNow(((ParserState.Element(""), acc, true), Chunk.empty))
-                      case _                   => IO.failNow("Expected '['")
+                      case _                   => IO.fail("Expected '['")
                     }
 
                   case (ParserState.Element(el), acc, _) =>
@@ -1475,7 +1475,7 @@ object SinkSpec extends ZIOBaseSpec {
                         UIO.succeedNow(((ParserState.Element(el + a), acc, true), Chunk.empty))
                       case ',' => UIO.succeedNow(((ParserState.Element(""), acc :+ el.toInt, true), Chunk.empty))
                       case ']' => UIO.succeedNow(((ParserState.Done, acc :+ el.toInt, false), Chunk.empty))
-                      case _   => IO.failNow("Expected a digit or ,")
+                      case _   => IO.fail("Expected a digit or ,")
                     }
 
                   case (ParserState.Done, acc, _) =>
@@ -1505,10 +1505,10 @@ object SinkSpec extends ZIOBaseSpec {
         val elements = numbers <* brace
 
         lazy val start: ZSink[Any, String, Char, Char, List[Int]] =
-          ZSink.pull1(IO.failNow("Input was empty")) {
+          ZSink.pull1(IO.fail("Input was empty")) {
             case a if a.isWhitespace => start
             case '['                 => elements
-            case _                   => ZSink.failNow("Expected '['")
+            case _                   => ZSink.fail("Expected '['")
           }
 
         val src1         = ZStreamChunk.succeedNow(Chunk.fromArray(Array('[', '1', '2')))

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -7,17 +7,17 @@ import zio.{ Chunk, IO, UIO }
 trait SinkUtils {
   def initErrorSink = new ZSink[Any, String, Int, Int, Int] {
     type State = Unit
-    val initial                    = IO.failNow("Ouch")
-    def step(state: State, a: Int) = IO.failNow("Ouch")
-    def extract(state: State)      = IO.failNow("Ouch")
+    val initial                    = IO.fail("Ouch")
+    def step(state: State, a: Int) = IO.fail("Ouch")
+    def extract(state: State)      = IO.fail("Ouch")
     def cont(state: State)         = false
   }
 
   def stepErrorSink = new ZSink[Any, String, Int, Int, Int] {
     type State = Unit
     val initial                    = UIO.unit
-    def step(state: State, a: Int) = IO.failNow("Ouch")
-    def extract(state: State)      = IO.failNow("Ouch")
+    def step(state: State, a: Int) = IO.fail("Ouch")
+    def extract(state: State)      = IO.fail("Ouch")
     def cont(state: State)         = false
   }
 
@@ -25,7 +25,7 @@ trait SinkUtils {
     type State = Unit
     val initial                    = UIO.unit
     def step(state: State, a: Int) = UIO.unit
-    def extract(state: State)      = IO.failNow("Ouch")
+    def extract(state: State)      = IO.fail("Ouch")
     def cont(state: State)         = false
   }
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
@@ -21,7 +21,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
         assertM(
-          (Stream.range(0, 10) ++ Stream.failNow(e))
+          (Stream.range(0, 10) ++ Stream.fail(e))
             .buffer(2)
             .run(Sink.collectAll[Int])
             .run
@@ -46,7 +46,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
         assertM(
-          (Stream.range(1, 1000) ++ Stream.failNow(e) ++ Stream.range(1001, 2000))
+          (Stream.range(1, 1000) ++ Stream.fail(e) ++ Stream.range(1001, 2000))
             .bufferDropping(2)
             .runCollect
             .run
@@ -87,7 +87,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
         assertM(
-          (Stream.range(1, 1000) ++ Stream.failNow(e) ++ Stream.range(1001, 2000))
+          (Stream.range(1, 1000) ++ Stream.fail(e) ++ Stream.range(1001, 2000))
             .bufferSliding(2)
             .runCollect
             .run
@@ -135,7 +135,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
       }),
       testM("buffer the Stream with Error") {
         val e = new RuntimeException("boom")
-        assertM((Stream.range(0, 10) ++ Stream.failNow(e)).bufferUnbounded.runCollect.run)(fails(equalTo(e)))
+        assertM((Stream.range(0, 10) ++ Stream.fail(e)).bufferUnbounded.runCollect.run)(fails(equalTo(e)))
       },
       testM("fast producer progress independently") {
         for {

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamDrainForkSpec.scala
@@ -28,11 +28,11 @@ object StreamDrainForkSpec extends ZIOBaseSpec {
       } yield assert(result)(isTrue)
     },
     testM("fails the foreground stream if the background fails with a typed error") {
-      assertM(ZStream.never.drainFork(ZStream.failNow("Boom")).runDrain.run)(fails(equalTo("Boom")))
+      assertM(ZStream.never.drainFork(ZStream.fail("Boom")).runDrain.run)(fails(equalTo("Boom")))
     },
     testM("fails the foreground stream if the background fails with a defect") {
       val ex = new RuntimeException("Boom")
-      assertM(ZStream.never.drainFork(ZStream.dieNow(ex)).runDrain.run)(dies(equalTo(ex)))
+      assertM(ZStream.never.drainFork(ZStream.die(ex)).runDrain.run)(dies(equalTo(ex)))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -29,7 +29,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
         for {
           result <- Stream
                      .effectAsyncMaybe[Nothing, Int] { k =>
-                       k(IO.failNow(None))
+                       k(IO.fail(None))
                        None
                      }
                      .runCollect
@@ -59,7 +59,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
                 (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
-                cb(refDone.set(true) *> ZIO.failNow(None))
+                cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               None
             },
@@ -96,7 +96,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           result <- Stream
                      .effectAsyncM[Nothing, Int] { k =>
                        inParallel {
-                         k(IO.failNow(None))
+                         k(IO.fail(None))
                        }(global)
                        UIO.unit
                      }
@@ -112,7 +112,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
                 (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
-                cb(refDone.set(true) *> ZIO.failNow(None))
+                cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               UIO.unit
             },
@@ -155,7 +155,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           result <- Stream
                      .effectAsyncInterrupt[Nothing, Int] { k =>
                        inParallel {
-                         k(IO.failNow(None))
+                         k(IO.fail(None))
                        }(global)
                        Left(UIO.succeedNow(()))
                      }
@@ -172,7 +172,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
                 (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
-                cb(refDone.set(true) *> ZIO.failNow(None))
+                cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               Left(UIO.unit)
             },

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -24,7 +24,7 @@ trait StreamUtils extends ChunkUtils with GenZIO {
 
   def failingStreamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, Stream[String, A]] =
     max match {
-      case 0 => Gen.const(ZStream.fromEffect(IO.failNow("fail-case")))
+      case 0 => Gen.const(ZStream.fromEffect(IO.fail("fail-case")))
       case _ =>
         Gen
           .int(1, max)
@@ -33,7 +33,7 @@ trait StreamUtils extends ChunkUtils with GenZIO {
               i  <- Gen.int(0, n - 1)
               it <- Gen.listOfN(n)(a)
             } yield ZStream.unfoldM((i, it)) {
-              case (_, Nil) | (0, _) => IO.failNow("fail-case")
+              case (_, Nil) | (0, _) => IO.fail("fail-case")
               case (n, head :: rest) => IO.succeedNow(Some((head, (n - 1, rest))))
             }
           )

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -311,15 +311,6 @@ object Sink extends Serializable {
   val utf8DecodeChunk: Sink[Nothing, Chunk[Byte], Chunk[Byte], String] =
     ZSink.utf8DecodeChunk
 
-  private[zio] def dieNow(e: Throwable): Sink[Nothing, Nothing, Any, Nothing] =
-    ZSink.dieNow(e)
-
-  private[zio] def failNow[E](e: E): Sink[E, Nothing, Any, Nothing] =
-    ZSink.failNow(e)
-
-  private[zio] def haltNow[E](e: Cause[E]): Sink[E, Nothing, Any, Nothing] =
-    ZSink.haltNow(e)
-
   private[zio] def succeedNow[A, B](b: B): Sink[Nothing, A, A, B] =
     ZSink.succeedNow(b)
 }

--- a/streams/shared/src/main/scala/zio/stream/Stream.scala
+++ b/streams/shared/src/main/scala/zio/stream/Stream.scala
@@ -369,15 +369,6 @@ object Stream extends Serializable {
   ): Stream[E, F] =
     ZStream.zipN(stream1, stream2, stream3, stream4)(f)
 
-  private[zio] def dieNow(ex: Throwable): Stream[Nothing, Nothing] =
-    ZStream.dieNow(ex)
-
-  private[zio] def failNow[E](error: E): Stream[E, Nothing] =
-    ZStream.failNow(error)
-
-  private[zio] def haltNow[E](cause: Cause[E]): Stream[E, Nothing] =
-    ZStream.haltNow(cause)
-
   private[zio] def succeedNow[A](a: A): Stream[Nothing, A] =
     ZStream.succeedNow(a)
 }

--- a/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamEffect.scala
@@ -28,8 +28,8 @@ private[stream] final class StreamEffect[-R, +E, +A](val processEffect: ZManaged
           UIO.effectTotal {
             try UIO.succeedNow(thunk())
             catch {
-              case StreamEffect.Failure(e) => IO.failNow(Some(e.asInstanceOf[E]))
-              case StreamEffect.End        => IO.failNow(None)
+              case StreamEffect.Failure(e) => IO.fail(Some(e.asInstanceOf[E]))
+              case StreamEffect.End        => IO.fail(None)
             }
           }.flatten
         }

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -121,6 +121,6 @@ object Take {
     io.flatMap {
       case Take.End      => IO.succeedNow(None)
       case Take.Value(a) => IO.succeedNow(Some(a))
-      case Take.Fail(e)  => IO.haltNow(e)
+      case Take.Fail(e)  => IO.halt(e)
     }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -313,7 +313,7 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
       def decide(state: State): ZIO[R1, E1, State] =
         state match {
-          case (Side.Error(_), Side.Error(e)) => IO.failNow(e)
+          case (Side.Error(_), Side.Error(e)) => IO.fail(e)
           case sides                          => UIO.succeedNow(sides)
         }
 
@@ -375,7 +375,7 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
       def extract(state: State) =
         state match {
-          case (Side.Error(_), Side.Error(e))             => IO.failNow(e)
+          case (Side.Error(_), Side.Error(e))             => IO.fail(e)
           case (Side.Error(_), Side.State(s))             => that.extract(s).map { case (c, leftover) => (Right(c), leftover) }
           case (Side.Error(_), Side.Value((c, leftover))) => UIO.succeedNow((Right(c), leftover))
           case (Side.Value((b, leftover)), _)             => UIO.succeedNow((Left(b), leftover))
@@ -466,7 +466,7 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
       def decide(state: State): ZIO[R1, E1, State] =
         state match {
-          case (Side.Error(e1), Side.Error(e2)) => IO.haltNow(Cause.Both(Cause.fail(e1), Cause.fail(e2)))
+          case (Side.Error(e1), Side.Error(e2)) => IO.halt(Cause.Both(Cause.fail(e1), Cause.fail(e2)))
           case sides                            => UIO.succeedNow(sides)
         }
 
@@ -524,7 +524,7 @@ trait ZSink[-R, +E, +A0, -A, +B] extends Serializable { self =>
 
       def extract(state: State) =
         state match {
-          case (Side.Error(e1), Side.Error(e2))           => IO.haltNow(Cause.Both(Cause.fail(e1), Cause.fail(e2)))
+          case (Side.Error(e1), Side.Error(e2))           => IO.halt(Cause.Both(Cause.fail(e1), Cause.fail(e2)))
           case (Side.Error(_), Side.State(s))             => that.extract(s).map { case (c, leftover) => (Right(c), leftover) }
           case (Side.Error(_), Side.Value((c, leftover))) => UIO.succeedNow((Right(c), leftover))
           case (Side.State(s), Side.Error(e)) =>
@@ -1203,11 +1203,11 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
     }
 
     def assertNonNegative(n: Long): UIO[Unit] =
-      if (n < 0) UIO.dieNow(new NegativeArgument(s"Unexpected negative unit value `$n`"))
+      if (n < 0) UIO.die(new NegativeArgument(s"Unexpected negative unit value `$n`"))
       else UIO.unit
 
     def assertPositive(n: Long): UIO[Unit] =
-      if (n <= 0) UIO.dieNow(new NonpositiveArgument(s"Unexpected nonpositive unit value `$n`"))
+      if (n <= 0) UIO.die(new NonpositiveArgument(s"Unexpected nonpositive unit value `$n`"))
       else UIO.unit
 
     class NegativeArgument(message: String) extends IllegalArgumentException(message)
@@ -1568,7 +1568,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       type State = Unit
       val initial                    = UIO.unit
       def step(state: State, a: Any) = UIO.unit
-      def extract(state: State)      = IO.haltNow(e)
+      def extract(state: State)      = IO.halt(e)
       def cont(state: State)         = false
     }
 
@@ -2047,15 +2047,6 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
 
       def cont(state: State) = state._3
     }
-
-  private[zio] def dieNow(e: Throwable): ZSink[Any, Nothing, Nothing, Any, Nothing] =
-    ZSink.haltNow(Cause.die(e))
-
-  private[zio] def failNow[E](e: E): ZSink[Any, E, Nothing, Any, Nothing] =
-    fail(e)
-
-  private[zio] def haltNow[E](e: Cause[E]): ZSink[Any, E, Nothing, Any, Nothing] =
-    halt(e)
 
   private[zio] def succeedNow[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
     succeed(b)

--- a/streams/shared/src/main/scala/zio/stream/internal/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/package.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.stream
+
+import zio.Chunk
+
+package object internal {
+
+  /**
+   * Creates a single-value sink from a value.
+   */
+  def ZSinkSucceedNow[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
+    ZSink.succeedNow(b)
+
+  /**
+   * Creates a `ZStreamChunk` from an eagerly evaluated chunk
+   */
+  def ZStreamChunkSucceedNow[A](as: Chunk[A]): ZStreamChunk[Any, Nothing, A] =
+    new StreamEffectChunk(StreamEffect.succeed(as))
+
+  /**
+   * Creates a single-valued pure stream
+   */
+  def ZStreamSucceedNow[A](a: A): ZStream[Any, Nothing, A] =
+    StreamEffect.succeed(a)
+}

--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -16,7 +16,7 @@ object AnnotationsSpec extends ZIOBaseSpec {
     },
     testM("withAnnotation returns annotation map with result") {
       for {
-        map <- Annotations.withAnnotation(Annotations.annotate(count, 3) *> ZIO.failNow("fail")).flip.map(_._2)
+        map <- Annotations.withAnnotation(Annotations.annotate(count, 3) *> ZIO.fail("fail")).flip.map(_._2)
         c   = map.get(count)
       } yield assert(c)(equalTo(3))
     }

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -25,7 +25,7 @@ object CheckSpec extends ZIOBaseSpec {
     testM("error in checkM is test failure") {
       checkM(Gen.int(1, 100)) { n =>
         for {
-          _ <- ZIO.failNow("fail")
+          _ <- ZIO.fail("fail")
           r <- random.nextInt(n)
         } yield assert(r)(isLessThan(n))
       }

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -29,7 +29,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(0)
         spec = testM("test") {
-          ZIO.failNow("error")
+          ZIO.fail("error")
         } @@ after(ref.set(-1))
         result <- isSuccess(spec)
         after  <- ref.get
@@ -198,7 +198,7 @@ object TestAspectSpec extends ZIOBaseSpec {
         assertM(ZIO.unit)(anything)
       } @@ nonTermination(1.minute) @@ failure,
       testM("makes a test fail if it fails within the specified time") {
-        assertM(ZIO.failNow("fail"))(anything)
+        assertM(ZIO.fail("fail"))(anything)
       } @@ nonTermination(1.minute) @@ failure
     ),
     testM("retry retries failed tests according to a schedule") {

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -14,7 +14,7 @@ object TestSpec extends ZIOBaseSpec {
     },
     testM("testM error is test failure") {
       for {
-        _      <- ZIO.failNow("fail")
+        _      <- ZIO.fail("fail")
         result <- ZIO.succeedNow("succeed")
       } yield assert(result)(equalTo("succeed"))
     } @@ failure,

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -81,7 +81,7 @@ object ExpectationSpec extends ZIOBaseSpec {
         equalTo("foo 1")
       ),
       testSpec("returns failureM")(
-        Module.singleParam(equalTo(1)) returns failureM(i => IO.failNow(s"foo $i")),
+        Module.singleParam(equalTo(1)) returns failureM(i => IO.fail(s"foo $i")),
         Module.>.singleParam(1).flip,
         equalTo("foo 1")
       )
@@ -113,7 +113,7 @@ object ExpectationSpec extends ZIOBaseSpec {
         equalTo("foo (1,2,3)")
       ),
       testSpec("returns failureM")(
-        Module.manyParams(equalTo((1, "2", 3L))) returns failureM(i => IO.failNow(s"foo $i")),
+        Module.manyParams(equalTo((1, "2", 3L))) returns failureM(i => IO.fail(s"foo $i")),
         Module.>.manyParams(1, "2", 3L).flip,
         equalTo("foo (1,2,3)")
       )
@@ -145,7 +145,7 @@ object ExpectationSpec extends ZIOBaseSpec {
         equalTo("foo (1,2,3)")
       ),
       testSpec("returns failureM")(
-        Module.manyParamLists(equalTo((1, "2", 3L))) returns failureM(i => IO.failNow(s"foo $i")),
+        Module.manyParamLists(equalTo((1, "2", 3L))) returns failureM(i => IO.fail(s"foo $i")),
         Module.>.manyParamLists(1)("2")(3L).flip,
         equalTo("foo (1,2,3)")
       )
@@ -185,7 +185,7 @@ object ExpectationSpec extends ZIOBaseSpec {
           equalTo("foo 1")
         ),
         testSpec("returns failureM")(
-          Module.overloaded._0(equalTo(1)) returns failureM(i => IO.failNow(s"foo $i")),
+          Module.overloaded._0(equalTo(1)) returns failureM(i => IO.fail(s"foo $i")),
           Module.>.overloaded(1).flip,
           equalTo("foo 1")
         )
@@ -217,7 +217,7 @@ object ExpectationSpec extends ZIOBaseSpec {
           equalTo("foo 1")
         ),
         testSpec("returns failureM")(
-          Module.overloaded._1(equalTo(1L)) returns failureM(i => IO.failNow(s"foo $i")),
+          Module.overloaded._1(equalTo(1L)) returns failureM(i => IO.fail(s"foo $i")),
           Module.>.overloaded(1L).flip,
           equalTo("foo 1")
         )
@@ -250,7 +250,7 @@ object ExpectationSpec extends ZIOBaseSpec {
         equalTo("foo (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)")
       ),
       testSpec("returns failureM")(
-        Module.maxParams(equalTo(intTuple22)) returns failureM(i => IO.failNow(s"foo $i")),
+        Module.maxParams(equalTo(intTuple22)) returns failureM(i => IO.fail(s"foo $i")),
         (Module.>.maxParams _).tupled(intTuple22).flip,
         equalTo("foo (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)")
       )

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -30,7 +30,7 @@ private[test] object Macros {
       c.Expr(q"zio.UIO.succeedNow(Right(()))")
     } catch {
       case e: TypecheckException => c.Expr(q"zio.UIO.succeedNow(Left(${e.getMessage}))")
-      case _: Throwable          => c.Expr(q"""zio.UIO.dieNow(new RuntimeException("Compilation failed"))""")
+      case _: Throwable          => c.Expr(q"""zio.UIO.die(new RuntimeException("Compilation failed"))""")
     }
   }
 }

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -33,7 +33,7 @@ trait CompileVariants {
       if (typeChecks(code)) UIO.succeedNow(Right(()))
       else UIO.succeedNow(Left(errorMessage))
     } catch {
-      case _: Throwable => UIO.dieNow(new RuntimeException("Compilation failed"))
+      case _: Throwable => UIO.die(new RuntimeException("Compilation failed"))
     }
 
   private val errorMessage =

--- a/test/shared/src/main/scala/zio/test/GenZIO.scala
+++ b/test/shared/src/main/scala/zio/test/GenZIO.scala
@@ -83,13 +83,13 @@ trait GenZIO {
    * A generator of effects that have died with a `Throwable`.
    */
   final def died[R](gen: Gen[R, Throwable]): Gen[R, ZIO[Any, Nothing, Nothing]] =
-    gen.map(ZIO.dieNow)
+    gen.map(ZIO.die(_))
 
   /**
    * A generator of effects that have failed with an error.
    */
   final def failures[R, E](gen: Gen[R, E]): Gen[R, ZIO[Any, E, Nothing]] =
-    gen.map(ZIO.failNow)
+    gen.map(ZIO.fail(_))
 
   /**
    * A generator of effects that are the result of applying parallelism

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -54,7 +54,7 @@ trait TimeoutVariants {
     duration: Duration
   ): ZTest[R with Live, E] =
     test.raceWith(Live.withLive(showWarning(suiteLabels, testLabel, duration))(_.delay(duration)))(
-      (result, fiber) => fiber.interrupt *> ZIO.doneNow(result),
+      (result, fiber) => fiber.interrupt *> ZIO.done(result),
       (_, fiber) => fiber.join
     )
 

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -1201,7 +1201,7 @@ package object environment extends PlatformSpecific {
 
       private def randomInt(n: Int): UIO[Int] =
         if (n <= 0)
-          UIO.dieNow(new IllegalArgumentException("n must be positive"))
+          UIO.die(new IllegalArgumentException("n must be positive"))
         else if ((n & -n) == n)
           randomBits(31).map(_ >> Integer.numberOfLeadingZeros(n))
         else {

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -104,7 +104,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
         state.callsRef.get
           .filterOrElse[Any, Nothing, Any](_.isEmpty) { calls =>
             val expectations = calls.map(call => call.method -> call.assertion)
-            ZIO.dieNow(UnmetExpectationsException(expectations))
+            ZIO.die(UnmetExpectationsException(expectations))
           }
 
     val makeEnvironment =
@@ -131,7 +131,7 @@ object Expectation {
   /**
    * Returns a return expectation to fail with `E`.
    */
-  def failure[E](failure: E): Fail[Any, E] = Fail(_ => IO.failNow(failure))
+  def failure[E](failure: E): Fail[Any, E] = Fail(_ => IO.fail(failure))
 
   /**
    * Maps the input arguments `I` to a return expectation to fail with `E`.

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -394,15 +394,15 @@ object Mock {
                 .flatMap {
                   case Some(Call(method, assertion, returns)) =>
                     if (invokedMethod != method)
-                      ZIO.dieNow(
+                      ZIO.die(
                         InvalidMethodException(invokedMethod.asInstanceOf[Method[Any, Any, Any]], method, assertion)
                       )
                     else
                       assertion.test(args).flatMap { p =>
-                        if (!p) ZIO.dieNow(InvalidArgumentsException(invokedMethod, args, assertion))
+                        if (!p) ZIO.die(InvalidArgumentsException(invokedMethod, args, assertion))
                         else promise.completeWith(returns(args).asInstanceOf[IO[E0, A0]])
                       }
-                  case None => ZIO.dieNow(UnexpectedCallExpection(invokedMethod, args))
+                  case None => ZIO.die(UnexpectedCallExpection(invokedMethod, args))
                 }
           output <- promise.await
         } yield output

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -99,11 +99,11 @@ package object test extends CompileVariants {
       ZIO
         .effectSuspendTotal(assertion)
         .foldCauseM(
-          cause => ZIO.failNow(TestFailure.Runtime(cause)),
+          cause => ZIO.fail(TestFailure.Runtime(cause)),
           result =>
             result.run.flatMap(_.failures match {
               case None           => ZIO.succeedNow(TestSuccess.Succeeded(BoolAlgebra.unit))
-              case Some(failures) => ZIO.failNow(TestFailure.Assertion(BoolAlgebraM(ZIO.succeedNow(failures))))
+              case Some(failures) => ZIO.fail(TestFailure.Assertion(BoolAlgebraM(ZIO.succeedNow(failures))))
             })
         )
   }
@@ -413,7 +413,7 @@ package object test extends CompileVariants {
    * Creates a failed test result with the specified runtime cause.
    */
   def failed[E](cause: Cause[E]): ZIO[Any, TestFailure[E], Nothing] =
-    ZIO.failNow(TestFailure.Runtime(cause))
+    ZIO.fail(TestFailure.Runtime(cause))
 
   /**
    * Creates an ignored test result.
@@ -653,7 +653,7 @@ package object test extends CompileVariants {
                 )
               }
             }
-          )(_.fold(e => ZIO.failNow(e), a => ZIO.succeedNow(BoolAlgebraM(ZIO.succeedNow(a)))))
+          )(_.fold(e => ZIO.fail(e), a => ZIO.succeedNow(BoolAlgebraM(ZIO.succeedNow(a)))))
       }
       .untraced
 


### PR DESCRIPTION
Deletes all now variants except `succeedNow`. Adds public versions of `succeedNow` variants in `zio.internal` and `zio.stream.internal` packages.