### PR TITLE
Improve fiber dump output

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -62,7 +62,7 @@ object RTSSpec extends ZIOBaseSpec {
       for {
         promise <- Promise.make[Nothing, Int]
         fiber   <- promise.await.fork
-        dump    <- fiber.dump
+        dump    <- fiber.dump(true)
         dumpStr <- dump.prettyPrintM
         _       <- console.putStrLn(dumpStr)
       } yield assert(dumpStr)(anything)

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -62,7 +62,7 @@ object RTSSpec extends ZIOBaseSpec {
       for {
         promise <- Promise.make[Nothing, Int]
         fiber   <- promise.await.fork
-        dump    <- fiber.dump(true)
+        dump    <- fiber.dump
         dumpStr <- dump.prettyPrintM
         _       <- console.putStrLn(dumpStr)
       } yield assert(dumpStr)(anything)

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -158,7 +158,7 @@ object FiberSpec extends ZIOBaseSpec {
             .reduce(_ && _)
         }
       }
-    )
+    ) @@ jvmOnly
   )
 
   val (initial, update) = ("initial", "update")

--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -42,7 +42,7 @@ private[zio] trait FiberPlatformSpecific {
           }
         }
 
-      final def children: UIO[Iterable[Fiber[Any, Any]]] = UIO(Nil)
+      final def children: UIO[Iterable[Fiber.Runtime[Any, Any]]] = UIO(Nil)
 
       final def getRef[A](ref: FiberRef[A]): UIO[A] = UIO(ref.initial)
 
@@ -72,7 +72,7 @@ private[zio] trait FiberPlatformSpecific {
           }
         }
 
-      def children: UIO[Iterable[Fiber[Any, Any]]] = UIO(Nil)
+      def children: UIO[Iterable[Fiber.Runtime[Any, Any]]] = UIO(Nil)
 
       def getRef[A](ref: FiberRef[A]): UIO[A] = UIO(ref.initial)
 

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -422,6 +422,12 @@ object Fiber extends FiberPlatformSpecific {
     def status: UIO[Fiber.Status]
 
     /**
+     * Collects a hierarchy tree starting from this this fiber
+     */
+    def tree(): UIO[Tree] =
+      FiberRenderer.collectTree(self)
+
+    /**
      * The trace of the fiber.
      */
     def trace: UIO[ZTrace]
@@ -472,6 +478,15 @@ object Fiber extends FiberPlatformSpecific {
      * }}}
      */
     def prettyPrintM: UIO[String] = FiberRenderer.prettyPrintM(this)
