### PR TITLE
add Scalac logo to the Sponsors section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To learn more about ZIO, see the following references:
 
 # Sponsors
 
+[![Scalac][Image-Scalac]][Link-Scalac]
+
+[Scalac][Link-Scalac] sponsors ZIO Hackathons and contributes work to multiple projects in ZIO ecosystem.
+
 [![Septimal Mind][Image-SeptimalMind]][Link-SeptimalMind]
 
 [Septimal Mind][Link-SeptimalMind] sponsors work on ZIO Tracing and continuous maintenance.
@@ -38,6 +42,7 @@ To learn more about ZIO, see the following references:
 [![SoftwareMill][Image-SoftwareMill]][Link-SoftwareMill]
 
 [SoftwareMill][Link-SoftwareMill] generously provides ZIO with paid-for CircleCI build infrastructure.
+
 
 ---
 
@@ -68,6 +73,7 @@ Copyright 2017 - 2020 John A. De Goes and the ZIO Contributors. All rights reser
 [Link-SonatypeReleases]: https://oss.sonatype.org/content/repositories/releases/dev/zio/zio_2.12/ "Sonatype Releases"
 [Link-SonatypeSnapshots]: https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio_2.12/ "Sonatype Snapshots"
 [Link-Circle]: https://circleci.com/gh/zio/zio "circleci"
+[Link-Scalac]: https://scalac.io "Scalac"
 [Link-SoftwareMill]: https://softwaremill.com "SoftwareMill"
 [Link-SeptimalMind]: https://7mind.io "Septimal Mind"
 [Link-Discord]: https://discord.gg/2ccFBr4 "Discord"
@@ -82,5 +88,6 @@ Copyright 2017 - 2020 John A. De Goes and the ZIO Contributors. All rights reser
 [Badge-Discord]: https://img.shields.io/discord/629491597070827530?logo=discord "chat on discord"
 [Badge-Twitter]: https://img.shields.io/twitter/follow/zioscala.svg?style=plastic&label=follow&logo=twitter
 
+[Image-Scalac]: ./website/static/img/scalac.svg "Scalac"
 [Image-SoftwareMill]: ./website/static/img/softwaremill.svg "SoftwareMill"
 [Image-SeptimalMind]: ./website/static/img/septimal_mind.svg "Septimal Mind"


### PR DESCRIPTION
Adding missing Scalac logo to the Readme page. I'm assuming an alphabetical order in the Sponsors section.

The problem:
Scalac logo fills the whole width of the page which makes it too big and breaks the "esthetics". You can see it here https://github.com/jczuchnowski/zio/tree/scalac-logo-readme. 
Any ideas on how to resize the image in github? The usual Markdown way doesn't seem to work.