### PR TITLE
Check if queue is empty before polling

### DIFF
--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -488,12 +488,14 @@ object ZQueue {
         if (shutdownFlag.get) ZIO.interrupt
         else {
           val noRemaining =
-            unsafePollN(takers, 1) match {
-              case taker :: _ =>
-                unsafeCompletePromise(taker, a)
-                true
-              case Nil => false
-            }
+            if (queue.isEmpty())
+              unsafePollN(takers, 1) match {
+                case taker :: _ =>
+                  unsafeCompletePromise(taker, a)
+                  true
+                case Nil => false
+              }
+            else false
 
           if (noRemaining) IO.succeedNow(true)
           else {


### PR DESCRIPTION
Fixes deficiency introduced in #3216. Overall magnitude of improvements is preserved, but there is a small penalty paid for checking. I will provide a full set of results once more improvements land.