### PR TITLE
Implement ZRef#Derived

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZRefSpec.scala
@@ -3,9 +3,9 @@ package zio
 import zio.test.Assertion._
 import zio.test._
 
-object RefSpec extends ZIOBaseSpec {
+object ZRefSpec extends ZIOBaseSpec {
 
-  def spec = suite("RefSpec")(
+  def spec = suite("ZRefSpec")(
     testM("get") {
       for {
         ref   <- Ref.make(current)

--- a/core-tests/shared/src/test/scala/zio/ZRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZRefSpec.scala
@@ -6,92 +6,268 @@ import zio.test._
 object ZRefSpec extends ZIOBaseSpec {
 
   def spec = suite("ZRefSpec")(
-    testM("get") {
-      for {
-        ref   <- Ref.make(current)
-        value <- ref.get
-      } yield assert(value)(equalTo(current))
-    },
-    testM("getAndUpdate") {
-      for {
-        ref    <- Ref.make(current)
-        value1 <- ref.getAndUpdate(_ => update)
-        value2 <- ref.get
-      } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
-    },
-    testM("getAndUpdateSome") {
-      for {
-        ref    <- Ref.make[State](Active)
-        value1 <- ref.getAndUpdateSome { case Closed => Changed }
-        value2 <- ref.get
-      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
-    },
-    testM("getAndUpdateSome twice") {
-      for {
-        ref    <- Ref.make[State](Active)
-        value1 <- ref.getAndUpdateSome { case Active => Changed }
-        value2 <- ref.getAndUpdateSome {
-                   case Active  => Changed
-                   case Changed => Closed
-                 }
-        value3 <- ref.get
-      } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
-    },
-    testM("modify") {
-      for {
-        ref   <- Ref.make(current)
-        r     <- ref.modify(_ => ("hello", update))
-        value <- ref.get
-      } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
-    },
-    testM("modifySome") {
-      for {
-        ref   <- Ref.make[State](Active)
-        value <- ref.modifySome("State doesn't change") { case Closed => ("active", Active) }
-      } yield assert(value)(equalTo("State doesn't change"))
-    },
-    testM("modifySome twice") {
-      for {
-        ref    <- Ref.make[State](Active)
-        value1 <- ref.modifySome("doesn't change the state") { case Active => ("changed", Changed) }
-        value2 <- ref.modifySome("doesn't change the state") {
-                   case Active  => ("changed", Changed)
-                   case Changed => ("closed", Closed)
-                 }
-      } yield assert(value1)(equalTo("changed")) && assert(value2)(equalTo("closed"))
-    },
-    testM("set") {
-      for {
-        ref   <- Ref.make(current)
-        _     <- ref.set(update)
-        value <- ref.get
-      } yield assert(value)(equalTo(update))
-    },
-    testM("toString") {
-      assertM(Ref.make(42).map(_.toString))(equalTo("Ref(42)"))
-    },
-    testM("updateAndGet") {
-      for {
-        ref   <- Ref.make(current)
-        value <- ref.updateAndGet(_ => update)
-      } yield assert(value)(equalTo(update))
-    },
-    testM("updateSomeAndGet") {
-      for {
-        ref   <- Ref.make[State](Active)
-        value <- ref.updateSomeAndGet { case Closed => Changed }
-      } yield assert(value)(equalTo(Active))
-    },
-    testM("updateSomeAndGet twice") {
-      for {
-        ref    <- Ref.make[State](Active)
-        value1 <- ref.updateSomeAndGet { case Active => Changed }
-        value2 <- ref.updateSomeAndGet {
-                   case Active  => Changed
-                   case Changed => Closed
-                 }
-      } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
-    }
+    suite("Atomic")(
+      testM("get") {
+        for {
+          ref   <- Ref.make(current)
+          value <- ref.get
+        } yield assert(value)(equalTo(current))
+      },
+      testM("getAndSet") {
+        for {
+          ref    <- Ref.make(current)
+          value1 <- ref.getAndSet(update)
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
+      },
+      testM("getAndUpdate") {
+        for {
+          ref    <- Ref.make(current)
+          value1 <- ref.getAndUpdate(_ => update)
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
+      },
+      testM("getAndUpdateSome") {
+        for {
+          ref    <- Ref.make[State](Active)
+          value1 <- ref.getAndUpdateSome { case Closed => Changed }
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
+      },
+      testM("getAndUpdateSome twice") {
+        for {
+          ref    <- Ref.make[State](Active)
+          value1 <- ref.getAndUpdateSome { case Active => Changed }
+          value2 <- ref.getAndUpdateSome {
+                     case Active  => Changed
+                     case Changed => Closed
+                   }
+          value3 <- ref.get
+        } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
+      },
+      testM("modify") {
+        for {
+          ref   <- Ref.make(current)
+          r     <- ref.modify(_ => ("hello", update))
+          value <- ref.get
+        } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
+      },
+      testM("modifySome") {
+        for {
+          ref   <- Ref.make[State](Active)
+          value <- ref.modifySome("State doesn't change") { case Closed => ("active", Active) }
+        } yield assert(value)(equalTo("State doesn't change"))
+      },
+      testM("modifySome twice") {
+        for {
+          ref    <- Ref.make[State](Active)
+          value1 <- ref.modifySome("doesn't change the state") { case Active => ("changed", Changed) }
+          value2 <- ref.modifySome("doesn't change the state") {
+                     case Active  => ("changed", Changed)
+                     case Changed => ("closed", Closed)
+                   }
+        } yield assert(value1)(equalTo("changed")) && assert(value2)(equalTo("closed"))
+      },
+      testM("set") {
+        for {
+          ref   <- Ref.make(current)
+          _     <- ref.set(update)
+          value <- ref.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("toString") {
+        assertM(Ref.make(42).map(_.toString))(equalTo("Ref(42)"))
+      },
+      testM("update") {
+        for {
+          ref   <- Ref.make(current)
+          _     <- ref.update(_ => update)
+          value <- ref.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("updateAndGet") {
+        for {
+          ref   <- Ref.make(current)
+          value <- ref.updateAndGet(_ => update)
+        } yield assert(value)(equalTo(update))
+      },
+      testM("updateSome") {
+        for {
+          ref   <- Ref.make[State](Active)
+          _     <- ref.updateSome { case Closed => Changed }
+          value <- ref.get
+        } yield assert(value)(equalTo(Active))
+      },
+      testM("updateSome twice") {
+        for {
+          ref    <- Ref.make[State](Active)
+          _      <- ref.updateSome { case Active => Changed }
+          value1 <- ref.get
+          _ <- ref.updateSomeAndGet {
+                case Active  => Changed
+                case Changed => Closed
+              }
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+      },
+      testM("updateSomeAndGet") {
+        for {
+          ref   <- Ref.make[State](Active)
+          value <- ref.updateSomeAndGet { case Closed => Changed }
+        } yield assert(value)(equalTo(Active))
+      },
+      testM("updateSomeAndGet twice") {
+        for {
+          ref    <- Ref.make[State](Active)
+          value1 <- ref.updateSomeAndGet { case Active => Changed }
+          value2 <- ref.updateSomeAndGet {
+                     case Active  => Changed
+                     case Changed => Closed
+                   }
+        } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+      }
+    ),
+    suite("Derived")(
+      testM("atomicity") {
+        for {
+          ref   <- Derived.make(0)
+          _     <- ZIO.collectAllPar(ZIO.replicate(100)(ref.update(_ + 1)))
+          value <- ref.get
+        } yield assert(value)(equalTo(100))
+      },
+      testM("get") {
+        for {
+          ref   <- Derived.make(current)
+          value <- ref.get
+        } yield assert(value)(equalTo(current))
+      },
+      testM("getAndSet") {
+        for {
+          ref    <- Derived.make(current)
+          value1 <- ref.getAndSet(update)
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
+      },
+      testM("getAndUpdate") {
+        for {
+          ref    <- Derived.make(current)
+          value1 <- ref.getAndUpdate(_ => update)
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
+      },
+      testM("getAndUpdateSome") {
+        for {
+          ref    <- Derived.make[State](Active)
+          value1 <- ref.getAndUpdateSome { case Closed => Changed }
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
+      },
+      testM("getAndUpdateSome twice") {
+        for {
+          ref    <- Derived.make[State](Active)
+          value1 <- ref.getAndUpdateSome { case Active => Changed }
+          value2 <- ref.getAndUpdateSome {
+                     case Active  => Changed
+                     case Changed => Closed
+                   }
+          value3 <- ref.get
+        } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
+      },
+      testM("modify") {
+        for {
+          ref   <- Derived.make(current)
+          r     <- ref.modify(_ => ("hello", update))
+          value <- ref.get
+        } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
+      },
+      testM("modifySome") {
+        for {
+          ref   <- Derived.make[State](Active)
+          value <- ref.modifySome("State doesn't change") { case Closed => ("active", Active) }
+        } yield assert(value)(equalTo("State doesn't change"))
+      },
+      testM("modifySome twice") {
+        for {
+          ref    <- Derived.make[State](Active)
+          value1 <- ref.modifySome("doesn't change the state") { case Active => ("changed", Changed) }
+          value2 <- ref.modifySome("doesn't change the state") {
+                     case Active  => ("changed", Changed)
+                     case Changed => ("closed", Closed)
+                   }
+        } yield assert(value1)(equalTo("changed")) && assert(value2)(equalTo("closed"))
+      },
+      testM("readOnly") {
+        for {
+          ref      <- Derived.make(current)
+          readOnly = ref.readOnly
+          _        <- ref.set(update)
+          value    <- readOnly.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("set") {
+        for {
+          ref   <- Derived.make(current)
+          _     <- ref.set(update)
+          value <- ref.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("update") {
+        for {
+          ref   <- Derived.make(current)
+          _     <- ref.update(_ => update)
+          value <- ref.get
+        } yield assert(value)(equalTo(update))
+      },
+      testM("updateAndGet") {
+        for {
+          ref   <- Derived.make(current)
+          value <- ref.updateAndGet(_ => update)
+        } yield assert(value)(equalTo(update))
+      },
+      testM("updateSome") {
+        for {
+          ref   <- Derived.make[State](Active)
+          _     <- ref.updateSome { case Closed => Changed }
+          value <- ref.get
+        } yield assert(value)(equalTo(Active))
+      },
+      testM("updateSome twice") {
+        for {
+          ref    <- Derived.make[State](Active)
+          _      <- ref.updateSome { case Active => Changed }
+          value1 <- ref.get
+          _ <- ref.updateSomeAndGet {
+                case Active  => Changed
+                case Changed => Closed
+              }
+          value2 <- ref.get
+        } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+      },
+      testM("updateSomeAndGet") {
+        for {
+          ref   <- Derived.make[State](Active)
+          value <- ref.updateSomeAndGet { case Closed => Changed }
+        } yield assert(value)(equalTo(Active))
+      },
+      testM("updateSomeAndGet twice") {
+        for {
+          ref    <- Derived.make[State](Active)
+          value1 <- ref.updateSomeAndGet { case Active => Changed }
+          value2 <- ref.updateSomeAndGet {
+                     case Active  => Changed
+                     case Changed => Closed
+                   }
+        } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
+      },
+      testM("writeOnly") {
+        for {
+          ref       <- Derived.make(current)
+          writeOnly = ref.writeOnly
+          _         <- writeOnly.set(update)
+          value     <- ref.get
+        } yield assert(value)(equalTo(update))
+      }
+    )
   )
 
   val (current, update) = ("value", "new value")
@@ -100,5 +276,10 @@ object ZRefSpec extends ZIOBaseSpec {
   case object Active  extends State
   case object Changed extends State
   case object Closed  extends State
+
+  object Derived {
+    def make[A](a: A): UIO[Ref[A]] =
+      Ref.make(a).map(ref => ref.unifyError(identity, identity).unifyValue(identity, identity))
+  }
 
 }

--- a/core/shared/src/main/scala-2.11/zio/either.scala
+++ b/core/shared/src/main/scala-2.11/zio/either.scala
@@ -1,7 +1,10 @@
 package zio
 
 trait EitherCompat {
-  implicit class EitherOps[L, R](e: Either[L, R]) {
-    def map[A](f: R => A): Either[L, A] = e.right.map(f)
+  implicit final class EitherOps[E, A](self: Either[E, A]) {
+    def flatMap[E1 >: E, B](f: A => Either[E1, B]): Either[E1, B] =
+      self.fold(e => Left(e), a => f(a))
+    def map[B](f: A => B): Either[E, B] =
+      self.fold(e => Left(e), a => Right(f(a)))
   }
 }

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -19,11 +19,8 @@ package zio
 object Ref extends Serializable {
 
   /**
-   * Creates a new `Ref` with the specified value.
-   *
-   * @param a value of the new `Ref`
-   * @tparam A type of the value
-   * @return `UIO[Ref[A]]`
+   * @see [[zio.ZRef.make]]
    */
-  final def make[A](a: A): UIO[Ref[A]] = ZRef.make[Nothing, A](a)
+  def make[A](a: A): UIO[Ref[A]] =
+    ZRef.make(a)
 }

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -382,11 +382,11 @@ object ZRef extends Serializable {
           derived.value.modify { s =>
             derived.getEither(s) match {
               case Left(e) => (Left(e), s)
-              case Right(b) => {
-                val (c, a) = f(b)
-                derived.setEither(a) match {
+              case Right(a1) => {
+                val (b, a2) = f(a1)
+                derived.setEither(a2) match {
                   case Left(e)  => (Left(e), s)
-                  case Right(s) => (Right(c), s)
+                  case Right(s) => (Right(b), s)
                 }
               }
             }

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -57,11 +57,17 @@ sealed trait ZRef[+EA, +EB, -A, +B] extends Serializable { self =>
   final def mapEither[EC >: EB, C](f: B => Either[EC, C]): ZRef[EA, EC, A, C] =
     dimapEither(Right(_), f)
 
+  final def readOnly: ZRef[EA, EB, Nothing, B] =
+    contramap[Nothing](identity)
+
   final def unifyError[E](ea: EA => E, eb: EB => E): ZRef[E, E, A, B] =
     dimapError(ea, eb)
 
   final def unifyValue[C](ca: C => A, bc: B => C): ZRef[EA, EB, C, C] =
     dimap(ca, bc)
+
+  final def writeOnly: ZRef[EA, EB, A, Any] =
+    map(_ => ())
 }
 
 object ZRef extends Serializable {

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -18,10 +18,38 @@ package zio
 
 import java.util.concurrent.atomic.AtomicReference
 
+/**
+ * A `ZRef[EA, EB, A, B]` is a polymorphic, purely functional description of a
+ * mutable reference. The fundamental operations of a `ZRef` are `set` and
+ * `get`. `set` takes a value of type `A` and sets the reference to a new
+ * value, potentially failing with an error of type `EA`. `get` gets the
+ * current value of the reference and returns a value of type `B`, potentially
+ * failing with an error of type `EB`.
+ *
+ * When the error and value types of the `ZRef` are unified, that is, it is a
+ * `ZRef[E, E, A, A]`, the `ZRef` also supports atomic `modify` and `update`
+ * operations. All operations are guaranteed to be safe for concurrent access.
+ *
+ * NOTE: While `ZRef` provides the functional equivalent of a mutable
+ * reference, the value inside the `ZRef` should be immutable. For performance
+ * reasons `ZRef` is implemented in terms of compare and swap operations rather
+ * than synchronization. These operations are not safe for mutable values that
+ * do not support concurrent access.
+ */
 sealed trait ZRef[+EA, +EB, -A, +B] extends Serializable { self =>
 
+  /**
+   * Reads the value from the `ZRef`.
+   */
   def get: IO[EB, B]
 
+  /**
+   * Folds over the error and value types of the `ZRef`. This is a highly
+   * polymorphic method that is capable of arbitrarily transforming the error
+   * and value types of the `ZRef`. For most use cases one of the more specific
+   * combinators implemented in terms of `fold` will be more ergonomic but this
+   * method is extremely useful for implementing new combinators.
+   */
   def fold[EC, ED, C, D](
     ea: EA => EC,
     eb: EB => ED,
@@ -29,43 +57,96 @@ sealed trait ZRef[+EA, +EB, -A, +B] extends Serializable { self =>
     bc: B => Either[ED, D]
   ): ZRef[EC, ED, C, D]
 
+  /**
+   * Writes a new value to the `ZRef`, with a guarantee of immediate
+   * consistency (at some cost to performance).
+   */
   def set(a: A): IO[EA, Unit]
 
+  /**
+   * Writes a new value to the `ZRef` without providing a guarantee of
+   * immediate consistency.
+   */
   def setAsync(a: A): IO[EA, Unit]
 
+  /**
+   * Maps and filters the `get` value of the `ZRef` with the specified partial
+   * function, returning a `ZRef` with a `get` value that succeeds with the
+   * result of the partial function if it is defined or else fails with `None`.
+   */
   final def collect[C](pf: PartialFunction[B, C]): ZRef[EA, Option[EB], A, C] =
     fold(identity, Some(_), Right(_), pf.lift(_).fold[Either[Option[EB], C]](Left(None))(Right(_)))
 
+  /**
+   * Transforms the `set` value of the `ZRef` with the specified function.
+   */
   final def contramap[C](f: C => A): ZRef[EA, EB, C, B] =
     contramapEither(c => Right(f(c)))
 
+  /**
+   * Transforms the `set` value of the `ZRef` with the specified fallible
+   * function.
+   */
   final def contramapEither[EC >: EA, C](f: C => Either[EC, A]): ZRef[EC, EB, C, B] =
     dimapEither(f, Right(_))
 
+  /**
+   * Transforms both the `set` and `get` values of the `ZRef` with the
+   * specified functions.
+   */
   final def dimap[C, D](f: C => A, g: B => D): ZRef[EA, EB, C, D] =
     dimapEither(c => Right(f(c)), b => Right(g(b)))
 
+  /**
+   * Transforms both the `set` and `get` values of the `ZRef` with the
+   * specified fallible functions.
+   */
   final def dimapEither[EC >: EA, ED >: EB, C, D](f: C => Either[EC, A], g: B => Either[ED, D]): ZRef[EC, ED, C, D] =
     fold(identity, identity, f, g)
 
+  /**
+   * Transforms both the `set` and `get` errors of the `ZRef` with the
+   * specified functions.
+   */
   final def dimapError[EC, ED](f: EA => EC, g: EB => ED): ZRef[EC, ED, A, B] =
     fold(f, g, Right(_), Right(_))
 
+  /**
+   * Transforms the `get` value of the `ZRef` with the specified function.
+   */
   final def map[C](f: B => C): ZRef[EA, EB, A, C] =
     mapEither(b => Right(f(b)))
 
+  /**
+   * Transforms the `get` value of the `ZRef` with the specified fallible
+   * function.
+   */
   final def mapEither[EC >: EB, C](f: B => Either[EC, C]): ZRef[EA, EC, A, C] =
     dimapEither(Right(_), f)
 
+  /**
+   * Returns a read only view of the `ZRef`.
+   */
   final def readOnly: ZRef[EA, EB, Nothing, B] =
     contramap[Nothing](identity)
 
+  /**
+   * Unifies the error types of the `ZRef` by mapping both error types with the
+   * specified functions.
+   */
   final def unifyError[E](ea: EA => E, eb: EB => E): ZRef[E, E, A, B] =
     dimapError(ea, eb)
 
+  /**
+   * Unifies the value types of the `ZRef` by mapping both value types with the
+   * specified function.
+   */
   final def unifyValue[C](ca: C => A, bc: B => C): ZRef[EA, EB, C, C] =
     dimap(ca, bc)
 
+  /**
+   * Returns a write only view of the `ZRef`.
+   */
   final def writeOnly: ZRef[EA, EB, A, Any] =
     map(_ => ())
 }
@@ -94,13 +175,10 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop       = true
         var current: A = null.asInstanceOf[A]
-
         while (loop) {
           current = value.get
-
           loop = !value.compareAndSet(current, a)
         }
-
         current
       }
 
@@ -108,15 +186,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop       = true
         var current: A = null.asInstanceOf[A]
-
         while (loop) {
           current = value.get
-
           val next = f(current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         current
       }
 
@@ -124,15 +198,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop       = true
         var current: A = null.asInstanceOf[A]
-
         while (loop) {
           current = value.get
-
           val next = pf.applyOrElse(current, (_: A) => current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         current
       }
 
@@ -140,17 +210,12 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop = true
         var b: B = null.asInstanceOf[B]
-
         while (loop) {
           val current = value.get
-
-          val tuple = f(current)
-
+          val tuple   = f(current)
           b = tuple._1
-
           loop = !value.compareAndSet(current, tuple._2)
         }
-
         b
       }
 
@@ -158,17 +223,12 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop = true
         var b: B = null.asInstanceOf[B]
-
         while (loop) {
           val current = value.get
-
-          val tuple = pf.applyOrElse(current, (_: A) => (default, current))
-
+          val tuple   = pf.applyOrElse(current, (_: A) => (default, current))
           b = tuple._1
-
           loop = !value.compareAndSet(current, tuple._2)
         }
-
         b
       }
 
@@ -185,15 +245,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop    = true
         var next: A = null.asInstanceOf[A]
-
         while (loop) {
           val current = value.get
-
           next = f(current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         ()
       }
 
@@ -201,15 +257,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop    = true
         var next: A = null.asInstanceOf[A]
-
         while (loop) {
           val current = value.get
-
           next = f(current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         next
       }
 
@@ -217,15 +269,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop    = true
         var next: A = null.asInstanceOf[A]
-
         while (loop) {
           val current = value.get
-
           next = pf.applyOrElse(current, (_: A) => current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         ()
       }
 
@@ -233,15 +281,11 @@ object ZRef extends Serializable {
       UIO.effectTotal {
         var loop    = true
         var next: A = null.asInstanceOf[A]
-
         while (loop) {
           val current = value.get
-
           next = pf.applyOrElse(current, (_: A) => current)
-
           loop = !value.compareAndSet(current, next)
         }
-
         next
       }
   }
@@ -282,73 +326,134 @@ object ZRef extends Serializable {
   }
 
   implicit class UnifiedSyntax[E, A](private val self: ZRef[E, E, A, A]) extends AnyVal {
-    def getAndSet(a: A): IO[E, A] = self match {
-      case atomic: Atomic[A]            => atomic.getAndSet(a)
-      case derived: Derived[E, E, A, A] => derived.modify(v => (v, a))
-    }
-    def getAndUpdate(f: A => A): IO[E, A] = self match {
-      case atomic: Atomic[A]            => atomic.getAndUpdate(f)
-      case derived: Derived[E, E, A, A] => derived.modify(v => (v, f(v)))
-    }
-    def getAndUpdateSome(pf: PartialFunction[A, A]): IO[E, A] = self match {
-      case atomic: Atomic[A] => atomic.getAndUpdateSome(pf)
-      case derived: Derived[E, E, A, A] =>
-        derived.modify { v =>
-          val result = pf.applyOrElse[A, A](v, identity)
-          (v, result)
-        }
-    }
-    def modify[B](f: A => (B, A)): IO[E, B] = self match {
-      case atomic: Atomic[A] => atomic.modify(f)
-      case derived: Derived[E, E, A, A] =>
-        derived.value.modify { s =>
-          derived.getEither(s) match {
-            case Left(e) => (Left(e), s)
-            case Right(b) => {
-              val (c, a) = f(b)
-              derived.setEither(a) match {
-                case Left(e)  => (Left(e), s)
-                case Right(s) => (Right(c), s)
+
+    /**
+     * Atomically writes the specified value to the `ZRef`, returning the value
+     * immediately before modification.
+     */
+    def getAndSet(a: A): IO[E, A] =
+      self match {
+        case atomic: Atomic[A]            => atomic.getAndSet(a)
+        case derived: Derived[E, E, A, A] => derived.modify(v => (v, a))
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified function, returning
+     * the value immediately before modification.
+     */
+    def getAndUpdate(f: A => A): IO[E, A] =
+      self match {
+        case atomic: Atomic[A]            => atomic.getAndUpdate(f)
+        case derived: Derived[E, E, A, A] => derived.modify(v => (v, f(v)))
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified partial function,
+     * returning the value immediately before modification. If the function is
+     * undefined on the current value it doesn't change it.
+     */
+    def getAndUpdateSome(pf: PartialFunction[A, A]): IO[E, A] =
+      self match {
+        case atomic: Atomic[A] => atomic.getAndUpdateSome(pf)
+        case derived: Derived[E, E, A, A] =>
+          derived.modify { v =>
+            val result = pf.applyOrElse[A, A](v, identity)
+            (v, result)
+          }
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified function, which
+     * computes a return value for the modification. This is a more powerful
+     * version of `update`.
+     */
+    def modify[B](f: A => (B, A)): IO[E, B] =
+      self match {
+        case atomic: Atomic[A] => atomic.modify(f)
+        case derived: Derived[E, E, A, A] =>
+          derived.value.modify { s =>
+            derived.getEither(s) match {
+              case Left(e) => (Left(e), s)
+              case Right(b) => {
+                val (c, a) = f(b)
+                derived.setEither(a) match {
+                  case Left(e)  => (Left(e), s)
+                  case Right(s) => (Right(c), s)
+                }
               }
             }
+          }.absolve
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified partial function,
+     * which computes a return value for the modification if the function is
+     * defined on the current value otherwise it returns a default value. This
+     * is a more powerful version of `updateSome`.
+     */
+    def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): IO[E, B] =
+      self match {
+        case atomic: Atomic[A] => atomic.modifySome(default)(pf)
+        case derived: Derived[E, E, A, A] =>
+          derived.modify(v => pf.applyOrElse[A, (B, A)](v, _ => (default, v)))
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified function.
+     */
+    def update(f: A => A): IO[E, Unit] =
+      self match {
+        case atomic: Atomic[A]            => atomic.update(f)
+        case derived: Derived[E, E, A, A] => derived.modify(v => ((), v))
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified function and returns
+     * the updated value.
+     */
+    def updateAndGet(f: A => A): IO[E, A] =
+      self match {
+        case atomic: Atomic[A] => atomic.updateAndGet(f)
+        case derived: Derived[E, E, A, A] =>
+          derived.modify { v =>
+            val result = f(v)
+            (result, result)
           }
-        }.absolve
-    }
-    def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): IO[E, B] = self match {
-      case atomic: Atomic[A] => atomic.modifySome(default)(pf)
-      case derived: Derived[E, E, A, A] =>
-        derived.modify(v => pf.applyOrElse[A, (B, A)](v, _ => (default, v)))
-    }
-    def update(f: A => A): IO[E, Unit] = self match {
-      case atomic: Atomic[A]            => atomic.update(f)
-      case derived: Derived[E, E, A, A] => derived.modify(v => ((), v))
-    }
-    def updateAndGet(f: A => A): IO[E, A] = self match {
-      case atomic: Atomic[A] => atomic.updateAndGet(f)
-      case derived: Derived[E, E, A, A] =>
-        derived.modify { v =>
-          val result = f(v)
-          (result, result)
-        }
-    }
-    def updateSome(pf: PartialFunction[A, A]): IO[E, Unit] = self match {
-      case atomic: Atomic[A] => atomic.updateSome(pf)
-      case derived: Derived[E, E, A, A] =>
-        derived.modify { v =>
-          val result = pf.applyOrElse[A, A](v, identity)
-          ((), result)
-        }
-    }
-    def updateSomeAndGet(pf: PartialFunction[A, A]): IO[E, A] = self match {
-      case atomic: Atomic[A] => atomic.updateSomeAndGet(pf)
-      case derived: Derived[E, E, A, A] =>
-        derived.modify { v =>
-          val result = pf.applyOrElse[A, A](v, identity)
-          (result, result)
-        }
-    }
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified partial function. If
+     * the function is undefined on the current value it doesn't change it.
+     */
+    def updateSome(pf: PartialFunction[A, A]): IO[E, Unit] =
+      self match {
+        case atomic: Atomic[A] => atomic.updateSome(pf)
+        case derived: Derived[E, E, A, A] =>
+          derived.modify { v =>
+            val result = pf.applyOrElse[A, A](v, identity)
+            ((), result)
+          }
+      }
+
+    /**
+     * Atomically modifies the `ZRef` with the specified partial function. If
+     * the function is undefined on the current value it returns the old value
+     * without changing it.
+     */
+    def updateSomeAndGet(pf: PartialFunction[A, A]): IO[E, A] =
+      self match {
+        case atomic: Atomic[A] => atomic.updateSomeAndGet(pf)
+        case derived: Derived[E, E, A, A] =>
+          derived.modify { v =>
+            val result = pf.applyOrElse[A, A](v, identity)
+            (result, result)
+          }
+      }
   }
 
+  /**
+   * Creates a new `ZRef` with the specified value.
+   */
   def make[A](a: A): UIO[Ref[A]] =
     UIO.effectTotal(Atomic(new AtomicReference(a)))
 }

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -32,7 +32,9 @@ package object zio extends EitherCompat with PlatformSpecific with VersionSpecif
   type TaskManaged[+A]   = ZManaged[Any, Throwable, A]
 
   type Queue[A] = ZQueue[Any, Nothing, Any, Nothing, A, A]
-  type Ref[A]   = ZRef[Nothing, Nothing, A, A]
+
+  type Ref[A]      = ZRef[Nothing, Nothing, A, A]
+  type ERef[+E, A] = ZRef[E, E, A, A]
 
   object <*> {
     def unapply[A, B](ab: (A, B)): Some[(A, B)] =


### PR DESCRIPTION
Implements `ZRef#Derived` to support transforming the type of the `Ref` while maintaining atomicity guarantees.