### PR TITLE
ZIO Core: Bring Back ZIO#forkAs

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -826,6 +826,27 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       }
     ),
+    suite("forkAs")(
+      testM("child has specified name") {
+        for {
+          fiber <- Fiber.fiberName.get.forkAs("child")
+          name  <- fiber.join
+        } yield assert(name)(isSome(equalTo("child")))
+      },
+      testM("parent name is unchanged") {
+        for {
+          _    <- ZIO.unit.forkAs("child")
+          name <- Fiber.fiberName.get
+        } yield assert(name)(isNone)
+      },
+      testM("parent does not inherit child name on join") {
+        for {
+          fiber <- ZIO.unit.forkAs("child")
+          _     <- fiber.join
+          name  <- Fiber.fiberName.get
+        } yield assert(name)(isNone)
+      }
+    ),
     suite("forkDaemon")(
       testM("child is unsupervised by parent") {
         for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -685,6 +685,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def fork: URIO[R, Fiber.Runtime[E, A]] = new ZIO.Fork(self)
 
   /**
+   * Forks the effect into a new independent fiber, with the specified name.
+   */
+  final def forkAs(name: String): URIO[R, Fiber.Runtime[E, A]] =
+    ZIO.uninterruptibleMask(restore => (Fiber.fiberName.set(Some(name)) *> restore(self)).fork)
+
+  /**
    * Forks the effect into a new fiber, but immediately disowns the fiber, so
    * that when the fiber executing this effect exits, the forked fiber will not
    * automatically be terminated. Disowned fibers become new root fibers.


### PR DESCRIPTION
`forkAs` got deleted in the changes to the fiber supervision model. I think it is still well defined. The only argument I see against it is that if you want to fork a fiber with multiple "settings" (e.g. you want to fork it with a name and fork it as a daemon) you have to fall back on more primitive combinators, but I don't think that is any different than the situation today.