### PR TITLE
 ZIO Test: Use Suite Execution Strategy in ProvideSomeLayerShared

### DIFF
--- a/core/shared/src/main/scala/zio/ExecutionStrategy.scala
+++ b/core/shared/src/main/scala/zio/ExecutionStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,30 @@
  * limitations under the License.
  */
 
-package zio.test
+package zio
 
+/**
+ * Describes a strategy for evaluating multiple effects, potentially in
+ * parallel. There are three possible execution strategies: `Sequential`,
+ * `Parallel`, and `ParallelN`.
+ */
 sealed trait ExecutionStrategy
+
 object ExecutionStrategy {
-  case object Sequential             extends ExecutionStrategy
-  case object Parallel               extends ExecutionStrategy
+
+  /**
+   * Execute effects sequentially.
+   */
+  case object Sequential extends ExecutionStrategy
+
+  /**
+   * Execute effects in parallel.
+   */
+  case object Parallel extends ExecutionStrategy
+
+  /**
+   * Execute effects in parallel, up to the specified number of concurrent
+   * fibers.
+   */
   final case class ParallelN(n: Int) extends ExecutionStrategy
 }

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -328,7 +328,7 @@ object IO {
     ZIO.foreach(in)(f)
 
   /**
-   * @see See [[[zio.ZIO.foreachExec]]
+   * @see See [[zio.ZIO.foreachExec]]
    */
   final def foreachExec[E, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => IO[E, B]): IO[E, List[B]] =
     ZIO.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -328,6 +328,12 @@ object IO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachExec]]
+   */
+  final def foreachExec[E, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => IO[E, B]): IO[E, List[B]] =
+    ZIO.foreachExec(as)(exec)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreachPar[R,E,A,B](as:Iterable*]]]
    */
   def foreachPar[E, A, B](as: Iterable[A])(fn: A => IO[E, B]): IO[E, List[B]] =

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -133,7 +133,7 @@ object Managed {
     ZManaged.foreach_(as)(f)
 
   /**
-   * See [[zio.ZManaged.foreachExac]]
+   * See [[zio.ZManaged.foreachExec]]
    */
   final def foreachExec[E, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => Managed[E, B]): Managed[E, List[B]] =
     ZManaged.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/Managed.scala
+++ b/core/shared/src/main/scala/zio/Managed.scala
@@ -133,6 +133,12 @@ object Managed {
     ZManaged.foreach_(as)(f)
 
   /**
+   * See [[zio.ZManaged.foreachExac]]
+   */
+  final def foreachExec[E, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => Managed[E, B]): Managed[E, List[B]] =
+    ZManaged.foreachExec(as)(exec)(f)
+
+  /**
    * See [[zio.ZManaged.foreachPar]]
    */
   def foreachPar[E, A1, A2](as: Iterable[A1])(f: A1 => Managed[E, A2]): Managed[E, List[A2]] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -357,7 +357,7 @@ object RIO {
     ZIO.foreach(in)(f)
 
   /**
-   * @see See [[[zio.ZIO.foreachExec]]
+   * @see See [[zio.ZIO.foreachExec]]
    */
   final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -357,6 +357,12 @@ object RIO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachExec]]
+   */
+  final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => RIO[R, B]): RIO[R, List[B]] =
+    ZIO.foreachExec(as)(exec)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreachPar[R,E,A,B](as:Iterable*]]]
    */
   def foreachPar[R, A, B](as: Iterable[A])(fn: A => RIO[R, B]): RIO[R, List[B]] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -328,7 +328,7 @@ object Task extends TaskPlatformSpecific {
     ZIO.foreach(in)(f)
 
   /**
-   * @see See [[[zio.ZIO.foreachExec]]
+   * @see See [[zio.ZIO.foreachExec]]
    */
   final def foreachExec[A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => Task[B]): Task[List[B]] =
     ZIO.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -328,6 +328,12 @@ object Task extends TaskPlatformSpecific {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachExec]]
+   */
+  final def foreachExec[A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => Task[B]): Task[List[B]] =
+    ZIO.foreachExec(as)(exec)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreachPar[R,E,A,B](as:Iterable*]]]
    */
   def foreachPar[A, B](as: Iterable[A])(fn: A => Task[B]): Task[List[B]] =

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -322,6 +322,12 @@ object UIO {
     ZIO.foreach_(as)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachExec]]
