### PR TITLE
Balanced Concat

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -1,0 +1,54 @@
+package zio.chunks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, Scope, Setup, State }
+
+import zio.{ Chunk, NonEmptyChunk }
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ChunkConcatBenchmarks {
+
+  @Param(Array("1", "8", "64", "512", "4096", "32768"))
+  var size: Int = _
+
+  var chunk: NonEmptyChunk[Int]     = _
+  var chunk_old: NonEmptyChunk[Int] = _
+  var array: Array[Int]             = _
+  var vector: Vector[Int]           = _
+
+  @Setup
+  def setup(): Unit = {
+    chunk = chunkAdd
+    chunk_old = chunkAdd_old
+    array = arrayAdd
+    vector = vectorAdd
+  }
+
+  @Benchmark
+  def chunkAdd = (1 to size).foldLeft(Chunk(0))(_ + _)
+
+  @Benchmark
+  def chunkAdd_old = (1 to size).foldLeft(Chunk(0))(Chunk.addOld)
+
+  @Benchmark
+  def arrayAdd = (1 to size).foldLeft(Array(0))(_ :+ _)
+
+  @Benchmark
+  def vectorAdd = (1 to size).foldLeft(Vector(0))(_ :+ _)
+
+  def transform(x: Int): Int = x + 1
+
+  @Benchmark
+  def chunkMap = chunk.map(transform)
+
+  @Benchmark
+  def chunkMap_old = chunk_old.map(transform)
+
+  @Benchmark
+  def arrayMap = array.map(transform)
+
+  @Benchmark
+  def vectorMap = vector.map(transform)
+}

--- a/benchmarks/src/main/scala/zio/chunks/ChunkPlusBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkPlusBenchmarks.scala
@@ -8,7 +8,7 @@ import zio.{ Chunk, NonEmptyChunk }
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-class ChunkConcatBenchmarks {
+class ChunkPlusBenchmarks {
 
   @Param(Array("1", "8", "64", "512", "4096", "32768"))
   var size: Int = _

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -393,6 +393,9 @@ object ChunkSpec extends ZIOBaseSpec {
       val _: NonEmptyChunk[A] = empty concatNonEmpty Chunk(new A {})
 
       assertCompletes
-    } @@ TestAspect.ignore
+    } @@ TestAspect.ignore,
+    zio.test.test("+ on large number of elements") {
+      assert[Seq[Int]]((1 to 32767).foldLeft(Chunk(0))(_ + _))(equalTo(0 until 32768))
+    }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -394,10 +394,13 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assertCompletes
     } @@ TestAspect.ignore, {
-      val max = 32768
-      val out = 1 to max
+      //numbers fit in JS short representation
+      val min = 128
+      val max = 32767
 
-      val maxDepth = 32 - Integer.numberOfLeadingZeros(out.size)
+      val out = min to max
+
+      val maxDepth = 2 + 31 - Integer.numberOfLeadingZeros(out.size)
 
       def check(label: String, ints_ : => Chunk[Int]) =
         zio.test.test(label)({
@@ -407,9 +410,9 @@ object ChunkSpec extends ZIOBaseSpec {
         })
 
       suite("balanced concat/+ ")(
-        check("+", (2 to max).foldLeft(Chunk(1))(_ + _)),
-        check("concat on the left", (2 to max).foldLeft(Chunk(1))((c, i) => Chunk.concat(c, Chunk.single(i)))),
-        check("concat on the right", (1 until max).foldRight(Chunk(max))((i, c) => Chunk.concat(Chunk.single(i), c)))
+        check("+", (min + 1 to max).foldLeft(Chunk(min))(_ + _)),
+        check("concat on the left", (min + 1 to max).foldLeft(Chunk(min))((c, i) => Chunk.concat(c, Chunk.single(i)))),
+        check("concat on the right", (min until max).foldRight(Chunk(max))((i, c) => Chunk.concat(Chunk.single(i), c)))
       )
     }
   )

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -395,7 +395,19 @@ object ChunkSpec extends ZIOBaseSpec {
       assertCompletes
     } @@ TestAspect.ignore,
     zio.test.test("+ on large number of elements") {
-      assert[Seq[Int]]((1 to 32767).foldLeft(Chunk(0))(_ + _))(equalTo(0 until 32768))
+      val max  = 32767
+      val ints = (1 to max).foldLeft(Chunk(0))(_ + _)
+      assert[Seq[Int]](ints)(equalTo(0 to 32767))
+    },
+    zio.test.test("concat on the left") {
+      val max  = 32767
+      val ints = (1 to max).map(Chunk.single).foldLeft(Chunk(0))(Chunk.concat)
+      assert[Seq[Int]](ints)(equalTo(0 to max))
+    },
+    zio.test.test("concat on the right") {
+      val max  = 32767
+      val ints = (1 to max).map(Chunk.single).foldLeft(Chunk(0))((acc, e) => Chunk.concat(e, acc))
+      assert[Seq[Int]](ints)(equalTo(max.to(0, -1)))
     }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -399,11 +399,12 @@ object ChunkSpec extends ZIOBaseSpec {
 
       val maxDepth = 32 - Integer.numberOfLeadingZeros(out.size)
 
-      def check(label: String, ints: Chunk[Int]) =
-        zio.test.test(label)(
+      def check(label: String, ints_ : => Chunk[Int]) =
+        zio.test.test(label)({
+          val ints = ints_
           assert[Seq[Int]](ints)(equalTo(out)) &&
-            assert(Chunk.depth(ints))(isLessThanEqualTo(maxDepth))
-        )
+          assert(Chunk.depth(ints))(isLessThanEqualTo(maxDepth))
+        })
 
       suite("balanced concat/+ ")(
         check("+", (2 to max).foldLeft(Chunk(1))(_ + _)),

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1664,4 +1664,11 @@ object Chunk {
     private val CharClass       = classTag[Char]
     private val CharClassBox    = classTag[java.lang.Character]
   }
+
+  private[zio] def depth[A](chunk: Chunk[A]): Int =
+    chunk match {
+      case Slice(ne, _, _) => 1 + depth(ne)
+      case Concat(l, r)    => 1 + Math.max(depth(l), depth(r))
+      case _               => 1
+    }
 }


### PR DESCRIPTION
following #3311 , fixing #3238 

This PR reimplement `+` and `concat` on Chunk, without changing the substructure.
On both methods is compute an insertion point in the tree using a local loop.

On `+`:
* it materializes the subtree before moving it when the `length` is equal to `8`.
* it uses a tail (the right-hand side of the root) to accelerate the `add`.


