### PR TITLE
Varargs support in mockable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,6 +219,7 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(testRunner)
   .settings(buildInfoSettings("zio.test"))
   .settings(skip in publish := true)
+  .settings(macroExpansionSettings)
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testTestsJVM = testTests.jvm.settings(dottySettings)

--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -1,0 +1,107 @@
+package zio.test.mock
+
+import zio.{ Has, IO, Tagged, ZIO }
+
+/**
+ * https://github.com/scalamacros/paradise/issues/75
+ *
+ * We can't define module in the same scope with macro application
+ * */
+object modules {
+  type EmptyModule = Has[EmptyModule.Service]
+  object EmptyModule {
+    trait Service
+  }
+
+  type SinglePureValModule = Has[SinglePureValModule.Service]
+  object SinglePureValModule {
+    trait Service {
+      val foo: ZIO[Any, Nothing, Unit]
+    }
+  }
+
+  type SimplePureDefsModule = Has[SimplePureDefsModule.Service]
+  object SimplePureDefsModule {
+    trait Service {
+      val static: IO[String, String]
+      def zeroParams: IO[String, String]
+      def zeroParamsWithParens(): IO[String, String]
+      def singleParam(a: Int): IO[String, String]
+      def manyParams(a: Int, b: String, c: Long): IO[String, String]
+      def manyParamLists(a: Int)(b: String)(c: Long): IO[String, String]
+    }
+  }
+
+  type SimpleImpureDefsModule = Has[SimpleImpureDefsModule.Service]
+  object SimpleImpureDefsModule {
+    trait Service {
+      def zeroParams: String
+      def zeroParamsWithParens(): String
+      def singleParam(a: Int): String
+      def manyParams(a: Int, b: String, c: Long): String
+      def manyParamLists(a: Int)(b: String)(c: Long): String
+    }
+  }
+
+  type OverloadedPureDefsModule = Has[OverloadedPureDefsModule.Service]
+  object OverloadedPureDefsModule {
+    trait Service {
+      def overloaded(n: Int): IO[String, String]
+      def overloaded(n: Long): IO[String, String]
+    }
+  }
+
+  type OverloadedImpureDefsModule = Has[OverloadedImpureDefsModule.Service]
+  object OverloadedImpureDefsModule {
+    trait Service {
+      def overloaded(n: Int): String
+      def overloaded(n: Long): String
+    }
+  }
+
+  type PolyPureDefsModule = Has[PolyPureDefsModule.Service]
+  object PolyPureDefsModule {
+    trait Service {
+      def polyInput[I: Tagged](v: I): IO[String, String]
+      def polyError[E: Tagged](v: String): IO[E, String]
+      def polyOutput[A: Tagged](v: String): IO[String, A]
+      def polyInputError[I: Tagged, E: Tagged](v: I): IO[E, String]
+      def polyInputOutput[I: Tagged, A: Tagged](v: I): IO[String, A]
+      def polyErrorOutput[E: Tagged, A: Tagged](v: String): IO[E, A]
+      def polyInputErrorOutput[I: Tagged, E: Tagged, A: Tagged](v: I): IO[E, A]
+      def polyMixed[A: Tagged]: IO[String, (A, String)]
+      def polyBounded[A <: AnyVal: Tagged]: IO[String, A]
+    }
+  }
+
+  type PolyImpureDefsModule = Has[PolyImpureDefsModule.Service]
+  object PolyImpureDefsModule {
+    trait Service {
+      def polyInput[I: Tagged](v: I): String
+      def polyError[E <: Throwable: Tagged](v: String): String
+      def polyOutput[A: Tagged](v: String): A
+      def polyInputError[I: Tagged, E <: Throwable: Tagged](v: I): String
+      def polyInputOutput[I: Tagged, A: Tagged](v: I): A
+      def polyErrorOutput[E <: Throwable: Tagged, A: Tagged](v: String): A
+      def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): A
+      def polyMixed[A: Tagged]: (A, String)
+      def polyBounded[A <: AnyVal: Tagged]: A
+    }
+  }
+
+  type VarargsPureDefsModule = Has[VarargsPureDefsModule.Service]
+  object VarargsPureDefsModule {
+    trait Service {
+      def simpleVarargs(a: Int, b: String*): IO[String, Int]
+      def curriedVarargs(a: Int, b: String*)(c: Long, d: Double*): IO[String, Int]
+    }
+  }
+
+  type VarargsImpureDefsModule = Has[VarargsImpureDefsModule.Service]
+  object VarargsImpureDefsModule {
+    trait Service {
+      def simpleVarargs(a: Int, b: String*): String
+      def curriedVarargs(a: Int, b: String*)(c: Long, d: Double*): String
+    }
+  }
+}

