### PR TITLE
Improve TMap's performance

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -1,6 +1,5 @@
 package zio.stm
 
-import java.lang.{ Runtime => JRuntime }
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
@@ -16,23 +15,22 @@ import zio._
 class TMapContentionBenchmarks {
   import IOBenchmarks.unsafeRun
 
-  @Param(Array("0", "10", "100", "1000", "10000", "100000"))
-  var size: Int = _
+  @Param(Array("100", "1000", "10000"))
+  var repeatedUpdates: Int = _
 
   private var mapUpdates: UIO[Unit] = _
   private var refUpdates: UIO[Unit] = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
-    val data     = (1 to size).toList.zipWithIndex
-    val map      = unsafeRun(TMap.fromIterable(data).commit)
-    val ref      = ZTRef.unsafeMake(data.toMap)
-    val schedule = Schedule.recurs(1000)
-    val cpus     = JRuntime.getRuntime().availableProcessors()
-    val updates  = List.fill(cpus)(size - 1)
+    val schedule     = Schedule.recurs(repeatedUpdates)
+    val keysToUpdate = (1 to 100).toList
+    val data         = (1 to 1000).toList.zipWithIndex
+    val map          = unsafeRun(TMap.fromIterable(data).commit)
+    val ref          = ZTRef.unsafeMake(data.toMap)
 
-    mapUpdates = UIO.foreachParN_(cpus)(updates)(i => map.put(i, i).commit.repeat(schedule))
-    refUpdates = UIO.foreachParN_(cpus)(updates)(i => ref.update(_.updated(i, i)).commit.repeat(schedule))
+    mapUpdates = UIO.foreachPar_(keysToUpdate)(i => map.put(i, i).commit.repeat(schedule))
+    refUpdates = UIO.foreachPar_(keysToUpdate)(i => ref.update(_.updated(i, i)).commit.repeat(schedule))
   }
 
   @Benchmark

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -63,7 +63,7 @@ final class TMap[K, V] private (
         case head :: tail => op(res, head).flatMap(loopM(_, tail))
       }
 
