### PR TITLE
Upgrade to Scala.JS 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-// shadow sbt-scalajs' crossProject from Scala.js 0.6.x
+// shadow sbt-scalajs' crossProject from Scala.js 1.0.x
 import BuildHelper._
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
@@ -226,7 +226,7 @@ lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
   .settings(
     crossScalaVersions --= Seq("2.11.12", dottyVersion),
     scalacOptions += "-language:experimental.macros",
-    libraryDependencies += "com.propensive" %%% "magnolia" % "0.12.6"
+    libraryDependencies += "com.propensive" %%% "magnolia" % "0.12.8"
   )
 
 lazy val testMagnoliaJVM = testMagnolia.jvm
@@ -273,7 +273,7 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
     ),
     mainClass in (Test, run) := Some("zio.test.sbt.TestMain")
   )
-  .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % "0.6.32"))
+  .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % "1.0.1"))
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
   .dependsOn(core)
   .dependsOn(test)

--- a/core/shared/src/main/scala/java/util/concurrent/ExecutorService.scala
+++ b/core/shared/src/main/scala/java/util/concurrent/ExecutorService.scala
@@ -1,0 +1,31 @@
+package java.util.concurrent
+
+import java.util.{ Collection, List => JList }
+import java.util.concurrent.{ Future => JFuture }
+
+trait ExecutorService extends Executor {
+
+  def shutdown(): Unit
+
+  def shutdownNow(): JList[Runnable]
+
+  def isShutdown(): Boolean
+
+  def isTerminated(): Boolean
+
+  def awaitTermination(timeout: Long, unit: TimeUnit): Boolean
+
+  def submit[T](task: Callable[T]): JFuture[T]
+
+  def submit[T](task: Runnable, result: T): JFuture[T]
+
+  def submit(task: Runnable): JFuture[_]
+
+  def invokeAll[T](tasks: Collection[_ <: Callable[T]]): JList[JFuture[T]]
+
+  def invokeAll[T](tasks: Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): JList[JFuture[T]]
+
+  def invokeAny[T](tasks: Collection[_ <: Callable[T]]): T
+
+  def invokeAny[T](tasks: Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T
+}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -88,7 +88,7 @@ object BuildHelper {
       (if (isDotty.value) Seq()
        else
          Seq(
-           "dev.zio" %%% "izumi-reflect" % "0.12.0-M0"
+           "dev.zio" %%% "izumi-reflect" % "0.12.0-M1"
          ))
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.bintrayRepo("ktosopl", "sbt-plugins/sbt-jcstress")
 
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.3.7")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "0.6.32")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.0.1")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.3.2")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.9.0")


### PR DESCRIPTION
Resolves #3019.

@adamgfraser `java.util.concurrent.ExecutorService` is a stop gap solution to the slightly eager construction of `ZEnv` (#3139). What do you think we should do here?

1) I can definitely open a PR with scala.js, to include this in their library, which will probably take some time until a new version is released, futher delaying our scala js 1.0 release.

2) We can remove this code once we fix the eager construction of the environment.

Opening this as a draft PR.