### PR TITLE
Implement ZIO#service

### DIFF
--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -506,6 +506,31 @@ object RIO {
   final def getOrFail[A](v: => Option[A]): Task[A] = ZIO.getOrFail(v)
 
   /**
+   * @see See [[zio.ZIO.getService]]
+   */
+  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.getService[A]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B]*]]
+   */
+  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.getServices[A, B]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B,C]*]]
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.getServices[A, B, C]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B,C,D]*]]
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.getServices[A, B, C, D]
+
+  /**
    * @see See [[zio.ZIO.halt]]
    */
   def halt(cause: => Cause[Throwable]): Task[Nothing] = ZIO.halt(cause)

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -377,7 +377,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.foreachExec]]
    */
-  final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => RIO[R, B]): RIO[R, List[B]] =
+  def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => RIO[R, B]): RIO[R, List[B]] =
     ZIO.foreachExec(as)(exec)(f)
 
   /**
@@ -503,32 +503,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.getOrFail]]
    */
-  final def getOrFail[A](v: => Option[A]): Task[A] = ZIO.getOrFail(v)
-
-  /**
-   * @see See [[zio.ZIO.getService]]
-   */
-  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
-    ZIO.getService[A]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B]*]]
-   */
-  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
-    ZIO.getServices[A, B]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B,C]*]]
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
-    ZIO.getServices[A, B, C]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B,C,D]*]]
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
-    ZIO.getServices[A, B, C, D]
+  def getOrFail[A](v: => Option[A]): Task[A] = ZIO.getOrFail(v)
 
   /**
    * @see See [[zio.ZIO.halt]]
@@ -753,6 +728,31 @@ object RIO {
    * @see See [[zio.ZIO.second]]
    */
   def second[A, B]: RIO[(A, B), B] = ZIO.second
+
+  /**
+   * @see See [[zio.ZIO.service]]
+   */
+  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.service[A]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B]*]]
+   */
+  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.services[A, B]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B,C]*]]
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.services[A, B, C]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B,C,D]*]]
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.services[A, B, C, D]
 
   /**
    * @see See [[zio.ZIO.sleep]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -349,7 +349,7 @@ object URIO {
   /**
    * @see See [[zio.ZIO.foreachExec]]
    */
-  final def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => URIO[R, B]): URIO[R, List[B]] =
+  def foreachExec[R, A, B](as: Iterable[A])(exec: ExecutionStrategy)(f: A => URIO[R, B]): URIO[R, List[B]] =
     ZIO.foreachExec(as)(exec)(f)
 
   /**
@@ -385,7 +385,7 @@ object URIO {
   /**
    * @see [[[zio.ZIO.foreach_[R,E,A](as:zio\.Chunk*]]]
    */
-  final def foreach_[R, A](as: Chunk[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
+  def foreach_[R, A](as: Chunk[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreach_(as)(f)
 
   /**
@@ -447,31 +447,6 @@ object URIO {
    */
   def fromFunctionM[R, A](f: R => UIO[A]): URIO[R, A] =
     ZIO.fromFunctionM(f)
-
-  /**
-   * @see See [[zio.ZIO.getService]]
-   */
-  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
-    ZIO.getService[A]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B]*]]
-   */
-  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
-    ZIO.getServices[A, B]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B,C]*]]
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
-    ZIO.getServices[A, B, C]
-
-  /**
-   * @see See [[zio.ZIO.getServices[A,B,C,D]*]]
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
-    ZIO.getServices[A, B, C, D]
 
   /**
    * @see [[zio.ZIO.halt]]
@@ -672,6 +647,31 @@ object URIO {
    * @see [[zio.ZIO.second]]
    */
   def second[A, B]: URIO[(A, B), B] = ZIO.second
