### PR TITLE
Add tests for mocking methods with by-name parameters

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
@@ -306,6 +306,38 @@ object BasicEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
           equalTo("foo 1, [2, 3], 4, [5, 6]")
         )
       ),
+      suite("byName")(
+        testValue("returns value")(
+          PureModuleMock.ByName(equalTo(1), value("foo")),
+          PureModule.byName(1),
+          equalTo("foo")
+        ),
+        testValue("returns valueF")(
+          PureModuleMock.ByName(equalTo(1), valueF(i => s"foo $i")),
+          PureModule.byName(1),
+          equalTo("foo 1")
+        ),
+        testValue("returns valueM")(
+          PureModuleMock.ByName(equalTo(1), valueM(i => UIO.succeed(s"foo $i"))),
+          PureModule.byName(1),
+          equalTo("foo 1")
+        ),
+        testError("returns failure")(
+          PureModuleMock.ByName(equalTo(1), failure("foo")),
+          PureModule.byName(1),
+          equalTo("foo")
+        ),
+        testError("returns failureF")(
+          PureModuleMock.ByName(equalTo(1), failureF(i => s"foo $i")),
+          PureModule.byName(1),
+          equalTo("foo 1")
+        ),
+        testError("returns failureM")(
+          PureModuleMock.ByName(equalTo(1), failureM(i => IO.fail(s"foo $i"))),
+          PureModule.byName(1),
+          equalTo("foo 1")
+        )
+      ),
       suite("maxParams")(
         testValue("returns value")(
           PureModuleMock.MaxParams(equalTo(intTuple22), value("foo")),

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
@@ -298,6 +298,38 @@ object BasicMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] 
             isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1, [2, 3], 4, [5, 6]")))
           )
         ),
+        suite("byName")(
+          testValue("returns value")(
+            ImpureModuleMock.ByName(equalTo(1), value("foo")),
+            ImpureModule.byName(1),
+            equalTo("foo")
+          ),
+          testValue("returns valueF")(
+            ImpureModuleMock.ByName(equalTo(1), valueF(i => s"foo $i")),
+            ImpureModule.byName(1),
+            equalTo("foo 1")
+          ),
+          testValue("returns valueM")(
+            ImpureModuleMock.ByName(equalTo(1), valueM(i => UIO.succeed(s"foo $i"))),
+            ImpureModule.byName(1),
+            equalTo("foo 1")
+          ),
+          testDied("returns failure")(
+            ImpureModuleMock.ByName(equalTo(1), failure(new Exception("foo"))),
+            ImpureModule.byName(1),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo")))
+          ),
+          testDied("returns failureF")(
+            ImpureModuleMock.ByName(equalTo(1), failureF(i => new Exception(s"foo $i"))),
+            ImpureModule.byName(1),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1")))
+          ),
+          testDied("returns failureM")(
+            ImpureModuleMock.ByName(equalTo(1), failureM(i => IO.fail(new Exception(s"foo $i")))),
+            ImpureModule.byName(1),
+            isSubtype[Exception](hasField("message", _.getMessage, equalTo("foo 1")))
+          )
+        ),
         suite("maxParams")(
           testValue("returns value")(
             ImpureModuleMock.MaxParams(equalTo(intTuple22), value("foo")),

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
@@ -48,6 +48,7 @@ object ImpureModule {
     def polyBounded[A <: AnyVal: Tagged]: A
     def varargs(a: Int, b: String*): String
     def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String
+    def byName(a: => Int): String
     def maxParams(
       a: Int,
       b: Int,
@@ -97,6 +98,7 @@ object ImpureModule {
   def varargs(a: Int, b: String*)      = ZIO.access[ImpureModule](_.get.varargs(a, b: _*))
   def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*) =
     ZIO.access[ImpureModule](_.get.curriedVarargs(a, b: _*)(c, d: _*))
+  def byName(a: => Int) = ZIO.access[ImpureModule](_.get.byName(a))
   def maxParams(
     a: Int,
     b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
@@ -44,6 +44,7 @@ object ImpureModuleMock extends Mock[ImpureModule] {
   object PolyBounded          extends Poly.Method.Output[Unit, Throwable]
   object Varargs              extends Method[(Int, Seq[String]), Throwable, String]
   object CurriedVarargs       extends Method[(Int, Seq[String], Long, Seq[Char]), Throwable, String]
+  object ByName               extends Effect[Int, Throwable, String]
 
   object Overloaded {
     object _0 extends Method[Int, Throwable, String]
@@ -81,6 +82,7 @@ object ImpureModuleMock extends Mock[ImpureModule] {
           def varargs(a: Int, b: String*): String = rts.unsafeRunTask(proxy(Varargs, (a, b)))
           def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String =
             rts.unsafeRunTask(proxy(CurriedVarargs, (a, b, c, d)))
+          def byName(a: => Int): String = rts.unsafeRunTask(proxy(ByName, a))
           def maxParams(
             a: Int,
             b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
@@ -47,6 +47,7 @@ object PureModule {
     def polyBounded[A <: AnyVal: Tagged]: IO[String, A]
     def varargs(a: Int, b: String*): IO[String, String]
     def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String]
+    def byName(a: => Int): IO[String, String]
     def maxParams(
       a: Int,
       b: Int,
@@ -97,6 +98,7 @@ object PureModule {
   def varargs(a: Int, b: String*)      = ZIO.accessM[PureModule](_.get.varargs(a, b: _*))
   def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*) =
     ZIO.accessM[PureModule](_.get.curriedVarargs(a, b: _*)(c, d: _*))
+  def byName(a: => Int) = ZIO.accessM[PureModule](_.get.byName(a))
   def maxParams(
     a: Int,
     b: Int,

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
@@ -46,6 +46,7 @@ object PureModuleMock extends Mock[PureModule] {
   object PolyBounded          extends Poly.Effect.Output[Unit, String]
   object Varargs              extends Effect[(Int, Seq[String]), String, String]
   object CurriedVarargs       extends Effect[(Int, Seq[String], Long, Seq[Char]), String, String]
+  object ByName               extends Effect[Int, String, String]
 
   object Overloaded {
     object _0 extends Effect[Int, String, String]
@@ -83,6 +84,7 @@ object PureModuleMock extends Mock[PureModule] {
           def varargs(a: Int, b: String*): IO[String, String] = proxy(Varargs, (a, b))
           def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String] =
             proxy(CurriedVarargs, (a, b, c, d))
+          def byName(a: => Int): IO[String, String] = proxy(ByName, a)
           def maxParams(
             a: Int,
             b: Int,


### PR DESCRIPTION
By-name parameters are supported, but they were not documented/tested. This PR fixes that.