### PR TITLE
Fix #3112: stacktracerNative/publishLocal is broken

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,8 +263,10 @@ lazy val stacktracerJVM = stacktracer.jvm
 
 lazy val stacktracerNative = stacktracer.native
   .settings(scalaVersion := "2.11.12")
+  .settings(scalacOptions -= "-Xfatal-warnings") // Issue 3112
   .settings(skip in Test := true)
   .settings(skip in doc := true)
+
 lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-sbt"))
   .settings(stdSettings("zio-test-sbt"))


### PR DESCRIPTION
  * As of this PR, stacktracerNative/publishLocal succeeds and works
    as it had previously.

Documentation:

    * None needed. This PR restores previous behavior and, I believe,
      stacktracerNative support is experimental.

Testing:

  * Efficacy:

    Manually tested that stacktracerNative/publishLocal succeeds and
    that the resultant artifact can be resolved by a simple
    hello-world project.

  * Safety:

    Manually tested that publishLocal in both stacktracerJS & stacktracerJVM
    continues to succeed.