### PR TITLE
DO NOT MERGE - ZIO Core: Add ifM Variants

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -461,13 +461,13 @@ object IO {
   def identity: IO[Nothing, Any] = ZIO.identity
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM(b:=>Boolean)*]]
    */
-  def ifM[E](b: => Boolean): ZIO.IfM[Any, E] =
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM[R,E]*]]
    */
   def ifM[E](b: IO[E, Boolean]): ZIO.IfM[Any, E] =
     ZIO.ifM(b)

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -463,8 +463,14 @@ object IO {
   /**
    * @see [[zio.ZIO.ifM]]
    */
+  def ifM[E](b: => Boolean): ZIO.IfM[Any, E] =
+    ZIO.ifM(b)
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
   def ifM[E](b: IO[E, Boolean]): ZIO.IfM[Any, E] =
-    new ZIO.IfM(b)
+    ZIO.ifM(b)
 
   /**
    * @see See [[zio.ZIO.interrupt]]

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -181,13 +181,13 @@ object Managed {
     ZManaged.halt(cause)
 
   /**
-   * See [[zio.ZManaged.ifM]]
+   * See [[zio.ZManaged.ifM(b:=>Boolean)*]]
    */
-  def ifM[E](b: => Boolean): ZManaged.IfM[Any, E] =
+  def ifM(b: => Boolean): ZManaged.IfM[Any, Nothing] =
     ZManaged.ifM(b)
 
   /**
-   * See [[zio.ZManaged.ifM]]
+   * See [[zio.ZManaged.ifM[R,E]*]]
    */
   def ifM[E](b: Managed[E, Boolean]): ZManaged.IfM[Any, E] =
     ZManaged.ifM(b)

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -183,8 +183,14 @@ object Managed {
   /**
    * See [[zio.ZManaged.ifM]]
    */
+  def ifM[E](b: => Boolean): ZManaged.IfM[Any, E] =
+    ZManaged.ifM(b)
+
+  /**
+   * See [[zio.ZManaged.ifM]]
+   */
   def ifM[E](b: Managed[E, Boolean]): ZManaged.IfM[Any, E] =
-    new ZManaged.IfM(b)
+    ZManaged.ifM(b)
 
   /**
    * See [[zio.ZManaged.interrupt]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -492,13 +492,13 @@ object RIO {
   def identity[R]: RIO[R, R] = ZIO.identity
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM(b:=>Boolean)*]]
    */
-  def ifM[R](b: => Boolean): ZIO.IfM[R, Throwable] =
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM[R,E]*]]
    */
   def ifM[R](b: RIO[R, Boolean]): ZIO.IfM[R, Throwable] =
     ZIO.ifM(b)

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -494,8 +494,14 @@ object RIO {
   /**
    * @see [[zio.ZIO.ifM]]
    */
+  def ifM[R](b: => Boolean): ZIO.IfM[R, Throwable] =
+    ZIO.ifM(b)
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
   def ifM[R](b: RIO[R, Boolean]): ZIO.IfM[R, Throwable] =
-    new ZIO.IfM(b)
+    ZIO.ifM(b)
 
   /**
    * @see [[zio.ZIO.infinity]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -463,8 +463,14 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see [[zio.ZIO.ifM]]
    */
+  def ifM(b: => Boolean): ZIO.IfM[Any, Throwable] =
+    ZIO.ifM(b)
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
   def ifM(b: Task[Boolean]): ZIO.IfM[Any, Throwable] =
-    new ZIO.IfM(b)
+    ZIO.ifM(b)
 
   /**
    * @see See [[zio.ZIO.interrupt]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -461,13 +461,13 @@ object Task extends TaskPlatformSpecific {
   def identity: Task[Any] = ZIO.identity
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM(b:=>Boolean)*]]
    */
-  def ifM(b: => Boolean): ZIO.IfM[Any, Throwable] =
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM[R,E]*]]
    */
   def ifM(b: Task[Boolean]): ZIO.IfM[Any, Throwable] =
     ZIO.ifM(b)

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -403,8 +403,14 @@ object UIO {
   /**
    * @see [[zio.ZIO.ifM]]
    */
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
+    ZIO.ifM(b)
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
   def ifM(b: UIO[Boolean]): ZIO.IfM[Any, Nothing] =
-    new ZIO.IfM(b)
+    ZIO.ifM(b)
 
   /**
    * @see See [[zio.ZIO.interrupt]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -401,13 +401,13 @@ object UIO {
   def identity: UIO[Any] = ZIO.identity
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM(b:=>Boolean)*]]
    */
   def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM[R,E]*]]
    */
   def ifM(b: UIO[Boolean]): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -437,8 +437,14 @@ object URIO {
   /**
    * @see [[zio.ZIO.ifM]]
    */
+  def ifM[R](b: => Boolean): ZIO.IfM[R, Nothing] =
+    ZIO.ifM(b)
+
+  /**
+   * @see [[zio.ZIO.ifM]]
+   */
   def ifM[R](b: URIO[R, Boolean]): ZIO.IfM[R, Nothing] =
-    new ZIO.IfM(b)
+    ZIO.ifM(b)
 
   /**
    * @see [[zio.ZIO.infinity]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -435,13 +435,13 @@ object URIO {
   def identity[R]: URIO[R, R] = ZIO.identity
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM(b:=>Boolean)*]]
    */
-  def ifM[R](b: => Boolean): ZIO.IfM[R, Nothing] =
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ZIO.ifM(b)
 
   /**
-   * @see [[zio.ZIO.ifM]]
+   * @see [[zio.ZIO.ifM[R,E]*]]
    */
   def ifM[R](b: URIO[R, Boolean]): ZIO.IfM[R, Nothing] =
     ZIO.ifM(b)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2794,6 +2794,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
+  def ifM[R, E](b: => Boolean): ZIO.IfM[R, E] =
+    ifM(succeed(b))
+
+  /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
   def ifM[R, E](b: ZIO[R, E, Boolean]): ZIO.IfM[R, E] =
     new ZIO.IfM(b)
 
@@ -3375,6 +3381,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   }
 
   final class IfM[R, E](private val b: ZIO[R, E, Boolean]) extends AnyVal {
+    def apply[R1 <: R, E1 >: E, A](onTrue: => ZIO[R1, E1, Any]): ZIO[R1, E1, Unit] =
+      b.flatMap(b => if (b) onTrue.unit else unit)
     def apply[R1 <: R, E1 >: E, A](onTrue: => ZIO[R1, E1, A], onFalse: => ZIO[R1, E1, A]): ZIO[R1, E1, A] =
       b.flatMap(b => if (b) onTrue else onFalse)
   }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2794,7 +2794,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
