### PR TITLE
Performance on Chunk.apply

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
@@ -38,5 +38,4 @@ class ChunkArrayBenchmarks {
 
   @Benchmark
   def foldM(): UIO[Int] = chunk.foldM(0)((s, a) => ZIO.succeed(s + a))
-
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
@@ -1,0 +1,293 @@
+package zio.chunks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State }
+
+import zio.Chunk
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ChunkCreationBenchmarks {
+
+  var a01: Int = _
+  var a02: Int = _
+  var a03: Int = _
+  var a04: Int = _
+  var a05: Int = _
+  var a06: Int = _
+  var a07: Int = _
+  var a08: Int = _
+  var a09: Int = _
+  var a10: Int = _
+  var a11: Int = _
+  var a12: Int = _
+  var a13: Int = _
+  var a14: Int = _
+  var a15: Int = _
+  var a16: Int = _
+  var a17: Int = _
+  var a18: Int = _
+  var a19: Int = _
+  var a20: Int = _
+  var a21: Int = _
+  var a22: Int = _
+  var a23: Int = _
+  var a24: Int = _
+  var a25: Int = _
+  var a26: Int = _
+  var a27: Int = _
+  var a28: Int = _
+  var a29: Int = _
+  var a30: Int = _
+  var a31: Int = _
+  var a32: Int = _
+
+  @Setup
+  def setup(): Unit = {
+    a01 = 1
+    a02 = 2
+    a03 = 3
+    a04 = 4
+    a05 = 5
+    a06 = 6
+    a07 = 7
+    a08 = 8
+    a09 = 9
+    a10 = 10
+    a11 = 11
+    a12 = 12
+    a13 = 13
+    a14 = 14
+    a15 = 15
+    a16 = 16
+    a17 = 17
+    a18 = 18
+    a19 = 19
+    a20 = 20
+    a21 = 21
+    a22 = 22
+    a23 = 23
+    a24 = 24
+    a25 = 25
+    a26 = 26
+    a27 = 27
+    a28 = 28
+    a29 = 29
+    a30 = 30
+    a31 = 31
+    a32 = 32
+
+  }
+
+  @Benchmark
+  def arrayCreate01(): Array[Int] = Array(a01)
+
+  @Benchmark
+  def arrayCreate02(): Array[Int] = Array(a01, a02)
+
+  @Benchmark
+  def arrayCreate04(): Array[Int] = Array(a01, a02, a03, a04)
+
+  @Benchmark
+  def arrayCreate08(): Array[Int] = Array(a01, a02, a03, a04, a05, a06, a07, a08)
+
+  @Benchmark
+  def arrayCreate16(): Array[Int] =
+    Array(a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16)
+
+  @Benchmark
+  def arrayCreate32(): Array[Int] =
+    Array(
+      a01,
+      a02,
+      a03,
+      a04,
+      a05,
+      a06,
+      a07,
+      a08,
+      a09,
+      a10,
+      a11,
+      a12,
+      a13,
+      a14,
+      a15,
+      a16,
+      a17,
+      a18,
+      a19,
+      a20,
+      a21,
+      a22,
+      a23,
+      a24,
+      a25,
+      a26,
+      a27,
+      a28,
+      a29,
+      a30,
+      a31,
+      a32
+    )
+
+  @Benchmark
+  def vectorCreate01(): Vector[Int] = Vector(a01)
+
+  @Benchmark
+  def vectorCreate02(): Vector[Int] = Vector(a01, a02)
+
+  @Benchmark
+  def vectorCreate04(): Vector[Int] = Vector(a01, a02, a03, a04)
+
+  @Benchmark
+  def vectorCreate08(): Vector[Int] = Vector(a01, a02, a03, a04, a05, a06, a07, a08)
+
+  @Benchmark
+  def vectorCreate16(): Vector[Int] =
+    Vector(a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16)
+
+  @Benchmark
+  def vectorCreate32(): Vector[Int] =
+    Vector(
+      1,
+      a02,
+      a03,
+      a04,
+      a05,
+      a06,
+      a07,
+      a08,
+      a09,
+      a10,
+      a11,
+      a12,
+      a13,
+      a14,
+      a15,
+      a16,
+      a17,
+      a18,
+      a19,
+      a20,
+      a21,
+      a22,
+      a23,
+      a24,
+      a25,
+      a26,
+      a27,
+      a28,
+      a29,
+      a30,
+      a31,
+      a32
+    )
+
+  @Benchmark
+  def chunkCreate01(): Chunk[Int] = Chunk(a01)
+
+  @Benchmark
+  def chunkCreate02(): Chunk[Int] = Chunk(a01, a02)
+
+  @Benchmark
+  def chunkCreate04(): Chunk[Int] = Chunk(a01, a02, a03, a04)
+
+  @Benchmark
+  def chunkCreate08(): Chunk[Int] = Chunk(a01, a02, a03, a04, a05, a06, a07, a08)
+
+  @Benchmark
+  def chunkCreate16(): Chunk[Int] =
+    Chunk(a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16)
+
+  @Benchmark
+  def chunkCreate32(): Chunk[Int] =
+    Chunk(
+      a01,
+      a02,
+      a03,
+      a04,
+      a05,
+      a06,
+      a07,
+      a08,
+      a09,
+      a10,
+      a11,
+      a12,
+      a13,
+      a14,
+      a15,
+      a16,
+      a17,
+      a18,
+      a19,
+      a20,
+      a21,
+      a22,
+      a23,
+      a24,
+      a25,
+      a26,
+      a27,
+      a28,
+      a29,
+      a30,
+      a31,
+      a32
+    )
+  @Benchmark
+  def chunkCreate01_old: Chunk[Int] = Chunk.applyOld(a01)
+
+  @Benchmark
+  def chunkCreate02_old: Chunk[Int] = Chunk.applyOld(a01, a02)
+
+  @Benchmark
+  def chunkCreate04_old: Chunk[Int] = Chunk.applyOld(a01, a02, a03, a04)
+
+  @Benchmark
+  def chunkCreate08_old: Chunk[Int] = Chunk.applyOld(a01, a02, a03, a04, a05, a06, a07, a08)
+
+  @Benchmark
+  def chunkCreate16_old: Chunk[Int] =
+    Chunk.applyOld(a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16)
+
+  @Benchmark
+  def chunkCreate32_old: Chunk[Int] =
+    Chunk.applyOld(
+      a01,
+      a02,
+      a03,
+      a04,
+      a05,
+      a06,
+      a07,
+      a08,
+      a09,
+      a10,
+      a11,
+      a12,
+      a13,
+      a14,
+      a15,
+      a16,
+      a17,
+      a18,
+      a19,
+      a20,
+      a21,
+      a22,
+      a23,
+      a24,
+      a25,
+      a26,
+      a27,
+      a28,
+      a29,
+      a30,
+      a31,
+      a32
+    )
+}

