### PR TITLE
ZIO Test: rename TestAspect failure -> failing

### DIFF
--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -477,7 +477,7 @@ object MySpec extends DefaultRunnableSpec {
     } @@ timeout(10.nanos), //@@ timeout will fail a test that doesn't pass within the specified time
     test("A failing test... that passes") {
       assert(true)(isFalse)
-    } @@ failure, //@@ failure turns a failing test into a passing test
+    } @@ failing, //@@ failing turns a failing test into a passing test
     test("A flaky test that only works on the JVM and sometimes fails; let's compose some aspects!") {
       assert(false)(isTrue)
     } @@ jvmOnly           // only run on the JVM
@@ -485,4 +485,4 @@ object MySpec extends DefaultRunnableSpec {
       @@ timeout(20.nanos) //it's a good idea to compose `eventually` with `timeout`, or the test may never end
   ) @@ timeout(60.seconds)   //apply a timeout to the whole suite
 }
-``` 
+```

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -15,7 +15,7 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("and must fail when one of assertions is not satisfied") {
       assert(sampleUser)(nameStartsWithA && ageGreaterThan20)
-    } @@ failure,
+    } @@ failing,
     test("anything must always succeeds") {
       assert(42)(anything)
     },
@@ -24,55 +24,55 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("approximatelyEquals must fail when number is not within range") {
       assert(50.0)(approximatelyEquals(5.0, 3.0))
-    } @@ failure,
+    } @@ failing,
     test("contains must succeed when iterable contains specified element") {
       assert(Seq("zio", "scala"))(contains("zio"))
     },
     test("contains must fail when iterable does not contain specified element") {
       assert(Seq("zio", "scala"))(contains("java"))
-    } @@ failure,
+    } @@ failing,
     test("containsString must succeed when string is found") {
       assert("this is a value")(containsString("is a"))
     },
     test("containsString must return false when the string is not contained") {
       assert("this is a value")(containsString("_NOTHING_"))
-    } @@ failure,
+    } @@ failing,
     test("dies must succeed when exception satisfy specified assertion") {
       assert(Exit.die(someException))(dies(equalTo(someException)))
     },
     test("dies must fail when exception does not satisfy specified assertion") {
       assert(Exit.die(new RuntimeException("Bam!")))(dies(equalTo(someException)))
-    } @@ failure,
+    } @@ failing,
     test("endWith must succeed when the supplied value ends with the specified sequence") {
       assert(List(1, 2, 3, 4, 5))(endsWith(List(3, 4, 5)))
     },
     test("startsWith must fail when the supplied value does not end with the specified sequence") {
       assert(List(1, 2, 3, 4, 5))(endsWith(List(1, 2, 3)))
-    } @@ failure,
+    } @@ failing,
     test("endsWithString must succeed when the supplied value ends with the specified string") {
       assert("zio")(endsWithString("o"))
     },
     test("endsWithString must fail when the supplied value does not end with the specified string") {
       assert("zio")(endsWithString("z"))
-    } @@ failure,
+    } @@ failing,
     test("equalsIgnoreCase must succeed when the supplied value matches") {
       assert("Some String")(equalsIgnoreCase("some string"))
     },
     test("equalsIgnoreCase must fail when the supplied value does not match") {
       assert("Some Other String")(equalsIgnoreCase("some string"))
-    } @@ failure,
+    } @@ failing,
     test("equalTo must succeed when value equals specified value") {
       assert(42)(equalTo(42))
     },
     test("equalTo must fail when value does not equal specified value") {
       assert(0)(equalTo(42))
-    } @@ failure,
+    } @@ failing,
     test("equalTo must succeed when array equals specified array") {
       assert(Array(1, 2, 3))(equalTo(Array(1, 2, 3)))
     },
     test("equalTo must fail when array does not equal specified array") {
       assert(Array(1, 2, 3))(equalTo(Array(1, 2, 4)))
-    } @@ failure,
+    } @@ failing,
     test("equalTo must not have type inference issues") {
       assert(List(1, 2, 3).filter(_ => false))(equalTo(List.empty))
     },
