### PR TITLE
Implement Random#between

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RandomSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RandomSpec.scala
@@ -1,0 +1,72 @@
+package zio
+
+import zio.random.Random
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.Live
+
+object RandomSpec extends ZIOBaseSpec {
+
+  def spec = suite("RandomSpec")(
+    testM("between generates doubles in specified range") {
+      checkM(genDoubles) {
+        case (min, max) =>
+          for {
+            n <- Live.live(random.between(min, max))
+          } yield assert(n)(isGreaterThanEqualTo(min)) &&
+            assert(n)(isLessThan(max))
+      }
+    },
+    testM("between generates floats in specified range") {
+      checkM(genFloats) {
+        case (min, max) =>
+          for {
+            n <- Live.live(random.between(min, max))
+          } yield assert(n)(isGreaterThanEqualTo(min)) &&
+            assert(n)(isLessThan(max))
+      }
+    },
+    testM("between generates integers in specified range") {
+      checkM(genInts) {
+        case (min, max) =>
+          for {
+            n <- Live.live(random.between(min, max))
+          } yield assert(n)(isGreaterThanEqualTo(min)) &&
+            assert(n)(isLessThan(max))
+      }
+    },
+    testM("between generates longs in specified range") {
+      checkM(genLongs) {
+        case (min, max) =>
+          for {
+            n <- Live.live(random.between(min, max))
+          } yield assert(n)(isGreaterThanEqualTo(min)) &&
+            assert(n)(isLessThan(max))
+      }
+    }
+  )
+
+  val genDoubles: Gen[Random, (Double, Double)] =
+    for {
+      a <- Gen.anyDouble
+      b <- Gen.anyDouble if a != b
+    } yield if (b > a) (a, b) else (b, a)
+
+  val genFloats: Gen[Random, (Float, Float)] =
+    for {
+      a <- Gen.anyFloat
+      b <- Gen.anyFloat if a != b
+    } yield if (b > a) (a, b) else (b, a)
+
+  val genInts: Gen[Random, (Int, Int)] =
+    for {
+      a <- Gen.anyInt
+      b <- Gen.anyInt if a != b
+    } yield if (b > a) (a, b) else (b, a)
+
+  val genLongs: Gen[Random, (Long, Long)] =
+    for {
+      a <- Gen.anyLong
+      b <- Gen.anyLong if a != b
+    } yield if (b > a) (a, b) else (b, a)
+}

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -28,9 +28,9 @@ package object random {
         import scala.util.{ Random => SRandom }
 
         def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-          betweenWith(nextLong, nextLong, minInclusive, maxExclusive)
+          betweenWith(nextLong, nextLong(_), minInclusive, maxExclusive)
         def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-          betweenWith(nextInt, nextInt, minInclusive, maxExclusive)
+          betweenWith(nextInt, nextInt(_), minInclusive, maxExclusive)
         def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
           betweenWith(nextFloat, minInclusive, maxExclusive)
         def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
@@ -64,8 +64,8 @@ package object random {
       ZLayer.succeed(Service.live)
 
     protected[zio] def betweenWith(
-      nextLongWith: Long => UIO[Long],
       nextLong: UIO[Long],
+      nextLongWith: Long => UIO[Long],
       minInclusive: Long,
       maxExclusive: Long
     ): UIO[Long] =
@@ -78,8 +78,8 @@ package object random {
       }
 
     protected[zio] def betweenWith(
-      nextIntWith: Int => UIO[Int],
       nextInt: UIO[Int],
+      nextIntWith: Int => UIO[Int],
       minInclusive: Int,
       maxExclusive: Int
     ): UIO[Int] =

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -5,7 +5,10 @@ package object random {
 
   object Random extends Serializable {
     trait Service extends Serializable {
-
+      def between(minInclusive: Long, maxExclusive: Long): UIO[Long]
+      def between(minInclusive: Int, maxExclusive: Int): UIO[Int]
+      def between(minInclusive: Float, maxExclusive: Float): UIO[Float]
+      def between(minInclusive: Double, maxExclusive: Double): UIO[Double]
       def nextBoolean: UIO[Boolean]
       def nextBytes(length: Int): UIO[Chunk[Byte]]
       def nextDouble: UIO[Double]
@@ -24,6 +27,14 @@ package object random {
       val live: Service = new Service {
         import scala.util.{ Random => SRandom }
 
+        def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+          betweenWith(nextLong, nextLong, minInclusive, maxExclusive)
+        def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+          betweenWith(nextInt, nextInt, minInclusive, maxExclusive)
+        def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+          betweenWith(nextFloat, minInclusive, maxExclusive)
+        def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+          betweenWith(nextDouble, minInclusive, maxExclusive)
         val nextBoolean: UIO[Boolean] = ZIO.effectTotal(SRandom.nextBoolean())
         def nextBytes(length: Int): UIO[Chunk[Byte]] =
           ZIO.effectTotal {
@@ -52,21 +63,53 @@ package object random {
     val live: Layer[Nothing, Random] =
       ZLayer.succeed(Service.live)
 
-    protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =
-      for {
-        bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
-        _         <- bufferRef.update(_ ++= list)
-        swap = (i1: Int, i2: Int) =>
-          bufferRef.update {
-            case buffer =>
-              val tmp = buffer(i1)
-              buffer(i1) = buffer(i2)
-              buffer(i2) = tmp
-              buffer
-          }
-        _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextInt(n).flatMap(k => swap(n - 1, k)))
-        buffer <- bufferRef.get
-      } yield buffer.toList
+    protected[zio] def betweenWith(
+      nextLongWith: Long => UIO[Long],
+      nextLong: UIO[Long],
+      minInclusive: Long,
+      maxExclusive: Long
+    ): UIO[Long] =
+      if (minInclusive >= maxExclusive)
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      else {
+        val difference = maxExclusive - minInclusive
+        if (difference > 0) nextLongWith(difference).map(_ + minInclusive)
+        else nextLong.doUntil(n => minInclusive <= n && n < maxExclusive)
+      }
+
+    protected[zio] def betweenWith(
+      nextIntWith: Int => UIO[Int],
+      nextInt: UIO[Int],
+      minInclusive: Int,
+      maxExclusive: Int
+    ): UIO[Int] =
+      if (minInclusive >= maxExclusive) {
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      } else {
+        val difference = maxExclusive - minInclusive
+        if (difference > 0) nextIntWith(difference).map(_ + minInclusive)
+        else nextInt.doUntil(n => minInclusive <= n && n < maxExclusive)
+      }
+
+    protected[zio] def betweenWith(nextFloat: UIO[Float], minInclusive: Float, maxExclusive: Float): UIO[Float] =
+      if (minInclusive >= maxExclusive)
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      else
+        nextFloat.map { n =>
+          val result = n * (maxExclusive - minInclusive) + minInclusive
+          if (result < maxExclusive) result
+          else Math.nextAfter(maxExclusive, Float.NegativeInfinity)
+        }
+
+    protected[zio] def betweenWith(nextDouble: UIO[Double], minInclusive: Double, maxExclusive: Double): UIO[Double] =
+      if (minInclusive >= maxExclusive)
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      else
+        nextDouble.map { n =>
+          val result = n * (maxExclusive - minInclusive) + minInclusive
+          if (result < maxExclusive) result
+          else Math.nextAfter(maxExclusive, Float.NegativeInfinity)
+        }
 
     protected[zio] def nextLongWith(nextLong: UIO[Long], n: Long): UIO[Long] =
       if (n <= 0)
@@ -84,7 +127,35 @@ package object random {
           }
         }
       }
+
+    protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =
+      for {
+        bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
+        _         <- bufferRef.update(_ ++= list)
+        swap = (i1: Int, i2: Int) =>
+          bufferRef.update {
+            case buffer =>
+              val tmp = buffer(i1)
+              buffer(i1) = buffer(i2)
+              buffer(i2) = tmp
+              buffer
+          }
+        _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextInt(n).flatMap(k => swap(n - 1, k)))
+        buffer <- bufferRef.get
+      } yield buffer.toList
   }
+
+  def between(minInclusive: Long, maxExclusive: Long): ZIO[Random, Nothing, Long] =
+    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+
+  def between(minInclusive: Int, maxExclusive: Int): ZIO[Random, Nothing, Int] =
+    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+
+  def between(minInclusive: Float, maxExclusive: Float): ZIO[Random, Nothing, Float] =
+    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+
+  def between(minInclusive: Double, maxExclusive: Double): ZIO[Random, Nothing, Double] =
+    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
 
   val nextBoolean: ZIO[Random, Nothing, Boolean]                   = ZIO.accessM(_.get.nextBoolean)
   def nextBytes(length: => Int): ZIO[Random, Nothing, Chunk[Byte]] = ZIO.accessM(_.get.nextBytes(length))

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -40,6 +40,10 @@ object RandomSpec extends ZIOBaseSpec {
     testM("bounded nextInt")(forAllEqualN(_.nextInt(_))(_.nextInt(_))),
     testM("bounded nextInt generates values within the bounds")(forAllBounded(Gen.anyInt)(_.nextInt(_))),
     testM("bounded nextLong generates values within the bounds")(forAllBounded(Gen.anyLong)(_.nextLong(_))),
+    testM("between generates doubles within the bounds")(forAllBetween(Gen.anyDouble)(_.between(_, _))),
+    testM("between generates floats within the bounds")(forAllBetween(Gen.anyFloat)(_.between(_, _))),
+    testM("between generates integers within the bounds")(forAllBetween(Gen.anyInt)(_.between(_, _))),
+    testM("between generates longs within the bounds")(forAllBetween(Gen.anyLong)(_.between(_, _))),
     testM("shuffle")(forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))),
     testM("referential transparency") {
       val test = TestRandom.makeTest(DefaultData)
@@ -188,6 +192,25 @@ object RandomSpec extends ZIOBaseSpec {
         testRandom <- ZIO.environment[Random].map(_.get[Random.Service])
         nextRandom <- next(testRandom, upper)
       } yield assert(nextRandom)(isWithin(zero, upper))
+    }
+  }
+
+  def forAllBetween[A: Numeric](gen: Gen[Random, A])(
+    between: (Random.Service, A, A) => UIO[A]
+  ): ZIO[Random, Nothing, TestResult] = {
+    val num = implicitly[Numeric[A]]
+    import num._
+    val genMinMax = for {
+      value1 <- gen
+      value2 <- gen if (value1 != value2)
+    } yield if (value2 > value1) (value1, value2) else (value2, value1)
+    checkM(genMinMax) {
+      case (min, max) =>
+        for {
+          testRandom <- ZIO.environment[Random].map(_.get[Random.Service])
+          nextRandom <- between(testRandom, min, max)
+        } yield assert(nextRandom)(isGreaterThanEqualTo(min)) &&
+          assert(nextRandom)(isLessThan(max))
     }
   }
 }

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -840,6 +840,34 @@ package object environment extends PlatformSpecific {
         with TestRandom.Service {
 
       /**
+       * Takes a long from the buffer if one exists or else generates a
+       * pseudo-random long in the specified range.
+       */
+      def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+        getOrElse(bufferedLong)(randomBetween(minInclusive, maxExclusive))
+
+      /**
+       * Takes an integer from the buffer if one exists or else generates a
+       * pseudo-random integer in the specified range.
+       */
+      def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+        getOrElse(bufferedInt)(randomBetween(minInclusive, maxExclusive))
+
+      /**
+       * Takes a float from the buffer if one exists or else generates a
+       * pseudo-random float in the specified range.
+       */
+      def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+        getOrElse(bufferedFloat)(randomBetween(minInclusive, maxExclusive))
+
+      /**
+       * Takes a double from the buffer if one exists or else generates a
+       * pseudo-random double in the specified range.
+       */
+      def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+        getOrElse(bufferedDouble)(randomBetween(minInclusive, maxExclusive))
+
+      /**
        * Clears the buffer of booleans.
        */
       val clearBooleans: UIO[Unit] =
@@ -1125,6 +1153,34 @@ package object environment extends PlatformSpecific {
       @inline
       private def mostSignificantBits(x: Double): Int =
         toInt((x / (1 << 24).toDouble))
+
+      /**
+       * Takes a long from the buffer if one exists or else generates a
+       * pseudo-random long in the specified range.
+       */
+      private def randomBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+        Random.betweenWith(nextLong, nextLong, minInclusive, maxExclusive)
+
+      /**
+       * Takes an integer from the buffer if one exists or else generates a
+       * pseudo-random integer in the specified range.
+       */
+      private def randomBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+        Random.betweenWith(nextInt, nextInt, minInclusive, maxExclusive)
+
+      /**
+       * Takes a float from the buffer if one exists or else generates a
+       * pseudo-random float in the specified range.
+       */
+      private def randomBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+        Random.betweenWith(nextFloat, minInclusive, maxExclusive)
+
+      /**
+       * Takes a double from the buffer if one exists or else generates a
+       * pseudo-random double in the specified range.
+       */
+      private def randomBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+        Random.betweenWith(nextDouble, minInclusive, maxExclusive)
 
       private def randomBits(bits: Int): UIO[Int] =
         randomState.modify { data =>

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -1159,14 +1159,14 @@ package object environment extends PlatformSpecific {
        * pseudo-random long in the specified range.
        */
       private def randomBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-        Random.betweenWith(nextLong, nextLong, minInclusive, maxExclusive)
+        Random.betweenWith(nextLong, nextLong(_), minInclusive, maxExclusive)
 
       /**
        * Takes an integer from the buffer if one exists or else generates a
        * pseudo-random integer in the specified range.
        */
       private def randomBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-        Random.betweenWith(nextInt, nextInt, minInclusive, maxExclusive)
+        Random.betweenWith(nextInt, nextInt(_), minInclusive, maxExclusive)
 
       /**
        * Takes a float from the buffer if one exists or else generates a

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -25,6 +25,12 @@ object MockRandom {
     def envBuilder = MockRandom.envBuilder
   }
 
+  object Between {
+    object _0 extends Tag[(Long, Long), Long]
+    object _1 extends Tag[(Int, Int), Int]
+    object _2 extends Tag[(Float, Float), Float]
+    object _3 extends Tag[(Double, Double), Double]
+  }
   object NextBoolean  extends Tag[Unit, Boolean]
   object NextBytes    extends Tag[Int, Chunk[Byte]]
   object NextDouble   extends Tag[Unit, Double]
@@ -45,6 +51,14 @@ object MockRandom {
   private lazy val envBuilder: URLayer[Has[Proxy], Random] =
     ZLayer.fromService(invoke =>
       new Random.Service {
+        def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+          invoke(Between._0, minInclusive, maxExclusive)
+        def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+          invoke(Between._1, minInclusive, maxExclusive)
+        def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+          invoke(Between._2, minInclusive, maxExclusive)
+        def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+          invoke(Between._3, minInclusive, maxExclusive)
         val nextBoolean: UIO[Boolean]                = invoke(NextBoolean)
         def nextBytes(length: Int): UIO[Chunk[Byte]] = invoke(NextBytes, length)
         val nextDouble: UIO[Double]                  = invoke(NextDouble)


### PR DESCRIPTION
Resolves #3146. These methods were added to `scala.util.Random` in 2.13 to generate numeric values within a specified range. Adding them to `Random` service maintains parity between our implementation of the standard services and the ones in the Scala standard library and should also provide an easier way for people to generate values in a range.