### PR TITLE
Add AssertionM for effectfull assertions.

### DIFF
--- a/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
+++ b/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
@@ -27,17 +27,17 @@ object DeriveGenSpec extends DefaultRunnableSpec {
 
   sealed trait NonEmptyList[+A] { self =>
     def foldLeft[S](s: S)(f: (S, A) => S): S =
-     self match {
-       case NonEmptyList.Cons(h, t) => t.foldLeft(f(s, h))(f)
-       case NonEmptyList.Single(h)  => f(s, h)
-     }
+      self match {
+        case NonEmptyList.Cons(h, t) => t.foldLeft(f(s, h))(f)
+        case NonEmptyList.Single(h)  => f(s, h)
+      }
     def length: Int =
-     foldLeft(0)((s, _) => s + 1)
+      foldLeft(0)((s, _) => s + 1)
   }
 
   object NonEmptyList {
     final case class Cons[+A](head: A, tail: NonEmptyList[A]) extends NonEmptyList[A]
-    final case class Single[+A](value: A) extends NonEmptyList[A]
+    final case class Single[+A](value: A)                     extends NonEmptyList[A]
   }
 
   def genNonEmptyList[A](implicit ev: DeriveGen[A]): Gen[Random with Sized, NonEmptyList[A]] =
@@ -54,9 +54,7 @@ object DeriveGenSpec extends DefaultRunnableSpec {
         checkSample(genColor)(equalTo(3), _.distinct.length)
       },
       testM("recursive types can be derived") {
-        check(genNonEmptyList[Int]) { as =>
-          assert(as.length)(isGreaterThan(0))
-        }
+        check(genNonEmptyList[Int])(as => assert(as.length)(isGreaterThan(0)))
       }
     ),
     suite("instances")(
@@ -87,7 +85,7 @@ object DeriveGenSpec extends DefaultRunnableSpec {
     suite("shrinking")(
       testM("derived generators shrink to smallest value") {
         checkShrink(genPerson)(Person("", 0))
-      },
+      }
     )
   )
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -19,7 +19,8 @@ package zio.test
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
-import zio.{ Cause, Exit }
+import zio.test.AssertionM.RenderParam
+import zio.{ Cause, Exit, ZIO }
 
 /**
  * An `Assertion[A]` is capable of producing assertion results on an `A`. As a
@@ -29,8 +30,11 @@ import zio.{ Cause, Exit }
 final class Assertion[-A] private (
   val render: Assertion.Render,
   val run: (=> A) => AssertResult
-) extends ((=> A) => AssertResult) { self =>
+) extends ((=> A) => AssertResult)
+    with AssertionM[A] { self =>
   import zio.test.Assertion.Render._
+
+  def runM: (=> A) => AssertResultM = a => BoolAlgebraM(ZIO.succeed(run(a)))
 
   /**
    * Returns a new assertion that succeeds only if both assertions succeed.
@@ -41,7 +45,7 @@ final class Assertion[-A] private (
   /**
    * A symbolic alias for `label`.
    */
-  def ??(string: String): Assertion[A] =
+  override def ??(string: String): Assertion[A] =
     label(string)
 
   /**
@@ -66,13 +70,13 @@ final class Assertion[-A] private (
   /**
    * Labels this assertion with the specified string.
    */
-  def label(string: String): Assertion[A] =
+  override def label(string: String): Assertion[A] =
     new Assertion(infix(param(self), "??", param(quoted(string))), run)
 
   /**
    * Returns the negation of this assertion.
    */
