### PR TITLE
clarify `ZSink#collectAllToMapN` behavior

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1081,7 +1081,7 @@ object SinkSpec extends ZIOBaseSpec {
                 .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _))
             )(equalTo(Map[Int, Int](0 -> 0, 1 -> 1)))
           ),
-          testM("collects entire stream is the number of keys doesn't exceed `n`")(
+          testM("collects entire stream if the number of keys doesn't exceed `n`")(
             assertM(
               Stream
                 .range(0, 10)

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1081,12 +1081,18 @@ object SinkSpec extends ZIOBaseSpec {
                 .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _))
             )(equalTo(Map[Int, Int](0 -> 0, 1 -> 1)))
           ),
-          testM("keep collecting as long as map size does not exceed the limit")(
+          testM("collects entire stream is the number of keys doesn't exceed `n`")(
             assertM(
               Stream
                 .range(0, 10)
                 .run(Sink.collectAllToMapN[Int, Int](3)(value => value % 3)(_ + _))
             )(equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15)))
+          ),
+          testM("keep collecting as long as map size does not exceed the limit")(
+            assertM(
+              Stream(0, 1, 3, 4, 2)
+                .run(Sink.collectAllToMapN[Int, Int](2)(value => value % 3)(_ + _))
+            )(equalTo(Map[Int, Int](0 -> 3, 1 -> 5)))
           )
         ),
         testM("collectAllWhile")(

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1267,6 +1267,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors with Serializable {
    * Key of each element is determined by supplied function.
    *
    * Combines elements with same key with supplied function f.
+   * Stops consuming the stream once sees a value belonging to `n+1`-th key.
    */
   def collectAllToMapN[K, A](n: Long)(key: A => K)(f: (A, A) => A): Sink[Nothing, A, A, Map[K, A]] = {
     type State = (Map[K, A], Boolean)


### PR DESCRIPTION
Had a question in discord about behavior of this method. 
Persisting this knowledge in docs and adding a test.