### PR TITLE
ZIO Test: Implement Generators for Chunks

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -665,6 +665,21 @@ object Chunk {
         arr(des)
     }
 
+  def fill[A](n: Int)(elem: => A): Chunk[A] =
+    if (n <= 0) Chunk.empty
+    else {
+      val first                     = elem
+      implicit val tag: ClassTag[A] = Tags.fromValue(first)
+      val array                     = Array.ofDim[A](n)
+      array(0) = first
+      var i = 1
+      while (i < n) {
+        array(i) = elem
+        i += 1
+      }
+      arr(array)
+    }
+
   /**
    * Returns a chunk backed by an array.
    */

--- a/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ChunkSpec.scala
@@ -30,6 +30,14 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    testM("fill") {
+      val smallInt = Gen.int(-10, 10)
+      check(smallInt, smallInt) { (n, elem) =>
+        val actual   = Chunk.fill(n)(elem)
+        val expected = Chunk.fromArray(Array.fill(n)(elem))
+        assert(actual)(equalTo(expected))
+      }
+    },
     testM("length") {
       check(largeChunks(intGen))(chunk => assert(chunk.length)(equalTo(chunk.toSeq.length)))
     },

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -3,9 +3,9 @@ package zio.test
 import scala.collection.immutable.SortedSet
 import scala.util.{ Failure, Success }
 
-import zio.Exit
 import zio.test.Assertion._
 import zio.test.TestAspect._
+import zio.{ Chunk, Exit }
 
 object AssertionSpec extends ZIOBaseSpec {
 
@@ -249,6 +249,12 @@ object AssertionSpec extends ZIOBaseSpec {
     test("hasSize must fail when iterable size is not equal to specified assertion") {
       assert(Seq(1, 2, 3))(hasSize(equalTo(1)))
     } @@ failing,
+    test("hasSizeChunk must succeed when iterable size is equal to specified assertion") {
+      assert(Chunk(1, 2, 3))(hasSizeChunk(equalTo(3)))
+    },
+    test("hasSizeChunk must fail when iterable size is not equal to specified assertion") {
+      assert(Chunk(1, 2, 3))(hasSizeChunk(equalTo(1)))
+    } @@ failing,
     test("hasSizeString must succeed when string size is equal to specified assertion") {
       assert("aaa")(hasSizeString(equalTo(3)))
     },
@@ -361,6 +367,12 @@ object AssertionSpec extends ZIOBaseSpec {
     } @@ failing,
     test("isNonEmpty must succeed when the traversable is not empty") {
       assert(Seq(1, 2, 3))(isNonEmpty)
+    },
+    test("isNonEmptyChunk must fail when the chunk is empty") {
+      assert(Chunk.empty)(isNonEmptyChunk)
+    } @@ failing,
+    test("isNonEmptyChunk must succeed when the chunk is not empty") {
+      assert(Chunk(1, 2, 3))(isNonEmptyChunk)
     },
     test("isNonEmpty must fail when the traversable is empty") {
       assert(Seq())(isNonEmpty)

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -19,7 +19,7 @@ package zio.test
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
-import zio.{ Cause, Exit }
+import zio.{ Cause, Chunk, Exit }
 
 /**
  * An `Assertion[A]` is capable of producing assertion results on an `A`. As a
@@ -462,6 +462,13 @@ object Assertion extends AssertionVariants {
     Assertion.assertionRec("hasSize")(param(assertion))(assertion)(actual => Some(actual.size))
 
   /**
+   * Makes a new assertion that requires the size of a chunk be satisfied by
+   * the specified assertion.
+   */
+  def hasSizeChunk[A](assertion: Assertion[Int]): Assertion[Chunk[A]] =
+    Assertion.assertionRec("hasSizeChunk")(param(assertion))(assertion)(actual => Some(actual.size))
+
+  /**
    * Makes a new assertion that requires the size of a string be satisfied by
    * the specified assertion.
    */
@@ -615,6 +622,12 @@ object Assertion extends AssertionVariants {
    */
   val isNonEmpty: Assertion[Iterable[Any]] =
     Assertion.assertion("isNonEmpty")()(_.nonEmpty)
+
+  /**
+   * Makes a new assertion that requires an Iterable to be non empty.
+   */
+  val isNonEmptyChunk: Assertion[Chunk[Any]] =
+    Assertion.assertion("isNonEmptyChunk")()(_.nonEmpty)
 
   /**
    * Makes a new assertion that requires a given string to be non empty


### PR DESCRIPTION
Implements generators for chunks analogous to existing generators for other collection types. Specializes generators for non-empty lists and chunks to return more specific type. Also implements `Chunk.fill`, `Assertion.hasSizeChunk`, and `Assertion.isEmptyChunk`.