### PR TITLE
Add support for setting Random seed

### DIFF
--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -23,44 +23,49 @@ package object random {
       def shuffle[A](list: List[A]): UIO[List[A]]
     }
 
-    object Service {
-      val live: Service = new Service {
-        import scala.util.{ Random => SRandom }
+    import scala.util.{ Random => SRandom }
 
+    object Service {
+      val live: Service = make(new SRandom())
+
+      def withSeed(seed: Long): Service =
+        make(new SRandom(seed))
+
+      def make(random: SRandom): Service = new Service {
         val nextBoolean: UIO[Boolean] =
-          ZIO.effectTotal(SRandom.nextBoolean())
+          ZIO.effectTotal(random.nextBoolean())
         def nextBytes(length: Int): UIO[Chunk[Byte]] =
           ZIO.effectTotal {
             val array = Array.ofDim[Byte](length)
-            SRandom.nextBytes(array)
+            random.nextBytes(array)
             Chunk.fromArray(array)
           }
         val nextDouble: UIO[Double] =
-          ZIO.effectTotal(SRandom.nextDouble())
+          ZIO.effectTotal(random.nextDouble())
         def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
           nextDoubleBetweenWith(minInclusive, maxExclusive)(nextDouble)
         val nextFloat: UIO[Float] =
-          ZIO.effectTotal(SRandom.nextFloat())
+          ZIO.effectTotal(random.nextFloat())
         def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
           nextFloatBetweenWith(minInclusive, maxExclusive)(nextFloat)
         val nextGaussian: UIO[Double] =
-          ZIO.effectTotal(SRandom.nextGaussian())
+          ZIO.effectTotal(random.nextGaussian())
         val nextInt: UIO[Int] =
-          ZIO.effectTotal(SRandom.nextInt())
+          ZIO.effectTotal(random.nextInt())
         def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
           nextIntBetweenWith(minInclusive, maxExclusive)(nextInt, nextIntBounded)
         def nextIntBounded(n: Int): UIO[Int] =
-          ZIO.effectTotal(SRandom.nextInt(n))
+          ZIO.effectTotal(random.nextInt(n))
         val nextLong: UIO[Long] =
-          ZIO.effectTotal(SRandom.nextLong())
+          ZIO.effectTotal(random.nextLong())
         def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
           nextLongBetweenWith(minInclusive, maxExclusive)(nextLong, nextLongBounded)
         def nextLongBounded(n: Long): UIO[Long] =
           Random.nextLongBoundedWith(n)(nextLong)
         val nextPrintableChar: UIO[Char] =
-          ZIO.effectTotal(SRandom.nextPrintableChar())
+          ZIO.effectTotal(random.nextPrintableChar())
         def nextString(length: Int): UIO[String] =
-          ZIO.effectTotal(SRandom.nextString(length))
+          ZIO.effectTotal(random.nextString(length))
         def shuffle[A](list: List[A]): UIO[List[A]] =
           Random.shuffleWith(nextIntBounded(_), list)
       }
@@ -71,6 +76,12 @@ package object random {
 
     val live: Layer[Nothing, Random] =
       ZLayer.succeed(Service.live)
+
+    def withSeed(seed: Long): Layer[Nothing, Random] =
+      ZLayer.succeed(Service.withSeed(seed))
+
+    def make(random: SRandom): Layer[Nothing, Random] =
+      ZLayer.succeed(Service.make(random))
 
     private[zio] def nextDoubleBetweenWith(minInclusive: Double, maxExclusive: Double)(
       nextDouble: UIO[Double]

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -36,6 +36,7 @@ object MockRandom extends Mock[Random] {
   object NextLongBounded   extends Effect[Long, Nothing, Long]
   object NextPrintableChar extends Effect[Unit, Nothing, Char]
   object NextString        extends Effect[Int, Nothing, String]
+  object SetSeed           extends Effect[Long, Nothing, Unit]
   object Shuffle           extends Effect[List[Any], Nothing, List[Any]]
 
   val compose: URLayer[Has[Proxy], Random] =
@@ -59,7 +60,8 @@ object MockRandom extends Mock[Random] {
           proxy(NextLongBetween, minInclusive, maxExclusive)
         def nextLongBounded(n: Long): UIO[Long]     = proxy(NextLongBounded, n)
         val nextPrintableChar: UIO[Char]            = proxy(NextPrintableChar)
-        def nextString(length: Int)                 = proxy(NextString, length)
+        def nextString(length: Int): UIO[String]    = proxy(NextString, length)
+        def setSeed(seed: Long): UIO[Unit]          = proxy(SetSeed, seed)
         def shuffle[A](list: List[A]): UIO[List[A]] = proxy(Shuffle, list).asInstanceOf[UIO[List[A]]]
       }
     )


### PR DESCRIPTION
A question in Discord brought up the fact that there currently doesn't seem to be a way to set the seed for Random.

This might be a little tricky in that Random is a "default" service that is already provided for you, but you could always override that with something like `provideLayer(random.Random.withSeed(5L))`.

Also, I'm not sure what the naming conventions would be in this situation. Some common names seem to be `default`, `live`, and `make`. And whether `live()` should take the params or not.

I went with keeping `live` the same and adding `withSeed` and `make`. But whatever is the most consistent is fine with me.