### PR TITLE
Add mapDependency to map over a ZLayer with Has

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -295,7 +295,7 @@ object ZLayerSpec extends ZIOBaseSpec {
         assertM(zio.provideLayer(live))(equalTo((1, "1")))
       },
       testM("singleService.map for single output layer") {
-        val layer = ZLayer.succeed(200).singleService[Int].map(_.toString)
+        val layer = ZLayer.succeed(200).singleService.map(_.toString)
         assertM(ZIO.environment[Has[String]].provideLayer(layer).map(_.get))(equalTo("200"))
       },
       testM("singleService.map doesn't compile for multi-output layer") {
@@ -304,10 +304,10 @@ object ZLayerSpec extends ZIOBaseSpec {
            (
              ZLayer.succeed(200) ++
              ZLayer.succeed(true)
-           ).singleService[Int].map(_.toString)
+           ).singleService.map(_.toString)
           """
         }
-        assertM(result)(isLeft(containsString("Cannot prove that") && containsString("=:= zio.Has[Int]")))
+        assertM(result)(isLeft(containsString("could not find implicit value for parameter ev: zio.ZLayer.HasSingleService")))
       }
     )
 }

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect.{ ignore, nonFlaky }
+import zio.test.TestAspect.{ ignore, nonFlaky, scala2Only }
 import zio.test._
 import zio.test.environment._
 
@@ -310,6 +310,6 @@ object ZLayerSpec extends ZIOBaseSpec {
         assertM(result)(
           isLeft(containsString("could not find implicit value for parameter ev: zio.ZLayer.HasSingleService"))
         )
-      }
+      } @@ scala2Only
     )
 }

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -294,9 +294,20 @@ object ZLayerSpec extends ZIOBaseSpec {
         } yield (i, s)
         assertM(zio.provideLayer(live))(equalTo((1, "1")))
       },
-      testM("mapDependency") {
-        val layer = ZLayer.succeed(200).mapDependency(_.toString)
+      testM("singleService.map for single output layer") {
+        val layer = ZLayer.succeed(200).singleService[Int].map(_.toString)
         assertM(ZIO.environment[Has[String]].provideLayer(layer).map(_.get))(equalTo("200"))
+      },
+      testM("singleService.map doesn't compile for multi-output layer") {
+        val result = typeCheck {
+          """
+           (
+             ZLayer.succeed(200) ++
+             ZLayer.succeed(true)
+           ).singleService[Int].map(_.toString)
+          """
+        }
+        assertM(result)(isLeft(containsString("Cannot prove that") && containsString("=:= zio.Has[Int]")))
       }
     )
 }

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -307,7 +307,9 @@ object ZLayerSpec extends ZIOBaseSpec {
            ).singleService.map(_.toString)
           """
         }
-        assertM(result)(isLeft(containsString("could not find implicit value for parameter ev: zio.ZLayer.HasSingleService")))
+        assertM(result)(
+          isLeft(containsString("could not find implicit value for parameter ev: zio.ZLayer.HasSingleService"))
+        )
       }
     )
 }

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -293,6 +293,10 @@ object ZLayerSpec extends ZIOBaseSpec {
           s <- ZIO.environment[Has[String]].map(_.get[String])
         } yield (i, s)
         assertM(zio.provideLayer(live))(equalTo((1, "1")))
+      },
+      testM("mapDependency") {
+        val layer = ZLayer.succeed(200).mapDependency(_.toString)
+        assertM(ZIO.environment[Has[String]].provideLayer(layer).map(_.get))(equalTo("200"))
       }
     )
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -2053,13 +2053,21 @@ object ZLayer {
      */
     def update[A: Tagged](f: A => A)(implicit ev: ROut <:< Has[A]): ZLayer[RIn, E, ROut] =
       self >>> ZLayer.fromFunctionMany(_.update[A](f))
+
+    /**
+     * Proves that this layer has a single `Has[_]` output,
+     * which allows more operations to be done lawfully, for example map a value inside `Has[_]`.
+     */
+    def singleService[A](implicit ev: ROut =:= Has[A]): SingleServiceOutputLayerOps[RIn, E, A] =
+      new SingleServiceOutputLayerOps[RIn, E, A](self.asInstanceOf[ZLayer[RIn, E, Has[A]]])
   }
 
-  implicit final class ZLayerHasROutOps1[RIn, E, A](private val self: ZLayer[RIn, E, Has[A]]) extends AnyVal {
+  final class SingleServiceOutputLayerOps[RIn, E, A](private val self: ZLayer[RIn, E, Has[A]]) extends AnyVal {
+
     /**
-     * Maps layer output which is wrapped in `Has`
+     * Maps this layer's single Has[A] output into a single Has[B] output.
      */
-    def mapDependency[B: Tagged](f: A => B)(implicit A: Tagged[A]): ZLayer[RIn, E, Has[B]] =
+    def map[B: Tagged](f: A => B)(implicit A: Tagged[A]): ZLayer[RIn, E, Has[B]] =
       self.map(x => Has(f(x.get)))
   }
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -1031,7 +1031,7 @@ object ZLayer {
     val layer = fromServicesManyM(andThen(f)(ZIO.succeedNow))
     layer
   }
- 
+
   /**
    * Constructs a layer that purely depends on the specified services, which
    * must return one or more services. For the more common variant that returns
@@ -2053,6 +2053,14 @@ object ZLayer {
      */
     def update[A: Tagged](f: A => A)(implicit ev: ROut <:< Has[A]): ZLayer[RIn, E, ROut] =
       self >>> ZLayer.fromFunctionMany(_.update[A](f))
+  }
+
+  implicit final class ZLayerHasROutOps1[RIn, E, A](private val self: ZLayer[RIn, E, Has[A]]) extends AnyVal {
+    /**
+     * Maps layer output which is wrapped in `Has`
+     */
+    def mapDependency[B: Tagged](f: A => B)(implicit A: Tagged[A]): ZLayer[RIn, E, Has[B]] =
+      self.map(x => Has(f(x.get)))
   }
 
   implicit final class ZLayerHasRInROutOps[RIn <: Has[_], E, ROut <: Has[_]](private val self: ZLayer[RIn, E, ROut])


### PR DESCRIPTION
This `mapDependency` (naming is up for suggestions) extension simplifies maps over `ZLayer` instances with `Has[_]` outputs.

An example would be a need "zoom" into a config layer to create a more specific layer with a config subset for specific component. Currently it's requires some boilerplate:

```scala
val configLayer = TypesafeConfig.fromDefaultLoader(appConfigDesc)
val dbConfigLayer = configLayer.map(c => Has(c.get.dbConfig))
val apiConfigLayer = configLayer.map(c => Has(c.get.apiConfig))
```
With this patch in the above code would look like:
```scala
val configLayer = TypesafeConfig.fromDefaultLoader(appConfigDesc)
val dbConfigLayer = configLayer.mapDependency(_.dbConfig)
val apiConfigLayer = configLayer.mapDependency(_.apiConfig)
```