### PR TITLE
ZSink.drop and ZSink.skip constructors.

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1331,6 +1331,32 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
     foldLeft(())((s, _) => s)
 
   /**
+   * Creates a sink that drops the first `n` values. Does not fail if there
+   * are fewer than `n` input values.
+   */
+  def drop[A](n: Long): ZSink[Any, Nothing, A, A, Unit] =
+    new SinkPure[Nothing, A, A, Unit] {
+      type State = Long
+      val initialPure                  = 0L
+      def stepPure(state: State, a: A) = state + 1
+      def extractPure(state: State)    = Right(((), Chunk.empty))
+      def cont(state: State)           = state < n
+    }
+
+  /**
+   * Creates a sink that drops the first `n` values and fails if there are
+   * fewer than `n` input values.
+   */
+  def skip[A](n: Long): ZSink[Any, Unit, A, A, Unit] =
+    new SinkPure[Unit, A, A, Unit] {
+      type State = Long
+      val initialPure                  = 0L
+      def stepPure(state: State, a: A) = state + 1
+      def extractPure(state: State)    = if (state < n) Left(()) else Right(((), Chunk.empty))
+      def cont(state: State)           = state < n
+    }
+
+  /**
    * Creates a sink containing the first value.
    */
   def head[A]: ZSink[Any, Nothing, A, A, Option[A]] =


### PR DESCRIPTION
Addresses incorrectly closed #2341.

Example of usage from work:
```scala
  def headerSink(headerConfig: HeaderConfig): ZSink[Any, StreamError, Arr[String], Arr[String], List[String]] = (for {
    _ <- skip[Arr[String]](headerConfig.skipBefore)

    result <- headerConfig.headerOverride match {
      case Some((true, list)) =>
        get[Arr[String]] *> ZSink.succeed[Arr[String], List[String]](list)
      case Some((false, list)) =>
        ZSink.succeed[Arr[String], List[String]](list)
      case None =>
        get[Arr[String]].map(_.toList)
    }

    _ <- skip[Arr[String]](headerConfig.skipAfter)
  } yield result).mapError(_ => StreamError.NoHeader())

  // A different way to implement skip.
  def skip[A](n: Long): ZSink[Any, Unit, Nothing, A, Unit] =
    ZSink.foldUntil[Long, A](0L, n)((s, _) => s + 1).flatMap {
      case m if n != m => ZSink.fail(())
      case _           => ZSink.succeed(())
    }
  
  // This is also known as ZSink.identity but it's a weird name.
  def get[A]: ZSink[Any, Unit, A, A, A] =
    ZSink.foldUntil[Option[A], A](None, 1)((_, a) => Some(a)).flatMap {
      case None    => ZSink.fail(())
      case Some(a) => ZSink.succeed(a)
    }
```

---

🤔 `drop(n) = skip(n).optional.as(())`?