### PR TITLE
ZIO Test: Implement TestClock#advance

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -140,14 +140,11 @@ object ZIOSpec extends ZIOBaseSpec {
           ref   <- Ref.make(0)
           cache <- incrementAndGet(ref).cached(60.minutes)
           a     <- cache
-          _     <- TestClock.adjust(59.minutes)
-          _     <- clock.sleep(59.minutes)
+          _     <- TestClock.advance(59.minutes)
           b     <- cache
-          _     <- TestClock.adjust(1.minute)
-          _     <- clock.sleep(1.minutes)
+          _     <- TestClock.advance(1.minute)
           c     <- cache
-          _     <- TestClock.adjust(59.minutes)
-          _     <- clock.sleep(1.minute)
+          _     <- TestClock.advance(59.minutes)
           d     <- cache
         } yield assert(a)(equalTo(b)) && assert(b)(not(equalTo(c))) && assert(c)(equalTo(d))
       },

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1414,8 +1414,7 @@ object SinkSpec extends ZIOBaseSpec {
               step1 <- sink.step(init1, 1)
               res1  <- sink.extract(step1).map(_._1)
               init2 <- sink.initial
-              _     <- TestClock.adjust(23.milliseconds)
-              _     <- clock.sleep(23.milliseconds)
+              _     <- TestClock.advance(23.milliseconds)
               step2 <- sink.step(init2, 2)
               res2  <- sink.extract(step2).map(_._1)
               init3 <- sink.initial
@@ -1424,8 +1423,7 @@ object SinkSpec extends ZIOBaseSpec {
               init4 <- sink.initial
               step4 <- sink.step(init4, 4)
               res4  <- sink.extract(step4).map(_._1)
-              _     <- TestClock.adjust(11.milliseconds)
-              _     <- clock.sleep(11.milliseconds)
+              _     <- TestClock.advance(11.milliseconds)
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)
@@ -1441,8 +1439,7 @@ object SinkSpec extends ZIOBaseSpec {
               step1 <- sink.step(init1, 1)
               res1  <- sink.extract(step1).map(_._1)
               init2 <- sink.initial
-              _     <- TestClock.adjust(23.milliseconds)
-              _     <- clock.sleep(23.milliseconds)
+              _     <- TestClock.advance(23.milliseconds)
               step2 <- sink.step(init2, 2)
               res2  <- sink.extract(step2).map(_._1)
               init3 <- sink.initial
@@ -1451,8 +1448,7 @@ object SinkSpec extends ZIOBaseSpec {
               init4 <- sink.initial
               step4 <- sink.step(init4, 4)
               res4  <- sink.extract(step4).map(_._1)
-              _     <- TestClock.adjust(11.milliseconds)
-              _     <- clock.sleep(11.milliseconds)
+              _     <- TestClock.advance(11.milliseconds)
               init5 <- sink.initial
               step5 <- sink.step(init5, 5)
               res5  <- sink.extract(step5).map(_._1)

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -91,6 +91,30 @@ object ClockSpec extends ZIOBaseSpec {
     testM("adjust does not produce sleeps") {
       adjust(1.millis) *> assertM(sleeps)(isEmpty)
     },
+    testM("advance correctly advances nanotime") {
+      for {
+        time1 <- nanoTime
+        _     <- advance(1.millis)
+        time2 <- nanoTime
+      } yield assert(fromNanos(time2 - time1))(equalTo(1.millis))
+    },
+    testM("advance correctly advances currentTime") {
+      for {
+        time1 <- currentTime(TimeUnit.NANOSECONDS)
+        _     <- advance(1.millis)
+        time2 <- currentTime(TimeUnit.NANOSECONDS)
+      } yield assert(time2 - time1)(equalTo(1.millis.toNanos))
+    },
+    testM("advance correctly advances currentDateTime") {
+      for {
+        time1 <- currentDateTime
+        _     <- advance(1.millis)
+        time2 <- currentDateTime
+      } yield assert((time2.toInstant.toEpochMilli - time1.toInstant.toEpochMilli))(equalTo(1L))
+    },
+    testM("advance does not produce sleeps") {
+      advance(1.millis) *> assertM(sleeps)(isEmpty)
+    },
     testM("setDateTime correctly sets currentDateTime") {
       for {
         expected <- UIO.effectTotal(OffsetDateTime.now(ZoneId.of("UTC+9")))


### PR DESCRIPTION
Since we changed `TestClock` methods that return time to return the fiber time in #2677, users now need to do a `sleep` call after an `adjust` call to get the updated time from methods like `currentTime`.

This PR implements a new combinator `advance` that does an `adjust` immediately followed by a `sleep` for this use case.

The one thing we are still potentially missing from this is the ability to adjust the fiber time in an already forked fiber. For example, in:

```scala
for {
  latch <- Promise.make[Nothing, Unit]
  fiber <- (latch.await *> clock.currentTime).fork
  _       <- TestClock.advance(1.second
  _       <- latch.succeed(())
  value <- fiber.join
} yield value
```

The result will not reflect the updated time because the forked fiber has its own `FiberRef`. This accurately reflects the fact that no sleeping has occurred on the fiber. And in fact allowing modifying the fiber time in situations like this can lead to inconsistent state as in the schedule issue in #2677. We could potentially add an `unsafeAdjust` method to do this but I wonder if that use case is better supported through the `MockClock`.

Copying @runtologist 