@@ -90,22 +90,22 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("exists must fail when all elements of iterable do not satisfy specified assertion") {
       assert(Seq(1, 42, 5))(exists(equalTo(0)))
-    } @@ failure,
+    } @@ failing,
     test("exists must fail when iterable is empty") {
       assert(Seq[String]())(exists(hasField("length", _.length, isWithin(0, 3))))
-    } @@ failure,
+    } @@ failing,
     test("fails must succeed when error value satisfy specified assertion") {
       assert(Exit.fail("Some Error"))(fails(equalTo("Some Error")))
     },
     test("fails must fail when error value does not satisfy specified assertion") {
       assert(Exit.fail("Other Error"))(fails(equalTo("Some Error")))
-    } @@ failure,
+    } @@ failing,
     test("forall must succeed when all elements of iterable satisfy specified assertion") {
       assert(Seq("a", "bb", "ccc"))(forall(hasField("length", _.length, isWithin(0, 3))))
     },
     test("forall must fail when one element of iterable do not satisfy specified assertion") {
       assert(Seq("a", "bb", "dddd"))(forall(hasField("length", _.length, isWithin(0, 3))))
-    } @@ failure,
+    } @@ failing,
     test("forall must succeed when an iterable is empty") {
       assert(Seq[String]())(forall(hasField("length", _.length, isWithin(0, 3))))
     },
@@ -127,19 +127,19 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasSameElementsDistinct must fail when iterable does not have all specified elements") {
       assert(Seq(1, 2, 3, 4))(hasSameElementsDistinct(Set(1, 2, 3, 4, 5)))
-    } @@ failure,
+    } @@ failing,
     test("hasSameElementsDistinct must fail when iterable contains unspecified elements") {
       assert(Seq(1, 2, 3, 4))(hasSameElementsDistinct(Set(1, 2, 3)))
-    } @@ failure,
+    } @@ failing,
     test("hasAt must fail when an index is outside of a sequence range") {
       assert(Seq(1, 2, 3))(hasAt(-1)(anything))
-    } @@ failure,
+    } @@ failing,
     test("hasAt must fail when an index is outside of a sequence range 2") {
       assert(Seq(1, 2, 3))(hasAt(3)(anything))
-    } @@ failure,
+    } @@ failing,
     test("hasAt must fail when a value is not equal to a specific assertion") {
       assert(Seq(1, 2, 3))(hasAt(1)(equalTo(1)))
-    } @@ failure,
+    } @@ failing,
     test("hasAt must succeed when a value is equal to a specific assertion") {
       assert(Seq(1, 2, 3))(hasAt(1)(equalTo(2)))
     },
@@ -151,7 +151,7 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasAtLeastOneOf must fail when iterable does not contain a specified element") {
       assert(Seq("zio", "scala"))(hasAtLeastOneOf(Set("python", "rust")))
-    } @@ failure,
+    } @@ failing,
     test("hasAtMostOneOf must succeed when iterable contains one of the specified elements") {
       assert(Seq("zio", "scala"))(hasAtMostOneOf(Set("zio", "test", "java")))
     },
@@ -160,19 +160,19 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasAtMostOneOf must fail when iterable contains more than one of the specified elements") {
       assert(Seq("zio", "scala"))(hasAtMostOneOf(Set("zio", "test", "scala")))
-    } @@ failure,
+    } @@ failing,
     test("hasField must succeed when field value satisfy specified assertion") {
       assert(SampleUser("User", 23))(hasField[SampleUser, Int]("age", _.age, isWithin(0, 99)))
     },
     test("hasFirst must fail when an iterable is empty") {
       assert(Seq())(hasFirst(anything))
-    } @@ failure,
+    } @@ failing,
     test("hasFirst must succeed when a head is equal to a specific assertion") {
       assert(Seq(1, 2, 3))(hasFirst(equalTo(1)))
     },
     test("hasFirst must fail when a head is not equal to a specific assertion") {
       assert(Seq(1, 2, 3))(hasFirst(equalTo(100)))
-    } @@ failure,
+    } @@ failing,
     test("hasIntersection must succeed when intersection satisfies specified assertion") {
       assert(Seq(1, 2, 3))(hasIntersection(Seq(3, 4, 5))(hasSize(equalTo(1))))
     },
