### PR TITLE
ZIO Stream: Simplify Signature of ZSink#succeed

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -92,7 +92,7 @@ object SinkSpec extends ZIOBaseSpec {
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("interaction with succeed") {
-          val sink = ZSink.succeed[Int, Int](5).collectAll
+          val sink = ZSink.succeed(5).collectAll
           for {
             init <- sink.initial
             s <- sink
@@ -309,19 +309,19 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("flatMap")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = ZSink.identity[Int].flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1))(equalTo(("1", Chunk.empty)))
         },
         testM("init error") {
-          val sink = initErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = initErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("step error") {
-          val sink = stepErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = stepErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("extract error") {
-          val sink = extractErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = extractErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         },
         testM("self done") {
@@ -337,7 +337,7 @@ object SinkSpec extends ZIOBaseSpec {
           } yield assert(result)(equalTo((List(1, 2, 3), Chunk(4, 5))))
         },
         testM("self more") {
-          val sink = ZSink.collectAll[Int].flatMap(list => ZSink.succeed[Int, Int](list.headOption.getOrElse(0)))
+          val sink = ZSink.collectAll[Int].flatMap(list => ZSink.succeed(list.headOption.getOrElse(0)))
           for {
             init   <- sink.initial
             step1  <- sink.step(init, 1)
@@ -618,7 +618,7 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("raceBoth")(
         testM("left") {
-          val sink = ZSink.identity[Int] raceBoth ZSink.succeed[Int, String]("Hello")
+          val sink = ZSink.identity[Int] raceBoth ZSink.succeed("Hello")
           assertM(sinkIteration(sink, 1))(equalTo((Left(1), Chunk.empty)))
         },
         testM("init error left") {
@@ -764,7 +764,7 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zip (<*>)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int] <*> ZSink.succeed[Int, String]("Hello")
+          val sink = ZSink.identity[Int] <*> ZSink.succeed("Hello")
           assertM(sinkIteration(sink, 1))(equalTo(((1, "Hello"), Chunk.empty)))
         },
         testM("init error left") {
@@ -806,7 +806,7 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zipLeft (<*)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].zipLeft(ZSink.succeed[Int, String]("Hello"))
+          val sink = ZSink.identity[Int].zipLeft(ZSink.succeed("Hello"))
           assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         }
       ),
@@ -867,13 +867,13 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zipRight (*>)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].zipRight(ZSink.succeed[Int, String]("Hello"))
+          val sink = ZSink.identity[Int].zipRight(ZSink.succeed("Hello"))
           assertM(sinkIteration(sink, 1))(equalTo(("Hello", Chunk.empty)))
         }
       ),
       suite("zipWith")(testM("happy path") {
         val sink =
-          ZSink.identity[Int].zipWith(ZSink.succeed[Int, String]("Hello"))((x, y) => x.toString + y.toString)
+          ZSink.identity[Int].zipWith(ZSink.succeed("Hello"))((x, y) => x.toString + y.toString)
         assertM(sinkIteration(sink, 1))(equalTo(("1Hello", Chunk.empty)))
       })
     ),
@@ -1120,7 +1120,7 @@ object SinkSpec extends ZIOBaseSpec {
       },
       testM("pull1") {
         val stream = Stream.fromIterable(List(1))
-        val sink   = Sink.pull1(IO.succeedNow(Option.empty[Int]))((i: Int) => Sink.succeedNow[Int, Option[Int]](Some(i)))
+        val sink   = Sink.pull1(IO.succeedNow(Option.empty[Int]))((i: Int) => Sink.succeedNow(Some(i)))
 
         assertM(stream.run(sink))(isSome(equalTo(1)))
       },

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1440,7 +1440,7 @@ object StreamSpec extends ZIOBaseSpec {
 
         assertM(
           s1.mergeWith(s2)(_.toString, _.toString)
-            .run(Sink.succeedNow[String, String]("done"))
+            .run(Sink.succeedNow("done"))
         )(equalTo("done"))
       },
       testM("mergeWith prioritizes failure") {

--- a/streams/shared/src/main/scala/zio/stream/Sink.scala
+++ b/streams/shared/src/main/scala/zio/stream/Sink.scala
@@ -265,8 +265,8 @@ object Sink extends Serializable {
   /**
    * see [[ZSink.succeed]]
    */
-  def succeed[A, B](b: => B): Sink[Nothing, A, A, B] =
-    ZSink.succeed(b)
+  def succeed[A](a: => A): Sink[Nothing, Nothing, Any, A] =
+    ZSink.succeed(a)
 
   /**
    * see [[ZSink.sum]]
@@ -320,6 +320,6 @@ object Sink extends Serializable {
   private[zio] def haltNow[E](e: Cause[E]): Sink[E, Nothing, Any, Nothing] =
     ZSink.haltNow(e)
 
-  private[zio] def succeedNow[A, B](b: B): Sink[Nothing, A, A, B] =
-    ZSink.succeedNow(b)
+  private[zio] def succeedNow[A](a: A): Sink[Nothing, Nothing, Any, A] =
+    ZSink.succeedNow(a)
 }

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1835,13 +1835,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a single-value sink from a value.
    */
-  def succeed[A, B](b: => B): ZSink[Any, Nothing, A, A, B] =
-    new SinkPure[Nothing, A, A, B] {
-      type State = Chunk[A]
-      val initialPure                  = Chunk.empty
-      def stepPure(state: State, a: A) = state ++ Chunk(a)
-      def extractPure(state: State)    = Right((b, state))
-      def cont(state: State)           = false
+  def succeed[A](a: => A): ZSink[Any, Nothing, Nothing, Any, A] =
+    new SinkPure[Nothing, Nothing, Any, A] {
+      type State = Chunk[Any]
+      val initialPure                    = Chunk.empty
+      def stepPure(state: State, a: Any) = state ++ Chunk(a)
+      def extractPure(state: State)      = Right((a, initialPure))
+      def cont(state: State)             = false
     }
 
   /**
@@ -2057,6 +2057,6 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   private[zio] def haltNow[E](e: Cause[E]): ZSink[Any, E, Nothing, Any, Nothing] =
     halt(e)
 
-  private[zio] def succeedNow[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
-    succeed(b)
+  private[zio] def succeedNow[A](a: A): ZSink[Any, Nothing, Nothing, Any, A] =
+    succeed(a)
 }

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1840,7 +1840,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       type State = Chunk[Any]
       val initialPure                    = Chunk.empty
       def stepPure(state: State, a: Any) = state ++ Chunk(a)
-      def extractPure(state: State)      = Right((a, initialPure))
+      def extractPure(state: State)      = Right((a, Chunk.empty))
       def cont(state: State)             = false
     }
 


### PR DESCRIPTION
Signature going from:

```scala
def succeed[A, B](b: => B): ZSink[Any, Nothing, A, A, B]
```

to:

```scala
def succeed[A](a: => A): ZSink[Any, Nothing, Nothing, Any, A]
```

In other words, the sink can accept any input and will never emit any leftovers but only the value provided. This is slightly different than the current semantic, which seems to be it will accept inputs of a specified type and return those same inputs as leftovers but every test passes with no changes so the leftovers don't seem to be something we were using and this seems to be a more specific contract and allows us to remove the totally unbound type parameter in the current implementation, allowing us to avoid manually specifying type parameters in several locations.