### PR TITLE
Add STM aliases

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -1,6 +1,8 @@
 package zio
 package stm
 
+import scala.util.Try
+
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
@@ -1019,7 +1021,7 @@ object ZSTMSpec extends ZIOBaseSpec {
           result <- STM.atomically(for {
                      _       <- ref.set(2)
                      newVal1 <- ref.get
-                     _       <- STM.partial(throw new RuntimeException).orElse(STM.unit)
+                     _       <- STM.fromTry(Try(throw new RuntimeException)).orElse(STM.unit)
                      newVal2 <- ref.get
                    } yield (newVal1, newVal2))
         } yield assert(result)(equalTo(2 -> 2))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3064,7 +3064,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  def second[A, B]: ZIO[(A, B), Nothing, B] = fromFunction[(A, B), B](_._2)
+  def second[A, B]: URIO[(A, B), B] = fromFunction[(A, B), B](_._2)
 
   /**
    * Returns an effect that suspends for the specified duration. This method is
@@ -3088,7 +3088,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  def swap[A, B]: ZIO[(A, B), Nothing, (B, A)] =
+  def swap[A, B]: URIO[(A, B), (B, A)] =
     fromFunction[(A, B), (B, A)](_.swap)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -37,7 +37,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.check]]
    */
-  def check(p: => Boolean): STM[Nothing, Unit] = ZSTM.check(p)
+  def check(p: => Boolean): USTM[Unit] = ZSTM.check(p)
 
   /**
    * @see See [[zio.stm.ZSTM.collectAll]]
@@ -48,13 +48,13 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.die]]
    */
-  def die(t: => Throwable): STM[Nothing, Nothing] =
+  def die(t: => Throwable): USTM[Nothing] =
     ZSTM.die(t)
 
   /**
    * @see See [[zio.stm.ZSTM.dieMessage]]
    */
-  def dieMessage(m: => String): STM[Nothing, Nothing] =
+  def dieMessage(m: => String): USTM[Nothing] =
     ZSTM.dieMessage(m)
 
   /**
@@ -72,7 +72,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.fiberId]]
    */
-  val fiberId: STM[Nothing, Fiber.Id] =
+  val fiberId: USTM[Fiber.Id] =
     ZSTM.fiberId
 
   /**
@@ -120,7 +120,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.fromFunction]]
    */
-  def fromFunction[A](f: Any => A): STM[Nothing, A] =
+  def fromFunction[A](f: Any => A): USTM[A] =
     ZSTM.fromFunction(f)
 
   /**
@@ -138,13 +138,13 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.fromTry]]
    */
-  def fromTry[A](a: => Try[A]): STM[Throwable, A] =
+  def fromTry[A](a: => Try[A]): TaskSTM[A] =
     ZSTM.fromTry(a)
 
   /**
    * @see See [[zio.stm.ZSTM.identity]]
    */
-  def identity: STM[Nothing, Any] = ZSTM.identity
+  def identity: USTM[Any] = ZSTM.identity
 
   /**
    * @see See [[zio.stm.ZSTM.ifM]]
@@ -161,7 +161,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.left]]
    */
-  def left[A](a: => A): STM[Nothing, Either[A, Nothing]] =
+  def left[A](a: => A): USTM[Either[A, Nothing]] =
     ZSTM.left(a)
 
   /**
@@ -208,12 +208,12 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.none]]
    */
-  val none: STM[Nothing, Option[Nothing]] = ZSTM.none
+  val none: USTM[Option[Nothing]] = ZSTM.none
 
   /**
    * @see See [[zio.stm.ZSTM.partial]]
    */
-  def partial[A](a: => A): STM[Throwable, A] =
+  def partial[A](a: => A): TaskSTM[A] =
     ZSTM.partial(a)
 
   /**
@@ -246,25 +246,25 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.retry]]
    */
-  val retry: STM[Nothing, Nothing] =
+  val retry: USTM[Nothing] =
     ZSTM.retry
 
   /**
    * @see See [[zio.stm.ZSTM.right]]
    */
-  def right[A](a: => A): STM[Nothing, Either[Nothing, A]] =
+  def right[A](a: => A): USTM[Either[Nothing, A]] =
     ZSTM.right(a)
 
   /**
    * @see See [[zio.stm.ZSTM.some]]
    */
-  def some[A](a: => A): STM[Nothing, Option[A]] =
+  def some[A](a: => A): USTM[Option[A]] =
     ZSTM.some(a)
 
   /**
    * @see See [[zio.stm.ZSTM.succeed]]
    */
-  def succeed[A](a: => A): STM[Nothing, A] =
+  def succeed[A](a: => A): USTM[A] =
     ZSTM.succeed(a)
 
   /**
@@ -276,7 +276,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.unit]]
    */
-  val unit: STM[Nothing, Unit] =
+  val unit: USTM[Unit] =
     ZSTM.unit
 
   /**
@@ -317,6 +317,6 @@ object STM {
    */
   def whenM[E](b: STM[E, Boolean])(stm: => STM[E, Any]): STM[E, Unit] = ZSTM.whenM(b)(stm)
 