@@ -181,16 +181,16 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasIntersection must fail when intersection does not satisfy specified assertion") {
       assert(Seq(1, 2, 3))(hasIntersection(Seq(3, 4, 5))(isEmpty))
-    } @@ failure,
+    } @@ failing,
     test("hasKey must succeed when map has key with value satisfying specified assertion") {
       assert(Map("scala" -> 1))(hasKey("scala", equalTo(1)))
     },
     test("hasKey must fail when map does not have the specified key") {
       assert(Map("scala" -> 1))(hasKey("java", equalTo(1)))
-    } @@ failure,
+    } @@ failing,
     test("hasKey must fail when map has key with value not satisfying specified assertion") {
       assert(Map("scala" -> 1))(hasKey("scala", equalTo(-10)))
-    } @@ failure,
+    } @@ failing,
     test("hasKey must succeed when map has the specified key") {
       assert(Map("scala" -> 1))(hasKey("scala"))
     },
@@ -199,16 +199,16 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasKeys must fail when map has keys not satisfying the specified assertion") {
       assert(Map("scala" -> 1, "java" -> 1))(hasKeys(contains("bash")))
-    } @@ failure,
+    } @@ failing,
     test("hasLast must fail when an iterable is empty") {
       assert(Seq())(hasLast(anything))
-    } @@ failure,
+    } @@ failing,
     test("hasLast must succeed when a last is equal to a specific assertion") {
       assert(Seq(1, 2, 3))(hasLast(equalTo(3)))
     },
     test("hasLast must fail when a last is not equal to specific assertion") {
       assert(Seq(1, 2, 3))(hasLast(equalTo(100)))
-    } @@ failure,
+    } @@ failing,
     test("hasNoneOf must succeed when iterable does not contain one of the specified elements") {
       assert(Seq("zio", "scala"))(hasNoneOf(Set("python", "rust")))
     },
@@ -217,22 +217,22 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasNoneOf must fail when iterable contains a specified element") {
       assert(Seq("zio", "scala"))(hasNoneOf(Set("zio", "test", "scala")))
-    } @@ failure,
+    } @@ failing,
     test("hasOneOf must succeed when iterable contains exactly one of the specified elements") {
       assert(Seq("zio", "scala"))(hasOneOf(Set("zio", "test", "java")))
     },
     test("hasOneOf must fail when iterable contains more than one of the specified elements") {
       assert(Seq("zio", "scala"))(hasOneOf(Set("zio", "test", "scala")))
-    } @@ failure,
+    } @@ failing,
     test("hasOneOf must fail when iterable does not contain at least one of the specified elements") {
       assert(Seq("zio", "scala"))(hasOneOf(Set("python", "rust")))
-    } @@ failure,
+    } @@ failing,
     test("hasSameElements must succeed when both iterables contain the same elements") {
       assert(Seq(1, 2, 3))(hasSameElements(Seq(1, 2, 3)))
     },
     test("hasSameElements must fail when the iterables do not contain the same elements") {
       assert(Seq(1, 2, 3, 4))(hasSameElements(Seq(1, 2, 3)) && hasSameElements(Seq(1, 2, 3, 4, 5)))
-    } @@ failure,
+    } @@ failing,
     test("hasSameElements must succeed when both iterables contain the same elements in different order") {
       assert(Seq(4, 3, 1, 2))(hasSameElements(Seq(1, 2, 3, 4)))
     },
@@ -242,19 +242,19 @@ object AssertionSpec extends ZIOBaseSpec {
       assert(Seq("a", "a", "b", "b", "b", "c", "c", "c", "c", "c"))(
         hasSameElements(Seq("a", "a", "a", "a", "a", "b", "b", "c", "c", "c"))
       )
-    } @@ failure,
+    } @@ failing,
     test("hasSize must succeed when iterable size is equal to specified assertion") {
       assert(Seq(1, 2, 3))(hasSize(equalTo(3)))
     },
     test("hasSize must fail when iterable size is not equal to specified assertion") {
       assert(Seq(1, 2, 3))(hasSize(equalTo(1)))
-    } @@ failure,
+    } @@ failing,
     test("hasSizeString must succeed when string size is equal to specified assertion") {
       assert("aaa")(hasSizeString(equalTo(3)))
     },
     test("hasSizeString must fail when string size is not equal to specified assertion") {
       assert("aaa")(hasSizeString(equalTo(2)))
-    } @@ failure,
+    } @@ failing,
     test("hasSubset must succeed when both iterables contain the same elements") {
       assert(Seq(1, 2, 3))(hasSubset(Set(1, 2, 3)))
     },