--- a/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
@@ -238,56 +238,5 @@ class ChunkCreationBenchmarks {
       a31,
       a32
     )
-  @Benchmark
-  def chunkCreate01_old: Chunk[Int] = Chunk.applyOld(a01)
 
-  @Benchmark
-  def chunkCreate02_old: Chunk[Int] = Chunk.applyOld(a01, a02)
-
-  @Benchmark
-  def chunkCreate04_old: Chunk[Int] = Chunk.applyOld(a01, a02, a03, a04)
-
-  @Benchmark
-  def chunkCreate08_old: Chunk[Int] = Chunk.applyOld(a01, a02, a03, a04, a05, a06, a07, a08)
-
-  @Benchmark
-  def chunkCreate16_old: Chunk[Int] =
-    Chunk.applyOld(a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16)
-
-  @Benchmark
-  def chunkCreate32_old: Chunk[Int] =
-    Chunk.applyOld(
-      a01,
-      a02,
-      a03,
-      a04,
-      a05,
-      a06,
-      a07,
-      a08,
-      a09,
-      a10,
-      a11,
-      a12,
-      a13,
-      a14,
-      a15,
-      a16,
-      a17,
-      a18,
-      a19,
-      a20,
-      a21,
-      a22,
-      a23,
-      a24,
-      a25,
-      a26,
-      a27,
-      a28,
-      a29,
-      a30,
-      a31,
-      a32
-    )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -626,9 +626,9 @@ object Chunk {
             i += 1
           }
 
-          Arr(dest, ct)
+          new Arr(dest, ct)
 