--- a/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
+++ b/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
@@ -1,0 +1,219 @@
+package zio.test.mock
+
+import zio.test.Assertion._
+import zio.test._
+import zio.test.mock.modules._
+
+/**
+ * https://github.com/scalamacros/paradise/issues/75
+ *
+ * We can't typecheck @mockable with typeCheck
+ * */
+object MockableSpec extends DefaultRunnableSpec {
+
+  def spec = suite("MockableSpec")(
+    suite("Mockable macro")(
+      test("compiles when applied to object with empty Service") {
+        assert({
+          @mockable[EmptyModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[EmptyModule] = ModuleMock
+          }
+
+          Check
+        })(anything)
+      },
+      testM("fails when applied to object without type arg") {
+        assertM(typeCheck {
+          """
+            @mockable
+            object ModuleMock
+          """
+        })(isLeft(anything))
+      },
+      testM("fails when applied to trait") {
+        assertM(typeCheck {
+          """
+            object Module {
+              trait Service
+            }
+
+            @mockable[Module.Service]
+            trait ModuleMock
+          """
+        })(isLeft(anything))
+      },
+      testM("fails when applied to class") {
+        assertM(typeCheck {
+          """
+            object Module {
+              trait Service
+            }
+
+            @mockable[Module.Service]
+            class ModuleMock
+          """
+        })(isLeft(anything))
+      },
+      test("generates mocks for pure value") {
+        assert({
+          @mockable[SinglePureValModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[SinglePureValModule] = ModuleMock
+
+            val Foo: ModuleMock.Effect[Unit, Nothing, Unit] = ModuleMock.Foo
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for simple pure methods") {
+        assert({
+          @mockable[SimplePureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[SimplePureDefsModule] = ModuleMock
+
+            val Static: ModuleMock.Effect[Unit, String, String]                        = ModuleMock.Static
+            val ZeroParams: ModuleMock.Effect[Unit, String, String]                    = ModuleMock.ZeroParams
+            val ZeroParamsWithParens: ModuleMock.Effect[Unit, String, String]          = ModuleMock.ZeroParamsWithParens
+            val SingleParam: ModuleMock.Effect[Int, String, String]                    = ModuleMock.SingleParam
+            val ManyParams: ModuleMock.Effect[(Int, String, Long), String, String]     = ModuleMock.ManyParams
+            val ManyParamLists: ModuleMock.Effect[(Int, String, Long), String, String] = ModuleMock.ManyParamLists
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for simple impure methods") {
+        assert({
+          @mockable[SimpleImpureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[SimpleImpureDefsModule] = ModuleMock
+
+            val ZeroParams: ModuleMock.Method[Unit, Throwable, String]                    = ModuleMock.ZeroParams
+            val ZeroParamsWithParens: ModuleMock.Method[Unit, Throwable, String]          = ModuleMock.ZeroParamsWithParens
+            val SingleParam: ModuleMock.Method[Int, Throwable, String]                    = ModuleMock.SingleParam
+            val ManyParams: ModuleMock.Method[(Int, String, Long), Throwable, String]     = ModuleMock.ManyParams
+            val ManyParamLists: ModuleMock.Method[(Int, String, Long), Throwable, String] = ModuleMock.ManyParamLists
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for overloaded pure methods") {
+        assert({
+          @mockable[OverloadedPureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[OverloadedPureDefsModule] = ModuleMock
+
+            val Overloaded_0: ModuleMock.Effect[Int, String, String]  = ModuleMock.Overloaded._0
+            val Overloaded_1: ModuleMock.Effect[Long, String, String] = ModuleMock.Overloaded._1
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for overloaded impure methods") {
+        assert({
+          @mockable[OverloadedImpureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[OverloadedImpureDefsModule] = ModuleMock
+
+            val Overloaded_0: ModuleMock.Method[Int, Throwable, String]  = ModuleMock.Overloaded._0
+            val Overloaded_1: ModuleMock.Method[Long, Throwable, String] = ModuleMock.Overloaded._1
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for poly pure methods") {
+        assert({
+          @mockable[PolyPureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[PolyPureDefsModule] = ModuleMock
+
+            val PolyInput: ModuleMock.Poly.Effect.Input[String, String]       = ModuleMock.PolyInput
+            val PolyError: ModuleMock.Poly.Effect.Error[String, String]       = ModuleMock.PolyError
+            val PolyOutput: ModuleMock.Poly.Effect.Output[String, String]     = ModuleMock.PolyOutput
+            val PolyInputError: ModuleMock.Poly.Effect.InputError[String]     = ModuleMock.PolyInputError
+            val PolyInputOutput: ModuleMock.Poly.Effect.InputOutput[String]   = ModuleMock.PolyInputOutput
+            val PolyErrorOutput: ModuleMock.Poly.Effect.ErrorOutput[String]   = ModuleMock.PolyErrorOutput
+            val PolyInputErrorOutput: ModuleMock.Poly.Effect.InputErrorOutput = ModuleMock.PolyInputErrorOutput
+            val PolyMixed: ModuleMock.Poly.Effect.Output[Unit, String]        = ModuleMock.PolyMixed
+            val PolyBounded: ModuleMock.Poly.Effect.Output[Unit, String]      = ModuleMock.PolyBounded
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for poly impure methods") {
+        assert({
+          @mockable[PolyImpureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[PolyImpureDefsModule] = ModuleMock
+
+            val PolyInput: ModuleMock.Poly.Method.Input[Throwable, String]          = ModuleMock.PolyInput
+            val PolyError: ModuleMock.Method[String, Throwable, String]             = ModuleMock.PolyError
+            val PolyOutput: ModuleMock.Poly.Method.Output[String, Throwable]        = ModuleMock.PolyOutput
+            val PolyInputError: ModuleMock.Poly.Method.Input[Throwable, String]     = ModuleMock.PolyInputError
+            val PolyInputOutput: ModuleMock.Poly.Method.InputOutput[Throwable]      = ModuleMock.PolyInputOutput
+            val PolyErrorOutput: ModuleMock.Poly.Method.Output[String, Throwable]   = ModuleMock.PolyErrorOutput
+            val PolyInputErrorOutput: ModuleMock.Poly.Method.InputOutput[Throwable] = ModuleMock.PolyInputErrorOutput
+            val PolyMixed: ModuleMock.Poly.Method.Output[Unit, Throwable]           = ModuleMock.PolyMixed
+            val PolyBounded: ModuleMock.Poly.Method.Output[Unit, Throwable]         = ModuleMock.PolyBounded
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for varargs pure methods") {
+        assert({
+          @mockable[VarargsPureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[VarargsPureDefsModule] = ModuleMock
+
+            val SimpleVarargs: ModuleMock.Effect[(Int, Seq[String]), String, Int] = ModuleMock.SimpleVarargs
+            val CurriedVarargs: ModuleMock.Effect[(Int, Seq[String], Long, Seq[Double]), String, Int] =
+              ModuleMock.CurriedVarargs
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for varargs impure methods") {
+        assert({
+          @mockable[VarargsImpureDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[VarargsImpureDefsModule] = ModuleMock
+
+            val SimpleVarargs: ModuleMock.Method[(Int, Seq[String]), Throwable, String] = ModuleMock.SimpleVarargs
+            val CurriedVarargs: ModuleMock.Method[(Int, Seq[String], Long, Seq[Double]), Throwable, String] =
+              ModuleMock.CurriedVarargs
+          }
+
+          Check
+        })(anything)
+      }
+    )
+  )
+}

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
@@ -227,6 +227,85 @@ object BasicEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
           )
         )
       ),
+      suite("varargs")(
+        testValue("returns value")(
+          PureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), value("foo")),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo")
+        ),
+        testValue("returns valueF")(
+          PureModuleMock
+            .Varargs(equalTo((1, Seq("2", "3"))), valueF { case (a, b) => s"foo $a, [${b.mkString(", ")}]" }),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo 1, [2, 3]")
+        ),
+        testValue("returns valueM")(
+          PureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), valueM {
+            case (a, b) => UIO.succeed(s"foo $a, [${b.mkString(", ")}]")
+          }),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo 1, [2, 3]")
+        ),
+        testError("returns failure")(
+          PureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failure("foo")),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo")
+        ),
+        testError("returns failureF")(
+          PureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failureF {
+            case (a, b) => s"foo $a, [${b.mkString(", ")}]"
+          }),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo 1, [2, 3]")
+        ),
+        testError("returns failureM")(
+          PureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failureM {
+            case (a, b) => IO.fail(s"foo $a, [${b.mkString(", ")}]")
+          }),
+          PureModule.varargs(1, "2", "3"),
+          equalTo("foo 1, [2, 3]")
+        )
+      ),
+      suite("curriedVarargs")(
+        testValue("returns value")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), value("foo")),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo")
+        ),
+        testValue("returns valueF")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), valueF {
+            case (a, b, c, d) => s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]"
+          }),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo 1, [2, 3], 4, [5, 6]")
+        ),
+        testValue("returns valueM")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), valueM {
+            case (a, b, c, d) => UIO.succeed(s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]")
+          }),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo 1, [2, 3], 4, [5, 6]")
+        ),
+        testError("returns failure")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failure("foo")),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo")
+        ),
+        testError("returns failureF")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failureF {
+            case (a, b, c, d) => s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]"
+          }),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo 1, [2, 3], 4, [5, 6]")
+        ),
+        testError("returns failureM")(
+          PureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failureM {
+            case (a, b, c, d) => IO.fail(s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]")
+          }),
+          PureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+          equalTo("foo 1, [2, 3], 4, [5, 6]")
+        )
+      ),
       suite("maxParams")(
         testValue("returns value")(
           PureModuleMock.MaxParams(equalTo(intTuple22), value("foo")),

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
@@ -215,6 +215,89 @@ object BasicMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] 
             )
           )
         ),