@@ -266,16 +266,16 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasSubset must fail when iterable does not contain elements specified in set") {
       assert(Seq(4, 3, 1, 2))(hasSubset(Set(1, 2, 10)))
-    } @@ failure,
+    } @@ failing,
     test("hasValues must succeed when map has values satisfying the specified assertion") {
       assert(Map("scala" -> 10, "java" -> 20))(hasValues(hasAtLeastOneOf(Set(0, 10))))
     },
     test("hasValues must fail when map has values not satisfying the specified assertion") {
       assert(Map("scala" -> 10, "java" -> 20))(hasValues(contains(0)))
-    } @@ failure,
+    } @@ failing,
     test("isCase must fail when unapply fails (returns None)") {
       assert(42)(isCase[Int, String](termName = "term", _ => None, equalTo("number: 42")))
-    } @@ failure,
+    } @@ failing,
     test("isCase must succeed when unapplied Proj satisfy specified assertion")(
       assert(sampleUser)(
         isCase[SampleUser, (String, Int)](
@@ -295,19 +295,19 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isDistinct must fail when iterable is not distinct") {
       assert(Seq(1, 2, 3, 3, 4))(isDistinct)
-    } @@ failure,
+    } @@ failing,
     test("isEmpty must succeed when the traversable is empty") {
       assert(Seq())(isEmpty)
     },
     test("isEmpty must fail when the traversable is not empty") {
       assert(Seq(1, 2, 3))(isEmpty)
-    } @@ failure,
+    } @@ failing,
     test("isEmptyString must succeed when the string is empty") {
       assert("")(isEmptyString)
     },
     test("isEmptyString must fail when the string is not empty") {
       assert("some string")(isEmptyString)
-    } @@ failure,
+    } @@ failing,
     test("isFalse must succeed when supplied value is false") {
       assert(false)(isFalse)
     },
@@ -322,7 +322,7 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isGreaterThan must fail when specified value is less than or equal supplied value") {
       assert(42)(isGreaterThan(42))
-    } @@ failure,
+    } @@ failing,
     test("isGreaterThanEqualTo must succeed when specified value is greater than or equal supplied value") {
       assert(42)(isGreaterThanEqualTo(42))
     },
@@ -334,13 +334,13 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isLeft must fail when supplied value is Right") {
       assert(Right(-42))(isLeft)
-    } @@ failure,
+    } @@ failing,
     test("isLessThan must succeed when specified value is less than supplied value") {
       assert(0)(isLessThan(42))
     },
     test("isLessThan must fail when specified value is greater than or equal supplied value") {
       assert(42)(isLessThan(42))
-    } @@ failure,
+    } @@ failing,
     test("isLessThanEqualTo must succeed when specified value is less than or equal supplied value") {
       assert(42)(isLessThanEqualTo(42))
     },
@@ -349,49 +349,49 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isNegative must fail when number is zero") {
       assert(0)(isNegative)
