### PR TITLE
Make Chunk Extend IndexedSeq

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -192,7 +192,7 @@ object ChunkSpec extends ZIOBaseSpec {
       trait Dog extends Animal
 
       val vector   = Vector(new Cat {}, new Dog {}, new Animal {})
-      val actual   = Chunk.fromIterable(vector).map(a => a)
+      val actual   = Chunk.fromIterable(vector).map[Animal](identity)
       val expected = Chunk.fromArray(vector.toArray)
 
       assert(actual)(equalTo(expected))
@@ -201,7 +201,7 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(Chunk.empty.toArray[String])(equalTo(Array.empty[String]))
     },
     zio.test.test("to Array for an empty Chunk using filter") {
-      assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
+      assert(Chunk(1).filter(_ == 2).map[String](_.toString).toArray[String])(equalTo(Array.empty[String]))
     },
     testM("toArray with elements of type String") {
       check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toList)(equalTo(c.toList)))
@@ -313,7 +313,7 @@ object ChunkSpec extends ZIOBaseSpec {
       // foreach should not throw
       c.foreach(_ => ())
 
-      assert(c.filter(_ => false).map(_ * 2).length)(equalTo(0))
+      assert(c.filter(_ => false).map[Int](_ * 2).length)(equalTo(0))
     },
     zio.test.test("toArrayOnConcatOfSlice") {
       val onlyOdd: Int => Boolean = _ % 2 != 0
@@ -367,8 +367,8 @@ object ChunkSpec extends ZIOBaseSpec {
         Chunk.succeed(x),
         nonEmptyChunk ++ chunk,
         // chunk ++ nonEmptyChunk,
-        nonEmptyChunk.flatMap(i => Chunk(i)),
-        nonEmptyChunk.map(identity(_)),
+        nonEmptyChunk.flatMap((i: Int) => Chunk(i)),
+        nonEmptyChunk.map[Int](identity),
         nonEmptyChunk.zipAllWith(Chunk(0))(l => (l, l), r => (r, r))((l, r) => (l, r)),
         nonEmptyChunk.zipWithIndex,
         nonEmptyChunk.zipWithIndexFrom(0)

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -60,7 +60,7 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("apply") {
       check(chunkWithIndex(Gen.unit)) {
         case (chunk, i) =>
-          assert(chunk.apply(i))(equalTo(chunk.toSeq.apply(i)))
+          assert(chunk.apply(i))(equalTo(chunk.toList.apply(i)))
       }
     },
     testM("corresponds") {
@@ -68,7 +68,7 @@ object ChunkSpec extends ZIOBaseSpec {
       val genFunction = Gen.function[Random with Sized, (Int, Int), Boolean](Gen.boolean).map(Function.untupled(_))
       check(genChunk, genChunk, genFunction) { (as, bs, f) =>
         val actual   = as.corresponds(bs)(f)
-        val expected = as.toSeq.corresponds(bs.toSeq)(f)
+        val expected = as.toList.corresponds(bs.toList)(f)
         assert(actual)(equalTo(expected))
       }
     },
@@ -81,18 +81,18 @@ object ChunkSpec extends ZIOBaseSpec {
       }
     },
     testM("length") {
-      check(largeChunks(intGen))(chunk => assert(chunk.length)(equalTo(chunk.toSeq.length)))
+      check(largeChunks(intGen))(chunk => assert(chunk.length)(equalTo(chunk.toList.length)))
     },
     testM("equality") {
       check(mediumChunks(intGen), mediumChunks(intGen)) { (c1, c2) =>
-        assert(c1.equals(c2))(equalTo(c1.toSeq.equals(c2.toSeq)))
+        assert(c1.equals(c2))(equalTo(c1.toList.equals(c2.toList)))
       }
     },
     zio.test.test("inequality") {
       assert(Chunk(1, 2, 3, 4, 5))(Assertion.not(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
     },
     testM("materialize") {
-      check(mediumChunks(intGen))(c => assert(c.materialize.toSeq)(equalTo(c.toSeq)))
+      check(mediumChunks(intGen))(c => assert(c.materialize.toList)(equalTo(c.toList)))
     },
     testM("foldLeft") {
       check(Gen.alphaNumericString, Gen.function2(Gen.alphaNumericString), smallChunks(Gen.alphaNumericString)) {
@@ -112,7 +112,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     testM("map") {
       val fn = Gen.function[Random with Sized, Int, Int](intGen)
-      check(smallChunks(intGen), fn)((c, f) => assert(c.map(f).toSeq)(equalTo(c.toSeq.map(f))))
+      check(smallChunks(intGen), fn)((c, f) => assert(c.map(f).toList)(equalTo(c.toList.map(f))))
     },
     suite("mapM")(
       testM("mapM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, f) =>
@@ -125,36 +125,36 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("flatMap") {
       val fn = Gen.function[Random with Sized, Int, Chunk[Int]](smallChunks(intGen))
       check(smallChunks(intGen), fn) { (c, f) =>
-        assert(c.flatMap(f).toSeq)(equalTo(c.toSeq.flatMap(f.andThen(_.toSeq))))
+        assert(c.flatMap(f).toList)(equalTo(c.toList.flatMap(f.andThen(_.toList))))
       }
     },
     testM("headOption") {
-      check(mediumChunks(intGen))(c => assert(c.headOption)(equalTo(c.toSeq.headOption)))
+      check(mediumChunks(intGen))(c => assert(c.headOption)(equalTo(c.toList.headOption)))
     },
     testM("lastOption") {
-      check(mediumChunks(intGen))(c => assert(c.lastOption)(equalTo(c.toSeq.lastOption)))
+      check(mediumChunks(intGen))(c => assert(c.lastOption)(equalTo(c.toList.lastOption)))
     },
     testM("indexWhere") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
       check(mediumChunks(intGen), fn, intGen) { (chunk, p, from) =>
-        assert(chunk.indexWhere(p, from).getOrElse(-1))(equalTo(chunk.toSeq.indexWhere(p, from)))
+        assert(chunk.indexWhere(p, from))(equalTo(chunk.toList.indexWhere(p, from)))
       }
     } @@ exceptScala211,
     testM("exists") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
-      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.exists(p))(equalTo(chunk.toSeq.exists(p))))
+      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.exists(p))(equalTo(chunk.toList.exists(p))))
     },
     testM("forall") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
-      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.forall(p))(equalTo(chunk.toSeq.forall(p))))
+      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.forall(p))(equalTo(chunk.toList.forall(p))))
     },
     testM("find") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
