### PR TITLE
ZIO Test: Support Laws for Capabilities Parameterized on Two Types

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/laws/Laws2Spec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/laws/Laws2Spec.scala
@@ -4,6 +4,8 @@ import zio.test._
 
 object Laws2Spec extends ZIOBaseSpec {
 
+  type AnyF[_] = Any
+
   def equalTo[A: Equal](expected: A): Assertion[A] =
     Assertion.assertion("equalTo")(Assertion.Render.param(expected))(_ === expected)
 
@@ -35,13 +37,13 @@ object Laws2Spec extends ZIOBaseSpec {
 
   object Equivalence extends Lawful2[Equivalence, Equal, Equal] {
 
-    val leftIdentity = new Laws2.Law1Left[Equivalence, Equal, Equal]("leftIdentity") {
-      def apply[A: Equal, B: Equal](a1: A)(implicit Equivalence: Equivalence[A, B]): TestResult =
+    val leftIdentity = new Laws2.Law1Left[Equivalence, Equal, AnyF]("leftIdentity") {
+      def apply[A: Equal, B: AnyF](a1: A)(implicit Equivalence: Equivalence[A, B]): TestResult =
         Equivalence.from(Equivalence.to(a1)) <-> a1
     }
 
-    val rightIdentity = new Laws2.Law1Right[Equivalence, Equal, Equal]("rightIdentity") {
-      def apply[A: Equal, B: Equal](b1: B)(implicit Equivalence: Equivalence[A, B]): TestResult =
+    val rightIdentity = new Laws2.Law1Right[Equivalence, AnyF, Equal]("rightIdentity") {
+      def apply[A: AnyF, B: Equal](b1: B)(implicit Equivalence: Equivalence[A, B]): TestResult =
         Equivalence.to(Equivalence.from(b1)) <-> b1
     }
 

--- a/test-tests/shared/src/test/scala/zio/test/laws/Laws2Spec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/laws/Laws2Spec.scala
@@ -1,0 +1,74 @@
+package zio.test.laws
+
+import zio.test._
+
+object Laws2Spec extends ZIOBaseSpec {
+
+  def equalTo[A: Equal](expected: A): Assertion[A] =
+    Assertion.assertion("equalTo")(Assertion.Render.param(expected))(_ === expected)
+
+  implicit class AssertEqualToSyntax[A](private val self: A) extends AnyVal {
+    def <->(that: A)(implicit eq: Equal[A]): TestResult =
+      assert(self)(equalTo(that))
+  }
+
+  trait Equal[-A] {
+    def equal(a1: A, a2: A): Boolean
+  }
+
+  object Equal {
+    implicit val byteEqual: Equal[Byte] = _ == _
+    implicit val charEqual: Equal[Char] = _ == _
+    implicit def listEqual[A: Equal]: Equal[List[A]] =
+      (l, r) => l.corresponds(r)(_ === _)
+    implicit val stringEqual: Equal[String] = _ == _
+    implicit def vectorEqual[A: Equal]: Equal[Vector[A]] =
+      (l, r) => l.corresponds(r)(_ === _)
+  }
+
+  implicit class EqualSyntax[A](private val self: A) extends AnyVal {
+    def ===(that: A)(implicit eq: Equal[A]): Boolean =
+      eq.equal(self, that)
+  }
+
+  final case class Equivalence[A, B](to: A => B, from: B => A)
+
+  object Equivalence extends Lawful2[Equivalence, Equal, Equal] {
+
+    val leftIdentity = new Laws2.Law1Left[Equivalence, Equal, Equal]("leftIdentity") {
+      def apply[A: Equal, B: Equal](a1: A)(implicit Equivalence: Equivalence[A, B]): TestResult =
+        Equivalence.from(Equivalence.to(a1)) <-> a1
+    }
+
+    val rightIdentity = new Laws2.Law1Right[Equivalence, Equal, Equal]("rightIdentity") {
+      def apply[A: Equal, B: Equal](b1: B)(implicit Equivalence: Equivalence[A, B]): TestResult =
+        Equivalence.to(Equivalence.from(b1)) <-> b1
+    }
+
+    val laws = leftIdentity + rightIdentity
+
+    val byteListByteVectorEquivalence: Equivalence[List[Byte], Vector[Byte]] =
+      Equivalence(_.toVector, _.toList)
+
+    val charListStringEquivalence: Equivalence[List[Char], String] =
+      Equivalence(_.mkString, _.toList)
+  }
+
+  def spec =
+    suite("Laws2Spec") {
+      suite("equivalenceLaws")(
+        testM("byteList <=> byteVector") {
+          val genByteList          = Gen.listOf(Gen.anyByte)
+          val genByteVector        = Gen.vectorOf(Gen.anyByte)
+          implicit val equivalence = Equivalence.byteListByteVectorEquivalence
+          checkAllLaws(Equivalence)(genByteList, genByteVector)
+        },
+        testM("charList <=> String") {
+          val genCharList          = Gen.listOf(Gen.anyChar)
+          val genString            = Gen.anyString
+          implicit val equivalence = Equivalence.charListStringEquivalence
+          checkAllLaws(Equivalence)(genCharList, genString)
+        }
+      )
+    }
+}

--- a/test/shared/src/main/scala/zio/test/laws/ZLawful2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawful2.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.laws
+
+trait ZLawful2[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_], -R] { self =>
+  def laws: ZLaws2[CapsBoth, CapsLeft, CapsRight, R]
+  def +[CapsBoth1[x, y] <: CapsBoth[x, y], CapsLeft1[x] <: CapsLeft[x], CapsRight1[x] <: CapsRight[x], R1 <: R](
+    that: ZLawful2[CapsBoth1, CapsLeft1, CapsRight1, R1]
+  ): ZLawful2[CapsBoth1, CapsLeft1, CapsRight1, R1] =
+    new ZLawful2[CapsBoth1, CapsLeft1, CapsRight1, R1] {
+      val laws = self.laws + that.laws
+    }
+}

--- a/test/shared/src/main/scala/zio/test/laws/ZLaws2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLaws2.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.laws
+
+import zio.ZIO
+import zio.test.{ check, Gen, TestResult }
+
+sealed trait ZLaws2[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_], -R] { self =>
+
+  def run[R1 <: R, A: CapsLeft, B: CapsRight](left: Gen[R1, A], right: Gen[R1, B])(
+    implicit CapsBoth: CapsBoth[A, B]
+  ): ZIO[R1, Nothing, TestResult]
+
+  def +[CapsBoth1[x, y] <: CapsBoth[x, y], CapsLeft1[x] <: CapsLeft[x], CapsRight1[x] <: CapsRight[x], R1 <: R](
+    that: ZLaws2[CapsBoth1, CapsLeft1, CapsRight1, R1]
+  ): ZLaws2[CapsBoth1, CapsLeft1, CapsRight1, R1] =
+    ZLaws2.Both(self, that)
+}
+
+object ZLaws2 {
+
+  private final case class Both[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_], -R](
+    left: ZLaws2[CapsBoth, CapsLeft, CapsRight, R],
+    right: ZLaws2[CapsBoth, CapsLeft, CapsRight, R]
+  ) extends ZLaws2[CapsBoth, CapsLeft, CapsRight, R] {
+    final def run[R1 <: R, A: CapsLeft, B: CapsRight](a: Gen[R1, A], b: Gen[R1, B])(
+      implicit CapsBoth: CapsBoth[A, B]
+    ): ZIO[R1, Nothing, TestResult] =
+      left.run(a, b).zipWith(right.run(a, b))(_ && _)
+  }
+
+  abstract class Law1Left[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]](label: String)
+      extends ZLaws2[CapsBoth, CapsLeft, CapsRight, Any] { self =>
+    def apply[A: CapsLeft, B: CapsRight](a1: A)(implicit CapsBoth: CapsBoth[A, B]): TestResult
+    final def run[R, A: CapsLeft, B: CapsRight](a: Gen[R, A], b: Gen[R, B])(
+      implicit CapsBoth: CapsBoth[A, B]
+    ): ZIO[R, Nothing, TestResult] =
+      check(a, b)((a, _) => apply(a).map(_.label(label)))
+  }
+
+  abstract class Law1Right[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]](label: String)
+      extends ZLaws2[CapsBoth, CapsLeft, CapsRight, Any] { self =>
+    def apply[A: CapsLeft, B: CapsRight](b1: B)(implicit CapsBoth: CapsBoth[A, B]): TestResult
+    final def run[R, A: CapsLeft, B: CapsRight](a: Gen[R, A], b: Gen[R, B])(
+      implicit CapsBoth: CapsBoth[A, B]
+    ): ZIO[R, Nothing, TestResult] =
+      check(a, b)((_, b) => apply(b).map(_.label(label)))
+  }
+}

