### PR TITLE
Prevent ZIO#fromCompletionStage From Creating Future Twice

### DIFF
--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -61,7 +61,8 @@ private[zio] object javaz {
       Task.succeedNow(f.get())
     } catch catchFromGet(isFatal)
 
-  def fromCompletionStage[A](cs: => CompletionStage[A]): Task[A] =
+  def fromCompletionStage[A](thunk: => CompletionStage[A]): Task[A] = {
+    lazy val cs: CompletionStage[A] = thunk
     Task.effectSuspendTotalWith { (p, _) =>
       val cf = cs.toCompletableFuture
       if (cf.isDone) {
@@ -77,6 +78,7 @@ private[zio] object javaz {
         }
       }
     }
+  }
 
   /** WARNING: this uses the blocking Future#get, consider using `fromCompletionStage` */
   def fromFutureJava[A](future: => Future[A]): RIO[Blocking, A] =


### PR DESCRIPTION
As reported on Discord this snippet:

```scala
import zio._
import java.util.concurrent._
import java.util.function._

val exec = Executors.newCachedThreadPool()
val supplier = new Supplier[Unit] {
  override def get(): Unit = {
    Thread.sleep(100)
    println("future done!")
  }
}

def cf = CompletableFuture.supplyAsync(supplier, exec)

val futureTask1 = ZIO.fromCompletionStage {
  println("making future 1")
  cf
}

lazy val future2 = {
  println("making future 2")
  cf
}

val futureTask2 = ZIO.fromCompletionStage(future2)

zio.Runtime.default.unsafeRunTask(futureTask1 *> futureTask2)
```

Will print the following:

```scala
making future 1
making future 1
future done!
future done!
making future 2
future done!
```

This PR resolves the issue by capturing the value of the by name parameter in a lazy value.