### PR TITLE
clock.currentDateTime reflects exceptions in type signature (#3052)

### DIFF
--- a/docs/howto/use_modules_and_layers.md
+++ b/docs/howto/use_modules_and_layers.md
@@ -248,7 +248,7 @@ Let's add some extra logic to our program that creates a user
 
 val makeUser2: ZIO[Logging with UserRepo with Clock with Random, DBError, Unit] = for {
     uId       <- zio.random.nextLong.map(UserId)
-    createdAt <- zio.clock.currentDateTime
+    createdAt <- zio.clock.currentDateTime.orDie
     _         <- Logging.info(s"inserting user")
     _         <- UserRepo.createUser(User(uId, "Chet"))
     _         <- Logging.info(s"user inserted, created at $createdAt")


### PR DESCRIPTION
Closes #3052. I've modified `clock.currentDateTime` to reflect the fact that an exception can be thrown, for that I've audited all Java methods we call in `clock/package.scala` to see if they throw exceptions or not, so we can properly reflect those in types:

- `System.currentTimeMillis`: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis-- This doesn't throw exceptions.
- `System.nanoTime`: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime-- This doesn't throw exceptions.
- `ZoneId.systemDefault`: https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#systemDefault-- It can throw a `DateTimeException` if the converted zone ID has an invalid format, or a `ZoneRulesException` if the converted zone region ID cannot be found. And, it turns out `ZoneRulesException` is a subtype of `DateTimeException`.
- `Instant.ofEpochMilli`: https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html#ofEpochMilli-long- It can throw a `DateTimeException` if the instant exceeds the maximum or minimum instant
- `OffsetDateTime.ofInstant`: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html#ofInstant-java.time.Instant-java.time.ZoneId- It can throw a `DateTimeException` if the result exceeds the supported range

As you can see, all of this methods throw a `DateTimeException`, so now the type signature of `clock.currentDateTime` is `IO[DateTimeException, OffsetDateTime]`.