-        } else Concat(Singleton(a), Arr(in, ct))
+        } else Concat(Singleton(a), new Arr(in, ct))
 
       case _ =>
         val ct: ClassTag[A] = Tags.fromValue(a)
@@ -809,11 +809,10 @@ object Chunk {
   }
 
   private def arr[A](array: Array[A]): Arr[A] =
-    Arr(array, ClassTag(array.getClass.getComponentType))
+    new Arr(array, ClassTag(array.getClass.getComponentType))
 
-  private final case class Arr[A](private val array: Array[A], ct: ClassTag[A]) extends NonEmpty[A] {
-
-    implicit val classTag: ClassTag[A] = ct
+  private final class Arr[A](private val array: Array[A],
+                             implicit val classTag: ClassTag[A]) extends NonEmpty[A] {
 
     override def collect[B](pf: PartialFunction[A, B]): Chunk[B] = {
       val self = array

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -615,15 +615,20 @@ object Chunk {
         val len: Int        = wa.size + 1
         val in: Array[A]    = wa.array.asInstanceOf[Array[A]]
         val ct: ClassTag[A] = wa.elemTag.asInstanceOf[ClassTag[A]]
-        val dest: Array[A]  = Array.ofDim[A](len)(ct)
 
-        dest(0) = a
-        var i: Int = 1
-        while (i < len) {
-          dest(i) = in(i - 1)
-          i += 1
-        }
-        Arr(dest, ct)
+        if (len <= 16) {
+
+          val dest: Array[A] = Array.ofDim[A](len)(ct)
+          dest(0) = a
+          var i: Int = 1
+          while (i < len) {
+            dest(i) = in(i - 1)
+            i += 1
+          }
+
+          Arr(dest, ct)
+
+        } else Concat(Singleton(a), Arr(in, ct))
 
       case _ =>
         val ct: ClassTag[A] = Tags.fromValue(a)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -811,8 +811,7 @@ object Chunk {
   private def arr[A](array: Array[A]): Arr[A] =
     new Arr(array, ClassTag(array.getClass.getComponentType))
 
-  private final class Arr[A](private val array: Array[A],
-                             implicit val classTag: ClassTag[A]) extends NonEmpty[A] {
+  private final class Arr[A](private val array: Array[A], implicit val classTag: ClassTag[A]) extends NonEmpty[A] {
 
     override def collect[B](pf: PartialFunction[A, B]): Chunk[B] = {
       val self = array

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -612,17 +612,25 @@ object Chunk {
       case Nil =>
         Singleton(a)
       case wa: scala.collection.mutable.WrappedArray[A] =>
-        val len  = wa.size + 1
-        val in   = wa.array
-        val ct   = wa.elemTag
-        val dest = Array.ofDim[A](len)(wa.elemTag)
+        val len: Int        = wa.size + 1
+        val in: Array[A]    = wa.array.asInstanceOf[Array[A]]
+        val ct: ClassTag[A] = wa.elemTag.asInstanceOf[ClassTag[A]]
+        val dest: Array[A]  = Array.ofDim[A](len)(ct)
+
         dest(0) = a
-        var i = 1
+        var i: Int = 1
         while (i < len) {
           dest(i) = in(i - 1)
           i += 1
         }
         Arr(dest, ct)
+
+      case _ =>
+        val ct: ClassTag[A] = Tags.fromValue(a)
+        val des: Array[A]   = Array.ofDim[A](as.length + 1)(ct)
+        des(0) = a
+        as.copyToArray(des, 1)
+        arr(des)
     }
 
   //TO REMOVE
@@ -1155,7 +1163,7 @@ object Chunk {
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = { val _ = vector.copyToArray(dest, n, length) }
   }
 
-  private final case object Empty extends Chunk[Nothing] { self =>
+  private case object Empty extends Chunk[Nothing] { self =>
     override val length: Int = 0
 
     override def collect[B](pf: PartialFunction[Nothing, B]): Chunk[B] = Empty

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -638,19 +638,6 @@ object Chunk {
         arr(des)
     }
 
-  //TO REMOVE
-  def applyOld[A](a: A, as: A*): NonEmptyChunk[A] =
-    if (as.isEmpty) Singleton(a)
-    else {
-      implicit val A: ClassTag[A] = Tags.fromValue(a)
-      val des: Array[A]           = Array.ofDim[A](as.length + 1)
-
-      des(0) = a
-      as.copyToArray(des, 1)
-
-      arr(des)
-    }
-
   /**
    * Returns a chunk backed by an array.
    */
@@ -811,7 +798,9 @@ object Chunk {
   private def arr[A](array: Array[A]): Arr[A] =
     new Arr(array, ClassTag(array.getClass.getComponentType))
 
-  private final class Arr[A](private val array: Array[A], implicit val classTag: ClassTag[A]) extends NonEmpty[A] {
+  private final class Arr[A](private val array: Array[A], implicit val classTag: ClassTag[A])
+      extends NonEmpty[A]
+      with Serializable {
 
     override def collect[B](pf: PartialFunction[A, B]): Chunk[B] = {
       val self = array


### PR DESCRIPTION
This PR improve performance on : 
```scala
Chunk(1, 2, 3)
```
(Not on `Chunk(1)`, the performance was improved by the last PR #3241)

Performance on `Chunk(1)` cannot be improved, even if we try something like : 
```scala
def apply[A](a: A): NonEmpty[A] = ...
def apply[A](a1: A, a2: A, as: A*): NonEmpty[A] = ...
```

```scala
[info] Benchmark                                  Mode  Cnt    Score   Error  Units
[info] ChunkCreationBenchmarks.arrayCreate01      avgt   15    4.920 ± 0.053  ns/op
[info] ChunkCreationBenchmarks.arrayCreate02      avgt   15    4.605 ± 0.022  ns/op
[info] ChunkCreationBenchmarks.arrayCreate04      avgt   15    5.919 ± 0.031  ns/op
[info] ChunkCreationBenchmarks.arrayCreate08      avgt   15    8.599 ± 0.032  ns/op
[info] ChunkCreationBenchmarks.arrayCreate16      avgt   15   13.805 ± 0.203  ns/op
[info] ChunkCreationBenchmarks.arrayCreate32      avgt   15   24.356 ± 0.179  ns/op
[info] ChunkCreationBenchmarks.chunkCreate01      avgt   15   43.861 ± 0.075  ns/op
[info] ChunkCreationBenchmarks.chunkCreate01_old  avgt   15   43.245 ± 0.077  ns/op
[info] ChunkCreationBenchmarks.chunkCreate02      avgt   15   14.035 ± 0.053  ns/op
[info] ChunkCreationBenchmarks.chunkCreate02_old  avgt   15   62.731 ± 0.584  ns/op
[info] ChunkCreationBenchmarks.chunkCreate04      avgt   15   18.850 ± 0.085  ns/op
[info] ChunkCreationBenchmarks.chunkCreate04_old  avgt   15   66.070 ± 0.308  ns/op
[info] ChunkCreationBenchmarks.chunkCreate08      avgt   15   29.366 ± 0.159  ns/op
[info] ChunkCreationBenchmarks.chunkCreate08_old  avgt   15   77.726 ± 0.244  ns/op
[info] ChunkCreationBenchmarks.chunkCreate16      avgt   15   60.301 ± 0.732  ns/op
[info] ChunkCreationBenchmarks.chunkCreate16_old  avgt   15  104.086 ± 0.604  ns/op
[info] ChunkCreationBenchmarks.chunkCreate32      avgt   15   72.600 ± 2.086  ns/op
[info] ChunkCreationBenchmarks.chunkCreate32_old  avgt   15  166.841 ± 0.867  ns/op
[info] ChunkCreationBenchmarks.vectorCreate01     avgt   15   72.004 ± 0.250  ns/op
[info] ChunkCreationBenchmarks.vectorCreate02     avgt   15   76.527 ± 0.097  ns/op
[info] ChunkCreationBenchmarks.vectorCreate04     avgt   15   93.290 ± 1.131  ns/op
[info] ChunkCreationBenchmarks.vectorCreate08     avgt   15  125.772 ± 0.167  ns/op
[info] ChunkCreationBenchmarks.vectorCreate16     avgt   15  194.918 ± 0.334  ns/op
[info] ChunkCreationBenchmarks.vectorCreate32     avgt   15  322.771 ± 0.365  ns/op
[success] Total time: 7227 s (02:00:27), completed 6 Apr 2020, 06:13:43
```

- [x] remove after approval https://github.com/zio/zio/pull/3297/files#diff-290e96e6c64027a32c36d751a35d65deR641-R652