+
+  /**
+   * @see See [[zio.ZIO.service]]
+   */
+  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.service[A]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B]*]]
+   */
+  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.services[A, B]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B,C]*]]
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.services[A, B, C]
+
+  /**
+   * @see See [[zio.ZIO.services[A,B,C,D]*]]
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.services[A, B, C, D]
 
   /**
    * @see [[zio.ZIO.sleep]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -449,6 +449,31 @@ object URIO {
     ZIO.fromFunctionM(f)
 
   /**
+   * @see See [[zio.ZIO.getService]]
+   */
+  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.getService[A]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B]*]]
+   */
+  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.getServices[A, B]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B,C]*]]
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.getServices[A, B, C]
+
+  /**
+   * @see See [[zio.ZIO.getServices[A,B,C,D]*]]
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.getServices[A, B, C, D]
+
+  /**
    * @see [[zio.ZIO.halt]]
    */
   def halt(cause: => Cause[Nothing]): UIO[Nothing] = ZIO.halt(cause)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2887,31 +2887,6 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     })
 
   /**
-   * Gets the specified service from the environment of the effect.
-   */
-  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
-    ZIO.access(_.get[A])
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
-    ZIO.access(r => (r.get[A], r.get[B]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
-    ZIO.access(r => (r.get[A], r.get[B], r.get[C]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
-    ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
-
-  /**
    * Returns an effect that models failure with the specified `Cause`.
    */
   def halt[E](cause: => Cause[E]): IO[E, Nothing] =
@@ -3277,6 +3252,31 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * tuple.
    */
   def second[A, B]: URIO[(A, B), B] = fromFunction[(A, B), B](_._2)
+
+  /**
+   * Accesses the specified service in the environment of the effect.
+   */
+  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.access(_.get[A])
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    * Returns an effect that suspends for the specified duration. This method is

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2887,6 +2887,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     })
 
   /**
+   * Accesses a service in the environment of the effect
+   */
+  final def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.access[Has[A]](_.get)
+
+  /**
    * Returns an effect that models failure with the specified `Cause`.
    */
   def halt[E](cause: => Cause[E]): IO[E, Nothing] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2887,10 +2887,29 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     })
 
   /**
-   * Accesses a service in the environment of the effect
+   * Gets the specified service from the environment of the effect.
    */
