### PR TITLE
ZIO Core: Implement Cause#stripDefects

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -211,6 +211,20 @@ object CauseSpec extends ZIOBaseSpec {
           )
         }
       }
+    ),
+    suite("stripSomeDefects")(
+      zio.test.test("returns `Some` with remaining causes") {
+        val c1       = Cause.die(new NumberFormatException("can't parse to int"))
+        val c2       = Cause.die(new ArithmeticException("division by zero"))
+        val cause    = Cause.Both(c1, c2)
+        val stripped = cause.stripSomeDefects { case _: NumberFormatException => }
+        assert(stripped)(isSome(equalTo(c2)))
+      },
+      zio.test.test("returns `None` if there are no remaining causes") {
+        val cause    = Cause.die(new NumberFormatException("can't parse to int"))
+        val stripped = cause.stripSomeDefects { case _: NumberFormatException => }
+        assert(stripped)(isNone)
+      }
     )
   )
 


### PR DESCRIPTION
Sometimes we want to remove all defects of a particular type from a cause, just like we remove failures with `stripFailures`. This PR implements `stripDefects` to do this.