### PR TITLE
Provide ZEnv in Default Runtime

### DIFF
--- a/core/js/src/main/scala/zio/App.scala
+++ b/core/js/src/main/scala/zio/App.scala
@@ -28,5 +28,5 @@ trait App extends BootstrapRuntime {
    * The Scala main function, intended to be called only by the Scala runtime.
    */
   final def main(args0: Array[String]): Unit =
-    unsafeRunAsync(run(args0.toList).provideLayer(ZEnv.live))(_ => ())
+    unsafeRunAsync(run(args0.toList))(_ => ())
 }

--- a/core/js/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/PlatformSpecific.scala
@@ -25,8 +25,20 @@ private[zio] trait PlatformSpecific {
   type ZEnv = Clock with Console with System with Random
 
   object ZEnv {
+
+    private[zio] object Services {
+      val live: ZEnv =
+        Has.allOf[Clock.Service, Console.Service, System.Service, Random.Service](
+          Clock.Service.live,
+          Console.Service.live,
+          System.Service.live,
+          Random.Service.live
+        )
+    }
+
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
+
     val live: ZLayer.NoDeps[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }

--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -61,7 +61,7 @@ trait App extends BootstrapRuntime {
               }))
           result <- fiber.join
           _      <- fiber.interrupt
-        } yield result).provideLayer(ZEnv.live)
+        } yield result)
       )
     )
     catch { case _: SecurityException => }

--- a/core/jvm/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/PlatformSpecific.scala
@@ -26,8 +26,21 @@ private[zio] trait PlatformSpecific {
   type ZEnv = Clock with Console with System with Random with Blocking
 
   object ZEnv {
+
+    private[zio] object Services {
+      val live: ZEnv =
+        Has.allOf[Clock.Service, Console.Service, System.Service, Random.Service, Blocking.Service](
+          Clock.Service.live,
+          Console.Service.live,
+          System.Service.live,
+          Random.Service.live,
+          Blocking.Service.live
+        )
+    }
+
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
+
     val live: ZLayer.NoDeps[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live ++ Blocking.live
   }

--- a/core/native/src/main/scala/zio/App.scala
+++ b/core/native/src/main/scala/zio/App.scala
@@ -28,5 +28,5 @@ trait App extends BootstrapRuntime {
    * The Scala main function, intended to be called only by the Scala runtime.
    */
   final def main(args0: Array[String]): Unit =
-    unsafeRunAsync(run(args0.toList).provideLayer(ZEnv.live))(_ => ())
+    unsafeRunAsync(run(args0.toList))(_ => ())
 }

--- a/core/native/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/PlatformSpecific.scala
@@ -25,8 +25,15 @@ private[zio] trait PlatformSpecific {
   type ZEnv = Clock with Console with System with Random
 
   object ZEnv {
+
+    object Services { 
+      val live: ZEnv =
+        Has.allOf[Clock.Service, Console.Service, System.Service, Random.Service](Clock.Service.live, Console.Service.live, System.Service.live, Random.Service.live)
+      }
+
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
+
     val live: ZLayer.NoDeps[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }

--- a/core/shared/src/main/scala/zio/BootstrapRuntime.scala
+++ b/core/shared/src/main/scala/zio/BootstrapRuntime.scala
@@ -18,8 +18,8 @@ package zio
 
 import zio.internal.Platform
 
-trait BootstrapRuntime extends Runtime[Unit] {
-  val environment: Unit = ()
+trait BootstrapRuntime extends Runtime[ZEnv] {
+  val environment: ZEnv = ZEnv.Services.live
 
   /**
    * The platform of the runtime, which provides the essential capabilities

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -226,9 +226,9 @@ object Runtime {
     val platform    = platform0
   }
 
-  lazy val default = Runtime((), Platform.default)
+  lazy val default: Runtime[ZEnv] = Runtime(ZEnv.Services.live, Platform.default)
 
-  lazy val global = Runtime((), Platform.global)
+  lazy val global: Runtime[ZEnv] = Runtime(ZEnv.Services.live, Platform.global)
 
   /**
    * Unsafely creates a `Runtime` from a `ZLayer` whose resources will be

--- a/docs/interop/catseffect.md
+++ b/docs/interop/catseffect.md
@@ -30,10 +30,10 @@ type Task [    +A] = ZIO[Any, Throwable, A]
 type RIO[-R, +A]   = ZIO[  R, Throwable, A]
 ```
 
-In order to use Cats Effect instances for these types, you should have an implicit `Runtime[R]` in scope for the environment type of your effects. The following code snippet creates an implicit `Runtime` for effects that do not require any environment:
+In order to use Cats Effect instances for these types, you should have an implicit `Runtime[R]` in scope for the environment type of your effects. The following code snippet creates an implicit `Runtime` for all the modules built into ZIO:
 
 ```scala
-implicit val runtime: Runtime[Unit] = Runtime.default
+implicit val runtime: Runtime[ZEnv] = Runtime.default
 ```
 
 If you are using `RIO` for a custom environment `R`, then you will have to create your own `Runtime[R]`, and ensure that implicit wherever you need Cats Effect instances.

--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -37,7 +37,7 @@ Most applications are not greenfield, and must integrate with legacy code, and p
 
 In these cases, a better solution for running effects is to create a `Runtime`, which can be passed around and used to run effects wherever required.
 
-ZIO contains a default runtime called `Runtime.default` that can be used to run effects that do not require any environment, for example because they have been provided with their environmental requirements using combinators such as `ZIO#provideLayer`.
+ZIO contains a default runtime called `Runtime.default`. This `Runtime` bundles together production implementations of all ZIO modules (including `Console`, `System`, `Clock`, `Random`, `Scheduler`, and on the JVM, `Blocking`), and it can run effects that require any combination of these modules.
 
 To access it, merely use
 


### PR DESCRIPTION
With the changes we made to expose the services for the default environment types we can bundle these services together and include them in the default runtime to provide the same experience as before. I think this will make it significantly easier to work with mixed applications and in particular it sounds like something like this is necessary for `cats-interop`.