-  def negate: Assertion[A] =
+  override def negate: Assertion[A] =
     Assertion.not(self)
 
   /**
@@ -89,91 +93,9 @@ final class Assertion[-A] private (
 }
 
 object Assertion extends AssertionVariants {
-  import zio.test.Assertion.Render._
-
-  /**
-   * `Render` captures both the name of an assertion as well as the parameters
-   * to the assertion combinator for pretty-printing.
-   */
-  sealed trait Render {
-    override final def toString: String = this match {
-      case Render.Function(name, paramLists) =>
-        name + paramLists.map(_.mkString("(", ", ", ")")).mkString
-      case Render.Infix(left, op, right) =>
-        "(" + left + " " + op + " " + right + ")"
-    }
-  }
-  object Render {
-    final case class Function(name: String, paramLists: List[List[RenderParam]]) extends Render
-    final case class Infix(left: RenderParam, op: String, right: RenderParam)    extends Render
-
-    /**
-     * Creates a string representation of a class name.
-     */
-    def className[A](C: ClassTag[A]): String =
-      try {
-        C.runtimeClass.getSimpleName
-      } catch {
-        // See https://github.com/scala/bug/issues/2034.
-        case t: InternalError if t.getMessage == "Malformed class name" =>
-          C.runtimeClass.getName
-      }
-
-    /**
-     * Creates a string representation of a field accessor.
-     */
-    def field(name: String): String =
-      "_." + name
-
-    /**
-     * Create a `Render` from an assertion combinator that should be rendered
-     * using standard function notation.
-     */
-    def function(name: String, paramLists: List[List[RenderParam]]): Render =
-      Render.Function(name, paramLists)
-
-    /**
-     * Create a `Render` from an assertion combinator that should be rendered
-     * using infix function notation.
-     */
-    def infix(left: RenderParam, op: String, right: RenderParam): Render =
-      Render.Infix(left, op, right)
-
-    /**
-     * Construct a `RenderParam` from an `Assertion`.
-     */
-    def param[A](assertion: Assertion[A]): RenderParam =
-      RenderParam.Assertion(assertion)
-
-    /**
-     * Construct a `RenderParam` from a value.
-     */
-    def param[A](value: A): RenderParam =
-      RenderParam.Value(value)
-
-    /**
-     * Quote a string so it renders as a valid Scala string when rendered.
-     */
-    def quoted(string: String): String =
-      "\"" + string + "\""
-
-    /**
-     * Creates a string representation of an unapply method for a term.
-     */
-    def unapply(termName: String): String =
-      termName + ".unapply"
-  }
-
-  sealed trait RenderParam {
-    override final def toString: String = this match {
-      case RenderParam.Assertion(assertion) => assertion.toString
-      case RenderParam.Value(value)         => value.toString
-    }
-  }
-  object RenderParam {
-    final case class Assertion[A](assertion: zio.test.Assertion[A]) extends RenderParam
-    final case class Value(value: Any)                              extends RenderParam
-  }
+  type Render = AssertionM.Render
+  val Render = AssertionM.Render
+  import Render._
 
   /**
    * Makes a new assertion that always succeeds.
@@ -186,8 +108,11 @@ object Assertion extends AssertionVariants {
    */
   def assertion[A](name: String)(params: RenderParam*)(run: (=> A) => Boolean): Assertion[A] = {
     lazy val assertion: Assertion[A] = assertionDirect(name)(params: _*) { actual =>
-      if (run(actual)) BoolAlgebra.success(AssertionValue(assertion, actual))
-      else BoolAlgebra.failure(AssertionValue(assertion, actual))
+      lazy val tryActual = Try(actual)
+      lazy val result: AssertResult =
+        if (run(tryActual.get)) BoolAlgebra.success(AssertionValue(assertion, tryActual.get, result))
+        else BoolAlgebra.failure(AssertionValue(assertion, tryActual.get, result))
+      result
     }
     assertion
   }