-    tBuckets.get.flatMap(_.foldM(zero)(loopM))
+    tBuckets.get.flatMap(_.toList).flatMap(data => loopM(zero, data.flatten))
   }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -129,10 +129,10 @@ final class TMap[K, V] private (
 
     for {
       buckets     <- tBuckets.get
-      idx         = TMap.indexOf(k, buckets.array.length)
+      capacity    = buckets.array.length
+      idx         = TMap.indexOf(k, capacity)
       _           <- buckets.updateM(idx, upsert)
       size        <- tSize.get
-      capacity    = buckets.array.length
       needsResize = capacity * TMap.LoadFactor < size
       _           <- STM.when(needsResize)(resize(capacity << 1))
     } yield ()

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -134,7 +134,7 @@ final class TMap[K, V] private (
       size        <- tSize.get
       capacity    = buckets.array.length
       needsResize = capacity * TMap.LoadFactor < size
-      _           <- if (needsResize) resize(capacity << 1) else STM.unit
+      _           <- STM.when(needsResize)(resize(capacity << 1))
     } yield ()
   }
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -51,7 +51,7 @@ final class TMap[K, V] private (
    * Atomically folds using a pure function.
    */
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
-    tBuckets.get.flatMap(_.fold(zero)((acc, bucket) => bucket.foldLeft(acc)(op)))
+    tBuckets.get.flatMap(_.toList).map(_.flatten.foldLeft(zero)(op))
 
   /**
    * Atomically folds using a transactional function.


### PR DESCRIPTION
Follow-up of work in #3340

### Summary

- Removed `tCapacity`.
- Implemented folds in terms of array's `toList`.
- Updated ref directly instead of calling `TArray.update` (`TMap.put`).

### Results

Before changes:

```
Benchmark                     (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.lookup           0  thrpt   15    4436.587 ±   10.183  ops/s
TMapOpsBenchmarks.lookup          10  thrpt   15    4368.201 ±   12.689  ops/s
TMapOpsBenchmarks.lookup         100  thrpt   15    4086.666 ±   15.626  ops/s
TMapOpsBenchmarks.lookup        1000  thrpt   15    4238.726 ±   13.847  ops/s
TMapOpsBenchmarks.lookup       10000  thrpt   15    4023.562 ±   13.877  ops/s
TMapOpsBenchmarks.lookup      100000  thrpt   15    4054.109 ±   11.264  ops/s
TMapOpsBenchmarks.removal          0  thrpt   15    2926.250 ±    8.003  ops/s
TMapOpsBenchmarks.removal         10  thrpt   15    2948.677 ±   14.846  ops/s
TMapOpsBenchmarks.removal        100  thrpt   15    2997.450 ±   11.158  ops/s
TMapOpsBenchmarks.removal       1000  thrpt   15    2931.569 ±   10.569  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15    2735.768 ±    9.069  ops/s
TMapOpsBenchmarks.removal     100000  thrpt   15    2799.613 ±   10.705  ops/s
TMapOpsBenchmarks.transform        0  thrpt   15  147626.711 ± 4480.114  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  117361.859 ± 2586.968  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   15410.151 ±  146.171  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    1851.614 ±    9.558  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      95.270 ±    0.856  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       6.637 ±    0.119  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  145586.842 ± 3118.637  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   98668.752 ± 1333.670  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   11833.112 ±   42.525  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1232.090 ±    5.360  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      74.487 ±    1.760  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       5.181 ±    0.062  ops/s
TMapOpsBenchmarks.update           0  thrpt   15    2297.043 ±   11.710  ops/s
TMapOpsBenchmarks.update          10  thrpt   15    2285.341 ±   11.546  ops/s
TMapOpsBenchmarks.update         100  thrpt   15    2272.868 ±   10.996  ops/s
TMapOpsBenchmarks.update        1000  thrpt   15    2190.605 ±    8.394  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15    2107.176 ±    7.606  ops/s
TMapOpsBenchmarks.update      100000  thrpt   15    2077.663 ±   10.517  ops/s
```

After changes:

```
Benchmark                     (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.lookup           0  thrpt   15    5072.946 ±   19.131  ops/s
TMapOpsBenchmarks.lookup          10  thrpt   15    5172.095 ±   20.090  ops/s
TMapOpsBenchmarks.lookup         100  thrpt   15    4838.867 ±   66.883  ops/s
TMapOpsBenchmarks.lookup        1000  thrpt   15    4963.935 ±    7.921  ops/s
TMapOpsBenchmarks.lookup       10000  thrpt   15    4845.461 ±   19.562  ops/s
TMapOpsBenchmarks.lookup      100000  thrpt   15    4592.221 ±   28.704  ops/s
TMapOpsBenchmarks.removal          0  thrpt   15    3566.088 ±   47.642  ops/s
TMapOpsBenchmarks.removal         10  thrpt   15    3588.899 ±   15.633  ops/s
TMapOpsBenchmarks.removal        100  thrpt   15    3510.764 ±   11.459  ops/s
TMapOpsBenchmarks.removal       1000  thrpt   15    3446.854 ±   13.075  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15    3431.371 ±    8.108  ops/s
TMapOpsBenchmarks.removal     100000  thrpt   15    3169.424 ±    6.962  ops/s
TMapOpsBenchmarks.transform        0  thrpt   15  148985.179 ± 3818.584  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  118974.349 ± 2685.904  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   15679.842 ±   42.883  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    1839.234 ±   22.481  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      96.660 ±    0.992  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       7.093 ±    0.112  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  144693.581 ± 4076.923  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   97583.697 ± 1395.881  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   11675.240 ±   85.219  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1237.373 ±    3.750  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      74.736 ±    1.810  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       5.120 ±    0.080  ops/s
TMapOpsBenchmarks.update           0  thrpt   15    2839.403 ±   16.044  ops/s
TMapOpsBenchmarks.update          10  thrpt   15    2813.640 ±   10.368  ops/s
TMapOpsBenchmarks.update         100  thrpt   15    2775.875 ±   16.918  ops/s
TMapOpsBenchmarks.update        1000  thrpt   15    2664.176 ±    8.966  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15    2618.346 ±   24.823  ops/s
TMapOpsBenchmarks.update      100000  thrpt   15    2507.069 ±    7.912  ops/s
```