### PR TITLE
Add Additional Combinators for ZQueue

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -699,6 +699,13 @@ object ZQueueSpec extends ZIOBaseSpec {
         v <- q.take
       } yield assert(v)(equalTo("10"))
     },
+    testM("queue dimap") {
+      for {
+        q <- Queue.bounded[String](100).map(_.dimap[Int, Int](_.toString, _.toInt))
+        _ <- q.offer(10)
+        v <- q.take
+      } yield assert(v)(equalTo(10))
+    },
     testM("queue filterInput") {
       for {
         q  <- Queue.bounded[Int](100).map(_.filterInput[Int](_ % 2 == 0))


### PR DESCRIPTION
Someone was asking today how to transform the type of a `Queue`. You can do that today with `map` and `contramap` but nice to have it together in one method. This also allows you to implement a bunch of the other queue transformation functions in terms of one function.