### PR TITLE
Add Higher Arity Variants of ZLayer and Has Combinators

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,3 +13,8 @@ spaces {
 optIn.annotationNewlines = true
 
 rewrite.rules = [SortImports, RedundantBraces]
+
+project.excludeFilters = [
+  "core/shared/src/main/scala/zio/Has.scala",
+  "core/shared/src/main/scala/zio/ZLayer.scala"
+]

--- a/core-tests/shared/src/test/scala/zio/HasSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/HasSpec.scala
@@ -63,13 +63,6 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.get[Dog])(equalTo(dog2)) &&
         assert(updated.get[Cat])(equalTo(cat2))
       },
-      zio.test.test("Upcast will delete what is not known about") {
-        val whole: Has[Dog] with Has[Cat] = Has(dog1).add(cat1)
-
-        assert(whole.size)(equalTo(2)) &&
-        assert(whole.upcast[Dog].size)(equalTo(1)) &&
-        assert(whole.upcast[Cat].size)(equalTo(1))
-      },
       zio.test.test("Prune will delete what is not known about") {
         val whole: Has[Dog] with Has[Cat] = Has(dog1).add(cat1)
 
@@ -114,13 +107,6 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.get[IList[Dog]])(equalTo(dogs2)) &&
         assert(updated.get[IList[Cat]])(equalTo(cats2))
       },
-      zio.test.test("Upcast will delete what is not known about") {
-        val whole: Has[IList[Dog]] with Has[IList[Cat]] = Has(dogs1).add(cats1)
-
-        assert(whole.size)(equalTo(2)) &&
-        assert(whole.upcast[IList[Dog]].size)(equalTo(1)) &&
-        assert(whole.upcast[IList[Cat]].size)(equalTo(1))
-      },
       zio.test.test("Prune will delete what is not known about") {
         val whole: Has[IList[Dog]] with Has[IList[Cat]] = Has(dogs1).add(cats1)
 
@@ -163,13 +149,6 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.size)(equalTo(2)) &&
         assert(updated.get[PetHotel[Dog]])(equalTo(dogHotel2)) &&
         assert(updated.get[PetHotel[Cat]])(equalTo(catHotel2))