-  private[zio] def succeedNow[A](a: A): STM[Nothing, A] =
+  private[zio] def succeedNow[A](a: A): USTM[A] =
     ZSTM.succeedNow(a)
 }

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -211,12 +211,6 @@ object STM {
   val none: USTM[Option[Nothing]] = ZSTM.none
 
   /**
-   * @see See [[zio.stm.ZSTM.partial]]
-   */
-  def partial[A](a: => A): TaskSTM[A] =
-    ZSTM.partial(a)
-
-  /**
    * @see See [[zio.stm.ZSTM.partition]]
    */
   def partition[E, A, B](

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -24,14 +24,14 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Extracts value from ref in array.
    */
-  def apply(index: Int): STM[Nothing, A] =
+  def apply(index: Int): USTM[A] =
     if (0 <= index && index < array.length) array(index).get
     else STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Finds the result of applying a partial function to the first value in its domain.
    */
-  def collectFirst[B](pf: PartialFunction[A, B]): STM[Nothing, Option[B]] =
+  def collectFirst[B](pf: PartialFunction[A, B]): USTM[Option[B]] =
     find(pf.isDefinedAt).map(_.map(pf))
 
   /**
@@ -47,12 +47,12 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Determine if the array contains a specified value.
    */
-  def contains(a: A): STM[Nothing, Boolean] = exists(_ == a)
+  def contains(a: A): USTM[Boolean] = exists(_ == a)
 
   /**
    * Count the values in the array matching a predicate.
    */
-  def count(p: A => Boolean): STM[Nothing, Int] =
+  def count(p: A => Boolean): USTM[Int] =
     fold(0)((n, a) => if (p(a)) n + 1 else n)
 
   /**
@@ -64,7 +64,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Determine if the array contains a value satisfying a predicate.
    */
-  def exists(p: A => Boolean): STM[Nothing, Boolean] = find(p).map(_.isDefined)
+  def exists(p: A => Boolean): USTM[Boolean] = find(p).map(_.isDefined)
 
   /**
    * Determine if the array contains a value satisfying a transactional predicate.
@@ -75,7 +75,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Find the first element in the array matching a predicate.
    */
-  def find(p: A => Boolean): STM[Nothing, Option[A]] =
+  def find(p: A => Boolean): USTM[Option[A]] =
     if (array.isEmpty) STM.succeedNow(None)
     else
       array.head.get.flatMap { a =>
@@ -86,7 +86,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Find the last element in the array matching a predicate.
    */
-  def findLast(p: A => Boolean): STM[Nothing, Option[A]] =
+  def findLast(p: A => Boolean): USTM[Option[A]] =
     new TArray(array.reverse).find(p)
 
   /**
@@ -111,13 +111,13 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * The first entry of the array, if it exists.
    */
-  def firstOption: STM[Nothing, Option[A]] =
+  def firstOption: USTM[Option[A]] =
     if (array.isEmpty) STM.succeedNow(None) else array.head.get.map(Some(_))
 
   /**
    * Atomically folds using a pure function.
    */
-  def fold[Z](acc: Z)(op: (Z, A) => Z): STM[Nothing, Z] =
+  def fold[Z](acc: Z)(op: (Z, A) => Z): USTM[Z] =
     if (array.isEmpty) STM.succeedNow(acc)
     else array.head.get.flatMap(a => new TArray(array.tail).fold(op(acc, a))(op))
 
@@ -133,7 +133,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically evaluate the conjunction of a predicate across the members
    * of the array.
    */
-  def forall(p: A => Boolean): STM[Nothing, Boolean] = exists(a => !p(a)).map(!_)
+  def forall(p: A => Boolean): USTM[Boolean] = exists(a => !p(a)).map(!_)
 
   /**
    * Atomically evaluate the conjunction of a transactional predicate across
@@ -152,26 +152,26 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Get the first index of a specific value in the array or -1 if it does
    * not occur.
    */
-  def indexOf(a: A): STM[Nothing, Int] = indexOf(a, 0)
+  def indexOf(a: A): USTM[Int] = indexOf(a, 0)
 
   /**
    * Get the first index of a specific value in the array, starting at a specific
    * index, or -1 if it does not occur.
    */
-  def indexOf(a: A, from: Int): STM[Nothing, Int] = indexWhere(_ == a, from)
+  def indexOf(a: A, from: Int): USTM[Int] = indexWhere(_ == a, from)
 
   /**
    * Get the index of the first entry in the array matching a predicate.
    */
-  def indexWhere(p: A => Boolean): STM[Nothing, Int] = indexWhere(p, 0)
+  def indexWhere(p: A => Boolean): USTM[Int] = indexWhere(p, 0)
 
   /**
    * Get the index of the first entry in the array, starting at a specific index,
    * matching a predicate.
    */
-  def indexWhere(p: A => Boolean, from: Int): STM[Nothing, Int] = {
+  def indexWhere(p: A => Boolean, from: Int): USTM[Int] = {
     val len = array.length
-    def forIndex(i: Int): STM[Nothing, Int] =
+    def forIndex(i: Int): USTM[Int] =
       if (i >= len) STM.succeedNow(-1)
       else apply(i).flatMap(a => if (p(a)) STM.succeedNow(i) else forIndex(i + 1))
 
@@ -200,15 +200,15 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Get the last index of a specific value in the array or -1 if it does not occur.
    */
-  def lastIndexOf(a: A): STM[Nothing, Int] =
+  def lastIndexOf(a: A): USTM[Int] =
     if (array.isEmpty) STM.succeedNow(-1) else lastIndexOf(a, array.length - 1)
 
   /**
    * Get the first index of a specific value in the array, bounded above by a
    * specific index, or -1 if it does not occur.
    */
-  def lastIndexOf(a: A, end: Int): STM[Nothing, Int] = {
-    def forIndex(i: Int): STM[Nothing, Int] =
+  def lastIndexOf(a: A, end: Int): USTM[Int] = {
+    def forIndex(i: Int): USTM[Int] =
       if (i < 0) STM.succeedNow(-1)
       else apply(i).flatMap(ai => if (ai == a) STM.succeedNow(i) else forIndex(i - 1))
 
@@ -218,25 +218,25 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * The last entry in the array, if it exists.
    */
-  def lastOption: STM[Nothing, Option[A]] =
+  def lastOption: USTM[Option[A]] =
     if (array.isEmpty) STM.succeedNow(None) else array.last.get.map(Some(_))
 
   /**
    * Atomically compute the greatest element in the array, if it exists.
    */
-  def maxOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
+  def maxOption(implicit ord: Ordering[A]): USTM[Option[A]] =
     reduceOption((acc, a) => if (ord.gt(a, acc)) a else acc)
 
   /**
    * Atomically compute the least element in the array, if it exists.
    */
-  def minOption(implicit ord: Ordering[A]): STM[Nothing, Option[A]] =
+  def minOption(implicit ord: Ordering[A]): USTM[Option[A]] =
     reduceOption((acc, a) => if (ord.lt(a, acc)) a else acc)
 
   /**
    * Atomically reduce the array, if non-empty, by a binary operator.
    */
-  def reduceOption(op: (A, A) => A): STM[Nothing, Option[A]] =
+  def reduceOption(op: (A, A) => A): USTM[Option[A]] =
     if (array.isEmpty) STM.succeedNow(None)
     else
       array.head.get
@@ -257,7 +257,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Atomically updates all elements using a pure function.
    */
-  def transform(f: A => A): STM[Nothing, Unit] =
+  def transform(f: A => A): USTM[Unit] =
     array.indices.foldLeft(STM.succeedNow(())) {
       case (tx, idx) => array(idx).update(f) *> tx
     }
@@ -275,7 +275,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
   /**
    * Updates element in the array with given function.
    */
-  def update(index: Int, fn: A => A): STM[Nothing, Unit] =
+  def update(index: Int, fn: A => A): USTM[Unit] =
     if (0 <= index && index < array.length) array(index).update(fn)
     else STM.die(new ArrayIndexOutOfBoundsException(index))
 
@@ -297,16 +297,16 @@ object TArray {
   /**
    * Makes a new `TArray` that is initialized with specified values.
    */
-  def make[A](data: A*): STM[Nothing, TArray[A]] = fromIterable(data)
+  def make[A](data: A*): USTM[TArray[A]] = fromIterable(data)
 
   /**
    * Makes an empty `TArray`.
    */
-  def empty[A]: STM[Nothing, TArray[A]] = fromIterable(Nil)
+  def empty[A]: USTM[TArray[A]] = fromIterable(Nil)
 
   /**
    * Makes a new `TArray` initialized with provided iterable.
    */
-  def fromIterable[A](data: Iterable[A]): STM[Nothing, TArray[A]] =
+  def fromIterable[A](data: Iterable[A]): USTM[TArray[A]] =
     STM.foreach(data)(TRef.make(_)).map(list => new TArray(list.toArray))
 }

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -29,14 +29,14 @@ final class TMap[K, V] private (
   /**
    * Tests whether or not map contains a key.
    */
-  def contains(k: K): STM[Nothing, Boolean] =
+  def contains(k: K): USTM[Boolean] =
     get(k).map(_.isDefined)
 
   /**
    * Removes binding for given key.
    */
-  def delete(k: K): STM[Nothing, Unit] = {
-    def removeMatching(bucket: List[(K, V)]): STM[Nothing, List[(K, V)]] = {
+  def delete(k: K): USTM[Unit] = {
+    def removeMatching(bucket: List[(K, V)]): USTM[List[(K, V)]] = {
       val (toRemove, toRetain) = bucket.partition(_._1 == k)
       if (toRemove.isEmpty) STM.succeedNow(toRetain) else tSize.update(_ - toRemove.size).as(toRetain)
     }
@@ -51,7 +51,7 @@ final class TMap[K, V] private (
   /**
    * Atomically folds using a pure function.
    */
-  def fold[A](zero: A)(op: (A, (K, V)) => A): STM[Nothing, A] =
+  def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
     tBuckets.get.flatMap(_.fold(zero)((acc, bucket) => bucket.foldLeft(acc)(op)))
 
   /**
@@ -76,7 +76,7 @@ final class TMap[K, V] private (
   /**
    * Retrieves value associated with given key.
    */
-  def get(k: K): STM[Nothing, Option[V]] =
+  def get(k: K): USTM[Option[V]] =
     for {
       buckets <- tBuckets.get
       idx     <- indexOf(k)
@@ -87,13 +87,13 @@ final class TMap[K, V] private (
    * Retrieves value associated with given key or default value, in case the
    * key isn't present.
    */
-  def getOrElse(k: K, default: => V): STM[Nothing, V] =
+  def getOrElse(k: K, default: => V): USTM[V] =
     get(k).map(_.getOrElse(default))
 
   /**
    * Collects all keys stored in map.
    */
-  def keys: STM[Nothing, List[K]] =
+  def keys: USTM[List[K]] =
     toList.map(_.map(_._1))
 
   /**
@@ -101,7 +101,7 @@ final class TMap[K, V] private (
    * value, otherwise merge the existing value with the new one using function `f`
    * and store the result
    */
-  def merge(k: K, v: V)(f: (V, V) => V): STM[Nothing, V] =
+  def merge(k: K, v: V)(f: (V, V) => V): USTM[V] =
     get(k).flatMap(_.fold(put(k, v).as(v)) { v0 =>
       val v1 = f(v0, v)
       put(k, v1).as(v1)
@@ -110,8 +110,8 @@ final class TMap[K, V] private (
   /**
    * Stores new binding into the map.
    */
-  def put(k: K, v: V): STM[Nothing, Unit] = {
-    def upsert(bucket: List[(K, V)]): STM[Nothing, List[(K, V)]] = {
+  def put(k: K, v: V): USTM[Unit] = {
+    def upsert(bucket: List[(K, V)]): USTM[List[(K, V)]] = {
       val exists = bucket.exists(_._1 == k)
 
       if (exists)
@@ -120,7 +120,7 @@ final class TMap[K, V] private (
         tSize.update(_ + 1).as((k, v) :: bucket)
     }
 
-    def resize(newCapacity: Int): STM[Nothing, Unit] =
+    def resize(newCapacity: Int): USTM[Unit] =
       for {
         data       <- toList
         tmap       <- TMap.allocate(newCapacity, data)
@@ -143,31 +143,31 @@ final class TMap[K, V] private (
   /**
    * Removes bindings matching predicate.
    */
-  def removeIf(p: (K, V) => Boolean): STM[Nothing, Unit] =
+  def removeIf(p: (K, V) => Boolean): USTM[Unit] =
     tBuckets.get.flatMap(_.transform(_.filterNot(kv => p(kv._1, kv._2))))
 
   /**
    * Retains bindings matching predicate.
    */
-  def retainIf(p: (K, V) => Boolean): STM[Nothing, Unit] =
+  def retainIf(p: (K, V) => Boolean): USTM[Unit] =
     tBuckets.get.flatMap(_.transform(_.filter(kv => p(kv._1, kv._2))))
 
   /**
    * Collects all bindings into a list.
    */
-  def toList: STM[Nothing, List[(K, V)]] =
+  def toList: USTM[List[(K, V)]] =
     fold(List.empty[(K, V)])((acc, kv) => kv :: acc)
 
   /**
    * Collects all bindings into a map.
    */
-  def toMap: STM[Nothing, Map[K, V]] =
+  def toMap: USTM[Map[K, V]] =
     fold(Map.empty[K, V])(_ + _)
 
   /**
    * Atomically updates all bindings using a pure function.
    */
-  def transform(f: (K, V) => (K, V)): STM[Nothing, Unit] =
+  def transform(f: (K, V) => (K, V)): USTM[Unit] =
     tBuckets.get.flatMap { tArr =>
       val g = f.tupled
 
@@ -228,7 +228,7 @@ final class TMap[K, V] private (
   /**
    * Atomically updates all values using a pure function.
    */
-  def transformValues(f: V => V): STM[Nothing, Unit] =
+  def transformValues(f: V => V): USTM[Unit] =
     tBuckets.get.flatMap(_.transform(_.map(kv => kv._1 -> f(kv._2))))
 
   /**
@@ -240,10 +240,10 @@ final class TMap[K, V] private (
   /**
    * Collects all values stored in map.
    */
-  def values: STM[Nothing, List[V]] =
+  def values: USTM[List[V]] =
     toList.map(_.map(_._2))
 
-  private def indexOf(k: K): STM[Nothing, Int] =
+  private def indexOf(k: K): USTM[Int] =
     tCapacity.get.map(c => TMap.indexOf(k, c))
 }
 
@@ -252,12 +252,12 @@ object TMap {
   /**
    * Makes an empty `TMap`.
    */
-  def empty[K, V]: STM[Nothing, TMap[K, V]] = fromIterable(Nil)
+  def empty[K, V]: USTM[TMap[K, V]] = fromIterable(Nil)
 
   /**
    * Makes a new `TMap` initialized with provided iterable.
    */
-  def fromIterable[K, V](data: Iterable[(K, V)]): STM[Nothing, TMap[K, V]] = {
+  def fromIterable[K, V](data: Iterable[(K, V)]): USTM[TMap[K, V]] = {
     val size     = data.size
     val capacity = if (size < InitialCapacity) InitialCapacity else nextPowerOfTwo(size)
     allocate(capacity, data.toList)
@@ -266,9 +266,9 @@ object TMap {
   /**
    * Makes a new `TMap` that is initialized with specified values.
    */
-  def make[K, V](data: (K, V)*): STM[Nothing, TMap[K, V]] = fromIterable(data)
+  def make[K, V](data: (K, V)*): USTM[TMap[K, V]] = fromIterable(data)
 
-  private def allocate[K, V](capacity: Int, data: List[(K, V)]): STM[Nothing, TMap[K, V]] = {
+  private def allocate[K, V](capacity: Int, data: List[(K, V)]): USTM[TMap[K, V]] = {
     val buckets  = Array.fill[List[(K, V)]](capacity)(Nil)
     val distinct = data.toMap
 

--- a/core/shared/src/main/scala/zio/stm/TPromise.scala
+++ b/core/shared/src/main/scala/zio/stm/TPromise.scala
@@ -22,26 +22,26 @@ final class TPromise[E, A] private (val ref: TRef[Option[Either[E, A]]]) extends
       case Some(e) => STM.fromEither(e)
     }.flatten
 
-  def done(v: Either[E, A]): STM[Nothing, Boolean] =
+  def done(v: Either[E, A]): USTM[Boolean] =
     ref.get.flatMap {
       case Some(_) => STM.succeedNow(false)
       case None    => ref.set(Some(v)) *> STM.succeedNow(true)
     }
 
-  def fail(e: E): STM[Nothing, Boolean] =
+  def fail(e: E): USTM[Boolean] =
     done(Left(e))
 
-  def poll: STM[Nothing, Option[STM[E, A]]] =
+  def poll: USTM[Option[STM[E, A]]] =
     ref.get.map {
       case Some(e) => Some(STM.fromEither(e))
       case None    => None
     }
 
-  def succeed(a: A): STM[Nothing, Boolean] =
+  def succeed(a: A): USTM[Boolean] =
     done(Right(a))
 }
 
 object TPromise {
-  def make[E, A]: STM[Nothing, TPromise[E, A]] =
+  def make[E, A]: USTM[TPromise[E, A]] =
     TRef.make[Option[Either[E, A]]](None).map(ref => new TPromise(ref))
 }

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -23,20 +23,20 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
   /**
    * Checks if the queue is empty.
    */
-  def isEmpty: STM[Nothing, Boolean] =
+  def isEmpty: USTM[Boolean] =
     ref.get.map(_.isEmpty)
 
   /**
    * Checks if the queue is at capacity.
    */
-  def isFull: STM[Nothing, Boolean] =
+  def isFull: USTM[Boolean] =
     ref.get.map(_.size == capacity)
 
   /**
    * Views the last element inserted into the queue, retrying if the queue is
    * empty.
    */
-  def last: STM[Nothing, A] =
+  def last: USTM[A] =
     ref.get.flatMap(
       _.lastOption match {
         case Some(a) => STM.succeedNow(a)
@@ -48,7 +48,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Offers the specified value to the queue, retrying if the queue is at
    * capacity.
    */
-  def offer(a: A): STM[Nothing, Unit] =
+  def offer(a: A): USTM[Unit] =
     ref.get.flatMap { q =>
       if (q.length < capacity) ref.update(_.enqueue(a)).unit
       else STM.retry
@@ -60,7 +60,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * the queue for all of these elements. Returns any remaining elements in the
    * specified collection.
    */
-  def offerAll(as: Iterable[A]): STM[Nothing, Iterable[A]] = {
+  def offerAll(as: Iterable[A]): USTM[Iterable[A]] = {
     val (forQueue, remaining) = as.splitAt(capacity)
     ref.get.flatMap { q =>
       if (forQueue.size <= capacity - q.length) ref.update(_.enqueue(forQueue.toList))
@@ -72,7 +72,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Views the next element in the queue without removing it, retrying if the
    * queue is empty.
    */
-  def peek: STM[Nothing, A] =
+  def peek: USTM[A] =
     ref.get.flatMap(
       _.headOption match {
         case Some(a) => STM.succeedNow(a)
@@ -84,14 +84,14 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Views the next element in the queue without removing it, returning `None`
    * if the queue is empty.
    */
-  def peekOption: STM[Nothing, Option[A]] =
+  def peekOption: USTM[Option[A]] =
     ref.get.map(_.headOption)
 
   /**
    * Takes a single element from the queue, returning `None` if the queue is
    * empty.
    */
-  def poll: STM[Nothing, Option[A]] =
+  def poll: USTM[Option[A]] =
     takeUpTo(1).map(_.headOption)
 
   /**
@@ -99,9 +99,9 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * taking and returning the first element that does satisfy the predicate.
    * Retries if no elements satisfy the predicate.
    */
-  def seek(f: A => Boolean): STM[Nothing, A] = {
+  def seek(f: A => Boolean): USTM[A] = {
     @annotation.tailrec
-    def go(q: ScalaQueue[A]): STM[Nothing, A] =
+    def go(q: ScalaQueue[A]): USTM[A] =
       q.dequeueOption match {
         case Some((a, as)) =>
           if (f(a)) ref.set(as) *> STM.succeedNow(a)
@@ -115,13 +115,13 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
   /**
    * Returns the number of elements currently in the queue.
    */
-  def size: STM[Nothing, Int] =
+  def size: USTM[Int] =
     ref.get.map(_.length)
 
   /**
    * Takes a single element from the queue, retrying if the queue is empty.
    */
-  def take: STM[Nothing, A] =
+  def take: USTM[A] =
     ref.get.flatMap { q =>
       q.dequeueOption match {
         case Some((a, as)) =>
@@ -133,13 +133,13 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
   /**
    * Takes all elements from the queue.
    */
-  def takeAll: STM[Nothing, List[A]] =
+  def takeAll: USTM[List[A]] =
     ref.modify(q => (q.toList, ScalaQueue.empty[A]))
 
   /**
    * Takes up to the specified maximum number of elements from the queue.
    */
-  def takeUpTo(max: Int): STM[Nothing, List[A]] =
+  def takeUpTo(max: Int): USTM[List[A]] =
     ref.get
       .map(_.splitAt(max))
       .flatMap(split => ref.set(split._2) *> STM.succeedNow(split._1))
@@ -151,12 +151,12 @@ object TQueue {
   /**
    * Constructs a new bounded queue with the specified capacity.
    */
-  def bounded[A](capacity: Int): STM[Nothing, TQueue[A]] =
+  def bounded[A](capacity: Int): USTM[TQueue[A]] =
     TRef.make(ScalaQueue.empty[A]).map(ref => new TQueue(capacity, ref))
 
   /**
    * Constructs a new unbounded queue.
    */
-  def unbounded[A]: STM[Nothing, TQueue[A]] =
+  def unbounded[A]: USTM[TQueue[A]] =
     bounded(Int.MaxValue)
 }

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import TReentrantLock._
 
-import zio.{ Fiber, Managed }
+import zio.{ Fiber, Managed, UManaged }
 
 /**
  * A `TReentrantLock` is a reentrant read/write lock. Multiple readers may all
@@ -43,7 +43,7 @@ final class TReentrantLock private (data: TRef[Either[ReadLock, WriteLock]]) {
    * is holding a write lock. Succeeds with the number of read locks held by
    * this fiber.
    */
-  lazy val acquireRead: STM[Nothing, Int] =
+  lazy val acquireRead: USTM[Int] =
     STM.fiberId.flatMap(fiberId => adjustRead(fiberId, 1))
 
   /**
@@ -51,7 +51,7 @@ final class TReentrantLock private (data: TRef[Either[ReadLock, WriteLock]]) {
    * fibers are holding read or write locks. Succeeds with the number of
    * write locks held by this fiber.
    */
-  lazy val acquireWrite: STM[Nothing, Int] =
+  lazy val acquireWrite: USTM[Int] =
     for {
       fiberId <- STM.fiberId
       w <- data.get.collect {
@@ -70,42 +70,42 @@ final class TReentrantLock private (data: TRef[Either[ReadLock, WriteLock]]) {
    *
    * See [[writeLock]].
    */
-  lazy val lock: Managed[Nothing, Int] = writeLock
+  lazy val lock: UManaged[Int] = writeLock
 
   /**
    * Determines if any fiber has a read or write lock.
    */
-  def locked: STM[Nothing, Boolean] =
+  def locked: USTM[Boolean] =
     (readLocked zipWith writeLocked)(_ || _)
 
   /**
    * Obtains a read lock in a managed context.
    */
-  lazy val readLock: Managed[Nothing, Int] =
+  lazy val readLock: UManaged[Int] =
     Managed.make(acquireRead.commit)(_ => releaseRead.commit)
 
   /**
    * Retrieves the number of acquired read locks.
    */
-  def readLocks: STM[Nothing, Int] = data.get.map(_.fold(_.readLocks, _.readLocks))
+  def readLocks: USTM[Int] = data.get.map(_.fold(_.readLocks, _.readLocks))
 
   /**
    * Determines if any fiber has a read lock.
    */
-  def readLocked: STM[Nothing, Boolean] = readLocks.map(_ > 0)
+  def readLocked: USTM[Boolean] = readLocks.map(_ > 0)
 
   /**
    * Releases a read lock held by this fiber. Succeeds with the outstanding
    * number of read locks held by this fiber.
    */
-  lazy val releaseRead: STM[Nothing, Int] =
+  lazy val releaseRead: USTM[Int] =
     STM.fiberId.flatMap(fiberId => adjustRead(fiberId, -1))
 
   /**
    * Releases a write lock held by this fiber. Succeeds with the outstanding
    * number of write locks held by this fiber.
    */
-  lazy val releaseWrite: STM[Nothing, Int] =
+  lazy val releaseWrite: USTM[Int] =
     STM.fiberId.flatMap(fiberId =>
       data.modify {
         case Right(WriteLock(1, m, `fiberId`)) =>
@@ -123,20 +123,20 @@ final class TReentrantLock private (data: TRef[Either[ReadLock, WriteLock]]) {
   /**
    * Obtains a write lock in a managed context.
    */
-  lazy val writeLock: Managed[Nothing, Int] =
+  lazy val writeLock: UManaged[Int] =
     Managed.make(acquireWrite.commit)(_ => releaseWrite.commit)
 
   /**
    * Determines if a write lock is held by some fiber.
    */
-  def writeLocked: STM[Nothing, Boolean] = writeLocks.map(_ > 0)
+  def writeLocked: USTM[Boolean] = writeLocks.map(_ > 0)
 
   /**
    * Computes the number of write locks held by fibers.
    */
-  def writeLocks: STM[Nothing, Int] = data.get.map(_.fold(_ => 0, _.writeLocks))
+  def writeLocks: USTM[Int] = data.get.map(_.fold(_ => 0, _.writeLocks))
 
-  private def adjustRead(fiberId: Fiber.Id, delta: Int): STM[Nothing, Int] =
+  private def adjustRead(fiberId: Fiber.Id, delta: Int): USTM[Int] =
     (data.get.collect {
       case Left(readLock) => Left(readLock.adjust(fiberId, delta))
       case Right(wl @ WriteLock(w, r, `fiberId`)) =>
@@ -216,7 +216,7 @@ object TReentrantLock {
   /**
    * Makes a new reentrant read/write lock.
    */
-  def make: STM[Nothing, TReentrantLock] =
+  def make: USTM[TReentrantLock] =
     TRef.make[Either[ReadLock, WriteLock]](Left(ReadLock.empty)).map(tref => new TReentrantLock(tref))
 
   private def die(message: String): Nothing =

--- a/core/shared/src/main/scala/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/zio/stm/TRef.scala
@@ -33,7 +33,7 @@ final class TRef[A] private (
   /**
    * Retrieves the value of the `TRef`.
    */
-  val get: STM[Nothing, A] =
+  val get: USTM[A] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -43,7 +43,7 @@ final class TRef[A] private (
   /**
    * Sets the value of the `TRef` and returns the old value.
    */
-  def getAndSet(a: A): STM[Nothing, A] =
+  def getAndSet(a: A): USTM[A] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -57,7 +57,7 @@ final class TRef[A] private (
   /**
    * Updates the value of the variable and returns the old value.
    */
-  def getAndUpdate(f: A => A): STM[Nothing, A] =
+  def getAndUpdate(f: A => A): USTM[A] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -72,14 +72,14 @@ final class TRef[A] private (
    * Updates some values of the variable but leaves others alone, returning the
    * old value.
    */
-  def getAndUpdateSome(f: PartialFunction[A, A]): STM[Nothing, A] =
+  def getAndUpdateSome(f: PartialFunction[A, A]): USTM[A] =
     getAndUpdate(f orElse { case a => a })
 
   /**
    * Updates the value of the variable, returning a function of the specified
    * value.
    */
-  def modify[B](f: A => (B, A)): STM[Nothing, B] =
+  def modify[B](f: A => (B, A)): USTM[B] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -94,13 +94,13 @@ final class TRef[A] private (
    * Updates some values of the variable, returning a function of the specified
    * value or the default.
    */
-  def modifySome[B](default: B)(f: PartialFunction[A, (B, A)]): STM[Nothing, B] =
+  def modifySome[B](default: B)(f: PartialFunction[A, (B, A)]): USTM[B] =
     modify(a => f.lift(a).getOrElse((default, a)))
 
   /**
    * Sets the value of the `TRef`.
    */
-  def set(newValue: A): STM[Nothing, Unit] =
+  def set(newValue: A): USTM[Unit] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -115,7 +115,7 @@ final class TRef[A] private (
   /**
    * Updates the value of the variable.
    */
-  def update(f: A => A): STM[Nothing, Unit] =
+  def update(f: A => A): USTM[Unit] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -129,7 +129,7 @@ final class TRef[A] private (
   /**
    * Updates the value of the variable and returns the new value.
    */
-  def updateAndGet(f: A => A): STM[Nothing, A] =
+  def updateAndGet(f: A => A): USTM[A] =
     new ZSTM((journal, _, _, _) => {
       val entry = getOrMakeEntry(journal)
 
@@ -143,14 +143,14 @@ final class TRef[A] private (
   /**
    * Updates some values of the variable but leaves others alone.
    */
-  def updateSome(f: PartialFunction[A, A]): STM[Nothing, Unit] =
+  def updateSome(f: PartialFunction[A, A]): USTM[Unit] =
     update(f orElse { case a => a })
 
   /**
    * Updates some values of the variable but leaves others alone, returning the
    * new value.
    */
-  def updateSomeAndGet(f: PartialFunction[A, A]): STM[Nothing, A] =
+  def updateSomeAndGet(f: PartialFunction[A, A]): USTM[A] =
     updateAndGet(f orElse { case a => a })
 
   private def getOrMakeEntry(journal: Journal): Entry =
@@ -167,7 +167,7 @@ object TRef {
   /**
    * Makes a new `TRef` that is initialized to the specified value.
    */
-  def make[A](a: => A): STM[Nothing, TRef[A]] =
+  def make[A](a: => A): USTM[TRef[A]] =
     new ZSTM((journal, _, _, _) => {
       val value     = a
       val versioned = new Versioned(value)

--- a/core/shared/src/main/scala/zio/stm/TSet.scala
+++ b/core/shared/src/main/scala/zio/stm/TSet.scala
@@ -24,26 +24,26 @@ final class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
   /**
    * Tests whether or not set contains an element.
    */
-  def contains(a: A): STM[Nothing, Boolean] =
+  def contains(a: A): USTM[Boolean] =
     tmap.contains(a)
 
   /**
    * Removes element from set.
    */
-  def delete(a: A): STM[Nothing, Unit] =
+  def delete(a: A): USTM[Unit] =
     tmap.delete(a)
 
   /**
    * Atomically transforms the set into the difference of itself and the
    * provided set.
    */
-  def diff(other: TSet[A]): STM[Nothing, Unit] =
+  def diff(other: TSet[A]): USTM[Unit] =
     other.toList.map(_.toSet).flatMap(vals => removeIf(vals.contains))
 
   /**
    * Atomically folds using a pure function.
    */
-  def fold[B](zero: B)(op: (B, A) => B): STM[Nothing, B] =
+  def fold[B](zero: B)(op: (B, A) => B): USTM[B] =
     tmap.fold(zero)((acc, kv) => op(acc, kv._1))
 
   /**
@@ -62,41 +62,41 @@ final class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * Atomically transforms the set into the intersection of itself and the
    * provided set.
    */
-  def intersect(other: TSet[A]): STM[Nothing, Unit] =
+  def intersect(other: TSet[A]): USTM[Unit] =
     other.toList.map(_.toSet).flatMap(vals => retainIf(vals.contains))
 
   /**
    * Stores new element in the set.
    */
-  def put(a: A): STM[Nothing, Unit] =
+  def put(a: A): USTM[Unit] =
     tmap.put(a, ())
 
   /**
    * Removes elements matching predicate.
    */
-  def removeIf(p: A => Boolean): STM[Nothing, Unit] =
+  def removeIf(p: A => Boolean): USTM[Unit] =
     tmap.removeIf((k, _) => p(k))
 
   /**
    * Retains elements matching predicate.
    */
-  def retainIf(p: A => Boolean): STM[Nothing, Unit] =
+  def retainIf(p: A => Boolean): USTM[Unit] =
     tmap.retainIf((k, _) => p(k))
 
   /**
    * Returns the set's cardinality.
    */
-  def size: STM[Nothing, Int] = toList.map(_.size)
+  def size: USTM[Int] = toList.map(_.size)
 
   /**
    * Collects all elements into a list.
    */
-  def toList: STM[Nothing, List[A]] = tmap.keys
+  def toList: USTM[List[A]] = tmap.keys
 
   /**
    * Atomically updates all elements using a pure function.
    */
-  def transform(f: A => A): STM[Nothing, Unit] =
+  def transform(f: A => A): USTM[Unit] =
     tmap.transform((k, v) => f(k) -> v)
 
   /**
@@ -109,7 +109,7 @@ final class TSet[A] private (private val tmap: TMap[A, Unit]) extends AnyVal {
    * Atomically transforms the set into the union of itself and the provided
    * set.
    */
-  def union(other: TSet[A]): STM[Nothing, Unit] =
+  def union(other: TSet[A]): USTM[Unit] =
     other.foreach(put)
 }
 
@@ -118,16 +118,16 @@ object TSet {
   /**
    * Makes an empty `TSet`.
    */
-  def empty[A]: STM[Nothing, TSet[A]] = fromIterable(Nil)
+  def empty[A]: USTM[TSet[A]] = fromIterable(Nil)
 
   /**
    * Makes a new `TSet` initialized with provided iterable.
    */
-  def fromIterable[A](data: Iterable[A]): STM[Nothing, TSet[A]] =
+  def fromIterable[A](data: Iterable[A]): USTM[TSet[A]] =
     TMap.fromIterable(data.map((_, ()))).map(new TSet(_))
 
   /**
    * Makes a new `TSet` that is initialized with specified values.
    */
-  def make[A](data: A*): STM[Nothing, TSet[A]] = fromIterable(data)
+  def make[A](data: A*): USTM[TSet[A]] = fromIterable(data)
 }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -248,7 +248,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Converts the failure channel into an `Either`.
    */
-  def either(implicit ev: CanFail[E]): ZSTM[R, Nothing, Either[E, A]] =
+  def either(implicit ev: CanFail[E]): URSTM[R, Either[E, A]] =
     fold(Left(_), Right(_))
 
   /**
@@ -262,7 +262,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Returns an effect that ignores errors and runs repeatedly until it eventually succeeds.
    */
-  def eventually(implicit ev: CanFail[E]): ZSTM[R, Nothing, A] =
+  def eventually(implicit ev: CanFail[E]): URSTM[R, A] =
     foldM(_ => eventually, ZSTM.succeedNow)
 
   /**
@@ -344,7 +344,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Folds over the `STM` effect, handling both failure and success, but not
    * retry.
    */
-  def fold[B](f: E => B, g: A => B)(implicit ev: CanFail[E]): ZSTM[R, Nothing, B] =
+  def fold[B](f: E => B, g: A => B)(implicit ev: CanFail[E]): URSTM[R, B] =
     self.continueWithM {
       case TExit.Fail(e)    => ZSTM.succeedNow(f(e))
       case TExit.Succeed(a) => ZSTM.succeedNow(g(a))
@@ -391,7 +391,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Returns a new effect that ignores the success or failure of this effect.
    */
-  def ignore: ZSTM[R, Nothing, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
+  def ignore: URSTM[R, Unit] = self.fold(ZIO.unitFn, ZIO.unitFn)
 
   /**
    * Returns a successful effect if the value is `Left`, or fails with the error `None`.
@@ -448,7 +448,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Returns a new effect where the error channel has been merged into the
    * success channel to their common combined type.
    */
-  def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): ZSTM[R, Nothing, A1] =
+  def merge[A1 >: A](implicit ev1: E <:< A1, ev2: CanFail[E]): URSTM[R, A1] =
     foldM(e => ZSTM.succeedNow(ev1(e)), ZSTM.succeedNow)
 
   /**
@@ -495,7 +495,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Converts the failure channel into an `Option`.
    */
-  def option(implicit ev: CanFail[E]): ZSTM[R, Nothing, Option[A]] =
+  def option(implicit ev: CanFail[E]): URSTM[R, Option[A]] =
     fold(_ => None, Some(_))
 
   /**
@@ -511,7 +511,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Translates `STM` effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZSTM[R, Nothing, A] =
+  def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): URSTM[R, A] =
     orDieWith(ev1)
 
   /**
@@ -519,7 +519,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * effect with them, using the specified function to convert the `E`
    * into a `Throwable`.
    */
-  def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZSTM[R, Nothing, A] =
+  def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): URSTM[R, A] =
     mapError(f).catchAll(ZSTM.die(_))
 
   /**
@@ -573,14 +573,14 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Tries this effect first, and if it fails, succeeds with the specified
    * value.
    */
-  def orElseSucceed[A1 >: A](a1: => A1)(implicit ev: CanFail[E]): ZSTM[R, Nothing, A1] =
+  def orElseSucceed[A1 >: A](a1: => A1)(implicit ev: CanFail[E]): URSTM[R, A1] =
     orElse(ZSTM.succeedNow(a1))
 
   /**
    * Provides the transaction its required environment, which eliminates
    * its dependency on `R`.
    */
-  def provide(r: R): ZSTM[Any, E, A] =
+  def provide(r: R): STM[E, A] =
     provideSome(_ => r)
 
   /**
@@ -883,7 +883,7 @@ object ZSTM {
   /**
    * Checks the condition, and if it's true, returns unit, otherwise, retries.
    */
-  def check[R](p: => Boolean): ZSTM[R, Nothing, Unit] =
+  def check[R](p: => Boolean): URSTM[R, Unit] =
     suspend(if (p) STM.unit else retry)
 
   /**
@@ -896,14 +896,14 @@ object ZSTM {
   /**
    * Kills the fiber running the effect.
    */
-  def die(t: => Throwable): STM[Nothing, Nothing] =
+  def die(t: => Throwable): USTM[Nothing] =
     succeed(throw t)
 
   /**
    * Kills the fiber running the effect with a `RuntimeException` that contains
    * the specified message.
    */
-  def dieMessage(m: => String): STM[Nothing, Nothing] =
+  def dieMessage(m: => String): USTM[Nothing] =
     die(new RuntimeException(m))
 
   /**
@@ -915,7 +915,7 @@ object ZSTM {
   /**
    * Retrieves the environment inside an stm.
    */
-  def environment[R]: ZSTM[R, Nothing, R] =
+  def environment[R]: URSTM[R, R] =
     new ZSTM((_, _, _, r) => TExit.Succeed(r))
 
   /**
@@ -927,7 +927,7 @@ object ZSTM {
   /**
    * Returns the fiber id of the fiber committing the transaction.
    */
-  val fiberId: STM[Nothing, Fiber.Id] = new ZSTM((_, fiberId, _, _) => TExit.Succeed(fiberId))
+  val fiberId: USTM[Fiber.Id] = new ZSTM((_, fiberId, _, _) => TExit.Succeed(fiberId))
 
   /**
    * Filters the collection using the specified effectual predicate.
@@ -1002,9 +1002,9 @@ object ZSTM {
     }
 
   /**
-   * Lifts a function `R => A` into a `ZSTM[R, Nothing, A]`.
+   * Lifts a function `R => A` into a `URSTM[R, A]`.
    */
-  def fromFunction[R, A](f: R => A): ZSTM[R, Nothing, A] =
+  def fromFunction[R, A](f: R => A): URSTM[R, A] =
     access(f)
 
   /**
@@ -1023,7 +1023,7 @@ object ZSTM {
   /**
    * Lifts a `Try` into a `STM`.
    */
-  def fromTry[A](a: => Try[A]): STM[Throwable, A] =
+  def fromTry[A](a: => Try[A]): TaskSTM[A] =
     STM.suspend {
       a match {
         case Failure(t) => STM.fail(t)
@@ -1034,7 +1034,7 @@ object ZSTM {
   /**
    * Returns the identity effectful function, which performs no effects
    */
-  def identity[R]: ZSTM[R, Nothing, R] = fromFunction[R, R](ZIO.identityFn)
+  def identity[R]: URSTM[R, R] = fromFunction[R, R](ZIO.identityFn)
 
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
@@ -1063,7 +1063,7 @@ object ZSTM {
   /**
    * Returns an effect with the value on the left part.
    */
-  def left[A](a: => A): STM[Nothing, Either[A, Nothing]] =
+  def left[A](a: => A): USTM[Either[A, Nothing]] =
     succeed(Left(a))
 
   /**
@@ -1150,12 +1150,12 @@ object ZSTM {
   /**
    * Returns an effect wth the empty value.
    */
-  val none: STM[Nothing, Option[Nothing]] = succeedNow(None)
+  val none: USTM[Option[Nothing]] = succeedNow(None)
 
   /**
    * Creates an `STM` value from a partial (but pure) function.
    */
-  def partial[A](a: => A): STM[Throwable, A] = fromTry(Try(a))
+  def partial[A](a: => A): TaskSTM[A] = fromTry(Try(a))
 
   /**
    * Feeds elements of type `A` to a function `f` that returns an effect.
@@ -1194,31 +1194,31 @@ object ZSTM {
    * Abort and retry the whole transaction when any of the underlying
    * transactional variables have changed.
    */
-  val retry: STM[Nothing, Nothing] = new ZSTM((_, _, _, _) => TExit.Retry)
+  val retry: USTM[Nothing] = new ZSTM((_, _, _, _) => TExit.Retry)
 
   /**
    * Returns an effect with the value on the right part.
    */
-  def right[A](a: => A): STM[Nothing, Either[Nothing, A]] =
+  def right[A](a: => A): USTM[Either[Nothing, A]] =
     succeed(Right(a))
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  def second[A, B]: ZSTM[(A, B), Nothing, B] =
+  def second[A, B]: URSTM[(A, B), B] =
     fromFunction[(A, B), B](_._2)
 
   /**
    * Returns an effect with the optional value.
    */
-  def some[A](a: => A): STM[Nothing, Option[A]] =
+  def some[A](a: => A): USTM[Option[A]] =
     succeed(Some(a))
 
   /**
    * Returns an `STM` effect that succeeds with the specified value.
    */
-  def succeed[A](a: => A): STM[Nothing, A] =
+  def succeed[A](a: => A): USTM[A] =
     new ZSTM((_, _, _, _) => TExit.Succeed(a))
 
   /**
@@ -1230,13 +1230,13 @@ object ZSTM {
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
-  def swap[A, B]: ZSTM[(A, B), Nothing, (B, A)] =
+  def swap[A, B]: URSTM[(A, B), (B, A)] =
     fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Returns an `STM` effect that succeeds with `Unit`.
    */
-  val unit: STM[Nothing, Unit] = succeedNow(())
+  val unit: USTM[Unit] = succeedNow(())
 
   /**
    * Feeds elements of type `A` to `f` and accumulates all errors in error
@@ -1286,7 +1286,7 @@ object ZSTM {
   def whenM[R, E](b: ZSTM[R, E, Boolean])(stm: => ZSTM[R, E, Any]): ZSTM[R, E, Unit] =
     b.flatMap(b => if (b) stm.unit else unit)
 
-  private[zio] def succeedNow[A](a: A): STM[Nothing, A] =
+  private[zio] def succeedNow[A](a: A): USTM[A] =
     succeed(a)
 
   final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1153,11 +1153,6 @@ object ZSTM {
   val none: USTM[Option[Nothing]] = succeedNow(None)
 
   /**
-   * Creates an `STM` value from a partial (but pure) function.
-   */
-  def partial[A](a: => A): TaskSTM[A] = fromTry(Try(a))
-
-  /**
    * Feeds elements of type `A` to a function `f` that returns an effect.
    * Collects all successes and failures in a tupled fashion.
    */

--- a/core/shared/src/main/scala/zio/stm/package.scala
+++ b/core/shared/src/main/scala/zio/stm/package.scala
@@ -18,6 +18,10 @@ package zio
 
 package object stm {
 
-  type STM[+E, +A] = ZSTM[Any, E, A]
+  type RSTM[-R, +A]  = ZSTM[R, Throwable, A]
+  type URSTM[-R, +A] = ZSTM[R, Nothing, A]
+  type STM[+E, +A]   = ZSTM[Any, E, A]
+  type USTM[+A]      = ZSTM[Any, Nothing, A]
+  type TaskSTM[+A]   = ZSTM[Any, Throwable, A]
 
 }


### PR DESCRIPTION
STM seems to be late to the Z-party :).

### Summary

- Added aliases to be consistent with the rest of library.
- Propagated aliases in `ZSTM` and `STM`.
- Removed `partial` as it was a bit misleading and used in a single test.
- Fixed some ZIO signatures.

### Question

- Should we add missing alias companions (i.e. for *STM, *Managed etc.)? That might be a good first issue.