### PR TITLE
Improve TQueue's performance

### DIFF
--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -18,41 +18,55 @@ package zio.stm
 
 import scala.collection.immutable.{ Queue => ScalaQueue }
 
+import zio.stm.ZSTM.internal._
+
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
   /**
    * Checks if the queue is empty.
    */
   def isEmpty: USTM[Boolean] =
-    ref.get.map(_.isEmpty)
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+      TExit.Succeed(q.isEmpty)
+    })
 
   /**
    * Checks if the queue is at capacity.
    */
   def isFull: USTM[Boolean] =
-    ref.get.map(_.size == capacity)
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+      TExit.Succeed(q.size == capacity)
+    })
 
   /**
    * Views the last element inserted into the queue, retrying if the queue is
    * empty.
    */
   def last: USTM[A] =
-    ref.get.flatMap(
-      _.lastOption match {
-        case Some(a) => STM.succeedNow(a)
-        case None    => STM.retry
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+
+      q.lastOption match {
+        case Some(a) => TExit.Succeed(a)
+        case None    => TExit.Retry
       }
-    )
+    })
 
   /**
    * Offers the specified value to the queue, retrying if the queue is at
    * capacity.
    */
   def offer(a: A): USTM[Unit] =
-    ref.get.flatMap { q =>
-      if (q.length < capacity) ref.update(_.enqueue(a)).unit
-      else STM.retry
-    }
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+
+      if (q.length < capacity)
+        TExit.Succeed(ref.unsafeSet(journal, q.enqueue(a)))
+      else
+        TExit.Retry
+    })
 
   /**
    * Offers each of the elements in the specified collection to the queue up to
@@ -60,32 +74,42 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * the queue for all of these elements. Returns any remaining elements in the
    * specified collection.
    */
-  def offerAll(as: Iterable[A]): USTM[Iterable[A]] = {
-    val (forQueue, remaining) = as.splitAt(capacity)
-    ref.get.flatMap { q =>
-      if (forQueue.size <= capacity - q.length) ref.update(_ ++ forQueue)
-      else STM.retry
-    } *> STM.succeedNow(remaining)
-  }
+  def offerAll(as: Iterable[A]): USTM[Iterable[A]] =
+    new ZSTM((journal, _, _, _) => {
+      val (forQueue, remaining) = as.splitAt(capacity)
+
+      val q = ref.unsafeGet(journal)
+
+      if (forQueue.size > capacity - q.length) TExit.Retry
+      else {
+        ref.unsafeSet(journal, q ++ forQueue)
+        TExit.Succeed(remaining)
+      }
+    })
 
   /**
    * Views the next element in the queue without removing it, retrying if the
    * queue is empty.
    */
   def peek: USTM[A] =
-    ref.get.flatMap(
-      _.headOption match {
-        case Some(a) => STM.succeedNow(a)
-        case None    => STM.retry
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+
+      q.headOption match {
+        case Some(a) => TExit.Succeed(a)
+        case None    => TExit.Retry
       }
-    )
+    })
 
   /**
    * Views the next element in the queue without removing it, returning `None`
    * if the queue is empty.
    */
   def peekOption: USTM[Option[A]] =
-    ref.get.map(_.headOption)
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+      TExit.Succeed(q.headOption)
+    })
 
   /**
    * Takes a single element from the queue, returning `None` if the queue is
@@ -99,51 +123,79 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * taking and returning the first element that does satisfy the predicate.
    * Retries if no elements satisfy the predicate.
    */
-  def seek(f: A => Boolean): USTM[A] = {
-    @annotation.tailrec
-    def go(q: ScalaQueue[A]): USTM[A] =
-      q.dequeueOption match {
-        case Some((a, as)) =>
-          if (f(a)) ref.set(as) *> STM.succeedNow(a)
-          else go(as)
-        case None => STM.retry
+  def seek(f: A => Boolean): USTM[A] =
+    new ZSTM((journal, _, _, _) => {
+      var q    = ref.unsafeGet(journal)
+      var loop = true
+      var res  = null.asInstanceOf[A]
+
+      while (loop) {
+        q.dequeueOption match {
+          case Some((a, as)) =>
+            if (f(a)) {
+              ref.unsafeSet(journal, as)
+              res = a
+              loop = false
+            } else {
+              q = as
+            }
+          case None =>
+            loop = false
+        }
       }
 
-    ref.get.flatMap(go)
-  }
+      res match {
+        case null => TExit.Retry
+        case a    => TExit.Succeed(a)
+      }
+    })
 
   /**
    * Returns the number of elements currently in the queue.
    */
   def size: USTM[Int] =
-    ref.get.map(_.length)
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+      TExit.Succeed(q.length)
+    })
 
   /**
    * Takes a single element from the queue, retrying if the queue is empty.
    */
   def take: USTM[A] =
-    ref.get.flatMap { q =>
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+
       q.dequeueOption match {
         case Some((a, as)) =>
-          ref.set(as) *> STM.succeedNow(a)
-        case _ => STM.retry
+          ref.unsafeSet(journal, as)
+          TExit.Succeed(a)
+        case None =>
+          TExit.Retry
       }
-    }
+    })
 
   /**
    * Takes all elements from the queue.
    */
   def takeAll: USTM[List[A]] =
-    ref.modify(q => (q.toList, ScalaQueue.empty[A]))
+    new ZSTM((journal, _, _, _) => {
+      val q = ref.unsafeGet(journal)
+      ref.unsafeSet(journal, ScalaQueue.empty[A])
+      TExit.Succeed(q.toList)
+    })
 
   /**
    * Takes up to the specified maximum number of elements from the queue.
    */
   def takeUpTo(max: Int): USTM[List[A]] =
-    ref.get
-      .map(_.splitAt(max))
-      .flatMap(split => ref.set(split._2) *> STM.succeedNow(split._1))
-      .map(_.toList)
+    new ZSTM((journal, _, _, _) => {
+      val q     = ref.unsafeGet(journal)
+      val split = q.splitAt(max)
+
+      ref.unsafeSet(journal, split._2)
+      TExit.Succeed(split._1.toList)
+    })
 }
 
 object TQueue {


### PR DESCRIPTION
Continuation of work from #3343.

### Benchmark results

#### Before changes

```
QueueParallelBenchmark.zioTQueue      thrpt   45  481.958 ± 14.418  ops/s
QueueSequentialBenchmark.zioTQueue    thrpt   45  291.183 ± 3.679   ops/s
QueueBackPressureBenchmark.zioTQueue  thrpt   45  313.379 ± 4.393   ops/s
```

#### After changes

```
QueueParallelBenchmark.zioTQueue      thrpt   45  626.895 ± 6.495  ops/s
QueueSequentialBenchmark.zioTQueue    thrpt   45  333.230 ± 9.095  ops/s
QueueBackPressureBenchmark.zioTQueue  thrpt   45  412.465 ± 8.194  ops/s
```