### PR TITLE
Don't Render Chunk Subtype in toString

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -541,7 +541,7 @@ sealed trait Chunk[+A] { self =>
   }
 
   override final def toString: String =
-    mkString("Chunk(", ", ", ")")
+    toArrayOption.fold("Chunk()")(_.mkString("Chunk(", ",", ")"))
 
   /**
    * Statefully and effectfully maps over the elements of this chunk to produce

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -540,8 +540,8 @@ sealed trait Chunk[+A] { self =>
     fromBuilder(vectorBuilder)
   }
 
-  override def toString: String =
-    toArrayOption.fold(s"${self.getClass.getSimpleName}()")(_.mkString(s"${self.getClass.getSimpleName}(", ",", ")"))
+  override final def toString: String =
+    mkString("Chunk(", ", ", ")")
 
   /**
    * Statefully and effectfully maps over the elements of this chunk to produce


### PR DESCRIPTION
Right now in `Chunk#toString` we render the underlying subtype of the chunk. While potentially useful internally for debugging this leaks implementation details that users should not have to know about and may change. We should render a chunk just like a list, vector, set, or map, where we show `Chunk(1, 2, 3)` rather than whether this is a `Concat` subtype.