### PR TITLE
Don't Use SucceedNow in Tests

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -478,7 +478,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
       _ <- ZIO.unit
       _ <- ZIO.unit
       untraceableFiber <- (ZIO.unit *> (ZIO.unit *> ZIO.unit *> ZIO.dieMessage("error!") *> ZIO.checkTraced(
-                           ZIO.succeedNow
+                           ZIO.succeed(_)
                          )).fork).untraced
       tracingStatus <- untraceableFiber.join
       _ <- ZIO.when(tracingStatus.isTraced) {
@@ -515,7 +515,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
   }
 
   object mapErrorPreservesTraceFixture {
-    val succ     = ZIO.succeedNow(_: ZTrace)
+    val succ     = ZIO.succeed(_: ZTrace)
     val fail     = () => throw new Exception("error!")
     val mapError = (_: Any) => ()
   }
@@ -534,7 +534,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
 
   object catchSomeWithOptimizedEffectFixture {
     val fail      = () => throw new Exception("error!")
-    val badMethod = ZIO.succeedNow(_: ZTrace)
+    val badMethod = ZIO.succeed(_: ZTrace)
   }
 
   def catchAllWithOptimizedEffect = {
@@ -548,7 +548,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
   }
 
   object catchAllWithOptimizedEffectFixture {
-    val succ               = ZIO.succeedNow(_: ZTrace)
+    val succ               = ZIO.succeed(_: ZTrace)
     val fail               = () => throw new Exception("error!")
     val refailAndLoseTrace = (_: Any) => ZIO.fail("bad!")
   }
