### PR TITLE
Optimize unsafe ZQueue methods

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -14,8 +14,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
-@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
 @Fork(3)
 /**
  * This benchmark offers and takes a number of items in parallel, with a very small queue to enforce back pressure mechanism is used.

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -14,8 +14,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
-@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
 @Fork(3)
 /**
  * This benchmark offers and takes a number of items in parallel, without back pressure.

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -17,8 +17,8 @@ import zio.stm._
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
-@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 10)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
 @Fork(3)
 /**
  * This benchmark sequentially offers a number of items to the queue, then takes them out of the queue.

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -239,7 +239,8 @@ object Promise {
    * Makes a new promise to be completed by the fiber with the specified id.
    */
   def makeAs[E, A](fiberId: Fiber.Id): UIO[Promise[E, A]] =
-    ZIO.effectTotal(
-      new Promise[E, A](new AtomicReference[State[E, A]](new internal.Pending[E, A](Nil)), fiberId :: Nil)
-    )
+    ZIO.effectTotal(unsafeMake(fiberId))
+
+  private[zio] def unsafeMake[E, A](fiberId: Fiber.Id): Promise[E, A] =
+    new Promise[E, A](new AtomicReference[State[E, A]](new internal.Pending[E, A](Nil)), fiberId :: Nil)
 }

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -401,7 +401,8 @@ object ZQueue {
         IO.effectTotal {
           unsafeSlidingOffer(as)
           unsafeCompleteTakers(queue, takers)
-        }.as(true)
+                  true
+                }
       }
 
       def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = ()

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -465,15 +465,14 @@ object ZQueue {
         var keepPolling = true
 
         while (keepPolling && !queue.isFull()) {
-          putters.poll(empty) match {
-            case null =>
-              keepPolling = false
-            case putter @ (a, p, lastItem) =>
-              val offered = queue.offer(a)
-              if (offered && lastItem)
-                unsafeCompletePromise(p, true)
-              else if (!offered)
-                unsafeOfferAll(putters, putter :: unsafePollAll(putters))
+          val putter = putters.poll(empty)
+          if (putter eq null) keepPolling = false
+          else {
+            val offered = queue.offer(putter._1)
+            if (offered && putter._3)
+              unsafeCompletePromise(putter._2, true)
+            else if (!offered)
+              unsafeOfferAll(putters, putter :: unsafePollAll(putters))
           }
         }
       }

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -453,15 +453,13 @@ object ZQueue {
       }
 
       def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {
-        val empty = null.asInstanceOf[(A, Promise[Nothing, Boolean], Boolean)]
-        var loop  = true
+        val empty       = null.asInstanceOf[(A, Promise[Nothing, Boolean], Boolean)]
+        var keepPolling = true
 
-        while (loop) {
-          loop = !queue.isFull()
-
+        while (keepPolling && !queue.isFull) {
           putters.poll(empty) match {
             case null =>
-              loop = false
+              keepPolling = false
             case putter @ (a, p, lastItem) =>
               val offered = queue.offer(a)
               if (offered && lastItem)

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -277,12 +277,15 @@ object ZQueue {
      * Poll all items from the queue
      */
     def unsafePollAll[A](q: MutableConcurrentQueue[A]): List[A] = {
+      val empty = null.asInstanceOf[A]
+
       @tailrec
       def poll(as: List[A]): List[A] =
-        q.poll(null.asInstanceOf[A]) match {
+        q.poll(empty) match {
           case null => as
           case a    => poll(a :: as)
         }
+
       poll(List.empty[A]).reverse
     }
 
@@ -290,14 +293,17 @@ object ZQueue {
      * Poll n items from the queue
      */
     def unsafePollN[A](q: MutableConcurrentQueue[A], max: Int): List[A] = {
+      val empty = null.asInstanceOf[A]
+
       @tailrec
       def poll(as: List[A], n: Int): List[A] =
         if (n < 1) as
         else
-          q.poll(null.asInstanceOf[A]) match {
+          q.poll(empty) match {
             case null => as
             case a    => poll(a :: as, n - 1)
           }
+
       poll(List.empty[A], max).reverse
     }
 
@@ -311,6 +317,7 @@ object ZQueue {
           case Nil          => as
           case head :: tail => if (q.offer(head)) offerAll(tail) else as
         }
+
       offerAll(as)
     }
 
@@ -460,10 +467,12 @@ object ZQueue {
         }
 
       def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {
+        val empty = null.asInstanceOf[(A, Promise[Nothing, Boolean], Boolean)]
+
         @tailrec
         def unsafeMovePutters(): Unit =
           if (!queue.isFull()) {
-            putters.poll(null.asInstanceOf[(A, Promise[Nothing, Boolean], Boolean)]) match {
+            putters.poll(empty) match {
               case null =>
               case putter @ (a, p, lastItem) =>
                 if (queue.offer(a)) {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -524,9 +524,9 @@ object ZQueue {
             val succeeded = queue.offer(a)
             strategy.unsafeCompleteTakers(queue, takers)
 
-            if (succeeded) 
+            if (succeeded)
               IO.succeedNow(true)
-            else 
+            else
               strategy.handleSurplus(List(a), queue, takers, shutdownFlag)
           }
         }
@@ -548,7 +548,8 @@ object ZQueue {
             val surplus = unsafeOfferAll(queue, remaining.toList)
             strategy.unsafeCompleteTakers(queue, takers)
 
-            if (surplus.isEmpty) IO.succeedNow(true)
+            if (surplus.isEmpty)
+              IO.succeedNow(true)
             else
               strategy.handleSurplus(surplus, queue, takers, shutdownFlag)
           }
@@ -559,7 +560,8 @@ object ZQueue {
 
     val size: UIO[Int] =
       UIO.effectSuspendTotal {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownFlag.get)
+          ZIO.interrupt
         else
           UIO.succeedNow(queue.size() - takers.size() + strategy.surplusSize)
       }
@@ -601,7 +603,8 @@ object ZQueue {
 
     val takeAll: UIO[List[A]] =
       UIO.effectSuspendTotal {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownFlag.get)
+          ZIO.interrupt
         else
           IO.effectTotal {
             val as = unsafePollAll(queue)
@@ -612,7 +615,8 @@ object ZQueue {
 
     def takeUpTo(max: Int): UIO[List[A]] =
       UIO.effectSuspendTotal {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownFlag.get)
+          ZIO.interrupt
         else
           IO.effectTotal {
             val as = unsafePollN(queue, max)

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -521,12 +521,13 @@ object ZQueue {
           if (noRemaining) IO.succeedNow(true)
           else {
             // not enough takers, offer to the queue
-            val surplus = unsafeOfferAll(queue, List(a))
+            val succeeded = queue.offer(a)
             strategy.unsafeCompleteTakers(queue, takers)
 
-            if (surplus.isEmpty) IO.succeedNow(true)
-            else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag)
+            if (succeeded) 
+              IO.succeedNow(true)
+            else 
+              strategy.handleSurplus(List(a), queue, takers, shutdownFlag)
           }
         }
       }

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -449,7 +449,7 @@ object ZQueue {
       private def unsafeOffer(as: List[A], p: Promise[Nothing, Boolean]): Unit = {
         val it = as.iterator
         while (it.hasNext)
-          putters.offer((it.next, p, it.hasNext))
+          putters.offer((it.next, p, !it.hasNext))
       }
 
       def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -478,6 +478,7 @@ object ZQueue {
         } yield ()
     }
   }
+
   private def unsafeCreate[A](
     queue: MutableConcurrentQueue[A],
     takers: MutableConcurrentQueue[Promise[Nothing, A]],

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -346,15 +346,16 @@ object ZQueue {
     ): Option[(Promise[Nothing, A], A)] =
       // check if there is both a taker and an item in the queue, starting by the taker
       if (!queue.isEmpty()) {
-        takers.poll(null.asInstanceOf[Promise[Nothing, A]]) match {
-          case null => None
-          case taker =>
-            queue.poll(null.asInstanceOf[A]) match {
-              case null =>
-                unsafeOfferAll(takers, taker :: unsafePollAll(takers))
-                pollTakersThenQueue(queue, takers)
-              case a => Some((taker, a))
-            }
+        val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
+        val taker     = takers.poll(nullTaker)
+        if (taker eq nullTaker) None
+        else {
+          queue.poll(null.asInstanceOf[A]) match {
+            case null =>
+              unsafeOfferAll(takers, taker :: unsafePollAll(takers))
+              pollTakersThenQueue(queue, takers)
+            case a => Some((taker, a))
+          }
         }
       } else None
 
@@ -508,11 +509,13 @@ object ZQueue {
         else {
           val noRemaining =
             if (queue.isEmpty()) {
-              takers.poll(null.asInstanceOf[Promise[Nothing, A]]) match {
-                case null => false
-                case taker =>
-                  unsafeCompletePromise(taker, a)
-                  true
+              val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
+              val taker     = takers.poll(nullTaker)
+
+              if (taker eq nullTaker) false
+              else {
+                unsafeCompletePromise(taker, a)
+                true
               }
             } else false
 

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -438,6 +438,18 @@ object ZQueue {
         isShutdown: AtomicBoolean
       ): UIO[Boolean] =
         UIO.effectSuspendTotalWith { (_, fiberId) =>
+          @tailrec
+          def unsafeOffer(as: List[A], p: Promise[Nothing, Boolean]): Unit =
+            as match {
+              case Nil =>
+              case head :: tail if tail.isEmpty =>
+                putters.offer((head, p, true))
+                ()
+              case head :: tail =>
+                putters.offer((head, p, false))
+                unsafeOffer(tail, p)
+            }
+
           val p = Promise.unsafeMake[Nothing, Boolean](fiberId)
 
           UIO.effectSuspendTotal {
@@ -448,12 +460,15 @@ object ZQueue {
           }.onInterrupt(IO.effectTotal(unsafeRemove(p)))
         }
 
+<<<<<<< HEAD
       private def unsafeOffer(as: List[A], p: Promise[Nothing, Boolean]): Unit = {
         val it = as.iterator
         while (it.hasNext)
           putters.offer((it.next, p, !it.hasNext))
       }
 
+=======
+>>>>>>> parent of 27e36b31... Replace tailrec with while loop in handleSurplus
       def unsafeOnQueueEmptySpace(queue: MutableConcurrentQueue[A]): Unit = {
         val empty       = null.asInstanceOf[(A, Promise[Nothing, Boolean], Boolean)]
         var keepPolling = true

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -346,16 +346,15 @@ object ZQueue {
     ): Option[(Promise[Nothing, A], A)] =
       // check if there is both a taker and an item in the queue, starting by the taker
       if (!queue.isEmpty()) {
-        val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
-        val taker     = takers.poll(nullTaker)
-        if (taker eq nullTaker) None
-        else {
-          queue.poll(null.asInstanceOf[A]) match {
-            case null =>
-              unsafeOfferAll(takers, taker :: unsafePollAll(takers))
-              pollTakersThenQueue(queue, takers)
-            case a => Some((taker, a))
-          }
+        takers.poll(null.asInstanceOf[Promise[Nothing, A]]) match {
+          case null => None
+          case taker =>
+            queue.poll(null.asInstanceOf[A]) match {
+              case null =>
+                unsafeOfferAll(takers, taker :: unsafePollAll(takers))
+                pollTakersThenQueue(queue, takers)
+              case a => Some((taker, a))
+            }
         }
       } else None
 
@@ -509,13 +508,11 @@ object ZQueue {
         else {
           val noRemaining =
             if (queue.isEmpty()) {
-              val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
-              val taker     = takers.poll(nullTaker)
-
-              if (taker eq nullTaker) false
-              else {
-                unsafeCompletePromise(taker, a)
-                true
+              takers.poll(null.asInstanceOf[Promise[Nothing, A]]) match {
+                case null => false
+                case taker =>
+                  unsafeCompletePromise(taker, a)
+                  true
               }
             } else false
 

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -348,9 +348,8 @@ object ZQueue {
       if (!queue.isEmpty()) {
         val nullTaker = null.asInstanceOf[Promise[Nothing, A]]
         val taker     = takers.poll(nullTaker)
-        if (taker eq nullTaker) {
-          None
-        } else {
+        if (taker eq nullTaker) None
+        else {
           queue.poll(null.asInstanceOf[A]) match {
             case null =>
               unsafeOfferAll(takers, taker :: unsafePollAll(takers))
@@ -515,7 +514,9 @@ object ZQueue {
 
             if (surplus.isEmpty) IO.succeedNow(true)
             else
-              strategy.handleSurplus(surplus, queue, shutdownFlag) <* IO.effectTotal(unsafeCompleteTakers(strategy, queue, takers))
+              strategy.handleSurplus(surplus, queue, shutdownFlag) <* IO.effectTotal(
+                unsafeCompleteTakers(strategy, queue, takers)
+              )
           }
         }
       }
@@ -538,7 +539,9 @@ object ZQueue {
 
             if (surplus.isEmpty) IO.succeedNow(true)
             else
-              strategy.handleSurplus(surplus, queue, shutdownFlag) <* IO.effectTotal(unsafeCompleteTakers(strategy, queue, takers))
+              strategy.handleSurplus(surplus, queue, shutdownFlag) <* IO.effectTotal(
+                unsafeCompleteTakers(strategy, queue, takers)
+              )
           }
         }
       }

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -452,7 +452,7 @@ object ZQueue {
       private def unsafeOffer(as: List[A], p: Promise[Nothing, Boolean]): Unit =
         as match {
           case Nil =>
-          case head :: tail if tail.isEmpty =>
+          case head :: Nil =>
             putters.offer((head, p, true))
             ()
           case head :: tail =>


### PR DESCRIPTION
### Summary

- Specialized one-element polling.
- Moved takers to surplus handling to avoid additional flat mapping.

### Baseline

```
Benchmark                             Mode  Cnt     Score    Error  Units
QueueBackPressureBenchmark.zioQueue  thrpt   45  1283.017 ±  9.913  ops/s
QueueParallelBenchmark.zioQueue      thrpt   45  3122.446 ± 37.989  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  4281.968 ± 34.725  ops/s
```

### Results

Dropping call to `unsafePollN` from `offer` and pulling out `unsafeCompleteTakers` resulted in:

```
QueueBackPressureBenchmark.zioQueue  thrpt   45  1317.294 ± 17.795  ops/s
QueueParallelBenchmark.zioQueue      thrpt   45  3111.200 ± 55.068  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  4236.902 ± 19.648  ops/s
```

After moving `unsafeCompleteTakers` to strategy, I've obtained the following results:

```
QueueBackPressureBenchmark.zioQueue  thrpt   45  1272.699 ± 11.950  ops/s
QueueParallelBenchmark.zioQueue      thrpt   45  3185.804 ± 61.126  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  4308.920 ± 13.430  ops/s
```

Profiling the code under sequential benchmark lead me to remove a singleton list allocation from `offer`'s "happy path". Here are the results:

```
QueueBackPressureBenchmark.zioQueue  thrpt   45  1439.267 ±  8.149  ops/s
QueueParallelBenchmark.zioQueue      thrpt   45  3123.395 ± 39.868  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  5091.036 ± 31.719  ops/s
```

Finally, profiling the code under parallel benchmark pointed out wasteful casts in 3 tail-recursive functions: `unsafePollAll`, `unsafePollN` and `unsafeOnQueueEmptySpace` (this one was actual culprit, the other ones were removed for consistency). Removing them produced the following results:

```
QueueBackPressureBenchmark.zioQueue  thrpt   45  1444.882 ± 23.077  ops/s
QueueParallelBenchmark.zioQueue      thrpt   45  3227.541 ± 35.157  ops/s
QueueSequentialBenchmark.zioQueue    thrpt   45  5049.260 ± 34.254  ops/s
```

There's probably room for some more scraping, but that might as well be misleading.