### PR TITLE
Avoid Overloading Standard Interfaces

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RandomSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RandomSpec.scala
@@ -14,38 +14,38 @@ object RandomSpec extends ZIOBaseSpec {
     (l, r) => java.lang.Float.compare(l, r)
 
   def spec = suite("RandomSpec")(
-    testM("between generates doubles in specified range") {
+    testM("nextDoubleBetween generates doubles in specified range") {
       checkM(genDoubles) {
         case (min, max) =>
           for {
-            n <- Live.live(random.between(min, max))
+            n <- Live.live(random.nextDoubleBetween(min, max))
           } yield assert(n)(isGreaterThanEqualTo(min)) &&
             assert(n)(isLessThan(max))
       }
     },
-    testM("between generates floats in specified range") {
+    testM("nextFloatBetween generates floats in specified range") {
       checkM(genFloats) {
         case (min, max) =>
           for {
-            n <- Live.live(random.between(min, max))
+            n <- Live.live(random.nextFloatBetween(min, max))
           } yield assert(n)(isGreaterThanEqualTo(min)) &&
             assert(n)(isLessThan(max))
       }
     },
-    testM("between generates integers in specified range") {
+    testM("nextIntBetween generates integers in specified range") {
       checkM(genInts) {
         case (min, max) =>
           for {
-            n <- Live.live(random.between(min, max))
+            n <- Live.live(random.nextIntBetween(min, max))
           } yield assert(n)(isGreaterThanEqualTo(min)) &&
             assert(n)(isLessThan(max))
       }
     },
-    testM("between generates longs in specified range") {
+    testM("nextLongBetween generates longs in specified range") {
       checkM(genLongs) {
         case (min, max) =>
           for {
-            n <- Live.live(random.between(min, max))
+            n <- Live.live(random.nextLongBetween(min, max))
           } yield assert(n)(isGreaterThanEqualTo(min)) &&
             assert(n)(isLessThan(max))
       }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -864,7 +864,7 @@ object Schedule {
     Schedule[Clock with Random, Duration, Any, Duration](
       ZIO.succeedNow(Duration.Zero), {
         case _ =>
-          random.nextLong(maxNanos - minNanos + 1).flatMap { n =>
+          random.nextLongBounded(maxNanos - minNanos + 1).flatMap { n =>
             val duration = Duration.fromNanos(n + minNanos)
             clock.sleep(duration).as(duration)
           }

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -5,19 +5,19 @@ package object random {
 
   object Random extends Serializable {
     trait Service extends Serializable {
-      def between(minInclusive: Long, maxExclusive: Long): UIO[Long]
-      def between(minInclusive: Int, maxExclusive: Int): UIO[Int]
-      def between(minInclusive: Float, maxExclusive: Float): UIO[Float]
-      def between(minInclusive: Double, maxExclusive: Double): UIO[Double]
       def nextBoolean: UIO[Boolean]
       def nextBytes(length: Int): UIO[Chunk[Byte]]
       def nextDouble: UIO[Double]
+      def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double]
       def nextFloat: UIO[Float]
+      def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float]
       def nextGaussian: UIO[Double]
-      def nextInt(n: Int): UIO[Int]
       def nextInt: UIO[Int]
+      def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int]
+      def nextIntBounded(n: Int): UIO[Int]
       def nextLong: UIO[Long]
-      def nextLong(n: Long): UIO[Long]
+      def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long]
+      def nextLongBounded(n: Long): UIO[Long]
       def nextPrintableChar: UIO[Char]
       def nextString(length: Int): UIO[String]
       def shuffle[A](list: List[A]): UIO[List[A]]
@@ -27,33 +27,42 @@ package object random {
       val live: Service = new Service {
         import scala.util.{ Random => SRandom }
 
-        def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-          betweenWith(nextLong, nextLong(_), minInclusive, maxExclusive)
-        def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-          betweenWith(nextInt, nextInt(_), minInclusive, maxExclusive)
-        def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
-          betweenWith(nextFloat, minInclusive, maxExclusive)
-        def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
-          betweenWith(nextDouble, minInclusive, maxExclusive)
-        val nextBoolean: UIO[Boolean] = ZIO.effectTotal(SRandom.nextBoolean())
+        val nextBoolean: UIO[Boolean] =
+          ZIO.effectTotal(SRandom.nextBoolean())
         def nextBytes(length: Int): UIO[Chunk[Byte]] =
           ZIO.effectTotal {
             val array = Array.ofDim[Byte](length)
-
             SRandom.nextBytes(array)
-
             Chunk.fromArray(array)
           }
-        val nextDouble: UIO[Double]                 = ZIO.effectTotal(SRandom.nextDouble())
-        val nextFloat: UIO[Float]                   = ZIO.effectTotal(SRandom.nextFloat())
-        val nextGaussian: UIO[Double]               = ZIO.effectTotal(SRandom.nextGaussian())
-        def nextInt(n: Int): UIO[Int]               = ZIO.effectTotal(SRandom.nextInt(n))
-        val nextInt: UIO[Int]                       = ZIO.effectTotal(SRandom.nextInt())
-        val nextLong: UIO[Long]                     = ZIO.effectTotal(SRandom.nextLong())
-        def nextLong(n: Long): UIO[Long]            = Random.nextLongWith(nextLong, n)
-        val nextPrintableChar: UIO[Char]            = ZIO.effectTotal(SRandom.nextPrintableChar())
-        def nextString(length: Int): UIO[String]    = ZIO.effectTotal(SRandom.nextString(length))
-        def shuffle[A](list: List[A]): UIO[List[A]] = Random.shuffleWith(nextInt(_), list)
+        val nextDouble: UIO[Double] =
+          ZIO.effectTotal(SRandom.nextDouble())
+        def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+          nextDoubleBetweenWith(minInclusive, maxExclusive)(nextDouble)
+        val nextFloat: UIO[Float] =
+          ZIO.effectTotal(SRandom.nextFloat())
+        def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+          nextFloatBetweenWith(minInclusive, maxExclusive)(nextFloat)
+        val nextGaussian: UIO[Double] =
+          ZIO.effectTotal(SRandom.nextGaussian())
+        val nextInt: UIO[Int] =
+          ZIO.effectTotal(SRandom.nextInt())
+        def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+          nextIntBetweenWith(minInclusive, maxExclusive)(nextInt, nextIntBounded)
+        def nextIntBounded(n: Int): UIO[Int] =
+          ZIO.effectTotal(SRandom.nextInt(n))
+        val nextLong: UIO[Long] =
+          ZIO.effectTotal(SRandom.nextLong())
+        def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+          nextLongBetweenWith(minInclusive, maxExclusive)(nextLong, nextLongBounded)
+        def nextLongBounded(n: Long): UIO[Long] =
+          Random.nextLongBoundedWith(n)(nextLong)
+        val nextPrintableChar: UIO[Char] =
+          ZIO.effectTotal(SRandom.nextPrintableChar())
+        def nextString(length: Int): UIO[String] =
+          ZIO.effectTotal(SRandom.nextString(length))
+        def shuffle[A](list: List[A]): UIO[List[A]] =
+          Random.shuffleWith(nextIntBounded(_), list)
       }
     }
 
@@ -63,45 +72,9 @@ package object random {
     val live: Layer[Nothing, Random] =
       ZLayer.succeed(Service.live)
 
-    protected[zio] def betweenWith(
-      nextLong: UIO[Long],
-      nextLongWith: Long => UIO[Long],
-      minInclusive: Long,
-      maxExclusive: Long
-    ): UIO[Long] =
-      if (minInclusive >= maxExclusive)
-        UIO.die(new IllegalArgumentException("invalid bounds"))
-      else {
-        val difference = maxExclusive - minInclusive
-        if (difference > 0) nextLongWith(difference).map(_ + minInclusive)
-        else nextLong.doUntil(n => minInclusive <= n && n < maxExclusive)
-      }
-
-    protected[zio] def betweenWith(
-      nextInt: UIO[Int],
-      nextIntWith: Int => UIO[Int],
-      minInclusive: Int,
-      maxExclusive: Int
-    ): UIO[Int] =
-      if (minInclusive >= maxExclusive) {
-        UIO.die(new IllegalArgumentException("invalid bounds"))
-      } else {
-        val difference = maxExclusive - minInclusive
-        if (difference > 0) nextIntWith(difference).map(_ + minInclusive)
-        else nextInt.doUntil(n => minInclusive <= n && n < maxExclusive)
-      }
-
-    protected[zio] def betweenWith(nextFloat: UIO[Float], minInclusive: Float, maxExclusive: Float): UIO[Float] =
-      if (minInclusive >= maxExclusive)
-        UIO.die(new IllegalArgumentException("invalid bounds"))
-      else
-        nextFloat.map { n =>
-          val result = n * (maxExclusive - minInclusive) + minInclusive
-          if (result < maxExclusive) result
-          else Math.nextAfter(maxExclusive, Float.NegativeInfinity)
-        }
-
-    protected[zio] def betweenWith(nextDouble: UIO[Double], minInclusive: Double, maxExclusive: Double): UIO[Double] =
+    protected[zio] def nextDoubleBetweenWith(minInclusive: Double, maxExclusive: Double)(
+      nextDouble: UIO[Double]
+    ): UIO[Double] =
       if (minInclusive >= maxExclusive)
         UIO.die(new IllegalArgumentException("invalid bounds"))
       else
@@ -111,7 +84,43 @@ package object random {
           else Math.nextAfter(maxExclusive, Float.NegativeInfinity)
         }
 
-    protected[zio] def nextLongWith(nextLong: UIO[Long], n: Long): UIO[Long] =
+    protected[zio] def nextFloatBetweenWith(minInclusive: Float, maxExclusive: Float)(
+      nextFloat: UIO[Float]
+    ): UIO[Float] =
+      if (minInclusive >= maxExclusive)
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      else
+        nextFloat.map { n =>
+          val result = n * (maxExclusive - minInclusive) + minInclusive
+          if (result < maxExclusive) result
+          else Math.nextAfter(maxExclusive, Float.NegativeInfinity)
+        }
+
+    protected[zio] def nextIntBetweenWith(
+      minInclusive: Int,
+      maxExclusive: Int
+    )(nextInt: UIO[Int], nextIntBounded: Int => UIO[Int]): UIO[Int] =
+      if (minInclusive >= maxExclusive) {
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      } else {
+        val difference = maxExclusive - minInclusive
+        if (difference > 0) nextIntBounded(difference).map(_ + minInclusive)
+        else nextInt.doUntil(n => minInclusive <= n && n < maxExclusive)
+      }
+
+    protected[zio] def nextLongBetweenWith(
+      minInclusive: Long,
+      maxExclusive: Long
+    )(nextLong: UIO[Long], nextLongBounded: Long => UIO[Long]): UIO[Long] =
+      if (minInclusive >= maxExclusive)
+        UIO.die(new IllegalArgumentException("invalid bounds"))
+      else {
+        val difference = maxExclusive - minInclusive
+        if (difference > 0) nextLongBounded(difference).map(_ + minInclusive)
+        else nextLong.doUntil(n => minInclusive <= n && n < maxExclusive)
+      }
+
+    protected[zio] def nextLongBoundedWith(n: Long)(nextLong: UIO[Long]): UIO[Long] =
       if (n <= 0)
         UIO.die(new IllegalArgumentException("n must be positive"))
       else {
@@ -128,7 +137,7 @@ package object random {
         }
       }
 
-    protected[zio] def shuffleWith[A](nextInt: Int => UIO[Int], list: List[A]): UIO[List[A]] =
+    protected[zio] def shuffleWith[A](nextIntBounded: Int => UIO[Int], list: List[A]): UIO[List[A]] =
       for {
         bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
         _         <- bufferRef.update(_ ++= list)
@@ -140,34 +149,108 @@ package object random {
               buffer(i2) = tmp
               buffer
           }
-        _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextInt(n).flatMap(k => swap(n - 1, k)))
+        _      <- ZIO.foreach(list.length to 2 by -1)((n: Int) => nextIntBounded(n).flatMap(k => swap(n - 1, k)))
         buffer <- bufferRef.get
       } yield buffer.toList
   }
 
-  def between(minInclusive: Long, maxExclusive: Long): ZIO[Random, Nothing, Long] =
-    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+  /**
+   * Generates a pseudo-random boolean.
+   */
+  val nextBoolean: ZIO[Random, Nothing, Boolean] =
+    ZIO.accessM(_.get.nextBoolean)
 
-  def between(minInclusive: Int, maxExclusive: Int): ZIO[Random, Nothing, Int] =
-    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+  /**
+   * Generates a pseudo-random chunk of bytes of the specified length.
+   */
+  def nextBytes(length: => Int): ZIO[Random, Nothing, Chunk[Byte]] =
+    ZIO.accessM(_.get.nextBytes(length))
 
-  def between(minInclusive: Float, maxExclusive: Float): ZIO[Random, Nothing, Float] =
-    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+  /**
+   * Generates a pseudo-random, uniformly distributed double between 0.0 and
+   * 1.0.
+   */
+  val nextDouble: ZIO[Random, Nothing, Double] = ZIO.accessM(_.get.nextDouble)
 
-  def between(minInclusive: Double, maxExclusive: Double): ZIO[Random, Nothing, Double] =
-    ZIO.accessM(_.get.between(minInclusive, maxExclusive))
+  /**
+   * Generates a pseudo-random double in the specified range.
+   */
+  def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): ZIO[Random, Nothing, Double] =
+    ZIO.accessM(_.get.nextDoubleBetween(minInclusive, maxExclusive))
 
-  val nextBoolean: ZIO[Random, Nothing, Boolean]                   = ZIO.accessM(_.get.nextBoolean)
-  def nextBytes(length: => Int): ZIO[Random, Nothing, Chunk[Byte]] = ZIO.accessM(_.get.nextBytes(length))
-  val nextDouble: ZIO[Random, Nothing, Double]                     = ZIO.accessM(_.get.nextDouble)
-  val nextFloat: ZIO[Random, Nothing, Float]                       = ZIO.accessM(_.get.nextFloat)
-  val nextGaussian: ZIO[Random, Nothing, Double]                   = ZIO.accessM(_.get.nextGaussian)
-  def nextInt(n: => Int): ZIO[Random, Nothing, Int]                = ZIO.accessM(_.get.nextInt(n))
-  val nextInt: ZIO[Random, Nothing, Int]                           = ZIO.accessM(_.get.nextInt)
-  val nextLong: ZIO[Random, Nothing, Long]                         = ZIO.accessM(_.get.nextLong)
-  def nextLong(n: => Long): ZIO[Random, Nothing, Long]             = ZIO.accessM(_.get.nextLong(n))
-  val nextPrintableChar: ZIO[Random, Nothing, Char]                = ZIO.accessM(_.get.nextPrintableChar)
-  def nextString(length: => Int): ZIO[Random, Nothing, String]     = ZIO.accessM(_.get.nextString(length))
-  def shuffle[A](list: => List[A]): ZIO[Random, Nothing, List[A]]  = ZIO.accessM(_.get.shuffle(list))
+  /**
+   * Generates a pseudo-random, uniformly distributed float between 0.0 and
+   * 1.0.
+   */
+  val nextFloat: ZIO[Random, Nothing, Float] =
+    ZIO.accessM(_.get.nextFloat)
 
+  /**
+   * Generates a pseudo-random float in the specified range.
+   */
+  def nextFloatBetween(minInclusive: Float, maxExclusive: Float): ZIO[Random, Nothing, Float] =
+    ZIO.accessM(_.get.nextFloatBetween(minInclusive, maxExclusive))
+
+  /**
+   * Generates a pseudo-random double from a normal distribution with mean 0.0
+   * and standard deviation 1.0.
+   */
+  val nextGaussian: ZIO[Random, Nothing, Double] =
+    ZIO.accessM(_.get.nextGaussian)
+
+  /**
+   * Generates a pseudo-random integer.
+   */
+  val nextInt: ZIO[Random, Nothing, Int] =
+    ZIO.accessM(_.get.nextInt)
+
+  /**
+   * Generates a pseudo-random integer in the specified range.
+   */
+  def nextIntBetween(minInclusive: Int, maxExclusive: Int): ZIO[Random, Nothing, Int] =
+    ZIO.accessM(_.get.nextIntBetween(minInclusive, maxExclusive))
+
+  /**
+   * Generates a pseudo-random integer between 0 (inclusive) and the specified
+   * value (exclusive).
+   */
+  def nextIntBounded(n: => Int): ZIO[Random, Nothing, Int] =
+    ZIO.accessM(_.get.nextIntBounded(n))
+
+  /**
+   * Generates a pseudo-random long.
+   */
+  val nextLong: ZIO[Random, Nothing, Long] =
+    ZIO.accessM(_.get.nextLong)
+
+  /**
+   * Generates a pseudo-random long in the specified range.
+   */
+  def nextLongBetween(minInclusive: Long, maxExclusive: Long): ZIO[Random, Nothing, Long] =
+    ZIO.accessM(_.get.nextLongBetween(minInclusive, maxExclusive))
+
+  /**
+   * Generates a pseudo-random long between 0 (inclusive) and the specified
+   * value (exclusive).
+   */
+  def nextLongBounded(n: => Long): ZIO[Random, Nothing, Long] =
+    ZIO.accessM(_.get.nextLongBounded(n))
+
+  /**
+   * Generates a pseudo-random character from the ASCII range 33-126.
+   */
+  val nextPrintableChar: ZIO[Random, Nothing, Char] =
+    ZIO.accessM(_.get.nextPrintableChar)
+
+  /**
+   * Generates a pseudo-random string of the specified length.
+   */
+  def nextString(length: => Int): ZIO[Random, Nothing, String] =
+    ZIO.accessM(_.get.nextString(length))
+
+  /**
+   * Randomly shuffles the specified list.
+   */
+  def shuffle[A](list: => List[A]): ZIO[Random, Nothing, List[A]] =
+    ZIO.accessM(_.get.shuffle(list))
 }

--- a/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
@@ -23,14 +23,14 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
       assertM(out)(isUnit)
     },
     testM("expect call with input satisfying assertion and transforming it into output") {
-      val app = random.nextInt(1)
-      val env = MockRandom.NextInt._0(equalTo(1), valueF(_ + 41))
+      val app = random.nextIntBounded(1)
+      val env = MockRandom.NextInt(equalTo(1), valueF(_ + 41))
       val out = app.provideLayer(env)
       assertM(out)(equalTo(42))
     },
     testM("expect call with input satisfying assertion and returning output") {
-      val app = random.nextInt(1)
-      val env = MockRandom.NextInt._0(equalTo(1), value(42))
+      val app = random.nextIntBounded(1)
+      val env = MockRandom.NextInt(equalTo(1), value(42))
       val out = app.provideLayer(env)
       assertM(out)(equalTo(42))
     },

--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -36,7 +36,7 @@ object AccessibleMacroExample {
       def baz(x: Int, y: Int): IO[String, Int]                       = UIO.succeed(x + y)
       def poly[A](a: A): IO[Long, A]                                 = UIO.succeed(a)
       def poly2[A <: Foo](a: Wrapped[A]): IO[String, List[A]]        = UIO.succeed(List(a.value))
-      def dependent(n: Int): ZIO[Random, Long, Int]                  = random.nextInt(n)
+      def dependent(n: Int): ZIO[Random, Long, Int]                  = random.nextIntBounded(n)
       val value: String                                              = "foo"
       def function(n: Int): String                                   = s"foo $n"
       def stream(n: Int): ZStream[Any, String, Int]                  = ZStream.fromIterable(List(1, 2, 3))

--- a/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
@@ -22,14 +22,14 @@ object MockExampleSpec extends DefaultRunnableSpec {
       assertM(out)(isUnit)
     },
     testM("expect call with input satisfying assertion and transforming it into output") {
-      val app = random.nextInt(1)
-      val env = MockRandom.NextInt._0(equalTo(1), valueF(_ + 41))
+      val app = random.nextIntBounded(1)
+      val env = MockRandom.NextInt(equalTo(1), valueF(_ + 41))
       val out = app.provideLayer(env)
       assertM(out)(equalTo(42))
     },
     testM("expect call with input satisfying assertion and returning output") {
-      val app = random.nextInt(1)
-      val env = MockRandom.NextInt._0(equalTo(1), value(42))
+      val app = random.nextIntBounded(1)
+      val env = MockRandom.NextInt(equalTo(1), value(42))
       val out = app.provideLayer(env)
       assertM(out)(equalTo(42))
     },

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -11,14 +11,14 @@ object CheckSpec extends ZIOBaseSpec {
       checkM(Gen.int(1, 100)) { n =>
         for {
           _ <- ZIO.effect(())
-          r <- random.nextInt(n)
+          r <- random.nextIntBounded(n)
         } yield assert(r)(isLessThan(n))
       }
     },
     testM("effectual properties can be tested") {
       checkM(Gen.int(1, 100)) { n =>
         for {
-          r <- random.nextInt(n)
+          r <- random.nextIntBounded(n)
         } yield assert(r)(isLessThan(n))
       }
     },
@@ -26,7 +26,7 @@ object CheckSpec extends ZIOBaseSpec {
       checkM(Gen.int(1, 100)) { n =>
         for {
           _ <- ZIO.fail("fail")
-          r <- random.nextInt(n)
+          r <- random.nextIntBounded(n)
         } yield assert(r)(isLessThan(n))
       }
     } @@ failing,
@@ -40,7 +40,7 @@ object CheckSpec extends ZIOBaseSpec {
         _ <- checkM(gen <*> gen) { _ =>
               for {
                 _ <- ref.update(_ + 1)
-                p <- random.nextInt(10).map(_ != 0)
+                p <- random.nextIntBounded(10).map(_ != 0)
               } yield assert(p)(isTrue)
             }
         result <- ref.get

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -10,13 +10,13 @@ object FunSpec extends ZIOBaseSpec {
   def spec = suite("FunSpec")(
     testM("fun converts effects into pure functions") {
       for {
-        f <- Fun.make((n: Int) => random.nextInt(n))
+        f <- Fun.make((n: Int) => random.nextIntBounded(n))
         n <- random.nextInt.map(abs(_))
       } yield assert(f(n))(equalTo(f(n)))
     },
     testM("fun does not have race conditions") {
       for {
-        f       <- Fun.make((_: Int) => random.nextInt(6))
+        f       <- Fun.make((_: Int) => random.nextIntBounded(6))
         results <- ZIO.foreachPar(List.range(0, 1000))(n => ZIO.effectTotal((n % 6, f(n % 6))))
       } yield assert(results.distinct.length)(equalTo(6))
     },

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -96,7 +96,7 @@ object GenUtils {
     gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(1000).runLast.map(_.get)
 
   val shrinkable: Gen[Random, Int] =
-    Gen.fromRandomSample(_.nextInt(90).map(_ + 10).map(Sample.shrinkIntegral(0)))
+    Gen.fromRandomSample(_.nextIntBounded(90).map(_ + 10).map(Sample.shrinkIntegral(0)))
 
   def shrinkWith[R, A](gen: Gen[R, A])(f: A => Boolean): ZIO[R, Nothing, List[A]] =
     gen.sample.take(1).flatMap(_.shrinkSearch(!f(_))).take(1000).filter(!f(_)).runCollect

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -37,13 +37,15 @@ object RandomSpec extends ZIOBaseSpec {
     testM("check nextLong")(forAllEqual(_.nextLong)(_.nextLong())),
     testM("check nextPrintableChar")(forAllEqual(_.nextPrintableChar)(_.nextPrintableChar())),
     testM("check nextString")(forAllEqualN(_.nextString(_))(_.nextString(_))),
-    testM("bounded nextInt")(forAllEqualN(_.nextInt(_))(_.nextInt(_))),
-    testM("bounded nextInt generates values within the bounds")(forAllBounded(Gen.anyInt)(_.nextInt(_))),
-    testM("bounded nextLong generates values within the bounds")(forAllBounded(Gen.anyLong)(_.nextLong(_))),
-    testM("between generates doubles within the bounds")(forAllBetween(Gen.anyDouble)(_.between(_, _))),
-    testM("between generates floats within the bounds")(forAllBetween(Gen.anyFloat)(_.between(_, _))),
-    testM("between generates integers within the bounds")(forAllBetween(Gen.anyInt)(_.between(_, _))),
-    testM("between generates longs within the bounds")(forAllBetween(Gen.anyLong)(_.between(_, _))),
+    testM("check nextIntBounded")(forAllEqualN(_.nextIntBounded(_))(_.nextInt(_))),
+    testM("nextIntBounded generates values within the bounds")(forAllBounded(Gen.anyInt)(_.nextIntBounded(_))),
+    testM("nextLongBounded generates values within the bounds")(forAllBounded(Gen.anyLong)(_.nextLongBounded(_))),
+    testM("nextDoubleBetween generates doubles within the bounds")(
+      forAllBetween(Gen.anyDouble)(_.nextDoubleBetween(_, _))
+    ),
+    testM("nextFloatBetween generates floats within the bounds")(forAllBetween(Gen.anyFloat)(_.nextFloatBetween(_, _))),
+    testM("nextIntBetween generates integers within the bounds")(forAllBetween(Gen.anyInt)(_.nextIntBetween(_, _))),
+    testM("nextLongBetween generates longs within the bounds")(forAllBetween(Gen.anyLong)(_.nextLongBetween(_, _))),
     testM("shuffle")(forAllEqualShuffle(_.shuffle(_))(_.shuffle(_))),
     testM("referential transparency") {
       val test = TestRandom.makeTest(DefaultData)

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -38,7 +38,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
 
         testValueComposed[Clock with Console, Nothing, Unit]("Console with Clock")(composed, program, isUnit)
       }, {
-        val cmd1 = MockRandom.NextInt._1(value(42))
+        val cmd1 = MockRandom.NextInt(value(42))
         val cmd2 = MockClock.Sleep(equalTo(42.seconds))
         val cmd3 = MockSystem.Property(equalTo("foo"), value(None))
         val cmd4 = MockConsole.PutStrLn(equalTo("None"))

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -186,7 +186,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    */
   val anyByte: Gen[Random, Byte] =
     fromEffectSample {
-      nextInt(Byte.MaxValue - Byte.MinValue + 1)
+      nextIntBounded(Byte.MaxValue - Byte.MinValue + 1)
         .map(r => (Byte.MinValue + r).toByte)
         .map(Sample.shrinkIntegral(0))
     }
@@ -196,7 +196,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    */
   val anyChar: Gen[Random, Char] =
     fromEffectSample {
-      nextInt(Char.MaxValue - Char.MinValue + 1)
+      nextIntBounded(Char.MaxValue - Char.MinValue + 1)
         .map(r => (Char.MinValue + r).toChar)
         .map(Sample.shrinkIntegral(0))
     }
@@ -230,7 +230,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    */
   val anyShort: Gen[Random, Short] =
     fromEffectSample {
-      nextInt(Short.MaxValue - Short.MinValue + 1)
+      nextIntBounded(Short.MaxValue - Short.MinValue + 1)
         .map(r => (Short.MinValue + r).toShort)
         .map(Sample.shrinkIntegral(0))
     }
@@ -438,7 +438,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     Gen.fromEffectSample {
       val difference = max - min + 1
       val effect =
-        if (difference > 0) nextInt(difference).map(min + _)
+        if (difference > 0) nextIntBounded(difference).map(min + _)
         else nextInt.doUntil(n => min <= n && n <= max)
       effect.map(Sample.shrinkIntegral(min))
     }
@@ -473,7 +473,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     Gen.fromEffectSample {
       val difference = max - min + 1
       val effect =
-        if (difference > 0) nextLong(difference).map(min + _)
+        if (difference > 0) nextLongBounded(difference).map(min + _)
         else nextLong.doUntil(n => min <= n && n <= max)
       effect.map(Sample.shrinkIntegral(min))
     }

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -794,9 +794,9 @@ package object environment extends PlatformSpecific {
    *
    * for {
    *   _ <- TestRandom.feedInts(4, 5, 2)
-   *   x <- random.nextInt(6)
-   *   y <- random.nextInt(6)
-   *   z <- random.nextInt(6)
+   *   x <- random.nextIntBounded(6)
+   *   y <- random.nextIntBounded(6)
+   *   z <- random.nextIntBounded(6)
    * } yield x + y + z == 11
    * }}}
    *
@@ -838,34 +838,6 @@ package object environment extends PlatformSpecific {
     final case class Test(randomState: Ref[Data], bufferState: Ref[Buffer])
         extends Random.Service
         with TestRandom.Service {
-
-      /**
-       * Takes a long from the buffer if one exists or else generates a
-       * pseudo-random long in the specified range.
-       */
-      def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-        getOrElse(bufferedLong)(randomBetween(minInclusive, maxExclusive))
-
-      /**
-       * Takes an integer from the buffer if one exists or else generates a
-       * pseudo-random integer in the specified range.
-       */
-      def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-        getOrElse(bufferedInt)(randomBetween(minInclusive, maxExclusive))
-
-      /**
-       * Takes a float from the buffer if one exists or else generates a
-       * pseudo-random float in the specified range.
-       */
-      def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
-        getOrElse(bufferedFloat)(randomBetween(minInclusive, maxExclusive))
-
-      /**
-       * Takes a double from the buffer if one exists or else generates a
-       * pseudo-random double in the specified range.
-       */
-      def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
-        getOrElse(bufferedDouble)(randomBetween(minInclusive, maxExclusive))
 
       /**
        * Clears the buffer of booleans.
@@ -1010,11 +982,25 @@ package object environment extends PlatformSpecific {
         getOrElse(bufferedDouble)(randomDouble)
 
       /**
+       * Takes a double from the buffer if one exists or else generates a
+       * pseudo-random double in the specified range.
+       */
+      def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+        getOrElse(bufferedDouble)(randomDoubleBetween(minInclusive, maxExclusive))
+
+      /**
        * Takes a float from the buffer if one exists or else generates a
        * pseudo-random, uniformly distributed float between 0.0 and 1.0.
        */
       lazy val nextFloat: UIO[Float] =
         getOrElse(bufferedFloat)(randomFloat)
+
+      /**
+       * Takes a float from the buffer if one exists or else generates a
+       * pseudo-random float in the specified range.
+       */
+      def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+        getOrElse(bufferedFloat)(randomFloatBetween(minInclusive, maxExclusive))
 
       /**
        * Takes a double from the buffer if one exists or else generates a
@@ -1033,11 +1019,18 @@ package object environment extends PlatformSpecific {
 
       /**
        * Takes an integer from the buffer if one exists or else generates a
+       * pseudo-random integer in the specified range.
+       */
+      def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+        getOrElse(bufferedInt)(randomIntBetween(minInclusive, maxExclusive))
+
+      /**
+       * Takes an integer from the buffer if one exists or else generates a
        * pseudo-random integer between 0 (inclusive) and the specified value
        * (exclusive).
        */
-      def nextInt(n: Int): UIO[Int] =
-        getOrElse(bufferedInt)(randomInt(n))
+      def nextIntBounded(n: Int): UIO[Int] =
+        getOrElse(bufferedInt)(randomIntBounded(n))
 
       /**
        * Takes a long from the buffer if one exists or else generates a
@@ -1048,11 +1041,18 @@ package object environment extends PlatformSpecific {
 
       /**
        * Takes a long from the buffer if one exists or else generates a
+       * pseudo-random long in the specified range.
+       */
+      def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+        getOrElse(bufferedLong)(randomLongBetween(minInclusive, maxExclusive))
+
+      /**
+       * Takes a long from the buffer if one exists or else generates a
        * pseudo-random long between 0 (inclusive) and the specified value
        * (exclusive).
        */
-      def nextLong(n: Long): UIO[Long] =
-        getOrElse(bufferedLong)(randomLong(n))
+      def nextLongBounded(n: Long): UIO[Long] =
+        getOrElse(bufferedLong)(randomLongBounded(n))
 
       /**
        * Takes a character from the buffer if one exists or else generates a
@@ -1093,7 +1093,7 @@ package object environment extends PlatformSpecific {
        * Randomly shuffles the specified list.
        */
       def shuffle[A](list: List[A]): UIO[List[A]] =
-        Random.shuffleWith(randomInt, list)
+        Random.shuffleWith(randomIntBounded, list)
 
       private def bufferedBoolean(buffer: Buffer): (Option[Boolean], Buffer) =
         (
@@ -1154,34 +1154,6 @@ package object environment extends PlatformSpecific {
       private def mostSignificantBits(x: Double): Int =
         toInt((x / (1 << 24).toDouble))
 
-      /**
-       * Takes a long from the buffer if one exists or else generates a
-       * pseudo-random long in the specified range.
-       */
-      private def randomBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-        Random.betweenWith(nextLong, nextLong(_), minInclusive, maxExclusive)
-
-      /**
-       * Takes an integer from the buffer if one exists or else generates a
-       * pseudo-random integer in the specified range.
-       */
-      private def randomBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-        Random.betweenWith(nextInt, nextInt(_), minInclusive, maxExclusive)
-
-      /**
-       * Takes a float from the buffer if one exists or else generates a
-       * pseudo-random float in the specified range.
-       */
-      private def randomBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
-        Random.betweenWith(nextFloat, minInclusive, maxExclusive)
-
-      /**
-       * Takes a double from the buffer if one exists or else generates a
-       * pseudo-random double in the specified range.
-       */
-      private def randomBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
-        Random.betweenWith(nextDouble, minInclusive, maxExclusive)
-
       private def randomBits(bits: Int): UIO[Int] =
         randomState.modify { data =>
           val multiplier  = 0X5DEECE66DL
@@ -1219,8 +1191,14 @@ package object environment extends PlatformSpecific {
           i2 <- randomBits(27)
         } yield ((i1.toDouble * (1L << 27).toDouble) + i2.toDouble) / (1L << 53).toDouble
 
+      private def randomDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+        Random.nextDoubleBetweenWith(minInclusive, maxExclusive)(randomDouble)
+
       private val randomFloat: UIO[Float] =
         randomBits(24).map(i => (i.toDouble / (1 << 24).toDouble).toFloat)
+
+      private def randomFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+        Random.nextFloatBetweenWith(minInclusive, maxExclusive)(randomFloat)
 
       private val randomGaussian: UIO[Double] =
         //  The Box-Muller transform generates two normally distributed random
@@ -1255,7 +1233,7 @@ package object environment extends PlatformSpecific {
       private val randomInt: UIO[Int] =
         randomBits(32)
 
-      private def randomInt(n: Int): UIO[Int] =
+      private def randomIntBounded(n: Int): UIO[Int] =
         if (n <= 0)
           UIO.die(new IllegalArgumentException("n must be positive"))
         else if ((n & -n) == n)
@@ -1270,20 +1248,26 @@ package object environment extends PlatformSpecific {
           loop
         }
 
+      private def randomIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+        Random.nextIntBetweenWith(minInclusive, maxExclusive)(randomInt, randomIntBounded)
+
       private val randomLong: UIO[Long] =
         for {
           i1 <- randomBits(32)
           i2 <- randomBits(32)
         } yield ((i1.toLong << 32) + i2)
 
-      private def randomLong(n: Long): UIO[Long] =
-        Random.nextLongWith(randomLong, n)
+      private def randomLongBounded(n: Long): UIO[Long] =
+        Random.nextLongBoundedWith(n)(randomLong)
+
+      private def randomLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+        Random.nextLongBetweenWith(minInclusive, maxExclusive)(randomLong, randomLongBounded)
 
       private val randomPrintableChar: UIO[Char] =
-        randomInt(127 - 33).map(i => (i + 33).toChar)
+        randomIntBounded(127 - 33).map(i => (i + 33).toChar)
 
       private def randomString(length: Int): UIO[String] = {
-        val safeChar = randomInt(0xD800 - 1).map(i => (i + 1).toChar)
+        val safeChar = randomIntBounded(0xD800 - 1).map(i => (i + 1).toChar)
         UIO.collectAll(List.fill(length)(safeChar)).map(_.mkString)
       }
 

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -21,25 +21,19 @@ import zio.{ Chunk, Has, UIO, URLayer, ZLayer }
 
 object MockRandom extends Mock[Random] {
 
-  object Between {
-    object _0 extends Effect[(Long, Long), Nothing, Long]
-    object _1 extends Effect[(Int, Int), Nothing, Int]
-    object _2 extends Effect[(Float, Float), Nothing, Float]
-    object _3 extends Effect[(Double, Double), Nothing, Double]
-  }
-  object NextBoolean  extends Effect[Unit, Nothing, Boolean]
-  object NextBytes    extends Effect[Int, Nothing, Chunk[Byte]]
-  object NextDouble   extends Effect[Unit, Nothing, Double]
-  object NextFloat    extends Effect[Unit, Nothing, Float]
-  object NextGaussian extends Effect[Unit, Nothing, Double]
-  object NextInt {
-    object _0 extends Effect[Int, Nothing, Int]
-    object _1 extends Effect[Unit, Nothing, Int]
-  }
-  object NextLong {
-    object _0 extends Effect[Unit, Nothing, Long]
-    object _1 extends Effect[Long, Nothing, Long]
-  }
+  object NextBoolean       extends Effect[Unit, Nothing, Boolean]
+  object NextBytes         extends Effect[Int, Nothing, Chunk[Byte]]
+  object NextDouble        extends Effect[Unit, Nothing, Double]
+  object NextDoubleBetween extends Effect[(Double, Double), Nothing, Double]
+  object NextFloat         extends Effect[Unit, Nothing, Float]
+  object NextFloatBetween  extends Effect[(Float, Float), Nothing, Float]
+  object NextGaussian      extends Effect[Unit, Nothing, Double]
+  object NextInt           extends Effect[Unit, Nothing, Int]
+  object NextIntBetween    extends Effect[(Int, Int), Nothing, Int]
+  object NextIntBounded    extends Effect[Int, Nothing, Int]
+  object NextLong          extends Effect[Unit, Nothing, Long]
+  object NextLongBetween   extends Effect[(Long, Long), Nothing, Long]
+  object NextLongBounded   extends Effect[Long, Nothing, Long]
   object NextPrintableChar extends Effect[Unit, Nothing, Char]
   object NextString        extends Effect[Int, Nothing, String]
   object Shuffle           extends Effect[List[Any], Nothing, List[Any]]
@@ -47,26 +41,26 @@ object MockRandom extends Mock[Random] {
   val compose: URLayer[Has[Proxy], Random] =
     ZLayer.fromService(proxy =>
       new Random.Service {
-        def between(minInclusive: Long, maxExclusive: Long): UIO[Long] =
-          proxy(Between._0, minInclusive, maxExclusive)
-        def between(minInclusive: Int, maxExclusive: Int): UIO[Int] =
-          proxy(Between._1, minInclusive, maxExclusive)
-        def between(minInclusive: Float, maxExclusive: Float): UIO[Float] =
-          proxy(Between._2, minInclusive, maxExclusive)
-        def between(minInclusive: Double, maxExclusive: Double): UIO[Double] =
-          proxy(Between._3, minInclusive, maxExclusive)
         val nextBoolean: UIO[Boolean]                = proxy(NextBoolean)
         def nextBytes(length: Int): UIO[Chunk[Byte]] = proxy(NextBytes, length)
         val nextDouble: UIO[Double]                  = proxy(NextDouble)
-        val nextFloat: UIO[Float]                    = proxy(NextFloat)
-        val nextGaussian: UIO[Double]                = proxy(NextGaussian)
-        def nextInt(n: Int): UIO[Int]                = proxy(NextInt._0, n)
-        val nextInt: UIO[Int]                        = proxy(NextInt._1)
-        val nextLong: UIO[Long]                      = proxy(NextLong._0)
-        def nextLong(n: Long): UIO[Long]             = proxy(NextLong._1, n)
-        val nextPrintableChar: UIO[Char]             = proxy(NextPrintableChar)
-        def nextString(length: Int)                  = proxy(NextString, length)
-        def shuffle[A](list: List[A]): UIO[List[A]]  = proxy(Shuffle, list).asInstanceOf[UIO[List[A]]]
+        def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
+          proxy(NextDoubleBetween, minInclusive, maxExclusive)
+        val nextFloat: UIO[Float] = proxy(NextFloat)
+        def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
+          proxy(NextFloatBetween, minInclusive, maxExclusive)
+        val nextGaussian: UIO[Double] = proxy(NextGaussian)
+        val nextInt: UIO[Int]         = proxy(NextInt)
+        def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
+          proxy(NextIntBetween, minInclusive, maxExclusive)
+        def nextIntBounded(n: Int): UIO[Int] = proxy(NextIntBounded, n)
+        val nextLong: UIO[Long]              = proxy(NextLong)
+        def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
+          proxy(NextLongBetween, minInclusive, maxExclusive)
+        def nextLongBounded(n: Long): UIO[Long]     = proxy(NextLongBounded, n)
+        val nextPrintableChar: UIO[Char]            = proxy(NextPrintableChar)
+        def nextString(length: Int)                 = proxy(NextString, length)
+        def shuffle[A](list: List[A]): UIO[List[A]] = proxy(Shuffle, list).asInstanceOf[UIO[List[A]]]
       }
     )
 }


### PR DESCRIPTION
Renames methods in `Random` service so that no core services uses overloaded method names. Changes are as follows:

- `nextLong(n)` goes to `nextLongBounded(n)`
- `nextInt(n)` goes to `nextIntBounded(n)`
- `between` goes to `nextDoubleBetween`, `nextFloatBetween`, `nextIntBetween`, and `nextLongBetween`

Removes numeric suffixes from ZIO Mock capability tags.