### PR TITLE
Temporarily Disable Parallelism in Layers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect.nonFlaky
+import zio.test.TestAspect.{ ignore, nonFlaky }
 import zio.test._
 import zio.test.environment._
 
@@ -248,7 +248,7 @@ object ZLayerSpec extends ZIOBaseSpec {
           _       <- env.use_(ZIO.unit).forkDaemon
           _       <- promise.await
         } yield assertCompletes
-      } @@ nonFlaky,
+      } @@ ignore,
       testM("map can map the output of a layer to an unrelated type") {
         case class A(name: String, value: Int)
         case class B(name: String)

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -160,7 +160,7 @@ final class ZLayer[-RIn, +E, +ROut <: Has[_]] private (
   )(f: (ROut, ROut2) => ROut3): ZLayer[RIn with RIn2, E1, ROut3] =
     new ZLayer(
       ZManaged.finalizerRef(_ => UIO.unit).map { finalizers => memoMap =>
-        memoMap.getOrElseMemoize(self, finalizers).zipWithPar(memoMap.getOrElseMemoize(that, finalizers))(f)
+        memoMap.getOrElseMemoize(self, finalizers).zipWith(memoMap.getOrElseMemoize(that, finalizers))(f)
       }
     )
 }


### PR DESCRIPTION
In preparation for release of 1.0-RC18-2 and given that #3073 has not been fixed yet temporarily disabling automatic parallelism in acquisition of layers. This should address issues that have been reported including #3087 and #3098 pending a more permanent solution.