### PR TITLE
Use chunks in TMap's folds and transform

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -52,4 +52,12 @@ class TMapOpsBenchmarks {
   @Benchmark
   def removal(): Unit =
     unsafeRun(ZIO.foreach_(calls)(_ => map.delete(idx).commit))
+
+  @Benchmark
+  def fold(): Int =
+    unsafeRun(map.fold(0)((acc, kv) => acc + kv._2).commit)
+
+  @Benchmark
+  def foldM(): Int =
+    unsafeRun(map.foldM(0)((acc, kv) => STM.succeedNow(acc + kv._2)).commit)
 }

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -15,9 +15,9 @@
  */
 package zio.stm
 
-import zio.{ Chunk, ZIOBaseSpec }
 import zio.test.Assertion._
 import zio.test._
+import zio.{ Chunk, ZIOBaseSpec }
 
 object TArraySpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -15,7 +15,7 @@
  */
 package zio.stm
 
-import zio.ZIOBaseSpec
+import zio.{ Chunk, ZIOBaseSpec }
 import zio.test.Assertion._
 import zio.test._
 
@@ -866,6 +866,12 @@ object TArraySpec extends ZIOBaseSpec {
           tArray <- TArray.make(1, 2, 3, 4).commit
           result <- tArray.toList.commit
         } yield assert(result)(equalTo(List(1, 2, 3, 4)))
