### PR TITLE
Bring Chunk to (Z)STM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -925,33 +925,49 @@ object ZSTMSpec extends ZIOBaseSpec {
         v2    <- tvar2.get.commit
       } yield assert(v1)(equalTo(oldV1)) && assert(v2)(equalTo(oldV2))
     },
-    testM(
-      "Using `collectAll` collect a list of transactional effects to a single transaction that produces a list of values"
-    ) {
-      for {
-        it    <- UIO((1 to 100).map(TRef.make(_)))
-        tvars <- STM.collectAll(it).commit
-        res   <- UIO.collectAllPar(tvars.map(_.get.commit))
-      } yield assert(res)(equalTo((1 to 100).toList))
-    },
-    testM(
-      "Using `foreach` perform an action in each value and return a single transaction that contains the result"
-    ) {
-      for {
-        tvar      <- TRef.makeCommit(0)
-        _         <- STM.foreach(1 to 100)(a => tvar.update(_ + a)).commit
-        expectedV = (1 to 100).sum
-        v         <- tvar.get.commit
-      } yield assert(v)(equalTo(expectedV))
-    },
-    testM("Using `foreach_` performs actions in order") {
-      val as = List(1, 2, 3, 4, 5)
-      for {
-        ref <- TRef.makeCommit(List.empty[Int])
-        _   <- STM.foreach_(as)(a => ref.update(_ :+ a)).commit
-        bs  <- ref.get.commit
-      } yield assert(bs)(equalTo(as))
-    },
+    suite("collectAll")(
+      testM("collects a list of transactional effects to a single transaction that produces a list of values") {
+        for {
+          it    <- UIO((1 to 100).map(TRef.make(_)))
+          tvars <- STM.collectAll(it).commit
+          res   <- UIO.collectAllPar(tvars.map(_.get.commit))
+        } yield assert(res)(equalTo((1 to 100).toList))
+      },
+      testM("collects a chunk of transactional effects to a single transaction that produces a chunk of values") {
+        for {
+          it    <- UIO((1 to 100).map(TRef.make(_)))
+          tvars <- STM.collectAll(Chunk.fromIterable(it)).commit
+          res   <- UIO.collectAllPar(tvars.map(_.get.commit))
+        } yield assert(res)(equalTo(Chunk.fromIterable((1 to 100).toList)))
+      }
+    ),
+    suite("foreach")(
+      testM("performs an action on each list element and return a single transaction that contains the result") {
+        for {
+          tvar      <- TRef.makeCommit(0)
+          _         <- STM.foreach(1 to 100)(a => tvar.update(_ + a)).commit
+          expectedV = (1 to 100).sum
+          v         <- tvar.get.commit
+        } yield assert(v)(equalTo(expectedV))
+      },
+      testM("performs an action on each chunk element and return a single transaction that contains the result") {
+        for {
+          tvar      <- TRef.makeCommit(0)
+          chunk     = Chunk.fromIterable((1 to 100).toList)
+          _         <- STM.foreach(chunk)(a => tvar.update(_ + a)).commit
+          expectedV = (1 to 100).sum
+          v         <- tvar.get.commit
+        } yield assert(v)(equalTo(expectedV))
+      },
+      testM("`foreach_` performs actions in order") {
+        val as = List(1, 2, 3, 4, 5)
+        for {
+          ref <- TRef.makeCommit(List.empty[Int])
+          _   <- STM.foreach_(as)(a => ref.update(_ :+ a)).commit
+          bs  <- ref.get.commit
+        } yield assert(bs)(equalTo(as))
+      }
+    ),
     testM(
       "Using `orElseEither` tries 2 computations and returns either left if the left computation succeed or right if the right one succeed"
     ) {

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -40,22 +40,22 @@ object STM {
   def check(p: => Boolean): USTM[Unit] = ZSTM.check(p)
 
   /**
-   * @see See [[zio.stm.ZSTM.collectAll]]
+   * @see See [[[zio.stm.ZSTM.collectAll[R,E,A](in:Iterable*]]]
    */
-  def collectAll[E, A](i: Iterable[STM[E, A]]): STM[E, List[A]] =
-    ZSTM.collectAll(i)
+  def collectAll[E, A](in: Iterable[STM[E, A]]): STM[E, List[A]] =
+    ZSTM.collectAll(in)
 
   /**
-   * @see See [[zio.stm.ZSTM.collectAll]]
+   * @see See [[[zio.stm.ZSTM.collectAll[R,E,A](in:Chunk*]]]
    */
-  def collectAll[E, A](i: Chunk[STM[E, A]]): STM[E, Chunk[A]] =
-    ZSTM.collectAll(i)
+  def collectAll[E, A](in: Chunk[STM[E, A]]): STM[E, Chunk[A]] =
+    ZSTM.collectAll(in)
 
   /**
    * @see See [[zio.stm.ZSTM.collectAll_]]
    */
-  def collectAll_[E, A](i: Iterable[STM[E, A]]): STM[E, Unit] =
-    ZSTM.collectAll_(i)
+  def collectAll_[E, A](in: Iterable[STM[E, A]]): STM[E, Unit] =
+    ZSTM.collectAll_(in)
 
   /**
    * @see See [[zio.stm.ZSTM.die]]
@@ -112,22 +112,22 @@ object STM {
     ZSTM.foldRight(in)(zero)(f)
 
   /**
-   * @see See [[zio.stm.ZSTM.foreach]]
+   * @see See [[[zio.stm.ZSTM.foreach[R,E,A](in:Iterable*]]]
    */
-  def foreach[E, A, B](as: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
-    ZSTM.foreach(as)(f)
+  def foreach[E, A, B](in: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
+    ZSTM.foreach(in)(f)
 
   /**
-   * @see See [[zio.stm.ZSTM.foreach]]
+   * @see See [[[zio.stm.ZSTM.foreach[R,E,A](in:Chunk*]]]
    */
-  def foreach[E, A, B](as: Chunk[A])(f: A => STM[E, B]): STM[E, Chunk[B]] =
-    ZSTM.foreach(as)(f)
+  def foreach[E, A, B](in: Chunk[A])(f: A => STM[E, B]): STM[E, Chunk[B]] =
+    ZSTM.foreach(in)(f)
 
   /**
    * @see See [[zio.stm.ZSTM.foreach_]]
    */
-  def foreach_[E, A, B](as: Iterable[A])(f: A => STM[E, B]): STM[E, Unit] =
-    ZSTM.foreach_(as)(f)
+  def foreach_[E, A, B](in: Iterable[A])(f: A => STM[E, B]): STM[E, Unit] =
+    ZSTM.foreach_(in)(f)
 
   /**
    * @see See [[zio.stm.ZSTM.fromEither]]

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -52,9 +52,15 @@ object STM {
     ZSTM.collectAll(in)
 
   /**
-   * @see See [[zio.stm.ZSTM.collectAll_]]
+   * @see See [[[zio.stm.ZSTM.collectAll_[R,E,A](in:Iterable*]]]
    */
   def collectAll_[E, A](in: Iterable[STM[E, A]]): STM[E, Unit] =
+    ZSTM.collectAll_(in)
+
+  /**
+   * @see See [[[zio.stm.ZSTM.collectAll_[R,E,A](in:Chunk*]]]
+   */
+  def collectAll_[E, A](in: Chunk[STM[E, A]]): STM[E, Unit] =
     ZSTM.collectAll_(in)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import scala.util.Try
 
-import zio.{ CanFail, Fiber, IO }
+import zio.{ CanFail, Chunk, Fiber, IO }
 
 object STM {
 
@@ -43,6 +43,12 @@ object STM {
    * @see See [[zio.stm.ZSTM.collectAll]]
    */
   def collectAll[E, A](i: Iterable[STM[E, A]]): STM[E, List[A]] =
+    ZSTM.collectAll(i)
+
+  /**
+   * @see See [[zio.stm.ZSTM.collectAll]]
+   */
+  def collectAll[E, A](i: Chunk[STM[E, A]]): STM[E, Chunk[A]] =
     ZSTM.collectAll(i)
 
   /**
@@ -109,6 +115,12 @@ object STM {
    * @see See [[zio.stm.ZSTM.foreach]]
    */
   def foreach[E, A, B](as: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
+    ZSTM.foreach(as)(f)
+
+  /**
+   * @see See [[zio.stm.ZSTM.foreach]]
+   */
+  def foreach[E, A, B](as: Chunk[A])(f: A => STM[E, B]): STM[E, Chunk[B]] =
     ZSTM.foreach(as)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -46,7 +46,7 @@ object STM {
     ZSTM.collectAll(in)
 
   /**
-   * @see See [[[zio.stm.ZSTM.collectAll[R,E,A](in:Chunk*]]]
+   * @see See [[[zio.stm.ZSTM.collectAll[R,E,A](in:zio\.Chunk*]]]
    */
   def collectAll[E, A](in: Chunk[STM[E, A]]): STM[E, Chunk[A]] =
     ZSTM.collectAll(in)
@@ -58,7 +58,7 @@ object STM {
     ZSTM.collectAll_(in)
 
   /**
-   * @see See [[[zio.stm.ZSTM.collectAll_[R,E,A](in:Chunk*]]]
+   * @see See [[[zio.stm.ZSTM.collectAll_[R,E,A](in:zio\.Chunk*]]]
    */
   def collectAll_[E, A](in: Chunk[STM[E, A]]): STM[E, Unit] =
     ZSTM.collectAll_(in)
@@ -118,25 +118,25 @@ object STM {
     ZSTM.foldRight(in)(zero)(f)
 
   /**
-   * @see See [[[zio.stm.ZSTM.foreach[R,E,A](in:Iterable*]]]
+   * @see See [[[zio.stm.ZSTM.foreach[R,E,A,B](in:Iterable*]]]
    */
   def foreach[E, A, B](in: Iterable[A])(f: A => STM[E, B]): STM[E, List[B]] =
     ZSTM.foreach(in)(f)
 
   /**
-   * @see See [[[zio.stm.ZSTM.foreach[R,E,A](in:Chunk*]]]
+   * @see See [[[zio.stm.ZSTM.foreach[R,E,A,B](in:zio\.Chunk*]]]
    */
   def foreach[E, A, B](in: Chunk[A])(f: A => STM[E, B]): STM[E, Chunk[B]] =
     ZSTM.foreach(in)(f)
 
   /**
-   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](as:Iterable*]]]
+   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](in:Iterable*]]]
    */
   def foreach_[E, A](in: Iterable[A])(f: A => STM[E, Any]): STM[E, Unit] =
     ZSTM.foreach_(in)(f)
 
   /**
-   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](as:Chunk*]]]
+   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](in:zio\.Chunk*]]]
    */
   def foreach_[E, A](in: Chunk[A])(f: A => STM[E, Any]): STM[E, Unit] =
     ZSTM.foreach_(in)(f)

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -124,9 +124,15 @@ object STM {
     ZSTM.foreach(in)(f)
 
   /**
-   * @see See [[zio.stm.ZSTM.foreach_]]
+   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](as:Iterable*]]]
    */
-  def foreach_[E, A, B](in: Iterable[A])(f: A => STM[E, B]): STM[E, Unit] =
+  def foreach_[E, A](in: Iterable[A])(f: A => STM[E, Any]): STM[E, Unit] =
+    ZSTM.foreach_(in)(f)
+
+  /**
+   * @see See [[[zio.stm.ZSTM.foreach_[R,E,A](as:Chunk*]]]
+   */
+  def foreach_[E, A](in: Chunk[A])(f: A => STM[E, Any]): STM[E, Unit] =
     ZSTM.foreach_(in)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1031,7 +1031,9 @@ object ZSTM {
    * returns a transactional effect that produces a new `Chunk[B]`.
    */
   def foreach[R, E, A, B](in: Chunk[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, Chunk[B]] =
-    in.foldRight[ZSTM[R, E, Chunk[B]]](ZSTM.succeedNow(Chunk.empty))((a, acc) => f(a).zipWith(acc)((b, acc) => Chunk.single(b) ++ acc))
+    in.fold[ZSTM[R, E, Chunk[B]]](ZSTM.succeedNow(Chunk.empty))((acc, a) =>
+      f(a).zipWith(acc)((b, acc) => acc ++ Chunk.single(b))
+    )
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and
@@ -1056,7 +1058,7 @@ object ZSTM {
    * the chunk of results.
    */
   def foreach_[R, E, A](in: Chunk[A])(f: A => ZSTM[R, E, Any]): ZSTM[R, E, Unit] =
-    in.fold[ZSTM[R, E, Unit]](ZSTM.unit)((tx, a) =>  tx *> f(a).unit)
+    in.fold[ZSTM[R, E, Unit]](ZSTM.unit)((tx, a) => tx *> f(a).unit)
 
   /**
    * Lifts an `Either` into a `STM`.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -914,15 +914,15 @@ object ZSTM {
    * Collects all the transactional effects in a list, returning a single
    * transactional effect that produces a list of values.
    */
-  def collectAll[R, E, A](i: Iterable[ZSTM[R, E, A]]): ZSTM[R, E, List[A]] =
-    foreach(i)(ZIO.identityFn)
+  def collectAll[R, E, A](in: Iterable[ZSTM[R, E, A]]): ZSTM[R, E, List[A]] =
+    foreach(in)(ZIO.identityFn)
 
   /**
    * Collects all the transactional effects in a list, returning a single
    * transactional effect that produces a chunk of values.
    */
-  def collectAll[R, E, A](i: Chunk[ZSTM[R, E, A]]): ZSTM[R, E, Chunk[A]] =
-    foreach(i)(ZIO.identityFn)
+  def collectAll[R, E, A](in: Chunk[ZSTM[R, E, A]]): ZSTM[R, E, Chunk[A]] =
+    foreach(in)(ZIO.identityFn)
 
   /**
    * Collects all the transactional effects, returning a single transactional
@@ -931,8 +931,8 @@ object ZSTM {
    * Equivalent to `collectAll(i).unit`, but without the cost of building the
    * list of results.
    */
-  def collectAll_[R, E, A](i: Iterable[ZSTM[R, E, A]]): ZSTM[R, E, Unit] =
-    foreach_(i)(ZIO.identityFn)
+  def collectAll_[R, E, A](in: Iterable[ZSTM[R, E, A]]): ZSTM[R, E, Unit] =
+    foreach_(in)(ZIO.identityFn)
 
   /**
    * Kills the fiber running the effect.
@@ -1013,15 +1013,15 @@ object ZSTM {
    * Applies the function `f` to each element of the `Iterable[A]` and
    * returns a transactional effect that produces a new `List[B]`.
    */
-  def foreach[R, E, A, B](as: Iterable[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, List[B]] =
-    as.foldRight[ZSTM[R, E, List[B]]](ZSTM.succeedNow(Nil))((a, tx) => f(a).zipWith(tx)(_ :: _))
+  def foreach[R, E, A, B](in: Iterable[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, List[B]] =
+    in.foldRight[ZSTM[R, E, List[B]]](ZSTM.succeedNow(Nil))((a, tx) => f(a).zipWith(tx)(_ :: _))
 
   /**
    * Applies the function `f` to each element of the `Chunk[A]` and
    * returns a transactional effect that produces a new `Chunk[B]`.
    */
-  def foreach[R, E, A, B](as: Chunk[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, Chunk[B]] =
-    as.foldRight[ZSTM[R, E, Chunk[B]]](ZSTM.succeedNow(Chunk.empty))((a, acc) => f(a).zipWith(acc)((b, acc) => Chunk.single(b) ++ acc))
+  def foreach[R, E, A, B](in: Chunk[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, Chunk[B]] =
+    in.foldRight[ZSTM[R, E, Chunk[B]]](ZSTM.succeedNow(Chunk.empty))((a, acc) => f(a).zipWith(acc)((b, acc) => Chunk.single(b) ++ acc))
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and
@@ -1030,8 +1030,8 @@ object ZSTM {
    * Equivalent to `foreach(as)(f).unit`, but without the cost of building
    * the list of results.
    */
-  def foreach_[R, E, A, B](as: Iterable[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, Unit] =
-    ZSTM.succeedNow(as.iterator).flatMap[R, E, Unit] { it =>
+  def foreach_[R, E, A, B](in: Iterable[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, Unit] =
+    ZSTM.succeedNow(in.iterator).flatMap[R, E, Unit] { it =>
       def loop: ZSTM[R, E, Unit] =
         if (it.hasNext) f(it.next) *> loop
         else ZSTM.unit

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -935,6 +935,16 @@ object ZSTM {
     foreach_(in)(ZIO.identityFn)
 
   /**
+   * Collects all the transactional effects, returning a single transactional
+   * effect that produces `Unit`.
+   *
+   * Equivalent to `collectAll(i).unit`, but without the cost of building the
+   * chunk of results.
+   */
+  def collectAll_[R, E, A](in: Chunk[ZSTM[R, E, A]]): ZSTM[R, E, Unit] =
+    foreach_(in)(ZIO.identityFn)
+
+  /**
    * Kills the fiber running the effect.
    */
   def die(t: => Throwable): USTM[Nothing] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -915,7 +915,7 @@ object ZSTM {
    * transactional effect that produces a list of values.
    */
   def collectAll[R, E, A](i: Iterable[ZSTM[R, E, A]]): ZSTM[R, E, List[A]] =
-    i.foldRight[ZSTM[R, E, List[A]]](ZSTM.succeedNow(Nil))(_.zipWith(_)(_ :: _))
+    foreach(i)(ZIO.identityFn)
 
   /**
    * Collects all the transactional effects, returning a single transactional
@@ -1007,7 +1007,7 @@ object ZSTM {
    * returns a transactional effect that produces a new `List[B]`.
    */
   def foreach[R, E, A, B](as: Iterable[A])(f: A => ZSTM[R, E, B]): ZSTM[R, E, List[B]] =
-    collectAll(as.map(f))
+    as.foldRight[ZSTM[R, E, List[B]]](ZSTM.succeedNow(Nil))((a, tx) => f(a).zipWith(tx)(_ :: _))
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and


### PR DESCRIPTION
Added versions of `foreach`, `foreach_`, `combineAll` and `combineAll_` that accept and return `Chunk`.