### PR TITLE
Simplify Signature of ZIO#absolve

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -152,8 +152,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect that submerges the error case of an `Either` into the
    * `ZIO`. The inverse operation of `ZIO.either`.
    */
-  final def absolve[R1 <: R, E1, B](implicit ev1: ZIO[R, E, A] <:< ZIO[R1, E1, Either[E1, B]]): ZIO[R1, E1, B] =
-    ZIO.absolve[R1, E1, B](ev1(self))
+  final def absolve[E1 >: E, B](implicit ev: A <:< Either[E1, B]): ZIO[R, E1, B] =
+    ZIO.absolve(self.map(ev))
 
   /**
    * Attempts to convert defects into a failure, throwing away all information

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -141,10 +141,8 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Submerges the error case of an `Either` into the `ZManaged`. The inverse
    * operation of `ZManaged.either`.
    */
-  def absolve[R1 <: R, E1, B](
-    implicit ev: ZManaged[R, E, A] <:< ZManaged[R1, E1, Either[E1, B]]
-  ): ZManaged[R1, E1, B] =
-    ZManaged.absolve(ev(self))
+  def absolve[E1 >: E, B](implicit ev: A <:< Either[E1, B]): ZManaged[R, E1, B] =
+    ZManaged.absolve(self.map(ev))
 
   /**
    * Attempts to convert defects into a failure, throwing away all information

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -151,8 +151,8 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Returns an effect that submerges the error case of an `Either` into the
    * `STM`. The inverse operation of `STM.either`.
    */
-  def absolve[R1 <: R, E1, B](implicit ev1: ZSTM[R, E, A] <:< ZSTM[R1, E1, Either[E1, B]]): ZSTM[R1, E1, B] =
-    ZSTM.absolve[R1, E1, B](ev1(self))
+  def absolve[E1 >: E, B](implicit ev: A <:< Either[E1, B]): ZSTM[R, E1, B] =
+    ZSTM.absolve(self.map(ev))
 
   /**
    * Named alias for `>>>`.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -78,10 +78,8 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Returns a stream that submerges the error case of an `Either` into the `ZStream`. Note that
    * this combinator and [[either]] cancel each other, i.e. `xs.either.absolve == xs` and vice versa.
    */
-  final def absolve[R1 <: R, E1, B](
-    implicit ev: ZStream[R, E, A] <:< ZStream[R1, E1, Either[E1, B]]
-  ): ZStream[R1, E1, B] =
-    ZStream.absolve(ev(self))
+  final def absolve[E1 >: E, B](implicit ev: A <:< Either[E1, B]): ZStream[R, E1, B] =
+    ZStream.absolve(self.map(ev))
 
   /**
    * Applies an aggregator to the stream, which converts one or more elements


### PR DESCRIPTION
We got reports of occasional type inference issues with the current signature of `ZIO#absolve` and the current signature is somewhat strange in indicating that additional environmental requirements could be added to the effect when this is not possible. Simplifies the implicit evidence requirement to avoid this.