-  def ifM[R, E](b: => Boolean): ZIO.IfM[R, E] =
+  def ifM(b: => Boolean): ZIO.IfM[Any, Nothing] =
     ifM(succeed(b))
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1606,7 +1606,7 @@ object ZManaged {
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
-  def ifM[R, E](b: => Boolean): ZManaged.IfM[R, E] =
+  def ifM(b: => Boolean): ZManaged.IfM[Any, Nothing] =
     ZManaged.ifM(succeed(b))
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1271,6 +1271,8 @@ object ZManaged {
   }
 
   final class IfM[R, E](private val b: ZManaged[R, E, Boolean]) extends AnyVal {
+    def apply[R1 <: R, E1 >: E, A](onTrue: => ZManaged[R1, E1, Any]): ZManaged[R1, E1, Unit] =
+      b.flatMap(b => if (b) onTrue.unit else unit)
     def apply[R1 <: R, E1 >: E, A](
       onTrue: => ZManaged[R1, E1, A],
       onFalse: => ZManaged[R1, E1, A]
@@ -1600,6 +1602,12 @@ object ZManaged {
    * Returns the identity effectful function, which performs no effects
    */
   def identity[R]: ZManaged[R, Nothing, R] = fromFunction(scala.Predef.identity)
+
+  /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
+  def ifM[R, E](b: => Boolean): ZManaged.IfM[R, E] =
+    ZManaged.ifM(succeed(b))
 
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -153,13 +153,13 @@ object STM {
   def identity: USTM[Any] = ZSTM.identity
 
   /**
-   * @see See [[zio.stm.ZSTM.ifM]]
+   * @see See [[zio.stm.ZSTM.ifM(b:=>Boolean)*]]
    */
-  def ifM[E](b: => Boolean): ZSTM.IfM[Any, E] =
+  def ifM(b: => Boolean): ZSTM.IfM[Any, Nothing] =
     ZSTM.ifM(b)
 
   /**
-   * @see See [[zio.stm.ZSTM.ifM]]
+   * @see See [[zio.stm.ZSTM.ifM[R,E]*]]
    */
   def ifM[E](b: STM[E, Boolean]): ZSTM.IfM[Any, E] =
     ZSTM.ifM(b)

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -155,8 +155,14 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.ifM]]
    */
+  def ifM[E](b: => Boolean): ZSTM.IfM[Any, E] =
+    ZSTM.ifM(b)
+
+  /**
+   * @see See [[zio.stm.ZSTM.ifM]]
+   */
   def ifM[E](b: STM[E, Boolean]): ZSTM.IfM[Any, E] =
-    new ZSTM.IfM(b)
+    ZSTM.ifM(b)
 
   /**
    * @see See [[zio.stm.ZSTM.iterate]]

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1061,6 +1061,12 @@ object ZSTM {
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
+  def ifM[R, E](b: => Boolean): ZSTM.IfM[R, E] =
+    ifM(succeed(b))
+
+  /**
+   * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
+   */
   def ifM[R, E](b: ZSTM[R, E, Boolean]): ZSTM.IfM[R, E] =
     new ZSTM.IfM(b)
 
@@ -1317,6 +1323,8 @@ object ZSTM {
   }
 
   final class IfM[R, E](private val b: ZSTM[R, E, Boolean]) {
+    def apply[R1 <: R, E1 >: E, A](onTrue: => ZSTM[R1, E1, Any]): ZSTM[R1, E1, Unit] =
+      b.flatMap(b => if (b) onTrue.unit else unit)
     def apply[R1 <: R, E1 >: E, A](onTrue: => ZSTM[R1, E1, A], onFalse: => ZSTM[R1, E1, A]): ZSTM[R1, E1, A] =
       b.flatMap(b => if (b) onTrue else onFalse)
   }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1061,7 +1061,7 @@ object ZSTM {
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
-  def ifM[R, E](b: => Boolean): ZSTM.IfM[R, E] =
+  def ifM(b: => Boolean): ZSTM.IfM[Any, Nothing] =
     ifM(succeed(b))
 
   /**


### PR DESCRIPTION
Resolves #3235. Resolves #3236.

We can't use `if` as a method name because it is a reserved keyword in Scala. To work around this, I overloaded `ifM` so it can accept either a pure of effectual condition. Overloading a method name is not ideal but given that we can't use the normal name I think this is the best alternative.

I also added variants to allow using `ifM` with a `onTrue` clause without an `onFalse` clause. This is duplicative of existing functionality provided by `when` and `whenM` so we could potentially remove these but given user expectations about the `if` control structure I think there is some value here.