### PR TITLE
Improve TMap transformations

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -860,7 +860,13 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- makeStair(n).commit
           result <- tArray.reduceOptionM((a, b) => if (b == 4) STM.fail(boom) else STM.succeed(a + b)).commit.flip
         } yield assert(result)(equalTo(boom))
-      } @@ zioTag(errors)
+      } @@ zioTag(errors),
+      testM("toList") {
+        for {
+          tArray <- TArray.make(1, 2, 3, 4).commit
+          result <- tArray.toList.commit
+        } yield assert(result)(equalTo(List(1, 2, 3, 4)))
+      }
     )
   )
 

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -214,7 +214,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit)(hasSameElements(List("key" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("key" -> 6)))
       },
       testM("transformM") {
         val tx =
@@ -234,7 +234,7 @@ object TMapSpec extends ZIOBaseSpec {
             res  <- tmap.toList
           } yield res
 
-        assertM(tx.commit)(hasSameElements(List("key" -> 2)))
+        assertM(tx.commit)(hasSameElements(List("key" -> 6)))
       },
       testM("transformValues") {
         val tx =

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -255,6 +255,12 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     }
 
   /**
+   * Collects all elements into a list.
+   */
+  def toList: USTM[List[A]] =
+    STM.collectAll(array.map(_.get))
+
+  /**
    * Atomically updates all elements using a pure function.
    */
   def transform(f: A => A): USTM[Unit] =

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -169,10 +169,9 @@ final class TMap[K, V] private (
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
     tBuckets.get.flatMap { buckets =>
-      val g        = f.tupled
-      val capacity = buckets.array.length
-
       buckets.toList.flatMap { list =>
+        val g          = f.tupled
+        val capacity   = buckets.array.length
         val currData   = list.flatten
         val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 
@@ -202,11 +201,11 @@ final class TMap[K, V] private (
    */
   def transformM[E](f: (K, V) => STM[E, (K, V)]): STM[E, Unit] =
     tBuckets.get.flatMap { buckets =>
-      val g        = f.tupled
-      val capacity = buckets.array.length
-
       buckets.toList.flatMap { list =>
+        val g = f.tupled
+
         STM.foreach(list.flatten)(g).flatMap { mappedData =>
+          val capacity   = buckets.array.length
           val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 
           val it = mappedData.iterator

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -16,8 +16,6 @@
 
 package zio.stm
 
-import scala.collection.mutable
-
 /**
  * Transactional map implemented on top of [[TRef]] and [[TArray]]. Resolves
  * conflicts via chaining.
@@ -174,8 +172,9 @@ final class TMap[K, V] private (
       val g        = f.tupled
       val capacity = buckets.array.length
 
-      buckets.fold(mutable.Buffer.empty[(K, V)])(_ ++= _).flatMap { currData =>
-        val newData = Array.fill[List[(K, V)]](capacity)(Nil)
+      buckets.toList.flatMap { list =>
+        val currData = list.flatten
+        val newData  = Array.fill[List[(K, V)]](capacity)(Nil)
 
         val it = currData.iterator
         while (it.hasNext) {

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -169,13 +169,12 @@ final class TMap[K, V] private (
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
     tBuckets.get.flatMap { buckets =>
-      buckets.toList.flatMap { list =>
+      buckets.toList.flatMap { data =>
         val g          = f.tupled
         val capacity   = buckets.array.length
-        val currData   = list.flatten
         val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 
-        val it = currData.iterator
+        val it = data.flatten.iterator
         while (it.hasNext) {
           val newPair = g(it.next)
           val idx     = TMap.indexOf(newPair._1, capacity)
@@ -201,10 +200,10 @@ final class TMap[K, V] private (
    */
   def transformM[E](f: (K, V) => STM[E, (K, V)]): STM[E, Unit] =
     tBuckets.get.flatMap { buckets =>
-      buckets.toList.flatMap { list =>
+      buckets.toList.flatMap { data =>
         val g = f.tupled
 
-        STM.foreach(list.flatten)(g).flatMap { mappedData =>
+        STM.foreach(data.flatten)(g).flatMap { mappedData =>
           val capacity   = buckets.array.length
           val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 


### PR DESCRIPTION
### Summary

- Added `toList` combinator to `TArray`.
- Improved performance of `TMap.transform` and `TMap.transformM`.
- Aligned behaviour of map with scala's map, e.g. `List("a" -> 1, "a" -> 2).toMap` results in `Map("a" -> 2)`.

### Results

Before change:

```
Benchmark                     (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.transform        0  thrpt   15  130167.494 ± 2935.334  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15   83186.545 ± 1943.449  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15    7968.935 ±  224.860  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15     721.115 ±   50.640  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      30.418 ±    1.403  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       2.165 ±    0.082  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  131919.275 ± 2508.328  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   75953.533 ±  885.021  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15    7719.947 ±   89.299  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15     673.047 ±   10.175  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      31.354 ±    0.195  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       2.113 ±    0.051  ops/s
```

After change:

```

Benchmark                     (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.transform        0  thrpt   15  145808.297 ± 2894.169  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  114747.115 ± 2945.949  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   15172.078 ±  198.040  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    1806.293 ±   18.680  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      94.207 ±    0.607  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       6.240 ±    0.113  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  142934.548 ± 3049.818  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   95933.273 ± 2993.504  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   11296.784 ±   62.835  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1211.265 ±    3.142  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      72.563 ±    2.014  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       4.923 ±    0.054  ops/s
```