### PR TITLE
Add isNative to TestAspect, TestPlatform, and TestAspectSpec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -73,6 +73,9 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("exceptJVM runs tests on all platforms except the JVM") {
       assert(TestPlatform.isJVM)(isFalse)
     } @@ exceptJVM,
+    test("exceptNative runs tests on all platforms except ScalaNative") {
+      assert(TestPlatform.isNative)(isFalse)
+    } @@ exceptNative,
     test("exceptScala2 runs tests on all versions except Scala 2") {
       assert(TestVersion.isScala2)(isFalse)
     } @@ exceptScala2,
@@ -185,6 +188,19 @@ object TestAspectSpec extends ZIOBaseSpec {
     testM("jvmOnly runs tests only on the JVM") {
       val spec   = test("JVM-only")(assert(TestPlatform.isJVM)(isTrue)) @@ jvmOnly
       val result = if (TestPlatform.isJVM) isSuccess(spec) else isIgnored(spec)
+      assertM(result)(isTrue)
+    },
+    testM("native applies test aspect only on ScalaNative") {
+      for {
+        ref    <- Ref.make(false)
+        spec   = test("test")(assert(true)(isTrue)) @@ native(after(ref.set(true)))
+        _      <- execute(spec)
+        result <- ref.get
+      } yield if (TestPlatform.isNative) assert(result)(isTrue) else assert(result)(isFalse)
+    },
+    testM("nativeOnly runs tests only on ScalaNative") {
+      val spec   = test("Javascript-only")(assert(TestPlatform.isNative)(isTrue)) @@ jsOnly
+      val result = if (TestPlatform.isNative) isSuccess(spec) else isIgnored(spec)
       assertM(result)(isTrue)
     },
     testM("noDelay causes sleep effects to be executed immediately") {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -199,7 +199,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       } yield if (TestPlatform.isNative) assert(result)(isTrue) else assert(result)(isFalse)
     },
     testM("nativeOnly runs tests only on ScalaNative") {
-      val spec   = test("Javascript-only")(assert(TestPlatform.isNative)(isTrue)) @@ jsOnly
+      val spec   = test("Native-only")(assert(TestPlatform.isNative)(isTrue)) @@ nativeOnly
       val result = if (TestPlatform.isNative) isSuccess(spec) else isIgnored(spec)
       assertM(result)(isTrue)
     },

--- a/test/js/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/js/src/main/scala/zio/test/TestPlatform.scala
@@ -31,4 +31,9 @@ object TestPlatform {
    * Returns whether the currently platform is the JVM.
    */
   final val isJVM = false
+
+  /**
+   * Returns whether the current platform is Scala Native.
+   */
+  final val isNative = false
 }

--- a/test/jvm/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/jvm/src/main/scala/zio/test/TestPlatform.scala
@@ -31,4 +31,9 @@ object TestPlatform {
    * Returns whether the currently platform is the JVM.
    */
   final val isJVM = true
+
+  /**
+   * Returns whether the current platform is Scala Native.
+   */
+  final val isNative = false
 }

--- a/test/native/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/native/src/main/scala/zio/test/TestPlatform.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+/**
+ * `TestPlatform` provides information about the platform tests are being run
+ * on to enable platform specific test configuration.
+ */
+object TestPlatform {
+
+  /**
+   * Returns whether the current platform is ScalaJS.
+   */
+  final val isJS = false
+
+  /**
+   * Returns whether the currently platform is the JVM.
+   */
+  final val isJVM = false
+
+  /**
+   * Returns whether the current platform is Scala Native.
+   */
+  final val isNative = true
+}

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -243,6 +243,12 @@ object TestAspect extends TimeoutVariants {
     if (TestPlatform.isJVM) ignore else identity
 
   /**
+   * An aspect that runs tests on all platforms except ScalaNative.
+   */
+  val exceptNative: TestAspectAtLeastR[Annotations] =
+    if (TestPlatform.isNative) ignore else identity
+
+  /**
    * An aspect that runs tests on all versions except Scala 2.
    */
   val exceptScala2: TestAspectAtLeastR[Annotations] =
@@ -391,6 +397,20 @@ object TestAspect extends TimeoutVariants {
    */
   val jvmOnly: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJVM) identity else ignore
+
+  /**
+   * An aspect that applies the specified aspect on ScalaNative.
+   */
+  def native[LowerR, UpperR, LowerE, UpperE](
+    that: TestAspect[LowerR, UpperR, LowerE, UpperE]
+  ): TestAspect[LowerR, UpperR, LowerE, UpperE] =
+    if (TestPlatform.isNative) that else identity
+
+  /**
+   * An aspect that only runs tests on ScalaNative.
+   */
+  val nativeOnly: TestAspectAtLeastR[Annotations] =
+    if (TestPlatform.isNative) identity else ignore
 
   /**
    * An aspect that causes calls to `sleep` and methods implemented in terms


### PR DESCRIPTION
This PR adds code for ScalaNative builds which corresponds to the
existing isJVM & isJS code.  ZIO on ScalaNative is experimental and
ZIOFramework is highly experimental.

This change has two benefits. It is small enough to allow easy
review and be non-controversial.  The second benefit is that it
reduces the effort to work on getting ZIOFramework to work on
ScalaNative.

Tested for safety (i.e. did no break existing JVM & JS) by
manually running testJS & testJVM (latter had a few problems with
-Xfatal-warnings, but I think this PR does not cause those.)

I will be testing for efficacy  (i.e. does it do what it says it does)
during my continuing ZIO ScalaNative work.