### PR TITLE
Prevent retry storms on ZSTM

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -9,6 +9,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class STMFlatMapBenchmark {
   @Param(Array("20"))
   var depth: Int = _

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -1,0 +1,35 @@
+package zio.stm
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
+class STMRetryBenchmark {
+  import IOBenchmarks.unsafeRun
+
+  private var longUpdates: List[UIO[Unit]] = _
+
+  private val Size = 10000
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val data       = (1 to Size).toList.zipWithIndex
+    val map        = unsafeRun(TMap.fromIterable(data).commit)
+    val schedule   = Schedule.recurs(1000).unit
+    val longUpdate = map.transformValues(_ + 1).commit.repeat(schedule)
+
+    longUpdates = List(longUpdate, longUpdate, longUpdate)
+  }
+
+  @Benchmark
+  def concurrentLongTransactions(): Unit =
+    unsafeRun(UIO.forkAll_(longUpdates))
+}

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -1,5 +1,6 @@
 package zio.stm
 
+import java.lang.{ Runtime => JRuntime }
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
@@ -18,7 +19,7 @@ class STMRetryBenchmark {
   private var updates: List[UIO[Unit]] = _
 
   private val Size        = 10000
-  private val Parallelism = 8
+  private val Parallelism = JRuntime.getRuntime().availableProcessors()
 
   @Setup(Level.Trial)
   def setup(): Unit = {

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -23,11 +23,11 @@ class STMRetryBenchmark {
 
   @Setup(Level.Trial)
   def setup(): Unit = {
-    val data     = (1 to Size).toList.zipWithIndex
-    val ref      = TRef.unsafeMake(data.toMap)
+    val data     = (1 to Size).toList
+    val ref      = TRef.unsafeMake(data)
     val schedule = Schedule.recurs(1000).unit
 
-    val update = ref.update(_.transform((_, v) => v + 1)).commit.repeat(schedule)
+    val update = ref.update(_.map(_ + 1)).commit.repeat(schedule)
 
     updates = List.fill(Parallelism)(update)
   }

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -31,7 +31,6 @@ class STMRetryBenchmark {
     updates = List.fill(Parallelism)(update)
   }
 
-  // ~43 ops/sec
   @Benchmark
   def concurrentLongTransactions(): Unit =
     unsafeRun(UIO.collectAllParN_(Parallelism)(updates))

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -27,7 +27,7 @@ class STMRetryBenchmark {
     val ref      = TRef.unsafeMake(data.toMap)
     val schedule = Schedule.recurs(1000).unit
 
-    val update = ref.update(map => map.transform((_, v) => v + 1)).commit.repeat(schedule)
+    val update = ref.update(_.transform((_, v) => v + 1)).commit.repeat(schedule)
 
     updates = List.fill(Parallelism)(update)
   }

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -13,6 +13,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class SemaphoreBenchmark {
   @Param(Array("10"))
   var fibers: Int = _

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -10,6 +10,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class SingleRefBenchmark {
   @Param(Array("10"))
   var fibers: Int = _

--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -9,6 +9,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class TMapContentionBenchmarks {
   import IOBenchmarks.unsafeRun
 

--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -9,6 +9,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class TMapOpsBenchmarks {
   import IOBenchmarks.unsafeRun
 

--- a/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
@@ -9,6 +9,9 @@ import zio._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Fork(1)
 class TSetOpsBenchmarks {
   import IOBenchmarks.unsafeRun
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1318,7 +1318,7 @@ object ZSTM {
 
   private[stm] object internal {
     val DefaultJournalSize = 4
-    val MaxRetries         = 100
+    val MaxRetries         = 10
 
     class Versioned[A](val value: A)
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1318,6 +1318,7 @@ object ZSTM {
 
   private[stm] object internal {
     val DefaultJournalSize = 4
+    val MaxRetries         = 100
 
     class Versioned[A](val value: A)
 
@@ -1549,32 +1550,44 @@ object ZSTM {
       var journal = null.asInstanceOf[MutableMap[TRef[_], Entry]]
       var value   = null.asInstanceOf[TExit[E, A]]
 
-      var loop = true
+      var loop    = true
+      var retries = 0
 
       while (loop) {
         journal = allocJournal(journal)
-        value = stm.run(journal, fiberId, r)
 
-        val analysis = analyzeJournal(journal)
+        if (retries > MaxRetries) {
+          Sync(globalLock) {
+            value = stm.run(journal, fiberId, r)
+            commitJournal(journal)
+            loop = false
+          }
+        } else {
+          value = stm.run(journal, fiberId, r)
 
-        if (analysis ne JournalAnalysis.Invalid) {
-          loop = false
+          val analysis = analyzeJournal(journal)
 
-          value match {
-            case _: TExit.Succeed[_] =>
-              if (analysis eq JournalAnalysis.ReadWrite) {
-                Sync(globalLock) {
-                  if (isValid(journal)) commitJournal(journal) else loop = true
+          if (analysis ne JournalAnalysis.Invalid) {
+            loop = false
+
+            value match {
+              case _: TExit.Succeed[_] =>
+                if (analysis eq JournalAnalysis.ReadWrite) {
+                  Sync(globalLock) {
+                    if (isValid(journal)) commitJournal(journal) else loop = true
+                  }
+                } else {
+                  Sync(globalLock) {
+                    if (isInvalid(journal)) loop = true
+                  }
                 }
-              } else {
-                Sync(globalLock) {
-                  if (isInvalid(journal)) loop = true
-                }
-              }
 
-            case _ =>
+              case _ =>
+            }
           }
         }
+
+        retries += 1
       }
 
       value match {


### PR DESCRIPTION
The current implementation of ZSTM suffers from "retry storms." For example, short transactions can force long-running ones to retry. 

To verify this behavior, I've set the following benchmark:

- make a `TRef` containing a list of 10000 elements
- have multiple short transactions updating only the head of the list
- have one transaction increment all elements
- race them

Running this benchmark on the current implementation produces the following result:

```
Benchmark                             Mode  Cnt  Score     Error  Units
STMRetryBenchmark.mixedTransactions  thrpt   15  0.125   ± 0.219  ops/s
```

The solution to this problem is to count the number of retries, and obtain a global lock once this count breaches some predefined limit. Acquiring a global lock should allow a long-running transaction to complete. To avoid paying the high locking "price," the number of max retries should be chosen from `[10, 100]`. Based on the results of my trial benchmarks, I've decided to set it to 10. 

With this change in place, the benchmark mentioned above produced the following result:

```
Benchmark                             Mode  Cnt  Score     Error  Units
STMRetryBenchmark.mixedTransactions  thrpt   15  425.153   ± 4.321  ops/s
```