-      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.find(p))(equalTo(chunk.toSeq.find(p))))
+      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.find(p))(equalTo(chunk.toList.find(p))))
     },
     testM("filter") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
-      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.filter(p).toSeq)(equalTo(chunk.toSeq.filter(p))))
+      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.filter(p).toList)(equalTo(chunk.toList.filter(p))))
     },
     suite("filterM")(
       testM("filterM happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
@@ -165,26 +165,26 @@ object ChunkSpec extends ZIOBaseSpec {
       } @@ zioTag(errors)
     ),
     testM("drop chunk") {
-      check(largeChunks(intGen), intGen)((chunk, n) => assert(chunk.drop(n).toSeq)(equalTo(chunk.toSeq.drop(n))))
+      check(largeChunks(intGen), intGen)((chunk, n) => assert(chunk.drop(n).toList)(equalTo(chunk.toList.drop(n))))
     },
     testM("take chunk") {
       check(chunkWithIndex(Gen.unit)) {
         case (c, n) =>
-          assert(c.take(n).toSeq)(equalTo(c.toSeq.take(n)))
+          assert(c.take(n).toList)(equalTo(c.toList.take(n)))
       }
     },
     testM("dropWhile chunk") {
       check(mediumChunks(intGen), toBoolFn[Random, Int]) { (c, p) =>
-        assert(c.dropWhile(p).toSeq)(equalTo(c.toSeq.dropWhile(p)))
+        assert(c.dropWhile(p).toList)(equalTo(c.toList.dropWhile(p)))
       }
     },
     testM("takeWhile chunk") {
       check(mediumChunks(intGen), toBoolFn[Random, Int]) { (c, p) =>
-        assert(c.takeWhile(p).toSeq)(equalTo(c.toSeq.takeWhile(p)))
+        assert(c.takeWhile(p).toList)(equalTo(c.toList.takeWhile(p)))
       }
     },
     testM("toArray") {
-      check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toSeq)(equalTo(c.toSeq)))
+      check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toList)(equalTo(c.toList)))
     },
     zio.test.test("non-homogeneous element type") {
       trait Animal
@@ -192,7 +192,7 @@ object ChunkSpec extends ZIOBaseSpec {
       trait Dog extends Animal
 
       val vector   = Vector(new Cat {}, new Dog {}, new Animal {})
-      val actual   = Chunk.fromIterable(vector).map(identity)
+      val actual   = Chunk.fromIterable(vector).map(a => a)
       val expected = Chunk.fromArray(vector.toArray)
 
       assert(actual)(equalTo(expected))
@@ -204,7 +204,7 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
     },
     testM("toArray with elements of type String") {
-      check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toSeq)(equalTo(c.toSeq)))
+      check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toList)(equalTo(c.toList)))
     },
     zio.test.test("toArray for a Chunk of any type") {
       val v: Vector[Any] = Vector("String", 1, Value(2))
@@ -212,11 +212,11 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("collect")(
       zio.test.test("collect empty Chunk") {
-        assert(Chunk.empty.collect { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
+        assert(Chunk.empty.collect[Int] { case _ => 1 })(isEmpty)
       },
       testM("collect chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
-        check(mediumChunks(intGen), pfGen)((c, pf) => assert(c.collect(pf).toSeq)(equalTo(c.toSeq.collect(pf))))
+        check(mediumChunks(intGen), pfGen)((c, pf) => assert(c.collect(pf).toList)(equalTo(c.toList.collect(pf))))
       }
     ),
     suite("collectM")(
@@ -238,12 +238,12 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectWhile")(
       zio.test.test("collectWhile empty Chunk") {
-        assert(Chunk.empty.collectWhile { case _ => 1 } == Chunk.empty)(Assertion.isTrue)
+        assert(Chunk.empty.collectWhile { case _ => 1 })(isEmpty)
       },
       testM("collectWhile chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
         check(mediumChunks(intGen), pfGen) { (c, pf) =>
-          assert(c.collectWhile(pf).toSeq)(equalTo(c.toSeq.takeWhile(pf.isDefinedAt).map(pf.apply)))
+          assert(c.collectWhile(pf).toList)(equalTo(c.toList.takeWhile(pf.isDefinedAt).map(pf.apply)))
         }
       }
     ),
@@ -269,12 +269,12 @@ object ChunkSpec extends ZIOBaseSpec {
         var sum = 0
         c.foreach(sum += _)
 
-        assert(sum)(equalTo(c.toSeq.sum))
+        assert(sum)(equalTo(c.toList.sum))
       }
     },
     testM("concat chunk") {
       check(smallChunks(intGen), smallChunks(intGen)) { (c1, c2) =>
-        assert((c1 ++ c2).toSeq)(equalTo(c1.toSeq ++ c2.toSeq))
+        assert((c1 ++ c2).toList)(equalTo(c1.toList ++ c2.toList))
       }
     },
     zio.test.test("chunk transitivity") {
@@ -343,9 +343,9 @@ object ChunkSpec extends ZIOBaseSpec {
         val f: Int => NonEmptyChunk[Int] = f_.andThen(_ + 0)
 
         val in: NonEmptyChunk[Int] = c.flatMap(f)
-        val expected: Seq[Int]     = c.toSeq.flatMap(f.andThen(_.toSeq))
+        val expected: Seq[Int]     = c.toList.flatMap(f.andThen(_.toList))
 
-        assert(in.toSeq)(equalTo(expected))
+        assert(in.toList)(equalTo(expected))
       }
     },
     zio.test.test("nonEmptyChunk subtype preservation") {
@@ -366,9 +366,9 @@ object ChunkSpec extends ZIOBaseSpec {
         Chunk.single(x),
         Chunk.succeed(x),
         nonEmptyChunk ++ chunk,
-        chunk ++ nonEmptyChunk,
+        // chunk ++ nonEmptyChunk,
         nonEmptyChunk.flatMap(i => Chunk(i)),
-        nonEmptyChunk.map(identity),
+        nonEmptyChunk.map(identity(_)),
         nonEmptyChunk.zipAllWith(Chunk(0))(l => (l, l), r => (r, r))((l, r) => (l, r)),
         nonEmptyChunk.zipWithIndex,
         nonEmptyChunk.zipWithIndexFrom(0)
@@ -382,17 +382,17 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assertCompletes
       //checks at compile time
-    } @@ TestAspect.ignore,
-    zio.test.test("++ should work with subtyping") {
-
-      trait A
-      trait B extends A
-
-      val empty: Chunk[B] = Chunk.empty
-
-      val _: NonEmptyChunk[A] = empty ++ Chunk(new A {})
-
-      assertCompletes
     } @@ TestAspect.ignore
+    // zio.test.test("++ should work with subtyping") {
+
+    //   trait A
+    //   trait B extends A
+
+    //   val empty: Chunk[B] = Chunk.empty
+
+    //   val _: NonEmptyChunk[A] = empty ++ Chunk(new A {})
+
+    //   assertCompletes
+    // } @@ TestAspect.ignore
   )
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -382,17 +382,17 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assertCompletes
       //checks at compile time
+    } @@ TestAspect.ignore,
+    zio.test.test("++ should work with subtyping") {
+
+      trait A
+      trait B extends A
+
+      val empty: Chunk[B] = Chunk.empty
+
+      val _: NonEmptyChunk[A] = empty concatNonEmpty Chunk(new A {})
+
+      assertCompletes
     } @@ TestAspect.ignore
-    // zio.test.test("++ should work with subtyping") {
-
-    //   trait A
-    //   trait B extends A
-
-    //   val empty: Chunk[B] = Chunk.empty
-
-    //   val _: NonEmptyChunk[A] = empty ++ Chunk(new A {})
-
-    //   assertCompletes
-    // } @@ TestAspect.ignore
   )
 }

