### PR TITLE
Implement Schedule#++

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -93,6 +93,12 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     (self && that).map(_._2)
 
   /**
+   * A symbolic alias for `andThen`.
+   */
+  final def ++[R1 <: R, A1 <: A, B1 >: B](that: Schedule[R1, A1, B1]): Schedule[R1, A1, B1] =
+    andThen(that)
+
+  /**
    * Chooses between two schedules with different outputs.
    */
   final def +++[R1 <: R, C, D](that: Schedule[R1, C, D]): Schedule[R1, Either[A, C], Either[B, D]] =
@@ -815,7 +821,7 @@ object Schedule {
    * the current duration between recurrences.
    */
   def fromDurations(duration: Duration, durations: Duration*): Schedule[Clock, Any, Duration] =
-    durations.foldLeft(fromDuration(duration))((schedule, duration) => schedule.andThen(fromDuration(duration)))
+    durations.foldLeft(fromDuration(duration))((schedule, duration) => schedule ++ fromDuration(duration))
 
   /**
    * A schedule that recurs forever, mapping input values through the


### PR DESCRIPTION
Running one schedule after another seems like a relatively common operation that we should have an operator alias for. Right now we have `<||>` for `andThenEither` but nothing for `andThen`. I thought about `|>` to mirror that but that has the conniption that we are preferred the right side over the left versus unifying them and also potentially seems more like we are piping the outputs of one schedule to the other. `++` seems quite intuitive if you think of a schedule as generating a series of recurrences.