--- a/test/shared/src/main/scala/zio/test/laws/package.scala
+++ b/test/shared/src/main/scala/zio/test/laws/package.scala
@@ -67,8 +67,10 @@ import zio.ZIO
  */
 package object laws {
 
-  type Lawful[-Caps[_]] = ZLawful[Caps, Any]
-  type Laws[-Caps[_]]   = ZLaws[Caps, Any]
+  type Lawful[-Caps[_]]                                      = ZLawful[Caps, Any]
+  type Lawful2[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]] = ZLawful2[CapsBoth, CapsLeft, CapsRight, Any]
+  type Laws[-Caps[_]]                                        = ZLaws[Caps, Any]
+  type Laws2[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]]   = ZLaws2[CapsBoth, CapsLeft, CapsRight, Any]
 
   object LawfulF {
     type Covariant[-CapsF[_[+_]], -Caps[_]]     = ZLawfulF.Covariant[CapsF, Caps, Any]
@@ -83,6 +85,11 @@ package object laws {
     type Law2M[-Caps[_]] = ZLaws.Law2M[Caps, Any]
     type Law3[-Caps[_]]  = ZLaws.Law3[Caps]
     type Law3M[-Caps[_]] = ZLaws.Law3M[Caps, Any]
+  }
+
+  object Laws2 {
+    type Law1Left[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]]  = ZLaws2.Law1Left[CapsBoth, CapsLeft, CapsRight]
+    type Law1Right[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_]] = ZLaws2.Law1Right[CapsBoth, CapsLeft, CapsRight]
   }
 
   object LawsF {
@@ -123,6 +130,11 @@ package object laws {
     lawful: ZLawful[Caps, R]
   )(gen: Gen[R1, A]): ZIO[R1, Nothing, TestResult] =
     lawful.laws.run(gen)
+
+  def checkAllLaws[CapsBoth[_, _], CapsLeft[_], CapsRight[_], R, R1 <: R, A: CapsLeft, B: CapsRight](
+    lawful: ZLawful2[CapsBoth, CapsLeft, CapsRight, R]
+  )(a: Gen[R1, A], b: Gen[R1, B])(implicit CapsBoth: CapsBoth[A, B]): ZIO[R1, Nothing, TestResult] =
+    lawful.laws.run(a, b)
 
   def checkAllLaws[CapsF[_[+_]], Caps[_], R, R1 <: R, F[+_]: CapsF, A: Caps](
     lawful: ZLawfulF.Covariant[CapsF, Caps, R]


### PR DESCRIPTION
This adds support for laws describing capabilities parameterized on two types, for example `Equivalence[A, B]` as opposed to `Equal[A]`. This is done by implementing a new `ZLaws2` trait that is parameterized on both a capability that takes two type parameters, such as `Equivalence`, as well as possibly capabilities that the left or right value must have.