### PR TITLE
remove clean from ci-release as its done for you

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ release: &release
             $HOME/bin/gpg --version
             echo RELOADAGENT | gpg-connect-agent
             echo $PGP_SECRET | base64 -di | gpg2 --import --no-tty --batch --yes
-            PATH=$HOME/bin:$PATH ./sbt ++${SCALA_VERSION}! clean ci-release
+            PATH=$HOME/bin:$PATH ./sbt ++${SCALA_VERSION}! ci-release
 
 microsite: &microsite
   steps:


### PR DESCRIPTION
scala steward upgraded ci-release to 1.5.2 (https://github.com/zio/zio/pull/3028) which does the clean for you so removing from circle config.

Ref: https://github.com/olafurpg/sbt-ci-release/blob/master/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L148