-    } @@ failure,
+    } @@ failing,
     test("isNegative must fail when number is positive") {
       assert(10)(isNegative)
-    } @@ failure,
+    } @@ failing,
     test("isNone must succeed when specified value is None") {
       assert(None)(isNone)
     },
     test("isNone must fail when specified value is not None") {
       assert(Some(42))(isNone)
-    } @@ failure,
+    } @@ failing,
     test("isNonEmpty must succeed when the traversable is not empty") {
       assert(Seq(1, 2, 3))(isNonEmpty)
     },
     test("isNonEmpty must fail when the traversable is empty") {
       assert(Seq())(isNonEmpty)
-    } @@ failure,
+    } @@ failing,
     test("isNonEmptyString must succeed when the string is not empty") {
       assert("some string")(isNonEmptyString)
     },
     test("isNonEmptyString must fail when the string is empty") {
       assert("")(isNonEmptyString)
-    } @@ failure,
+    } @@ failing,
     test("isNull must succeed when specified value is null") {
       assert(null)(isNull)
     },
     test("isNull must fail when specified value is not null") {
       assert("not null")(isNull)
-    } @@ failure,
+    } @@ failing,
     test("isOneOf must succeed when value is equal to one of the specified values") {
       assert('a')(isOneOf(Set('a', 'b', 'c')))
     },
     test("isOneOf must fail when value is not equal to one of the specified values") {
       assert('z')(isOneOf(Set('a', 'b', 'c')))
-    } @@ failure,
+    } @@ failing,
     test("isPositive must succeed when number is positive") {
       assert(10)(isPositive)
     },
     test("isPositive must fail when number is zero") {
       assert(0)(isPositive)
-    } @@ failure,
+    } @@ failing,
     test("isPositive must fail when number is negative") {
       assert(-10)(isPositive)
-    } @@ failure,
+    } @@ failing,
     test("isRight must succeed when supplied value is Right and satisfy specified assertion") {
       assert(Right(42))(isRight(equalTo(42)))
     },
@@ -406,13 +406,13 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isSome must fail when supplied value is None") {
       assert(None)(isSome(equalTo("zio")))
-    } @@ failure,
+    } @@ failing,
     test("isSome must succeed when supplied value is Some") {
       assert(Some("zio"))(isSome)
     },
     test("isSome must fail when supplied value is None") {
       assert(None)(isSome)
-    } @@ failure,
+    } @@ failing,
     test("isSorted must succeed when iterable is sorted") {
       assert(Seq(1, 2, 2, 3, 4))(isSorted)
     },
@@ -424,22 +424,22 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isSorted must fail when iterable is not sorted") {
       assert(Seq(1, 2, 0, 3, 4))(isSorted)
-    } @@ failure,
+    } @@ failing,
     test("isSortedReverse must succeed when iterable is reverse sorted") {
       assert(Seq(4, 3, 3, 2, 1))(isSortedReverse)
     },
     test("isSortedReverse must fail when iterable is not reverse sorted") {
       assert(Seq(1, 2, 0, 3, 4))(isSortedReverse)
-    } @@ failure,
+    } @@ failing,
     test("isSubtype must succeed when value is subtype of specified type") {
       assert(dog)(isSubtype[Animal](anything))
     },
     test("isSubtype must fail when value is supertype of specified type") {
       assert(animal)(isSubtype[Cat](anything))
-    } @@ failure,
+    } @@ failing,
     test("isSubtype must fail when value is neither subtype nor supertype of specified type") {
       assert(cat)(isSubtype[Dog](anything))
-    } @@ failure,
+    } @@ failing,
     test("isSubtype must handle primitive types") {
       assert(1)(isSubtype[Int](anything))
     },
@@ -472,19 +472,19 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("isWithin must fail when supplied value is out of range") {
       assert(42)(isWithin(0, 10))
-    } @@ failure,
+    } @@ failing,
     test("isZero must succeed when number is zero") {
       assert(0)(isZero)
     },
     test("isZero must fail when number is not zero") {
       assert(10)(isZero)
-    } @@ failure,
+    } @@ failing,
     test("matches must succeed when the string matches the regex") {
       assert("(123) 456-7890")(matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
     },
     test("matches must fail when the string does not match the regex") {
       assert("456-7890")(matchesRegex("\\([1-9]{3}\\) [0-9]{3}\\-[0-9]{4}$"))
-    } @@ failure,
+    } @@ failing,
     test("negate must succeed when negation of assertion is true") {
       assert(sampleUser)(nameStartsWithA.negate)
     },
@@ -496,7 +496,7 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("nonNegative must fail when number is negative") {
       assert(-10)(nonNegative)
-    } @@ failure,
+    } @@ failing,
     test("nonPositive must succeed when number is negative") {
       assert(-10)(nonPositive)
     },
