### PR TITLE
ZIO Core: Implement ZLayer#passthrough

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -274,7 +274,8 @@ object ZLayerSpec extends ZIOBaseSpec {
       testM("passthrough") {
         val layer: ZLayer[Has[Int], Nothing, Has[String]] =
           ZLayer.fromService(_.toString)
-        val live = ZLayer.succeed(1) >>> layer.passthrough
+        val live: ZLayer[Any, Nothing, Has[Int] with Has[String]] =
+          ZLayer.succeed(1) >>> layer.passthrough
         val zio = for {
           i <- ZIO.environment[Has[Int]].map(_.get[Int])
           s <- ZIO.environment[Has[String]].map(_.get[String])

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -270,6 +270,16 @@ object ZLayerSpec extends ZIOBaseSpec {
               }
           actual <- ref.get
         } yield assert(actual)(equalTo(expected))
-      } @@ nonFlaky
+      } @@ nonFlaky,
+      testM("passthrough") {
+        val layer: ZLayer[Has[Int], Nothing, Has[String]] =
+          ZLayer.fromService(_.toString)
+        val live = ZLayer.succeed(1) >>> layer.passthrough
+        val zio = for {
+          i <- ZIO.environment[Has[Int]].map(_.get[Int])
+          s <- ZIO.environment[Has[String]].map(_.get[String])
+        } yield (i, s)
+        assertM(zio.provideLayer(live))(equalTo((1, "1")))
+      }
     )
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -2019,6 +2019,17 @@ object ZLayer {
   def succeedMany[A <: Has[_]](a: => A): Layer[Nothing, A] =
     ZLayer(ZManaged.succeed(a))
 
+  implicit final class ZLayerPassthroughOps[RIn <: Has[_], E, ROut <: Has[_]](private val self: ZLayer[RIn, E, ROut])
+      extends AnyVal {
+
+    /**
+     * Returns a new layer that produces the outputs of this layer but also
+     * passes through the inputs to this layer.
+     */
+    def passthrough(implicit tag: Tagged[ROut]): ZLayer[RIn, E, RIn with ROut] =
+      ZLayer.identity ++ self
+  }
+
   /**
    * A `MemoMap` memoizes dependencies.
    */


### PR DESCRIPTION
Resolves #3084. Returns a new layer that produces that outputs of the original layer but also passes through the inputs unchanged.