### PR TITLE
Comment expectation creation code in mocking docs

### DIFF
--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -281,7 +281,7 @@ import zio.test.Assertion._
 import zio.test.mock.Expectation._
 import zio.test.mock.MockSystem._
 
-val exp01 = SomeCapability(
+val exp01 = Property( // capability to build an expectation for
   equalTo("foo"), // assertion of the expected input argument
   value(Some("bar")) // result, that will be returned
 )

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -281,7 +281,10 @@ import zio.test.Assertion._
 import zio.test.mock.Expectation._
 import zio.test.mock.MockSystem._
 
-val exp01 = Property(equalTo("foo"), value(Some("bar")))
+val exp01 = SomeCapability(
+  equalTo("foo"), // assertion of the expected input argument
+  value(Some("bar")) // result, that will be returned
+)
 ```
 
 For methods that take input, the first argument will be an assertion on input, and the second the predefined result.


### PR DESCRIPTION
I have a small addition in the scope of #3268.
Overall it feels like a very solid doc to my eye. I had one bump though while reading - "Setting up expectations" part starts with a piece of code I couldn't understand at all. Of course it's explained in detail afterwards, but it forced me to go back and revisit the snippet again.

I propose a more self-explaining sample so that following text is based on some initial understanding already.