-      },
-      zio.test.test("Upcast will delete what is not known about") {
-        val whole: Has[PetHotel[Dog]] with Has[PetHotel[Cat]] = Has(dogHotel1).add(catHotel1)
-
-        assert(whole.size)(equalTo(2)) &&
-        assert(whole.upcast[PetHotel[Dog]].size)(equalTo(1)) &&
-        assert(whole.upcast[PetHotel[Cat]].size)(equalTo(1))
       },
       zio.test.test("Prune will delete what is not known about") {
         val whole: Has[PetHotel[Dog]] with Has[PetHotel[Cat]] = Has(dogHotel1).add(catHotel1)

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -49,7 +49,6 @@ object Has {
   private val TaggedAnyRef: Tagged[AnyRef] = implicitly[Tagged[AnyRef]]
 
   type MustHave[A, B]    = A <:< Has[B]
-  type MustNotHave[A, B] = NotExtends[A, Has[B]]
 
   trait IsHas[-R] {
     def add[R0 <: R, M: Tagged](r: R0, m: M): R0 with Has[M]
@@ -74,7 +73,7 @@ object Has {
     /**
      * Adds a service to the environment.
      */
-    def add[B](b: B)(implicit tagged: Tagged[B], ev: Self MustNotHave B): Self with Has[B] =
+    def add[B](b: B)(implicit tagged: Tagged[B]): Self with Has[B] =
       new Has(self.map + (tagged -> b)).asInstanceOf[Self with Has[B]]
 
     /**

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -340,7 +340,7 @@ object Has {
     l: L,
     m: M,
     n: N,
-    o: O,
+    o: O
   ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o)
 

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -124,27 +124,6 @@ object Has {
     def unionAll[B <: Has[_]](that: B): Self with B =
       (new Has(self.map ++ that.map)).asInstanceOf[Self with B]
 
-    def upcast[A: Tagged](implicit ev: Self <:< Has[A]): Has[A] =
-      Has(ev(self).get[A])
-
-    def upcast[A: Tagged, B: Tagged](implicit ev: Self <:< Has[A] with Has[B]): Has[A] with Has[B] =
-      Has.allOf[A, B](ev(self).get[A], ev(self).get[B])
-
-    def upcast[A: Tagged, B: Tagged, C: Tagged](
-      implicit ev: Self <:< Has[A] with Has[B] with Has[C]
-    ): Has[A] with Has[B] with Has[C] =
-      Has.allOf[A, B, C](ev(self).get[A], ev(self).get[B], ev(self).get[C])
-
-    def upcast[A: Tagged, B: Tagged, C: Tagged, D: Tagged](
-      implicit ev: Self <:< Has[A] with Has[B] with Has[C] with Has[D]
-    ): Has[A] with Has[B] with Has[C] with Has[D] =
-      Has.allOf[A, B, C, D](ev(self).get[A], ev(self).get[B], ev(self).get[C], ev(self).get[D])
-
-    def upcast[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged](
-      implicit ev: Self <:< Has[A] with Has[B] with Has[C] with Has[D] with Has[E]
-    ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] =
-      Has.allOf[A, B, C, D, E](ev(self).get[A], ev(self).get[B], ev(self).get[C], ev(self).get[D], ev(self).get[E])
-
     /**
      * Updates a service in the environment.
      */
@@ -153,27 +132,23 @@ object Has {
   }
 
   /**
-   * Constructs a new environment holding the single service. The service
-   * must be monomorphic.
+   * Constructs a new environment holding the single service.
    */
   def apply[A: Tagged](a: A): Has[A] = new Has[AnyRef](Map(), Map(TaggedAnyRef -> (()))).add(a)
 
   /**
-   * Constructs a new environment holding the specified services. The service
-   * must be monomorphic.
+   * Constructs a new environment holding the specified services.
    */
   def allOf[A: Tagged, B: Tagged](a: A, b: B): Has[A] with Has[B] = Has(a).add(b)
 
   /**
-   * Constructs a new environment holding the specified services. The service
-   * must be monomorphic.
+   * Constructs a new environment holding the specified services.
    */
   def allOf[A: Tagged, B: Tagged, C: Tagged](a: A, b: B, c: C): Has[A] with Has[B] with Has[C] =
     Has(a).add(b).add(c)
 
   /**
-   * Constructs a new environment holding the specified services. The service
-   * must be monomorphic.
+   * Constructs a new environment holding the specified services.
    */
   def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged](
     a: A,
@@ -184,8 +159,7 @@ object Has {
     Has(a).add(b).add(c).add(d)
 
   /**
-   * Constructs a new environment holding the specified services. The service
-   * must be monomorphic.
+   * Constructs a new environment holding the specified services.
    */
   def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged](
     a: A,
@@ -195,6 +169,890 @@ object Has {
     e: E
   ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] =
     Has(a).add(b).add(c).add(d).add(e)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] =
+    Has(a).add(b).add(c).add(d).add(e).add(f)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged,
+    R: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q,
+    r: R
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q]
+    with Has[R] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+      .add(r)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged,
+    R: Tagged,
+    S: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q,
+    r: R,
+    s: S
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q]
+    with Has[R]
+    with Has[S] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+      .add(r)
+      .add(s)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged,
+    R: Tagged,
+    S: Tagged,
+    T: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q,
+    r: R,
+    s: S,
+    t: T
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q]
+    with Has[R]
+    with Has[S]
+    with Has[T] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+      .add(r)
+      .add(s)
+      .add(t)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged,
+    R: Tagged,
+    S: Tagged,
+    T: Tagged,
+    U: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q,
+    r: R,
+    s: S,
+    t: T,
+    u: U
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q]
+    with Has[R]
+    with Has[S]
+    with Has[T]
+    with Has[U] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+      .add(r)
+      .add(s)
+      .add(t)
+      .add(u)
+
+  /**
+   * Constructs a new environment holding the specified services.
+   */
+  def allOf[
+    A: Tagged,
+    B: Tagged,
+    C: Tagged,
+    D: Tagged,
+    E: Tagged,
+    F: Tagged,
+    G: Tagged,
+    H: Tagged,
+    I: Tagged,
+    J: Tagged,
+    K: Tagged,
+    L: Tagged,
+    M: Tagged,
+    N: Tagged,
+    O: Tagged,
+    P: Tagged,
+    Q: Tagged,
+    R: Tagged,
+    S: Tagged,
+    T: Tagged,
+    U: Tagged,
+    V: Tagged
+  ](
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+    q: Q,
+    r: R,
+    s: S,
+    t: T,
+    u: U,
+    v: V
+  ): Has[A]
+    with Has[B]
+    with Has[C]
+    with Has[D]
+    with Has[E]
+    with Has[F]
+    with Has[G]
+    with Has[H]
+    with Has[I]
+    with Has[J]
+    with Has[K]
+    with Has[L]
+    with Has[M]
+    with Has[N]
+    with Has[O]
+    with Has[P]
+    with Has[Q]
+    with Has[R]
+    with Has[S]
+    with Has[T]
+    with Has[U]
+    with Has[V] =
+    Has(a)
+      .add(b)
+      .add(c)
+      .add(d)
+      .add(e)
+      .add(f)
+      .add(g)
+      .add(h)
+      .add(i)
+      .add(j)
+      .add(k)
+      .add(l)
+      .add(m)
+      .add(n)
+      .add(o)
+      .add(p)
+      .add(q)
+      .add(r)
+      .add(s)
+      .add(t)
+      .add(u)
+      .add(v)
 
   /**
    * Modifies an environment in a scoped way.

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -230,18 +230,7 @@ object Has {
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged](
     a: A,
     b: B,
     c: C,
@@ -252,34 +241,13 @@ object Has {
     h: H,
     i: I,
     j: J
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged](
     a: A,
     b: B,
     c: C,
@@ -291,36 +259,13 @@ object Has {
     i: I,
     j: J,
     k: K
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged](
     a: A,
     b: B,
     c: C,
@@ -333,38 +278,13 @@ object Has {
     j: J,
     k: K,
     l: L
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged](
     a: A,
     b: B,
     c: C,
@@ -378,40 +298,13 @@ object Has {
     k: K,
     l: L,
     m: M
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged](
     a: A,
     b: B,
     c: C,
@@ -426,42 +319,13 @@ object Has {
     l: L,
     m: M,
     n: N
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged](
     a: A,
     b: B,
     c: C,
@@ -476,45 +340,14 @@ object Has {
     l: L,
     m: M,
     n: N,
-    o: O
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O] =
+    o: O,
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged](
     a: A,
     b: B,
     c: C,
@@ -531,46 +364,13 @@ object Has {
     n: N,
     o: O,
     p: P
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P] =
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] =
     Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged](
     a: A,
     b: B,
     c: C,
@@ -588,64 +388,13 @@ object Has {
     o: O,
     p: P,
     q: Q
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged,
-    R: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged, R: Tagged](
     a: A,
     b: B,
     c: C,
@@ -664,67 +413,13 @@ object Has {
     p: P,
     q: Q,
     r: R
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q]
-    with Has[R] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
-      .add(r)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] with Has[R] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q).add(r)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged,
-    R: Tagged,
-    S: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged, R: Tagged, S: Tagged](
     a: A,
     b: B,
     c: C,
@@ -744,70 +439,13 @@ object Has {
     q: Q,
     r: R,
     s: S
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q]
-    with Has[R]
-    with Has[S] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
-      .add(r)
-      .add(s)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] with Has[R] with Has[S] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q).add(r).add(s)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged,
-    R: Tagged,
-    S: Tagged,
-    T: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged, R: Tagged, S: Tagged, T: Tagged](
     a: A,
     b: B,
     c: C,
@@ -828,73 +466,13 @@ object Has {
     r: R,
     s: S,
     t: T
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q]
-    with Has[R]
-    with Has[S]
-    with Has[T] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
-      .add(r)
-      .add(s)
-      .add(t)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] with Has[R] with Has[S] with Has[T] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q).add(r).add(s).add(t)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged,
-    R: Tagged,
-    S: Tagged,
-    T: Tagged,
-    U: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged, R: Tagged, S: Tagged, T: Tagged, U: Tagged](
     a: A,
     b: B,
     c: C,
@@ -916,76 +494,13 @@ object Has {
     s: S,
     t: T,
     u: U
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q]
-    with Has[R]
-    with Has[S]
-    with Has[T]
-    with Has[U] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
-      .add(r)
-      .add(s)
-      .add(t)
-      .add(u)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] with Has[R] with Has[S] with Has[T] with Has[U] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q).add(r).add(s).add(t).add(u)
 
   /**
    * Constructs a new environment holding the specified services.
    */
