### PR TITLE
Enable ReloadOnSourceChanges in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "zio"
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 inThisBuild(
   List(
     organization := "dev.zio",


### PR DESCRIPTION
The sbt 1.3.8 [documentation](https://www.scala-sbt.org/1.x/docs/Triggered-Execution.html) 
describes the action of onChangedBuildSource := ReloadSourceChanges as
"then sbt will monitor the build sources (i.e. *.sbt and *.{java,scala}
files in the project directory)." and reload when any of the monitored
files change.

This is reduces frustration and developer cycle time when working
with any of the monitored files.

Sbt documents the setting as Global.  Pascal taught me to put
Globals at the top of the file.  If anyone with a better understanding
of sbt suggests, I can move the one line to a better place in the
file. (Some) Bikeshedding welcome! That is how I learn.

Tested for safety by doing a "sbt testJS". All worked as expected.

Tested for efficacy by:

       start an sbt shell, should look as usual

       edit build.sbt, say by adding a blank character, and write file.

       In the sbt shell, enter a newline. sbt shell should reload
       the monitored build files.

       In this case, there would be no visible change in behavior.
       If a real change had been made in build.sbt, say a
       change in a setting, that change should be evident now.