### PR TITLE
Simplify TSet.union

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
@@ -1,0 +1,28 @@
+package zio.stm
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TSetOpsBenchmarks {
+  import IOBenchmarks.unsafeRun
+
+  @Param(Array("100", "10000"))
+  var size: Int = _
+
+  private var set: TSet[Int] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val data = (1 to size).toList
+    set = unsafeRun(TSet.fromIterable(data).commit)
+  }
+
+  @Benchmark
+  def union(): Unit = unsafeRun(set.union(set).commit)
+}

--- a/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
@@ -12,7 +12,7 @@ import zio._
 class TSetOpsBenchmarks {
   import IOBenchmarks.unsafeRun
 
-  @Param(Array("100", "10000"))
+  @Param(Array("10", "100", "10000", "100000"))
   var size: Int = _
 
   private var set: TSet[Int] = _

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -186,7 +186,7 @@ final class TMap[K, V] private (
       val overwrite =
         STM
           .foreach(original)(_.get.map(_.view.map(g)))
-          .flatMap[Any, Nothing, Unit] { xs =>
+          .flatMap { xs =>
             STM.foreach_(xs.view.flatten.toMap)(kv => newBuckets.update(TMap.indexOf(kv._1, capacity), kv :: _))
           }
 

--- a/core/shared/src/main/scala/zio/stm/TSet.scala
+++ b/core/shared/src/main/scala/zio/stm/TSet.scala
@@ -110,7 +110,7 @@ final class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * set.
    */
   def union(other: TSet[A]): STM[Nothing, Unit] =
-    other.toList.flatMap[Any, Nothing, List[Unit]](vals => STM.collectAll(vals.map(put))).unit
+    other.toList.flatMap(vals => STM.foreach_(vals)(put))
 }
 
 object TSet {

--- a/core/shared/src/main/scala/zio/stm/TSet.scala
+++ b/core/shared/src/main/scala/zio/stm/TSet.scala
@@ -110,7 +110,7 @@ final class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * set.
    */
   def union(other: TSet[A]): STM[Nothing, Unit] =
-    other.toList.flatMap(vals => STM.foreach_(vals)(put))
+    other.foreach(put)
 }
 
 object TSet {


### PR DESCRIPTION
This PR contains an attempt to simplify the implementation of TSet `union`. I have considered the following "candidates":

- `other.toList.flatMap[Any, Nothing, List[Unit]](vals => STM.collectAll(vals.map(put))).unit` (current)
- `other.toList.flatMap(vals => STM.foreach_(vals)(put))`
- `other.foreach(put)`

Benchmarking the current implementation produced the following results:

```
[info] Benchmark                (size)   Mode  Cnt       Score     Error  Units
[info] TSetOpsBenchmarks.union      10  thrpt   10  127120.025 ± 889.010  ops/s
[info] TSetOpsBenchmarks.union     100  thrpt   10    8504.425 ±  28.764  ops/s
[info] TSetOpsBenchmarks.union   10000  thrpt   10      13.149 ±   0.038  ops/s
[info] TSetOpsBenchmarks.union  100000  thrpt   10       0.077 ±   0.001  ops/s
```

Using the 2nd implementation resulted in:

```
[info] Benchmark                (size)   Mode  Cnt       Score     Error  Units
[info] TSetOpsBenchmarks.union      10  thrpt   10  122493.402 ± 303.178  ops/s
[info] TSetOpsBenchmarks.union     100  thrpt   10    7534.687 ±  14.302  ops/s
[info] TSetOpsBenchmarks.union   10000  thrpt   10      12.701 ±   0.045  ops/s
[info] TSetOpsBenchmarks.union  100000  thrpt   10       0.077 ±   0.001  ops/s
```

Finally, running the benchmark with the last candidate produced the following results:

```
[info] Benchmark                (size)   Mode  Cnt       Score     Error  Units
[info] TSetOpsBenchmarks.union      10  thrpt   10  126633.925 ± 350.935  ops/s
[info] TSetOpsBenchmarks.union     100  thrpt   10    8413.893 ±  14.323  ops/s
[info] TSetOpsBenchmarks.union   10000  thrpt   10      13.708 ±   0.033  ops/s
[info] TSetOpsBenchmarks.union  100000  thrpt   10       0.075 ±   0.001  ops/s
```

As it can be seen from the results, 2nd implementation is outperformed in most cases by both other candidates, while 1st and 3rd are comparable with 1st one being slightly better.

Considering the simplicity of 3rd implementation, as well as the fact that it's implemented in terms of `foldM` which has some room for improvement, I propose to use it as the default one.