### PR TITLE
ZIO Test: Don't use Private Method in Type Checking Implementation

### DIFF
--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -27,9 +27,9 @@ private[test] object Macros {
     import c.universe._
     try {
       c.typecheck(c.parse(c.eval(c.Expr[String](c.untypecheck(code.tree)))))
-      c.Expr(q"zio.UIO.succeedNow(Right(()))")
+      c.Expr(q"zio.UIO.succeed(Right(()))")
     } catch {
-      case e: TypecheckException => c.Expr(q"zio.UIO.succeedNow(Left(${e.getMessage}))")
+      case e: TypecheckException => c.Expr(q"zio.UIO.succeed(Left(${e.getMessage}))")
       case _: Throwable          => c.Expr(q"""zio.UIO.die(new RuntimeException("Compilation failed"))""")
     }
   }


### PR DESCRIPTION
Using private methods can result in code failing to compile for reasons unrelated to the code being tested because the implementation calls `succeedNow` which is `private[zio]`. Switches to using public `succeed` combinator.