### PR TITLE
Simpler ZSink.succeed signature.

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -94,7 +94,7 @@ object SinkSpec extends ZIOBaseSpec {
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("interaction with succeed") {
-          val sink = ZSink.succeed[Int, Int](5).collectAll
+          val sink = ZSink.succeed(5).collectAll
           for {
             init <- sink.initial
             s <- sink
@@ -311,19 +311,19 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("flatMap")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = ZSink.identity[Int].flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1))(equalTo(("1", Chunk.empty)))
         },
         testM("init error") {
-          val sink = initErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = initErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("step error") {
-          val sink = stepErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = stepErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("extract error") {
-          val sink = extractErrorSink.flatMap(n => ZSink.succeed[Int, String](n.toString))
+          val sink = extractErrorSink.flatMap(n => ZSink.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("self done") {
@@ -339,7 +339,7 @@ object SinkSpec extends ZIOBaseSpec {
           } yield assert(result)(equalTo((List(1, 2, 3), Chunk(4, 5))))
         },
         testM("self more") {
-          val sink = ZSink.collectAll[Int].flatMap(list => ZSink.succeed[Int, Int](list.headOption.getOrElse(0)))
+          val sink = ZSink.collectAll[Int].flatMap(list => ZSink.succeed(list.headOption.getOrElse(0)))
           for {
             init   <- sink.initial
             step1  <- sink.step(init, 1)
@@ -620,7 +620,7 @@ object SinkSpec extends ZIOBaseSpec {
       ) @@ zioTag(errors),
       suite("raceBoth")(
         testM("left") {
-          val sink = ZSink.identity[Int] raceBoth ZSink.succeed[Int, String]("Hello")
+          val sink = ZSink.identity[Int] raceBoth ZSink.succeed("Hello")
           assertM(sinkIteration(sink, 1))(equalTo((Left(1), Chunk.empty)))
         },
         testM("init error left") {
@@ -766,7 +766,7 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zip (<*>)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int] <*> ZSink.succeed[Int, String]("Hello")
+          val sink = ZSink.identity[Int] <*> ZSink.succeed("Hello")
           assertM(sinkIteration(sink, 1))(equalTo(((1, "Hello"), Chunk.empty)))
         },
         testM("init error left") {
@@ -808,7 +808,7 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zipLeft (<*)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].zipLeft(ZSink.succeed[Int, String]("Hello"))
+          val sink = ZSink.identity[Int].zipLeft(ZSink.succeed("Hello"))
           assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         }
       ),
@@ -871,13 +871,13 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("zipRight (*>)")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].zipRight(ZSink.succeed[Int, String]("Hello"))
+          val sink = ZSink.identity[Int].zipRight(ZSink.succeed("Hello"))
           assertM(sinkIteration(sink, 1))(equalTo(("Hello", Chunk.empty)))
         }
       ),
       suite("zipWith")(testM("happy path") {
         val sink =
-          ZSink.identity[Int].zipWith(ZSink.succeed[Int, String]("Hello"))((x, y) => x.toString + y.toString)
+          ZSink.identity[Int].zipWith(ZSink.succeed("Hello"))((x, y) => x.toString + y.toString)
         assertM(sinkIteration(sink, 1))(equalTo(("1Hello", Chunk.empty)))
       })
     ),

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1906,13 +1906,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
   /**
    * Creates a single-value sink from a value.
    */
-  def succeed[A, B](b: => B): ZSink[Any, Nothing, A, A, B] =
-    new SinkPure[Nothing, A, A, B] {
-      type State = Chunk[A]
-      val initialPure                  = Chunk.empty
-      def stepPure(state: State, a: A) = state ++ Chunk(a)
-      def extractPure(state: State)    = Right((b, state))
-      def cont(state: State)           = false
+  def succeed[B](b: => B): ZSink[Any, Nothing, Nothing, Any, B] =
+    new SinkPure[Nothing, Nothing, Any, B] {
+      type State = Unit
+      val initialPure                    = ()
+      def stepPure(state: State, a: Any) = ()
+      def extractPure(state: State)      = Right((b, Chunk.empty))
+      def cont(state: State)             = false
     }
 
   /**
@@ -2119,6 +2119,6 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
       def cont(state: State) = state._3
     }
 
-  private[zio] def succeedNow[A, B](b: B): ZSink[Any, Nothing, A, A, B] =
+  private[zio] def succeedNow[B](b: B): ZSink[Any, Nothing, Nothing, Any, B] =
     succeed(b)
 }


### PR DESCRIPTION
```scala
// BEFORE
def succeed[A, B](b: => B): ZSink[Any, Nothing, A, A, B]
// AFTER
def succeed[B](b: => B): ZSink[Any, Nothing, Nothing, Any, B]
```

This is also in line with:
```scala
def fromEffect[R, E, B](b: => ZIO[R, E, B]): ZSink[R, E, Nothing, Any, B]
```

And the new behavior ensures:
```scala
ZSink.succeed(x) == ZSink.fromEffect(UIO.succeed(x))
```

Semi-related to #3187 