### PR TITLE
Sort todos before executing them

### DIFF
--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -17,7 +17,7 @@
 package zio.stm
 
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
-import java.util.{ HashMap => MutableMap }
+import java.util.{ Arrays, HashMap => MutableMap }
 
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success, Try }
@@ -1468,8 +1468,18 @@ object ZSTM {
      * Executes the todos in the current thread, sequentially.
      */
     def execTodos(todos: MutableMap[TxnId, Todo]): Unit = {
-      val it = todos.entrySet.iterator
-      while (it.hasNext) it.next.getValue.apply()
+      val keys = todos.keySet.toArray
+      var i    = 0
+
+      Arrays.sort(keys)
+
+      while (i < keys.length) {
+        val id   = keys(i)
+        val todo = todos.get(id)
+
+        todo.apply()
+        i += 1
+      }
     }
 
     /**


### PR DESCRIPTION
Improves fairness of STM by sorting todos before executing them. To determine how much performance dropped, I ran two "standard" benchmarking suites for STM - TMap operations and a deep flat map.

### Before the change

Deep flat map:

```
Benchmark                        (depth)   Mode  Cnt      Score     Error  Units
STMFlatMapBenchmark.deepFlatMap       20  thrpt   15    888.181 ±    4.118  ops/s
```

TMap operations:

```
Benchmark                     (size)   Mode  Cnt      Score     Error  Units
TMapOpsBenchmarks.lookup       10000  thrpt   15   3782.983 ±  22.903  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15   2651.815 ±  13.043  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15     27.559 ±   0.163  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15    21.695 ±   0.146  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15   2014.471 ±  14.065  ops/s
```

### After the change

Deep flat map:

```
Benchmark                        (depth)   Mode  Cnt      Score     Error  Units
STMFlatMapBenchmark.deepFlatMap       20  thrpt   15    870.717 ±   40.045  ops/s
```

TMap operations:

```
Benchmark                     (size)   Mode  Cnt      Score     Error  Units
TMapOpsBenchmarks.lookup       10000  thrpt   15   3914.755 ±  19.434  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15   2376.030 ±  19.728  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15     27.365 ±   0.216  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15     25.187 ±   0.154  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15   1945.318 ±  15.071  ops/s
```