+      },
+      testM("toList") {
+        for {
+          tArray <- TArray.make(1, 2, 3, 4).commit
+          result <- tArray.toChunk.commit
+        } yield assert(result)(equalTo(Chunk(1, 2, 3, 4)))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -142,6 +142,16 @@ object TMapSpec extends ZIOBaseSpec {
 
         assertM(tx.commit)(hasSameElements(elems))
       },
+      testM("toChunk") {
+        val elems = List("a" -> 1, "b" -> 2)
+        val tx =
+          for {
+            tmap  <- TMap.fromIterable(elems)
+            chunk <- tmap.toChunk
+          } yield chunk.toList
+
+        assertM(tx.commit)(hasSameElements(elems))
+      },
       testM("toMap") {
         val elems = Map("a" -> 1, "b" -> 2)
         val tx =

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -260,7 +260,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Collects all elements into a list.
    */
   def toList: USTM[List[A]] =
-    STM.collectAll(array.map(_.get))
+    STM.foreach(array)(_.get)
 
   /**
    * Collects all elements into a chunk.

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -16,6 +16,8 @@
 
 package zio.stm
 
+import zio.Chunk
+
 /**
  * Wraps array of [[TRef]] and adds methods for convenience.
  */
@@ -259,6 +261,12 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    */
   def toList: USTM[List[A]] =
     STM.collectAll(array.map(_.get))
+
+  /**
+   * Collects all elements into a chunk.
+   */
+  def toChunk: USTM[Chunk[A]] =
+    STM.collectAll(Chunk.fromArray(array).map(_.get))
 
   /**
    * Atomically updates all elements using a pure function.

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -266,7 +266,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Collects all elements into a chunk.
    */
   def toChunk: USTM[Chunk[A]] =
-    STM.collectAll(Chunk.fromArray(array).map(_.get))
+    STM.foreach(Chunk.fromArray(array))(_.get)
 
   /**
    * Atomically updates all elements using a pure function.

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -191,7 +191,7 @@ final class TMap[K, V] private (
           val idx       = TMap.indexOf(newPair._1, capacity)
           val newBucket = newBuckets(idx)
 
-          if (!bucket.exists(_._1 == newPair._1))
+          if (!newBucket.exists(_._1 == newPair._1))
             newBuckets(idx) = newPair :: newBucket
         }
       }

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -122,7 +122,7 @@ final class TMap[K, V] private (
           if (exists)
             bucket.map(kv => if (kv._1 == k) (k, v) else kv)
           else
-            Chunk.single(k -> v) ++ bucket
+            Chunk(k -> v) ++ bucket
 
         buckets.array(idx).set(updated) *> tSize.updateAndGet(s => if (exists) s else s + 1)
       }
@@ -167,7 +167,7 @@ final class TMap[K, V] private (
    * Collects all bindings into a chunk.
    */
   def toChunk: USTM[Chunk[(K, V)]] =
-    fold[Chunk[(K, V)]](Chunk.empty)((acc, kv) => Chunk.single(kv) ++ acc)
+    fold[Chunk[(K, V)]](Chunk.empty)((acc, kv) => Chunk(kv) ++ acc)
 
   /**
    * Collects all bindings into a map.
@@ -191,7 +191,7 @@ final class TMap[K, V] private (
           val bucket  = newBuckets(idx)
 
           if (!bucket.exists(_._1 == newPair._1))
-            newBuckets(idx) = Chunk.single(newPair) ++ bucket
+            newBuckets(idx) = Chunk(newPair) ++ bucket
         }
 
         val newArr = Array.ofDim[TRef[Chunk[(K, V)]]](capacity)
@@ -222,7 +222,7 @@ final class TMap[K, V] private (
             val bucket = newBuckets(idx)
 
             if (!bucket.exists(_._1 == newPair._1))
-              newBuckets(idx) = Chunk.single(newPair) ++ bucket
+              newBuckets(idx) = Chunk(newPair) ++ bucket
           }
 
           val newArr = Array.ofDim[TRef[Chunk[(K, V)]]](capacity)
@@ -288,7 +288,7 @@ object TMap {
       val kv  = it.next
       val idx = indexOf(kv._1, capacity)
 
-      buckets(idx) = Chunk.single(kv) ++ buckets(idx)
+      buckets(idx) = Chunk(kv) ++ buckets(idx)
       size = size + 1
     }
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -168,7 +168,7 @@ final class TMap[K, V] private (
    * Collects all bindings into a chunk.
    */
   def toChunk: USTM[Chunk[(K, V)]] =
-    fold[Chunk[(K, V)]](Chunk.empty)((acc, kv) => Chunk(kv) ++ acc)
+    tBuckets.get.flatMap(_.toChunk).map(_.flatten)
 
   /**
    * Collects all bindings into a map.

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -164,6 +164,12 @@ final class TMap[K, V] private (
     fold(List.empty[(K, V)])((acc, kv) => kv :: acc)
 
   /**
+   * Collects all bindings into a chunk.
+   */
+  def toChunk: USTM[Chunk[(K, V)]] =
+    fold[Chunk[(K, V)]](Chunk.empty)((acc, kv) => Chunk.single(kv) ++ acc)
+
+  /**
    * Collects all bindings into a map.
    */
   def toMap: USTM[Map[K, V]] =

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -39,7 +39,7 @@ final class TMap[K, V] private (
   def delete(k: K): USTM[Unit] = {
     def removeMatching(bucket: List[(K, V)]): USTM[List[(K, V)]] = {
       val (toRemove, toRetain) = bucket.partition(_._1 == k)
-      if (toRemove.isEmpty) STM.succeedNow(toRetain) else tSize.update(_ - toRemove.size).as(toRetain)
+      if (toRemove.isEmpty) STM.succeedNow(toRetain) else tSize.update(_ - 1).as(toRetain)
     }
 
     for {

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -180,20 +180,20 @@ final class TMap[K, V] private (
    * Atomically updates all bindings using a pure function.
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
-    tBuckets.get.flatMap(_.toChunk).flatMap { chunked =>
+    tBuckets.get.flatMap(_.toChunk).flatMap { buckets =>
       val g          = f.tupled
-      val capacity   = chunked.length
+      val capacity   = buckets.length
       val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 
-      chunked.foreach { bucket =>
+      buckets.foreach { bucket =>
         val it = bucket.iterator
         while (it.hasNext) {
-          val newPair = g(it.next)
-          val idx     = TMap.indexOf(newPair._1, capacity)
-          val bucket  = newBuckets(idx)
+          val newPair   = g(it.next)
+          val idx       = TMap.indexOf(newPair._1, capacity)
+          val newBucket = newBuckets(idx)
 
           if (!bucket.exists(_._1 == newPair._1))
-            newBuckets(idx) = newPair :: bucket
+            newBuckets(idx) = newPair :: newBucket
         }
       }
 
@@ -211,33 +211,30 @@ final class TMap[K, V] private (
    * Atomically updates all bindings using a transactional function.
    */
   def transformM[E](f: (K, V) => STM[E, (K, V)]): STM[E, Unit] =
-    tBuckets.get.flatMap { buckets =>
-      buckets.toList.flatMap { data =>
-        val g = f.tupled
+    tBuckets.get.flatMap(_.toChunk).flatMap { buckets =>
+      val g        = f.tupled
+      val capacity = buckets.length
+      val data     = buckets.flatMap(b => Chunk.fromArray(b.toArray))
 
-        STM.foreach(data.flatten)(g).flatMap { mappedData =>
-          val capacity   = buckets.array.length
-          val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
+      STM.foreach(data)(g).flatMap { newData =>
+        val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
 
-          val it = mappedData.iterator
-          while (it.hasNext) {
-            val newPair = it.next
-            val idx     = TMap.indexOf(newPair._1, capacity)
-            val bucket  = newBuckets(idx)
+        newData.foreach { newPair =>
+          val idx       = TMap.indexOf(newPair._1, capacity)
+          val newBucket = newBuckets(idx)
 
-            if (!bucket.exists(_._1 == newPair._1))
-              newBuckets(idx) = newPair :: bucket
-          }
-
-          val newArr = Array.ofDim[TRef[List[(K, V)]]](capacity)
-          var idx    = 0
-          while (idx < capacity) {
-            newArr(idx) = ZTRef.unsafeMake(newBuckets(idx))
-            idx += 1
-          }
-
-          tBuckets.set(new TArray(newArr))
+          if (!newBucket.exists(_._1 == newPair._1))
+            newBuckets(idx) = newPair :: newBucket
         }
+
+        val newArr = Array.ofDim[TRef[List[(K, V)]]](capacity)
+        var idx    = 0
+        while (idx < capacity) {
+          newArr(idx) = ZTRef.unsafeMake(newBuckets(idx))
+          idx += 1
+        }
+
+        tBuckets.set(new TArray(newArr))
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -187,8 +187,8 @@ final class TMap[K, V] private (
 
         data.flatten.foreach { kv =>
           val newPair = g(kv)
-          val idx = TMap.indexOf(newPair._1, capacity)
-          val bucket = newBuckets(idx)
+          val idx     = TMap.indexOf(newPair._1, capacity)
+          val bucket  = newBuckets(idx)
 
           if (!bucket.exists(_._1 == newPair._1))
             newBuckets(idx) = Chunk.single(newPair) ++ bucket
@@ -218,8 +218,8 @@ final class TMap[K, V] private (
           val newBuckets = Array.fill[Chunk[(K, V)]](capacity)(Chunk.empty)
 
           mappedData.foreach { newPair =>
-            val idx     = TMap.indexOf(newPair._1, capacity)
-            val bucket  = newBuckets(idx)
+            val idx    = TMap.indexOf(newPair._1, capacity)
+            val bucket = newBuckets(idx)
 
             if (!bucket.exists(_._1 == newPair._1))
               newBuckets(idx) = Chunk.single(newPair) ++ bucket

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -16,12 +16,14 @@
 
 package zio.stm
 
+import zio.Chunk
+
 /**
  * Transactional map implemented on top of [[TRef]] and [[TArray]]. Resolves
  * conflicts via chaining.
  */
 final class TMap[K, V] private (
-  private val tBuckets: TRef[TArray[List[(K, V)]]],
+  private val tBuckets: TRef[TArray[Chunk[(K, V)]]],
   private val tSize: TRef[Int]
 ) {
 
@@ -35,9 +37,13 @@ final class TMap[K, V] private (
    * Removes binding for given key.
    */
   def delete(k: K): USTM[Unit] = {
-    def removeMatching(bucket: List[(K, V)]): USTM[List[(K, V)]] = {
-      val (toRemove, toRetain) = bucket.partition(_._1 == k)
-      if (toRemove.isEmpty) STM.succeedNow(toRetain) else tSize.update(_ - toRemove.size).as(toRetain)
+    def removeMatching(bucket: Chunk[(K, V)]): USTM[Chunk[(K, V)]] = {
+      val toRetain = bucket.filter(_._1 != k)
+
+      if (bucket.length == toRetain.length)
+        STM.succeedNow(toRetain)
+      else
+        tSize.update(_ - 1).as(toRetain)
     }
 
     for {
@@ -51,20 +57,15 @@ final class TMap[K, V] private (
    * Atomically folds using a pure function.
    */
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
-    tBuckets.get.flatMap(_.toList).map(_.flatten.foldLeft(zero)(op))
+    tBuckets.get.flatMap(_.toChunk).map(_.flatten.fold(zero)(op))
 
   /**
    * Atomically folds using a transactional function.
    */
-  def foldM[A, E](zero: A)(op: (A, (K, V)) => STM[E, A]): STM[E, A] = {
-    def loopM(res: A, remaining: List[(K, V)]): STM[E, A] =
-      remaining match {
-        case Nil          => STM.succeedNow(res)
-        case head :: tail => op(res, head).flatMap(loopM(_, tail))
-      }
-
-    tBuckets.get.flatMap(_.toList).flatMap(data => loopM(zero, data.flatten))
-  }
+  def foldM[A, E](zero: A)(op: (A, (K, V)) => STM[E, A]): STM[E, A] =
+    tBuckets.get
+      .flatMap(_.toChunk)
+      .flatMap(_.flatten.fold[STM[E, A]](STM.succeedNow(zero))((tx, kv) => tx.flatMap(op(_, kv))))
 
   /**
    * Atomically performs transactional-effect for each binding present in map.
@@ -110,7 +111,7 @@ final class TMap[K, V] private (
    * Stores new binding into the map.
    */
   def put(k: K, v: V): USTM[Unit] = {
-    def update(buckets: TArray[List[(K, V)]]): USTM[Int] = {
+    def update(buckets: TArray[Chunk[(K, V)]]): USTM[Int] = {
       val capacity = buckets.array.length
       val idx      = TMap.indexOf(k, capacity)
 
@@ -121,7 +122,7 @@ final class TMap[K, V] private (
           if (exists)
             bucket.map(kv => if (kv._1 == k) (k, v) else kv)
           else
-            (k, v) :: bucket
+            Chunk.single(k -> v) ++ bucket
 
         buckets.array(idx).set(updated) *> tSize.updateAndGet(s => if (exists) s else s + 1)
       }
@@ -148,7 +149,7 @@ final class TMap[K, V] private (
    * Removes bindings matching predicate.
    */
   def removeIf(p: (K, V) => Boolean): USTM[Unit] =
-    tBuckets.get.flatMap(_.transform(_.filterNot(kv => p(kv._1, kv._2))))
+    tBuckets.get.flatMap(_.transform(_.filter(kv => !p(kv._1, kv._2))))
 
   /**
    * Retains bindings matching predicate.
@@ -173,22 +174,21 @@ final class TMap[K, V] private (
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
     tBuckets.get.flatMap { buckets =>
-      buckets.toList.flatMap { data =>
+      buckets.toChunk.flatMap { data =>
         val g          = f.tupled
         val capacity   = buckets.array.length
-        val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
+        val newBuckets = Array.fill[Chunk[(K, V)]](capacity)(Chunk.empty)
 
-        val it = data.flatten.iterator
-        while (it.hasNext) {
-          val newPair = g(it.next)
-          val idx     = TMap.indexOf(newPair._1, capacity)
-          val bucket  = newBuckets(idx)
+        data.flatten.foreach { kv =>
+          val newPair = g(kv)
+          val idx = TMap.indexOf(newPair._1, capacity)
+          val bucket = newBuckets(idx)
 
           if (!bucket.exists(_._1 == newPair._1))
-            newBuckets(idx) = newPair :: bucket
+            newBuckets(idx) = Chunk.single(newPair) ++ bucket
         }
 
-        val newArr = Array.ofDim[TRef[List[(K, V)]]](capacity)
+        val newArr = Array.ofDim[TRef[Chunk[(K, V)]]](capacity)
         var idx    = 0
         while (idx < capacity) {
           newArr(idx) = ZTRef.unsafeMake(newBuckets(idx))
@@ -204,24 +204,22 @@ final class TMap[K, V] private (
    */
   def transformM[E](f: (K, V) => STM[E, (K, V)]): STM[E, Unit] =
     tBuckets.get.flatMap { buckets =>
-      buckets.toList.flatMap { data =>
+      buckets.toChunk.flatMap { data =>
         val g = f.tupled
 
         STM.foreach(data.flatten)(g).flatMap { mappedData =>
           val capacity   = buckets.array.length
-          val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
+          val newBuckets = Array.fill[Chunk[(K, V)]](capacity)(Chunk.empty)
 
-          val it = mappedData.iterator
-          while (it.hasNext) {
-            val newPair = it.next
+          mappedData.foreach { newPair =>
             val idx     = TMap.indexOf(newPair._1, capacity)
             val bucket  = newBuckets(idx)
 
             if (!bucket.exists(_._1 == newPair._1))
-              newBuckets(idx) = newPair :: bucket
+              newBuckets(idx) = Chunk.single(newPair) ++ bucket
           }
 
-          val newArr = Array.ofDim[TRef[List[(K, V)]]](capacity)
+          val newArr = Array.ofDim[TRef[Chunk[(K, V)]]](capacity)
           var idx    = 0
           while (idx < capacity) {
             newArr(idx) = ZTRef.unsafeMake(newBuckets(idx))
@@ -274,7 +272,7 @@ object TMap {
   def make[K, V](data: (K, V)*): USTM[TMap[K, V]] = fromIterable(data)
 
   private def allocate[K, V](capacity: Int, data: List[(K, V)]): USTM[TMap[K, V]] = {
-    val buckets  = Array.fill[List[(K, V)]](capacity)(Nil)
+    val buckets  = Array.fill[Chunk[(K, V)]](capacity)(Chunk.empty)
     val distinct = data.toMap
 
     var size = 0
@@ -284,7 +282,7 @@ object TMap {
       val kv  = it.next
       val idx = indexOf(kv._1, capacity)
 
-      buckets(idx) = kv :: buckets(idx)
+      buckets(idx) = Chunk.single(kv) ++ buckets(idx)
       size = size + 1
     }
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -55,7 +55,7 @@ final class TMap[K, V] private (
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
     tBuckets.get
       .flatMap(_.toChunk)
-      .map(_.flatMap(b => Chunk.fromArray(b.toArray)).fold(zero)(op))
+      .map(_.flatMap(b => Chunk.fromArray(b.toArray)).foldLeft(zero)(op))
 
   /**
    * Atomically folds using a transactional function.
@@ -64,7 +64,7 @@ final class TMap[K, V] private (
     tBuckets.get.flatMap(_.toChunk).flatMap { buckets =>
       buckets
         .flatMap(b => Chunk.fromArray(b.toArray))
-        .fold[STM[E, A]](STM.succeedNow(zero))((tx, kv) => tx.flatMap(op(_, kv)))
+        .foldLeft[STM[E, A]](STM.succeedNow(zero))((tx, kv) => tx.flatMap(op(_, kv)))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -26,7 +26,7 @@ import scala.util.{ Failure, Success, Try }
 import com.github.ghik.silencer.silent
 
 import zio.internal.{ Platform, Stack, Sync }
-import zio.{ CanFail, Chunk, Fiber, IO, UIO, ZIO }
+import zio.{ CanFail, Chunk, ChunkBuilder, Fiber, IO, UIO, ZIO }
 
 /**
  * `STM[E, A]` represents an effect that can be performed transactionally,
@@ -1045,7 +1045,7 @@ object ZSTM {
     val length = in.length
     var idx    = 0
 
-    var tx: ZSTM[R, E, ArrayBuffer[B]] = ZSTM.succeedNow(ArrayBuffer.empty[B])
+    var tx: ZSTM[R, E, ChunkBuilder[B]] = ZSTM.succeedNow(ChunkBuilder.make[B])
 
     while (idx < length) {
       val a = in(idx)
@@ -1053,7 +1053,7 @@ object ZSTM {
       idx += 1
     }
 
-    tx.map(Chunk.fromIterable)
+    tx.map(_.result())
   }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 import java.util.{ HashMap => MutableMap }
 
 import scala.annotation.tailrec
-import scala.collection.mutable.ArrayBuffer
 import scala.util.{ Failure, Success, Try }
 
 import com.github.ghik.silencer.silent


### PR DESCRIPTION
### Summary

- Added `toChunk` to `TMap` and `TArray`.
- Removed `indices` from `TArray` transformations.
- Added `fold` / `foldM` benchmarks.
- Replaced lists with chunks inside folds and transformations.
- Improve efficiency and safety of chunked foreach (ZSTM).

### Results

#### Folds

Before:

```
Benchmark                (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.fold        0  thrpt   15  258658.256 ± 8415.195  ops/s
TMapOpsBenchmarks.fold       10  thrpt   15  184811.477 ± 1966.108  ops/s
TMapOpsBenchmarks.fold      100  thrpt   15   22520.429 ±   76.867  ops/s
TMapOpsBenchmarks.fold     1000  thrpt   15    2396.229 ±    6.618  ops/s
TMapOpsBenchmarks.fold    10000  thrpt   15     109.687 ±    1.259  ops/s
TMapOpsBenchmarks.fold   100000  thrpt   15       6.887 ±    0.156  ops/s
TMapOpsBenchmarks.foldM       0  thrpt   15  281237.383 ± 9172.810  ops/s
TMapOpsBenchmarks.foldM      10  thrpt   15  165526.805 ± 2169.245  ops/s
TMapOpsBenchmarks.foldM     100  thrpt   15   19590.089 ±  120.782  ops/s
TMapOpsBenchmarks.foldM    1000  thrpt   15    1929.585 ±    5.396  ops/s
TMapOpsBenchmarks.foldM   10000  thrpt   15     100.054 ±    3.493  ops/s
TMapOpsBenchmarks.foldM  100000  thrpt   15       5.975 ±    0.102  ops/s
```

After:

```
Benchmark                (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.fold        0  thrpt   15  229489.328 ± 7150.990  ops/s
TMapOpsBenchmarks.fold       10  thrpt   15  207447.701 ± 4881.882  ops/s
TMapOpsBenchmarks.fold      100  thrpt   15   28134.487 ±   82.870  ops/s
TMapOpsBenchmarks.fold     1000  thrpt   15    2652.985 ±   16.872  ops/s
TMapOpsBenchmarks.fold    10000  thrpt   15     122.824 ±    0.596  ops/s
TMapOpsBenchmarks.fold   100000  thrpt   15       7.985 ±    0.066  ops/s
TMapOpsBenchmarks.foldM       0  thrpt   15  241354.670 ± 7260.260  ops/s
TMapOpsBenchmarks.foldM      10  thrpt   15  186563.730 ± 4521.997  ops/s
TMapOpsBenchmarks.foldM     100  thrpt   15   24254.184 ±  114.819  ops/s
TMapOpsBenchmarks.foldM    1000  thrpt   15    1931.638 ±   10.842  ops/s
TMapOpsBenchmarks.foldM   10000  thrpt   15     104.820 ±    0.640  ops/s
TMapOpsBenchmarks.foldM  100000  thrpt   15       6.992 ±    0.205  ops/s
```

#### Transformations

Before:

```
TMapOpsBenchmarks.transform        0  thrpt   15  148985.179 ± 3818.584  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  118974.349 ± 2685.904  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   15679.842 ±   42.883  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    1839.234 ±   22.481  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      96.660 ±    0.992  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       7.093 ±    0.112  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  144693.581 ± 4076.923  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   97583.697 ± 1395.881  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   11675.240 ±   85.219  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1237.373 ±    3.750  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      74.736 ±    1.810  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       5.120 ±    0.080  ops/s
```

After:

```
Benchmark                     (size)   Mode  Cnt       Score      Error  Units
TMapOpsBenchmarks.transform        0  thrpt   15  144259.175 ± 5290.334  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  145538.922 ± 3996.517  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   20636.735 ±  311.573  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    2371.484 ±  120.327  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15     120.811 ±    4.753  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       7.330 ±    0.329  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  139583.672 ± 3749.977  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15  105385.824 ± 1371.753  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   12748.558 ±   37.286  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1385.189 ±    4.494  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      63.870 ±    0.910  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       4.902 ±    0.077  ops/s
```