### PR TITLE
Add ZStream.aggregateAsync

### DIFF
--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import TReentrantLock._
 
-import zio.{ Fiber, Managed }
+import zio.{ Fiber, Managed, UIO }
 
 /**
  * A `TReentrantLock` is a reentrant read/write lock. Multiple readers may all
@@ -216,8 +216,14 @@ object TReentrantLock {
   /**
    * Makes a new reentrant read/write lock.
    */
-  def make: STM[Nothing, TReentrantLock] =
+  val make: STM[Nothing, TReentrantLock] =
     TRef.make[Either[ReadLock, WriteLock]](Left(ReadLock.empty)).map(tref => new TReentrantLock(tref))
+
+  /**
+   * Makes a new reentrant read/write lock.
+   */
+  val makeCommit: UIO[TReentrantLock] =
+    make.commit
 
   private def die(message: String): Nothing =
     throw new RuntimeException(message)

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -100,9 +100,9 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
             fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.untraced.fork
             _      <- latch.await
-            _ <- console.putStrLn("Interrupting")
+            _      <- console.putStrLn("Interrupting")
             _      <- fiber.interrupt
-            _ <- console.putStrLn("Interrupted")
+            _      <- console.putStrLn("Interrupted")
             result <- cancelled.get
           } yield assert(result)(isTrue)
         }

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -100,9 +100,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
             fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.untraced.fork
             _      <- latch.await
-            _      <- console.putStrLn("Interrupting")
             _      <- fiber.interrupt
-            _      <- console.putStrLn("Interrupted")
             result <- cancelled.get
           } yield assert(result)(isTrue)
         }

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -103,7 +103,7 @@ abstract class ZStream[-R, +E, +O](
         push   <- transducer.push
         lock   <- Semaphore.make(1).toManaged_
         bucket <- ZRef.makeManaged[Take[E1, P]](Take.End)
-        start <- Promise.make[Nothing, Unit].toManaged_
+        start  <- Promise.make[Nothing, Unit].toManaged_
         done   <- ZRef.makeManaged(false)
         produce = {
           def finish: ZIO[R1, Nothing, Boolean] =

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -134,7 +134,7 @@ abstract class ZStream[-R, +E, +O](
           // Upstream is done, we need to flush the transducer. If the output is
           // empty, we send the end signal downstream.
           def finish(ps: Chunk[P]): URIO[R1, Boolean] =
-            bucket.offer(if (ps.isEmpty) Take.End else Exit.succeed(ps)) as false
+            bucket.offerAll(if (ps.isEmpty) List(Take.End) else List(Exit.succeed(ps), Take.End)) as false
 
           // We have to make progress in the transducer. If the output is empty,
           // we must keep making progress until it isn't.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -134,7 +134,7 @@ abstract class ZStream[-R, +E, +O](
           // Upstream is done, we need to flush the transducer. If the output is
           // empty, we send the end signal downstream.
           def finish(ps: Chunk[P]): URIO[R1, Boolean] =
-            bucket.offer(if (ps.isEmpty) Take.End else Exit.succeed(ps))
+            bucket.offer(if (ps.isEmpty) Take.End else Exit.succeed(ps)) as false
 
           // We have to make progress in the transducer. If the output is empty,
           // we must keep making progress until it isn't.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZTransducer.scala
@@ -110,7 +110,7 @@ object ZTransducer {
 
   def die(e: => Throwable): ZTransducer[Any, Nothing, Any, Nothing] =
     ZTransducer(Managed.succeed((_: Any) => IO.die(e)))
-    
+
   def fail[E](e: => E): ZTransducer[Any, E, Any, Nothing] =
     ZTransducer(ZManaged.succeed((_: Option[Any]) => Push.fail(e)))
 

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZTransducer.scala
@@ -78,6 +78,12 @@ object ZTransducer {
       } yield push
     }
 
+  def die(e: => Throwable): ZTransducer[Any, Nothing, Any, Nothing] =
+    ZTransducer(Managed.succeed((_: Any) => IO.die(e)))
+
+  def fromEffect[R, E, A](zio: ZIO[R, E, A]): ZTransducer[R, E, Any, A] =
+    ZTransducer(Managed.succeed((_: Any) => zio.map(Chunk.single(_)).mapError(Some(_))))
+
   def fromPush[R, E, I, O](push: Option[Chunk[I]] => ZIO[R, Option[E], Chunk[O]]): ZTransducer[R, E, I, O] =
     ZTransducer(Managed.succeed(push))
 }


### PR DESCRIPTION
I used a reentrant lock instead of a semaphore, but there may be a performance cost so happy to change that. Also, nice simplification over [the existing one](https://github.com/zio/zio/blob/master/streams/shared/src/main/scala/zio/stream/ZStream.scala#L103-L266).