+   */
+  final def foreachExec[A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => UIO[B]): UIO[List[B]] =
+    ZIO.foreachExec(as)(exec)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreachPar[R,E,A,B](as:Iterable*]]]
    */
   def foreachPar[A, B](as: Iterable[A])(fn: A => UIO[B]): UIO[List[B]] =

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -322,7 +322,7 @@ object UIO {
     ZIO.foreach_(as)(f)
 
   /**
-   * @see See [[[zio.ZIO.foreachExec]]
+   * @see See [[zio.ZIO.foreachExec]]
    */
   final def foreachExec[A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => UIO[B]): UIO[List[B]] =
     ZIO.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -329,7 +329,7 @@ object URIO {
     ZIO.foreach(in)(f)
 
   /**
-   * @see See [[[zio.ZIO.foreachExec]]
+   * @see See [[zio.ZIO.foreachExec]]
    */
   final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.foreachExec(as)(exec)(f)

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -329,6 +329,12 @@ object URIO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachExec]]
+   */
+  final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => URIO[R, B]): URIO[R, List[B]] =
+    ZIO.foreachExec(as)(exec)(f)
+
+  /**
    * @see [[[zio.ZIO.foreachPar[R,E,A,B](as:Iterable*]]]
    */
   def foreachPar[R, A, B](as: Iterable[A])(fn: A => URIO[R, B]): URIO[R, List[B]] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2517,6 +2517,19 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     as.mapM_(f)
 
   /**
+   * Applies the function `f` to each element of the `Iterable[A]` and returns
+   * the result in a new `List[B]` using the specified execution strategy.
+   */
+  final def foreachExec[R, E, A, B](
+    as: Iterable[A]
+  )(exec: ExecutionStrategy)(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]] =
+    exec match {
+      case ExecutionStrategy.Parallel     => ZIO.foreachPar(as)(f)
+      case ExecutionStrategy.ParallelN(n) => ZIO.foreachParN(n)(as)(f)
+      case ExecutionStrategy.Sequential   => ZIO.foreach(as)(f)
+    }
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
    * and returns the results in a new `List[B]`.
    *

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1481,6 +1481,19 @@ object ZManaged {
     in.fold[ZManaged[R, E, Option[A2]]](succeed(None))(f(_).map(Some(_)))
 
   /**
+   * Applies the function `f` to each element of the `Iterable[A]` and returns
+   * the result in a new `List[B]` using the specified execution strategy.
+   */
+  final def foreachExec[R, E, A, B](
+    as: Iterable[A]
+  )(exec: ExecutionStrategy)(f: A => ZManaged[R, E, B]): ZManaged[R, E, List[B]] =
+    exec match {
+      case ExecutionStrategy.Parallel     => ZManaged.foreachPar(as)(f)
+      case ExecutionStrategy.ParallelN(n) => ZManaged.foreachParN(n)(as)(f)
+      case ExecutionStrategy.Sequential   => ZManaged.foreach(as)(f)
+    }
+
+  /**
    * Applies the function `f` to each element of the `Iterable[A]` in parallel,
    * and returns the results in a new `List[B]`.
    *

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -2,6 +2,7 @@ package zio.test
 
 import zio._
 import zio.test.Assertion.equalTo
+import zio.test.TestAspect.sequential
 
 object ManagedSpec extends ZIOBaseSpec {
 
@@ -27,24 +28,26 @@ object ManagedSpec extends ZIOBaseSpec {
   }
 
   def spec = suite("ManagedSpec")(
-    suite("managed shared")(
-      suite("first suite")(
-        testM("first test") {
-          assertM(Counter.incrementAndGet)(equalTo(2))
-        },
-        testM("second test") {
-          assertM(Counter.incrementAndGet)(equalTo(3))
-        }
-      ),
-      suite("second suite")(
-        testM("third test") {
-          assertM(Counter.incrementAndGet)(equalTo(4))
-        },
-        testM("fourth test") {
-          assertM(Counter.incrementAndGet)(equalTo(5))
-        }
+    sequential {
+      suite("managed shared")(
+        suite("first suite")(
+          testM("first test") {
+            assertM(Counter.incrementAndGet)(equalTo(2))
+          },
+          testM("second test") {
+            assertM(Counter.incrementAndGet)(equalTo(3))
+          }
+        ),
+        suite("second suite")(
+          testM("third test") {
+            assertM(Counter.incrementAndGet)(equalTo(4))
+          },
+          testM("fourth test") {
+            assertM(Counter.incrementAndGet)(equalTo(5))
+          }
+        )
       )
-    ).provideLayerShared(Counter.live),
+    }.provideLayerShared(Counter.live),
     suite("managed per test")(
       suite("first suite")(
         testM("first test") {

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.environment.TestEnvironment
-import zio.{ UIO, ZIO }
+import zio.{ ExecutionStrategy, UIO, ZIO }
 
 object TestUtils {
 

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ Has, Layer, UIO, ZIO }
+import zio.{ ExecutionStrategy, Has, Layer, UIO, ZIO }
 
 /**
  * A `TestExecutor[R, E]` is capable of executing specs that require an


### PR DESCRIPTION
In `provideSomeLayerShared` we need to create one effect that models execution of all tests in the spec to provide the layer to. This PR updates the implementation to use the execution strategy for each suite in the composed effect.