-  def allOf[
-    A: Tagged,
-    B: Tagged,
-    C: Tagged,
-    D: Tagged,
-    E: Tagged,
-    F: Tagged,
-    G: Tagged,
-    H: Tagged,
-    I: Tagged,
-    J: Tagged,
-    K: Tagged,
-    L: Tagged,
-    M: Tagged,
-    N: Tagged,
-    O: Tagged,
-    P: Tagged,
-    Q: Tagged,
-    R: Tagged,
-    S: Tagged,
-    T: Tagged,
-    U: Tagged,
-    V: Tagged
-  ](
+  def allOf[A: Tagged, B: Tagged, C: Tagged, D: Tagged, E: Tagged, F: Tagged, G: Tagged, H: Tagged, I: Tagged, J: Tagged, K: Tagged, L: Tagged, M: Tagged, N: Tagged, O: Tagged, P: Tagged, Q: Tagged, R: Tagged, S: Tagged, T: Tagged, U: Tagged, V: Tagged](
     a: A,
     b: B,
     c: C,
@@ -1008,50 +523,8 @@ object Has {
     t: T,
     u: U,
     v: V
-  ): Has[A]
-    with Has[B]
-    with Has[C]
-    with Has[D]
-    with Has[E]
-    with Has[F]
-    with Has[G]
-    with Has[H]
-    with Has[I]
-    with Has[J]
-    with Has[K]
-    with Has[L]
-    with Has[M]
-    with Has[N]
-    with Has[O]
-    with Has[P]
-    with Has[Q]
-    with Has[R]
-    with Has[S]
-    with Has[T]
-    with Has[U]
-    with Has[V] =
-    Has(a)
-      .add(b)
-      .add(c)
-      .add(d)
-      .add(e)
-      .add(f)
-      .add(g)
-      .add(h)
-      .add(i)
-      .add(j)
-      .add(k)
-      .add(l)
-      .add(m)
-      .add(n)
-      .add(o)
-      .add(p)
-      .add(q)
-      .add(r)
-      .add(s)
-      .add(t)
-      .add(u)
-      .add(v)
+  ): Has[A] with Has[B] with Has[C] with Has[D] with Has[E] with Has[F] with Has[G] with Has[H] with Has[I] with Has[J] with Has[K] with Has[L] with Has[M] with Has[N] with Has[O] with Has[P] with Has[Q] with Has[R] with Has[S] with Has[T] with Has[U] with Has[V] =
+    Has(a).add(b).add(c).add(d).add(e).add(f).add(g).add(h).add(i).add(j).add(k).add(l).add(m).add(n).add(o).add(p).add(q).add(r).add(s).add(t).add(u).add(v)
 
   /**
    * Modifies an environment in a scoped way.

--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -48,7 +48,7 @@ final class Has[A] private (
 object Has {
   private val TaggedAnyRef: Tagged[AnyRef] = implicitly[Tagged[AnyRef]]
 
-  type MustHave[A, B]    = A <:< Has[B]
+  type MustHave[A, B] = A <:< Has[B]
 
   trait IsHas[-R] {
     def add[R0 <: R, M: Tagged](r: R0, m: M): R0 with Has[M]

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -220,75 +220,1091 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified service.
    */
   def fromService[A: Tagged, B: Tagged](f: A => B): ZLayer[Has[A], Nothing, Has[B]] =
-    fromServiceMany(a => Has(f(a)))
+    fromServiceM[A, Any, Nothing, B](a => ZIO.succeedNow(f(a)))
 
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[A0: Tagged, A1: Tagged, B: Tagged](f: (A0, A1) => B): ZLayer[Has[A0] with Has[A1], Nothing, Has[B]] =
-    fromServicesMany[A0, A1, Has[B]]((a0, a1) => Has(f(a0, a1)))
+  def fromServices[A0: Tagged, A1: Tagged, B: Tagged](
+    f: (A0, A1) => B
+  ): ZLayer[Has[A0] with Has[A1], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services.
    */
   def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, B: Tagged](
     f: (A0, A1, A2) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2], Nothing, Has[B]] =
