### PR TITLE
publishLocal broken because of inference to Any warning in TMap

### DIFF
--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -16,6 +16,8 @@
 
 package zio.stm
 
+import com.github.ghik.silencer.silent
+
 /**
  * Transactional map implemented on top of [[TRef]] and [[TArray]]. Resolves
  * conflicts via chaining.
@@ -183,6 +185,7 @@ final class TMap[K, V] private (
 
       val newBuckets = new TArray(newArr)
 
+      @silent("inferred to be `Any`")
       val overwrite =
         STM
           .foreach(original)(_.get.map(_.view.map(g)))

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -16,8 +16,6 @@
 
 package zio.stm
 
-import com.github.ghik.silencer.silent
-
 /**
  * Transactional map implemented on top of [[TRef]] and [[TArray]]. Resolves
  * conflicts via chaining.
@@ -185,11 +183,10 @@ final class TMap[K, V] private (
 
       val newBuckets = new TArray(newArr)
 
-      @silent("inferred to be `Any`")
       val overwrite =
         STM
           .foreach(original)(_.get.map(_.view.map(g)))
-          .flatMap { xs =>
+          .flatMap[Any, Nothing, Unit] { xs =>
             STM.foreach_(xs.view.flatten.toMap)(kv => newBuckets.update(TMap.indexOf(kv._1, capacity), kv :: _))
           }
 


### PR DESCRIPTION
In current master, for scala 2.13.1 / zio coreJVM, I observer that error:
```
sbt:zio> publishLocal
[info] Wrote /home/fanf/code/zio-ecosystem/zio/core/jvm/target/scala-2.13/zio_2.13-1.0.0-RC18-1+44-24f507c2-SNAPSHOT.pom
[info] Main Scala API documentation to /home/fanf/code/zio-ecosystem/zio/core/jvm/target/scala-2.13/api...
[error] /home/fanf/code/zio-ecosystem/zio/core/shared/src/main/scala/zio/stm/TMap.scala:189:12: a type was inferred to be `Any`; this may indicate a programming error.
[error]           .flatMap { xs =>
[error]            ^
[error] one error found
[error] (Compile / doc) Scaladoc generation failed
[error] Total time: 5 s, completed 10-Mar-2020 21:45:36
```
Corrected by silencer.