### PR TITLE
Consistent naming for ensuring* methods

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -28,7 +28,7 @@ object FiberRefSpecJvm extends ZIOBaseSpec {
 
         _      <- fiberRef.set(update1)
         thread <- UIO(new Thread(unsafelyGetSetGet))
-        _      <- UIO(thread.start()).ensuring(UIO(thread.join()))
+        _      <- UIO(thread.start()).ensuring_(UIO(thread.join()))
 
         value0                   <- fiberRef.get
         values                   <- UIO(resRef.get())

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -37,7 +37,7 @@ object RTSSpec extends ZIOBaseSpec {
         done  <- Ref.make(false)
         start <- IO.succeed(internal.OneShot.make[Unit])
         fiber <- blocking.effectBlockingInterrupt { start.set(()); Thread.sleep(60L * 60L * 1000L) }
-                  .ensuring(done.set(true))
+                  .ensuring_(done.set(true))
                   .fork
         _     <- IO.succeed(start.get())
         res   <- fiber.interrupt
@@ -130,7 +130,7 @@ object RTSSpec extends ZIOBaseSpec {
       def test =
         IO.effect(if (c.incrementAndGet() <= 1) throw new RuntimeException("x"))
           .forever
-          .ensuring(IO.unit)
+          .ensuring_(IO.unit)
           .either
           .forever
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -109,7 +109,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         for {
           p          <- Promise.make[Nothing, Unit]
           r          <- Ref.make(0)
-          _          <- r.update(_ + 2).repeat(Schedule.recurs(2)).ensuring(p.succeed(()))
+          _          <- r.update(_ + 2).repeat(Schedule.recurs(2)).ensuring_(p.succeed(()))
           v          <- r.get
           finalizerV <- p.poll
         } yield assert(v)(equalTo(6)) && assert(finalizerV.isDefined)(equalTo(true))
@@ -283,7 +283,7 @@ object ScheduleSpec extends ZIOBaseSpec {
       testM("run the specified finalizer as soon as the schedule is complete") {
         for {
           p          <- Promise.make[Nothing, Unit]
-          v          <- IO.fail("oh no").retry(Schedule.recurs(2)).ensuring(p.succeed(())).option
+          v          <- IO.fail("oh no").retry(Schedule.recurs(2)).ensuring_(p.succeed(())).option
           finalizerV <- p.poll
         } yield assert(v.isEmpty)(equalTo(true)) && assert(finalizerV.isDefined)(equalTo(true))
       }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1164,7 +1164,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("executes that a cleanup function runs when effect succeeds") {
         for {
           ref <- Ref.make(false)
-          _ <- ZIO.unit.onExit {
+          _ <- ZIO.unit.ensuring {
                 case Exit.Success(_) => ref.set(true)
                 case _               => UIO.unit
               }
@@ -1176,7 +1176,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ref <- Ref.make(false)
           _ <- ZIO
                 .die(new RuntimeException)
-                .onExit {
+                .ensuring {
                   case Exit.Failure(c) if c.died => ref.set(true)
                   case _                         => UIO.unit
                 }
@@ -1189,7 +1189,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           latch1 <- Promise.make[Nothing, Unit]
           latch2 <- Promise.make[Nothing, Unit]
-          fiber <- (latch1.succeed(()) *> ZIO.never).onExit {
+          fiber <- (latch1.succeed(()) *> ZIO.never).ensuring {
                     case Exit.Failure(c) if c.interrupted => latch2.succeed(())
                     case _                                => UIO.unit
                   }.fork

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -182,8 +182,12 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("Runs on failures") {
         for {
           effects <- Ref.make[List[String]](Nil)
-          _       <- ZManaged.fromEffect(ZIO.fail(())).ensuringBeforeRelease_(effects.update("Ensured" :: _)).use_(ZIO.unit).either
-          result  <- effects.get
+          _ <- ZManaged
+                .fromEffect(ZIO.fail(()))
+                .ensuringBeforeRelease_(effects.update("Ensured" :: _))
+                .use_(ZIO.unit)
+                .either
+          result <- effects.get
         } yield assert(result)(equalTo(List("Ensured")))
       } @@ zioTag(errors),
       testM("Works when finalizers have defects") {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1235,7 +1235,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           latch   <- Promise.make[Nothing, Unit]
           ref     <- Ref.make(0)
           managed = ZManaged.make(ZIO.unit)(_ => ref.update(_ + 1)).withEarlyRelease
-          _       <- managed.use(_._1).ensuring(latch.succeed(()))
+          _       <- managed.use(_._1).ensuring_(latch.succeed(()))
           _       <- latch.await
           result  <- ref.get
         } yield assert(result)(equalTo(1))

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -569,7 +569,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         managed.use(res => ZIO.succeed(assert(res)(isSome(equalTo(1)))))
       }
     ),
-    suite("onExitFirst")(
+    suite("ensuringBeforeRelease")(
       testM("Calls the cleanup") {
         for {
           finalizersRef <- Ref.make[List[String]](Nil)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -144,7 +144,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(effects.update("First" :: _))
-                .ensuring(effects.update("Second" :: _))
+                .ensuring_(effects.update("Second" :: _))
                 .use_(ZIO.unit)
           result <- effects.get
         } yield assert(result)(equalTo(List("Second", "First")))
@@ -152,7 +152,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("Runs on failures") {
         for {
           effects <- Ref.make[List[String]](Nil)
-          _       <- ZManaged.fromEffect(ZIO.fail(())).ensuring(effects.update("Ensured" :: _)).use_(ZIO.unit).either
+          _       <- ZManaged.fromEffect(ZIO.fail(())).ensuring_(effects.update("Ensured" :: _)).use_(ZIO.unit).either
           result  <- effects.get
         } yield assert(result)(equalTo(List("Ensured")))
       } @@ zioTag(errors),
@@ -161,7 +161,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(ZIO.dieMessage("Boom"))
-                .ensuring(effects.update("Ensured" :: _))
+                .ensuring_(effects.update("Ensured" :: _))
                 .use_(ZIO.unit)
                 .run
           result <- effects.get

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -174,7 +174,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(effects.update("First" :: _))
-                .ensuringBeforeRelease_(effects.update("Second" :: _))
+                .ensuringBeforeRelease(effects.update("Second" :: _))
                 .use_(ZIO.unit)
           result <- effects.get
         } yield assert(result)(equalTo(List("First", "Second")))
@@ -184,7 +184,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .fromEffect(ZIO.fail(()))
-                .ensuringBeforeRelease_(effects.update("Ensured" :: _))
+                .ensuringBeforeRelease(effects.update("Ensured" :: _))
                 .use_(ZIO.unit)
                 .either
           result <- effects.get
@@ -195,7 +195,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(ZIO.dieMessage("Boom"))
-                .ensuringBeforeRelease_(effects.update("Ensured" :: _))
+                .ensuringBeforeRelease(effects.update("Ensured" :: _))
                 .use_(ZIO.unit)
                 .run
           result <- effects.get
@@ -528,7 +528,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           resultRef     <- Ref.make[Option[Exit[Nothing, String]]](None)
           _ <- ZManaged
                 .make(UIO.succeed("42"))(_ => finalizersRef.update("First" :: _))
-                .onExit(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
+                .ensuring(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
           result     <- resultRef.get

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -521,14 +521,14 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(count)(equalTo(3))
       }
     ),
-    suite("onExit")(
+    suite("ensuring")(
       testM("Calls the cleanup") {
         for {
           finalizersRef <- Ref.make[List[String]](Nil)
           resultRef     <- Ref.make[Option[Exit[Nothing, String]]](None)
           _ <- ZManaged
                 .make(UIO.succeed("42"))(_ => finalizersRef.update("First" :: _))
-                .onExit(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
+                .ensuring(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
           result     <- resultRef.get

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -174,7 +174,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(effects.update("First" :: _))
-                .ensuringBeforeRelease(effects.update("Second" :: _))
+                .ensuringBeforeRelease_(effects.update("Second" :: _))
                 .use_(ZIO.unit)
           result <- effects.get
         } yield assert(result)(equalTo(List("First", "Second")))
@@ -184,7 +184,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .fromEffect(ZIO.fail(()))
-                .ensuringBeforeRelease(effects.update("Ensured" :: _))
+                .ensuringBeforeRelease_(effects.update("Ensured" :: _))
                 .use_(ZIO.unit)
                 .either
           result <- effects.get
@@ -195,7 +195,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           effects <- Ref.make[List[String]](Nil)
           _ <- ZManaged
                 .finalizer(ZIO.dieMessage("Boom"))
-                .ensuringBeforeRelease(effects.update("Ensured" :: _))
+                .ensuringBeforeRelease_(effects.update("Ensured" :: _))
                 .use_(ZIO.unit)
                 .run
           result <- effects.get
@@ -528,7 +528,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           resultRef     <- Ref.make[Option[Exit[Nothing, String]]](None)
           _ <- ZManaged
                 .make(UIO.succeed("42"))(_ => finalizersRef.update("First" :: _))
-                .ensuring(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
+                .onExit(e => finalizersRef.update("Second" :: _) *> resultRef.set(Some(e)))
                 .use_(ZIO.unit)
           finalizers <- finalizersRef.get
           result     <- resultRef.get

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -136,7 +136,7 @@ package object blocking {
                               withMutex { thread.set(None); end.set(()) }
                             }
                           }.forkDaemon
-                  a <- restore(fiber.join.refailWithTrace).ensuring(interruptThread)
+                  a <- restore(fiber.join.refailWithTrace).ensuring_(interruptThread)
                 } yield a
               )
             )

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -205,7 +205,7 @@ object RefM extends Serializable {
       interrupted.get.flatMap {
         case Some(cause) => onDefect(cause)
         case None =>
-          update(a).foldCauseM(c => onDefect(c).ensuring(promise.halt(c)), {
+          update(a).foldCauseM(c => onDefect(c).ensuring_(promise.halt(c)), {
             case (b, a) => ref.set(a) <* promise.succeed(b)
           })
       }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -508,7 +508,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * specified `finalizer` is guaranteed to begin execution, whether this effect
    * succeeds, fails, or is interrupted.
    *
-   * For use cases that need access to the effect's result, see [[ZIO#onExit]].
+   * For use cases that need access to the effect's result, see [[ZIO#ensuring]].
    *
    * Finalizers offer very powerful guarantees, but they are low-level, and
    * should generally not be used for releasing resources. For higher-level
@@ -923,7 +923,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Ensures that a cleanup functions runs, whether this effect succeeds,
    * fails, or is interrupted.
    */
-  final def onExit[R1 <: R](cleanup: Exit[E, A] => URIO[R1, Any]): ZIO[R1, E, A] =
+  final def ensuring[R1 <: R](cleanup: Exit[E, A] => URIO[R1, Any]): ZIO[R1, E, A] =
     ZIO.bracketExit(ZIO.unit)((_, exit: Exit[E, A]) => cleanup(exit))(_ => self)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -262,7 +262,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that `f` is executed when this ZManaged is finalized, after
    * the existing finalizer.
    *
-   * For usecases that need access to the ZManaged's result, see [[ZManaged#onExit]].
+   * For usecases that need access to the ZManaged's result, see [[ZManaged#ensuring]].
    */
   def ensuring_[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
@@ -524,7 +524,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */
-  def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuring[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -273,7 +273,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that `f` is executed when this ZManaged is finalized, before
    * the existing finalizer.
    *
-   * For usecases that need access to the ZManaged's result, see [[ZManaged#onExitFirst]].
+   * For usecases that need access to the ZManaged's result, see [[ZManaged#ensuringBeforeRelease]].
    */
   def ensuringBeforeRelease_[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -275,7 +275,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#ensuringBeforeRelease]].
    */
-  def ensuringBeforeRelease[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuringBeforeRelease_[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map(r => r.copy(release = e => f.ensuring(r.release(e))))
     }
@@ -524,7 +524,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */
-  def ensuring[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -264,7 +264,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#onExit]].
    */
-  def ensuring[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuring_[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map(r => r.copy(release = e => r.release(e).ensuring(f)))
     }

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -275,7 +275,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    *
    * For usecases that need access to the ZManaged's result, see [[ZManaged#ensuringBeforeRelease]].
    */
-  def ensuringBeforeRelease_[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuringBeforeRelease[R1 <: R](f: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       reserve.map(r => r.copy(release = e => f.ensuring(r.release(e))))
     }
@@ -524,7 +524,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Ensures that a cleanup function runs when this ZManaged is finalized, after
    * the existing finalizers.
    */
-  def onExit[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
+  def ensuring[R1 <: R](cleanup: Exit[E, A] => ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
     ZManaged {
       Ref.make[Exit[Any, Any] => ZIO[R1, Nothing, Any]](_ => UIO.unit).map { finalizer =>
         Reservation(

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -909,7 +909,7 @@ object ZSTM {
             val interrupt = UIO(Sync(done)(done.set(true)))
             val async     = ZIO.effectAsync(tryCommitAsync(journal, platform, fiberId, stm, txnId, done, r))
 
-            async ensuring interrupt
+            async ensuring_ interrupt
         }
       }
     }

--- a/docs/datatypes/io.md
+++ b/docs/datatypes/io.md
@@ -154,7 +154,7 @@ A helper method called `ensuring` provides a simpler analogue of `finally`:
 var i: Int = 0
 val action: Task[String] = Task.effectTotal(i += 1) *> Task.fail(new Throwable("Boom!"))
 val cleanupAction: UIO[Unit] = UIO.effectTotal(i -= 1)
-val composite = action.ensuring(cleanupAction)
+val composite = action.ensuring_(cleanupAction)
 ```
 ### A full working example on using brackets
 ```scala mdoc:silent

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -22,7 +22,7 @@ val finalizer =
   UIO.effectTotal(println("Finalizing!"))
 
 val finalized: IO[String, Unit] = 
-  IO.fail("Failed!").ensuring(finalizer)
+  IO.fail("Failed!").ensuring_(finalizer)
 ```
 
 The finalizer is not allowed to fail, which means that it must handle any errors internally.

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -594,13 +594,13 @@ object StreamSpec extends ZIOBaseSpec {
         execution <- log.get
       } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
     },
-    testM("Stream.ensuringFirst") {
+    testM("Stream.ensuringBeforeFinalizer") {
       for {
         log <- Ref.make[List[String]](Nil)
         _ <- (for {
               _ <- Stream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
               _ <- Stream.fromEffect(log.update("Use" :: _))
-            } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
+            } yield ()).ensuringBeforeFinalizer(log.update("Ensuring" :: _)).runDrain
         execution <- log.get
       } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
     },

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -260,7 +260,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                .repeatEffectOption(consume(stateVar, permits))
                .mapConcatChunk(identity)
                .process
-               .ensuringBeforeRelease(producer.interrupt.fork)
+               .ensuringBeforeRelease_(producer.interrupt.fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -562,7 +562,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                      )
                      .fork
         bs <- consumerStream(stateVar, permits).process
-               .ensuringBeforeRelease(producer.interruptAs(fiberId).fork)
+               .ensuringBeforeRelease_(producer.interruptAs(fiberId).fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -1232,7 +1232,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Executes the provided finalizer before this stream's finalizers run.
    */
   final def ensuringBeforeFinalizer[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
-    ZStream(self.process.ensuringBeforeRelease(fin))
+    ZStream(self.process.ensuringBeforeRelease_(fin))
 
   /**
    * Filters this stream by the specified predicate, retaining all elements for

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1226,7 +1226,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Executes the provided finalizer after this stream's finalizers run.
    */
   final def ensuring[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
-    ZStream(self.process.ensuring(fin))
+    ZStream(self.process.ensuring_(fin))
 
   /**
    * Executes the provided finalizer before this stream's finalizers run.
@@ -3236,7 +3236,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
                            .fold[Pull[R, E, Nothing]](done.set(true) *> output.shutdown *> Pull.end)(Pull.halt(_)),
                          Pull.emitNow
                        )
-                   }).ensuring(canceler)
+                   }).ensuring_(canceler)
                  case Right(stream) => output.shutdown.toManaged_ *> stream.process
                }
       } yield pull

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -260,7 +260,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                .repeatEffectOption(consume(stateVar, permits))
                .mapConcatChunk(identity)
                .process
-               .ensuringBeforeRelease_(producer.interrupt.fork)
+               .ensuringBeforeRelease(producer.interrupt.fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -562,7 +562,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                      )
                      .fork
         bs <- consumerStream(stateVar, permits).process
-               .ensuringBeforeRelease_(producer.interruptAs(fiberId).fork)
+               .ensuringBeforeRelease(producer.interruptAs(fiberId).fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -1232,7 +1232,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Executes the provided finalizer before this stream's finalizers run.
    */
   final def ensuringBeforeFinalizer[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
-    ZStream(self.process.ensuringBeforeRelease_(fin))
+    ZStream(self.process.ensuringBeforeRelease(fin))
 
   /**
    * Filters this stream by the specified predicate, retaining all elements for

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -260,7 +260,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                .repeatEffectOption(consume(stateVar, permits))
                .mapConcatChunk(identity)
                .process
-               .ensuringFirst(producer.interrupt.fork)
+               .ensuringBeforeRelease_(producer.interrupt.fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -562,7 +562,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                      )
                      .fork
         bs <- consumerStream(stateVar, permits).process
-               .ensuringFirst(producer.interruptAs(fiberId).fork)
+               .ensuringBeforeRelease_(producer.interruptAs(fiberId).fork)
       } yield bs
     }.flatMap(ZStream.repeatEffectOption)
   }
@@ -1232,7 +1232,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
    * Executes the provided finalizer before this stream's finalizers run.
    */
   final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
-    ZStream(self.process.ensuringFirst(fin))
+    ZStream(self.process.ensuringBeforeRelease_(fin))
 
   /**
    * Filters this stream by the specified predicate, retaining all elements for

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1231,7 +1231,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
   /**
    * Executes the provided finalizer before this stream's finalizers run.
    */
-  final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
+  final def ensuringBeforeFinalizer[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
     ZStream(self.process.ensuringBeforeRelease_(fin))
 
   /**
@@ -3431,7 +3431,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
    * Creates a stream from a [[zio.ZQueue]] of values. The queue will be shutdown once the stream is closed.
    */
   def fromQueueWithShutdown[R, E, A](queue: ZQueue[Nothing, Any, R, E, Nothing, A]): ZStream[R, E, A] =
-    fromQueue(queue).ensuringFirst(queue.shutdown)
+    fromQueue(queue).ensuringBeforeFinalizer(queue.shutdown)
 
   /**
    * Creates a stream from a [[zio.Schedule]] that does not require any further

--- a/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamChunk.scala
@@ -239,7 +239,7 @@ class ZStreamChunk[-R, +E, +A](val chunks: ZStream[R, E, Chunk[A]]) extends Seri
    * Executes the provided finalizer before this stream's finalizers run.
    */
   final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStreamChunk[R1, E, A] =
-    ZStreamChunk(chunks.ensuringFirst(fin))
+    ZStreamChunk(chunks.ensuringBeforeFinalizer(fin))
 
   /**
    * Returns a stream whose failures and successes have been lifted into an


### PR DESCRIPTION
The goal of this change is to improve usability of methods performing effects before and after finalizers.
This can be achieved by using consistent naming scheme. 
It is all about convenience of usage and making this functionality easy to discover and use.
- [x] propose a naming scheme
- [ ] check test names and adjust them accordingly
- [ ] sort methods in file (by name)