-    fromServicesMany[A0, A1, A2, Has[B]]((a0, a1, a2) => Has(f(a0, a1, a2)))
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services.
    */
   def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, B: Tagged](
     f: (A0, A1, A2, A3) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3], Nothing, Has[B]] =
-    fromServicesMany[A0, A1, A2, A3, Has[B]]((a0, a1, a2, a3) => Has(f(a0, a1, a2, a3)))
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services.
    */
   def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], Nothing, Has[B]] =
-    fromServicesMany[A0, A1, A2, A3, A4, Has[B]]((a0, a1, a2, a3, a4) => Has(f(a0, a1, a2, a3, a4)))
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5, A6) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], Nothing, Has[
+    B
+  ]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, Has[
+    B
+  ]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services.
+   */
+  def fromServices[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, Has[B]] = {
+    val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified service.
    */
   def fromServiceM[A: Tagged, R, E, B: Tagged](f: A => ZIO[R, E, B]): ZLayer[R with Has[A], E, Has[B]] =
-    fromServiceManyM(a => f(a).asService)
+    fromServiceManaged(a => f(a).toManaged_)
 
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
   def fromServicesM[A0: Tagged, A1: Tagged, R, E, B: Tagged](
     f: (A0, A1) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1], E, Has[B]] =
-    fromServicesManyM[A0, A1, R, E, Has[B]]((a0, a1) => f(a0, a1).asService)
+  ): ZLayer[R with Has[A0] with Has[A1], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
   def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, Has[B]] =
-    fromServicesManyM[A0, A1, A2, R, E, Has[B]]((a0, a1, a2) => f(a0, a1, a2).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
   def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, Has[B]] =
-    fromServicesManyM[A0, A1, A2, A3, R, E, Has[B]]((a0, a1, a2, a3) => f(a0, a1, a2, a3).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
   def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, Has[B]] =
-    fromServicesManyM[A0, A1, A2, A3, A4, R, E, Has[B]]((a0, a1, a2, a3, a4) => f(a0, a1, a2, a3, a4).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[
+    B
+  ]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[
+    B
+  ]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services.
+   */
+  def fromServicesM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20,
+      A21
+    ) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
+    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
@@ -303,8 +1319,10 @@ object ZLayer {
    */
   def fromServicesManaged[A0: Tagged, A1: Tagged, R, E, B: Tagged](
     f: (A0, A1) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1], E, Has[B]] =
-    fromServicesManyManaged[A0, A1, R, E, Has[B]]((a0, a1) => f(a0, a1).asService)
+  ): ZLayer[R with Has[A0] with Has[A1], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
@@ -312,8 +1330,10 @@ object ZLayer {
    */
   def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, Has[B]] =
-    fromServicesManyManaged[A0, A1, A2, R, E, Has[B]]((a0, a1, a2) => f(a0, a1, a2).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
@@ -321,8 +1341,10 @@ object ZLayer {
    */
   def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, Has[B]] =
-    fromServicesManyManaged[A0, A1, A2, A3, R, E, Has[B]]((a0, a1, a2, a3) => f(a0, a1, a2, a3).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
@@ -330,15 +1352,612 @@ object ZLayer {
    */
   def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, Has[B]] =
-    fromServicesManyManaged[A0, A1, A2, A3, A4, R, E, Has[B]]((a0, a1, a2, a3, a4) => f(a0, a1, a2, a3, a4).asService)
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[
+    B
+  ]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[
+    B
+  ]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20
+    ) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] =
+    fromServicesManyManaged[
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20,
+      R,
+      E,
+      Has[B]
+    ]((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =>
+      f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20).asService
+    )
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services.
+   */
+  def fromServicesManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    R,
+    E,
+    B: Tagged
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20,
+      A21
+    ) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.asService))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified service, which
    * must return one or more services.
    */
   def fromServiceMany[A: Tagged, B <: Has[_]](f: A => B): ZLayer[Has[A], Nothing, B] =
