### PR TITLE
Schedule: add operator alias for `andThenEither`

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -110,6 +110,12 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     }
 
   /**
+   * Operator alias for `andThenEither`.
+   */
+  final def <||>[R1 <: R, A1 <: A, C](that: Schedule[R1, A1, C]): Schedule[R1, A1, Either[B, C]] =
+    andThenEither(that)
+
+  /**
    * The same as `&&`, but ignores the right output.
    */
   final def <*[R1 <: R, A1 <: A, C](that: Schedule[R1, A1, C]): Schedule[R1, A1, B] =


### PR DESCRIPTION
`<||>` operator got renamed to `andThenEither` over a year ago in [this commit](https://github.com/zio/zio/commit/b13d950861eb4a09791e16a8ff6d56b0516540b5#diff-341b80f6ff3a662fd472c215b214accaR220)