### PR TITLE
Add links to `Systematic error management in application` talk

### DIFF
--- a/docs/resources/resources.md
+++ b/docs/resources/resources.md
@@ -41,6 +41,7 @@ _These articles reflect the state of ZIO at the time of their publication. The c
 
 ## Talks
 
+- Systematic error management in application - We ported Rudder to ZIO: [video in French](https://www.youtube.com/watch?v=q0PlcgR5M1Q), [slides in English](https://speakerdeck.com/fanf42/systematic-error-management-we-ported-rudder-to-zio) by François Armand (Scala.io, October 2020)
 - [Upgrade Your Future](https://www.youtube.com/watch?v=USgfku1h7Hw) by John De Goes (September 2019)
 - [One Monad to Rule Them All](https://www.youtube.com/watch?v=POUEz8XHMhE) by John De Goes (August 2019)
 - [Functional Concurrency in Scala with ZIO](https://www.youtube.com/watch?v=m5nas4Hndqo) by Itamar Ravid (June 2019)


### PR DESCRIPTION
Add a link to Scala.io talk: "Systematic error management in application". Video is in French, but slides are in English.
- video: https://www.youtube.com/watch?v=q0PlcgR5M1Q
- slides: https://speakerdeck.com/fanf42/systematic-error-management-we-ported-rudder-to-zio