### PR TITLE
Add *WithTrace variants for error handling combinators

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -77,7 +77,7 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
    * Returns the `E` associated with the first `Fail` in this `Cause` if one
    * exists, along with its (optional) trace.
    */
-  def failureWithTraceOption: Option[(E, Option[ZTrace])] =
+  def failureTraceOption: Option[(E, Option[ZTrace])] =
     find {
       case Traced(Fail(e), trace) => (e, Some(trace))
       case Fail(e)                => (e, None)
@@ -98,7 +98,7 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
    * if there are no checked errors return the rest of the `Cause`
    * that is known to contain only `Die` or `Interrupt` causes.
    * */
-  final def failureWithTraceOrCause: Either[(E, Option[ZTrace]), Cause[Nothing]] = failureWithTraceOption match {
+  final def failureTraceOrCause: Either[(E, Option[ZTrace]), Cause[Nothing]] = failureTraceOption match {
     case Some(errorAndTrace) => Left(errorAndTrace)
     case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -74,6 +74,16 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
     find { case Fail(e) => e }
 
   /**
+   * Returns the `E` associated with the first `Fail` in this `Cause` if one
+   * exists, along with its (optional) trace.
+   */
+  def failureWithTraceOption: Option[(E, Option[ZTrace])] =
+    find {
+      case Traced(Fail(e), trace) => (e, Some(trace))
+      case Fail(e)                => (e, None)
+    }
+
+  /**
    * Retrieve the first checked error on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause`
    * that is known to contain only `Die` or `Interrupt` causes.
@@ -81,6 +91,16 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
     case Some(error) => Left(error)
     case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  }
+
+  /**
+   * Retrieve the first checked error and its trace on the `Left` if available,
+   * if there are no checked errors return the rest of the `Cause`
+   * that is known to contain only `Die` or `Interrupt` causes.
+   * */
+  final def failureWithTraceOrCause: Either[(E, Option[ZTrace]), Cause[Nothing]] = failureWithTraceOption match {
+    case Some(errorAndTrace) => Left(errorAndTrace)
+    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
   /**


### PR DESCRIPTION
Fixes #2323 by providing `*WithTrace` variants of error handling combinators. The `Cause.failureWithTraceOption` should probably be extended to handle at least `Traced(Meta(...Meta(Fail(e), ...)), trace)` cases, maybe more (does `Traced(Traced(Fail(e), trace2), trace1)` make sense?). Would appreciate some input on this. 