@@ -505,37 +505,37 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("nonPositive must fail when number is positive") {
       assert(10)(nonPositive)
-    } @@ failure,
+    } @@ failing,
     test("not must succeed when negation of specified assertion is true") {
       assert(0)(not(equalTo(42)))
     },
     test("nothing must always fail") {
       assert(42)(nothing)
-    } @@ failure,
+    } @@ failing,
     test("or must succeed when one of assertions is satisfied") {
       assert(sampleUser)((nameStartsWithA || nameStartsWithU) && ageGreaterThan20)
     },
     test("or must fail when both assertions are not satisfied") {
       assert(sampleUser)(nameStartsWithA || ageLessThan20)
-    } @@ failure,
+    } @@ failing,
     test("startsWith must succeed when the supplied value starts with the specified sequence") {
       assert(List(1, 2, 3, 4, 5))(startsWith(List(1, 2, 3)))
     },
     test("startsWith must fail when the supplied value does not start with the specified sequence") {
       assert(List(1, 2, 3, 4, 5))(startsWith(List(3, 4, 5)))
-    } @@ failure,
+    } @@ failing,
     test("startsWithString must succeed when the supplied value starts with the specified string") {
       assert("zio")(startsWithString("z"))
     },
     test("startsWithString must fail when the supplied value does not start with the specified string") {
       assert("zio")(startsWithString("o"))
-    } @@ failure,
+    } @@ failing,
     test("succeeds must succeed when supplied value is Exit.succeed and satisfy specified assertion") {
       assert(Exit.succeed("Some Error"))(succeeds(equalTo("Some Error")))
     },
     test("succeeds must fail when supplied value is Exit.fail") {
       assert(Exit.fail("Some Error"))(succeeds(equalTo("Some Error")))
-    } @@ failure,
+    } @@ failing,
     testM("test must return true when given element satisfy assertion") {
       assertM(nameStartsWithU.test(sampleUser))(isTrue)
     },

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.Assertion._
-import zio.test.TestAspect.failure
+import zio.test.TestAspect.failing
 import zio.{ random, Chunk, Ref, ZIO }
 
 object CheckSpec extends ZIOBaseSpec {
@@ -29,7 +29,7 @@ object CheckSpec extends ZIOBaseSpec {
           r <- random.nextInt(n)
         } yield assert(r)(isLessThan(n))
       }
-    } @@ failure,
+    } @@ failing,
     testM("overloaded check methods work") {
       check(Gen.anyInt, Gen.anyInt, Gen.anyInt)((x, y, z) => assert((x + y) + z)(equalTo(x + (y + z))))
     },