-    ZLayer(ZManaged.fromEffect(ZIO.access[Has[A]](m => f(m.get[A]))))
+    fromServiceManyM[A, Any, Nothing, B](a => ZIO.succeedNow(f(a)))
 
   /**
    * Constructs a layer that purely depends on the specified services, which
@@ -346,13 +1965,10 @@ object ZLayer {
    */
   def fromServicesMany[A0: Tagged, A1: Tagged, B <: Has[_]](
     f: (A0, A1) => B
-  ): ZLayer[Has[A0] with Has[A1], Nothing, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-      } yield f(a0, a1)
-    })
+  ): ZLayer[Has[A0] with Has[A1], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services, which
@@ -360,14 +1976,10 @@ object ZLayer {
    */
   def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, B <: Has[_]](
     f: (A0, A1, A2) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2], Nothing, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-      } yield f(a0, a1, a2)
-    })
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services, which
@@ -375,15 +1987,10 @@ object ZLayer {
    */
   def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3], Nothing, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-        a3 <- ZIO.environment[Has[A3]].map(_.get[A3])
-      } yield f(a0, a1, a2, a3)
-    })
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
 
   /**
    * Constructs a layer that purely depends on the specified services, which
@@ -391,23 +1998,497 @@ object ZLayer {
    */
   def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], Nothing, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-        a3 <- ZIO.environment[Has[A3]].map(_.get[A3])
-        a4 <- ZIO.environment[Has[A4]].map(_.get[A4])
-      } yield f(a0, a1, a2, a3, a4)
-    })
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5, A6) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[
+    A9
+  ] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
+
+  /**
+   * Constructs a layer that purely depends on the specified services, which
+   * must return one or more services.
+   */
+  def fromServicesMany[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, B] = {
+    val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified service,
    * which must return one or more services.
    */
   def fromServiceManyM[A: Tagged, R, E, B <: Has[_]](f: A => ZIO[R, E, B]): ZLayer[R with Has[A], E, B] =
-    ZLayer(ZManaged.fromEffect(ZIO.accessM[R with Has[A]](m => f(m.get[A]))))
+    fromServiceManyManaged(a => f(a).toManaged_)
 
   /**
    * Constructs a layer that effectfully depends on the specified services,
@@ -415,14 +2496,10 @@ object ZLayer {
    */
   def fromServicesManyM[A0: Tagged, A1: Tagged, R, E, B <: Has[_]](
     f: (A0, A1) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1], E, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        b  <- f(a0, a1)
-      } yield b
-    })
+  ): ZLayer[R with Has[A0] with Has[A1], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services,
@@ -430,15 +2507,10 @@ object ZLayer {
    */
   def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-        b  <- f(a0, a1, a2)
-      } yield b
-    })
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services,
@@ -446,16 +2518,10 @@ object ZLayer {
    */
   def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-        a3 <- ZIO.environment[Has[A3]].map(_.get[A3])
-        b  <- f(a0, a1, a2, a3)
-      } yield b
-    })
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that effectfully depends on the specified services,
@@ -463,17 +2529,554 @@ object ZLayer {
    */
   def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, B] =