--- a/core/shared/src/main/scala-2.11-2.12/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.11-2.12/ChunkBuilder.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.collection.mutable.{ ArrayBuilder, Builder }
+
+/**
+ * A `ChunkBuilder[A]` can build a `Chunk[A]` given elements of type `A`.
+ * `ChunkBuilder` is a mutable data structure that is implemented purely for
+ * compatibility with Scala's collection library and should not be used for
+ * other purposes.
+ *
+ * Its implementation wraps an `ArrayBuilder`, delegating all operations to
+ * it. Because we need a `ClassTag` to construct an `Array` but cannot require
+ * one, the implementation defers the creation of the underlying
+ * `ArrayBuilder` until the first element is added, using the `ClassTag` of
+ * that element as the `ClassTag` of the `ArrayBuilder`. This is similar to
+ * the approach in `Chunk`.
+ */
+private[zio] trait ChunkBuilder[A] extends Builder[A, Chunk[A]]
+
+private[zio] object ChunkBuilder {
+
+  /**
+   * Constructs a new `ChunkBuilder`.
+   */
+  def make[A](): ChunkBuilder[A] =
+    new ChunkBuilder[A] {
+      var arrayBuilder: ArrayBuilder[A] = null
+      def +=(a: A): this.type = {
+        if (arrayBuilder eq null) {
+          implicit val tag = Chunk.Tags.fromValue(a)
+          arrayBuilder = ArrayBuilder.make()
+        }
+        arrayBuilder += a
+        this
+      }
+      def clear(): Unit =
+        if (arrayBuilder ne null) {
+          arrayBuilder.clear()
+        }
+      def result(): Chunk[A] =
+        if (arrayBuilder eq null) {
+          Chunk.empty
+        } else {
+          Chunk.fromArray(arrayBuilder.result)
+        }
+    }
+}

