### PR TITLE
Make Sleep in Timeout Interruptible

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1774,6 +1774,10 @@ object ZIOSpec extends ZIOBaseSpec {
 
         assertM(Live.live(effect.timeout(1.second)))(isNone)
       } @@ jvmOnly,
+      testM("timeout in uninterruptible region") {
+        val effect = (ZIO.unit.timeout(Duration.Infinity)).uninterruptible
+        assertM(effect)(isSome(isUnit))
+      },
       testM("catchAllCause") {
         val io =
           for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3241,7 +3241,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
 
   final class TimeoutTo[R, E, A, B](self: ZIO[R, E, A], b: B) {
     def apply[B1 >: B](f: A => B1)(duration: Duration): ZIO[R with Clock, E, B1] =
-      (self map f) raceFirst (ZIO.sleep(duration) as b) // TODO: Make right-hand side interruptible?
+      (self map f) raceFirst (ZIO.sleep(duration).interruptible as b)
   }
 
   final class BracketAcquire_[-R, +E](private val acquire: ZIO[R, E, Any]) extends AnyVal {


### PR DESCRIPTION
Resolves #3065. I couldn't think of a situation where you would call timeout and would want to wait for the full timeout period to expire before returning when the effect you are timing out completes first.