@@ -566,8 +566,8 @@ object StackTracesSpec extends DefaultRunnableSpec {
   object foldMWithOptimizedEffectFixture {
     val mkTrace    = (_: Any) => ZIO.trace
     val fail       = () => throw new Exception("error!")
-    val badMethod1 = ZIO.succeedNow(_: ZTrace)
-    val badMethod2 = ZIO.succeedNow(_: ZTrace)
+    val badMethod1 = ZIO.succeed(_: ZTrace)
+    val badMethod2 = ZIO.succeed(_: ZTrace)
   }
 
   object singleTaskForCompFixture {

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -49,7 +49,7 @@ object SerializableSpec extends ZIOBaseSpec {
     },
     testM("IO is serializable") {
       val list = List("1", "2", "3")
-      val io   = IO.succeedNow(list)
+      val io   = IO.succeed(list)
       for {
         returnIO <- serializeAndBack(io)
         result   <- returnIO
@@ -64,7 +64,7 @@ object SerializableSpec extends ZIOBaseSpec {
     },
     testM("FiberStatus is serializable") {
       val list = List("1", "2", "3")
-      val io   = IO.succeedNow(list)
+      val io   = IO.succeed(list)
       for {
         fiber          <- io.fork
         status         <- fiber.await

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -81,7 +81,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
         for {
           p1 <- Promise.make[Nothing, Unit]
           p2 <- Promise.make[Nothing, Unit]
-          f1 <- (ZIO.succeedNow(42) <* p1.succeed(())).toFuture
+          f1 <- (ZIO.succeed(42) <* p1.succeed(())).toFuture
           f2 <- ZIO.fail(t).onError(_ => p2.succeed(())).toFuture
           _  <- p1.await *> p2.await
           e1 <- ZIO.fromFuture(_ => f1.cancel())

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -70,7 +70,7 @@ object PromiseSpec extends ZIOBaseSpec {
       for {
         p <- Promise.make[Nothing, Int]
         _ <- p.succeed(1)
-        s <- p.complete(IO.succeedNow(9))
+        s <- p.complete(IO.succeed(9))
         v <- p.await
       } yield assert(s)(isFalse) && assert(v)(equalTo(1))
     },

--- a/core-tests/shared/src/test/scala/zio/RefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefMSpec.scala
@@ -30,17 +30,17 @@ object RefMSpec extends ZIOBaseSpec {
     testM("getAndUpdateSome") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.getAndUpdateSome { case Closed => IO.succeedNow(Active) }
+        value1 <- refM.getAndUpdateSome { case Closed => IO.succeed(Active) }
         value2 <- refM.get
       } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Active))
     },
     testM("getAndUpdateSome twice") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.getAndUpdateSome { case Active => IO.succeedNow(Changed) }
+        value1 <- refM.getAndUpdateSome { case Active => IO.succeed(Changed) }
         value2 <- refM.getAndUpdateSome {
-                   case Active  => IO.succeedNow(Changed)
-                   case Changed => IO.succeedNow(Closed)
+                   case Active  => IO.succeed(Changed)
+                   case Changed => IO.succeed(Closed)
                  }
         value3 <- refM.get
       } yield assert(value1)(equalTo(Active)) && assert(value2)(equalTo(Changed)) && assert(value3)(equalTo(Closed))
@@ -59,7 +59,7 @@ object RefMSpec extends ZIOBaseSpec {
         fiber       <- makeAndWait.fork
         refM        <- promise.await
         _           <- fiber.interrupt
-        value       <- refM.updateAndGet(_ => ZIO.succeedNow(Closed))
+        value       <- refM.updateAndGet(_ => ZIO.succeed(Closed))
       } yield assert(value)(equalTo(Closed))
     } @@ zioTag(interruption),
     testM("modify") {
@@ -78,11 +78,11 @@ object RefMSpec extends ZIOBaseSpec {
     testM("modify twice") {
       for {
         refM   <- RefM.make[State](Active)
-        r1     <- refM.modifySome("doesn't change the state") { case Active => IO.succeedNow("changed" -> Changed) }
+        r1     <- refM.modifySome("doesn't change the state") { case Active => IO.succeed("changed" -> Changed) }
         value1 <- refM.get
         r2 <- refM.modifySome("doesn't change the state") {
-               case Active  => IO.succeedNow("changed" -> Changed)
-               case Changed => IO.succeedNow("closed"  -> Closed)
+               case Active  => IO.succeed("changed" -> Changed)
+               case Changed => IO.succeed("closed"  -> Closed)
              }
         value2 <- refM.get
       } yield assert(r1)(equalTo("changed")) &&
@@ -93,7 +93,7 @@ object RefMSpec extends ZIOBaseSpec {
     testM("modifySome") {
       for {
         refM  <- RefM.make[State](Active)
-        r     <- refM.modifySome("State doesn't change") { case Closed => IO.succeedNow("active" -> Active) }
+        r     <- refM.modifySome("State doesn't change") { case Closed => IO.succeed("active" -> Active) }
         value <- refM.get
       } yield assert(r)(equalTo("State doesn't change")) && assert(value)(equalTo(Active))
     },
@@ -138,16 +138,16 @@ object RefMSpec extends ZIOBaseSpec {
     testM("updateSomeAndGet") {
       for {
         refM  <- RefM.make[State](Active)
-        value <- refM.updateSomeAndGet { case Closed => IO.succeedNow(Active) }
+        value <- refM.updateSomeAndGet { case Closed => IO.succeed(Active) }
       } yield assert(value)(equalTo(Active))
     },
     testM("updateSomeAndGet twice") {
       for {
         refM   <- RefM.make[State](Active)
-        value1 <- refM.updateSomeAndGet { case Active => IO.succeedNow(Changed) }
+        value1 <- refM.updateSomeAndGet { case Active => IO.succeed(Changed) }
         value2 <- refM.updateSomeAndGet {
-                   case Active  => IO.succeedNow(Changed)
-                   case Changed => IO.succeedNow(Closed)
+                   case Active  => IO.succeed(Changed)
+                   case Changed => IO.succeed(Closed)
                  }
       } yield assert(value1)(equalTo(Changed)) && assert(value2)(equalTo(Closed))
     },

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -35,7 +35,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(TaskExampleDie.absorbWith(identity).run)(fails(equalTo(ExampleError)))
       },
       testM("on success") {
-        assertM(ZIO.succeedNow(1).absorbWith(_ => ExampleError))(equalTo(1))
+        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError))(equalTo(1))
       }
     ) @@ zioTag(errors),
     suite("bimap")(
@@ -50,14 +50,14 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("bracket happy path") {
         for {
           release  <- Ref.make(false)
-          result   <- ZIO.bracket(IO.succeedNow(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
+          result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
           released <- release.get
         } yield assert(result)(equalTo(43)) && assert(released)(isTrue)
       },
       testM("bracket_ happy path") {
         for {
           release  <- Ref.make(false)
-          result   <- IO.succeedNow(42).bracket_(release.set(true), ZIO.effectTotal(0))
+          result   <- IO.succeed(42).bracket_(release.set(true), ZIO.effectTotal(0))
           released <- release.get
         } yield assert(result)(equalTo(0)) && assert(released)(isTrue)
       },
@@ -65,9 +65,9 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           release <- Ref.make(false)
           result <- ZIO.bracketExit(
-                     IO.succeedNow(42),
+                     IO.succeed(42),
                      (_: Int, _: Exit[Any, Any]) => release.set(true),
-                     (_: Int) => IO.succeedNow(0L)
+                     (_: Int) => IO.succeed(0L)
                    )
           released <- release.get
         } yield assert(result)(equalTo(0L)) && assert(released)(isTrue)
@@ -77,12 +77,12 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           exit <- ZIO
                    .bracketExit[Any, String, Int, Int](
-                     ZIO.succeedNow(42),
+                     ZIO.succeed(42),
                      (_, _) => ZIO.die(releaseDied),
                      _ => ZIO.fail("use failed")
                    )
                    .run
-          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.fail("effect should have failed"))
+          cause <- exit.foldM(cause => ZIO.succeed(cause), _ => ZIO.fail("effect should have failed"))
         } yield assert(cause.failures)(equalTo(List("use failed"))) &&
           assert(cause.defects)(equalTo(List(releaseDied)))
       } @@ zioTag(errors)
@@ -92,7 +92,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           release <- Ref.make(false)
           result <- ZIO
-                     .bracket(IO.succeedNow(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
+                     .bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.effectTotal(a + 1))
                      .disconnect
           released <- release.get
         } yield assert(result)(equalTo(43)) && assert(released)(isTrue)
@@ -100,7 +100,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("bracket_ happy path") {
         for {
           release  <- Ref.make(false)
-          result   <- IO.succeedNow(42).bracket_(release.set(true), ZIO.effectTotal(0)).disconnect
+          result   <- IO.succeed(42).bracket_(release.set(true), ZIO.effectTotal(0)).disconnect
           released <- release.get
         } yield assert(result)(equalTo(0)) && assert(released)(isTrue)
       },
@@ -109,9 +109,9 @@ object ZIOSpec extends ZIOBaseSpec {
           release <- Ref.make(false)
           result <- ZIO
                      .bracketExit(
-                       IO.succeedNow(42),
+                       IO.succeed(42),
                        (_: Int, _: Exit[Any, Any]) => release.set(true),
-                       (_: Int) => IO.succeedNow(0L)
+                       (_: Int) => IO.succeed(0L)
                      )
                      .disconnect
           released <- release.get
@@ -122,13 +122,13 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           exit <- ZIO
                    .bracketExit[Any, String, Int, Int](
-                     ZIO.succeedNow(42),
+                     ZIO.succeed(42),
                      (_, _) => ZIO.die(releaseDied),
                      _ => ZIO.fail("use failed")
                    )
                    .disconnect
                    .run
-          cause <- exit.foldM(cause => ZIO.succeedNow(cause), _ => ZIO.fail("effect should have failed"))
+          cause <- exit.foldM(cause => ZIO.succeed(cause), _ => ZIO.fail("effect should have failed"))
         } yield assert(cause.failures)(equalTo(List("use failed"))) &&
           assert(cause.defects)(equalTo(List(releaseDied)))
       } @@ zioTag(errors)
@@ -167,28 +167,28 @@ object ZIOSpec extends ZIOBaseSpec {
         val s   = "division by zero"
         val zio = ZIO.die(new IllegalArgumentException(s))
         for {
-          result <- zio.catchAllDefect(e => ZIO.succeedNow(e.getMessage))
+          result <- zio.catchAllDefect(e => ZIO.succeed(e.getMessage))
         } yield assert(result)(equalTo(s))
       },
       testM("leaves errors") {
         val t   = new IllegalArgumentException("division by zero")
         val zio = ZIO.fail(t)
         for {
-          exit <- zio.catchAllDefect(e => ZIO.succeedNow(e.getMessage)).run
+          exit <- zio.catchAllDefect(e => ZIO.succeed(e.getMessage)).run
         } yield assert(exit)(fails(equalTo(t)))
       },
       testM("leaves values") {
         val t   = new IllegalArgumentException("division by zero")
-        val zio = ZIO.succeedNow(t)
+        val zio = ZIO.succeed(t)
         for {
-          result <- zio.catchAllDefect(e => ZIO.succeedNow(e.getMessage))
+          result <- zio.catchAllDefect(e => ZIO.succeed(e.getMessage))
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
     suite("catchSomeCause")(
       testM("catches matching cause") {
         ZIO.interrupt.catchSomeCause {
-          case c if c.interrupted => ZIO.succeedNow(true)
+          case c if c.interrupted => ZIO.succeed(true)
         }.sandbox.map(
           assert(_)(isTrue)
         )
@@ -196,7 +196,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("halts if cause doesn't match") {
         ZIO.fiberId.flatMap { fiberId =>
           ZIO.interrupt.catchSomeCause {
-            case c if (!c.interrupted) => ZIO.succeedNow(true)
+            case c if (!c.interrupted) => ZIO.succeed(true)
           }.sandbox.either.map(
             assert(_)(isLeft(equalTo(Cause.interrupt(fiberId))))
           )
@@ -209,7 +209,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val zio = ZIO.die(new IllegalArgumentException(s))
         for {
           result <- zio.catchSomeDefect {
-                     case e: IllegalArgumentException => ZIO.succeedNow(e.getMessage)
+                     case e: IllegalArgumentException => ZIO.succeed(e.getMessage)
                    }
         } yield assert(result)(equalTo(s))
       },
@@ -218,7 +218,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val zio = ZIO.die(t)
         for {
           exit <- zio.catchSomeDefect {
-                   case e: NumberFormatException => ZIO.succeedNow(e.getMessage)
+                   case e: NumberFormatException => ZIO.succeed(e.getMessage)
                  }.run
         } yield assert(exit)(dies(equalTo(t)))
       },
@@ -227,16 +227,16 @@ object ZIOSpec extends ZIOBaseSpec {
         val zio = ZIO.fail(t)
         for {
           exit <- zio.catchSomeDefect {
-                   case e: IllegalArgumentException => ZIO.succeedNow(e.getMessage)
+                   case e: IllegalArgumentException => ZIO.succeed(e.getMessage)
                  }.run
         } yield assert(exit)(fails(equalTo(t)))
       },
       testM("leaves values") {
         val t   = new IllegalArgumentException("division by zero")
-        val zio = ZIO.succeedNow(t)
+        val zio = ZIO.succeed(t)
         for {
           result <- zio.catchSomeDefect {
-                     case e: IllegalArgumentException => ZIO.succeedNow(e.getMessage)
+                     case e: IllegalArgumentException => ZIO.succeed(e.getMessage)
                    }
         } yield assert(result)((equalTo(t)))
       }
@@ -271,14 +271,14 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("collectM")(
       testM("returns failure ignoring value") {
         val goodCase =
-          exactlyOnce(0)(_.collectM[Any, String, Int]("Predicate failed!")({ case v @ 0 => ZIO.succeedNow(v) })).sandbox.either
+          exactlyOnce(0)(_.collectM[Any, String, Int]("Predicate failed!")({ case v @ 0 => ZIO.succeed(v) })).sandbox.either
 
         val partialBadCase =
           exactlyOnce(0)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.fail("Partial failed!") })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         val badCase =
-          exactlyOnce(1)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.succeedNow(v) })).sandbox.either
+          exactlyOnce(1)(_.collectM("Predicate failed!")({ case v @ 0 => ZIO.succeed(v) })).sandbox.either
             .map(_.left.map(_.failureOrCause))
 
         assertM(goodCase)(isRight(equalTo(0))) &&
@@ -289,7 +289,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("companion object method consistency")(
       testM("absolve") {
         checkM(Gen.alphaNumericString) { str =>
-          val ioEither: UIO[Either[Nothing, String]] = IO.succeedNow(Right(str))
+          val ioEither: UIO[Either[Nothing, String]] = IO.succeed(Right(str))
           for {
             abs1 <- ioEither.absolve
             abs2 <- IO.absolve(ioEither)
@@ -370,14 +370,14 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           in     <- Ref.make(10)
           out    <- Ref.make(0)
-          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doUntilM(v => UIO.succeedNow(v == 0))
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doUntilM(v => UIO.succeed(v == 0))
           result <- out.get
         } yield assert(result)(equalTo(10))
       },
       testM("doUntilM always evaluates effect at least once") {
         for {
           ref    <- Ref.make(0)
-          _      <- ref.update(_ + 1).doUntilM(_ => UIO.succeedNow(true))
+          _      <- ref.update(_ + 1).doUntilM(_ => UIO.succeed(true))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -415,14 +415,14 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           in     <- Ref.make(10)
           out    <- Ref.make(0)
-          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doWhileM(v => UIO.succeedNow(v >= 0))
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).doWhileM(v => UIO.succeed(v >= 0))
           result <- out.get
         } yield assert(result)(equalTo(11))
       },
       testM("doWhileM always evaluates effect at least once") {
         for {
           ref    <- Ref.make(0)
-          _      <- ref.update(_ + 1).doWhileM(_ => UIO.succeedNow(false))
+          _      <- ref.update(_ + 1).doWhileM(_ => UIO.succeed(false))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -430,7 +430,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("eventually")(
       testM("succeeds eventually") {
         def effect(ref: Ref[Int]) =
-          ref.get.flatMap(n => if (n < 10) ref.update(_ + 1) *> IO.fail("Ouch") else UIO.succeedNow(n))
+          ref.get.flatMap(n => if (n < 10) ref.update(_ + 1) *> IO.fail("Ouch") else UIO.succeed(n))
 
         val test = for {
           ref <- Ref.make(0)
@@ -500,14 +500,14 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(task.run)(fails(equalTo("Default")))
       },
       testM("succeeds when given a value") {
-        val task: IO[String, Int] = IO.succeedNow(1).flattenErrorOption("Default")
+        val task: IO[String, Int] = IO.succeed(1).flattenErrorOption("Default")
         assertM(task)(equalTo(1))
       }
     ) @@ zioTag(errors),
     suite("foldLeft")(
       testM("with a successful step function sums the list properly") {
         checkM(Gen.listOf(Gen.anyInt)) { l =>
-          val res = IO.foldLeft(l)(0)((acc, el) => IO.succeedNow(acc + el))
+          val res = IO.foldLeft(l)(0)((acc, el) => IO.succeed(acc + el))
           assertM(res)(equalTo(l.sum))
         }
       },
@@ -519,7 +519,7 @@ object ZIOSpec extends ZIOBaseSpec {
       } @@ zioTag(errors),
       testM("run sequentially from left to right") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
-          val res = IO.foldLeft(l)(List.empty[Int])((acc, el) => IO.succeedNow(el :: acc))
+          val res = IO.foldLeft(l)(List.empty[Int])((acc, el) => IO.succeed(el :: acc))
           assertM(res)(equalTo(l.reverse))
         }
       }
@@ -527,7 +527,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("foldRight")(
       testM("with a successful step function sums the list properly") {
         checkM(Gen.listOf(Gen.anyInt)) { l =>
-          val res = IO.foldRight(l)(0)((el, acc) => IO.succeedNow(acc + el))
+          val res = IO.foldRight(l)(0)((el, acc) => IO.succeed(acc + el))
           assertM(res)(equalTo(l.sum))
         }
       },
@@ -539,7 +539,7 @@ object ZIOSpec extends ZIOBaseSpec {
       } @@ zioTag(errors),
       testM("run sequentially from right to left") {
         checkM(Gen.listOf1(Gen.anyInt)) { l =>
-          val res = IO.foldRight(l)(List.empty[Int])((el, acc) => IO.succeedNow(el :: acc))
+          val res = IO.foldRight(l)(List.empty[Int])((el, acc) => IO.succeed(el :: acc))
           assertM(res)(equalTo(l))
         }
       }
@@ -604,17 +604,17 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("foreachPar")(
       testM("runs single task") {
         val as      = List(2)
-        val results = IO.foreachPar(as)(a => IO.succeedNow(2 * a))
+        val results = IO.foreachPar(as)(a => IO.succeed(2 * a))
         assertM(results)(equalTo(List(4)))
       },
       testM("runs two tasks") {
         val as      = List(2, 3)
-        val results = IO.foreachPar(as)(a => IO.succeedNow(2 * a))
+        val results = IO.foreachPar(as)(a => IO.succeed(2 * a))
         assertM(results)(equalTo(List(4, 6)))
       },
       testM("runs many tasks") {
         val as      = (1 to 1000)
-        val results = IO.foreachPar(as)(a => IO.succeedNow(2 * a))
+        val results = IO.foreachPar(as)(a => IO.succeed(2 * a))
         assertM(results)(equalTo(as.toList.map(2 * _)))
       },
       testM("runs a task that fails") {
@@ -622,7 +622,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val results = IO
           .foreachPar(as) {
             case 5 => IO.fail("Boom!")
-            case a => IO.succeedNow(2 * a)
+            case a => IO.succeed(2 * a)
           }
           .flip
         assertM(results)(equalTo("Boom!"))
@@ -633,7 +633,7 @@ object ZIOSpec extends ZIOBaseSpec {
           .foreachPar(as) {
             case 5 => IO.fail("Boom1!")
             case 8 => IO.fail("Boom2!")
-            case a => IO.succeedNow(2 * a)
+            case a => IO.succeed(2 * a)
           }
           .flip
         assertM(results)(equalTo("Boom1!") || equalTo("Boom2!"))
@@ -643,7 +643,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val results = IO
           .foreachPar(as) {
             case 5 => IO.dieMessage("Boom!")
-            case a => IO.succeedNow(2 * a)
+            case a => IO.succeed(2 * a)
           }
           .run
         assertM(results)(dies(hasMessage(equalTo("Boom!"))))
@@ -653,7 +653,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val results = IO
           .foreachPar(as) {
             case 5 => IO.interrupt
-            case a => IO.succeedNow(2 * a)
+            case a => IO.succeed(2 * a)
           }
           .run
         assertM(results)(isInterrupted)
@@ -684,7 +684,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
-        val odds = ZIO.foreachPar(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.fail("not odd"))
+        val odds = ZIO.foreachPar(ints)(n => if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd"))
         assertM(odds.flip)(equalTo("not odd"))
       } @@ zioTag(errors),
       testM("interrupts effects on first failure") {
@@ -693,7 +693,7 @@ object ZIOSpec extends ZIOBaseSpec {
           promise <- Promise.make[Nothing, Unit]
           actions = List(
             ZIO.never,
-            ZIO.succeedNow(1),
+            ZIO.succeed(1),
             ZIO.fail("C"),
             promise.await *> ref.set(true)
           )
@@ -749,7 +749,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("works on large lists") {
         val n   = 10
         val seq = List.range(0, 100000)
-        val res = IO.foreachParN(n)(seq)(UIO.succeedNow)
+        val res = IO.foreachParN(n)(seq)(UIO.succeed(_))
         assertM(res)(equalTo(seq))
       },
       testM("runs effects in parallel") {
@@ -762,13 +762,13 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
-        val odds = ZIO.foreachParN(4)(ints)(n => if (n % 2 != 0) ZIO.succeedNow(n) else ZIO.fail("not odd"))
+        val odds = ZIO.foreachParN(4)(ints)(n => if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd"))
         assertM(odds.either)(isLeft(equalTo("not odd")))
       } @@ zioTag(errors),
       testM("interrupts effects on first failure") {
         val actions = List(
           ZIO.never,
-          ZIO.succeedNow(1),
+          ZIO.succeed(1),
           ZIO.fail("C")
         )
         val io = ZIO.foreachParN(4)(actions)(a => a)
@@ -904,10 +904,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ) @@ zioTag(future, interruption),
     suite("head")(
       testM("on non empty list") {
-        assertM(ZIO.succeedNow(List(1, 2, 3)).head.either)(isRight(equalTo(1)))
+        assertM(ZIO.succeed(List(1, 2, 3)).head.either)(isRight(equalTo(1)))
       },
       testM("on empty list") {
-        assertM(ZIO.succeedNow(List.empty).head.either)(isLeft(isNone))
+        assertM(ZIO.succeed(List.empty).head.either)(isLeft(isNone))
       },
       testM("on failure") {
         assertM(ZIO.fail("Fail").head.either)(isLeft(isSome(equalTo("Fail"))))
@@ -915,11 +915,11 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("ifM")(
       testM("runs `onTrue` if result of `b` is `true`") {
-        val zio = ZIO.ifM(ZIO.succeedNow(true))(ZIO.succeedNow(true), ZIO.succeedNow(false))
+        val zio = ZIO.ifM(ZIO.succeed(true))(ZIO.succeed(true), ZIO.succeed(false))
         assertM(zio)(isTrue)
       },
       testM("runs `onFalse` if result of `b` is `false`") {
-        val zio = ZIO.ifM(ZIO.succeedNow(false))(ZIO.succeedNow(true), ZIO.succeedNow(false))
+        val zio = ZIO.ifM(ZIO.succeed(false))(ZIO.succeed(true), ZIO.succeed(false))
         assertM(zio)(isFalse)
       },
       testM("infers correctly") {
@@ -928,16 +928,16 @@ object ZIOSpec extends ZIOBaseSpec {
         trait E1
         trait E extends E1
         trait A
-        val b: ZIO[R, E, Boolean]   = ZIO.succeedNow(true)
-        val onTrue: ZIO[R1, E1, A]  = ZIO.succeedNow(new A {})
-        val onFalse: ZIO[R1, E1, A] = ZIO.succeedNow(new A {})
+        val b: ZIO[R, E, Boolean]   = ZIO.succeed(true)
+        val onTrue: ZIO[R1, E1, A]  = ZIO.succeed(new A {})
+        val onFalse: ZIO[R1, E1, A] = ZIO.succeed(new A {})
         val _                       = ZIO.ifM(b)(onTrue, onFalse)
         ZIO.succeed(assertCompletes)
       }
     ),
     suite("ignore")(
       testM("return success as Unit") {
-        assertM(ZIO.succeedNow(11).ignore)(equalTo(()))
+        assertM(ZIO.succeed(11).ignore)(equalTo(()))
       },
       testM("return failure as Unit") {
         assertM(ZIO.fail(123).ignore)(equalTo(()))
@@ -965,16 +965,16 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("iterate")(
       testM("iterates with the specified effectual function") {
         for {
-          result <- ZIO.iterate(100)(_ > 0)(a => ZIO.succeedNow(a - 1))
+          result <- ZIO.iterate(100)(_ > 0)(a => ZIO.succeed(a - 1))
         } yield assert(result)(equalTo(0))
       }
     ),
     suite("left")(
       testM("on Left value") {
-        assertM(ZIO.succeedNow(Left("Left")).left)(equalTo("Left"))
+        assertM(ZIO.succeed(Left("Left")).left)(equalTo("Left"))
       },
       testM("on Right value") {
-        assertM(ZIO.succeedNow(Right("Right")).left.either)(isLeft(isNone))
+        assertM(ZIO.succeed(Right("Right")).left.either)(isLeft(isNone))
       },
       testM("on failure") {
         assertM(ZIO.fail("Fail").left.either)(isLeft(isSome(equalTo("Fail"))))
@@ -990,10 +990,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("leftOrFailException")(
       testM("on Left value") {
-        assertM(ZIO.succeedNow(Left(42)).leftOrFailException)(equalTo(42))
+        assertM(ZIO.succeed(Left(42)).leftOrFailException)(equalTo(42))
       },
       testM("on Right value") {
-        assertM(ZIO.succeedNow(Right(2)).leftOrFailException.run)(fails(Assertion.anything))
+        assertM(ZIO.succeed(Right(2)).leftOrFailException.run)(fails(Assertion.anything))
       } @@ zioTag(errors)
     ),
     suite("loop")(
@@ -1006,7 +1006,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("collects the results into a list") {
         for {
-          result <- ZIO.loop(0)(_ < 5, _ + 2)(a => ZIO.succeedNow(a * 3))
+          result <- ZIO.loop(0)(_ < 5, _ + 2)(a => ZIO.succeed(a * 3))
         } yield assert(result)(equalTo(List(0, 6, 12)))
       }
     ),
@@ -1023,7 +1023,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("with Tuple2") {
         checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
           def f(i: Int, s: String): String = i.toString + s
-          val actual                       = ZIO.mapN(ZIO.succeedNow(int), ZIO.succeedNow(str))(f)
+          val actual                       = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str))(f)
           val expected                     = f(int, str)
           assertM(actual)(equalTo(expected))
         }
@@ -1031,7 +1031,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("with Tuple3") {
         checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
           def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
-          val actual                                    = ZIO.mapN(ZIO.succeedNow(int), ZIO.succeedNow(str1), ZIO.succeedNow(str2))(f)
+          val actual                                    = ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
           val expected                                  = f(int, str1, str2)
           assertM(actual)(equalTo(expected))
         }
@@ -1041,7 +1041,7 @@ object ZIOSpec extends ZIOBaseSpec {
           (int: Int, str1: String, str2: String, str3: String) =>
             def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
             val actual =
-              ZIO.mapN(ZIO.succeedNow(int), ZIO.succeedNow(str1), ZIO.succeedNow(str2), ZIO.succeedNow(str3))(f)
+              ZIO.mapN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
             val expected = f(int, str1, str2, str3)
             assertM(actual)(equalTo(expected))
         }
@@ -1051,7 +1051,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("with Tuple2") {
         checkM(Gen.anyInt, Gen.alphaNumericString) { (int: Int, str: String) =>
           def f(i: Int, s: String): String = i.toString + s
-          val actual                       = ZIO.mapParN(ZIO.succeedNow(int), ZIO.succeedNow(str))(f)
+          val actual                       = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str))(f)
           val expected                     = f(int, str)
           assertM(actual)(equalTo(expected))
         }
@@ -1059,7 +1059,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("with Tuple3") {
         checkM(Gen.anyInt, Gen.alphaNumericString, Gen.alphaNumericString) { (int: Int, str1: String, str2: String) =>
           def f(i: Int, s1: String, s2: String): String = i.toString + s1 + s2
-          val actual                                    = ZIO.mapParN(ZIO.succeedNow(int), ZIO.succeedNow(str1), ZIO.succeedNow(str2))(f)
+          val actual                                    = ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2))(f)
           val expected                                  = f(int, str1, str2)
           assertM(actual)(equalTo(expected))
         }
@@ -1069,7 +1069,7 @@ object ZIOSpec extends ZIOBaseSpec {
           (int: Int, str1: String, str2: String, str3: String) =>
             def f(i: Int, s1: String, s2: String, s3: String): String = i.toString + s1 + s2 + s3
             val actual =
-              ZIO.mapParN(ZIO.succeedNow(int), ZIO.succeedNow(str1), ZIO.succeedNow(str2), ZIO.succeedNow(str3))(f)
+              ZIO.mapParN(ZIO.succeed(int), ZIO.succeed(str1), ZIO.succeed(str2), ZIO.succeed(str3))(f)
             val expected = f(int, str1, str2, str3)
             assertM(actual)(equalTo(expected))
         }
@@ -1090,7 +1090,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("merge")(
       testM("on flipped result") {
-        val zio: IO[Int, Int] = ZIO.succeedNow(1)
+        val zio: IO[Int, Int] = ZIO.succeed(1)
 
         for {
           a <- zio.merge
@@ -1107,7 +1107,7 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("merge list using function") {
-        val effects = List(3, 5, 7).map(UIO.succeedNow)
+        val effects = List(3, 5, 7).map(UIO.succeed(_))
         UIO.mergeAll(effects)(zero = 1)(_ + _).map {
           assert(_)(equalTo(1 + 3 + 5 + 7))
         }
@@ -1127,7 +1127,7 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("merge list using function") {
-        val effects = List(3, 5, 7).map(UIO.succeedNow)
+        val effects = List(3, 5, 7).map(UIO.succeed(_))
         UIO.mergeAllPar(effects)(zero = 1)(_ + _).map {
           assert(_)(equalTo(1 + 3 + 5 + 7))
         }
@@ -1205,7 +1205,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("option")(
       testM("return success in Some") {
         implicit val canFail = CanFail
-        assertM(ZIO.succeedNow(11).option)(equalTo(Some(11)))
+        assertM(ZIO.succeed(11).option)(equalTo(Some(11)))
       },
       testM("return failure as None") {
         assertM(ZIO.fail(123).option)(equalTo(None))
@@ -1228,7 +1228,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(task)(isNone)
       } @@ zioTag(errors),
       testM("succeeds with Some given a value") {
-        val task: IO[String, Option[Int]] = IO.succeedNow(1).optional
+        val task: IO[String, Option[Int]] = IO.succeed(1).optional
         assertM(task)(isSome(equalTo(1)))
       }
     ),
@@ -1286,7 +1286,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("orElseFail")(
       testM("executes this effect and returns its value if it succeeds") {
         implicit val canFail = CanFail
-        assertM(ZIO.succeedNow(true).orElseFail(false))(isTrue)
+        assertM(ZIO.succeed(true).orElseFail(false))(isTrue)
       },
       testM("otherwise fails with the specified error") {
         assertM(ZIO.fail(false).orElseFail(true).flip)(isTrue)
@@ -1295,7 +1295,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("orElseSucceed")(
       testM("executes this effect and returns its value if it succeeds") {
         implicit val canFail = CanFail
-        assertM(ZIO.succeedNow(true).orElseSucceed(false))(isTrue)
+        assertM(ZIO.succeed(true).orElseSucceed(false))(isTrue)
       },
       testM("otherwise succeeds with the specified value") {
         assertM(ZIO.fail(false).orElseSucceed(true))(isTrue)
@@ -1305,7 +1305,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("oneFailure") {
         for {
           f1     <- IO.fail("error1").fork
-          f2     <- IO.succeedNow("success1").fork
+          f2     <- IO.succeed("success1").fork
           errors <- f1.zip(f2).join.parallelErrors[String].flip
         } yield assert(errors)(equalTo(List("error1")))
       },
@@ -1326,7 +1326,7 @@ object ZIOSpec extends ZIOBaseSpec {
         implicit val canFail = CanFail
         val in               = List.range(0, 10)
         for {
-          res <- ZIO.partition(in)(a => ZIO.succeedNow(a))
+          res <- ZIO.partition(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects only failures") {
@@ -1338,7 +1338,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partition(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
+          res <- ZIO.partition(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors),
       testM("evaluates effects in correct order") {
@@ -1356,7 +1356,7 @@ object ZIOSpec extends ZIOBaseSpec {
         implicit val canFail = CanFail
         val in               = List.range(0, 1000)
         for {
-          res <- ZIO.partitionPar(in)(a => ZIO.succeedNow(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
@@ -1368,7 +1368,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
+          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors)
     ),
@@ -1377,7 +1377,7 @@ object ZIOSpec extends ZIOBaseSpec {
         implicit val canFail = CanFail
         val in               = List.range(0, 1000)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => ZIO.succeedNow(a))
+          res <- ZIO.partitionParN(3)(in)(a => ZIO.succeed(a))
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       testM("collects failures") {
@@ -1389,7 +1389,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeedNow(a))
+          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors)
     ),
@@ -1411,26 +1411,26 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("raceAll")(
       testM("returns first success") {
-        assertM(ZIO.fail("Fail").raceAll(List(IO.succeedNow(24))))(equalTo(24))
+        assertM(ZIO.fail("Fail").raceAll(List(IO.succeed(24))))(equalTo(24))
       },
       testM("returns last failure") {
         assertM(Live.live(ZIO.sleep(100.millis) *> ZIO.fail(24)).raceAll(List(ZIO.fail(25))).flip)(equalTo(24))
       } @@ flaky @@ zioTag(errors),
       testM("returns success when it happens after failure") {
-        assertM(ZIO.fail(42).raceAll(List(IO.succeedNow(24) <* Live.live(ZIO.sleep(100.millis)))))(equalTo(24))
+        assertM(ZIO.fail(42).raceAll(List(IO.succeed(24) <* Live.live(ZIO.sleep(100.millis)))))(equalTo(24))
       } @@ zioTag(errors)
     ),
     suite("reduceAllPar")(
       testM("return zero element on empty input") {
         val zeroElement = 42
         val nonZero     = 43
-        UIO.reduceAllPar(UIO.succeedNow(zeroElement), Nil)((_, _) => nonZero).map {
+        UIO.reduceAllPar(UIO.succeed(zeroElement), Nil)((_, _) => nonZero).map {
           assert(_)(equalTo(zeroElement))
         }
       },
       testM("reduce list using function") {
-        val zeroElement  = UIO.succeedNow(1)
-        val otherEffects = List(3, 5, 7).map(UIO.succeedNow)
+        val zeroElement  = UIO.succeed(1)
+        val otherEffects = List(3, 5, 7).map(UIO.succeed(_))
         UIO.reduceAllPar(zeroElement, otherEffects)(_ + _).map {
           assert(_)(equalTo(1 + 3 + 5 + 7))
         }
@@ -1450,15 +1450,15 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("replicate")(
       testM("zero") {
-        val lst: Iterable[UIO[Int]] = ZIO.replicate(0)(ZIO.succeedNow(12))
+        val lst: Iterable[UIO[Int]] = ZIO.replicate(0)(ZIO.succeed(12))
         assertM(ZIO.collectAll(lst))(equalTo(List.empty))
       },
       testM("negative") {
-        val anotherList: Iterable[UIO[Int]] = ZIO.replicate(-2)(ZIO.succeedNow(12))
+        val anotherList: Iterable[UIO[Int]] = ZIO.replicate(-2)(ZIO.succeed(12))
         assertM(ZIO.collectAll(anotherList))(equalTo(List.empty))
       },
       testM("positive") {
-        val lst: Iterable[UIO[Int]] = ZIO.replicate(2)(ZIO.succeedNow(12))
+        val lst: Iterable[UIO[Int]] = ZIO.replicate(2)(ZIO.succeed(12))
         assertM(ZIO.collectAll(lst))(equalTo(List(12, 12)))
       }
     ),
@@ -1495,14 +1495,14 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           in     <- Ref.make(10)
           out    <- Ref.make(0)
-          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryUntilM(v => UIO.succeedNow(v == 0)))
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryUntilM(v => UIO.succeed(v == 0)))
           result <- out.get
         } yield assert(result)(equalTo(10))
       },
       testM("retryUntilM runs at least once") {
         for {
           ref    <- Ref.make(0)
-          _      <- ref.update(_ + 1).flipWith(_.retryUntilM(_ => UIO.succeedNow(true)))
+          _      <- ref.update(_ + 1).flipWith(_.retryUntilM(_ => UIO.succeed(true)))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
@@ -1540,24 +1540,24 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           in     <- Ref.make(10)
           out    <- Ref.make(0)
-          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryWhileM(v => UIO.succeedNow(v >= 0)))
+          _      <- (in.updateAndGet(_ - 1) <* out.update(_ + 1)).flipWith(_.retryWhileM(v => UIO.succeed(v >= 0)))
           result <- out.get
         } yield assert(result)(equalTo(11))
       },
       testM("retryWhileM runs at least once") {
         for {
           ref    <- Ref.make(0)
-          _      <- ref.update(_ + 1).flipWith(_.retryWhileM(_ => UIO.succeedNow(false)))
+          _      <- ref.update(_ + 1).flipWith(_.retryWhileM(_ => UIO.succeed(false)))
           result <- ref.get
         } yield assert(result)(equalTo(1))
       }
     ),
     suite("right")(
       testM("on Right value") {
-        assertM(ZIO.succeedNow(Right("Right")).right)(equalTo("Right"))
+        assertM(ZIO.succeed(Right("Right")).right)(equalTo("Right"))
       },
       testM("on Left value") {
-        assertM(ZIO.succeedNow(Left("Left")).right.either)(isLeft(isNone))
+        assertM(ZIO.succeed(Left("Left")).right.either)(isLeft(isNone))
       },
       testM("on failure") {
         assertM(ZIO.fail("Fail").right.either)(isLeft(isSome(equalTo("Fail"))))
@@ -1587,10 +1587,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("rightOrFailException")(
       testM("on Right value") {
-        assertM(ZIO.succeedNow(Right(42)).rightOrFailException)(equalTo(42))
+        assertM(ZIO.succeed(Right(42)).rightOrFailException)(equalTo(42))
       },
       testM("on Left value") {
-        assertM(ZIO.succeedNow(Left(2)).rightOrFailException.run)(fails(Assertion.anything))
+        assertM(ZIO.succeed(Left(2)).rightOrFailException.run)(fails(Assertion.anything))
       } @@ zioTag(errors)
     ),
     suite("some")(
@@ -1616,18 +1616,18 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
-        assertM(ZIO.succeedNow(Some(42)).someOrFailException)(equalTo(42))
+        assertM(ZIO.succeed(Some(42)).someOrFailException)(equalTo(42))
       },
       testM("fails when given a None") {
-        val task = ZIO.succeedNow(Option.empty[Int]).someOrFailException
+        val task = ZIO.succeed(Option.empty[Int]).someOrFailException
         assertM(task.run)(fails(isSubtype[NoSuchElementException](anything)))
       } @@ zioTag(errors),
       suite("without another error type")(
         testM("succeed something") {
-          assertM(ZIO.succeedNow(Option(3)).someOrFailException)(equalTo(3))
+          assertM(ZIO.succeed(Option(3)).someOrFailException)(equalTo(3))
         },
         testM("succeed nothing") {
-          assertM(ZIO.succeedNow(None: Option[Int]).someOrFailException.run)(fails(Assertion.anything))
+          assertM(ZIO.succeed(None: Option[Int]).someOrFailException.run)(fails(Assertion.anything))
         } @@ zioTag(errors)
       ),
       suite("with throwable as base error type")(
@@ -1637,7 +1637,7 @@ object ZIOSpec extends ZIOBaseSpec {
       ),
       suite("with exception as base error type")(
         testM("return something") {
-          assertM((ZIO.succeedNow(Option(3)): IO[Exception, Option[Int]]).someOrFailException)(equalTo(3))
+          assertM((ZIO.succeed(Option(3)): IO[Exception, Option[Int]]).someOrFailException)(equalTo(3))
         }
       )
     ),
@@ -1657,7 +1657,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("rejectM")(
       testM("Check `rejectM` returns failure ignoring value") {
         val goodCase =
-          exactlyOnce(0)(_.rejectM[Any, String]({ case v if v != 0 => ZIO.succeedNow("Partial failed!") })).sandbox.either
+          exactlyOnce(0)(_.rejectM[Any, String]({ case v if v != 0 => ZIO.succeed("Partial failed!") })).sandbox.either
 
         val partialBadCase =
           exactlyOnce(1)(_.rejectM({ case v if v != 0 => ZIO.fail("Partial failed!") })).sandbox.either
@@ -1679,13 +1679,13 @@ object ZIOSpec extends ZIOBaseSpec {
 
         assertM(op1.zipWith(op2)(_ + _))(equalTo("12"))
       },
-      testM("now must be eager") {
+      testM("succeed must be lazy") {
         val io =
           try {
-            IO.succeedNow(throw ExampleError)
-            IO.succeedNow(false)
+            IO.succeed(throw ExampleError)
+            IO.succeed(true)
           } catch {
-            case _: Throwable => IO.succeedNow(true)
+            case _: Throwable => IO.succeed(false)
           }
 
         assertM(io)(isTrue)
@@ -1694,9 +1694,9 @@ object ZIOSpec extends ZIOBaseSpec {
         val io =
           try {
             IO.effectSuspend(throw ExampleError)
-            IO.succeedNow(false)
+            IO.succeed(false)
           } catch {
-            case _: Throwable => IO.succeedNow(true)
+            case _: Throwable => IO.succeed(true)
           }
 
         assertM(io)(isFalse)
@@ -1718,7 +1718,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("point, bind, map") {
         def fibIo(n: Int): Task[BigInt] =
-          if (n <= 1) IO.succeedNow(n)
+          if (n <= 1) IO.succeed(n)
           else
             for {
               a <- fibIo(n - 1)
@@ -1784,11 +1784,11 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io)(equalTo(ExampleError))
       } @@ zioTag(errors),
       testM("flip must make value into error") {
-        val io = IO.succeedNow(42).flip
+        val io = IO.succeed(42).flip
         assertM(io.either)(isLeft(equalTo(42)))
       } @@ zioTag(errors),
       testM("flipping twice returns identical value") {
-        val io = IO.succeedNow(42)
+        val io = IO.succeed(42)
         assertM(io.flip.flip)(equalTo(42))
       }
     ),
@@ -1879,7 +1879,7 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(res)(equalTo(42))
       } @@ zioTag(interruption),
       testM("timeout a long computation") {
-        val io = (clock.sleep(5.seconds) *> IO.succeedNow(true)).timeout(10.millis)
+        val io = (clock.sleep(5.seconds) *> IO.succeed(true)).timeout(10.millis)
         assertM(Live.live(io))(isNone)
       },
       testM("timeout repetition of uninterruptible effect") {
@@ -1894,11 +1894,11 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("catchAllCause") {
         val io =
           for {
-            _ <- ZIO.succeedNow(42)
+            _ <- ZIO.succeed(42)
             f <- ZIO.fail("Uh oh!")
           } yield f
 
-        assertM(io.catchAllCause(ZIO.succeedNow))(equalTo(Cause.fail("Uh oh!")))
+        assertM(io.catchAllCause(ZIO.succeed(_)))(equalTo(Cause.fail("Uh oh!")))
       } @@ zioTag(errors),
       testM("exception in fromFuture does not kill fiber") {
         val io = ZIO.fromFuture(_ => throw ExampleError).either
@@ -1955,7 +1955,7 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield a1 && a2
       } @@ zioTag(errors),
       testM("bracket exit is usage result") {
-        val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.succeedNow[Int](42))
+        val io = IO.bracket(IO.unit)(_ => IO.unit)(_ => IO.succeed[Int](42))
         assertM(io)(equalTo(42))
       },
       testM("error in just acquisition") {
@@ -2046,11 +2046,11 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("deep flatMap") {
         def fib(n: Int, a: BigInt = 0, b: BigInt = 1): IO[Error, BigInt] =
-          IO.succeedNow(a + b).flatMap { b2 =>
+          IO.succeed(a + b).flatMap { b2 =>
             if (n > 0)
               fib(n - 1, b, b2)
             else
-              IO.succeedNow(b2)
+              IO.succeed(b2)
           }
 
         val expected = BigInt(
@@ -2061,12 +2061,12 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("deep absolve/attempt is identity") {
         implicit val canFail = CanFail
-        val io               = (0 until 1000).foldLeft(IO.succeedNow(42))((acc, _) => IO.absolve(acc.either))
+        val io               = (0 until 1000).foldLeft(IO.succeed(42))((acc, _) => IO.absolve(acc.either))
 
         assertM(io)(equalTo(42))
       },
       testM("deep async absolve/attempt is identity") {
-        val io = (0 until 1000).foldLeft(IO.effectAsync[Int, Int](k => k(IO.succeedNow(42)))) { (acc, _) =>
+        val io = (0 until 1000).foldLeft(IO.effectAsync[Int, Int](k => k(IO.succeed(42)))) { (acc, _) =>
           IO.absolve(acc.either)
         }
 
@@ -2075,21 +2075,21 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("RTS asynchronous correctness")(
       testM("simple effectAsync must return") {
-        val io = IO.effectAsync[Throwable, Int](k => k(IO.succeedNow(42)))
+        val io = IO.effectAsync[Throwable, Int](k => k(IO.succeed(42)))
         assertM(io)(equalTo(42))
       },
       testM("simple effectAsyncM must return") {
-        val io = IO.effectAsyncM[Throwable, Int](k => IO.effectTotal(k(IO.succeedNow(42))))
+        val io = IO.effectAsyncM[Throwable, Int](k => IO.effectTotal(k(IO.succeed(42))))
         assertM(io)(equalTo(42))
       },
       testM("deep effectAsyncM doesn't block threads") {
         def stackIOs(count: Int): URIO[Clock, Int] =
-          if (count <= 0) IO.succeedNow(42)
+          if (count <= 0) IO.succeed(42)
           else asyncIO(stackIOs(count - 1))
 
         def asyncIO(cont: URIO[Clock, Int]): URIO[Clock, Int] =
           ZIO.effectAsyncM[Clock, Nothing, Int] { k =>
-            clock.sleep(5.millis) *> cont *> IO.effectTotal(k(IO.succeedNow(42)))
+            clock.sleep(5.millis) *> cont *> IO.effectTotal(k(IO.succeed(42)))
           }
 
         val procNum = java.lang.Runtime.getRuntime.availableProcessors()
@@ -2174,8 +2174,8 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(Live.live(clock.sleep(1.nanos)))(isUnit)
       },
       testM("shallow bind of async chain") {
-        val io = (0 until 10).foldLeft[Task[Int]](IO.succeedNow[Int](0)) { (acc, _) =>
-          acc.flatMap(n => IO.effectAsync[Throwable, Int](_(IO.succeedNow(n + 1))))
+        val io = (0 until 10).foldLeft[Task[Int]](IO.succeed[Int](0)) { (acc, _) =>
+          acc.flatMap(n => IO.effectAsync[Throwable, Int](_(IO.succeed(n + 1))))
         }
 
         assertM(io)(equalTo(10))
@@ -2199,7 +2199,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("RTS concurrency correctness")(
       testM("shallow fork/join identity") {
         for {
-          f <- IO.succeedNow(42).fork
+          f <- IO.succeed(42).fork
           r <- f.join
         } yield assert(r)(equalTo(42))
       },
@@ -2229,7 +2229,7 @@ object ZIOSpec extends ZIOBaseSpec {
           fiber   <- async.fork
           _ <- IO.effectAsync[Throwable, Unit] { k =>
                 latch.future.onComplete {
-                  case Success(a) => k(IO.succeedNow(a))
+                  case Success(a) => k(IO.succeed(a))
                   case Failure(t) => k(IO.fail(t))
                 }(scala.concurrent.ExecutionContext.global)
               }
@@ -2292,11 +2292,11 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(Live.live(io))(equalTo(2))
       } @@ zioTag(supervision) @@ forked @@ flaky, // Due to weak supervision, this test is expected to fail sometimes
       testM("race of fail with success") {
-        val io = IO.fail(42).race(IO.succeedNow(24)).either
+        val io = IO.fail(42).race(IO.succeed(24)).either
         assertM(io)(isRight(equalTo(24)))
       },
       testM("race of terminate with success") {
-        val io = IO.die(new Throwable {}).race(IO.succeedNow(24))
+        val io = IO.die(new Throwable {}).race(IO.succeed(24))
         assertM(io)(equalTo(24))
       },
       testM("race of fail with fail") {
@@ -2312,7 +2312,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(effect)(isUnit)
       },
       testM("firstSuccessOf of values") {
-        val io = IO.firstSuccessOf(IO.fail(0), List(IO.succeedNow(100))).either
+        val io = IO.firstSuccessOf(IO.fail(0), List(IO.succeed(100))).either
         assertM(io)(isRight(equalTo(100)))
       },
       testM("firstSuccessOf of failures") {
@@ -2320,7 +2320,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(Live.live(io))(isLeft(equalTo(101)))
       },
       testM("firstSuccessOF of failures & 1 success") {
-        val io = ZIO.firstSuccessOf(IO.fail(0), List(IO.succeedNow(102).delay(1.millis))).either
+        val io = ZIO.firstSuccessOf(IO.fail(0), List(IO.succeed(102).delay(1.millis))).either
         assertM(Live.live(io))(isRight(equalTo(102)))
       },
       testM("raceFirst interrupts loser on success") {
@@ -2347,19 +2347,19 @@ object ZIOSpec extends ZIOBaseSpec {
       } @@ zioTag(interruption),
       testM("par regression") {
         val io =
-          IO.succeedNow[Int](1).zipPar(IO.succeedNow[Int](2)).flatMap(t => IO.succeedNow(t._1 + t._2)).map(_ == 3)
+          IO.succeed[Int](1).zipPar(IO.succeed[Int](2)).flatMap(t => IO.succeed(t._1 + t._2)).map(_ == 3)
         assertM(io)(isTrue)
       } @@ zioTag(regression) @@ jvm(nonFlaky),
       testM("par of now values") {
         def countdown(n: Int): UIO[Int] =
-          if (n == 0) IO.succeedNow(0)
+          if (n == 0) IO.succeed(0)
           else
-            IO.succeedNow[Int](1).zipPar(IO.succeedNow[Int](2)).flatMap(t => countdown(n - 1).map(y => t._1 + t._2 + y))
+            IO.succeed[Int](1).zipPar(IO.succeed[Int](2)).flatMap(t => countdown(n - 1).map(y => t._1 + t._2 + y))
 
         assertM(countdown(50))(equalTo(150))
       },
       testM("mergeAll") {
-        val io = IO.mergeAll(List("a", "aa", "aaa", "aaaa").map(IO.succeedNow[String](_)))(0)((b, a) => b + a.length)
+        val io = IO.mergeAll(List("a", "aa", "aaa", "aaaa").map(IO.succeed[String](_)))(0)((b, a) => b + a.length)
 
         assertM(io)(equalTo(10))
       },
@@ -2368,7 +2368,7 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(io)(equalTo(0))
       },
       testM("reduceAll") {
-        val io = IO.reduceAll(IO.effectTotal(1), List(2, 3, 4).map(IO.succeedNow[Int](_)))(_ + _)
+        val io = IO.reduceAll(IO.effectTotal(1), List(2, 3, 4).map(IO.succeed[Int](_)))(_ + _)
         assertM(io)(equalTo(10))
       },
       testM("reduceAll Empty List") {
@@ -2452,9 +2452,9 @@ object ZIOSpec extends ZIOBaseSpec {
           for {
             promise <- Promise.make[Nothing, Unit]
             fiber <- IO
-                      .bracketExit(promise.succeed(()) *> IO.never *> IO.succeedNow(1))((_, _: Exit[Any, Any]) =>
-                        IO.unit
-                      )(_ => IO.unit: IO[Nothing, Unit])
+                      .bracketExit(promise.succeed(()) *> IO.never *> IO.succeed(1))((_, _: Exit[Any, Any]) => IO.unit)(
+                        _ => IO.unit: IO[Nothing, Unit]
+                      )
                       .forkDaemon
             res <- promise.await *> fiber.interrupt.timeoutTo(42)(_ => 0)(1.second)
           } yield res
@@ -2923,16 +2923,16 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("unsandbox")(
       testM("unwraps exception") {
         val failure: IO[Cause[Exception], String] = IO.fail(fail(new Exception("fail")))
-        val success: IO[Cause[Any], Int]          = IO.succeedNow(100)
+        val success: IO[Cause[Any], Int]          = IO.succeed(100)
         for {
-          message <- failure.unsandbox.foldM(e => IO.succeedNow(e.getMessage), _ => IO.succeedNow("unexpected"))
+          message <- failure.unsandbox.foldM(e => IO.succeed(e.getMessage), _ => IO.succeed("unexpected"))
           result  <- success.unsandbox
         } yield assert(message)(equalTo("fail")) && assert(result)(equalTo(100))
       },
       testM("no information is lost during composition") {
         val causes = Gen.causes(Gen.anyString, Gen.throwable)
         def cause[R, E](zio: ZIO[R, E, Nothing]): ZIO[R, Nothing, Cause[E]] =
-          zio.foldCauseM(ZIO.succeedNow, ZIO.fail)
+          zio.foldCauseM(ZIO.succeed(_), ZIO.fail)
         checkM(causes) { c =>
           for {
             result <- cause(ZIO.halt(c).sandbox.mapErrorCause(e => e.untraced).unsandbox)
@@ -2950,13 +2950,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("accumulate errors and ignore successes") {
         implicit val canFail = CanFail
         val in               = List.range(0, 10)
-        val res              = ZIO.validate(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.fail(a))
+        val res              = ZIO.validate(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors),
       testM("accumulate successes") {
         implicit val canFail = CanFail
         val in               = List.range(0, 10)
-        val res              = IO.validate(in)(a => ZIO.succeedNow(a))
+        val res              = IO.validate(in)(a => ZIO.succeed(a))
         assertM(res)(equalTo(in))
       }
     ),
@@ -2969,13 +2969,13 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("accumulate errors and ignore successes") {
         implicit val canFail = CanFail
         val in               = List.range(0, 10)
-        val res              = ZIO.validatePar(in)(a => if (a % 2 == 0) ZIO.succeedNow(a) else ZIO.fail(a))
+        val res              = ZIO.validatePar(in)(a => if (a % 2 == 0) ZIO.succeed(a) else ZIO.fail(a))
         assertM(res.flip)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors),
       testM("accumulate successes") {
         implicit val canFail = CanFail
         val in               = List.range(0, 10)
-        val res              = IO.validatePar(in)(a => ZIO.succeedNow(a))
+        val res              = IO.validatePar(in)(a => ZIO.succeed(a))
         assertM(res)(equalTo(in))
       }
     ),
@@ -2988,12 +2988,12 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("runs sequentially and short circuits on first success validation") {
         implicit val canFail = CanFail
         val in               = List.range(1, 10)
-        val f                = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.fail(a)
+        val f                = (a: Int) => if (a == 6) ZIO.succeed(a) else ZIO.fail(a)
 
         for {
           counter    <- Ref.make(0)
           res        <- ZIO.validateFirst(in)(a => counter.update(_ + 1) *> f(a))
-          assertions <- assertM(ZIO.succeedNow(res))(equalTo(6)) && assertM(counter.get)(equalTo(6))
+          assertions <- assertM(ZIO.succeed(res))(equalTo(6)) && assertM(counter.get)(equalTo(6))
         } yield assertions
       },
       testM("returns errors in correct order") {
@@ -3012,7 +3012,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns success if valid") {
         implicit val canFail = CanFail
         val in               = List.range(1, 10)
-        val f                = (a: Int) => if (a == 6) ZIO.succeedNow(a) else ZIO.fail(a)
+        val f                = (a: Int) => if (a == 6) ZIO.succeed(a) else ZIO.fail(a)
         val res              = ZIO.validateFirstPar(in)(f(_))
         assertM(res)(equalTo(6))
       }
@@ -3054,9 +3054,9 @@ object ZIOSpec extends ZIOBaseSpec {
         val v2: Option[Int] = Some(0)
         for {
           ref  <- Ref.make(false)
-          _    <- ZIO.whenCaseM(IO.succeedNow(v1)) { case Some(_) => ref.set(true) }
+          _    <- ZIO.whenCaseM(IO.succeed(v1)) { case Some(_) => ref.set(true) }
           res1 <- ref.get
-          _    <- ZIO.whenCaseM(IO.succeedNow(v2)) { case Some(_) => ref.set(true) }
+          _    <- ZIO.whenCaseM(IO.succeed(v2)) { case Some(_) => ref.set(true) }
           res2 <- ref.get
         } yield assert(res1)(isFalse) && assert(res2)(isTrue)
       }
@@ -3127,7 +3127,7 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       },
       testM("does not report failure when interrupting loser after it succeeded") {
-        val io          = ZIO.interrupt.zipPar(IO.succeedNow(1))
+        val io          = ZIO.interrupt.zipPar(IO.succeed(1))
         val interrupted = io.sandbox.either.map(_.left.map(_.interrupted))
         assertM(interrupted)(isLeft(isTrue))
       } @@ zioTag(interruption)
@@ -3153,7 +3153,7 @@ object ZIOSpec extends ZIOBaseSpec {
   def exactlyOnce[R, A, A1](value: A)(func: UIO[A] => ZIO[R, String, A1]): ZIO[R, String, A1] =
     Ref.make(0).flatMap { ref =>
       for {
-        res   <- func(ref.update(_ + 1) *> ZIO.succeedNow(value))
+        res   <- func(ref.update(_ + 1) *> ZIO.succeed(value))
         count <- ref.get
         _ <- if (count != 1) {
               ZIO.fail("Accessed more than once")
@@ -3191,7 +3191,7 @@ object ZIOSpec extends ZIOBaseSpec {
       if (n <= 0) acc
       else loop(n - 1, acc.map(_ + 1))
 
-    loop(n, IO.succeedNow(0))
+    loop(n, IO.succeed(0))
   }
 
   def deepMapEffect(n: Int): UIO[Int] = {
@@ -3216,7 +3216,7 @@ object ZIOSpec extends ZIOBaseSpec {
     else fib(n - 1) + fib(n - 2)
 
   def concurrentFib(n: Int): Task[BigInt] =
-    if (n <= 1) IO.succeedNow[BigInt](n)
+    if (n <= 1) IO.succeed[BigInt](n)
     else
       for {
         f1 <- concurrentFib(n - 1).fork

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -14,7 +14,7 @@ object ZLayerSpec extends ZIOBaseSpec {
   trait Cat extends Animal
 
   def testSize[R <: Has[_]](layer: Layer[Nothing, R], n: Int, label: String = ""): UIO[TestResult] =
-    layer.build.use(env => ZIO.succeedNow(assert(env.size)(if (label == "") equalTo(n) else equalTo(n) ?? label)))
+    layer.build.use(env => ZIO.succeed(assert(env.size)(if (label == "") equalTo(n) else equalTo(n) ?? label)))
 
   val acquire1 = "Acquiring Module 1"
   val acquire2 = "Acquiring Module 2"

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -15,17 +15,17 @@ object ZManagedSpec extends ZIOBaseSpec {
   def spec = suite("ZManaged")(
     suite("absorbWith")(
       testM("on fail") {
-        assertM(ZManagedExampleError.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeedNow).run)(
+        assertM(ZManagedExampleError.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed(_)).run)(
           fails(equalTo(ExampleError))
         )
       } @@ zioTag(errors),
       testM("on die") {
-        assertM(ZManagedExampleDie.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeedNow).run)(
+        assertM(ZManagedExampleDie.absorbWith(identity).use[Any, Throwable, Int](ZIO.succeed(_)).run)(
           fails(equalTo(ExampleError))
         )
       } @@ zioTag(errors),
       testM("on success") {
-        assertM(ZIO.succeedNow(1).absorbWith(_ => ExampleError))(equalTo(1))
+        assertM(ZIO.succeed(1).absorbWith(_ => ExampleError))(equalTo(1))
       }
     ),
     suite("make")(
@@ -40,9 +40,9 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("Properly performs parallel acquire and release") {
         for {
           log      <- Ref.make[List[String]](Nil)
-          a        = ZManaged.make(UIO.succeedNow("A"))(_ => log.update("A" :: _))
-          b        = ZManaged.make(UIO.succeedNow("B"))(_ => log.update("B" :: _))
-          result   <- a.zipWithPar(b)(_ + _).use(ZIO.succeedNow)
+          a        = ZManaged.make(UIO.succeed("A"))(_ => log.update("A" :: _))
+          b        = ZManaged.make(UIO.succeed("B"))(_ => log.update("B" :: _))
+          result   <- a.zipWithPar(b)(_ + _).use(ZIO.succeed(_))
           cleanups <- log.get
         } yield assert(result.length)(equalTo(2)) && assert(cleanups)(hasSize(equalTo(2)))
       },
@@ -66,7 +66,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         def managed3: ZManaged[R2, E, A]         = ZManaged.make(acquire2)(release3)
         def managed4: ZManaged[R2, E, A]         = ZManaged.make(acquire3)(release2)
         lazy val result                          = (managed1, managed2, managed3, managed4)
-        ZIO.succeedNow(assert(result)(anything))
+        ZIO.succeed(assert(result)(anything))
       }
     ),
     suite("makeEffect")(
@@ -126,14 +126,14 @@ object ZManagedSpec extends ZIOBaseSpec {
     ) @@ zioTag(errors),
     suite("fromEffect")(
       testM("Performed interruptibly") {
-        assertM(ZManaged.fromEffect(ZIO.checkInterruptible(ZIO.succeedNow)).use(ZIO.succeedNow))(
+        assertM(ZManaged.fromEffect(ZIO.checkInterruptible(ZIO.succeed(_))).use(ZIO.succeed(_)))(
           equalTo(InterruptStatus.interruptible)
         )
       }
     ) @@ zioTag(interruption),
     suite("fromEffectUninterruptible")(
       testM("Performed uninterruptibly") {
-        assertM(ZManaged.fromEffectUninterruptible(ZIO.checkInterruptible(ZIO.succeedNow)).use(ZIO.succeedNow))(
+        assertM(ZManaged.fromEffectUninterruptible(ZIO.checkInterruptible(ZIO.succeed(_))).use(ZIO.succeed(_)))(
           equalTo(InterruptStatus.uninterruptible)
         )
       }
@@ -203,7 +203,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         for {
           v <- ref.get
           r <- if (v < 10) ref.update(_ + 1) *> IO.fail("Ouch")
-              else UIO.succeedNow(v)
+              else UIO.succeed(v)
         } yield r
 
       for {
@@ -242,7 +242,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         for {
           effects <- Ref.make[List[Int]](Nil)
           res     = (x: Int) => Managed.make(effects.update(x :: _))(_ => effects.update(x :: _))
-          program = ZManaged.succeedNow(()).foldM(_ => Managed.unit, _ => res(1))
+          program = ZManaged.succeed(()).foldM(_ => Managed.unit, _ => res(1))
           values  <- program.use_(ZIO.unit).ignore *> effects.get
         } yield assert(values)(equalTo(List(1, 1)))
       },
@@ -283,10 +283,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("foreach")(
       testM("Returns elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
 
         val managed = ZManaged.foreach(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.foreach(List(1, 2, 3, 4))(_ => res))
@@ -322,10 +322,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("foreachPar")(
       testM("Returns elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
 
         val managed = ZManaged.foreachPar(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.foreachPar(List(1, 2, 3, 4))(_ => res))
@@ -340,10 +340,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("foreachParN")(
       testM("Returns elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
 
         val managed = ZManaged.foreachParN(2)(List(1, 2, 3, 4))(res)
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Uses at most n fibers for reservation") {
         testFinalizersPar(4, res => ZManaged.foreachParN(2)(List(1, 2, 3, 4))(_ => res))
@@ -431,12 +431,12 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("ifM")(
       testM("runs `onTrue` if result of `b` is `true`") {
-        val managed = ZManaged.ifM(ZManaged.succeedNow(true))(ZManaged.succeedNow(true), ZManaged.succeedNow(false))
-        assertM(managed.use(ZIO.succeedNow))(isTrue)
+        val managed = ZManaged.ifM(ZManaged.succeed(true))(ZManaged.succeed(true), ZManaged.succeed(false))
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
       },
       testM("runs `onFalse` if result of `b` is `false`") {
-        val managed = ZManaged.ifM(ZManaged.succeedNow(false))(ZManaged.succeedNow(true), ZManaged.succeedNow(false))
-        assertM(managed.use(ZIO.succeedNow))(isFalse)
+        val managed = ZManaged.ifM(ZManaged.succeed(false))(ZManaged.succeed(true), ZManaged.succeed(false))
+        assertM(managed.use(ZIO.succeed(_)))(isFalse)
       },
       testM("infers correctly") {
         trait R
@@ -444,9 +444,9 @@ object ZManagedSpec extends ZIOBaseSpec {
         trait E1
         trait E extends E1
         trait A
-        val b: ZManaged[R, E, Boolean]   = ZManaged.succeedNow(true)
-        val onTrue: ZManaged[R1, E1, A]  = ZManaged.succeedNow(new A {})
-        val onFalse: ZManaged[R1, E1, A] = ZManaged.succeedNow(new A {})
+        val b: ZManaged[R, E, Boolean]   = ZManaged.succeed(true)
+        val onTrue: ZManaged[R1, E1, A]  = ZManaged.succeed(new A {})
+        val onFalse: ZManaged[R1, E1, A] = ZManaged.succeed(new A {})
         val _                            = ZManaged.ifM(b)(onTrue, onFalse)
         ZIO.succeed(assertCompletes)
       }
@@ -454,10 +454,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("mergeAll")(
       testM("Merges elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
 
         val managed = ZManaged.mergeAll(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(4, res => ZManaged.mergeAll(List.fill(4)(res))(()) { case (_, b) => b })
@@ -466,10 +466,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("mergeAllPar")(
       testM("Merges elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
 
         val managed = ZManaged.mergeAllPar(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Runs reservations in parallel") {
         testReservePar(4, res => ZManaged.mergeAllPar(List.fill(4)(res))(()) { case (_, b) => b })
@@ -484,9 +484,9 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("mergeAllParN")(
       testM("Merges elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(int)
+          ZManaged.succeed(int)
         val managed = ZManaged.mergeAllParN(2)(List(1, 2, 3, 4).map(res))(List[Int]()) { case (acc, a) => a :: acc }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Uses at most n fibers for reservation") {
         testReservePar(2, res => ZManaged.mergeAllParN(2)(List.fill(4)(res))(0) { case (a, _) => a })
@@ -523,7 +523,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           finalizersRef <- Ref.make[List[String]](Nil)
           resultRef     <- Ref.make[Option[Exit[Nothing, String]]](None)
           _ <- ZManaged
-                .make(UIO.succeedNow("42"))(_ => finalizersRef.update("First" :: _))
+                .make(UIO.succeed("42"))(_ => finalizersRef.update("First" :: _))
                 .onExit(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
@@ -534,35 +534,35 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("option")(
       testM("return success in Some") {
         implicit val canFail = CanFail
-        val managed          = ZManaged.succeedNow(11).option
-        managed.use(res => ZIO.succeedNow(assert(res)(equalTo(Some(11)))))
+        val managed          = ZManaged.succeed(11).option
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(Some(11)))))
       },
       testM("return failure as None") {
         val managed = ZManaged.fail(123).option
-        managed.use(res => ZIO.succeedNow(assert(res)(equalTo(None))))
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(None))))
       } @@ zioTag(errors),
       testM("not catch throwable") {
         implicit val canFail                                          = CanFail
         val managed: Managed[Nothing, Exit[Nothing, Option[Nothing]]] = ZManaged.die(ExampleError).option.run
-        managed.use(res => ZIO.succeedNow(assert(res)(dies(equalTo(ExampleError)))))
+        managed.use(res => ZIO.succeed(assert(res)(dies(equalTo(ExampleError)))))
       } @@ zioTag(errors),
       testM("catch throwable after sandboxing") {
         val managed: Managed[Nothing, Option[Nothing]] = ZManaged.die(ExampleError).sandbox.option
-        managed.use(res => ZIO.succeedNow(assert(res)(equalTo(None))))
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(None))))
       } @@ zioTag(errors)
     ),
     suite("optional")(
       testM("fails when given Some error") {
         val managed: UManaged[Exit[String, Option[Int]]] = Managed.fail(Some("Error")).optional.run
-        managed.use(res => ZIO.succeedNow(assert(res)(fails(equalTo("Error")))))
+        managed.use(res => ZIO.succeed(assert(res)(fails(equalTo("Error")))))
       } @@ zioTag(errors),
       testM("succeeds with None given None error") {
         val managed: Managed[String, Option[Int]] = Managed.fail(None).optional
-        managed.use(res => ZIO.succeedNow(assert(res)(isNone)))
+        managed.use(res => ZIO.succeed(assert(res)(isNone)))
       } @@ zioTag(errors),
       testM("succeeds with Some given a value") {
-        val managed: Managed[String, Option[Int]] = Managed.succeedNow(1).optional
-        managed.use(res => ZIO.succeedNow(assert(res)(isSome(equalTo(1)))))
+        val managed: Managed[String, Option[Int]] = Managed.succeed(1).optional
+        managed.use(res => ZIO.succeed(assert(res)(isSome(equalTo(1)))))
       }
     ),
     suite("onExitFirst")(
@@ -571,7 +571,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           finalizersRef <- Ref.make[List[String]](Nil)
           resultRef     <- Ref.make[Option[Exit[Nothing, String]]](None)
           _ <- ZManaged
-                .make(UIO.succeedNow("42"))(_ => finalizersRef.update("First" :: _))
+                .make(UIO.succeed("42"))(_ => finalizersRef.update("First" :: _))
                 .onExitFirst(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
@@ -582,23 +582,23 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("orElseFail")(
       testM("executes this effect and returns its value if it succeeds") {
         implicit val canFail = CanFail
-        val managed          = ZManaged.succeedNow(true).orElseFail(false)
-        assertM(managed.use(ZIO.succeedNow))(isTrue)
+        val managed          = ZManaged.succeed(true).orElseFail(false)
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
       },
       testM("otherwise fails with the specified error") {
         val managed = ZManaged.fail(false).orElseFail(true).flip
-        assertM(managed.use(ZIO.succeedNow))(isTrue)
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
       }
     ) @@ zioTag(errors),
     suite("orElseSucceed")(
       testM("executes this effect and returns its value if it succeeds") {
         implicit val canFail = CanFail
-        val managed          = ZManaged.succeedNow(true).orElseSucceed(false)
-        assertM(managed.use(ZIO.succeedNow))(isTrue)
+        val managed          = ZManaged.succeed(true).orElseSucceed(false)
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
       },
       testM("otherwise succeeds with the specified value") {
         val managed = ZManaged.fail(false).orElseSucceed(true)
-        assertM(managed.use(ZIO.succeedNow))(isTrue)
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
       }
     ) @@ zioTag(errors),
     suite("preallocate")(
@@ -667,75 +667,75 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("reduceAll")(
       testM("Reduces elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(List(int))
+          ZManaged.succeed(List(int))
 
-        val managed = ZManaged.reduceAll(ZManaged.succeedNow(Nil), List(1, 2, 3, 4).map(res)) {
+        val managed = ZManaged.reduceAll(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (a1, a2) => a1 ++ a2
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs finalizers") {
         testFinalizersPar(
           4,
-          res => ZManaged.reduceAll(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAll(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       }
     ),
     suite("reduceAllPar")(
       testM("Reduces elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(List(int))
+          ZManaged.succeed(List(int))
 
-        val managed = ZManaged.reduceAllPar(ZManaged.succeedNow(Nil), List(1, 2, 3, 4).map(res)) {
+        val managed = ZManaged.reduceAllPar(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (a1, a2) => a1 ++ a2
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(1, 2, 3, 4)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(1, 2, 3, 4)))))
       },
       testM("Runs reservations in parallel") {
         testReservePar(
           4,
-          res => ZManaged.reduceAllPar(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllPar(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       },
       testM("Runs acquisitions in parallel") {
         testAcquirePar(
           4,
-          res => ZManaged.reduceAllPar(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllPar(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       },
       testM("Runs finalizers") {
         testFinalizersPar(
           4,
-          res => ZManaged.reduceAllPar(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllPar(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       }
     ),
     suite("reduceAllParN")(
       testM("Reduces elements in the correct order") {
         def res(int: Int) =
-          ZManaged.succeedNow(List(int))
+          ZManaged.succeed(List(int))
 
-        val managed = ZManaged.reduceAllParN(2)(ZManaged.succeedNow(Nil), List(1, 2, 3, 4).map(res)) {
+        val managed = ZManaged.reduceAllParN(2)(ZManaged.succeed(Nil), List(1, 2, 3, 4).map(res)) {
           case (acc, a) => a ++ acc
         }
-        managed.use[Any, Nothing, TestResult](res => ZIO.succeedNow(assert(res)(equalTo(List(4, 3, 2, 1)))))
+        managed.use[Any, Nothing, TestResult](res => ZIO.succeed(assert(res)(equalTo(List(4, 3, 2, 1)))))
       },
       testM("Uses at most n fibers for reservation") {
         testFinalizersPar(
           4,
-          res => ZManaged.reduceAllParN(2)(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllParN(2)(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       },
       testM("Uses at most n fibers for acquisition") {
         testReservePar(
           2,
-          res => ZManaged.reduceAllParN(2)(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllParN(2)(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       },
       testM("Runs finalizers") {
         testAcquirePar(
           2,
-          res => ZManaged.reduceAllParN(2)(ZManaged.succeedNow(0), List.fill(4)(res)) { case (a, _) => a }
+          res => ZManaged.reduceAllParN(2)(ZManaged.succeed(0), List.fill(4)(res)) { case (a, _) => a }
         )
       },
       testM("All finalizers run even when finalizers have defects") {
@@ -761,65 +761,65 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("some")(
       testM("extracts the value from Some") {
         val managed: Managed[Option[Throwable], Int] = Managed.succeed(Some(1)).some
-        managed.use(res => ZIO.succeedNow(assert(res)(equalTo(1))))
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(1))))
       },
       testM("fails on None") {
         val managed: Managed[Option[Throwable], Int] = Managed.succeed(None).some
-        managed.run.use(res => ZIO.succeedNow(assert(res)(fails(isNone))))
+        managed.run.use(res => ZIO.succeed(assert(res)(fails(isNone))))
       } @@ zioTag(errors),
       testM("fails when given an exception") {
         val ex                                       = new RuntimeException("Failed Task")
         val managed: Managed[Option[Throwable], Int] = Managed.fail(ex).some
-        managed.run.use(res => ZIO.succeedNow(assert(res)(fails(isSome(equalTo(ex))))))
+        managed.run.use(res => ZIO.succeed(assert(res)(fails(isSome(equalTo(ex))))))
       } @@ zioTag(errors)
     ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
-        val managed = Managed.succeedNow(Some(42)).someOrFailException
-        managed.use(res => ZIO.succeedNow(assert(res)(equalTo(42))))
+        val managed = Managed.succeed(Some(42)).someOrFailException
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(42))))
       },
       testM("fails when given a None") {
-        val managed = Managed.succeedNow(Option.empty[Int]).someOrFailException
-        managed.run.use(res => ZIO.succeedNow(assert(res)(fails(isSubtype[NoSuchElementException](anything)))))
+        val managed = Managed.succeed(Option.empty[Int]).someOrFailException
+        managed.run.use(res => ZIO.succeed(assert(res)(fails(isSubtype[NoSuchElementException](anything)))))
       } @@ zioTag(errors),
       suite("without another error type")(
         testM("succeed something") {
-          val managed = Managed.succeedNow(Option(3)).someOrFailException
-          managed.use(res => ZIO.succeedNow(assert(res)(equalTo(3))))
+          val managed = Managed.succeed(Option(3)).someOrFailException
+          managed.use(res => ZIO.succeed(assert(res)(equalTo(3))))
         },
         testM("succeed nothing") {
-          val managed = Managed.succeedNow(None: Option[Int]).someOrFailException.run
-          managed.use(res => ZIO.succeedNow(assert(res)(fails(anything))))
+          val managed = Managed.succeed(None: Option[Int]).someOrFailException.run
+          managed.use(res => ZIO.succeed(assert(res)(fails(anything))))
         } @@ zioTag(errors)
       ),
       suite("with throwable as base error type")(
         testM("return something") {
           val managed = Managed.succeed(Option(3)).someOrFailException
-          managed.use(res => ZIO.succeedNow(assert(res)(equalTo(3))))
+          managed.use(res => ZIO.succeed(assert(res)(equalTo(3))))
         }
       ),
       suite("with exception as base error type")(
         testM("return something") {
-          val managed = (Managed.succeedNow(Option(3)): Managed[Exception, Option[Int]]).someOrFailException
-          managed.use(res => ZIO.succeedNow(assert(res)(equalTo(3))))
+          val managed = (Managed.succeed(Option(3)): Managed[Exception, Option[Int]]).someOrFailException
+          managed.use(res => ZIO.succeed(assert(res)(equalTo(3))))
         }
       )
     ),
     suite("reject")(
       testM("returns failure ignoring value") {
         val goodCase =
-          ZManaged.succeedNow(0).reject({ case v if v != 0 => "Partial failed!" }).sandbox.either
+          ZManaged.succeed(0).reject({ case v if v != 0 => "Partial failed!" }).sandbox.either
 
         val badCase = ZManaged
-          .succeedNow(1)
+          .succeed(1)
           .reject({ case v if v != 0 => "Partial failed!" })
           .sandbox
           .either
           .map(_.left.map(_.failureOrCause))
 
         for {
-          goodCaseCheck <- goodCase.use(r => ZIO.succeedNow(assert(r)(isRight(equalTo(0)))))
-          badCaseCheck  <- badCase.use(r => ZIO.succeedNow(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
+          goodCaseCheck <- goodCase.use(r => ZIO.succeed(assert(r)(isRight(equalTo(0)))))
+          badCaseCheck  <- badCase.use(r => ZIO.succeed(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
         } yield goodCaseCheck && badCaseCheck
       }
     ) @@ zioTag(errors),
@@ -827,14 +827,14 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("returns failure ignoring value") {
         val goodCase =
           ZManaged
-            .succeedNow(0)
-            .rejectM[Any, String]({ case v if v != 0 => ZManaged.succeedNow("Partial failed!") })
+            .succeed(0)
+            .rejectM[Any, String]({ case v if v != 0 => ZManaged.succeed("Partial failed!") })
             .sandbox
             .either
 
         val partialBadCase =
           ZManaged
-            .succeedNow(1)
+            .succeed(1)
             .rejectM({ case v if v != 0 => ZManaged.fail("Partial failed!") })
             .sandbox
             .either
@@ -842,16 +842,16 @@ object ZManagedSpec extends ZIOBaseSpec {
 
         val badCase =
           ZManaged
-            .succeedNow(1)
+            .succeed(1)
             .rejectM({ case v if v != 0 => ZManaged.fail("Partial failed!") })
             .sandbox
             .either
             .map(_.left.map(_.failureOrCause))
 
         for {
-          r1 <- goodCase.use(r => ZIO.succeedNow(assert(r)(isRight(equalTo(0)))))
-          r2 <- partialBadCase.use(r => ZIO.succeedNow(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
-          r3 <- badCase.use(r => ZIO.succeedNow(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
+          r1 <- goodCase.use(r => ZIO.succeed(assert(r)(isRight(equalTo(0)))))
+          r2 <- partialBadCase.use(r => ZIO.succeed(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
+          r3 <- badCase.use(r => ZIO.succeed(assert(r)(isLeft(isLeft(equalTo("Partial failed!"))))))
         } yield r1 && r2 && r3
       }
     ) @@ zioTag(errors),
@@ -886,7 +886,7 @@ object ZManagedSpec extends ZIOBaseSpec {
             retries1.updateAndGet(_ + 1).flatMap { r1 =>
               if (r1 < 3) ZIO.fail(())
               else
-                ZIO.succeedNow {
+                ZIO.succeed {
                   Reservation(
                     retries2.updateAndGet(_ + 1).flatMap(r2 => if (r2 == 3) ZIO.unit else ZIO.fail(())),
                     _ => ZIO.unit
@@ -1036,10 +1036,10 @@ object ZManagedSpec extends ZIOBaseSpec {
     suite("tap")(
       testM("Doesn't change the managed resource") {
         ZManaged
-          .succeedNow(1)
-          .tap(n => ZManaged.succeedNow(n + 1))
+          .succeed(1)
+          .tap(n => ZManaged.succeed(n + 1))
           .map(actual => assert(1)(equalTo(actual)))
-          .use(ZIO.succeedNow)
+          .use(ZIO.succeed(_))
       },
       testM("Runs given effect") {
         Ref
@@ -1048,16 +1048,16 @@ object ZManagedSpec extends ZIOBaseSpec {
           .tap(_.update(_ + 1).toManaged_)
           .mapM(_.get)
           .map(i => assert(i)(equalTo(1)))
-          .use(ZIO.succeedNow)
+          .use(ZIO.succeed(_))
       }
     ),
     suite("tapBoth")(
       testM("Doesn't change the managed resource") {
         ZManaged
           .fromEither(Right[String, Int](1))
-          .tapBoth(_ => ZManaged.unit, n => ZManaged.succeedNow(n + 1))
+          .tapBoth(_ => ZManaged.unit, n => ZManaged.succeed(n + 1))
           .map(actual => assert(1)(equalTo(actual)))
-          .use(ZIO.succeedNow)
+          .use(ZIO.succeed(_))
       },
       testM("Runs given effect on failure") {
         (
@@ -1068,7 +1068,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                   .tapBoth(e => ref.update(_ + e).toManaged_, (_: Any) => ZManaged.unit)
             actual <- ref.get.toManaged_
           } yield assert(actual)(equalTo(2))
-        ).fold(e => assert(e)(equalTo(1)), identity).use(ZIO.succeedNow)
+        ).fold(e => assert(e)(equalTo(1)), identity).use(ZIO.succeed(_))
       } @@ zioTag(errors),
       testM("Runs given effect on success") {
         (
@@ -1079,7 +1079,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                   .tapBoth(_ => ZManaged.unit, n => ref.update(_ + n).toManaged_)
             actual <- ref.get.toManaged_
           } yield assert(actual)(equalTo(3))
-        ).use(ZIO.succeedNow)
+        ).use(ZIO.succeed(_))
       }
     ),
     suite("tapCause")(
@@ -1089,16 +1089,16 @@ object ZManagedSpec extends ZIOBaseSpec {
           result <- ZManaged.dieMessage("die").tapCause(_ => ref.set(true).toManaged_).run
           effect <- ref.get.toManaged_
         } yield assert(result)(dies(hasMessage(equalTo("die")))) &&
-          assert(effect)(isTrue)).use(ZIO.succeedNow)
+          assert(effect)(isTrue)).use(ZIO.succeed(_))
       }
     ) @@ zioTag(errors),
     suite("tapError")(
       testM("Doesn't change the managed resource") {
         ZManaged
           .fromEither(Right[String, Int](1))
-          .tapError(str => ZManaged.succeedNow(str.length))
+          .tapError(str => ZManaged.succeed(str.length))
           .map(actual => assert(1)(equalTo(actual)))
-          .use(ZIO.succeedNow)
+          .use(ZIO.succeed(_))
       },
       testM("Runs given effect on failure") {
         (
@@ -1109,7 +1109,7 @@ object ZManagedSpec extends ZIOBaseSpec {
                   .tapError(e => ref.update(_ + e).toManaged_)
             actual <- ref.get.toManaged_
           } yield assert(actual)(equalTo(2))
-        ).fold(e => assert(e)(equalTo(1)), identity).use(ZIO.succeedNow)
+        ).fold(e => assert(e)(equalTo(1)), identity).use(ZIO.succeed(_))
       } @@ zioTag(errors),
       testM("Doesn't run given effect on success") {
         (
@@ -1120,17 +1120,17 @@ object ZManagedSpec extends ZIOBaseSpec {
                   .tapError(n => ref.update(_ + n).toManaged_)
             actual <- ref.get.toManaged_
           } yield assert(actual)(equalTo(1))
-        ).use(ZIO.succeedNow)
+        ).use(ZIO.succeed(_))
       }
     ),
     suite("timed")(
       testM("Should time both the reservation and the acquisition") {
         val managed = ZManaged(
-          clock.sleep(20.milliseconds) *> ZIO.succeedNow(Reservation(clock.sleep(20.milliseconds), _ => ZIO.unit))
+          clock.sleep(20.milliseconds) *> ZIO.succeed(Reservation(clock.sleep(20.milliseconds), _ => ZIO.unit))
         )
         val test = managed.timed.use {
           case (duration, _) =>
-            ZIO.succeedNow(assert(duration.toNanos)(isGreaterThanEqualTo(40.milliseconds.toNanos)))
+            ZIO.succeed(assert(duration.toNanos)(isGreaterThanEqualTo(40.milliseconds.toNanos)))
         }
         def awaitSleeps(n: Int): ZIO[TestClock with Live, Nothing, Unit] =
           TestClock.sleeps.flatMap {
@@ -1149,14 +1149,14 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("timeout")(
       testM("Returns Some if the timeout isn't reached") {
-        val managed = ZManaged.make(ZIO.succeedNow(1))(_ => ZIO.unit)
-        managed.timeout(Duration.Infinity).use(res => ZIO.succeedNow(assert(res)(isSome(equalTo(1)))))
+        val managed = ZManaged.make(ZIO.succeed(1))(_ => ZIO.unit)
+        managed.timeout(Duration.Infinity).use(res => ZIO.succeed(assert(res)(isSome(equalTo(1)))))
       },
       testM("Returns None if the reservation takes longer than d") {
         for {
           latch   <- Promise.make[Nothing, Unit]
           managed = ZManaged.make(latch.await)(_ => ZIO.unit)
-          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeedNow(assert(res)(isNone)))
+          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res)(isNone)))
           _       <- latch.succeed(())
         } yield res
       },
@@ -1164,7 +1164,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         for {
           latch   <- Promise.make[Nothing, Unit]
           managed = ZManaged.reserve(Reservation(latch.await, _ => ZIO.unit))
-          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeedNow(assert(res)(isNone)))
+          res     <- managed.timeout(Duration.Zero).use(res => ZIO.succeed(assert(res)(isNone)))
           _       <- latch.succeed(())
         } yield res
       },
@@ -1173,7 +1173,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           reserveLatch <- Promise.make[Nothing, Unit]
           releaseLatch <- Promise.make[Nothing, Unit]
           managed      = ZManaged.reserve(Reservation(reserveLatch.await, _ => releaseLatch.succeed(())))
-          res          <- managed.timeout(Duration.Zero).use(ZIO.succeedNow)
+          res          <- managed.timeout(Duration.Zero).use(ZIO.succeed(_))
           _            <- reserveLatch.succeed(())
           _            <- releaseLatch.await
         } yield assert(res)(isNone)
@@ -1183,9 +1183,9 @@ object ZManagedSpec extends ZIOBaseSpec {
           acquireLatch <- Promise.make[Nothing, Unit]
           releaseLatch <- Promise.make[Nothing, Unit]
           managed = ZManaged(
-            acquireLatch.await *> ZIO.succeedNow(Reservation(ZIO.unit, _ => releaseLatch.succeed(())))
+            acquireLatch.await *> ZIO.succeed(Reservation(ZIO.unit, _ => releaseLatch.succeed(())))
           )
-          res <- managed.timeout(Duration.Zero).use(ZIO.succeedNow)
+          res <- managed.timeout(Duration.Zero).use(ZIO.succeed(_))
           _   <- acquireLatch.succeed(())
           _   <- releaseLatch.await
         } yield assert(res)(isNone)
@@ -1313,22 +1313,22 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("Returns the same as ZManaged.flatten") {
         checkM(Gen.string(Gen.alphaNumericChar)) { str =>
           val test = for {
-            flatten1 <- ZManaged.succeedNow(ZManaged.succeedNow(str)).flatten
-            flatten2 <- ZManaged.flatten(ZManaged.succeedNow(ZManaged.succeedNow(str)))
+            flatten1 <- ZManaged.succeed(ZManaged.succeed(str)).flatten
+            flatten2 <- ZManaged.flatten(ZManaged.succeed(ZManaged.succeed(str)))
           } yield assert(flatten1)(equalTo(flatten2))
-          test.use[Any, Nothing, TestResult](r => ZIO.succeedNow(r))
+          test.use[Any, Nothing, TestResult](r => ZIO.succeed(r))
         }
       }
     ),
     suite("absolve")(
       testM("Returns the same as ZManaged.absolve") {
         checkM(Gen.string(Gen.alphaNumericChar)) { str =>
-          val managedEither: ZManaged[Any, Nothing, Either[Nothing, String]] = ZManaged.succeedNow(Right(str))
+          val managedEither: ZManaged[Any, Nothing, Either[Nothing, String]] = ZManaged.succeed(Right(str))
           val test = for {
             abs1 <- managedEither.absolve
             abs2 <- ZManaged.absolve(managedEither)
           } yield assert(abs1)(equalTo(abs2))
-          test.use[Any, Nothing, TestResult](result => ZIO.succeedNow(result))
+          test.use[Any, Nothing, TestResult](result => ZIO.succeed(result))
         }
       }
     ),
@@ -1449,11 +1449,11 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("merge")(
       testM("on flipped result") {
-        val managed: Managed[Int, Int] = ZManaged.succeedNow(1)
+        val managed: Managed[Int, Int] = ZManaged.succeed(1)
 
         for {
-          a <- managed.merge.use(ZIO.succeedNow)
-          b <- managed.flip.merge.use(ZIO.succeedNow)
+          a <- managed.merge.use(ZIO.succeed(_))
+          b <- managed.flip.merge.use(ZIO.succeed(_))
         } yield assert(a)(equalTo(b))
       }
     ),
@@ -1461,53 +1461,53 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("catchAllCause") {
         val zm: ZManaged[Any, String, String] =
           for {
-            _ <- ZManaged.succeedNow("foo")
+            _ <- ZManaged.succeed("foo")
             f <- ZManaged.fail("Uh oh!")
           } yield f
 
-        val errorToVal = zm.catchAllCause(c => ZManaged.succeedNow(c.failureOption.getOrElse(c.toString)))
-        assertM(errorToVal.use(ZIO.succeedNow))(equalTo("Uh oh!"))
+        val errorToVal = zm.catchAllCause(c => ZManaged.succeed(c.failureOption.getOrElse(c.toString)))
+        assertM(errorToVal.use(ZIO.succeed(_)))(equalTo("Uh oh!"))
       },
       testM("catchAllSomeCause transforms cause if matched") {
         val zm: ZManaged[Any, String, String] =
           for {
-            _ <- ZManaged.succeedNow("foo")
+            _ <- ZManaged.succeed("foo")
             f <- ZManaged.fail("Uh oh!")
           } yield f
 
         val errorToVal = zm.catchSomeCause {
-          case Cause.Fail("Uh oh!") => ZManaged.succeedNow("matched")
+          case Cause.Fail("Uh oh!") => ZManaged.succeed("matched")
         }
-        assertM(errorToVal.use(ZIO.succeedNow))(equalTo("matched"))
+        assertM(errorToVal.use(ZIO.succeed(_)))(equalTo("matched"))
       } @@ zioTag(errors),
       testM("catchAllSomeCause keeps the failure cause if not matched") {
         val zm: ZManaged[Any, String, String] =
           for {
-            _ <- ZManaged.succeedNow("foo")
+            _ <- ZManaged.succeed("foo")
             f <- ZManaged.fail("Uh oh!")
           } yield f
 
         val errorToVal = zm.catchSomeCause {
-          case Cause.Fail("not matched") => ZManaged.succeedNow("matched")
+          case Cause.Fail("not matched") => ZManaged.succeed("matched")
         }
-        val executed = errorToVal.use[Any, String, String](ZIO.succeedNow).run
+        val executed = errorToVal.use[Any, String, String](ZIO.succeed(_)).run
         assertM(executed)(fails(equalTo("Uh oh!")))
       } @@ zioTag(errors)
     ),
     suite("collect")(
       testM("collectM maps value, if PF matched") {
-        val managed = ZManaged.succeedNow(42).collectM("Oh No!") {
-          case 42 => ZManaged.succeedNow(84)
+        val managed = ZManaged.succeed(42).collectM("Oh No!") {
+          case 42 => ZManaged.succeed(84)
         }
-        val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeedNow)
+        val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeed(_))
 
         assertM(effect)(equalTo(84))
       },
       testM("collectM produces given error, if PF not matched") {
-        val managed = ZManaged.succeedNow(42).collectM("Oh No!") {
-          case 43 => ZManaged.succeedNow(84)
+        val managed = ZManaged.succeed(42).collectM("Oh No!") {
+          case 43 => ZManaged.succeed(84)
         }
-        val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeedNow)
+        val effect: ZIO[Any, String, Int] = managed.use(ZIO.succeed(_))
 
         assertM(effect.run)(fails(equalTo("Oh No!")))
       }
@@ -1549,7 +1549,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       val reserve = ref.update(_ + 1)
       val acquire = ref.update(_ + 1)
       val release = ref.update(n => if (n > 0) 0 else -1)
-      reserve *> ZIO.succeedNow(Reservation(acquire, _ => release))
+      reserve *> ZIO.succeed(Reservation(acquire, _ => release))
     }
 
   def testFinalizersPar[R, E](
@@ -1558,7 +1558,7 @@ object ZManagedSpec extends ZIOBaseSpec {
   ) =
     for {
       releases <- Ref.make[Int](0)
-      baseRes  = ZManaged.make(ZIO.succeedNow(()))(_ => releases.update(_ + 1))
+      baseRes  = ZManaged.make(ZIO.succeed(()))(_ => releases.update(_ + 1))
       res      = f(baseRes)
       _        <- res.use_(ZIO.unit)
       count    <- releases.get

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -39,7 +39,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         queue  <- Queue.bounded[Int](10)
         f      <- IO.forkAll(List.fill(10)(queue.take))
         values = Range.inclusive(1, 10).toList
-        _      <- values.map(queue.offer).foldLeft[UIO[Boolean]](IO.succeedNow(false))(_ *> _)
+        _      <- values.map(queue.offer).foldLeft[UIO[Boolean]](IO.succeed(false))(_ *> _)
         v      <- f.join
       } yield assert(v.toSet)(equalTo(values.toSet))
     },
@@ -134,7 +134,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       for {
         queue  <- Queue.bounded[Int](4)
         values = List(1, 2, 3, 4)
-        _      <- values.map(queue.offer).foldLeft(IO.succeedNow(false))(_ *> _)
+        _      <- values.map(queue.offer).foldLeft(IO.succeed(false))(_ *> _)
         _      <- queue.offer(5).fork
         _      <- waitForSize(queue, 5)
         v      <- queue.takeAll
@@ -227,7 +227,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       for {
         queue  <- Queue.bounded[Int](4)
         values = List(1, 2, 3, 4)
-        _      <- values.map(queue.offer).foldLeft(IO.succeedNow(false))(_ *> _)
+        _      <- values.map(queue.offer).foldLeft(IO.succeed(false))(_ *> _)
         f      <- queue.offer(5).fork
         _      <- waitForSize(queue, 5)
         l      <- queue.takeUpTo(5)
@@ -555,7 +555,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("dropping strategy with offerAll") {
       for {
-        capacity <- IO.succeedNow(4)
+        capacity <- IO.succeed(4)
         queue    <- Queue.dropping[Int](capacity)
         iter     = Range.inclusive(1, 5)
         _        <- queue.offerAll(iter)
@@ -564,7 +564,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("dropping strategy with offerAll, check offer returns false") {
       for {
-        capacity <- IO.succeedNow(2)
+        capacity <- IO.succeed(2)
         queue    <- Queue.dropping[Int](capacity)
         v1       <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
         _        <- queue.takeAll
@@ -572,7 +572,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("dropping strategy with offerAll, check ordering") {
       for {
-        capacity <- IO.succeedNow(128)
+        capacity <- IO.succeed(128)
         queue    <- Queue.dropping[Int](capacity)
         iter     = Range.inclusive(1, 256)
         _        <- queue.offerAll(iter)
@@ -581,7 +581,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("dropping strategy with pending taker") {
       for {
-        capacity <- IO.succeedNow(2)
+        capacity <- IO.succeed(2)
         queue    <- Queue.dropping[Int](capacity)
         iter     = Range.inclusive(1, 4)
         f        <- queue.take.fork
@@ -593,7 +593,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("sliding strategy with pending taker") {
       for {
-        capacity <- IO.succeedNow(2)
+        capacity <- IO.succeed(2)
         queue    <- Queue.sliding[Int](capacity)
         iter     = Range.inclusive(1, 4)
         _        <- queue.take.fork
@@ -605,7 +605,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("sliding strategy, check offerAll returns true") {
       for {
-        capacity <- IO.succeedNow(5)
+        capacity <- IO.succeed(5)
         queue    <- Queue.sliding[Int](capacity)
         iter     = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
@@ -613,7 +613,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("bounded strategy, check offerAll returns true") {
       for {
-        capacity <- IO.succeedNow(5)
+        capacity <- IO.succeed(5)
         queue    <- Queue.bounded[Int](capacity)
         iter     = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
@@ -664,7 +664,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     },
     testM("queue mapM") {
       for {
-        q <- Queue.bounded[Int](100).map(_.mapM(IO.succeedNow))
+        q <- Queue.bounded[Int](100).map(_.mapM(IO.succeed(_)))
         _ <- q.offer(10)
         v <- q.take
       } yield assert(v)(equalTo(10))
@@ -672,7 +672,7 @@ object ZQueueSpec extends ZIOBaseSpec {
     testM("queue mapM with success") {
       for {
         q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
-        _ <- q.offer(IO.succeedNow(10))
+        _ <- q.offer(IO.succeed(10))
         v <- q.take.sandbox.either
       } yield assert(v)(isRight(equalTo(10)))
     },

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -80,7 +80,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
-                     case Some(i) if i > 2 => STM.succeedNow(i.toString)
+                     case Some(i) if i > 2 => STM.succeed(i.toString)
                    }.commit
         } yield assert(result)(isSome(equalTo("4")))
       },
@@ -88,7 +88,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray[Option[Int]](0)(None).commit
           result <- tArray.collectFirstM {
-                     case any => STM.succeedNow(any)
+                     case any => STM.succeed(any)
                    }.commit
         } yield assert(result)(isNone)
       },
@@ -96,7 +96,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
-                     case Some(i) if i > n => STM.succeedNow(i.toString)
+                     case Some(i) if i > n => STM.succeed(i.toString)
                    }.commit
         } yield assert(result)(isNone)
       } @@ zioTag(errors),
@@ -104,7 +104,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStairWithHoles(N).commit
           findFiber <- tArray.collectFirstM {
-                        case Some(i) if (i % largePrime) == 0 => STM.succeedNow(i.toString)
+                        case Some(i) if (i % largePrime) == 0 => STM.succeed(i.toString)
                       }.commit.fork
           _      <- STM.foreach(0 until N)(i => tArray.update(i, _ => Some(1))).commit
           result <- findFiber.join
@@ -114,7 +114,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
-                     case Some(i) if i > 2 => STM.succeedNow(i.toString)
+                     case Some(i) if i > 2 => STM.succeed(i.toString)
                      case _                => STM.fail(boom)
                    }.commit.flip
         } yield assert(result)(equalTo(boom))
@@ -123,7 +123,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeStairWithHoles(n).commit
           result <- tArray.collectFirstM {
-                     case Some(i) if i > 2 => STM.succeedNow(i.toString)
+                     case Some(i) if i > 2 => STM.succeed(i.toString)
                      case Some(7)          => STM.fail(boom)
                    }.commit
         } yield assert(result)(isSome(equalTo("4")))
@@ -173,19 +173,19 @@ object TArraySpec extends ZIOBaseSpec {
       testM("computes correct sum") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.countM(i => STM.succeedNow(i % 2 == 0)).commit
+          result <- tArray.countM(i => STM.succeed(i % 2 == 0)).commit
         } yield assert(result)(equalTo(5))
       },
       testM("zero for absent") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.countM(i => STM.succeedNow(i > n)).commit
+          result <- tArray.countM(i => STM.succeed(i > n)).commit
         } yield assert(result)(equalTo(0))
       },
       testM("zero for empty") {
         for {
           tArray <- TArray.empty[Int].commit
-          result <- tArray.countM(_ => STM.succeedNow(true)).commit
+          result <- tArray.countM(_ => STM.succeed(true)).commit
         } yield assert(result)(equalTo(0))
       }
     ),
@@ -213,31 +213,31 @@ object TArraySpec extends ZIOBaseSpec {
       testM("detects satisfaction") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => STM.succeedNow(i % 2 == 0)).commit
+          result <- tArray.existsM(i => STM.succeed(i % 2 == 0)).commit
         } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => STM.succeedNow(i % 11 == 0)).commit
+          result <- tArray.existsM(i => STM.succeed(i % 11 == 0)).commit
         } yield assert(result)(isFalse)
       },
       testM("false for empty") {
         for {
           tArray <- TArray.empty[Int].commit
-          result <- tArray.existsM(_ => STM.succeedNow(true)).commit
+          result <- tArray.existsM(_ => STM.succeed(true)).commit
         } yield assert(result)(isFalse)
       },
       testM("fails for errors before witness") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.existsM(i => if (i == 4) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors),
       testM("fails for errors after witness") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.existsM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.existsM(i => if (i == 6) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors)
     ),
@@ -301,25 +301,25 @@ object TArraySpec extends ZIOBaseSpec {
       testM("finds correctly") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.findLastM(i => STM.succeed(i % 5 == 0)).commit
         } yield assert(result)(isSome(equalTo(10)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
-          result <- tArray.findLastM(_ => STM.succeedNow(true)).commit
+          result <- tArray.findLastM(_ => STM.succeed(true)).commit
         } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => STM.succeedNow(i > n)).commit
+          result <- tArray.findLastM(i => STM.succeed(i > n)).commit
         } yield assert(result)(isNone)
       } @@ zioTag(errors),
       testM("is atomic") {
         for {
           tArray    <- makeStair(N).commit
-          findFiber <- tArray.findLastM(i => STM.succeedNow(i % largePrime == 0)).commit.fork
+          findFiber <- tArray.findLastM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
         } yield assert(result)(isSome(equalTo(largePrime * 4)) || isNone)
@@ -327,13 +327,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("succeeds on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 7 == 0)).commit
+          result <- tArray.findLastM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 7 == 0)).commit
         } yield assert(result)(isSome(equalTo(7)))
       },
       testM("fails on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findLastM(i => if (i == 8) STM.fail(boom) else STM.succeedNow(i % 7 == 0)).commit.flip
+          result <- tArray.findLastM(i => if (i == 8) STM.fail(boom) else STM.succeed(i % 7 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors)
     ),
@@ -341,25 +341,25 @@ object TArraySpec extends ZIOBaseSpec {
       testM("finds correctly") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.findM(i => STM.succeed(i % 5 == 0)).commit
         } yield assert(result)(isSome(equalTo(5)))
       },
       testM("succeeds for empty") {
         for {
           tArray <- makeTArray(0)(0).commit
-          result <- tArray.findM(_ => STM.succeedNow(true)).commit
+          result <- tArray.findM(_ => STM.succeed(true)).commit
         } yield assert(result)(isNone)
       },
       testM("fails to find absent") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => STM.succeedNow(i > n)).commit
+          result <- tArray.findM(i => STM.succeed(i > n)).commit
         } yield assert(result)(isNone)
       } @@ zioTag(errors),
       testM("is atomic") {
         for {
           tArray    <- makeStair(N).commit
-          findFiber <- tArray.findM(i => STM.succeedNow(i % largePrime == 0)).commit.fork
+          findFiber <- tArray.findM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
         } yield assert(result)(isSome(equalTo(largePrime)) || isNone)
@@ -367,13 +367,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
+          result <- tArray.findM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors),
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.findM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.findM(i => if (i == 6) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit
         } yield assert(result)(isSome(equalTo(5)))
       }
     ),
@@ -405,14 +405,14 @@ object TArraySpec extends ZIOBaseSpec {
       testM("is atomic") {
         for {
           tArray    <- makeTArray(N)(0).commit
-          sum1Fiber <- tArray.foldM(0)((z, a) => STM.succeedNow(z + a)).commit.fork
+          sum1Fiber <- tArray.foldM(0)((z, a) => STM.succeed(z + a)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ + 1)).commit
           sum1      <- sum1Fiber.join
         } yield assert(sum1)(equalTo(0) || equalTo(N))
       },
       testM("returns effect failure") {
         def failInTheMiddle(acc: Int, a: Int): STM[Exception, Int] =
-          if (acc == N / 2) STM.fail(boom) else STM.succeedNow(acc + a)
+          if (acc == N / 2) STM.fail(boom) else STM.succeed(acc + a)
 
         for {
           tArray <- makeTArray(N)(1).commit
@@ -444,31 +444,31 @@ object TArraySpec extends ZIOBaseSpec {
       testM("detects satisfaction") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => STM.succeedNow(i < n + 1)).commit
+          result <- tArray.forallM(i => STM.succeed(i < n + 1)).commit
         } yield assert(result)(isTrue)
       },
       testM("detects lack of satisfaction") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => STM.succeedNow(i < n - 1)).commit
+          result <- tArray.forallM(i => STM.succeed(i < n - 1)).commit
         } yield assert(result)(isFalse)
       },
       testM("true for empty") {
         for {
           tArray <- TArray.empty[Int].commit
-          result <- tArray.forallM(_ => STM.succeedNow(false)).commit
+          result <- tArray.forallM(_ => STM.succeed(false)).commit
         } yield assert(result)(isTrue)
       },
       testM("fails for errors before counterexample") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i != 5)).commit.flip
+          result <- tArray.forallM(i => if (i == 4) STM.fail(boom) else STM.succeed(i != 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors),
       testM("fails for errors after counterexample") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.forallM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i == 5)).commit.flip
+          result <- tArray.forallM(i => if (i == 6) STM.fail(boom) else STM.succeed(i == 5)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors)
     ),
@@ -582,25 +582,25 @@ object TArraySpec extends ZIOBaseSpec {
       testM("determines the correct index") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.indexWhereM(i => STM.succeed(i % 5 == 0)).commit
         } yield assert(result)(equalTo(4))
       },
       testM("-1 for empty array") {
         for {
           tArray <- TArray.empty[Int].commit
-          result <- tArray.indexWhereM(_ => STM.succeedNow(true)).commit
+          result <- tArray.indexWhereM(_ => STM.succeed(true)).commit
         } yield assert(result)(equalTo(-1))
       },
       testM("-1 for absent") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => STM.succeedNow(i > n)).commit
+          result <- tArray.indexWhereM(i => STM.succeed(i > n)).commit
         } yield assert(result)(equalTo(-1))
       },
       testM("is atomic") {
         for {
           tArray    <- makeStair(N).commit
-          findFiber <- tArray.indexWhereM(i => STM.succeedNow(i % largePrime == 0)).commit.fork
+          findFiber <- tArray.indexWhereM(i => STM.succeed(i % largePrime == 0)).commit.fork
           _         <- STM.foreach(0 until N)(i => tArray.update(i, _ => 1)).commit
           result    <- findFiber.join
         } yield assert(result)(equalTo(largePrime - 1) || equalTo(-1))
@@ -608,43 +608,43 @@ object TArraySpec extends ZIOBaseSpec {
       testM("correct index if in array, with offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => STM.succeedNow(i % 2 == 0), 5).commit
+          result <- tArray.indexWhereM(i => STM.succeed(i % 2 == 0), 5).commit
         } yield assert(result)(equalTo(5))
       },
       testM("-1 if absent after offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => STM.succeedNow(i % 7 == 0), 7).commit
+          result <- tArray.indexWhereM(i => STM.succeed(i % 7 == 0), 7).commit
         } yield assert(result)(equalTo(-1))
       },
       testM("-1 for negative offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(_ => STM.succeedNow(true), -1).commit
+          result <- tArray.indexWhereM(_ => STM.succeed(true), -1).commit
         } yield assert(result)(equalTo(-1))
       },
       testM("-1 for too high offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(_ => STM.succeedNow(true), n + 1).commit
+          result <- tArray.indexWhereM(_ => STM.succeed(true), n + 1).commit
         } yield assert(result)(equalTo(-1))
       },
       testM("fails on errors before result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 4) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit.flip
+          result <- tArray.indexWhereM(i => if (i == 4) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors),
       testM("succeeds on errors after result found") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 6) STM.fail(boom) else STM.succeedNow(i % 5 == 0)).commit
+          result <- tArray.indexWhereM(i => if (i == 6) STM.fail(boom) else STM.succeed(i % 5 == 0)).commit
         } yield assert(result)(equalTo(4))
       },
       testM("succeeds when error excluded by offset") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.indexWhereM(i => if (i == 1) STM.fail(boom) else STM.succeedNow(i % 5 == 0), 2).commit
+          result <- tArray.indexWhereM(i => if (i == 1) STM.fail(boom) else STM.succeed(i % 5 == 0), 2).commit
         } yield assert(result)(equalTo(4))
       }
     ),
@@ -722,7 +722,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("updates values atomically") {
         for {
           tArray         <- makeTArray(N)("a").commit
-          transformFiber <- tArray.transformM(a => STM.succeedNow(a + "+b")).commit.fork
+          transformFiber <- tArray.transformM(a => STM.succeed(a + "+b")).commit.fork
           _              <- STM.foreach(0 until N)(idx => tArray.update(idx, _ + "+c")).commit
           _              <- transformFiber.join
           first          <- tArray(0).commit
@@ -733,7 +733,7 @@ object TArraySpec extends ZIOBaseSpec {
         for {
           tArray <- makeTArray(N)(0).commit
           _      <- tArray.update(N / 2, _ => 1).commit
-          result <- tArray.transformM(a => if (a == 0) STM.succeedNow(42) else STM.fail(boom)).commit.either
+          result <- tArray.transformM(a => if (a == 0) STM.succeed(42) else STM.fail(boom)).commit.either
           first  <- tArray(0).commit
         } yield assert(result.left.map(r => (first, r)))(isLeft(equalTo((0, boom))))
       }
@@ -756,13 +756,13 @@ object TArraySpec extends ZIOBaseSpec {
       testM("happy-path") {
         for {
           tArray <- makeTArray(1)(42).commit
-          items  <- (tArray.updateM(0, a => STM.succeedNow(-a)) *> valuesOf(tArray)).commit
+          items  <- (tArray.updateM(0, a => STM.succeed(-a)) *> valuesOf(tArray)).commit
         } yield assert(items)(equalTo(List(-42)))
       },
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(10)(0).commit
-          result <- tArray.updateM(10, STM.succeedNow).commit.run
+          result <- tArray.updateM(10, STM.succeed(_)).commit.run
         } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       },
       testM("updateM failure") {
@@ -858,7 +858,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("fails on errors") {
         for {
           tArray <- makeStair(n).commit
-          result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.fail(boom) else STM.succeedNow(a + b)).commit.flip
+          result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.fail(boom) else STM.succeed(a + b)).commit.flip
         } yield assert(result)(equalTo(boom))
       } @@ zioTag(errors)
     )
@@ -873,7 +873,7 @@ object TArraySpec extends ZIOBaseSpec {
   val isArrayIndexOutOfBoundsException: Assertion[Throwable] =
     Assertion.assertion[Throwable]("isArrayIndexOutOfBoundsException")()(_.isInstanceOf[ArrayIndexOutOfBoundsException])
 
-  def sumSucceed(a: Int, b: Int): STM[Nothing, Int] = STM.succeedNow(a + b)
+  def sumSucceed(a: Int, b: Int): STM[Nothing, Int] = STM.succeed(a + b)
 
   def makeTArray[T](n: Int)(a: T): STM[Nothing, TArray[T]] =
     TArray.fromIterable(List.fill(n)(a))

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -220,7 +220,7 @@ object TMapSpec extends ZIOBaseSpec {
         val tx =
           for {
             tmap <- TMap.make("a" -> 1, "aa" -> 2, "aaa" -> 3)
-            _    <- tmap.transformM((k, v) => STM.succeedNow(k.replaceAll("a", "b") -> v * 2))
+            _    <- tmap.transformM((k, v) => STM.succeed(k.replaceAll("a", "b") -> v * 2))
             res  <- tmap.toList
           } yield res
 
@@ -230,7 +230,7 @@ object TMapSpec extends ZIOBaseSpec {
         val tx =
           for {
             tmap <- TMap.make("a" -> 1, "aa" -> 2, "aaa" -> 3)
-            _    <- tmap.transformM((_, v) => STM.succeedNow("key" -> v * 2))
+            _    <- tmap.transformM((_, v) => STM.succeed("key" -> v * 2))
             res  <- tmap.toList
           } yield res
 
@@ -250,7 +250,7 @@ object TMapSpec extends ZIOBaseSpec {
         val tx =
           for {
             tmap <- TMap.make("a" -> 1, "aa" -> 2, "aaa" -> 3)
-            _    <- tmap.transformValuesM(v => STM.succeedNow(v * 2))
+            _    <- tmap.transformValuesM(v => STM.succeed(v * 2))
             res  <- tmap.toList
           } yield res
 
@@ -280,7 +280,7 @@ object TMapSpec extends ZIOBaseSpec {
         val tx =
           for {
             tmap <- TMap.make("a" -> 1, "b" -> 2, "c" -> 3)
-            res  <- tmap.foldM(0)((acc, kv) => STM.succeedNow(acc + kv._2))
+            res  <- tmap.foldM(0)((acc, kv) => STM.succeed(acc + kv._2))
           } yield res
 
         assertM(tx.commit)(equalTo(6))
@@ -289,7 +289,7 @@ object TMapSpec extends ZIOBaseSpec {
         val tx =
           for {
             tmap <- TMap.empty[String, Int]
-            res  <- tmap.foldM(0)((acc, kv) => STM.succeedNow(acc + kv._2))
+            res  <- tmap.foldM(0)((acc, kv) => STM.succeed(acc + kv._2))
           } yield res
 
         assertM(tx.commit)(equalTo(0))

--- a/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
@@ -31,13 +31,13 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
     testM("1 read lock") {
       for {
         lock  <- TReentrantLock.make.commit
-        count <- lock.readLock.use(count => ZIO.succeedNow(count))
+        count <- lock.readLock.use(count => ZIO.succeed(count))
       } yield assert(count)(equalTo(1))
     },
     testM("2 read locks from same fiber") {
       for {
         lock  <- TReentrantLock.make.commit
-        count <- lock.readLock.use(_ => lock.readLock.use(count => ZIO.succeedNow(count)))
+        count <- lock.readLock.use(_ => lock.readLock.use(count => ZIO.succeed(count)))
       } yield assert(count)(equalTo(2))
     },
     testM("2 read locks from different fibers") {
@@ -61,7 +61,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         mlatch <- Promise.make[Nothing, Unit]
         _      <- lock.writeLock.use(count => rlatch.succeed(()) *> wlatch.await as count).fork
         _      <- rlatch.await
-        reader <- (mlatch.succeed(()) *> lock.readLock.use(ZIO.succeedNow(_))).fork
+        reader <- (mlatch.succeed(()) *> lock.readLock.use(ZIO.succeed(_))).fork
         _      <- mlatch.await
         locks  <- (lock.readLocks zipWith lock.writeLocks)(_ + _).commit
         option <- reader.poll.repeat(pollSchedule)
@@ -79,7 +79,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         mlatch <- Promise.make[Nothing, Unit]
         _      <- lock.writeLock.use(count => rlatch.succeed(()) *> wlatch.await as count).fork
         _      <- rlatch.await
-        reader <- (mlatch.succeed(()) *> lock.writeLock.use(ZIO.succeedNow(_))).fork
+        reader <- (mlatch.succeed(()) *> lock.writeLock.use(ZIO.succeed(_))).fork
         _      <- mlatch.await
         locks  <- (lock.readLocks zipWith lock.writeLocks)(_ + _).commit
         option <- reader.poll.repeat(pollSchedule)
@@ -115,7 +115,7 @@ object TReentrantLockSpec extends DefaultRunnableSpec {
         wlatch <- Promise.make[Nothing, Unit]
         _      <- lock.readLock.use(count => mlatch.succeed(()) *> rlatch.await as count).fork
         _      <- mlatch.await
-        writer <- lock.readLock.use(_ => wlatch.succeed(()) *> lock.writeLock.use(count => ZIO.succeedNow(count))).fork
+        writer <- lock.readLock.use(_ => wlatch.succeed(()) *> lock.writeLock.use(count => ZIO.succeed(count))).fork
         _      <- wlatch.await
         option <- writer.poll.repeat(pollSchedule)
         _      <- rlatch.succeed(())

--- a/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSetSpec.scala
@@ -147,7 +147,7 @@ object TSetSpec extends ZIOBaseSpec {
         val tx =
           for {
             tset <- TSet.make(1, 2, 3)
-            _    <- tset.transformM(a => STM.succeedNow(a * 2))
+            _    <- tset.transformM(a => STM.succeed(a * 2))
             res  <- tset.toList
           } yield res
 
@@ -157,7 +157,7 @@ object TSetSpec extends ZIOBaseSpec {
         val tx =
           for {
             tset <- TSet.make(1, 2, 3)
-            _    <- tset.transformM(_ => STM.succeedNow(1))
+            _    <- tset.transformM(_ => STM.succeed(1))
             res  <- tset.toList
           } yield res
 
@@ -187,7 +187,7 @@ object TSetSpec extends ZIOBaseSpec {
         val tx =
           for {
             tset <- TSet.make(1, 2, 3)
-            res  <- tset.foldM(0)((acc, a) => STM.succeedNow(acc + a))
+            res  <- tset.foldM(0)((acc, a) => STM.succeed(acc + a))
           } yield res
 
         assertM(tx.commit)(equalTo(6))
@@ -196,7 +196,7 @@ object TSetSpec extends ZIOBaseSpec {
         val tx =
           for {
             tset <- TSet.empty[Int]
-            res  <- tset.foldM(0)((acc, a) => STM.succeedNow(acc + a))
+            res  <- tset.foldM(0)((acc, a) => STM.succeed(acc + a))
           } yield res
 
         assertM(tx.commit)(equalTo(0))

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -45,7 +45,7 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("mapAccumM")(
       testM("mapAccumM happy path") {
-        assertM(Chunk(1, 1, 1).mapAccumM(0)((s, el) => UIO.succeedNow((s + el, s + el))))(equalTo((3, Chunk(1, 2, 3))))
+        assertM(Chunk(1, 1, 1).mapAccumM(0)((s, el) => UIO.succeed((s + el, s + el))))(equalTo((3, Chunk(1, 2, 3))))
       },
       testM("mapAccumM error") {
         Chunk(1, 1, 1).mapAccumM(0)((_, _) => IO.fail("Ouch")).either.map(assert(_)(isLeft(equalTo("Ouch"))))
@@ -57,7 +57,7 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("mapM")(
       testM("mapM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, f) =>
-        chunk.mapM(s => UIO.succeedNow(f(s))).map(assert(_)(equalTo(chunk.map(f))))
+        chunk.mapM(s => UIO.succeed(f(s))).map(assert(_)(equalTo(chunk.map(f))))
       }),
       testM("mapM error") {
         Chunk(1, 2, 3).mapM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
@@ -99,7 +99,7 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("filterM")(
       testM("filterM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
-        chunk.filterM(s => UIO.succeedNow(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
+        chunk.filterM(s => UIO.succeed(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
       }),
       testM("filterM error") {
         Chunk(1, 2, 3).filterM(_ => IO.fail("Ouch")).either.map(assert(_)(equalTo(Left("Ouch"))))
@@ -162,7 +162,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectM")(
       testM("collectM empty Chunk") {
-        assertM(Chunk.empty.collectM { case _ => UIO.succeedNow(1) })(equalTo(Chunk.empty))
+        assertM(Chunk.empty.collectM { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
       },
       testM("collectM chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))
@@ -190,7 +190,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectWhileM")(
       testM("collectWhileM empty Chunk") {
-        assertM(Chunk.empty.collectWhileM { case _ => UIO.succeedNow(1) })(equalTo(Chunk.empty))
+        assertM(Chunk.empty.collectWhileM { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
       },
       testM("collectWhileM chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -198,19 +198,19 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("contramapM")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].contramapM[Any, Unit, String](s => UIO.succeedNow(s.toInt))
+          val sink = ZSink.identity[Int].contramapM[Any, Unit, String](s => UIO.succeed(s.toInt))
           assertM(sinkIteration(sink, "1"))(equalTo((1, Chunk.empty)))
         },
         testM("init error") {
-          val sink = initErrorSink.contramapM[Any, String, String](s => UIO.succeedNow(s.toInt))
+          val sink = initErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
           assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("step error") {
-          val sink = stepErrorSink.contramapM[Any, String, String](s => UIO.succeedNow(s.toInt))
+          val sink = stepErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
           assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("extract error") {
-          val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeedNow(s.toInt))
+          val sink = extractErrorSink.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
           assertM(sinkIteration(sink, "1").either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors)
       ),
@@ -460,23 +460,23 @@ object SinkSpec extends ZIOBaseSpec {
       ),
       suite("filterM")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeedNow(n < 5))
+          val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeed(n < 5))
           assertM(sinkIteration(sink, 1))(equalTo((1, Chunk.empty)))
         },
         testM("false predicate") {
-          val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeedNow(n > 5))
+          val sink = ZSink.identity[Int].filterM[Any, Unit](n => UIO.succeed(n > 5))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo(())))
         },
         testM("init error") {
-          val sink = initErrorSink.filterM[Any, String](n => UIO.succeedNow(n < 5))
+          val sink = initErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("step error") {
-          val sink = stepErrorSink.filterM[Any, String](n => UIO.succeedNow(n < 5))
+          val sink = stepErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("extractError") {
-          val sink = extractErrorSink.filterM[Any, String](n => UIO.succeedNow(n < 5))
+          val sink = extractErrorSink.filterM[Any, String](n => UIO.succeed(n < 5))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors)
       ),
@@ -532,19 +532,19 @@ object SinkSpec extends ZIOBaseSpec {
       ) @@ zioTag(errors),
       suite("mapM")(
         testM("happy path") {
-          val sink = ZSink.identity[Int].mapM[Any, Unit, String](n => UIO.succeedNow(n.toString))
+          val sink = ZSink.identity[Int].mapM[Any, Unit, String](n => UIO.succeed(n.toString))
           assertM(sinkIteration(sink, 1))(equalTo(("1", Chunk.empty)))
         },
         testM("init error") {
-          val sink = initErrorSink.mapM[Any, String, String](n => UIO.succeedNow(n.toString))
+          val sink = initErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("step error") {
-          val sink = stepErrorSink.mapM[Any, String, String](n => UIO.succeedNow(n.toString))
+          val sink = stepErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors),
         testM("extract error") {
-          val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeedNow(n.toString))
+          val sink = extractErrorSink.mapM[Any, String, String](n => UIO.succeed(n.toString))
           assertM(sinkIteration(sink, 1).either)(isLeft(equalTo("Ouch")))
         } @@ zioTag(errors)
       ),
@@ -983,7 +983,7 @@ object SinkSpec extends ZIOBaseSpec {
         }),
         testM("short circuits") {
           val empty: Stream[Nothing, Int]     = ZStream.empty
-          val single: Stream[Nothing, Int]    = ZStream.succeedNow(1)
+          val single: Stream[Nothing, Int]    = ZStream.succeed(1)
           val double: Stream[Nothing, Int]    = ZStream(1, 2)
           val failed: Stream[String, Nothing] = ZStream.fail("Ouch")
 
@@ -991,7 +991,7 @@ object SinkSpec extends ZIOBaseSpec {
             for {
               effects <- Ref.make[List[Int]](Nil)
               sink = ZSink.foldM[Any, Nothing, Int, Int, Int](0)(_ => true) { (_, a) =>
-                effects.update(a :: _) *> UIO.succeedNow((30, Chunk.empty))
+                effects.update(a :: _) *> UIO.succeed((30, Chunk.empty))
               }
               exit   <- stream.run(sink).run
               result <- effects.get
@@ -1025,7 +1025,7 @@ object SinkSpec extends ZIOBaseSpec {
         },
         testM("short circuits") {
           val empty: Stream[Nothing, Int]     = ZStream.empty
-          val single: Stream[Nothing, Int]    = ZStream.succeedNow(1)
+          val single: Stream[Nothing, Int]    = ZStream.succeed(1)
           val double: Stream[Nothing, Int]    = ZStream(1, 2)
           val failed: Stream[String, Nothing] = ZStream.fail("Ouch")
 
@@ -1033,7 +1033,7 @@ object SinkSpec extends ZIOBaseSpec {
             (for {
               effects <- Ref.make[List[Int]](Nil)
               sink = ZSink.foldM[Any, E, Int, Int, Int](0)(_ => true) { (_, a) =>
-                effects.update(a :: _) *> UIO.succeedNow((30, Chunk.empty))
+                effects.update(a :: _) *> UIO.succeed((30, Chunk.empty))
               }
               exit   <- stream.run(sink)
               result <- effects.get
@@ -1126,9 +1126,7 @@ object SinkSpec extends ZIOBaseSpec {
             Stream[Long](1, 5, 2, 3)
               .aggregate(
                 Sink
-                  .foldWeightedM(List[Long]())((a: Long) => UIO.succeedNow(a * 2), 12)((acc, el) =>
-                    UIO.succeedNow(el :: acc)
-                  )
+                  .foldWeightedM(List[Long]())((a: Long) => UIO.succeed(a * 2), 12)((acc, el) => UIO.succeed(el :: acc))
                   .map(_.reverse)
               )
               .runCollect
@@ -1140,10 +1138,10 @@ object SinkSpec extends ZIOBaseSpec {
               .aggregate(
                 Sink
                   .foldWeightedDecomposeM(List[Int]())(
-                    (i: Int) => UIO.succeedNow(i.toLong),
+                    (i: Int) => UIO.succeed(i.toLong),
                     4,
-                    (i: Int) => UIO.succeedNow(Chunk(i - 1, 1))
-                  )((acc, el) => UIO.succeedNow(el :: acc))
+                    (i: Int) => UIO.succeed(Chunk(i - 1, 1))
+                  )((acc, el) => UIO.succeed(el :: acc))
                   .map(_.reverse)
               )
               .runCollect
@@ -1159,7 +1157,7 @@ object SinkSpec extends ZIOBaseSpec {
         testM("foldUntilM")(
           assertM(
             Stream[Long](1, 1, 1, 1, 1, 1)
-              .aggregate(Sink.foldUntilM(0L, 3)((s, a: Long) => UIO.succeedNow(s + a)))
+              .aggregate(Sink.foldUntilM(0L, 3)((s, a: Long) => UIO.succeed(s + a)))
               .runCollect
           )(equalTo(List(3L, 3L)))
         ),
@@ -1191,7 +1189,7 @@ object SinkSpec extends ZIOBaseSpec {
       },
       testM("pull1") {
         val stream = Stream.fromIterable(List(1))
-        val sink   = Sink.pull1(IO.succeedNow(Option.empty[Int]))((i: Int) => Sink.succeedNow[Int, Option[Int]](Some(i)))
+        val sink   = Sink.pull1(IO.succeed(Option.empty[Int]))((i: Int) => Sink.succeed[Int, Option[Int]](Some(i)))
 
         assertM(stream.run(sink))(isSome(equalTo(1)))
       },
@@ -1598,29 +1596,29 @@ object SinkSpec extends ZIOBaseSpec {
                 s match {
                   case (ParserState.Start, acc, _) =>
                     a match {
-                      case a if a.isWhitespace => UIO.succeedNow(((ParserState.Start, acc, true), Chunk.empty))
-                      case '['                 => UIO.succeedNow(((ParserState.Element(""), acc, true), Chunk.empty))
+                      case a if a.isWhitespace => UIO.succeed(((ParserState.Start, acc, true), Chunk.empty))
+                      case '['                 => UIO.succeed(((ParserState.Element(""), acc, true), Chunk.empty))
                       case _                   => IO.fail("Expected '['")
                     }
 
                   case (ParserState.Element(el), acc, _) =>
                     a match {
                       case a if a.isDigit =>
-                        UIO.succeedNow(((ParserState.Element(el + a), acc, true), Chunk.empty))
-                      case ',' => UIO.succeedNow(((ParserState.Element(""), acc :+ el.toInt, true), Chunk.empty))
-                      case ']' => UIO.succeedNow(((ParserState.Done, acc :+ el.toInt, false), Chunk.empty))
+                        UIO.succeed(((ParserState.Element(el + a), acc, true), Chunk.empty))
+                      case ',' => UIO.succeed(((ParserState.Element(""), acc :+ el.toInt, true), Chunk.empty))
+                      case ']' => UIO.succeed(((ParserState.Done, acc :+ el.toInt, false), Chunk.empty))
                       case _   => IO.fail("Expected a digit or ,")
                     }
 
                   case (ParserState.Done, acc, _) =>
-                    UIO.succeedNow(((ParserState.Done, acc, false), Chunk.empty))
+                    UIO.succeed(((ParserState.Done, acc, false), Chunk.empty))
                 }
             }
             .map(_._2)
             .chunked
 
-        val src1         = ZStreamChunk.succeedNow(Chunk.fromArray(Array('[', '1', '2')))
-        val src2         = ZStreamChunk.succeedNow(Chunk.fromArray(Array('3', ',', '4', ']')))
+        val src1         = ZStreamChunk.succeed(Chunk.fromArray(Array('[', '1', '2')))
+        val src2         = ZStreamChunk.succeed(Chunk.fromArray(Array('3', ',', '4', ']')))
         val partialParse = src1.run(numArrayParser).run
         val fullParse    = (src1 ++ src2).run(numArrayParser).run
 
@@ -1645,8 +1643,8 @@ object SinkSpec extends ZIOBaseSpec {
             case _                   => ZSink.fail("Expected '['")
           }
 
-        val src1         = ZStreamChunk.succeedNow(Chunk.fromArray(Array('[', '1', '2')))
-        val src2         = ZStreamChunk.succeedNow(Chunk.fromArray(Array('3', ',', '4', ']')))
+        val src1         = ZStreamChunk.succeed(Chunk.fromArray(Array('[', '1', '2')))
+        val src2         = ZStreamChunk.succeed(Chunk.fromArray(Array('3', ',', '4', ']')))
         val partialParse = src1.run(start.chunked).run
         val fullParse    = (src1 ++ src2).run(start.chunked).run
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -38,23 +38,23 @@ trait SinkUtils {
       type State = Option[List[A]]
 
       def extract(state: State) =
-        UIO.succeedNow(state match {
+        UIO.succeed(state match {
           case Some(elems) => (target, Chunk.fromIterable(elems))
           case None        => (default, Chunk.empty)
         })
 
-      def initial = UIO.succeedNow(None)
+      def initial = UIO.succeed(None)
 
       def step(state: State, a: A) =
         state match {
           case None =>
             val st = if (a == target) Some(Nil) else None
-            UIO.succeedNow(st)
+            UIO.succeed(st)
           case Some(acc) =>
             if (acc.length >= accumulateAfterMet)
-              UIO.succeedNow(state)
+              UIO.succeed(state)
             else
-              UIO.succeedNow(Some(acc :+ a))
+              UIO.succeed(Some(acc :+ a))
         }
 
       def cont(state: State) = state.map(_.length < accumulateAfterMet).getOrElse(true)
@@ -94,7 +94,7 @@ trait SinkUtils {
         assert(longer)(equalTo(rem))
         assert(rem.endsWith(shorter))(isTrue)
       }
-      maybeProp.catchAll(_ => UIO.succeedNow(assert(true)(isTrue)))
+      maybeProp.catchAll(_ => UIO.succeed(assert(true)(isTrue)))
     }
 
     def laws[A, B, C](

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamBufferSpec.scala
@@ -144,7 +144,7 @@ object StreamBufferSpec extends ZIOBaseSpec {
           ref   <- Ref.make(List[Int]())
           latch <- Promise.make[Nothing, Unit]
           s = Stream
-            .fromEffect(UIO.succeedNow(()))
+            .fromEffect(UIO.succeed(()))
             .flatMap(_ => Stream.range(1, 1000).tap(i => ref.update(i :: _)).ensuring(latch.succeed(())))
             .bufferUnbounded
           l <- s.process.use { as =>

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -67,7 +67,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
     suite("StreamChunk.filterM")(
       testM("filterM happy path")(checkM(chunksOfInts, toBoolFn[Random with Sized, Int]) { (s, p) =>
         for {
-          res1 <- slurp(s.filterM(s => UIO.succeedNow(p(s))))
+          res1 <- slurp(s.filterM(s => UIO.succeed(p(s))))
           res2 <- slurp(s).map(_.filter(p))
         } yield assert(res1)(equalTo(res2))
       }),
@@ -106,14 +106,14 @@ object StreamChunkSpec extends ZIOBaseSpec {
         val fn = Gen.function[Random with Sized, Int, Chunk[Int]](smallChunks(intGen))
         checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
-            res1 <- slurp(s.mapConcatChunkM(s => UIO.succeedNow(f(s))))
+            res1 <- slurp(s.mapConcatChunkM(s => UIO.succeed(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
           } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatM error") {
         StreamChunk
-          .succeedNow(Chunk.single(1))
+          .succeed(Chunk.single(1))
           .mapConcatChunkM(_ => IO.fail("Ouch"))
           .run(Sink.drain)
           .either
@@ -125,14 +125,14 @@ object StreamChunkSpec extends ZIOBaseSpec {
         val fn = Gen.function[Random with Sized, Int, Iterable[Int]](Gen.listOf(intGen))
         checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
-            res1 <- slurp(s.mapConcatM(s => UIO.succeedNow(f(s))))
+            res1 <- slurp(s.mapConcatM(s => UIO.succeed(f(s))))
             res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
           } yield assert(res1)(equalTo(res2))
         }
       },
       testM("mapConcatM error") {
         StreamChunk
-          .succeedNow(Chunk.single(1))
+          .succeed(Chunk.single(1))
           .mapConcatM(_ => IO.fail("Ouch"))
           .run(Sink.drain)
           .either
@@ -213,7 +213,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       testM("mapAccumM happy path") {
         checkM(chunksOfInts) { s =>
           for {
-            res1 <- slurp(s.mapAccumM(0)((acc, el) => UIO.succeedNow((acc + el, acc + el))))
+            res1 <- slurp(s.mapAccumM(0)((acc, el) => UIO.succeed((acc + el, acc + el))))
             res2 <- slurp(s).map(_.scanLeft(0)((acc, el) => acc + el).drop(1))
           } yield assert(res1)(equalTo(res2))
         }
@@ -230,7 +230,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
     testM("StreamChunk.mapM") {
       checkM(chunksOfInts, Gen.function[Random, Int, Int](intGen)) { (s, f) =>
         for {
-          res1 <- slurp(s.mapM(a => IO.succeedNow(f(a))))
+          res1 <- slurp(s.mapM(a => IO.succeed(f(a))))
           res2 <- slurp(s).map(_.map(f))
         } yield assert(res1)(equalTo(res2))
       }
@@ -257,9 +257,9 @@ object StreamChunkSpec extends ZIOBaseSpec {
           acc <- Ref.make[List[Int]](Nil)
           res1 <- s.foreachWhile { a =>
                    if (cont(a))
-                     acc.update(a :: _) *> IO.succeedNow(true)
+                     acc.update(a :: _) *> IO.succeed(true)
                    else
-                     IO.succeedNow(false)
+                     IO.succeed(false)
                  }.flatMap(_ => acc.updateAndGet(_.reverse))
           res2 <- slurp(s.takeWhile(cont)).map(_.toList)
         } yield assert(res1)(equalTo(res2))
@@ -278,7 +278,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       val fn = Gen.function[Random with Sized, Int, StreamChunk[Nothing, Int]](chunksOfInts)
       checkM(intGen, fn) { (x, f) =>
         for {
-          res1 <- slurp(ZStreamChunk.succeedNow(Chunk(x)).flatMap(f))
+          res1 <- slurp(ZStreamChunk.succeed(Chunk(x)).flatMap(f))
           res2 <- slurp(f(x))
         } yield assert(res1)(equalTo(res2))
       }
@@ -286,7 +286,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
     testM("StreamChunk.monadLaw2") {
       checkM(chunksOfInts) { m =>
         for {
-          res1 <- slurp(m.flatMap(i => ZStreamChunk.succeedNow(Chunk(i))))
+          res1 <- slurp(m.flatMap(i => ZStreamChunk.succeed(Chunk(i))))
           res2 <- slurp(m)
         } yield assert(res1)(equalTo(res2))
       }
@@ -346,7 +346,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         Gen.function2(intGen)
       ) { (s, zero, cont, f) =>
         for {
-          res1 <- s.foldWhileM[Any, Nothing, Int, Int](zero)(cont)((acc, a) => IO.succeedNow(f(acc, a)))
+          res1 <- s.foldWhileM[Any, Nothing, Int, Int](zero)(cont)((acc, a) => IO.succeed(f(acc, a)))
           res2 <- slurp(s).map(l => foldLazyList(l.toList, zero)(cont)(f))
         } yield assert(res1)(equalTo(res2))
       }
@@ -387,7 +387,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       val stream = StreamChunk.fromChunks(Chunk.fromIterable(orig1), Chunk[Byte](), Chunk.fromIterable(orig2))
       @silent("Any")
       val inputStreamResult = stream.toInputStream.use { inputStream =>
-        ZIO.succeedNow(
+        ZIO.succeed(
           Iterator
             .continually(inputStream.read)
             .takeWhile(_ != -1)
@@ -404,7 +404,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
               _ <- StreamChunk(
                     Stream
                       .bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
-                      .flatMap(_ => Stream.succeedNow(Chunk(())))
+                      .flatMap(_ => Stream.succeed(Chunk(())))
                   )
               _ <- StreamChunk(Stream.fromEffect(log.update("Use" :: _)).flatMap(_ => Stream.empty))
             } yield ()).ensuring(log.update("Ensuring" :: _)).run(Sink.drain)
@@ -418,7 +418,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
               _ <- StreamChunk(
                     Stream
                       .bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
-                      .flatMap(_ => Stream.succeedNow(Chunk(())))
+                      .flatMap(_ => Stream.succeed(Chunk(())))
                   )
               _ <- StreamChunk(Stream.fromEffect(log.update("Use" :: _)).flatMap(_ => Stream.empty))
             } yield ()).ensuringFirst(log.update("Ensuring" :: _)).run(Sink.drain)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -60,7 +60,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
             cb => {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
+                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeed(1)))
                 cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               None
@@ -113,7 +113,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
             cb => {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
+                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeed(1)))
                 cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               UIO.unit
@@ -135,7 +135,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
           fiber <- Stream
                     .effectAsyncInterrupt[Nothing, Unit] { offer =>
                       inParallel {
-                        offer(ZIO.succeedNow(()))
+                        offer(ZIO.succeed(()))
                       }(global)
                       Left(cancelled.set(true))
                     }
@@ -159,7 +159,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
                        inParallel {
                          k(IO.fail(None))
                        }(global)
-                       Left(UIO.succeedNow(()))
+                       Left(UIO.succeed(()))
                      }
                      .runCollect
         } yield assert(result)(equalTo(Nil))
@@ -173,7 +173,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
             cb => {
               inParallel {
                 // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(1)))
+                (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeed(1)))
                 cb(refDone.set(true) *> ZIO.fail(None))
               }(global)
               Left(UIO.unit)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -38,7 +38,7 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(stream.absolve.runCollect)(equalTo(xs))
       }),
       testM("failure")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { xs =>
-        val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeedNow(Left("Ouch"))
+        val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
         assertM(stream.absolve.runCollect.run)(fails(equalTo("Ouch")))
       }) @@ zioTag(errors),
       testM("round-trip #1")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt)), Gen.anyString) { (xs, s) =>
@@ -66,7 +66,7 @@ object StreamSpec extends ZIOBaseSpec {
     suite("Stream.accessM")(
       testM("accessM") {
         for {
-          result <- ZStream.accessM[String](ZIO.succeedNow).provide("test").runHead.get
+          result <- ZStream.accessM[String](ZIO.succeed(_)).provide("test").runHead.get
         } yield assert(result)(equalTo("test"))
       },
       testM("accessM fails") {
@@ -78,7 +78,7 @@ object StreamSpec extends ZIOBaseSpec {
     suite("Stream.accessStream")(
       testM("accessStream") {
         for {
-          result <- ZStream.accessStream[String](ZStream.succeedNow).provide("test").runHead.get
+          result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.get
         } yield assert(result)(equalTo("test"))
       },
       testM("accessStream fails") {
@@ -122,7 +122,7 @@ object StreamSpec extends ZIOBaseSpec {
           latch     <- Promise.make[Nothing, Unit]
           cancelled <- Ref.make(false)
           sink = ZSink.foldM(List[Int]())(_ => true) { (acc, el: Int) =>
-            if (el == 1) UIO.succeedNow((el :: acc, Chunk[Int]()))
+            if (el == 1) UIO.succeed((el :: acc, Chunk[Int]()))
             else
               (latch.succeed(()) *> ZIO.infinity)
                 .onInterrupt(cancelled.set(true))
@@ -203,7 +203,7 @@ object StreamSpec extends ZIOBaseSpec {
           latch     <- Promise.make[Nothing, Unit]
           cancelled <- Ref.make(false)
           sink = ZSink.foldM(List[Int]())(_ => true) { (acc, el: Int) =>
-            if (el == 1) UIO.succeedNow((el :: acc, Chunk[Int]()))
+            if (el == 1) UIO.succeed((el :: acc, Chunk[Int]()))
             else
               (latch.succeed(()) *> ZIO.infinity)
                 .onInterrupt(cancelled.set(true))
@@ -315,12 +315,12 @@ object StreamSpec extends ZIOBaseSpec {
         for {
           leftAssoc <- Stream
                         .bracket(Ref.make(true))(_.set(false))
-                        .flatMap(Stream.succeedNow)
+                        .flatMap(Stream.succeed(_))
                         .flatMap(r => Stream.fromEffect(r.get))
                         .run(Sink.await[Boolean])
           rightAssoc <- Stream
                          .bracket(Ref.make(true))(_.set(false))
-                         .flatMap(Stream.succeedNow(_).flatMap(r => Stream.fromEffect(r.get)))
+                         .flatMap(Stream.succeed(_).flatMap(r => Stream.fromEffect(r.get)))
                          .run(Sink.await[Boolean])
         } yield assert(leftAssoc -> rightAssoc)(equalTo(true -> true))
       )
@@ -431,7 +431,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("error") {
         (Stream(1, 2, 3, 4, 5) ++ Stream.fail("broken"))
           .chunkN(3)
-          .catchAll(_ => ZStreamChunk.succeedNow(Chunk(6)))
+          .catchAll(_ => ZStreamChunk.succeed(Chunk(6)))
           .chunks
           .runCollect
           .map(assert(_)(equalTo(List(Chunk(1, 2, 3), Chunk(4, 5), Chunk(6)))))
@@ -489,7 +489,7 @@ object StreamSpec extends ZIOBaseSpec {
         assertM(
           (Stream(Option(1)) ++ Stream.fail("Ouch"))
             .collectWhileM[Any, String, Int] {
-              case None => ZIO.succeedNow(1)
+              case None => ZIO.succeed(1)
             }
             .runDrain
             .either
@@ -528,7 +528,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("ensures no race between subscription and stream end") {
 
         val stream: ZStream[Any, Nothing, Either[Unit, Unit]] = ZStream.empty
-        stream.distributedWithDynamic[Nothing, Either[Unit, Unit]](1, _ => UIO.succeedNow(_ => true)).use { add =>
+        stream.distributedWithDynamic[Nothing, Either[Unit, Unit]](1, _ => UIO.succeed(_ => true)).use { add =>
           val subscribe = ZStream.unwrap(add.map {
             case (_, queue) =>
               ZStream.fromQueue(queue).unTake
@@ -537,7 +537,7 @@ object StreamSpec extends ZIOBaseSpec {
             subscribe.ensuring(onEnd.succeed(())).runDrain.fork *>
               onEnd.await *>
               subscribe.runDrain *>
-              ZIO.succeedNow(assertCompletes)
+              ZIO.succeed(assertCompletes)
           }
         }
       }
@@ -613,7 +613,7 @@ object StreamSpec extends ZIOBaseSpec {
     }),
     testM("Stream.filterM")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
       for {
-        res1 <- s.filterM(s => IO.succeedNow(p(s))).runCollect
+        res1 <- s.filterM(s => IO.succeed(p(s))).runCollect
         res2 <- s.runCollect.map(_.filter(p))
       } yield assert(res1)(equalTo(res2))
     }),
@@ -639,9 +639,9 @@ object StreamSpec extends ZIOBaseSpec {
     suite("Stream.flatMap")(
       testM("deep flatMap stack safety") {
         def fib(n: Int): Stream[Nothing, Int] =
-          if (n <= 1) Stream.succeedNow(n)
+          if (n <= 1) Stream.succeed(n)
           else
-            fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => Stream.succeedNow(a + b)))
+            fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => Stream.succeed(a + b)))
 
         val stream   = fib(20)
         val expected = 6765
@@ -715,7 +715,7 @@ object StreamSpec extends ZIOBaseSpec {
               }
             )
             .flatMap(_ => Stream.fail("Ouch"))
-          _   <- Stream.succeedNow(()).flatMap(_ => inner).runDrain.either.unit
+          _   <- Stream.succeed(()).flatMap(_ => inner).runDrain.either.unit
           fin <- ref.get
         } yield assert(fin)(isTrue)
       }
@@ -989,7 +989,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("foreachWhile short circuits") {
         for {
           flag    <- Ref.make(true)
-          _       <- (Stream(true, true, false) ++ Stream.fromEffect(flag.set(false)).drain).foreachWhile(ZIO.succeedNow)
+          _       <- (Stream(true, true, false) ++ Stream.fromEffect(flag.set(false)).drain).foreachWhile(ZIO.succeed(_))
           skipped <- flag.get
         } yield assert(skipped)(isTrue)
       }
@@ -1036,9 +1036,7 @@ object StreamSpec extends ZIOBaseSpec {
         _     <- queue.offerAll(c.toSeq)
         fiber <- Stream
                   .fromQueue(queue)
-                  .foldWhileM[Any, Nothing, Int, List[Int]](List[Int]())(_ => true)((acc, el) =>
-                    IO.succeedNow(el :: acc)
-                  )
+                  .foldWhileM[Any, Nothing, Int, List[Int]](List[Int]())(_ => true)((acc, el) => IO.succeed(el :: acc))
                   .map(_.reverse)
                   .fork
         _     <- waitForSize(queue, -1)
@@ -1069,7 +1067,7 @@ object StreamSpec extends ZIOBaseSpec {
     },
     suite("Stream.fromEffectOption")(
       testM("emit one element with success") {
-        val fa: ZIO[Any, Option[Int], Int] = ZIO.succeedNow(5)
+        val fa: ZIO[Any, Option[Int], Int] = ZIO.succeed(5)
         assertM(Stream.fromEffectOption(fa).runCollect)(equalTo(List(5)))
       },
       testM("emit one element with failure") {
@@ -1249,7 +1247,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("mapAccumM happy path") {
         assertM(
           Stream(1, 1, 1)
-            .mapAccumM[Any, Nothing, Int, Int](0)((acc, el) => IO.succeedNow((acc + el, acc + el)))
+            .mapAccumM[Any, Nothing, Int, Int](0)((acc, el) => IO.succeed((acc + el, acc + el)))
             .runCollect
         )(equalTo(List(1, 2, 3)))
       },
@@ -1277,7 +1275,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("mapConcatChunkM happy path") {
         checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
           for {
-            res1 <- s.mapConcatChunkM(b => UIO.succeedNow(f(b))).runCollect
+            res1 <- s.mapConcatChunkM(b => UIO.succeed(f(b))).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
           } yield assert(res1)(equalTo(res2))
         }
@@ -1294,7 +1292,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("mapConcatM happy path") {
         checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
           for {
-            res1 <- s.mapConcatM(b => UIO.succeedNow(f(b))).runCollect
+            res1 <- s.mapConcatM(b => UIO.succeed(f(b))).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
           } yield assert(res1)(equalTo(res2))
         }
@@ -1336,7 +1334,7 @@ object StreamSpec extends ZIOBaseSpec {
     testM("Stream.repeatEffect")(
       assertM(
         Stream
-          .repeatEffect(IO.succeedNow(1))
+          .repeatEffect(IO.succeed(1))
           .take(2)
           .run(Sink.collectAll[Int])
       )(equalTo(List(1, 1)))
@@ -1345,7 +1343,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("emit elements")(
         assertM(
           Stream
-            .repeatEffectOption(IO.succeedNow(1))
+            .repeatEffectOption(IO.succeed(1))
             .take(2)
             .run(Sink.collectAll[Int])
         )(equalTo(List(1, 1)))
@@ -1355,7 +1353,7 @@ object StreamSpec extends ZIOBaseSpec {
           ref <- Ref.make(0)
           fa = for {
             newCount <- ref.updateAndGet(_ + 1)
-            res      <- if (newCount >= 5) ZIO.fail(None) else ZIO.succeedNow(newCount)
+            res      <- if (newCount >= 5) ZIO.fail(None) else ZIO.succeed(newCount)
           } yield res
           res <- Stream
                   .repeatEffectOption(fa)
@@ -1407,8 +1405,8 @@ object StreamSpec extends ZIOBaseSpec {
       } @@ zioTag(interruption),
       testM("guarantee ordering")(checkM(Gen.int(1, 4096), Gen.listOf(Gen.anyInt)) { (n: Int, m: List[Int]) =>
         for {
-          mapM    <- Stream.fromIterable(m).mapM(UIO.succeedNow).runCollect
-          mapMPar <- Stream.fromIterable(m).mapMPar(n)(UIO.succeedNow).runCollect
+          mapM    <- Stream.fromIterable(m).mapM(UIO.succeed(_)).runCollect
+          mapMPar <- Stream.fromIterable(m).mapMPar(n)(UIO.succeed(_)).runCollect
         } yield assert(n)(isGreaterThan(0)) implies assert(mapM)(equalTo(mapMPar))
       })
     ) @@ TestAspect.forked,
@@ -1446,7 +1444,7 @@ object StreamSpec extends ZIOBaseSpec {
 
         assertM(
           s1.mergeWith(s2)(_.toString, _.toString)
-            .run(Sink.succeedNow[String, String]("done"))
+            .run(Sink.succeed[String, String]("done"))
         )(equalTo("done"))
       },
       testM("mergeWith prioritizes failure") {
@@ -1478,8 +1476,8 @@ object StreamSpec extends ZIOBaseSpec {
       assertM(
         ZStream
           .paginateM(s) {
-            case (x, Nil)      => ZIO.succeedNow(x -> None)
-            case (x, x0 :: xs) => ZIO.succeedNow(x -> Some(x0 -> xs))
+            case (x, Nil)      => ZIO.succeed(x -> None)
+            case (x, x0 :: xs) => ZIO.succeed(x -> Some(x0 -> xs))
           }
           .runCollect
       )(equalTo(List(0, 1, 2, 3)))
@@ -1488,7 +1486,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("allows repeated runs without hanging") {
         val stream = ZStream
           .fromIterable[Int](Seq.empty)
-          .partitionEither(i => ZIO.succeedNow(if (i % 2 == 0) Left(i) else Right(i)))
+          .partitionEither(i => ZIO.succeed(if (i % 2 == 0) Left(i) else Right(i)))
           .map { case (evens, odds) => evens.mergeEither(odds) }
           .use(_.runCollect)
         assertM(ZIO.collectAll(Range(0, 100).toList.map(_ => stream)).map(_ => 0))(equalTo(0))
@@ -1497,8 +1495,8 @@ object StreamSpec extends ZIOBaseSpec {
         Stream
           .range(0, 6)
           .partitionEither { i =>
-            if (i % 2 == 0) ZIO.succeedNow(Left(i))
-            else ZIO.succeedNow(Right(i))
+            if (i % 2 == 0) ZIO.succeed(Left(i))
+            else ZIO.succeed(Right(i))
           }
           .use {
             case (s1, s2) =>
@@ -1510,8 +1508,8 @@ object StreamSpec extends ZIOBaseSpec {
       },
       testM("errors") {
         (Stream.range(0, 1) ++ Stream.fail("Boom")).partitionEither { i =>
-          if (i % 2 == 0) ZIO.succeedNow(Left(i))
-          else ZIO.succeedNow(Right(i))
+          if (i % 2 == 0) ZIO.succeed(Left(i))
+          else ZIO.succeed(Right(i))
         }.use {
           case (s1, s2) =>
             for {
@@ -1525,8 +1523,8 @@ object StreamSpec extends ZIOBaseSpec {
           .range(0, 6)
           .partitionEither(
             i =>
-              if (i % 2 == 0) ZIO.succeedNow(Left(i))
-              else ZIO.succeedNow(Right(i)),
+              if (i % 2 == 0) ZIO.succeed(Left(i))
+              else ZIO.succeed(Right(i)),
             1
           )
           .use {
@@ -1731,7 +1729,7 @@ object StreamSpec extends ZIOBaseSpec {
       testM("succeed") {
         assertM(
           Stream
-            .succeedNow(1)
+            .succeed(1)
             .timeout(Duration.Infinity)
             .runCollect
         )(equalTo(List(1)))
@@ -1818,9 +1816,9 @@ object StreamSpec extends ZIOBaseSpec {
         final class TestSink(ref: Ref[Int]) extends ZSink[Any, Throwable, Int, Int, List[Int]] {
           type State = (List[Int], Boolean)
 
-          def extract(state: State) = UIO.succeedNow((state._1, Chunk.empty))
+          def extract(state: State) = UIO.succeed((state._1, Chunk.empty))
 
-          def initial = UIO.succeedNow((Nil, true))
+          def initial = UIO.succeed((Nil, true))
 
           def step(state: State, a: Int) =
             for {
@@ -1861,8 +1859,8 @@ object StreamSpec extends ZIOBaseSpec {
       assertM(
         Stream
           .unfoldM(0) { i =>
-            if (i < 10) IO.succeedNow(Some((i, i + 1)))
-            else IO.succeedNow(None)
+            if (i < 10) IO.succeed(Some((i, i + 1)))
+            else IO.succeed(None)
           }
           .runCollect
       )(equalTo((0 to 9).toList))
@@ -1953,7 +1951,7 @@ object StreamSpec extends ZIOBaseSpec {
       for {
         streamResult <- stream.runCollect
         inputStreamResult <- stream.toInputStream.use { inputStream =>
-                              ZIO.succeedNow(
+                              ZIO.succeed(
                                 Iterator
                                   .continually(inputStream.read)
                                   .takeWhile(_ != -1)
@@ -1974,6 +1972,6 @@ object StreamSpec extends ZIOBaseSpec {
               .take(n.toLong)
               .runCollect
               .toManaged_
-    } yield assert(out)(equalTo((1 to n).toList))).use(ZIO.succeedNow))
+    } yield assert(out)(equalTo((1 to n).toList))).use(ZIO.succeed(_)))
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -34,7 +34,7 @@ trait StreamUtils extends ChunkUtils with GenZIO {
               it <- Gen.listOfN(n)(a)
             } yield ZStream.unfoldM((i, it)) {
               case (_, Nil) | (0, _) => IO.fail("fail-case")
-              case (n, head :: rest) => IO.succeedNow(Some((head, (n - 1, rest))))
+              case (n, head :: rest) => IO.succeed(Some((head, (n - 1, rest))))
             }
           )
     }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -124,7 +124,7 @@ object ZTestFrameworkSpec {
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
-          UIO.succeedNow(Summary(1, 0, 0, "foo")) >>> zTestTask.sendSummary,
+          UIO.succeed(Summary(1, 0, 0, "foo")) >>> zTestTask.sendSummary,
           TestArgs.empty
         )
       }
@@ -145,7 +145,7 @@ object ZTestFrameworkSpec {
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
-          UIO.succeedNow(Summary(0, 0, 0, "foo")) >>> zTestTask.sendSummary,
+          UIO.succeed(Summary(0, 0, 0, "foo")) >>> zTestTask.sendSummary,
           TestArgs.empty
         )
       }

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -32,7 +32,7 @@ object FunSpec extends ZIOBaseSpec {
     },
     testM("fun is supported on Scala.js") {
       for {
-        f <- Fun.make((_: Int) => ZIO.foreach(List.range(0, 100000))(ZIO.succeedNow))
+        f <- Fun.make((_: Int) => ZIO.foreach(List.range(0, 100000))(ZIO.succeed(_)))
       } yield assert(f(1))(anything)
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -227,7 +227,7 @@ object GenSpec extends ZIOBaseSpec {
         checkSample(Gen.long(min, max))(forall(isGreaterThanEqualTo(min) && isLessThanEqualTo(max)))
       },
       testM("mapM maps an effectual function over a generator") {
-        val gen = Gen.int(1, 6).mapM(n => ZIO.succeedNow(n + 6))
+        val gen = Gen.int(1, 6).mapM(n => ZIO.succeed(n + 6))
         checkSample(gen)(forall(Assertion.isGreaterThanEqualTo(7) && isLessThanEqualTo(12)))
       },
       testM("mapOf generates sizes in range") {

--- a/test-tests/shared/src/test/scala/zio/test/SampleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SampleSpec.scala
@@ -27,8 +27,8 @@ object SampleSpec extends ZIOBaseSpec {
     },
     testM("traverse fusion") {
       val sample              = Sample.shrinkIntegral(0)(5)
-      def f(n: Int): UIO[Int] = ZIO.succeedNow(n + 2)
-      def g(n: Int): UIO[Int] = ZIO.succeedNow(n * 3)
+      def f(n: Int): UIO[Int] = ZIO.succeed(n + 2)
+      def g(n: Int): UIO[Int] = ZIO.succeed(n * 3)
       val result = equalEffects(
         sample.foreach(a => f(a).flatMap(g)),
         sample.foreach(f).flatMap(_.foreach(g))
@@ -44,7 +44,7 @@ object SampleSpec extends ZIOBaseSpec {
     left.flatMap(a => right.flatMap(b => equalSamples(a, b)))
 
   def equalSamples[A, B](left: Sample[Any, A], right: Sample[Any, B]): UIO[Boolean] =
-    if (left.value != right.value) UIO.succeedNow(false) else equalShrinks(left.shrink, right.shrink)
+    if (left.value != right.value) UIO.succeed(false) else equalShrinks(left.shrink, right.shrink)
 
   def equalShrinks[A, B](
     left: ZStream[Any, Nothing, Sample[Any, A]],

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -250,7 +250,7 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         ref <- Ref.make(false)
         spec = suite("verify")(
-          testM("first test")(ZIO.succeedNow(assertCompletes)),
+          testM("first test")(ZIO.succeed(assertCompletes)),
           testM("second test")(ref.set(true).as(assertCompletes))
         ) @@ sequential @@ verify(assertM(ref.get)(isTrue))
         result <- succeeded(spec)

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -15,13 +15,13 @@ object TestSpec extends ZIOBaseSpec {
     testM("testM error is test failure") {
       for {
         _      <- ZIO.fail("fail")
-        result <- ZIO.succeedNow("succeed")
+        result <- ZIO.succeed("succeed")
       } yield assert(result)(equalTo("succeed"))
     } @@ failing,
     testM("testM is polymorphic in error type") {
       for {
         _      <- ZIO.effect(())
-        result <- ZIO.succeedNow("succeed")
+        result <- ZIO.succeed("succeed")
       } yield assert(result)(equalTo("succeed"))
     },
     testM("testM suspends effects") {
@@ -29,11 +29,11 @@ object TestSpec extends ZIOBaseSpec {
       val spec = suite("suite")(
         testM("test1") {
           n += 1
-          ZIO.succeedNow(assertCompletes)
+          ZIO.succeed(assertCompletes)
         },
         testM("test2") {
           n += 1
-          ZIO.succeedNow(assertCompletes)
+          ZIO.succeed(assertCompletes)
         }
       ).filterLabels(_ == "test2").get
       for {

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -12,7 +12,7 @@ object TestUtils {
     execSpec: UIO[ExecutedSpec[E]]
   )(f: Either[TestFailure[E], TestSuccess] => Boolean): ZIO[Any, Nothing, Boolean] =
     execSpec.flatMap { results =>
-      results.forall { case Spec.TestCase(_, test, _) => test.map(r => f(r)); case _ => ZIO.succeedNow(true) }
+      results.forall { case Spec.TestCase(_, test, _) => test.map(r => f(r)); case _ => ZIO.succeed(true) }
     }
 
   def isIgnored[E](spec: ZSpec[environment.TestEnvironment, E]): ZIO[Any, Nothing, Boolean] = {

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMockSpec.scala
@@ -63,7 +63,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
           equalTo("foo 1")
         ),
         testSpec("returns valueM")(
-          ModuleMock.SingleParam(equalTo(1), valueM(i => UIO.succeedNow(s"foo $i"))),
+          ModuleMock.SingleParam(equalTo(1), valueM(i => UIO.succeed(s"foo $i"))),
           Module.singleParam(1),
           equalTo("foo 1")
         ),
@@ -95,7 +95,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
           equalTo("foo (1,2,3)")
         ),
         testSpec("returns valueM")(
-          ModuleMock.ManyParams(equalTo((1, "2", 3L)), valueM(i => UIO.succeedNow(s"foo $i"))),
+          ModuleMock.ManyParams(equalTo((1, "2", 3L)), valueM(i => UIO.succeed(s"foo $i"))),
           Module.manyParams(1, "2", 3L),
           equalTo("foo (1,2,3)")
         ),
@@ -127,7 +127,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
           equalTo("foo (1,2,3)")
         ),
         testSpec("returns valueM")(
-          ModuleMock.ManyParamLists(equalTo((1, "2", 3L)), valueM(i => UIO.succeedNow(s"foo $i"))),
+          ModuleMock.ManyParamLists(equalTo((1, "2", 3L)), valueM(i => UIO.succeed(s"foo $i"))),
           Module.manyParamLists(1)("2")(3L),
           equalTo("foo (1,2,3)")
         ),
@@ -174,7 +174,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
             equalTo("foo 1")
           ),
           testSpec("returns valueM")(
-            ModuleMock.Overloaded._0(equalTo(1), valueM(i => UIO.succeedNow(s"foo $i"))),
+            ModuleMock.Overloaded._0(equalTo(1), valueM(i => UIO.succeed(s"foo $i"))),
             Module.overloaded(1),
             equalTo("foo 1")
           ),
@@ -206,7 +206,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
             equalTo("foo 1")
           ),
           testSpec("returns valueM")(
-            ModuleMock.Overloaded._1(equalTo(1L), valueM(i => UIO.succeedNow(s"foo $i"))),
+            ModuleMock.Overloaded._1(equalTo(1L), valueM(i => UIO.succeed(s"foo $i"))),
             Module.overloaded(1L),
             equalTo("foo 1")
           ),
@@ -239,7 +239,7 @@ object BasicMockSpec extends ZIOBaseSpec with MockSpecUtils {
           equalTo("foo (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)")
         ),
         testSpec("returns valueM")(
-          ModuleMock.MaxParams(equalTo(intTuple22), valueM(i => UIO.succeedNow(s"foo $i"))),
+          ModuleMock.MaxParams(equalTo(intTuple22), valueM(i => UIO.succeed(s"foo $i"))),
           (Module.maxParams _).tupled(intTuple22),
           equalTo("foo (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22)")
         ),


### PR DESCRIPTION
Since `succeedNow` is private we should be using `succeed` instead of `succeedNow` in tests to mirror the methods that users would call when working with our code.