### PR TITLE
Port ZSink fold, foldleft

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamGen.scala
@@ -3,9 +3,9 @@ package zio.stream.experimental
 import zio._
 import zio.random.Random
 import zio.stream.ChunkUtils._
-import zio.test.{ Gen, Sized }
+import zio.test.{ Gen, GenZIO, Sized }
 
-object ZStreamGen {
+object ZStreamGen extends GenZIO {
   def streamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, ZStream[Any, String, A]] =
     Gen.oneOf(failingStreamGen(a, max), pureStreamGen(a, max))
 

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -364,7 +364,7 @@ object ZSink {
         if (shouldStart) {
           for {
             state <- Ref.make(z).toManaged_
-            push: zio.stream.experimental.ZSink.Push[R, E, I, S] = (is: Option[Chunk[I]]) =>
+            push = (is: Option[Chunk[I]]) =>
               is match {
                 case None => state.get.flatMap(Push.emit)
                 case Some(is) => {


### PR DESCRIPTION
Bring back `contFn` to `ZSink#fold`
Add `foldLeft`
Port existing tests that are still relevant
Add couple of new tests