### PR TITLE
ZIO Test: Implement TestAspect#only

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.Assertion.{ equalTo, isFalse, isTrue }
-import zio.test.TestAspect.ifEnvSet
+import zio.test.TestAspect.{ ifEnvSet, only }
 import zio.test.TestUtils._
 import zio.test.environment.TestEnvironment
 import zio.{ Has, NeedsEnv, Ref, ZIO, ZLayer }
@@ -65,22 +65,50 @@ object SpecSpec extends ZIOBaseSpec {
       }
     ),
     suite("only")(
-      testM("ignores all tests except one matching the given label") {
-        for {
-          passed1 <- succeeded(mixedSpec.only(passingTest))
-          passed2 <- succeeded(mixedSpec.only(failingTest))
-        } yield assert(passed1)(isTrue) && assert(passed2)(isFalse)
+      testM("ignores all tests except one tagged") {
+        val spec = suite("root suite")(
+          suite("failing suite")(
+            test("failing test") {
+              assert(1)(equalTo(2))
+            }
+          ),
+          suite("passing suite")(
+            test("passing test") {
+              assert(1)(equalTo(1))
+            } @@ only
+          )
+        )
+        assertM(succeeded(spec))(isTrue)
       },
-      testM("ignores all tests except ones in the suite matching the given label") {
-        for {
-          passed1 <- succeeded(mixedSpec.only(passingSuite))
-          passed2 <- succeeded(mixedSpec.only(failingSuite))
-        } yield assert(passed1)(isTrue) && assert(passed2)(isFalse)
+      testM("ignores all tests except ones in the tagged suite") {
+        val spec = suite("root suite")(
+          suite("failing suite")(
+            test("failing test") {
+              assert(1)(equalTo(2))
+            }
+          ),
+          suite("passing suite")(
+            test("passing test") {
+              assert(1)(equalTo(1))
+            }
+          ) @@ only
+        )
+        assertM(succeeded(spec))(isTrue)
       },
-      testM("runs everything if root suite label given") {
-        for {
-          passed <- succeeded(mixedSpec.only(rootSuite))
-        } yield assert(passed)(isFalse)
+      testM("runs everything if no tests are tagged") {
+        val spec = suite("root suite")(
+          suite("failing suite")(
+            test("failing test") {
+              assert(1)(equalTo(2))
+            }
+          ),
+          suite("passing suite")(
+            test("passing test") {
+              assert(1)(equalTo(1))
+            }
+          )
+        )
+        assertM(succeeded(spec))(isFalse)
       }
     ),
     suite("provideCustomLayer")(
@@ -98,22 +126,5 @@ object SpecSpec extends ZIOBaseSpec {
         } yield assertCompletes
       }.provideLayer(layer)
     )
-  )
-
-  val failingTest  = "failing-test"
-  val failingSuite = "failing-suite"
-  val passingTest  = "passing-test"
-  val passingSuite = "passing-suite"
-  val rootSuite    = "root-suite"
-  val prefix       = "prefix"
-  val suffix       = "suffix"
-
-  val mixedSpec = suite(prefix + rootSuite + suffix)(
-    suite(prefix + failingSuite + suffix)(test(prefix + failingTest + suffix) {
-      assert(1)(equalTo(2))
-    }),
-    suite(prefix + passingSuite + suffix)(test(prefix + passingTest + suffix) {
-      assert(1)(equalTo(1))
-    })
   )
 }

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -49,6 +49,12 @@ object TestAnnotation {
     TestAnnotation("ignored", 0, _ + _)
 
   /**
+   * An annotation which tags tests to be the only ones evaluated.
+   */
+  val only: TestAnnotation[Boolean] =
+    TestAnnotation("only", false, _ || _)
+
+  /**
    * An annotation which counts repeated tests.
    */
   val repeated: TestAnnotation[Int] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,7 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   lazy val default: TestAnnotationRenderer =
-    CompositeRenderer(Vector(ignored, repeated, retried, tagged, timed))
+    CompositeRenderer(Vector(ignored, only, repeated, retried, tagged, timed))
 
   /**
    * A test annotation renderer that renders the number of ignored tests.
@@ -82,6 +82,17 @@ object TestAnnotationRenderer {
       case (child :: _) =>
         if (child == 0) None
         else Some(s"ignored: $child")
+    }
+
+  /**
+   * A test annotation renderer that renders tags for the only tests
+   * evaluated.
+   */
+  val only: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.only) {
+      case (child :: _) =>
+        if (!child) None
+        else Some("only")
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -458,6 +458,12 @@ object TestAspect extends TimeoutVariants {
     before(Live.live(clock.nanoTime).flatMap(TestRandom.setSeed(_)))
 
   /**
+   * Annotates tests to be the only ones evaluated.
+   */
+  val only: TestAspectPoly =
+    annotate(TestAnnotation.only, true)
+
+  /**
    * An aspect that executes the members of a suite in parallel.
    */
   val parallel: TestAspectPoly =

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -32,7 +32,7 @@ object TestExecutor {
     env: Layer[Nothing, R]
   ): TestExecutor[R, E] = new TestExecutor[R, E] {
     def run(spec: ZSpec[R, E], defExec: ExecutionStrategy): UIO[ExecutedSpec[E]] =
-      spec.annotated
+      spec.only.annotated
         .provideLayer(environment)
         .foreachExec(defExec)(
           e =>


### PR DESCRIPTION
Resolves #3226. Adds an `only` test annotation and an `only` test aspect that adds the annotation. The test executor then first traverses the spec to determine if any specs are annotated with `only`, if so it runs those specs, otherwise it runs all specs.