### PR TITLE
Improve ZQueue performance

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -14,8 +14,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
 @Fork(3)
 /**
  * This benchmark offers and takes a number of items in parallel, with a very small queue to enforce back pressure mechanism is used.

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -14,8 +14,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
 @Fork(3)
 /**
  * This benchmark offers and takes a number of items in parallel, without back pressure.

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -17,8 +17,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
 @Fork(3)
 /**
  * This benchmark sequentially offers a number of items to the queue, then takes them out of the queue.

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -17,6 +17,7 @@
 package zio
 
 import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.annotation.tailrec
 
 import zio.ZQueue.internal._


### PR DESCRIPTION
Benchmarking the current implementation of ZQueue produced the following results:

```
Benchmark                           Mode  Cnt     Score     Error  Units
QueueParallelBenchmark.fs2Queue    thrpt   45  1204.274 ±  60.423  ops/s
QueueParallelBenchmark.monixQueue  thrpt   45  5081.348 ±  63.149  ops/s
QueueParallelBenchmark.zioQueue    thrpt   45  1584.057 ± 366.933  ops/s
QueueParallelBenchmark.zioTQueue   thrpt   45   200.517 ±  27.726  ops/s

Benchmark                             Mode  Cnt      Score    Error  Units
QueueSequentialBenchmark.fs2Queue    thrpt   45   3315.031 ± 17.993  ops/s
QueueSequentialBenchmark.monixQueue  thrpt   45  15968.575 ± 11.872  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45   1596.692 ± 16.479  ops/s
QueueSequentialBenchmark.zioTQueue   thrpt   45    341.544 ±  0.716  ops/s

Benchmark                               Mode  Cnt     Score     Error  Units
QueueBackPressureBenchmark.fs2Queue    thrpt   45   494.531 ±   3.835  ops/s
QueueBackPressureBenchmark.monixQueue  thrpt   45  3035.008 ±  39.692  ops/s
QueueBackPressureBenchmark.zioQueue    thrpt   45   552.961 ± 178.826  ops/s
QueueBackPressureBenchmark.zioTQueue   thrpt   45   422.290 ±   0.839  ops/s
```

I've identified the following problems:

- frequent invocation of expensive `checkShutdownState`
- multiple layers of effect nesting
- generic offer
- tail map calls (for-comprehension)

Running benchmarks mentioned above using the updated implementation produced the following results:

```
Benchmark                             Mode  Cnt     Score     Error  Units
QueueParallelBenchmark.zioQueue      thrpt   45  3363.840 ±  42.224  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  4571.890 ±  30.653  ops/s
QueueBackPressureBenchmark.zioQueue  thrpt   45  1189.765 ±  12.754  ops/s
```