+  }
+
+  final case class Tree(
+    fiberId: Fiber.Id,
+    fiberName: Option[String],
+    status: Status,
+    children: Iterable[Tree]
+  ) { self =>
+    def render(): String = FiberRenderer.renderOne(self, false)
   }
 
   /**

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,13 +16,14 @@
 
 package zio
 
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
 import com.github.ghik.silencer.silent
+
 import zio.console.Console
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.{ Executor, FiberRenderer }
-
-import scala.collection.JavaConverters._
-import scala.concurrent.Future
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -698,7 +698,7 @@ private[zio] final class FiberContext[E, A](
 
   final def interruptAs(fiberId: Fiber.Id): UIO[Exit[E, A]] = kill0(fiberId)
 
-  final def children: UIO[Iterable[Fiber[Any, Any]]] = UIO(childrenToScala())
+  final def children: UIO[Iterable[Fiber.Runtime[Any, Any]]] = UIO(childrenToScala())
 
   @silent("JavaConverters")
   private def childrenToScala(): Iterable[FiberContext[Any, Any]] =

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -95,7 +95,7 @@ private[zio] object FiberRenderer {
 
   def dumpStr(fibers: Seq[Fiber.Runtime[_, _]], withTrace: Boolean): UIO[String] =
     for {
-      dumps <- ZIO.foreach(fibers)(f => f.dump(withTrace))
+      dumps <- ZIO.foreach(fibers)(f => f.dumpWith(withTrace))
       now   <- UIO(System.currentTimeMillis())
     } yield {
       val treeString  = renderHierarchy(dumps)

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
+import scala.annotation.tailrec
+
 import zio.Fiber.Dump
 import zio.Fiber.Status.{ Done, Finishing, Running, Suspended }
 import zio.{ Fiber, UIO, ZIO }
-
-import scala.annotation.tailrec
 
 private[zio] object FiberRenderer {
   private def zipWithHasNext[A](it: Iterable[A]): Iterable[(A, Boolean)] =

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -1,0 +1,75 @@
+package zio.internal
+
+import zio.Fiber.Status.{ Done, Finishing, Running, Suspended }
+import zio.{ Fiber, UIO, ZIO }
+
+private[zio] object FiberRenderer {
+  def prettyPrintM(dump: Fiber.Dump): UIO[String] = UIO {
+    val time = System.currentTimeMillis()
+
+    val millis  = (time - dump.fiberId.startTimeMillis)
+    val seconds = millis / 1000L
+    val minutes = seconds / 60L
+    val hours   = minutes / 60L
+
+    val name = dump.fiberName.fold("")(name => "\"" + name + "\" ")
+    val lifeMsg = (if (hours == 0) "" else s"${hours}h") +
+      (if (hours == 0 && minutes == 0) "" else s"${minutes}m") +
+      (if (hours == 0 && minutes == 0 && seconds == 0) "" else s"${seconds}s") +
+      (s"${millis}ms")
+    val waitMsg = dump.status match {
+      case Suspended(_, _, _, blockingOn, _) =>
+        if (blockingOn.nonEmpty)
+          "waiting on " + blockingOn.map(id => s"#${id.seqNumber}").mkString(", ")
+        else ""
+      case _ => ""
+    }
+    val statMsg = renderStatus(dump.status)
+
+    s"""
+       |${name}#${dump.fiberId.seqNumber} (${lifeMsg}) ${waitMsg}
+       |   Status: ${statMsg}
+       |${dump.trace.prettyPrint}
+       |""".stripMargin
+  }
+
+  def renderStatus(status: Fiber.Status): String =
+    status match {
+      case Done         => "Done"
+      case Finishing(b) => "Finishing(" + (if (b) "interrupting" else "") + ")"
+      case Running(b)   => "Running(" + (if (b) "interrupting" else "") + ")"
+      case Suspended(_, interruptible, epoch, _, asyncTrace) =>
+        val in = if (interruptible) "interruptible" else "uninterruptible"
+        val ep = s"${epoch} asyncs"
+        val as = asyncTrace.map(_.prettyPrint).mkString(" ")
+        s"Suspended(${in}, ${ep}, ${as})"
+    }
+
+  def renderHierarchy(fiber: Fiber.Runtime[_, _]): UIO[String] = {
+    def go(f: Fiber.Runtime[_, _], prefix: String): UIO[String] =
+      for {
+        id              <- f.id
+        name            <- f.getRef(Fiber.fiberName)
+        status          <- f.status
+        children        <- f.children
+        newPrefix       = prefix + "|   "
+        childrenResults <- ZIO.foreach(children)(c => go(c.asInstanceOf[Fiber.Runtime[_, _]], newPrefix))
+      } yield {
+        val nameStr   = name.fold("")(n => "\"" + n + "\" ")
+        val statusMsg = renderStatus(status)
+        s"${prefix}+---${nameStr}#${id.seqNumber} Status: $statusMsg\n" + childrenResults.mkString
+      }
+
+    go(fiber, "")
+  }
+
+  def dumpStr(fibers: Seq[Fiber.Runtime[_, _]]): UIO[String] =
+    for {
+      trees    <- ZIO.foreach(fibers)(FiberRenderer.renderHierarchy)
+      dumps    <- Fiber.dump(fibers: _*)
+      dumpStrs <- ZIO.foreach(dumps)(_.prettyPrintM)
+    } yield {
+      Seq.concat(trees, Seq("\n"), dumpStrs).mkString
+    }
+
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -57,7 +57,7 @@ private[zio] object FiberRenderer {
       .foreach(zipWithHasNext(fibers)) {
         case (fiber, hasNext) => renderOne(fiber, hasNext)
       }
-      .map(_.mkString("\n"))
+      .map(_.mkString)
 
   def renderOne(fiber: Fiber.Runtime[_, _], hasNexSibling: Boolean): UIO[String] = {
 

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -46,6 +46,7 @@ private[zio] object FiberRenderer {
     }
 
   def renderHierarchy(fiber: Fiber.Runtime[_, _]): UIO[String] = {
+
     def go(f: Fiber.Runtime[_, _], prefix: String): UIO[String] =
       for {
         id              <- f.id


### PR DESCRIPTION
Closes #2981

Added fiber hierarchy tree to the fiber dump output.

@bogdanmanate @adamgfraser could you please help with the testcase?
How do I create a non-trivial fiber hierarchy?
To create this output I cheated and dumped Fiber.roots.

Fiber dump output example:

![Screenshot from 2020-03-22 15-38-02](https://user-images.githubusercontent.com/5566453/77253002-fcf39d80-6c57-11ea-9101-ecb80194ff48.png)