-    ZLayer(ZManaged.fromEffect {
-      for {
-        a0 <- ZIO.environment[Has[A0]].map(_.get[A0])
-        a1 <- ZIO.environment[Has[A1]].map(_.get[A1])
-        a2 <- ZIO.environment[Has[A2]].map(_.get[A2])
-        a3 <- ZIO.environment[Has[A3]].map(_.get[A3])
-        a4 <- ZIO.environment[Has[A4]].map(_.get[A4])
-        b  <- f(a0, a1, a2, a3, a4)
-      } yield b
-    })
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
+
+  /**
+   * Constructs a layer that effectfully depends on the specified services,
+   * which must return one or more services.
+   */
+  def fromServicesManyM[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20,
+      A21
+    ) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] = {
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    layer
+  }
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
@@ -545,6 +3148,846 @@ object ZLayer {
         a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
         a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
         b  <- f(a0, a1, a2, a3, a4)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B <: Has[
+    _
+  ]](
+    f: (A0, A1, A2, A3, A4, A5) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, B] =
+    ZLayer {
+      for {
+        a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1 <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2 <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5 <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        b  <- f(a0, a1, a2, a3, a4, a5)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, B] =
+    ZLayer {
+      for {
+        a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1 <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2 <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5 <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6 <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        b  <- f(a0, a1, a2, a3, a4, a5, a6)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, B] =
+    ZLayer {
+      for {
+        a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1 <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2 <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5 <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6 <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7 <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        b  <- f(a0, a1, a2, a3, a4, a5, a6, a7)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ], E, B] =
+    ZLayer {
+      for {
+        a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1 <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2 <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5 <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6 <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7 <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8 <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        b  <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9], E, B] =
+    ZLayer {
+      for {
+        a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1 <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2 <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3 <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4 <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5 <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6 <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7 <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8 <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9 <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        b  <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        a17 <- ZManaged.environment[Has[A17]].map(_.get[A17])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        a17 <- ZManaged.environment[Has[A17]].map(_.get[A17])
+        a18 <- ZManaged.environment[Has[A18]].map(_.get[A18])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        a17 <- ZManaged.environment[Has[A17]].map(_.get[A17])
+        a18 <- ZManaged.environment[Has[A18]].map(_.get[A18])
+        a19 <- ZManaged.environment[Has[A19]].map(_.get[A19])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20
+    ) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        a17 <- ZManaged.environment[Has[A17]].map(_.get[A17])
+        a18 <- ZManaged.environment[Has[A18]].map(_.get[A18])
+        a19 <- ZManaged.environment[Has[A19]].map(_.get[A19])
+        a20 <- ZManaged.environment[Has[A20]].map(_.get[A20])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+      } yield b
+    }
+
+  /**
+   * Constructs a layer that resourcefully and effectfully depends on the
+   * specified services, which must return one or more services.
+   */
+  def fromServicesManyManaged[
+    A0: Tagged,
+    A1: Tagged,
+    A2: Tagged,
+    A3: Tagged,
+    A4: Tagged,
+    A5: Tagged,
+    A6: Tagged,
+    A7: Tagged,
+    A8: Tagged,
+    A9: Tagged,
+    A10: Tagged,
+    A11: Tagged,
+    A12: Tagged,
+    A13: Tagged,
+    A14: Tagged,
+    A15: Tagged,
+    A16: Tagged,
+    A17: Tagged,
+    A18: Tagged,
+    A19: Tagged,
+    A20: Tagged,
+    A21: Tagged,
+    R,
+    E,
+    B <: Has[_]
+  ](
+    f: (
+      A0,
+      A1,
+      A2,
+      A3,
+      A4,
+      A5,
+      A6,
+      A7,
+      A8,
+      A9,
+      A10,
+      A11,
+      A12,
+      A13,
+      A14,
+      A15,
+      A16,
+      A17,
+      A18,
+      A19,
+      A20,
+      A21
+    ) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
+    A17
+  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] =
+    ZLayer {
+      for {
+        a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
+        a1  <- ZManaged.environment[Has[A1]].map(_.get[A1])
+        a2  <- ZManaged.environment[Has[A2]].map(_.get[A2])
+        a3  <- ZManaged.environment[Has[A3]].map(_.get[A3])
+        a4  <- ZManaged.environment[Has[A4]].map(_.get[A4])
+        a5  <- ZManaged.environment[Has[A5]].map(_.get[A5])
+        a6  <- ZManaged.environment[Has[A6]].map(_.get[A6])
+        a7  <- ZManaged.environment[Has[A7]].map(_.get[A7])
+        a8  <- ZManaged.environment[Has[A8]].map(_.get[A8])
+        a9  <- ZManaged.environment[Has[A9]].map(_.get[A9])
+        a10 <- ZManaged.environment[Has[A10]].map(_.get[A10])
+        a11 <- ZManaged.environment[Has[A11]].map(_.get[A11])
+        a12 <- ZManaged.environment[Has[A12]].map(_.get[A12])
+        a13 <- ZManaged.environment[Has[A13]].map(_.get[A13])
+        a14 <- ZManaged.environment[Has[A14]].map(_.get[A14])
+        a15 <- ZManaged.environment[Has[A15]].map(_.get[A15])
+        a16 <- ZManaged.environment[Has[A16]].map(_.get[A16])
+        a17 <- ZManaged.environment[Has[A17]].map(_.get[A17])
+        a18 <- ZManaged.environment[Has[A18]].map(_.get[A18])
+        a19 <- ZManaged.environment[Has[A19]].map(_.get[A19])
+        a20 <- ZManaged.environment[Has[A20]].map(_.get[A20])
+        a21 <- ZManaged.environment[Has[A21]].map(_.get[A21])
+        b   <- f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
       } yield b
     }
 
@@ -669,4 +4112,160 @@ object ZLayer {
           }
         }
   }
