### PR TITLE
Improve TArray's performance

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -15,7 +15,7 @@ import zio._
 class TArrayOpsBenchmarks {
   import IOBenchmarks.unsafeRun
 
-  @Param(Array("0", "10", "100", "1000", "10000", "100000"))
+  @Param(Array("10", "100", "1000", "10000", "100000"))
   var size: Int = _
 
   private var idx: Int           = _
@@ -59,6 +59,14 @@ class TArrayOpsBenchmarks {
   @Benchmark
   def indexWhereM(): Int = 
     unsafeRun(array.indexWhereM(a => STM.succeedNow(a == size)).commit)
+
+  @Benchmark
+  def reduceOption(): Option[Int] =
+    unsafeRun(array.reduceOption(_ + _).commit)
+
+  @Benchmark
+  def reduceOptionM(): Option[Int] =
+    unsafeRun(array.reduceOptionM((a, b) => STM.succeedNow(a + b)).commit)
 
   @Benchmark
   def transform(): Unit =

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -53,11 +53,11 @@ class TArrayOpsBenchmarks {
     unsafeRun(array.foldM(0)((acc, e) => STM.succeedNow(acc + e)).commit)
 
   @Benchmark
-  def indexWhere(): Int = 
+  def indexWhere(): Int =
     unsafeRun(array.indexWhere(_ == size).commit)
 
   @Benchmark
-  def indexWhereM(): Int = 
+  def indexWhereM(): Int =
     unsafeRun(array.indexWhereM(a => STM.succeedNow(a == size)).commit)
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -38,11 +38,11 @@ class TArrayOpsBenchmarks {
 
   @Benchmark
   def find(): Option[Int] =
-    unsafeRun(array.find(_ == (size - 1)).commit)
+    unsafeRun(array.find(_ == size).commit)
 
   @Benchmark
   def findM(): Option[Int] =
-    unsafeRun(array.findM(i => STM.succeedNow(i == (size - 1))).commit)
+    unsafeRun(array.findM(a => STM.succeedNow(a == size)).commit)
 
   @Benchmark
   def fold(): Int =
@@ -51,6 +51,14 @@ class TArrayOpsBenchmarks {
   @Benchmark
   def foldM(): Int =
     unsafeRun(array.foldM(0)((acc, e) => STM.succeedNow(acc + e)).commit)
+
+  @Benchmark
+  def indexWhere(): Int = 
+    unsafeRun(array.indexWhere(_ == size).commit)
+
+  @Benchmark
+  def indexWhereM(): Int = 
+    unsafeRun(array.indexWhereM(a => STM.succeedNow(a == size)).commit)
 
   @Benchmark
   def transform(): Unit =

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -1,0 +1,70 @@
+package zio.stm
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(1)
+class TArrayOpsBenchmarks {
+  import IOBenchmarks.unsafeRun
+
+  @Param(Array("0", "10", "100", "1000", "10000", "100000"))
+  var size: Int = _
+
+  private var idx: Int           = _
+  private var array: TArray[Int] = _
+
+  // used to ammortize the relative cost of unsafeRun
+  // compared to benchmarked operations
+  private val calls = List.fill(500)(false)
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val data = (1 to size).toList
+    idx = size / 2
+    array = unsafeRun(TArray.fromIterable(data).commit)
+  }
+
+  @Benchmark
+  def lookup(): Unit =
+    unsafeRun(ZIO.foreach_(calls)(_ => array(idx).commit))
+
+  @Benchmark
+  def find(): Option[Int] =
+    unsafeRun(array.find(_ == (size - 1)).commit)
+
+  @Benchmark
+  def findM(): Option[Int] =
+    unsafeRun(array.findM(i => STM.succeedNow(i == (size - 1))).commit)
+
+  @Benchmark
+  def fold(): Int =
+    unsafeRun(array.fold(0)(_ + _).commit)
+
+  @Benchmark
+  def foldM(): Int =
+    unsafeRun(array.foldM(0)((acc, e) => STM.succeedNow(acc + e)).commit)
+
+  @Benchmark
+  def transform(): Unit =
+    unsafeRun(array.transform(_ + 1).commit)
+
+  @Benchmark
+  def transformM(): Unit =
+    unsafeRun(array.transformM(i => STM.succeedNow(i + 1)).commit)
+
+  @Benchmark
+  def update(): Unit =
+    unsafeRun(ZIO.foreach_(calls)(_ => array.update(idx, _ + 1).commit))
+
+  @Benchmark
+  def updateM(): Unit =
+    unsafeRun(ZIO.foreach_(calls)(_ => array.updateM(idx, i => STM.succeedNow(i + 1)).commit))
+}

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -163,7 +163,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically folds using a transactional function.
    */
   def foldM[E, Z](zero: Z)(op: (Z, A) => STM[E, Z]): STM[E, Z] =
-    toChunk.flatMap(_.foldLeft[STM[E, Z]](STM.succeedNow(zero))((tx, a) => tx.flatMap(op(_, a))))
+    toChunk.flatMap(STM.foldLeft(_)(zero)(op))
 
   /**
    * Atomically evaluate the conjunction of a predicate across the members

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -28,8 +28,10 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Extracts value from ref in array.
    */
   def apply(index: Int): USTM[A] =
-    if (0 <= index && index < array.length) array(index).get
-    else STM.die(new ArrayIndexOutOfBoundsException(index))
+    if (0 <= index && index < array.length) 
+      array(index).get
+    else 
+      STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Finds the result of applying a partial function to the first value in its domain.
@@ -138,7 +140,8 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically folds using a transactional function.
    */
   def foldM[E, Z](acc: Z)(op: (Z, A) => STM[E, Z]): STM[E, Z] =
-    if (array.isEmpty) STM.succeedNow(acc)
+    if (array.isEmpty) 
+      STM.succeedNow(acc)
     else
       array.head.get.flatMap(a => op(acc, a).flatMap(acc2 => new TArray(array.tail).foldM(acc2)(op)))
 
@@ -305,8 +308,10 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Updates element in the array with given function.
    */
   def update(index: Int, fn: A => A): USTM[Unit] =
-    if (0 <= index && index < array.length) array(index).update(fn)
-    else STM.die(new ArrayIndexOutOfBoundsException(index))
+    if (0 <= index && index < array.length) 
+      array(index).update(fn)
+    else 
+      STM.die(new ArrayIndexOutOfBoundsException(index))
 
   /**
    * Atomically updates element in the array with given transactional effect.

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -309,7 +309,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically reduce the non-empty array using a transactional binary operator.
    */
   def reduceOptionM[E](op: (A, A) => STM[E, A]): STM[E, Option[A]] =
-    foldM[E, Option[A]](None) { (acc, a) =>
+    foldM(Option.empty[A]) { (acc, a) =>
       acc match {
         case Some(acc) => op(acc, a).map(Some(_))
         case _         => STM.some(a)

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -79,7 +79,7 @@ final class TMap[K, V] private (
    * Atomically folds using a transactional function.
    */
   def foldM[A, E](zero: A)(op: (A, (K, V)) => STM[E, A]): STM[E, A] =
-    toChunk.flatMap(_.foldLeft[STM[E, A]](STM.succeedNow(zero))((tx, kv) => tx.flatMap(op(_, kv))))
+    toChunk.flatMap(STM.foldLeft(_)(zero)(op))
 
   /**
    * Atomically performs transactional-effect for each binding present in map.


### PR DESCRIPTION
This PR is a continuation of work started in #3382 .

### Summary

- Re-implemented `fold`, `transform`, `transformM`, `indexWhere`, `lastIndexOf` and `reduceOption` using the "trick" introduced in the referenced PR.
- Re-implemented `foldM` in both TMap and TArray using `ZSTM.foldLeft`.
- Re-implemented `findLastM` and `findM` via iterate.

### Benchmark results

#### Baseline

```
Benchmark                          (size)   Mode  Cnt       Score        Error  Units
TArrayOpsBenchmarks.find               10  thrpt   15  405477.474 ±  16971.418  ops/s
TArrayOpsBenchmarks.find              100  thrpt   15   60775.132 ±    399.990  ops/s
TArrayOpsBenchmarks.find             1000  thrpt   15    1908.379 ±     11.496  ops/s
TArrayOpsBenchmarks.find            10000  thrpt   15      35.358 ±      0.281  ops/s
TArrayOpsBenchmarks.find           100000  thrpt   15       0.418 ±      0.004  ops/s
TArrayOpsBenchmarks.findM              10  thrpt   15  350369.085 ±  13578.418  ops/s
TArrayOpsBenchmarks.findM             100  thrpt   15   44995.329 ±    191.070  ops/s
TArrayOpsBenchmarks.findM            1000  thrpt   15    1892.096 ±      5.457  ops/s
TArrayOpsBenchmarks.findM           10000  thrpt   15      35.355 ±      0.266  ops/s
TArrayOpsBenchmarks.findM          100000  thrpt   15       0.424 ±      0.004  ops/s
TArrayOpsBenchmarks.fold               10  thrpt   15  378034.964 ±  21127.231  ops/s
TArrayOpsBenchmarks.fold              100  thrpt   15   59638.607 ±    246.920  ops/s
TArrayOpsBenchmarks.fold             1000  thrpt   15    1930.512 ±     18.778  ops/s
TArrayOpsBenchmarks.fold            10000  thrpt   15      36.793 ±      0.218  ops/s
TArrayOpsBenchmarks.fold           100000  thrpt   15       0.428 ±      0.005  ops/s
TArrayOpsBenchmarks.foldM              10  thrpt   15  324890.504 ±  11519.193  ops/s
TArrayOpsBenchmarks.foldM             100  thrpt   15   44814.627 ±    374.170  ops/s
TArrayOpsBenchmarks.foldM            1000  thrpt   15    1849.918 ±     12.799  ops/s
TArrayOpsBenchmarks.foldM           10000  thrpt   15      35.082 ±      0.297  ops/s
TArrayOpsBenchmarks.foldM          100000  thrpt   15       0.424 ±      0.004  ops/s
TArrayOpsBenchmarks.indexWhere         10  thrpt   15  463839.940 ±  22176.609  ops/s
TArrayOpsBenchmarks.indexWhere        100  thrpt   15   95673.948 ±   5193.067  ops/s
TArrayOpsBenchmarks.indexWhere       1000  thrpt   15    5742.562 ±     65.931  ops/s
TArrayOpsBenchmarks.indexWhere      10000  thrpt   15     497.766 ±     60.353  ops/s
TArrayOpsBenchmarks.indexWhere     100000  thrpt   15      14.802 ±      0.364  ops/s
TArrayOpsBenchmarks.indexWhereM        10  thrpt   15  395447.148 ±  20817.798  ops/s
TArrayOpsBenchmarks.indexWhereM       100  thrpt   15   66952.525 ±   1476.058  ops/s
TArrayOpsBenchmarks.indexWhereM      1000  thrpt   15    3995.659 ±     52.600  ops/s
TArrayOpsBenchmarks.indexWhereM     10000  thrpt   15     351.180 ±      8.792  ops/s
TArrayOpsBenchmarks.indexWhereM    100000  thrpt   15      12.686 ±      0.321  ops/s
TArrayOpsBenchmarks.lookup             10  thrpt   15    9253.884 ±     16.991  ops/s
TArrayOpsBenchmarks.lookup            100  thrpt   15    9235.146 ±     21.912  ops/s
TArrayOpsBenchmarks.lookup           1000  thrpt   15    9086.750 ±     15.830  ops/s
TArrayOpsBenchmarks.lookup          10000  thrpt   15    9085.484 ±     23.434  ops/s
TArrayOpsBenchmarks.lookup         100000  thrpt   15    8216.286 ±     81.725  ops/s
TArrayOpsBenchmarks.reduceOption       10  thrpt   15  509344.032 ±  41800.482  ops/s
TArrayOpsBenchmarks.reduceOption      100  thrpt   15  148541.444 ±   2641.666  ops/s
TArrayOpsBenchmarks.reduceOption     1000  thrpt   15   11527.269 ±     45.674  ops/s
TArrayOpsBenchmarks.reduceOption    10000  thrpt   15     843.443 ±      2.366  ops/s
TArrayOpsBenchmarks.reduceOption   100000  thrpt   15      19.989 ±      0.419  ops/s
TArrayOpsBenchmarks.reduceOptionM      10  thrpt   15  260851.163 ±   8934.823  ops/s
TArrayOpsBenchmarks.reduceOptionM     100  thrpt   15   36158.703 ±    121.950  ops/s
TArrayOpsBenchmarks.reduceOptionM    1000  thrpt   15    2125.801 ±     16.623  ops/s
TArrayOpsBenchmarks.reduceOptionM   10000  thrpt   15     186.894 ±      0.721  ops/s
TArrayOpsBenchmarks.reduceOptionM  100000  thrpt   15       8.291 ±      0.150  ops/s
TArrayOpsBenchmarks.transform          10  thrpt   15  327445.472 ±  13095.857  ops/s
TArrayOpsBenchmarks.transform         100  thrpt   15   28461.602 ±     86.539  ops/s
TArrayOpsBenchmarks.transform        1000  thrpt   15    2204.637 ±      5.690  ops/s
TArrayOpsBenchmarks.transform       10000  thrpt   15     143.489 ±      0.375  ops/s
TArrayOpsBenchmarks.transform      100000  thrpt   15       7.262 ±      0.088  ops/s
TArrayOpsBenchmarks.transformM         10  thrpt   15  242949.587 ±   6672.991  ops/s
TArrayOpsBenchmarks.transformM        100  thrpt   15   18731.244 ±     53.826  ops/s
TArrayOpsBenchmarks.transformM       1000  thrpt   15    1630.248 ±      9.430  ops/s
TArrayOpsBenchmarks.transformM      10000  thrpt   15     133.296 ±      1.198  ops/s
TArrayOpsBenchmarks.transformM     100000  thrpt   15       5.963 ±      0.078  ops/s
TArrayOpsBenchmarks.update             10  thrpt   15    8560.412 ±    102.551  ops/s
TArrayOpsBenchmarks.update            100  thrpt   15    8231.116 ±     20.074  ops/s
TArrayOpsBenchmarks.update           1000  thrpt   15    8114.494 ±     22.628  ops/s
TArrayOpsBenchmarks.update          10000  thrpt   15    8248.420 ±    155.670  ops/s
TArrayOpsBenchmarks.update         100000  thrpt   15    7921.203 ±     21.176  ops/s
TArrayOpsBenchmarks.updateM            10  thrpt   15    5457.188 ±     22.644  ops/s
TArrayOpsBenchmarks.updateM           100  thrpt   15    5606.793 ±      9.790  ops/s
TArrayOpsBenchmarks.updateM          1000  thrpt   15    5516.821 ±      9.978  ops/s
TArrayOpsBenchmarks.updateM         10000  thrpt   15    5638.752 ±     23.829  ops/s
TArrayOpsBenchmarks.updateM        100000  thrpt   15    5157.774 ±     21.232  ops/s
```

#### Post-change

```
Benchmark                          (size)   Mode  Cnt       Score       Error  Units
TArrayOpsBenchmarks.find               10  thrpt   15  567534.450 ± 50850.718  ops/s
TArrayOpsBenchmarks.find              100  thrpt   15  157043.985 ±  2043.866  ops/s
TArrayOpsBenchmarks.find             1000  thrpt   15   12072.342 ±   100.264  ops/s
TArrayOpsBenchmarks.find            10000  thrpt   15     883.031 ±     3.818  ops/s
TArrayOpsBenchmarks.find           100000  thrpt   15      23.114 ±     0.517  ops/s
TArrayOpsBenchmarks.findM              10  thrpt   15  311877.287 ± 12341.726  ops/s
TArrayOpsBenchmarks.findM             100  thrpt   15   41814.705 ±   397.552  ops/s
TArrayOpsBenchmarks.findM            1000  thrpt   15    3800.453 ±    11.564  ops/s
TArrayOpsBenchmarks.findM           10000  thrpt   15     319.412 ±     1.664  ops/s
TArrayOpsBenchmarks.findM          100000  thrpt   15      11.936 ±     0.107  ops/s
TArrayOpsBenchmarks.fold               10  thrpt   15  572038.949 ± 56070.054  ops/s
TArrayOpsBenchmarks.fold              100  thrpt   15  157629.417 ±  3061.470  ops/s
TArrayOpsBenchmarks.fold             1000  thrpt   15   11691.250 ±    49.853  ops/s
TArrayOpsBenchmarks.fold            10000  thrpt   15     878.357 ±     5.457  ops/s
TArrayOpsBenchmarks.fold           100000  thrpt   15      20.581 ±     0.497  ops/s
TArrayOpsBenchmarks.foldM              10  thrpt   15  294085.800 ± 12500.458  ops/s
TArrayOpsBenchmarks.foldM             100  thrpt   15   42821.920 ±   149.682  ops/s
TArrayOpsBenchmarks.foldM            1000  thrpt   15    2285.957 ±     7.840  ops/s
TArrayOpsBenchmarks.foldM           10000  thrpt   15     203.901 ±     0.708  ops/s
TArrayOpsBenchmarks.foldM          100000  thrpt   15       8.839 ±     0.115  ops/s
TArrayOpsBenchmarks.indexWhere         10  thrpt   15  574551.804 ± 49528.959  ops/s
TArrayOpsBenchmarks.indexWhere        100  thrpt   15  159153.772 ±  2530.755  ops/s
TArrayOpsBenchmarks.indexWhere       1000  thrpt   15   12143.196 ±    57.736  ops/s
TArrayOpsBenchmarks.indexWhere      10000  thrpt   15     912.341 ±     3.390  ops/s
TArrayOpsBenchmarks.indexWhere     100000  thrpt   15      24.553 ±     0.551  ops/s
TArrayOpsBenchmarks.indexWhereM        10  thrpt   15  404982.870 ± 15127.150  ops/s
TArrayOpsBenchmarks.indexWhereM       100  thrpt   15   71965.743 ±   755.097  ops/s
TArrayOpsBenchmarks.indexWhereM      1000  thrpt   15    5095.332 ±    17.460  ops/s
TArrayOpsBenchmarks.indexWhereM     10000  thrpt   15     438.821 ±     2.889  ops/s
TArrayOpsBenchmarks.indexWhereM    100000  thrpt   15      14.303 ±     0.394  ops/s
TArrayOpsBenchmarks.lookup             10  thrpt   15    9358.747 ±    35.654  ops/s
TArrayOpsBenchmarks.lookup            100  thrpt   15    9167.199 ±    22.532  ops/s
TArrayOpsBenchmarks.lookup           1000  thrpt   15    9080.917 ±    33.005  ops/s
TArrayOpsBenchmarks.lookup          10000  thrpt   15    9188.290 ±    24.460  ops/s
TArrayOpsBenchmarks.lookup         100000  thrpt   15    8224.555 ±   121.616  ops/s
TArrayOpsBenchmarks.reduceOption       10  thrpt   15  570498.852 ± 46099.461  ops/s
TArrayOpsBenchmarks.reduceOption      100  thrpt   15  156147.982 ±  3139.540  ops/s
TArrayOpsBenchmarks.reduceOption     1000  thrpt   15   11583.770 ±   149.035  ops/s
TArrayOpsBenchmarks.reduceOption    10000  thrpt   15     837.847 ±     3.422  ops/s
TArrayOpsBenchmarks.reduceOption   100000  thrpt   15      22.144 ±     0.655  ops/s
TArrayOpsBenchmarks.reduceOptionM      10  thrpt   15  263770.168 ±  8241.147  ops/s
TArrayOpsBenchmarks.reduceOptionM     100  thrpt   15   36187.872 ±   373.598  ops/s
TArrayOpsBenchmarks.reduceOptionM    1000  thrpt   15    2091.037 ±    23.852  ops/s
TArrayOpsBenchmarks.reduceOptionM   10000  thrpt   15     181.242 ±     1.890  ops/s
TArrayOpsBenchmarks.reduceOptionM  100000  thrpt   15       7.958 ±     0.167  ops/s
TArrayOpsBenchmarks.transform          10  thrpt   15  480546.918 ± 47954.342  ops/s
TArrayOpsBenchmarks.transform         100  thrpt   15  110509.390 ±  1384.038  ops/s
TArrayOpsBenchmarks.transform        1000  thrpt   15    7670.995 ±    74.684  ops/s
TArrayOpsBenchmarks.transform       10000  thrpt   15     623.801 ±     3.953  ops/s
TArrayOpsBenchmarks.transform      100000  thrpt   15      15.684 ±     1.003  ops/s
TArrayOpsBenchmarks.transformM         10  thrpt   15  285651.775 ± 11933.671  ops/s
TArrayOpsBenchmarks.transformM        100  thrpt   15   33167.552 ±   297.916  ops/s
TArrayOpsBenchmarks.transformM       1000  thrpt   15    2587.763 ±    47.288  ops/s
TArrayOpsBenchmarks.transformM      10000  thrpt   15     208.365 ±     7.275  ops/s
TArrayOpsBenchmarks.transformM     100000  thrpt   15       7.052 ±     0.233  ops/s
TArrayOpsBenchmarks.update             10  thrpt   15    8306.448 ±    76.714  ops/s
TArrayOpsBenchmarks.update            100  thrpt   15    7785.314 ±   377.915  ops/s
TArrayOpsBenchmarks.update           1000  thrpt   15    8005.931 ±   130.745  ops/s
TArrayOpsBenchmarks.update          10000  thrpt   15    7756.638 ±   227.476  ops/s
TArrayOpsBenchmarks.update         100000  thrpt   15    7097.309 ±   378.763  ops/s
TArrayOpsBenchmarks.updateM            10  thrpt   15    4808.898 ±   288.837  ops/s
TArrayOpsBenchmarks.updateM           100  thrpt   15    5057.312 ±   195.207  ops/s
TArrayOpsBenchmarks.updateM          1000  thrpt   15    5060.756 ±   262.645  ops/s
TArrayOpsBenchmarks.updateM         10000  thrpt   15    4999.414 ±   188.607  ops/s
TArrayOpsBenchmarks.updateM        100000  thrpt   15    4907.370 ±   262.661  ops/s
```