@@ -60,7 +60,7 @@ object CheckSpec extends ZIOBaseSpec {
     },
     testM("tests with filtered generators terminate") {
       check(Gen.anyInt.filter(_ > 0), Gen.anyInt.filter(_ > 0))((a, b) => assert(a)(equalTo(b)))
-    } @@ failure,
+    } @@ failing,
     testM("failing tests contain gen failure details") {
       check(Gen.anyInt)(a => assert(a)(isGreaterThan(0))).flatMap {
         _.run.map(_.failures match {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -81,24 +81,24 @@ object TestAspectSpec extends ZIOBaseSpec {
     } @@ exceptScala2,
     test("failure makes a test pass if the result was a failure") {
       assert(throw new java.lang.Exception("boom"))(isFalse)
-    } @@ failure,
+    } @@ failing,
     test("failure makes a test pass if it died with a specified failure") {
       assert(throw new NullPointerException())(isFalse)
-    } @@ failure(diesWithSubtypeOf[NullPointerException]),
+    } @@ failing(diesWithSubtypeOf[NullPointerException]),
     test("failure does not make a test pass if it failed with an unexpected exception") {
       assert(throw new NullPointerException())(isFalse)
-    } @@ failure(diesWithSubtypeOf[IllegalArgumentException])
-      @@ failure,
+    } @@ failing(diesWithSubtypeOf[IllegalArgumentException])
+      @@ failing,
     test("failure does not make a test pass if the specified failure does not match") {
       assert(throw new RuntimeException())(isFalse)
-    } @@ failure(diesWith(hasMessage(equalTo("boom"))))
-      @@ failure,
+    } @@ failing(diesWith(hasMessage(equalTo("boom"))))
+      @@ failing,
     test("failure makes tests pass on any assertion failure") {
       assert(true)(equalTo(false))
-    } @@ failure,
+    } @@ failing,
     test("failure makes tests pass on an expected assertion failure") {
       assert(true)(equalTo(false))
-    } @@ failure(
+    } @@ failing(
       isCase[TestFailure[Any], Any](
         "Assertion",
         { case TestFailure.Assertion(result) => Some(result); case _ => None },
@@ -127,7 +127,7 @@ object TestAspectSpec extends ZIOBaseSpec {
     },
     test("flaky retries a test with a limit") {
       assert(true)(isFalse)
-    } @@ flaky @@ failure,
+    } @@ flaky @@ failing,
     testM("forked runs each test on its own separate fiber") {
       for {
         _        <- ZIO.infinity.fork
@@ -212,10 +212,10 @@ object TestAspectSpec extends ZIOBaseSpec {
       } @@ nonTermination(10.milliseconds),
       testM("makes a test fail if it succeeds within the specified time") {
         assertM(ZIO.unit)(anything)
-      } @@ nonTermination(1.minute) @@ failure,
+      } @@ nonTermination(1.minute) @@ failing,
       testM("makes a test fail if it fails within the specified time") {
         assertM(ZIO.fail("fail"))(anything)
-      } @@ nonTermination(1.minute) @@ failure
+      } @@ nonTermination(1.minute) @@ failing
     ),
     testM("retry retries failed tests according to a schedule") {
       for {
@@ -245,7 +245,7 @@ object TestAspectSpec extends ZIOBaseSpec {
     testM("timeout makes tests fail after given duration") {
       assertM(ZIO.never *> ZIO.unit)(equalTo(()))
     } @@ timeout(1.nanos)
-      @@ failure(diesWithSubtypeOf[TestTimeoutException]),
+      @@ failing(diesWithSubtypeOf[TestTimeoutException]),
     testM("verify verifies the specified post-condition after each test is run") {
       for {
         ref <- Ref.make(false)

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -3,7 +3,7 @@ package zio.test
 import zio.ZIO
 import zio.clock._
 import zio.test.Assertion._
-import zio.test.TestAspect.failure
+import zio.test.TestAspect.failing
 import zio.test.TestUtils.execute
 
 object TestSpec extends ZIOBaseSpec {
@@ -17,7 +17,7 @@ object TestSpec extends ZIOBaseSpec {
         _      <- ZIO.fail("fail")
         result <- ZIO.succeedNow("succeed")
       } yield assert(result)(equalTo("succeed"))
-    } @@ failure,
+    } @@ failing,
     testM("testM is polymorphic in error type") {
       for {
         _      <- ZIO.effect(())

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -289,15 +289,15 @@ object TestAspect extends TimeoutVariants {
    * An aspect that makes a test that failed for any reason pass. Note that if
    * the test passes this aspect will make it fail.
    */
-  val failure: TestAspectPoly =
-    failure(Assertion.anything)
+  val failing: TestAspectPoly =
+    failing(Assertion.anything)
 
   /**
    * An aspect that makes a test that failed for the specified failure pass.
    * Note that the test will fail for other failures and also if it passes
    * correctly.
    */
-  def failure[E0](p: Assertion[TestFailure[E0]]): TestAspect[Nothing, Any, Nothing, E0] =
+  def failing[E0](p: Assertion[TestFailure[E0]]): TestAspect[Nothing, Any, Nothing, E0] =
     new TestAspect.PerTest[Nothing, Any, Nothing, E0] {
       def perTest[R, E <: E0](test: ZIO[R, TestFailure[E], TestSuccess]): ZIO[R, TestFailure[E], TestSuccess] = {
         lazy val succeed = ZIO.succeedNow(TestSuccess.Succeeded(BoolAlgebra.unit))
@@ -440,7 +440,7 @@ object TestAspect extends TimeoutVariants {
    */
   def nonTermination(duration: Duration): TestAspectAtLeastR[Live] =
     timeout(duration) >>>
-      failure(
+      failing(
         isCase[TestFailure[Any], Throwable](
           "Runtime", {
             case TestFailure.Runtime(cause) => cause.dieOption


### PR DESCRIPTION
Due to name clash we can't import both `TestAspect._` and `Expectation._`.
Since `fails` alternative is already taken by `Assertion._` I believe the most semantically sound fix is to rename `TestAspect.failure` to `TestAspect.failing`. It also happens to be same length.

@adamgfraser 