+
+  private def andThen[A0, A1, B, C](f: (A0, A1) => B)(g: B => C): (A0, A1) => C =
+    (a0, a1) => g(f(a0, a1))
+
+  private def andThen[A0, A1, A2, B, C](f: (A0, A1, A2) => B)(g: B => C): (A0, A1, A2) => C =
+    (a0, a1, a2) => g(f(a0, a1, a2))
+
+  private def andThen[A0, A1, A2, A3, B, C](f: (A0, A1, A2, A3) => B)(g: B => C): (A0, A1, A2, A3) => C =
+    (a0, a1, a2, a3) => g(f(a0, a1, a2, a3))
+
+  private def andThen[A0, A1, A2, A3, A4, B, C](f: (A0, A1, A2, A3, A4) => B)(g: B => C): (A0, A1, A2, A3, A4) => C =
+    (a0, a1, a2, a3, a4) => g(f(a0, a1, a2, a3, a4))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, B, C](
+    f: (A0, A1, A2, A3, A4, A5) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5) => C =
+    (a0, a1, a2, a3, a4, a5) => g(f(a0, a1, a2, a3, a4, a5))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6) => C =
+    (a0, a1, a2, a3, a4, a5, a6) => g(f(a0, a1, a2, a3, a4, a5, a6))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7) => g(f(a0, a1, a2, a3, a4, a5, a6, a7))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, B, C](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+
+  private def andThen[
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+    A8,
+    A9,
+    A10,
+    A11,
+    A12,
+    A13,
+    A14,
+    A15,
+    A16,
+    A17,
+    A18,
+    A19,
+    A20,
+    B,
+    C
+  ](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
+  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+
+  private def andThen[
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+    A8,
+    A9,
+    A10,
+    A11,
+    A12,
+    A13,
+    A14,
+    A15,
+    A16,
+    A17,
+    A18,
+    A19,
+    A20,
+    A21,
+    B,
+    C
+  ](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B)(
+    g: B => C
+  ): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) =>
+      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21))
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -285,21 +285,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], Nothing, Has[
-    B
-  ]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -307,22 +295,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -330,23 +305,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -354,24 +315,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -379,25 +325,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -405,26 +335,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -432,27 +345,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -460,28 +355,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -489,29 +365,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -519,32 +375,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, Has[
-    B
-  ]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -552,33 +385,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -586,34 +395,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -621,35 +405,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -657,36 +415,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -694,37 +425,9 @@ object ZLayer {
   /**
    * Constructs a layer that purely depends on the specified services.
    */
-  def fromServices[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    B: Tagged
-  ](
+  def fromServices[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, Has[B]] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, Has[B]] = {
     val layer = fromServicesM(andThen(f)(ZIO.succeedNow(_)))
     layer
   }
@@ -788,18 +491,7 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
@@ -809,23 +501,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[
-    B
-  ]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -833,24 +511,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -858,25 +521,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -884,26 +531,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -911,27 +541,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -939,28 +551,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -968,29 +561,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -998,30 +571,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1029,31 +581,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1061,34 +591,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[
-    B
-  ]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1096,35 +601,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1132,36 +611,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1169,37 +621,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1207,38 +631,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1246,62 +641,9 @@ object ZLayer {
   /**
    * Constructs a layer that effectfully depends on the specified services.
    */
-  def fromServicesM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20,
-      A21
-    ) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
+  def fromServicesM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, R, E, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
     val layer = fromServicesManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -1372,18 +714,7 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZManaged[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
@@ -1394,23 +725,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[
-    B
-  ]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1419,24 +736,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1445,25 +747,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1472,26 +758,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1500,27 +769,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1529,28 +780,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1559,29 +791,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1590,30 +802,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1622,31 +813,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1655,34 +824,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[
-    B
-  ]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1691,35 +835,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1728,36 +846,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1766,37 +857,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, R, E, B: Tagged](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], E, Has[B]] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -1805,149 +868,18 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20
-    ) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] =
-    fromServicesManyManaged[
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20,
-      R,
-      E,
-      Has[B]
-    ]((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =>
-      f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20).asService
-    )
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, R, E, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] =
+    fromServicesManyManaged[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, R, E, Has[B]]((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) => f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20).asService)
 
   /**
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services.
    */
-  def fromServicesManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    R,
-    E,
-    B: Tagged
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20,
-      A21
-    ) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
+  def fromServicesManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, R, E, B: Tagged](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
     val layer = fromServicesManyManaged(andThen(f)(_.asService))
     layer
   }
@@ -2029,17 +961,7 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
   ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
@@ -2050,22 +972,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2074,23 +983,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2099,51 +994,20 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
-
+ 
   /**
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2152,26 +1016,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2180,27 +1027,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2209,28 +1038,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2239,29 +1049,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2270,32 +1060,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[
-    A9
-  ] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2304,33 +1071,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2339,34 +1082,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2375,35 +1093,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2412,36 +1104,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2450,37 +1115,9 @@ object ZLayer {
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services.
    */
