### PR TITLE
ZIO Test: Remove Chunk Specific Assertions

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -249,11 +249,11 @@ object AssertionSpec extends ZIOBaseSpec {
     test("hasSize must fail when iterable size is not equal to specified assertion") {
       assert(Seq(1, 2, 3))(hasSize(equalTo(1)))
     } @@ failing,
-    test("hasSizeChunk must succeed when iterable size is equal to specified assertion") {
-      assert(Chunk(1, 2, 3))(hasSizeChunk(equalTo(3)))
+    test("hasSize must succeed when chunk size is equal to specified assertion") {
+      assert(Chunk(1, 2, 3))(hasSize(equalTo(3)))
     },
-    test("hasSizeChunk must fail when iterable size is not equal to specified assertion") {
-      assert(Chunk(1, 2, 3))(hasSizeChunk(equalTo(1)))
+    test("hasSize must fail when chunk size is not equal to specified assertion") {
+      assert(Chunk(1, 2, 3))(hasSize(equalTo(1)))
     } @@ failing,
     test("hasSizeString must succeed when string size is equal to specified assertion") {
       assert("aaa")(hasSizeString(equalTo(3)))
@@ -368,11 +368,11 @@ object AssertionSpec extends ZIOBaseSpec {
     test("isNonEmpty must succeed when the traversable is not empty") {
       assert(Seq(1, 2, 3))(isNonEmpty)
     },
-    test("isNonEmptyChunk must fail when the chunk is empty") {
-      assert(Chunk.empty)(isNonEmptyChunk)
+    test("isNonEmpty must fail when the chunk is empty") {
+      assert(Chunk.empty)(isNonEmpty)
     } @@ failing,
-    test("isNonEmptyChunk must succeed when the chunk is not empty") {
-      assert(Chunk(1, 2, 3))(isNonEmptyChunk)
+    test("isNonEmpty must succeed when the chunk is not empty") {
+      assert(Chunk(1, 2, 3))(isNonEmpty)
     },
     test("isNonEmpty must fail when the traversable is empty") {
       assert(Seq())(isNonEmpty)

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -163,10 +163,10 @@ object GenSpec extends ZIOBaseSpec {
         )
       },
       testM("chunkOfBounded generates chunks whose size is in bounds") {
-        checkSample(Gen.chunkOfBounded(2, 10)(smallInt))(forall(hasSizeChunk(isWithin(2, 10))))
+        checkSample(Gen.chunkOfBounded(2, 10)(smallInt))(forall(hasSize(isWithin(2, 10))))
       },
       testM("chunkOf1 generates nonempty chunks") {
-        checkSample(Gen.chunkOf1(smallInt), size = 0)(forall(isNonEmptyChunk))
+        checkSample(Gen.chunkOf1(smallInt), size = 0)(forall(isNonEmpty))
       },
       testM("chunkOfN generates chunks of correct size") {
         checkSample(Gen.chunkOfN(10)(smallInt))(forall(equalTo(10)), _.map(_.length))

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -19,7 +19,7 @@ package zio.test
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
-import zio.{ Cause, Chunk, Exit }
+import zio.{ Cause, Exit }
 
 /**
  * An `Assertion[A]` is capable of producing assertion results on an `A`. As a
@@ -462,13 +462,6 @@ object Assertion extends AssertionVariants {
     Assertion.assertionRec("hasSize")(param(assertion))(assertion)(actual => Some(actual.size))
 
   /**
-   * Makes a new assertion that requires the size of a chunk be satisfied by
-   * the specified assertion.
-   */
-  def hasSizeChunk[A](assertion: Assertion[Int]): Assertion[Chunk[A]] =
-    Assertion.assertionRec("hasSizeChunk")(param(assertion))(assertion)(actual => Some(actual.size))
-
-  /**
    * Makes a new assertion that requires the size of a string be satisfied by
    * the specified assertion.
    */
@@ -622,12 +615,6 @@ object Assertion extends AssertionVariants {
    */
   val isNonEmpty: Assertion[Iterable[Any]] =
     Assertion.assertion("isNonEmpty")()(_.nonEmpty)
-
-  /**
-   * Makes a new assertion that requires an Iterable to be non empty.
-   */
-  val isNonEmptyChunk: Assertion[Chunk[Any]] =
-    Assertion.assertion("isNonEmptyChunk")()(_.nonEmpty)
 
   /**
    * Makes a new assertion that requires a given string to be non empty


### PR DESCRIPTION
Not that `Chunk` is an `Iterable` we no longer need different variants of assertions for `Chunk`.