--- a/core/shared/src/main/scala-2.11-2.12/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.11-2.12/ChunkBuilder.scala
@@ -41,10 +41,14 @@ private[zio] object ChunkBuilder {
   def make[A](): ChunkBuilder[A] =
     new ChunkBuilder[A] {
       var arrayBuilder: ArrayBuilder[A] = null
+      var size: Int                     = -1
       def +=(a: A): this.type = {
         if (arrayBuilder eq null) {
           implicit val tag = Chunk.Tags.fromValue(a)
           arrayBuilder = ArrayBuilder.make()
+          if (size != -1) {
+            arrayBuilder.sizeHint(size)
+          }
         }
         arrayBuilder += a
         this
@@ -58,6 +62,12 @@ private[zio] object ChunkBuilder {
           Chunk.empty
         } else {
           Chunk.fromArray(arrayBuilder.result)
+        }
+      override def sizeHint(n: Int): Unit =
+        if (arrayBuilder eq null) {
+          size = n
+        } else {
+          arrayBuilder.sizeHint(n)
         }
     }
 }

--- a/core/shared/src/main/scala-2.11-2.12/ChunkCanBuildFrom.scala
+++ b/core/shared/src/main/scala-2.11-2.12/ChunkCanBuildFrom.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+
+/**
+ * `ChunkCanBuildFrom` provides implicit evidence that a collection of type
+ * `Chunk[A]` can be built from elements of type `A`. Since a `Chunk[A]` can
+ * be built from elements of type `A` for any type `A`, this implicit
+ * evidence always exists. It is used primarily to provide proof that the
+ * target type of a collection operation is a `Chunk` to support high
+ * performance implementations of transformation operations for chunks.
+ */
+sealed trait ChunkCanBuildFrom[A] extends CanBuildFrom[Chunk[Any], A, Chunk[A]] {
+  override def apply(from: Chunk[Any]): Builder[A, Chunk[A]] = ChunkBuilder.make()
+  override def apply(): Builder[A, Chunk[A]]                 = ChunkBuilder.make()
+}
+
+object ChunkCanBuildFrom {
+
+  /**
+   * Construct a new instance of `ChunkCanBuildFrom` for the specified type.
+   */
+  implicit def apply[A]: ChunkCanBuildFrom[A] =
+    new ChunkCanBuildFrom[A] {}
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Boolean`.
+   */
+  implicit val chunkCanBuildFromBoolean: ChunkCanBuildFrom[Boolean] =
+    ChunkCanBuildFrom[Boolean]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Byte`.
+   */
+  implicit val chunkCanBuildFromByte: ChunkCanBuildFrom[Byte] =
+    ChunkCanBuildFrom[Byte]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Char`.
+   */
+  implicit val chunkCanBuildFromChar: ChunkCanBuildFrom[Char] =
+    ChunkCanBuildFrom[Char]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Double`.
+   */
+  implicit val chunkCanBuildFromDouble: ChunkCanBuildFrom[Double] =
+    ChunkCanBuildFrom[Double]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Float`.
+   */
+  implicit val chunkCanBuildFromFloat: ChunkCanBuildFrom[Float] =
+    ChunkCanBuildFrom[Float]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Int`.
+   */
+  implicit val chunkCanBuildFromInt: ChunkCanBuildFrom[Int] =
+    ChunkCanBuildFrom[Int]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Long`.
+   */
+  implicit val chunkCanBuildFromLong: ChunkCanBuildFrom[Long] =
+    ChunkCanBuildFrom[Long]
+
+  /**
+   * The instance of `ChunkCanBuildFrom` for `Short`.
+   */
+  implicit val chunkCanBuildFromShort: ChunkCanBuildFrom[Short] =
+    ChunkCanBuildFrom[Short]
+}

--- a/core/shared/src/main/scala-2.11-2.12/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.11-2.12/ChunkLike.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.collection.IndexedSeqLike
+import scala.collection.generic.CanBuildFrom
+import scala.collection.immutable.IndexedSeq
+
+/**
+ * `ChunkLike` represents the capability for a `Chunk` to extend Scala's
+ * collection library. Because of changes to Scala's collection library in
+ * 2.13, separate versions of this trait are implemented for 2.11 / 2.12 and
+ * 2.13 / Dotty. This allows code in `Chunk` to be written without concern for
+ * the implementation details of Scala's collection library to the maximum
+ * extent possible.
+ *
+ * Note that `IndexedSeq` is not a referentially transparent interface in that
+ * it exposes methods that are partial (e.g. `apply`), allocate mutable state
+ * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `Chunk`
+ * extends `IndexedSeq` to provide interoperability with Scala's collection
+ * library but users should avoid these methods whenever possible.
+ */
+private[zio] trait ChunkLike[+A] extends IndexedSeq[A] with IndexedSeqLike[A, Chunk[A]] { self: Chunk[A] =>
+
+  /**
+   * Returns a filtered, mapped subset of the elements of this chunk.
+   */
+  def collect[B](pf: PartialFunction[A, B]): Chunk[B] =
+    self.materialize.collect(pf)
+
+  /**
+   * Returns the first index for which the given predicate is satisfied.
+   */
+  override def indexWhere(f: A => Boolean): Int =
+    indexWhere(f, 0)
+
+  /**
+   * Generates a readable string representation of this chunk using the
+   * specified start, separator, and end strings.
+   */
+  override final def mkString(start: String, sep: String, end: String): String = {
+    val builder = new scala.collection.mutable.StringBuilder()
+
+    builder.append(start)
+
+    var i   = 0
+    val len = self.length
+
+    while (i < len) {
+      if (i != 0) builder.append(sep)
+      builder.append(self(i).toString)
+      i += 1
+    }
+
+    builder.append(end)
+
+    builder.toString
+  }
+
+  /**
+   * Generates a readable string representation of this chunk using the
+   * specified separator string.
+   */
+  override final def mkString(sep: String): String =
+    mkString("", sep, "")
+
+  /**
+   * Generates a readable string representation of this chunk.
+   */
+  override final def mkString: String =
+    mkString("")
+
+  /**
+   * Determines if the chunk is not empty.
+   */
+  override final def nonEmpty: Boolean =
+    length > 0
+
+  /**
+   * The number of elements in the chunk.
+   */
+  override final def size: Int =
+    length
+
+  override final def toSeq: Chunk[A] =
+    self
+
+  /**
+   * Constructs a new `ChunkBuilder`. This operation allocates mutable state
+   * and is not referentially transparent. It is provided for compatibility
+   * with Scala's collection library and should not be used for other purposes.
+   */
+  override protected[this] def newBuilder: ChunkBuilder[A] =
+    ChunkLike.newBuilder
+}
+
+private object ChunkLike {
+
+  /**
+   * Constructs a new `ChunkBuilder`.
+   */
+  def newBuilder[A]: ChunkBuilder[A] =
+    ChunkBuilder.make()
+
+  /**
+   * Provides implicit evidence that that a collection of type `Chunk[A]` can
+   * be build from elements of type `A`.
+   */
+  implicit def canBuildFrom[A]: CanBuildFrom[Chunk[A], A, Chunk[A]] =
+    new CanBuildFrom[Chunk[A], A, Chunk[A]] {
+      def apply(chunk: Chunk[A]): ChunkBuilder[A] =
+        ChunkBuilder.make()
+      def apply(): ChunkBuilder[A] =
+        ChunkBuilder.make()
+    }
+}

--- a/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
@@ -41,10 +41,14 @@ private[zio] object ChunkBuilder {
   def make[A]: ChunkBuilder[A] =
     new ChunkBuilder[A] {
       var arrayBuilder: ArrayBuilder[A] = null
+      var size: Int                     = -1
       def addOne(a: A): this.type = {
         if (arrayBuilder eq null) {
           implicit val tag = Chunk.Tags.fromValue(a)
           arrayBuilder = ArrayBuilder.make
+          if (size != -1) {
+            arrayBuilder.sizeHint(size)
+          }
         }
         arrayBuilder.addOne(a)
         this
@@ -58,6 +62,12 @@ private[zio] object ChunkBuilder {
           Chunk.empty
         } else {
           Chunk.fromArray(arrayBuilder.result)
+        }
+      override def sizeHint(n: Int): Unit =
+        if (arrayBuilder eq null) {
+          size = n
+        } else {
+          arrayBuilder.sizeHint(n)
         }
     }
 }

--- a/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.collection.mutable.{ ArrayBuilder, Builder }
+
+/**
+ * A `ChunkBuilder[A]` can build a `Chunk[A]` given elements of type `A`.
+ * `ChunkBuilder` is a mutable data structure that is implemented purely for
+ * compatibility with Scala's collection library and should not be used for
+ * other purposes.
+ *
+ * Its implementation wraps an `ArrayBuilder`, delegating all operations to
+ * it. Because we need a `ClassTag` to construct an `Array` but cannot require
+ * one, the implementation defers the creation of the underlying
+ * `ArrayBuilder` until the first element is added, using the `ClassTag` of
+ * that element as the `ClassTag` of the `ArrayBuilder`. This is similar to
+ * the approach in `Chunk`.
+ */
+private[zio] trait ChunkBuilder[A] extends Builder[A, Chunk[A]]
+
+private[zio] object ChunkBuilder {
+
+  /**
+   * Constructs a new `ChunkBuilder`.
+   */
+  def make[A](): ChunkBuilder[A] =
+    new ChunkBuilder[A] {
+      var arrayBuilder: ArrayBuilder[A] = null
+      def addOne(a: A): this.type = {
+        if (arrayBuilder eq null) {
+          implicit val tag = Chunk.Tags.fromValue(a)
+          arrayBuilder = ArrayBuilder.make
+        }
+        arrayBuilder.addOne(a)
+        this
+      }
+      def clear(): Unit =
+        if (arrayBuilder ne null) {
+          arrayBuilder.clear()
+        }
+      def result(): Chunk[A] =
+        if (arrayBuilder eq null) {
+          Chunk.empty
+        } else {
+          Chunk.fromArray(arrayBuilder.result)
+        }
+    }
+}

--- a/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/ChunkBuilder.scala
@@ -38,7 +38,7 @@ private[zio] object ChunkBuilder {
   /**
    * Constructs a new `ChunkBuilder`.
    */
-  def make[A](): ChunkBuilder[A] =
+  def make[A]: ChunkBuilder[A] =
     new ChunkBuilder[A] {
       var arrayBuilder: ArrayBuilder[A] = null
       def addOne(a: A): this.type = {

--- a/core/shared/src/main/scala-2.13+/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/ChunkLike.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.collection.IterableFactoryDefaults
+import scala.collection.SeqFactory
+import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps }
+
+/**
+ * `ChunkLike` represents the capability for a `Chunk` to extend Scala's
+ * collection library. Because of changes to Scala's collection library in
+ * 2.13, separate versions of this trait are implemented for 2.11 / 2.12 and
+ * 2.13 / Dotty. This allows code in `Chunk` to be written without concern for
+ * the implementation details of Scala's collection library to the maximum
+ * extent possible.
+ *
+ * Note that `IndexedSeq` is not a referentially transparent interface in that
+ * it exposes methods that are partial (e.g. `apply`), allocate mutable state
+ * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `Chunk`
+ * extends `IndexedSeq` to provide interoperability with Scala's collection
+ * library but users should avoid these methods whenever possible.
+ */
+trait ChunkLike[+A]
+    extends IndexedSeq[A]
+    with IndexedSeqOps[A, Chunk, Chunk[A]]
+    with StrictOptimizedSeqOps[A, Chunk, Chunk[A]]
+    with IterableFactoryDefaults[A, Chunk] { self: Chunk[A] =>
+
+  /**
+   * Returns a filtered, mapped subset of the elements of this `Chunk`.
+   */
+  override def collect[B](pf: PartialFunction[A, B]): Chunk[B] =
+    self.materialize.collect(pf)
+
+  /**
+   * Returns a `SeqFactory` that can construct `Chunk` values. The
+   * `SeqFactory` exposes a `newBuilder` method that is not referentially
+   * transparent beacuse it allocates mutable state.
+   */
+  override val iterableFactory: SeqFactory[Chunk] =
+    ChunkLike
+}
+
+object ChunkLike extends SeqFactory[Chunk] {
+
+  /**
+   * Returns the empty `Chunk`.
+   */
+  def empty[A]: Chunk[A] =
+    Chunk.empty
+
+  /**
+   * Constructs a `Chunk` from the specified `IterableOnce`.
+   */
+  def from[A](source: IterableOnce[A]): Chunk[A] =
+    Chunk.fromIterable(source.iterator.to(Iterable))
+
+  /**
+   * Constructs a new `ChunkBuilder`. This operation allocates mutable state
+   * and is not referentially transparent. It is provided for compatibility
+   * with Scala's collection library and should not be used for other purposes.
+   */
+  def newBuilder[A]: ChunkBuilder[A] =
+    ChunkBuilder.make
+}

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -704,18 +704,15 @@ object Chunk {
    * Returns a chunk backed by an iterable.
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
-    if (it.size <= 0) Empty
-    else if (it.size == 1) Singleton(it.head)
-    else {
-      it match {
-        case l: Vector[A] => VectorChunk(l)
-        case _ =>
-          val first = it.head
-
-          implicit val A: ClassTag[A] = Tags.fromValue(first)
-
-          fromArray(it.toArray)
-      }
+    it match {
+      case chunk: Chunk[A]                => chunk
+      case iterable if iterable.size == 0 => Empty
+      case iterable if iterable.size == 1 => Singleton(iterable.head)
+      case vector: Vector[A]              => VectorChunk(vector)
+      case iterable =>
+        val first                   = iterable.head
+        implicit val A: ClassTag[A] = Tags.fromValue(first)
+        fromArray(it.toArray)
     }
 
   def fill[A](n: Int)(elem: => A): Chunk[A] =

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -706,7 +706,7 @@ object Chunk {
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
       case chunk: Chunk[A]                => chunk
-      case iterable if iterable.size == 0 => Empty
+      case iterable if iterable.isEmpty   => Empty
       case iterable if iterable.size == 1 => Singleton(iterable.head)
       case vector: Vector[A]              => VectorChunk(vector)
       case iterable =>

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -47,6 +47,12 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
       case ne: NonEmptyChunk[A] => Chunk.concat(ne, Chunk.single(a))
     }
 
+    /**
+     * Returns the concatenation of this chunk with the specified chunk.
+     */
+    def ++[A1 >: A](chunk: Chunk[A1]): Chunk[A1] =
+      Chunk.concat(self, chunk)
+
   /**
    * Returns a filtered, mapped subset of the elements of this chunk based on a .
    */
@@ -552,19 +558,6 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
 }
 
 object Chunk {
-
-  implicit class ChunkOps[+A](private val self: Chunk[A]) extends AnyVal {
-
-    /**
-     * Returns the concatenation of this chunk with the specified chunk.
-     */
-    def ++[A1 >: A](chunk: Chunk[A1]): Chunk[A1] = concat(self, chunk)
-
-    /**
-     * Returns the concatenation of this chunk with the specified chunk.
-     */
-    def ++[A1 >: A](nonEmptyChunk: NonEmptyChunk[A1]): NonEmptyChunk[A1] = concat(self, nonEmptyChunk)
-  }
 
   /**
    * Returns the empty chunk.
@@ -1237,7 +1230,8 @@ object Chunk {
     /**
      * Returns the concatenation of this chunk with the specified chunk.
      */
-    final def ++[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] = Chunk.concat(self, that)
+    override final def ++[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
+      Chunk.concat(self, that)
 
     /**
      * Materializes a chunk into a chunk backed by an array. This method can

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -47,11 +47,11 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
       case ne: NonEmptyChunk[A] => Chunk.concat(ne, Chunk.single(a))
     }
 
-    /**
-     * Returns the concatenation of this chunk with the specified chunk.
-     */
-    def ++[A1 >: A](chunk: Chunk[A1]): Chunk[A1] =
-      Chunk.concat(self, chunk)
+  /**
+   * Returns the concatenation of this chunk with the specified chunk.
+   */
+  def ++[A1 >: A](chunk: Chunk[A1]): Chunk[A1] =
+    Chunk.concat(self, chunk)
 
   /**
    * Returns a filtered, mapped subset of the elements of this chunk based on a .

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -705,10 +705,9 @@ object Chunk {
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
-      case chunk: Chunk[A]                => chunk
-      case iterable if iterable.isEmpty   => Empty
-      case iterable if iterable.size == 1 => Singleton(iterable.head)
-      case vector: Vector[A]              => VectorChunk(vector)
+      case chunk: Chunk[A]              => chunk
+      case iterable if iterable.isEmpty => Empty
+      case vector: Vector[A]            => VectorChunk(vector)
       case iterable =>
         val first                   = iterable.head
         implicit val A: ClassTag[A] = Tags.fromValue(first)

--- a/docs/datatypes/chunk.md
+++ b/docs/datatypes/chunk.md
@@ -30,12 +30,12 @@ How to use `collect` function to cherry-pick all strings from Chunk[A]:
 ```scala mdoc
 val collectChunk = Chunk("Hello ZIO", 1.5, "Hello ZIO NIO", 2.0, "Some string", 2.5)
 
-collectChunk.collect { case string: String => string }
+collectChunk.collect[String] { case string: String => string }
 ```
 How to use `collect` function to cherry-pick all the digits from Chunk[A]:
 
 ```scala mdoc
-collectChunk.collect { case digit: Double => digit }
+collectChunk.collect[Double] { case digit: Double => digit }
 ```
 
 `collectWhile` collects the elements (from left to right) until the predicate returns "false" for the first time:

--- a/docs/datatypes/chunk.md
+++ b/docs/datatypes/chunk.md
@@ -30,12 +30,12 @@ How to use `collect` function to cherry-pick all strings from Chunk[A]:
 ```scala mdoc
 val collectChunk = Chunk("Hello ZIO", 1.5, "Hello ZIO NIO", 2.0, "Some string", 2.5)
 
-collectChunk.collect[String] { case string: String => string }
+collectChunk.collect { case string: String => string }
 ```
 How to use `collect` function to cherry-pick all the digits from Chunk[A]:
 
 ```scala mdoc
-collectChunk.collect[Double] { case digit: Double => digit }
+collectChunk.collect { case digit: Double => digit }
 ```
 
 `collectWhile` collects the elements (from left to right) until the predicate returns "false" for the first time:

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -241,16 +241,28 @@ object BuildHelper {
             Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.11")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.11")),
-            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.x"))
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.x")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.11-2.12"))
           ).flatten
-        case Some((2, x)) if x >= 12 =>
+        case Some((2, x)) if x == 12 =>
           Seq(
             Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12")),
             Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12+")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.12+")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.x")),
-            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12-2.13"))
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12-2.13")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.11-2.12"))
+          ).flatten
+        case Some((2, x)) if x >= 13 =>
+          Seq(
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12")),
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12+")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.12+")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.x")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12-2.13")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.13+"))
           ).flatten
         case _ =>
           if (isDotty.value)
@@ -259,7 +271,8 @@ object BuildHelper {
               Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12+")),
               CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")),
               CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.12+")),
-              CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-dotty"))
+              CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-dotty")),
+              CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.13+"))
             ).flatten
           else
             Nil

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1575,7 +1575,7 @@ object SinkSpec extends ZIOBaseSpec {
                          init,
                          Chunk(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte, 0xF0.toByte, 0x90.toByte)
                        )
-            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap(identity).toArray[Byte])
+            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap(identity(_)).toArray[Byte])
           } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isFalse) && assert(result)(
             equalTo(Array(0xF0.toByte, 0x90.toByte))
           )

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1575,7 +1575,7 @@ object SinkSpec extends ZIOBaseSpec {
                          init,
                          Chunk(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte, 0xF0.toByte, 0x90.toByte)
                        )
-            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap[Byte](identity).toArray[Byte])
+            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatten.toArray[Byte])
           } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isFalse) && assert(result)(
             equalTo(Array(0xF0.toByte, 0x90.toByte))
           )

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkSpec.scala
@@ -1575,7 +1575,7 @@ object SinkSpec extends ZIOBaseSpec {
                          init,
                          Chunk(0xF0.toByte, 0x90.toByte, 0x8D.toByte, 0x88.toByte, 0xF0.toByte, 0x90.toByte)
                        )
-            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap(identity(_)).toArray[Byte])
+            result <- ZSink.utf8DecodeChunk.extract(state1).map(_._2.flatMap[Byte](identity).toArray[Byte])
           } yield assert(ZSink.utf8DecodeChunk.cont(state1))(isFalse) && assert(result)(
             equalTo(Array(0xF0.toByte, 0x90.toByte))
           )

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkSpec.scala
@@ -100,7 +100,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
         for {
           res1 <- slurp(s.mapConcat(f))
-          res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
+          res2 <- slurp(s).map(_.flatMap(v => f(v)))
         } yield assert(res1)(equalTo(res2))
       }
     },
@@ -109,7 +109,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
       checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
         for {
           res1 <- slurp(s.mapConcatChunk(f))
-          res2 <- slurp(s).map(_.flatMap(v => f(v).toSeq))
+          res2 <- slurp(s).map(_.flatMap(v => f(v)))
         } yield assert(res1)(equalTo(res2))
       }
     },
@@ -119,7 +119,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
             res1 <- slurp(s.mapConcatChunkM(s => UIO.succeed(f(s))))
-            res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
+            res2 <- slurp(s).map(_.flatMap(s => f(s)))
           } yield assert(res1)(equalTo(res2))
         }
       },
@@ -138,7 +138,7 @@ object StreamChunkSpec extends ZIOBaseSpec {
         checkM(pureStreamChunkGen(tinyChunks(intGen)), fn) { (s, f) =>
           for {
             res1 <- slurp(s.mapConcatM(s => UIO.succeed(f(s))))
-            res2 <- slurp(s).map(_.flatMap(s => f(s).toSeq))
+            res2 <- slurp(s).map(_.flatMap(s => f(s)))
           } yield assert(res1)(equalTo(res2))
         }
       },
@@ -439,13 +439,13 @@ object StreamChunkSpec extends ZIOBaseSpec {
     },
     testM("StreamChunk.ChunkN") {
       val s1 = StreamChunk(Stream(Chunk(1, 2, 3, 4, 5), Chunk(6, 7), Chunk(8, 9, 10, 11)))
-      assertM(s1.chunkN(2).chunks.map(_.toSeq).runCollect)(
+      assertM(s1.chunkN(2).chunks.map(_.toList).runCollect)(
         equalTo(List(List(1, 2), List(3, 4), List(5, 6), List(7, 8), List(9, 10), List(11)))
       )
     },
     testM("StreamChunk.ChunkN Non-Empty") {
       val s1 = StreamChunk(Stream(Chunk(1), Chunk(2), Chunk(3)))
-      assertM(s1.chunkN(1).chunks.map(_.toSeq).runCollect)(equalTo(List(List(1), List(2), List(3))))
+      assertM(s1.chunkN(1).chunks.map(_.toList).runCollect)(equalTo(List(List(1), List(2), List(3))))
     }
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamChunkUtils.scala
@@ -27,7 +27,6 @@ object StreamChunkUtils extends StreamChunkUtils {
   def slurp[E, A](s: StreamChunk[E, A]): IO[E, Seq[A]] =
     s.chunks
       .fold(Chunk.empty: Chunk[A])(_ ++ _)
-      .map(_.toSeq)
 
   def foldLazyList[S, T](list: List[T], zero: S)(cont: S => Boolean)(f: (S, T) => S): S = {
     @tailrec

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1008,7 +1008,7 @@ object StreamSpec extends ZIOBaseSpec {
       } yield assert(sum)(equalTo(10))
     },
     testM("Stream.fromChunk")(checkM(smallChunks(Gen.anyInt)) { c =>
-      assertM(Stream.fromChunk(c).runCollect)(equalTo(c.toSeq.toList))
+      assertM(Stream.fromChunk(c).runCollect)(equalTo(c.toList))
     }),
     testM("Stream.fromInputStream") {
       import java.io.ByteArrayInputStream
@@ -1037,7 +1037,7 @@ object StreamSpec extends ZIOBaseSpec {
     testM("Stream.fromQueue")(checkM(smallChunks(Gen.anyInt)) { c =>
       for {
         queue <- Queue.unbounded[Int]
-        _     <- queue.offerAll(c.toSeq)
+        _     <- queue.offerAll(c)
         fiber <- Stream
                   .fromQueue(queue)
                   .foldWhileM(List[Int]())(_ => true)((acc, el) => IO.succeed(el :: acc))
@@ -1046,7 +1046,7 @@ object StreamSpec extends ZIOBaseSpec {
         _     <- waitForSize(queue, -1)
         _     <- queue.shutdown
         items <- fiber.join
-      } yield assert(items)(equalTo(c.toSeq.toList))
+      } yield assert(items)(equalTo(c.toList))
     }),
     testM("Stream.fromSchedule") {
       val schedule = Schedule.exponential(1.second) <* Schedule.recurs(5)
@@ -1266,13 +1266,13 @@ object StreamSpec extends ZIOBaseSpec {
     testM("Stream.mapConcat")(checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
       for {
         res1 <- s.mapConcat(f).runCollect
-        res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        res2 <- s.runCollect.map(_.flatMap(v => f(v)))
       } yield assert(res1)(equalTo(res2))
     }),
     testM("Stream.mapConcatChunk")(checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
       for {
         res1 <- s.mapConcatChunk(f).runCollect
-        res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        res2 <- s.runCollect.map(_.flatMap(v => f(v)))
       } yield assert(res1)(equalTo(res2))
     }),
     suite("Stream.mapConcatChunkM")(
@@ -1280,7 +1280,7 @@ object StreamSpec extends ZIOBaseSpec {
         checkM(pureStreamOfBytes, Gen.function(smallChunks(Gen.anyInt))) { (s, f) =>
           for {
             res1 <- s.mapConcatChunkM(b => UIO.succeed(f(b))).runCollect
-            res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+            res2 <- s.runCollect.map(_.flatMap(v => f(v)))
           } yield assert(res1)(equalTo(res2))
         }
       },
@@ -1297,7 +1297,7 @@ object StreamSpec extends ZIOBaseSpec {
         checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
           for {
             res1 <- s.mapConcatM(b => UIO.succeed(f(b))).runCollect
-            res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+            res2 <- s.runCollect.map(_.flatMap(v => f(v).toList))
           } yield assert(res1)(equalTo(res2))
         }
       },
@@ -1778,13 +1778,13 @@ object StreamSpec extends ZIOBaseSpec {
       val s = Stream.fromChunk(c)
       assertM(s.toQueue(1000).use { (queue: Queue[Take[Nothing, Int]]) =>
         waitForSize(queue, c.length + 1) *> queue.takeAll
-      })(equalTo(c.toSeq.toList.map(i => Take.Value(i)) :+ Take.End))
+      })(equalTo(c.toList.map(i => Take.Value(i)) :+ Take.End))
     }),
     testM("Stream.toQueueUnbounded")(checkM(smallChunks(Gen.anyInt)) { (c: Chunk[Int]) =>
       val s = Stream.fromChunk(c)
       assertM(s.toQueueUnbounded.use { (queue: Queue[Take[Nothing, Int]]) =>
         waitForSize(queue, c.length + 1) *> queue.takeAll
-      })(equalTo(c.toSeq.toList.map(i => Take.Value(i)) :+ Take.End))
+      })(equalTo(c.toList.map(i => Take.Value(i)) :+ Take.End))
     }),
     suite("Stream.aggregate")(
       testM("aggregate") {

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -277,7 +277,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    */
   final def flatMap[R1 <: R, E1 >: E, B](f0: A => ZStreamChunk[R1, E1, B]): ZStreamChunk[R1, E1, B] =
     ZStreamChunk(
-      chunks.flatMap(_.map(f0).fold[ZStream[R1, E1, Chunk[B]]](ZStream.empty)((acc, el) => acc ++ el.chunks))
+      chunks.flatMap(_.map(f0).foldLeft[ZStream[R1, E1, Chunk[B]]](ZStream.empty)((acc, el) => acc ++ el.chunks))
     )
 
   /**
@@ -502,10 +502,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Equivalent to `run(Sink.collectAll[A])`.
    */
   final def runCollect: ZIO[R, E, List[A]] =
-    for {
-      chunks <- chunks.runCollect
-      list   <- ZIO.succeedNow(chunks.flatMap(_.toSeq))
-    } yield list
+    chunks.runCollect.map(_.flatten)
 
   /**
    * Takes the specified number of elements from this stream.

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -55,7 +55,7 @@ object CheckSpec extends ZIOBaseSpec {
       } yield (chunk, i)
       check(chunkWithLength) {
         case (chunk, i) =>
-          assert(chunk.apply(i))(equalTo(chunk.toSeq.apply(i)))
+          assert(chunk.apply(i))(equalTo(chunk.toList.apply(i)))
       }
     },
     testM("tests with filtered generators terminate") {

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -328,7 +328,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A sized generator of non-empty chunks.
    */
   def chunkOf1[R <: Random with Sized, A](g: Gen[R, A]): Gen[R, NonEmptyChunk[A]] =
-    listOf1(g).map { case h :: t => Chunk(h) ++ Chunk.fromIterable(t) }
+    listOf1(g).map { case h :: t => Chunk(h, t: _*) }
 
   /**
    * A generator of chunks whose size falls within the specified bounds.


### PR DESCRIPTION
Makes Chunk extend `IndexedSeq` from the Scala standard library. This will improve interoperability with other code and pave the way for us to unify the `Iterable` and `Chunk` versions of a variety of combinators.

Because of changes to Scala's collection library in 2.13, this is implemented in terms of a new version specific trait `ChunkLike` that `Chunk` extends. `ChunkLike` extends the appropriate traits for each versions and implements the corresponding builder interface so that code in `Chunk` can continue to be written on a cross-version basis.

Potential issues:

- I think we are going to have to give up on `empty ++ nonempty`  returning a nonempty chunk because we now have another `++` variant on `IndexedSeq`. We could address by picking another operator for combining two chunks that doesn't clash to get back the current behavior.
- A few methods had to be move to `ChunkLike` due to version specific differences. In some cases Scala 2.13 provides a signature that matches ours because it doesn't include `CanBuildFrom` but Scala 2.12 doesn't. So we need to `override` in one case but not the other. In other cases methods are defined as `final` in `IndexedSeq` in Scala 2.13 (e.g. `size` is defined in terms of `length`) so we can't override them.
- `ChunkBuiler` implementation could be optimized further. It is already backed by an `ArrayBuilder` that has specialized implementations for primitives but we could override the `++=` method for increased efficiency.
- `Chunk#fold` has to be renamed `Chunk#foldLeft`. I think this is fine and it probably should have been this way all along but it is a breaking change.