-  def fromServicesMany[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    B <: Has[_]
-  ](
+  def fromServicesMany[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, B] = {
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
@@ -2551,18 +1188,7 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
@@ -2573,19 +1199,7 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
@@ -2596,24 +1210,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2622,25 +1221,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2649,26 +1232,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2677,27 +1243,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2706,28 +1254,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2736,29 +1265,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2767,30 +1276,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2799,31 +1287,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2832,32 +1298,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2866,35 +1309,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2903,36 +1320,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2941,37 +1331,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -2980,38 +1342,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], E, B] = {
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -3020,62 +1353,9 @@ object ZLayer {
    * Constructs a layer that effectfully depends on the specified services,
    * which must return one or more services.
    */
-  def fromServicesManyM[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20,
-      A21
-    ) => ZIO[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] = {
+  def fromServicesManyM[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, R, E, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => ZIO[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] = {
     val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
     layer
   }
@@ -3157,9 +1437,7 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B <: Has[
-    _
-  ]](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5) => ZManaged[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, B] =
     ZLayer {
@@ -3178,18 +1456,7 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZManaged[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, B] =
     ZLayer {
@@ -3209,19 +1476,7 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7) => ZManaged[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7], E, B] =
     ZLayer {
@@ -3242,24 +1497,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8], E, B] =
     ZLayer {
       for {
         a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3279,25 +1519,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9], E, B] =
     ZLayer {
       for {
         a0 <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3318,26 +1542,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3359,27 +1566,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3402,28 +1591,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3447,29 +1617,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3494,30 +1644,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3543,31 +1672,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3594,32 +1701,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3647,35 +1731,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3704,36 +1762,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3763,37 +1794,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, R, E, B <: Has[_]](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19], E, B] =
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3824,60 +1827,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20
-    ) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20], E, B] =
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, R, E, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -3909,62 +1861,9 @@ object ZLayer {
    * Constructs a layer that resourcefully and effectfully depends on the
    * specified services, which must return one or more services.
    */
-  def fromServicesManyManaged[
-    A0: Tagged,
-    A1: Tagged,
-    A2: Tagged,
-    A3: Tagged,
-    A4: Tagged,
-    A5: Tagged,
-    A6: Tagged,
-    A7: Tagged,
-    A8: Tagged,
-    A9: Tagged,
-    A10: Tagged,
-    A11: Tagged,
-    A12: Tagged,
-    A13: Tagged,
-    A14: Tagged,
-    A15: Tagged,
-    A16: Tagged,
-    A17: Tagged,
-    A18: Tagged,
-    A19: Tagged,
-    A20: Tagged,
-    A21: Tagged,
-    R,
-    E,
-    B <: Has[_]
-  ](
-    f: (
-      A0,
-      A1,
-      A2,
-      A3,
-      A4,
-      A5,
-      A6,
-      A7,
-      A8,
-      A9,
-      A10,
-      A11,
-      A12,
-      A13,
-      A14,
-      A15,
-      A16,
-      A17,
-      A18,
-      A19,
-      A20,
-      A21
-    ) => ZManaged[R, E, B]
-  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
-    A8
-  ] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[
-    A17
-  ] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] =
+  def fromServicesManyManaged[A0: Tagged, A1: Tagged, A2: Tagged, A3: Tagged, A4: Tagged, A5: Tagged, A6: Tagged, A7: Tagged, A8: Tagged, A9: Tagged, A10: Tagged, A11: Tagged, A12: Tagged, A13: Tagged, A14: Tagged, A15: Tagged, A16: Tagged, A17: Tagged, A18: Tagged, A19: Tagged, A20: Tagged, A21: Tagged, R, E, B <: Has[_]](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => ZManaged[R, E, B]
+  ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] =
     ZLayer {
       for {
         a0  <- ZManaged.environment[Has[A0]].map(_.get[A0])
@@ -4127,147 +2026,54 @@ object ZLayer {
   private def andThen[A0, A1, A2, A3, A4, B, C](f: (A0, A1, A2, A3, A4) => B)(g: B => C): (A0, A1, A2, A3, A4) => C =
     (a0, a1, a2, a3, a4) => g(f(a0, a1, a2, a3, a4))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, B, C](
-    f: (A0, A1, A2, A3, A4, A5) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, B, C](f: (A0, A1, A2, A3, A4, A5) => B)(g: B => C): (A0, A1, A2, A3, A4, A5) => C =
     (a0, a1, a2, a3, a4, a5) => g(f(a0, a1, a2, a3, a4, a5))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, B, C](f: (A0, A1, A2, A3, A4, A5, A6) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6) => C =
     (a0, a1, a2, a3, a4, a5, a6) => g(f(a0, a1, a2, a3, a4, a5, a6))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7) => C =
     (a0, a1, a2, a3, a4, a5, a6, a7) => g(f(a0, a1, a2, a3, a4, a5, a6, a7))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8) => C =
     (a0, a1, a2, a3, a4, a5, a6, a7, a8) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => C =
     (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => C =
     (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => C =
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => C =
     (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
 
-  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, B, C](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
 
-  private def andThen[
-    A0,
-    A1,
-    A2,
-    A3,
-    A4,
-    A5,
-    A6,
-    A7,
-    A8,
-    A9,
-    A10,
-    A11,
-    A12,
-    A13,
-    A14,
-    A15,
-    A16,
-    A17,
-    A18,
-    A19,
-    A20,
-    B,
-    C
-  ](
-    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B
-  )(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
 
-  private def andThen[
-    A0,
-    A1,
-    A2,
-    A3,
-    A4,
-    A5,
-    A6,
-    A7,
-    A8,
-    A9,
-    A10,
-    A11,
-    A12,
-    A13,
-    A14,
-    A15,
-    A16,
-    A17,
-    A18,
-    A19,
-    A20,
-    A21,
-    B,
-    C
-  ](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B)(
-    g: B => C
-  ): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => C =
-    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) =>
-      g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21))
+  private def andThen[A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, B, C](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B)(g: B => C): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => C =
+    (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) => g(f(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21))
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -2291,7 +2291,9 @@ object ZLayer {
     B <: Has[_]
   ](
     f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B
-  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[A8] with Has[
+  ): ZLayer[Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[A7] with Has[
+    A8
+  ] with Has[
     A9
   ] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[A15] with Has[A16], Nothing, B] = {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))


### PR DESCRIPTION
Implements higher arity variants of all relevant `ZLayer` and `Has` combinators up to arity 22. Removes unused `upcast` methods. Removes remaining documentation referring to restriction to monomorphic services.