-  final def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
-    ZIO.access[Has[A]](_.get)
+  def getService[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+    ZIO.access(_.get[A])
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+    ZIO.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+    ZIO.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+    ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    * Returns an effect that models failure with the specified `Cause`.

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1634,6 +1634,31 @@ object ZManaged {
   def fromFunctionM[R, E, A](f: R => ZManaged[Any, E, A]): ZManaged[R, E, A] = flatten(fromFunction(f))
 
   /**
+   * Gets the specified service from the environment of the effect.
+   */
+  def getService[A](implicit tagged: Tagged[A]): ZManaged[Has[A], Nothing, A] =
+    ZManaged.access(_.get[A])
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged]: ZManaged[Has[A] with Has[B], Nothing, (A, B)] =
+    ZManaged.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZManaged[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZManaged.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZManaged[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZManaged.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
+
+  /**
    * Returns an effect that models failure with the specified `Cause`.
    */
   def halt[E](cause: => Cause[E]): ZManaged[Any, E, Nothing] =

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1634,31 +1634,6 @@ object ZManaged {
   def fromFunctionM[R, E, A](f: R => ZManaged[Any, E, A]): ZManaged[R, E, A] = flatten(fromFunction(f))
 
   /**
-   * Gets the specified service from the environment of the effect.
-   */
-  def getService[A](implicit tagged: Tagged[A]): ZManaged[Has[A], Nothing, A] =
-    ZManaged.access(_.get[A])
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged]: ZManaged[Has[A] with Has[B], Nothing, (A, B)] =
-    ZManaged.access(r => (r.get[A], r.get[B]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZManaged[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
-    ZManaged.access(r => (r.get[A], r.get[B], r.get[C]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : ZManaged[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
-    ZManaged.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
-
-  /**
    * Returns an effect that models failure with the specified `Cause`.
    */
   def halt[E](cause: => Cause[E]): ZManaged[Any, E, Nothing] =
@@ -2065,6 +2040,31 @@ object ZManaged {
    * tuple.
    */
   def second[A, B]: ZManaged[(A, B), Nothing, B] = fromFunction(_._2)
+
+  /**
+   * Accesses the specified service in the environment of the effect.
+   */
+  def service[A](implicit tagged: Tagged[A]): ZManaged[Has[A], Nothing, A] =
+    ZManaged.access(_.get[A])
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged]: ZManaged[Has[A] with Has[B], Nothing, (A, B)] =
+    ZManaged.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: ZManaged[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZManaged.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZManaged[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZManaged.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    *  Returns an effect with the optional value.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -24,8 +24,8 @@ import scala.util.{ Failure, Success, Try }
 
 import com.github.ghik.silencer.silent
 
+import zio._
 import zio.internal.{ Platform, Stack, Sync }
-import zio.{ CanFail, Chunk, ChunkBuilder, Fiber, IO, UIO, ZIO }
 
 /**
  * `STM[E, A]` represents an effect that can be performed transactionally,
@@ -1129,6 +1129,31 @@ object ZSTM {
         case Success(a) => STM.succeedNow(a)
       }
     }
+
+  /**
+   * Gets the specified service from the environment of the effect.
+   */
+  def getService[A](implicit tagged: Tagged[A]): ZSTM[Has[A], Nothing, A] =
+    ZSTM.access(_.get[A])
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged]: ZSTM[Has[A] with Has[B], Nothing, (A, B)] =
+    ZSTM.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZSTM[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZSTM.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZSTM[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZSTM.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    * Returns the identity effectful function, which performs no effects

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1131,31 +1131,6 @@ object ZSTM {
     }
 
   /**
-   * Gets the specified service from the environment of the effect.
-   */
-  def getService[A](implicit tagged: Tagged[A]): ZSTM[Has[A], Nothing, A] =
-    ZSTM.access(_.get[A])
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged]: ZSTM[Has[A] with Has[B], Nothing, (A, B)] =
-    ZSTM.access(r => (r.get[A], r.get[B]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZSTM[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
-    ZSTM.access(r => (r.get[A], r.get[B], r.get[C]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : ZSTM[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
-    ZSTM.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
-
-  /**
    * Returns the identity effectful function, which performs no effects
    */
   def identity[R]: URSTM[R, R] = fromFunction[R, R](ZIO.identityFn)
@@ -1333,6 +1308,31 @@ object ZSTM {
    */
   def second[A, B]: URSTM[(A, B), B] =
     fromFunction[(A, B), B](_._2)
+
+  /**
+   * Accesses the specified service in the environment of the effect.
+   */
+  def service[A](implicit tagged: Tagged[A]): ZSTM[Has[A], Nothing, A] =
+    ZSTM.access(_.get[A])
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged]: ZSTM[Has[A] with Has[B], Nothing, (A, B)] =
+    ZSTM.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: ZSTM[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZSTM.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZSTM[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZSTM.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    * Returns an effect with the optional value.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3451,6 +3451,31 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     ZStream.repeatEffect(queue.take.commit)
 
   /**
+   * Gets the specified service from the environment of the effect.
+   */
+  def getService[A](implicit tagged: Tagged[A]): ZStream[Has[A], Nothing, A] =
+    ZStream.access(_.get[A])
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
+    ZStream.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Gets the specified services from the environment of the effect.
+   */
+  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZStream[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
+
+  /**
    * The stream that always halts with `cause`.
    */
   def halt[E](cause: => Cause[E]): ZStream[Any, E, Nothing] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3451,31 +3451,6 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     ZStream.repeatEffect(queue.take.commit)
 
   /**
-   * Gets the specified service from the environment of the effect.
-   */
-  def getService[A](implicit tagged: Tagged[A]): ZStream[Has[A], Nothing, A] =
-    ZStream.access(_.get[A])
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
-    ZStream.access(r => (r.get[A], r.get[B]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
-    ZStream.access(r => (r.get[A], r.get[B], r.get[C]))
-
-  /**
-   * Gets the specified services from the environment of the effect.
-   */
-  def getServices[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : ZStream[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
-    ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
-
-  /**
    * The stream that always halts with `cause`.
    */
   def halt[E](cause: => Cause[E]): ZStream[Any, E, Nothing] =
@@ -3576,6 +3551,31 @@ object ZStream extends ZStreamPlatformSpecificConstructors with Serializable {
     schedule: Schedule[R, Unit, _]
   ): ZStream[R, E, A] =
     fromEffect(fa).repeat(schedule)
+
+  /**
+   * Accesses the specified service in the environment of the effect.
+   */
+  def service[A](implicit tagged: Tagged[A]): ZStream[Has[A], Nothing, A] =
+    ZStream.access(_.get[A])
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
+    ZStream.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+    : ZStream[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
    * Creates a single-valued pure stream


### PR DESCRIPTION
Following up on good suggestion from @ghostdogpr implements `getService` which is like `environment` but does the `get` for you. So if you wanted the `Clock.Service` you could do `ZIO.getService[Clock.Service]` and get a `ZIO[Clock, Nothing, Clock.Service]`. Still needs variants for other type aliases and other ZIO effect types assuming we like this.