### PR TITLE
Fiber.Status.Suspended: make asyncTrace Option instead of List

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -550,7 +550,7 @@ object Fiber extends FiberPlatformSpecific {
       interruptible: Boolean,
       epoch: Long,
       blockingOn: List[Fiber.Id],
-      asyncTrace: List[ZTraceElement]
+      asyncTrace: Option[ZTraceElement]
     ) extends Status
   }
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -737,7 +737,7 @@ private[zio] final class FiberContext[E, A](
 
     oldState match {
       case Executing(status, observers, interrupt) =>
-        val asyncTrace = if (traceStack && inTracingRegion) traceLocation(register) :: Nil else Nil
+        val asyncTrace = if (traceStack && inTracingRegion) Some(traceLocation(register)) else None
 
         val newState =
           Executing(


### PR DESCRIPTION
This field always consists of 0 or 1 elements