### PR TITLE
ZIO Core: Add ZLayer Type Aliases

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -10,7 +10,7 @@ object ZLayerSpec extends ZIOBaseSpec {
   trait Dog extends Animal
   trait Cat extends Animal
 
-  def testSize[R <: Has[_]](layer: ZLayer.NoDeps[Nothing, R], n: Int, label: String = ""): UIO[TestResult] =
+  def testSize[R <: Has[_]](layer: Layer[Nothing, R], n: Int, label: String = ""): UIO[TestResult] =
     layer.build.use(env => ZIO.succeedNow(assert(env.size)(if (label == "") equalTo(n) else equalTo(n) ?? label)))
 
   val acquire1 = "Acquiring Module 1"
@@ -236,9 +236,9 @@ object ZLayerSpec extends ZIOBaseSpec {
       testM("map can map the output of a layer to an unrelated type") {
         case class A(name: String, value: Int)
         case class B(name: String)
-        val l1: ZLayer.NoDeps[Nothing, Has[A]]       = ZLayer.succeed(A("name", 1))
+        val l1: Layer[Nothing, Has[A]]               = ZLayer.succeed(A("name", 1))
         val l2: ZLayer[Has[String], Nothing, Has[B]] = ZLayer.fromService(B)
-        val live: ZLayer.NoDeps[Nothing, Has[B]]     = l1.map(a => Has(a.get[A].name)) >>> l2
+        val live: Layer[Nothing, Has[B]]             = l1.map(a => Has(a.get[A].name)) >>> l2
         assertM(ZIO.access[Has[B]](_.get).provideLayer(live))(equalTo(B("name")))
       },
       testM("memoization") {

--- a/core/js/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/PlatformSpecific.scala
@@ -39,7 +39,7 @@ private[zio] trait PlatformSpecific {
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
 
-    val live: ZLayer.NoDeps[Nothing, ZEnv] =
+    val live: Layer[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }
 }

--- a/core/jvm/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/PlatformSpecific.scala
@@ -41,7 +41,7 @@ private[zio] trait PlatformSpecific {
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
 
-    val live: ZLayer.NoDeps[Nothing, ZEnv] =
+    val live: Layer[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live ++ Blocking.live
   }
 }

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -153,7 +153,7 @@ package object blocking {
     val any: ZLayer[Blocking, Nothing, Blocking] =
       ZLayer.requires[Blocking]
 
-    val live: ZLayer.NoDeps[Nothing, Blocking] =
+    val live: Layer[Nothing, Blocking] =
       ZLayer.succeed(Service.live)
   }
 

--- a/core/native/src/main/scala/zio/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/PlatformSpecific.scala
@@ -34,7 +34,7 @@ private[zio] trait PlatformSpecific {
     val any: ZLayer[ZEnv, Nothing, ZEnv] =
       ZLayer.requires[ZEnv]
 
-    val live: ZLayer.NoDeps[Nothing, ZEnv] =
+    val live: Layer[Nothing, ZEnv] =
       Clock.live ++ Console.live ++ System.live ++ Random.live
   }
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -242,7 +242,7 @@ object Runtime {
    * [[ZIO.provideLayer]] directly in their application entry points.
    */
   def unsafeFromLayer[R <: Has[_]](
-    layer: ZLayer.NoDeps[Any, R],
+    layer: Layer[Any, R],
     platform: Platform = Platform.default
   ): Runtime.Managed[R] = {
     val runtime = Runtime((), platform)

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -146,6 +146,7 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
 }
 
 object ZLayer {
+  @deprecated("use Layer", "1.0.0")
   type NoDeps[+E, +B <: Has[_]] = ZLayer[Any, E, B]
 
   /**
@@ -1935,14 +1936,14 @@ object ZLayer {
   /**
    * Constructs a layer from the specified value.
    */
-  def succeed[A: Tagged](a: => A): ZLayer.NoDeps[Nothing, Has[A]] =
+  def succeed[A: Tagged](a: => A): Layer[Nothing, Has[A]] =
     ZLayer(ZManaged.succeed(Has(a)))
 
   /**
    * Constructs a layer from the specified value, which must return one or more
    * services.
    */
-  def succeedMany[A <: Has[_]](a: => A): ZLayer.NoDeps[Nothing, A] =
+  def succeedMany[A <: Has[_]](a: => A): Layer[Nothing, A] =
     ZLayer(ZManaged.succeed(a))
 
   /**

--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -57,7 +57,7 @@ package object clock {
     val any: ZLayer[Clock, Nothing, Clock] =
       ZLayer.requires[Clock]
 
-    val live: ZLayer.NoDeps[Nothing, Clock] =
+    val live: Layer[Nothing, Clock] =
       ZLayer.succeed(Service.live)
   }
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -84,7 +84,7 @@ package object console {
     val any: ZLayer[Console, Nothing, Console] =
       ZLayer.requires[Console]
 
-    val live: ZLayer.NoDeps[Nothing, Console] =
+    val live: Layer[Nothing, Console] =
       ZLayer.succeed(Service.live)
   }
 

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -31,6 +31,12 @@ package object zio extends EitherCompat with PlatformSpecific with VersionSpecif
   type UManaged[+A]      = ZManaged[Any, Nothing, A]
   type TaskManaged[+A]   = ZManaged[Any, Throwable, A]
 
+  type RLayer[-RIn, +ROut <: Has[_]]  = ZLayer[RIn, Throwable, ROut]
+  type URLayer[-RIn, +ROut <: Has[_]] = ZLayer[RIn, Nothing, ROut]
+  type Layer[+E, +ROut <: Has[_]]     = ZLayer[Any, E, ROut]
+  type ULayer[+ROut <: Has[_]]        = ZLayer[Any, Nothing, ROut]
+  type TaskLayer[+ROut <: Has[_]]     = ZLayer[Any, Throwable, ROut]
+
   type Queue[A] = ZQueue[Any, Nothing, Any, Nothing, A, A]
 
   object <*> {

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -49,7 +49,7 @@ package object random {
     val any: ZLayer[Random, Nothing, Random] =
       ZLayer.requires[Random]
 
-    val live: ZLayer.NoDeps[Nothing, Random] =
+    val live: Layer[Nothing, Random] =
       ZLayer.succeed(Service.live)
 
     protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -47,7 +47,7 @@ package object system {
     val any: ZLayer[System, Nothing, System] =
       ZLayer.requires[System]
 
-    val live: ZLayer.NoDeps[Nothing, System] =
+    val live: Layer[Nothing, System] =
       ZLayer.succeed(Service.live)
   }
 

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -255,16 +255,16 @@ import zio.random.Random
 import MockConsole._
 import MockRandom._
 
-val mockConsole: ZLayer.NoDeps[Nothing, Console] = (
+val mockConsole: Layer[Nothing, Console] = (
   (putStrLn(equalTo("What is your name?")) returns unit) *>
   (getStrLn returns value("Mike")) *>
   (putStrLn(equalTo("Mike, your lucky number today is 42!")) returns unit)
 )
 
-val mockRandom: ZLayer.NoDeps[Nothing, Random] =
+val mockRandom: Layer[Nothing, Random] =
   nextInt._1 returns value(42)
 
-val combinedEnv: ZLayer.NoDeps[Nothing, Console with Random] =
+val combinedEnv: Layer[Nothing, Console with Random] =
   mockConsole ++ mockRandom
 
 val combinedApp =

--- a/docs/howto/use_modules_and_layers.md
+++ b/docs/howto/use_modules_and_layers.md
@@ -16,12 +16,7 @@ The result is a program that, in turn, depends on the `DBConnection`.
 
 
 ```scala mdoc:invisible
-import zio.ZIO          
-import zio.IO
-import zio.UIO    
-import zio.Has
-import zio.ZEnv
-import zio.ZLayer
+import zio. { Has, IO, Layer, UIO, ZEnv, ZIO, ZLayer }
 import zio.clock.Clock
 import zio.console.Console
 import zio.random.Random
@@ -81,7 +76,7 @@ Let's build a module for user data access, following these simple steps:
 1. Define a type alias like `type ModuleName = Has[Service]` (see below for details on `Has`)
 
 ```scala mdoc:silent
-import zio.{Has, ZLayer}
+import zio.{ Has, ZLayer }
 
 type UserRepo = Has[UserRepo.Service]
 
@@ -96,12 +91,7 @@ object UserRepo {
 ```
 
 ```scala mdoc:reset:invisible
-import zio.ZIO          
-import zio.IO
-import zio.UIO    
-import zio.Has
-import zio.ZEnv
-import zio.ZLayer
+import zio. { Has, IO, Layer, UIO, ZEnv, ZIO, ZLayer }          
 import zio.clock.Clock
 import zio.console.Console
 import zio.random.Random
@@ -155,7 +145,7 @@ Usually we don't create a `Has` directly, but we do that through `ZLayer`.
 
 `ZLayer[-RIn, +E, +ROut <: Has[_]]` is a recipe to build an environment of type `ROut`, starting from a value `RIn`, possibly producing an error `E` during creation. 
 
-In adherence with environmental concepts, the absence of a required input is represented by `RIn = Any`, conveniently  used in the type alias `ZLayer#NoDeps`.
+In adherence with environmental concepts, the absence of a required input is represented by `RIn = Any`, conveniently  used in the type alias `Layer`.
 
 There are many ways to create a `ZLayer`, here's an incomplete list:
  - `ZLayer.succeed` or `ZIO.asService`  to create a layer from an existing service

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -5,7 +5,7 @@ import sbt.testing.{ EventHandler, Logger, Task, TaskDef }
 import zio.UIO
 import zio.clock.Clock
 import zio.test.{ AbstractRunnableSpec, FilteredSpec, SummaryBuilder, TestArgs, TestLogger }
-import zio.{ Runtime, ZIO, ZLayer }
+import zio.{ Layer, Runtime, ZIO, ZLayer }
 
 abstract class BaseTestTask(
   val taskDef: TaskDef,
@@ -33,7 +33,7 @@ abstract class BaseTestTask(
       _       <- ZIO.foreach[Any, Throwable, ZTestEvent, Unit](events)(e => ZIO.effect(eventHandler.handle(e)))
     } yield ()
 
-  protected def sbtTestLayer(loggers: Array[Logger]): ZLayer.NoDeps[Nothing, TestLogger with Clock] =
+  protected def sbtTestLayer(loggers: Array[Logger]): Layer[Nothing, TestLogger with Clock] =
     ZLayer.succeed[TestLogger.Service](new TestLogger.Service {
       def logLine(line: String): UIO[Unit] =
         ZIO

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -13,7 +13,7 @@ object ManagedSpec extends ZIOBaseSpec {
       def incrementAndGet: UIO[Int]
     }
 
-    val live: ZLayer.NoDeps[Nothing, Counter] =
+    val live: Layer[Nothing, Counter] =
       ZLayer.fromManaged {
         Ref.make(1).toManaged(_.set(-10)).map { ref =>
           new Counter.Service {

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -12,7 +12,7 @@ import zio.test.mock.MockException.{
   UnexpectedCallExpection,
   UnmetExpectationsException
 }
-import zio.{ Cause, ZIO, ZLayer }
+import zio.{ Cause, Layer, ZIO }
 
 object ReportingTestUtils {
 
@@ -65,7 +65,7 @@ object ReportingTestUtils {
       actualSummary <- SummaryBuilder.buildSummary(results)
     } yield actualSummary.summary
 
-  private[this] def TestTestRunner(testEnvironment: ZLayer.NoDeps[Nothing, TestEnvironment]) =
+  private[this] def TestTestRunner(testEnvironment: Layer[Nothing, TestEnvironment]) =
     TestRunner[TestEnvironment, String](
       executor = TestExecutor.default[TestEnvironment, String](testEnvironment),
       reporter = DefaultTestReporter(TestAnnotationRenderer.default)

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala
@@ -19,12 +19,12 @@ package zio.test.mock
 import zio.duration.Duration
 import zio.test.environment.Live
 import zio.test.{ assertM, testM, Assertion }
-import zio.{ Has, IO, UIO, ZIO, ZLayer }
+import zio.{ Has, IO, Layer, UIO, ZIO }
 
 object ExpectationSpecUtils {
 
   private[mock] def testSpec[E, A](name: String)(
-    mock: ZLayer.NoDeps[Nothing, Has[Module]],
+    mock: Layer[Nothing, Has[Module]],
     app: ZIO[Has[Module], E, A],
     check: Assertion[A]
   ) = testM(name) {
@@ -33,7 +33,7 @@ object ExpectationSpecUtils {
   }
 
   private[mock] def testSpecTimeboxed[E, A](name: String)(duration: Duration)(
-    mock: ZLayer.NoDeps[Nothing, Has[Module]],
+    mock: Layer[Nothing, Has[Module]],
     app: ZIO[Has[Module], E, A],
     check: Assertion[Option[A]]
   ) = testM(name) {
@@ -48,7 +48,7 @@ object ExpectationSpecUtils {
   }
 
   private[mock] def testSpecDied[E, A](name: String)(
-    mock: ZLayer.NoDeps[Nothing, Has[Module]],
+    mock: Layer[Nothing, Has[Module]],
     app: ZIO[Has[Module], E, A],
     check: Assertion[Throwable]
   ) = testM(name) {

--- a/test-tests/shared/src/test/scala/zio/test/mock/SpySpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/SpySpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.test.Assertion._
 import zio.test._
-import zio.{ Has, Ref, UIO, ZIO, ZLayer }
+import zio.{ Has, Layer, Ref, UIO, ZIO, ZLayer }
 
 object SpySpec extends DefaultRunnableSpec {
 
@@ -24,7 +24,7 @@ object SpySpec extends DefaultRunnableSpec {
       def reset: UIO[Unit]     = counterState.set(0)
     }
 
-    val live: ZLayer.NoDeps[Nothing, Counter] =
+    val live: Layer[Nothing, Counter] =
       ZLayer.fromEffect(Ref.make(0).map(ref => Live(ref)))
   }
 

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ Has, UIO, ZIO, ZLayer }
+import zio.{ Has, Layer, UIO, ZIO }
 
 /**
  * A `TestExecutor[R, E]` is capable of executing specs that require an
@@ -24,12 +24,12 @@ import zio.{ Has, UIO, ZIO, ZLayer }
  */
 trait TestExecutor[+R <: Has[_], E] {
   def run(spec: ZSpec[R, E], defExec: ExecutionStrategy): UIO[ExecutedSpec[E]]
-  def environment: ZLayer.NoDeps[Nothing, R]
+  def environment: Layer[Nothing, R]
 }
 
 object TestExecutor {
   def default[R <: Annotations, E](
-    env: ZLayer.NoDeps[Nothing, R]
+    env: Layer[Nothing, R]
   ): TestExecutor[R, E] = new TestExecutor[R, E] {
     def run(spec: ZSpec[R, E], defExec: ExecutionStrategy): UIO[ExecutedSpec[E]] =
       spec.annotated

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -30,7 +30,7 @@ final case class TestRunner[R <: Has[_], E](
   executor: TestExecutor[R, E],
   platform: Platform = Platform.makeDefault().withReportFailure(_ => ()),
   reporter: TestReporter[E] = DefaultTestReporter(TestAnnotationRenderer.default),
-  bootstrap: ZLayer.NoDeps[Nothing, TestLogger with Clock] = ((Console.live >>> TestLogger.fromConsole) ++ Clock.live)
+  bootstrap: Layer[Nothing, TestLogger with Clock] = ((Console.live >>> TestLogger.fromConsole) ++ Clock.live)
 ) { self =>
 
   lazy val runtime = Runtime((), platform)

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -87,9 +87,9 @@ package object environment extends PlatformSpecific {
   type TestRandom  = Has[TestRandom.Service]
   type TestSystem  = Has[TestSystem.Service]
 
-  val liveEnvironment: ZLayer.NoDeps[Nothing, ZEnv] = ZEnv.live
+  val liveEnvironment: Layer[Nothing, ZEnv] = ZEnv.live
 
-  val testEnvironment: ZLayer.NoDeps[Nothing, TestEnvironment] =
+  val testEnvironment: Layer[Nothing, TestEnvironment] =
     ZEnv.live >>> TestEnvironment.live
 
   /**
@@ -1373,7 +1373,7 @@ package object environment extends PlatformSpecific {
      * be useful for providing the required environment to an effect that
      * requires a `Random`, such as with `ZIO#provide`.
      */
-    def make(data: Data): ZLayer.NoDeps[Nothing, Random with TestRandom] =
+    def make(data: Data): Layer[Nothing, Random with TestRandom] =
       ZLayer.fromEffectMany(for {
         data   <- Ref.make(data)
         buffer <- Ref.make(Buffer())
@@ -1383,7 +1383,7 @@ package object environment extends PlatformSpecific {
     val any: ZLayer[Random with TestRandom, Nothing, Random with TestRandom] =
       ZLayer.requires[Random with TestRandom]
 
-    val deterministic: ZLayer.NoDeps[Nothing, Random with TestRandom] =
+    val deterministic: Layer[Nothing, Random with TestRandom] =
       make(DefaultData)
 
     val random: ZLayer[Clock, Nothing, Random with TestRandom] =
@@ -1541,7 +1541,7 @@ package object environment extends PlatformSpecific {
      * be useful for providing the required environment to an effect that
      * requires a `Console`, such as with `ZIO#provide`.
      */
-    def live(data: Data): ZLayer.NoDeps[Nothing, System with TestSystem] =
+    def live(data: Data): Layer[Nothing, System with TestSystem] =
       ZLayer.fromEffectMany(
         Ref.make(data).map(ref => Has.allOf[System.Service, TestSystem.Service](Test(ref), Test(ref)))
       )
@@ -1549,7 +1549,7 @@ package object environment extends PlatformSpecific {
     val any: ZLayer[System with TestSystem, Nothing, System with TestSystem] =
       ZLayer.requires[System with TestSystem]
 
-    val default: ZLayer.NoDeps[Nothing, System with TestSystem] =
+    val default: Layer[Nothing, System with TestSystem] =
       live(DefaultData)
 
     /**

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -22,8 +22,7 @@ import zio.test.Assertion
 import zio.test.mock.Expectation.{ AnyCall, Call, Compose, Empty, Next, State }
 import zio.test.mock.MockException.UnmetExpectationsException
 import zio.test.mock.ReturnExpectation.{ Fail, Succeed }
-import zio.{ Has, IO, Managed, Ref, UIO, ZIO, ZLayer }
-import zio.{ IO, Managed, Ref, UIO, ZIO }
+import zio.{ Has, IO, Layer, Managed, Ref, UIO, ZIO, ZLayer }
 
 /**
  * An `Expectation[-M, +E, +A]` is an immutable data structure that represents
@@ -57,7 +56,7 @@ sealed trait Expectation[-M, +E, +A] { self =>
   /**
    * Converts this Expectation to ZManaged mock environment.
    */
-  final def toLayer[M1 <: M](implicit mockable: Mockable[M1]): ZLayer.NoDeps[Nothing, Has[M1]] = {
+  final def toLayer[M1 <: M](implicit mockable: Mockable[M1]): Layer[Nothing, Has[M1]] = {
 
     def extract(
       state: State[M, E],
@@ -178,7 +177,7 @@ object Expectation {
    */
   implicit def toLayer[M: Mockable, E, A](
     expectation: Expectation[M, E, A]
-  ): ZLayer.NoDeps[Nothing, Has[M]] = expectation.toLayer
+  ): Layer[Nothing, Has[M]] = expectation.toLayer
 
   private[Expectation] type AnyCall      = Call[Any, Any, Any, Any]
   private[Expectation] type Next[-M, +E] = Expectation[M, E, Any]

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -492,7 +492,7 @@ package object test extends CompileVariants {
     /**
      * Constructs a new `Annotations` service.
      */
-    def live: ZLayer.NoDeps[Nothing, Annotations] =
+    def live: Layer[Nothing, Annotations] =
       ZLayer.fromEffect(FiberRef.make(TestAnnotationMap.empty).map { fiberRef =>
         new Annotations.Service {
           def annotate[V](key: TestAnnotation[V], value: V): UIO[Unit] =
@@ -521,7 +521,7 @@ package object test extends CompileVariants {
       def withSize[R, E, A](size: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A]
     }
 
-    def live(size: Int): ZLayer.NoDeps[Nothing, Sized] =
+    def live(size: Int): Layer[Nothing, Sized] =
       ZLayer.fromEffect(FiberRef.make(size).map { fiberRef =>
         new Sized.Service {
           val size: UIO[Int] =


### PR DESCRIPTION
Adds standard ZIO type aliases:

```scala
type RLayer[-RIn, +ROut <: Has[_]]  = ZLayer[RIn, Throwable, ROut]
type URLayer[-RIn, +ROut <: Has[_]] = ZLayer[RIn, Nothing, ROut]
type Layer[+E, +ROut <: Has[_]]     = ZLayer[Any, E, ROut]
type ULayer[+ROut <: Has[_]]        = ZLayer[Any, Nothing, ROut]
type TaskLayer[+ROut <: Has[_]]     = ZLayer[Any, Throwable, ROut]
```

Deprecates `ZLayer.NoDeps`.