### PR TITLE
ZIO Core: Make ZIO#orElse Associative

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1151,10 +1151,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val z1                = Task.fail(new Throwable("1"))
         val z2: Task[Nothing] = Task.die(new Throwable("2"))
         val orElse: Task[Boolean] = z1.orElse(z2).catchAllCause {
-          case Then(Die(FiberFailure(Traced(Fail(a: Throwable), _))), Traced(Die(b: Throwable), _)) =>
-            Task(a.getMessage == "1" && b.getMessage == "2")
-          case _ =>
-            Task(false)
+          case Traced(Die(e: Throwable), _) => Task(e.getMessage == "2")
+          case _                            => Task(false)
         }
         assertM(orElse)(equalTo(true))
       },
@@ -1162,12 +1160,27 @@ object ZIOSpec extends ZIOBaseSpec {
         val z1                = Task.fail(new Throwable("1"))
         val z2: Task[Nothing] = Task.fail(new Throwable("2"))
         val orElse: Task[Boolean] = z1.orElse(z2).catchAllCause {
-          case Then(Die(FiberFailure(Traced(Fail(a: Throwable), _))), Traced(Fail(b: Throwable), _)) =>
-            Task(a.getMessage == "1" && b.getMessage == "2")
-          case _ =>
-            Task(false)
+          case Traced(Fail(e: Throwable), _) => Task(e.getMessage == "2")
+          case _                             => Task(false)
         }
         assertM(orElse)(equalTo(true))
+      },
+      testM("is associative") {
+        val smallInts = Gen.int(0, 100)
+        val causes    = Gen.causes(smallInts, Gen.throwable)
+        val successes = Gen.successes(smallInts)
+        val exits     = Gen.either(causes, successes).map(_.fold(Exit.halt, Exit.succeed))
+        checkM(exits, exits, exits) { (exit1, exit2, exit3) =>
+          val zio1  = ZIO.done(exit1)
+          val zio2  = ZIO.done(exit2)
+          val zio3  = ZIO.done(exit3)
+          val left  = (zio1 orElse zio2) orElse zio3
+          val right = zio1 orElse (zio2 orElse zio3)
+          for {
+            left  <- left.run
+            right <- right.run
+          } yield assert(left)(equalTo(right))
+        }
       }
     ),
     suite("orElseFail")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1678,7 +1678,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
       self,
       ZIOFn(() => that) { cause =>
         cause.stripFailures match {
-          case None    => that.catchAllCause(cause2 => ZIO.halt(Cause.die(FiberFailure(cause)) ++ cause2))
+          case None    => that
           case Some(c) => ZIO.halt(c)
         }
       },


### PR DESCRIPTION
Makes `orElse` associative

The issue was the way that in `orElse` if the left hand side only contains failures and the right hand side fails we don't just return the right hand side but instead return a `Cause.Then` with the left hand side wrapped in a `FiberFailure` in a `Die`.

This violates associativity. Because of the order in which we wrap things in fiber failures and also creates other more serious problems. In particular, it means that calling `orElse` with two effects that fail with checked exceptions can results in an effect that fails with an unchecked exception. For example, consider this test:

```scala
testM("orElse can be recovered from") {
  val zio1 = ZIO.fail(1)
  val zio2 = ZIO.fail(2)
  val zio3 = ZIO.succeed(3)
  val recovered = zio1 orElse zio2 orElse zio3
  assertM(recovered)(equalTo(3))
}
```

We would expect that the effect would succeed with a value of three because no effect dies and the last effect in the chain succeeds. But in fact this will die with a fiber failure.

To address, this PR changes `orElse` to fail with only the right hand side error if the left hand side contains no unchecked exceptions. This restores associativity and eliminates the possibility of unintentionally converting a checked into an unchecked exception.