+        suite("varargs")(
+          testValue("returns value")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), value("foo")),
+            ImpureModule.varargs(1, "2", "3"),
+            equalTo("foo")
+          ),
+          testValue("returns valueF")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), valueF {
+              case (a, b) => s"foo $a, [${b.mkString(", ")}]"
+            }),
+            ImpureModule.varargs(1, "2", "3"),
+            equalTo("foo 1, [2, 3]")
+          ),
+          testValue("returns valueM")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), valueM {
+              case (a, b) => UIO.succeed(s"foo $a, [${b.mkString(", ")}]")
+            }),
+            ImpureModule.varargs(1, "2", "3"),
+            equalTo("foo 1, [2, 3]")
+          ),
+          testDied("returns failure")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failure(new Exception("foo"))),
+            ImpureModule.varargs(1, "2", "3"),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo")))
+          ),
+          testDied("returns failureF")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failureF {
+              case (a, b) => new Exception(s"foo $a, [${b.mkString(", ")}]")
+            }),
+            ImpureModule.varargs(1, "2", "3"),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1, [2, 3]")))
+          ),
+          testDied("returns failureM")(
+            ImpureModuleMock.Varargs(equalTo((1, Seq("2", "3"))), failureM {
+              case (a, b) => IO.fail(new Exception(s"foo $a, [${b.mkString(", ")}]"))
+            }),
+            ImpureModule.varargs(1, "2", "3"),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1, [2, 3]")))
+          )
+        ),
+        suite("curriedVarargs")(
+          testValue("returns value")(
+            ImpureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), value("foo")),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            equalTo("foo")
+          ),
+          testValue("returns valueF")(
+            ImpureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), valueF {
+              case (a, b, c, d) => s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]"
+            }),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            equalTo("foo 1, [2, 3], 4, [5, 6]")
+          ),
+          testValue("returns valueM")(
+            ImpureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), valueM {
+              case (a, b, c, d) => UIO.succeed(s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]")
+            }),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            equalTo("foo 1, [2, 3], 4, [5, 6]")
+          ),
+          testDied("returns failure")(
+            ImpureModuleMock
+              .CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failure(new Exception("foo"))),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo")))
+          ),
+          testDied("returns failureF")(
+            ImpureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failureF {
+              case (a, b, c, d) => new Exception(s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]")
+            }),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            isSubtype[Exception](
+              hasField("message", _.getMessage, equalTo("foo 1, [2, 3], 4, [5, 6]"))
+            )
+          ),
+          testDied("returns failureM")(
+            ImpureModuleMock.CurriedVarargs(equalTo((1, Seq("2", "3"), 4L, Seq('5', '6'))), failureM {
+              case (a, b, c, d) => IO.fail(new Exception(s"foo $a, [${b.mkString(", ")}], $c, [${d.mkString(", ")}]"))
+            }),
+            ImpureModule.curriedVarargs(1, "2", "3")(4L, '5', '6'),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1, [2, 3], 4, [5, 6]")))
+          )
+        ),
         suite("maxParams")(
           testValue("returns value")(
             ImpureModuleMock.MaxParams(equalTo(intTuple22), value("foo")),

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
@@ -46,6 +46,8 @@ object ImpureModule {
     def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): A
     def polyMixed[A: Tagged]: (A, String)
     def polyBounded[A <: AnyVal: Tagged]: A
+    def varargs(a: Int, b: String*): String
+    def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String
     def maxParams(
       a: Int,
       b: Int,
@@ -92,6 +94,9 @@ object ImpureModule {
     ZIO.access[ImpureModule](_.get.polyInputErrorOutput[I, E, A](v))
   def polyMixed[A: Tagged]             = ZIO.access[ImpureModule](_.get.polyMixed[A])
   def polyBounded[A <: AnyVal: Tagged] = ZIO.access[ImpureModule](_.get.polyBounded[A])
+  def varargs(a: Int, b: String*)      = ZIO.access[ImpureModule](_.get.varargs(a, b: _*))
+  def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*) =
+    ZIO.access[ImpureModule](_.get.curriedVarargs(a, b: _*)(c, d: _*))
   def maxParams(
     a: Int,
     b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
@@ -42,6 +42,8 @@ object ImpureModuleMock extends Mock[ImpureModule] {
   object PolyInputErrorOutput extends Poly.Method.InputErrorOutput
   object PolyMixed            extends Poly.Method.Output[Unit, Throwable]
   object PolyBounded          extends Poly.Method.Output[Unit, Throwable]
+  object Varargs              extends Method[(Int, Seq[String]), Throwable, String]
+  object CurriedVarargs       extends Method[(Int, Seq[String], Long, Seq[Char]), Throwable, String]
 
   object Overloaded {
     object _0 extends Method[Int, Throwable, String]
@@ -76,6 +78,9 @@ object ImpureModuleMock extends Mock[ImpureModule] {
             rts.unsafeRunTask(proxy(PolyInputErrorOutput.of[I, E, A], v))
           def polyMixed[A: Tagged]: (A, String)   = rts.unsafeRunTask(proxy(PolyMixed.of[(A, String)]))
           def polyBounded[A <: AnyVal: Tagged]: A = rts.unsafeRunTask(proxy(PolyBounded.of[A]))
+          def varargs(a: Int, b: String*): String = rts.unsafeRunTask(proxy(Varargs, (a, b)))
+          def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String =
+            rts.unsafeRunTask(proxy(CurriedVarargs, (a, b, c, d)))
           def maxParams(
             a: Int,
             b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
@@ -45,6 +45,8 @@ object PureModule {
     def polyInputErrorOutput[I: Tagged, E: Tagged, A: Tagged](v: I): IO[E, A]
     def polyMixed[A: Tagged]: IO[String, (A, String)]
     def polyBounded[A <: AnyVal: Tagged]: IO[String, A]
+    def varargs(a: Int, b: String*): IO[String, String]
+    def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String]
     def maxParams(
       a: Int,
       b: Int,
@@ -92,6 +94,9 @@ object PureModule {
     ZIO.accessM[PureModule](_.get.polyInputErrorOutput[I, E, A](v))
   def polyMixed[A: Tagged]             = ZIO.accessM[PureModule](_.get.polyMixed[A])
   def polyBounded[A <: AnyVal: Tagged] = ZIO.accessM[PureModule](_.get.polyBounded[A])
+  def varargs(a: Int, b: String*)      = ZIO.accessM[PureModule](_.get.varargs(a, b: _*))
+  def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*) =
+    ZIO.accessM[PureModule](_.get.curriedVarargs(a, b: _*)(c, d: _*))
   def maxParams(
     a: Int,
     b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
@@ -44,6 +44,8 @@ object PureModuleMock extends Mock[PureModule] {
   object PolyInputErrorOutput extends Poly.Effect.InputErrorOutput
   object PolyMixed            extends Poly.Effect.Output[Unit, String]
   object PolyBounded          extends Poly.Effect.Output[Unit, String]
+  object Varargs              extends Effect[(Int, Seq[String]), String, String]
+  object CurriedVarargs       extends Effect[(Int, Seq[String], Long, Seq[Char]), String, String]
 
   object Overloaded {
     object _0 extends Effect[Int, String, String]
@@ -78,6 +80,9 @@ object PureModuleMock extends Mock[PureModule] {
             proxy(PolyInputErrorOutput.of[I, E, A], v)
           def polyMixed[A: Tagged]: IO[String, (A, String)]   = proxy(PolyMixed.of[(A, String)])
           def polyBounded[A <: AnyVal: Tagged]: IO[String, A] = proxy(PolyBounded.of[A])
+          def varargs(a: Int, b: String*): IO[String, String] = proxy(Varargs, (a, b))
+          def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String] =
+            proxy(CurriedVarargs, (a, b, c, d))
           def maxParams(
             a: Int,
             b: Int,

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -30,7 +30,7 @@ private[test] object Macros {
       c.Expr(q"zio.UIO.succeed(Right(()))")
     } catch {
       case e: TypecheckException => c.Expr(q"zio.UIO.succeed(Left(${e.getMessage}))")
-      case _: Throwable          => c.Expr(q"""zio.UIO.die(new RuntimeException("Compilation failed"))""")
+      case t: Throwable          => c.Expr(q"""zio.UIO.die(new RuntimeException("Compilation failed: " + ${t.getMessage}))""")
     }
   }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/mock/MockableMacro.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/mock/MockableMacro.scala
@@ -20,6 +20,8 @@ import scala.reflect.macros.whitebox.Context
 
 import com.github.ghik.silencer.silent
 
+import zio.test.TestVersion
+
 /**
  * Generates method tags for a service into annotated object.
  */
@@ -37,11 +39,13 @@ private[mock] object MockableMacro {
       case _            => abort("@mockable macro should only be applied to objects.")
     }
 
-    val service: Type    = c.typecheck(q"(??? : ${c.prefix.tree})").tpe.typeArgs.head
+    val service: Type = c.typecheck(q"(??? : ${c.prefix.tree})").tpe.typeArgs.head
+    if (service == definitions.NothingTpe) abort(s"@mockable macro requires type parameter: @mockable[Module.Service]")
+
     val env: Type        = c.typecheck(tq"_root_.zio.Has[$service]", c.TYPEmode).tpe
-    val any: Type        = tq"_root_.scala.Any".tpe
-    val throwable: Type  = tq"_root_.java.lang.Throwable".tpe
-    val unit: Type       = tq"_root_.scala.Unit".tpe
+    val any: Type        = definitions.AnyTpe
+    val throwable: Type  = c.typecheck(q"(??? : _root_.java.lang.Throwable)").tpe
+    val unit: Type       = definitions.UnitTpe
     val composeAsc: Tree = tq"_root_.zio.URLayer[_root_.zio.Has[_root_.zio.test.mock.Proxy], $env]"
     val taggedFcqns      = List("izumi.reflect.Tags.Tag", "scala.reflect.ClassTag")
 
@@ -121,9 +125,15 @@ private[mock] object MockableMacro {
         if (symbol.isVar) abort(s"Error generating tag for $name. Variables are not supported by @mockable macro.")
         if (params.size > 22) abort(s"Unable to generate tag for method $name with more than 22 arguments.")
 
+        def paramTypeToTupleType(symbol: Symbol) = {
+          val ts = symbol.typeSignature
+          if (ts.typeSymbol == definitions.RepeatedParamClass) tq"_root_.scala.Seq[${ts.typeArgs.head}]"
+          else tq"$ts"
+        }
+
         val i =
           if (symbol.isVal) unit
-          else c.typecheck(tq"(..${params.map(_.typeSignature)})", c.TYPEmode).tpe
+          else c.typecheck(tq"(..${params.map(paramTypeToTupleType(_))})", c.TYPEmode).tpe
 
         val dealiased = symbol.returnType.dealias
         val capability =
@@ -208,7 +218,10 @@ private[mock] object MockableMacro {
         if (info.symbol.isAbstract) Modifiers(Flag.FINAL)
         else Modifiers(Flag.FINAL | Flag.OVERRIDE)
 
-      val returnType = tq"_root_.zio.ZIO[$r, $e, $a]"
+      val returnType = info.capability match {
+        case Capability.Method(t) => tq"$t"
+        case _                    => tq"_root_.zio.ZIO[$r, $e, $a]"
+      }
       val returnValue =
         (info.capability, info.params.map(_.name)) match {
           case (_: Capability.Effect, Nil)        => q"proxy($tag)"
@@ -223,7 +236,8 @@ private[mock] object MockableMacro {
           case (_: Capability.Stream, paramNames) => q"rts.unsafeRun(proxy($tag, ..$paramNames))"
         }
 
-      if (info.symbol.isVal) q"$mods val $name: $returnType = $returnValue"
+      val noParams = info.symbol.paramLists.isEmpty // Scala 2.11 workaround. For some reason isVal == false in 2.11
+      if (info.symbol.isVal || (noParams && TestVersion.isScala211)) q"$mods val $name: $returnType = $returnValue"
       else {
         info.symbol.paramLists.map(_.map { ts =>
           val name = ts.asTerm.name
@@ -247,13 +261,18 @@ private[mock] object MockableMacro {
       .toList
       .groupBy(_.symbol.name)
 
+    def sortOverloads(infos: List[MethodInfo]): List[MethodInfo] = {
+      import scala.math.Ordering.Implicits._
+      infos.sortBy(_.symbol.paramLists.flatten.map(_.info.toString))
+    }
+
     val tags =
       methods.collect {
         case (name, info :: Nil) =>
           makeTag(name.toTermName, info)
         case (name, infos) =>
           val tagName = capitalize(name.toTermName)
-          val overloadedTags = infos.zipWithIndex.map {
+          val overloadedTags = sortOverloads(infos).zipWithIndex.map {
             case (info, idx) =>
               val idxName = TermName(s"_$idx")
               makeTag(idxName, info)
@@ -267,12 +286,14 @@ private[mock] object MockableMacro {
         case (name, info :: Nil) =>
           List(makeMock(name.toTermName, info, None))
         case (name, infos) =>
-          infos.zipWithIndex.map {
+          sortOverloads(infos).zipWithIndex.map {
             case (info, idx) =>
               val idxName = TermName(s"_$idx")
               makeMock(name.toTermName, info, Some(idxName))
           }
       }.toList.flatten
+
+    val serviceClassName = TypeName(c.freshName())
 
     val structure =
       q"""
@@ -283,9 +304,10 @@ private[mock] object MockableMacro {
           val compose: $composeAsc =
             _root_.zio.ZLayer.fromServiceM { proxy =>
               withRuntime.map { rts =>
-                new $service {
+                class $serviceClassName extends $service {
                   ..$mocks
                 }
+                new $serviceClassName
               }
             }
         }


### PR DESCRIPTION
Varargs support in mockable annotation macro together with tests for mockable annotation macro.

Unfortunately due to bugs in `Context.typecheck` it's impossible to use `typeCheck` tests for mockable annotation. It might be possible to implement such tests with calls to `scalac`, though it looks quite difficult.

There is also a fix for impure methods support in mockable macro (it was broken).