@@ -214,17 +139,21 @@ object Assertion extends AssertionVariants {
     name: String
   )(params: RenderParam*)(
     assertion: Assertion[B]
-  )(get: (=> A) => Option[B], orElse: AssertionValue => AssertResult = BoolAlgebra.failure): Assertion[A] = {
-    lazy val result: Assertion[A] = assertionDirect(name)(params: _*) { a =>
-      get(a) match {
+  )(get: (=> A) => Option[B], orElse: AssertionData => AssertResult = _.asFailure): Assertion[A] = {
+    lazy val resultAssertion: Assertion[A] = assertionDirect(name)(params: _*) { a =>
+      lazy val tryA = Try(a)
+      get(tryA.get) match {
         case Some(b) =>
-          if (assertion.test(b)) BoolAlgebra.success(AssertionValue(result, a))
-          else BoolAlgebra.failure(AssertionValue(assertion, b))
+          val innerResult = assertion.run(b)
+          lazy val result: AssertResult =
+            if (innerResult.isSuccess) BoolAlgebra.success(AssertionValue(resultAssertion, tryA.get, result))
+            else BoolAlgebra.failure(AssertionValue(assertion, b, innerResult))
+          result
         case None =>
-          orElse(AssertionValue(result, a))
+          orElse(AssertionData(resultAssertion, tryA.get))
       }
     }
-    result
+    resultAssertion
   }
 
   /**
@@ -333,7 +262,7 @@ object Assertion extends AssertionVariants {
   def forall[A](assertion: Assertion[A]): Assertion[Iterable[A]] =
     Assertion.assertionRec("forall")(param(assertion))(assertion)(
       _.find(!assertion.test(_)),
-      BoolAlgebra.success
+      _.asSuccess
     )
 
   /**

--- a/test/shared/src/main/scala/zio/test/AssertionData.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionData.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.ZIO
+
+sealed trait AssertionData {
+  type Value
+  def value: Value
+  val assertion: Assertion[Value]
+
+  lazy val asFailure: AssertResult = BoolAlgebra.failure(AssertionValue(assertion, value, result = asFailure))
+  lazy val asSuccess: AssertResult = BoolAlgebra.success(AssertionValue(assertion, value, result = asSuccess))
+}
+
+object AssertionData {
+  def apply[A](assertion0: Assertion[A], value0: => A): AssertionData =
+    new AssertionData {
+      type Value = A
+      lazy val value: Value           = value0
+      val assertion: Assertion[Value] = assertion0
+    }
+}
+
+sealed trait AssertionMData {
+  type Value
+  def value: Value
+  val assertion: AssertionM[Value]
+
+  lazy val asFailure: AssertResult = BoolAlgebra.failure(AssertionValue(assertion, value, result = asFailure))
+  lazy val asSuccess: AssertResult = BoolAlgebra.success(AssertionValue(assertion, value, result = asSuccess))
+
+  def asFailureM: AssertResultM = BoolAlgebraM(ZIO.succeed(asFailure))
+  def asSuccessM: AssertResultM = BoolAlgebraM(ZIO.succeed(asSuccess))
+}
+
+object AssertionMData {
+  def apply[A](assertion0: AssertionM[A], value0: => A): AssertionMData =
+    new AssertionMData {
+      type Value = A
+      lazy val value: Value            = value0
+      val assertion: AssertionM[Value] = assertion0
+    }
+}

--- a/test/shared/src/main/scala/zio/test/AssertionM.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionM.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+import zio.ZIO
+
+/**
+ * An `AssertionM[A]` is capable of producing assertion results on an `A`. As a
+ * proposition, assertions compose using logical conjunction and disjunction,
+ * and can be negated.
+ */
+trait AssertionM[-A] { self =>
+  import zio.test.AssertionM.Render._
+
+  def render: AssertionM.Render
+  def runM: (=> A) => AssertResultM
+
+  /**
+   * Returns a new assertion that succeeds only if both assertions succeed.
+   */
+  def &&[A1 <: A](that: => AssertionM[A1]): AssertionM[A1] =
+    AssertionM(infix(param(self), "&&", param(that)), actual => self.runM(actual) && that.runM(actual))
+
+  /**
+   * A symbolic alias for `label`.
+   */
+  def ??(string: String): AssertionM[A] =
+    label(string)
+
+  /**
+   * Returns a new assertion that succeeds if either assertion succeeds.
+   */
+  def ||[A1 <: A](that: => AssertionM[A1]): AssertionM[A1] =
+    AssertionM(infix(param(self), "||", param(that)), actual => self.runM(actual) || that.runM(actual))
+
+  override def equals(that: Any): Boolean = that match {
+    case that: AssertionM[_] => this.toString == that.toString
+  }
+
+  override def hashCode: Int =
+    toString.hashCode
+
+  /**
+   * Labels this assertion with the specified string.
+   */
+  def label(string: String): AssertionM[A] =
+    AssertionM(infix(param(self), "??", param(quoted(string))), runM)
+
+  /**
+   * Returns the negation of this assertion.
+   */
+  def negate: AssertionM[A] =
+    AssertionM.not(self)
+
+  /**
+   * Provides a meaningful string rendering of the assertion.
+   */
+  override def toString: String =
+    render.toString
+}
+
+object AssertionM {
+  import zio.test.AssertionM.Render._
+
+  def apply[A](_render: Render, _runM: (=> A) => AssertResultM): AssertionM[A] = new AssertionM[A] {
+    val render: Render                = _render
+    val runM: (=> A) => AssertResultM = _runM
+  }
+
+  /**
+   * `Render` captures both the name of an assertion as well as the parameters
+   * to the assertion combinator for pretty-printing.
+   */
+  sealed trait Render {
+    override final def toString: String = this match {
+      case Render.Function(name, paramLists) =>
+        name + paramLists.map(_.mkString("(", ", ", ")")).mkString
+      case Render.Infix(left, op, right) =>
+        "(" + left + " " + op + " " + right + ")"
+    }
+  }
+  object Render {
+    final case class Function(name: String, paramLists: List[List[RenderParam]]) extends Render
+    final case class Infix(left: RenderParam, op: String, right: RenderParam)    extends Render
+
+    /**
+     * Creates a string representation of a class name.
+     */
+    def className[A](C: ClassTag[A]): String =
+      try {
+        C.runtimeClass.getSimpleName
+      } catch {
+        // See https://github.com/scala/bug/issues/2034.
+        case t: InternalError if t.getMessage == "Malformed class name" =>
+          C.runtimeClass.getName
+      }
+
+    /**
+     * Creates a string representation of a field accessor.
+     */
+    def field(name: String): String =
+      "_." + name
+
+    /**
+     * Create a `Render` from an assertion combinator that should be rendered
+     * using standard function notation.
+     */
+    def function(name: String, paramLists: List[List[RenderParam]]): Render =
+      Render.Function(name, paramLists)
+
+    /**
+     * Create a `Render` from an assertion combinator that should be rendered
+     * using infix function notation.
+     */
+    def infix(left: RenderParam, op: String, right: RenderParam): Render =
+      Render.Infix(left, op, right)
+
+    /**
+     * Construct a `RenderParam` from an `AssertionM`.
+     */
+    def param[A](assertion: AssertionM[A]): RenderParam =
+      RenderParam.AssertionM(assertion)
+
+    /**
+     * Construct a `RenderParam` from a value.
+     */
+    def param[A](value: A): RenderParam =
+      RenderParam.Value(value)
+
+    /**
+     * Quote a string so it renders as a valid Scala string when rendered.
+     */
+    def quoted(string: String): String =
+      "\"" + string + "\""
+
+    /**
+     * Creates a string representation of an unapply method for a term.
+     */
+    def unapply(termName: String): String =
+      termName + ".unapply"
+  }
+
+  sealed trait RenderParam {
+    override final def toString: String = this match {
+      case RenderParam.AssertionM(assertion) => assertion.toString
+      case RenderParam.Value(value)          => value.toString
+    }
+  }
+  object RenderParam {
+    final case class AssertionM[A](assertion: zio.test.AssertionM[A]) extends RenderParam
+    final case class Value(value: Any)                                extends RenderParam
+  }
+
+  /**
+   * Makes a new `AssertionM` from a pretty-printing and a function.
+   */
+  def assertionM[R, E, A](
+    name: String
+  )(params: RenderParam*)(run: (=> A) => ZIO[Any, Nothing, Boolean]): AssertionM[A] = {
+    lazy val assertion: AssertionM[A] = assertionDirect(name)(params: _*) { actual =>
+      lazy val tryActual = Try(actual)
+      BoolAlgebraM.fromEffect(run(tryActual.get)).flatMap { p =>
+        lazy val result: AssertResult =
+          if (p) BoolAlgebra.success(AssertionValue(assertion, tryActual.get, result))
+          else BoolAlgebra.failure(AssertionValue(assertion, tryActual.get, result))
+        BoolAlgebraM(ZIO.succeed(result))
+      }
+    }
+    assertion
+  }
+
+  /**
+   * Makes a new `AssertionM` from a pretty-printing and a function.
+   */
+  def assertionDirect[A](
+    name: String
+  )(params: RenderParam*)(run: (=> A) => AssertResultM): AssertionM[A] =
+    AssertionM(function(name, List(params.toList)), run)
+
+  def assertionRecM[R, E, A, B](
+    name: String
+  )(params: RenderParam*)(
+    assertion: AssertionM[B]
+  )(
+    get: (=> A) => ZIO[Any, Nothing, Option[B]],
+    orElse: AssertionMData => AssertResultM = _.asFailureM
+  ): AssertionM[A] = {
+    lazy val resultAssertion: AssertionM[A] = assertionDirect(name)(params: _*) { a =>
+      lazy val tryA = Try(a)
+      BoolAlgebraM.fromEffect(get(tryA.get)).flatMap {
+        case Some(b) =>
+          BoolAlgebraM(assertion.runM(b).run.map { p =>
+            lazy val result: AssertResult =
+              if (p.isSuccess) BoolAlgebra.success(AssertionValue(resultAssertion, tryA.get, result))
+              else BoolAlgebra.failure(AssertionValue(assertion, b, p))
+            result
+          })
+        case None =>
+          orElse(AssertionMData(resultAssertion, tryA.get))
+      }
+    }
+    resultAssertion
+  }
+
+  /**
+   * Makes a new assertion that negates the specified assertion.
+   */
+  def not[A](assertion: AssertionM[A]): AssertionM[A] =
+    AssertionM.assertionDirect("not")(param(assertion))(!assertion.runM(_))
+
+}

--- a/test/shared/src/main/scala/zio/test/BoolAlgebraM.scala
+++ b/test/shared/src/main/scala/zio/test/BoolAlgebraM.scala
@@ -1,0 +1,49 @@
+package zio.test
+
+import zio.ZIO
+import zio.test.BoolAlgebraM._
+
+final case class BoolAlgebraM[-R, +E, +A](run: ZIO[R, E, BoolAlgebra[A]]) { self =>
+
+  def &&[R1 <: R, E1 >: E, A1 >: A](that: BoolAlgebraM[R1, E1, A1]): BoolAlgebraM[R1, E1, A1] =
+    BoolAlgebraM(run.zipWith(that.run)(_ && _))
+
+  def ||[R1 <: R, E1 >: E, A1 >: A](that: BoolAlgebraM[R1, E1, A1]): BoolAlgebraM[R1, E1, A1] =
+    BoolAlgebraM(run.zipWith(that.run)(_ || _))
+
+  def ==>[R1 <: R, E1 >: E, A1 >: A](that: BoolAlgebraM[R1, E1, A1]): BoolAlgebraM[R1, E1, A1] =
+    BoolAlgebraM(run.zipWith(that.run)(_ ==> _))
+
+  def <==>[R1 <: R, E1 >: E, A1 >: A](that: BoolAlgebraM[R1, E1, A1]): BoolAlgebraM[R1, E1, A1] =
+    BoolAlgebraM(run.zipWith(that.run)(_ <==> _))
+
+  def unary_! : BoolAlgebraM[R, E, A] =
+    BoolAlgebraM(run.map(!_))
+
+  def as[B](b: B): BoolAlgebraM[R, E, B] =
+    map(_ => b)
+
+  def flatMap[R1 <: R, E1 >: E, B](f: A => BoolAlgebraM[R1, E1, B]): BoolAlgebraM[R1, E1, B] =
+    BoolAlgebraM(run.flatMap(_.flatMapM(f(_).run)))
+
+  def implies[R1 <: R, E1 >: E, A1 >: A](that: BoolAlgebraM[R1, E1, A1]): BoolAlgebraM[R1, E1, A1] =
+    BoolAlgebraM(run.zipWith(that.run)(_ implies _))
+
+  def isSuccess: ZIO[R, E, Boolean] =
+    run.map(_.isSuccess)
+
+  def map[B](f: A => B): BoolAlgebraM[R, E, B] =
+    flatMap(f andThen success)
+}
+
+object BoolAlgebraM {
+
+  def failure[A](a: A): BoolAlgebraM[Any, Nothing, A] =
+    BoolAlgebraM(ZIO.succeedNow(BoolAlgebra.failure(a)))
+
+  def fromEffect[R, E, A](effect: ZIO[R, E, A]): BoolAlgebraM[R, E, A] =
+    BoolAlgebraM(effect.map(BoolAlgebra.success))
+
+  def success[A](a: A): BoolAlgebraM[Any, Nothing, A] =
+    BoolAlgebraM(ZIO.succeedNow(BoolAlgebra.success(a)))
+}

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -263,11 +263,8 @@ object FailureRenderer {
   import FailureMessage._
 
   def renderFailureDetails(failureDetails: FailureDetails, offset: Int): Message =
-    failureDetails match {
-      case FailureDetails(assertionFailureDetails, genFailureDetails) =>
-        renderGenFailureDetails(genFailureDetails, offset) ++
-          renderAssertionFailureDetails(assertionFailureDetails, offset)
-    }
+    renderGenFailureDetails(failureDetails.gen, offset) ++
+      renderAssertionFailureDetails(failureDetails.assertion, offset)
 
   private def renderAssertionFailureDetails(failureDetails: ::[AssertionValue], offset: Int): Message = {
     def loop(failureDetails: List[AssertionValue], rendered: Message): Message =
@@ -303,14 +300,14 @@ object FailureRenderer {
     withOffset(offset + tabSize) {
       blue(whole.value.toString) +
         renderSatisfied(whole) ++
-        highlight(cyan(whole.assertion.toString), fragment.assertion.toString)
+        highlight(cyan(whole.printAssertion), fragment.printAssertion)
     }
 
   private def renderFragment(fragment: AssertionValue, offset: Int): Line =
     withOffset(offset + tabSize) {
       blue(fragment.value.toString) +
         renderSatisfied(fragment) +
-        cyan(fragment.assertion.toString)
+        cyan(fragment.printAssertion)
     }
 
   private def highlight(fragment: Fragment, substring: String, colorCode: String = AnsiColor.YELLOW): Line = {
@@ -325,7 +322,7 @@ object FailureRenderer {
   }
 
   private def renderSatisfied(fragment: AssertionValue): Fragment =
-    if (fragment.assertion.test(fragment.value)) Fragment(" satisfied ")
+    if (fragment.result.isSuccess) Fragment(" satisfied ")
     else Fragment(" did not satisfy ")
 
   def renderCause(cause: Cause[Any], offset: Int): Message =

--- a/test/shared/src/main/scala/zio/test/FailureDetails.scala
+++ b/test/shared/src/main/scala/zio/test/FailureDetails.scala
@@ -24,7 +24,7 @@ final case class FailureDetails(assertion: ::[AssertionValue], gen: Option[GenFa
   def label(string: String): FailureDetails =
     FailureDetails(
       assertion match {
-        case h :: t => ::(AssertionValue(h.assertion.label(string), h.value), t)
+        case h :: t => ::(h.label(string), t)
       },
       gen
     )

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -16,6 +16,8 @@
 
 package zio
 
+import scala.util.Try
+
 import zio.console.Console
 import zio.duration.Duration
 import zio.stream.{ ZSink, ZStream }
@@ -49,7 +51,8 @@ package object test extends CompileVariants {
   type Sized       = Has[Sized.Service]
   type TestLogger  = Has[TestLogger.Service]
 
-  type AssertResult = BoolAlgebra[AssertionValue]
+  type AssertResultM = BoolAlgebraM[Any, Nothing, AssertionValue]
+  type AssertResult  = BoolAlgebra[AssertionValue]
 
   /**
    * A `TestAspectAtLeast[R]` is a `TestAspect` that requires at least an `R` in its environment.
@@ -130,24 +133,29 @@ package object test extends CompileVariants {
    */
   type Annotated[+A] = (A, TestAnnotationMap)
 
-  /**
-   * Checks the assertion holds for the given value.
-   */
-  def assert[A](value: => A)(assertion: Assertion[A]): TestResult =
-    assertion.run(value).flatMap { fragment =>
+  private def traverseResult[A](value: => A, assertResult: AssertResult, assertion: AssertionM[A]): TestResult =
+    assertResult.flatMap { fragment =>
       def loop(whole: AssertionValue, failureDetails: FailureDetails): TestResult =
-        if (whole.assertion == failureDetails.assertion.head.assertion)
+        if (whole.sameAssertion(failureDetails.assertion.head))
           BoolAlgebra.success(failureDetails)
         else {
-          val satisfied = whole.assertion.test(whole.value)
-          val fragment  = whole.assertion.run(whole.value)
-          val result    = if (satisfied) fragment else !fragment
+          val fragment = whole.result
+          val result   = if (fragment.isSuccess) fragment else !fragment
           result.flatMap { fragment =>
             loop(fragment, FailureDetails(::(whole, failureDetails.assertion), failureDetails.gen))
           }
         }
-      loop(fragment, FailureDetails(::(AssertionValue(assertion, value), Nil)))
+
+      loop(fragment, FailureDetails(::(AssertionValue(assertion, value, assertResult), Nil)))
     }
+
+  /**
+   * Checks the assertion holds for the given value.
+   */
+  def assert[A](value: => A)(assertion: Assertion[A]): TestResult = {
+    lazy val tryValue = Try(value)
+    traverseResult(tryValue.get, assertion.run(tryValue.get), assertion)
+  }
 
   /**
    * Asserts that the given test was completed.
@@ -158,8 +166,11 @@ package object test extends CompileVariants {
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  def assertM[R, E, A](value: ZIO[R, E, A])(assertion: Assertion[A]): ZIO[R, E, TestResult] =
-    value.map(assert(_)(assertion))
+  def assertM[R, E, A](effect: ZIO[R, E, A])(assertion: AssertionM[A]): ZIO[R, E, TestResult] =
+    for {
+      value        <- effect
+      assertResult <- assertion.runM(value).run
+    } yield traverseResult(value, assertResult, assertion)
 
   /**
    * Checks the test passes for "sufficient" numbers of samples from the
@@ -646,7 +657,7 @@ package object test extends CompileVariants {
             ZIO.succeedNow {
               BoolAlgebra.success {
                 FailureDetails(
-                  ::(AssertionValue(Assertion.anything, ()), Nil)
+                  ::(AssertionValue(Assertion.anything, (), Assertion.anything.run(())), Nil)
                 )
               }
             }


### PR DESCRIPTION
Add `result` field to `AssertionValue` to avoid test reevaluation.
Protect `AssertionValue.assertion` to avoid test reevaluation.

Use `lazy val tryValue = Try(value)` to avoid exception reevaluation:
`lazy val` stores only successful case.

This `PR` reverts #3307 in a sense, but without effects in `Assertion` class. So we can use `Assertion` in pure computations.