### PR TITLE
Remove sonatype public resolver

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -84,7 +84,6 @@ object BuildHelper {
   )
 
   val scalaReflectSettings = Seq(
-    resolvers += Resolver.sonatypeRepo("public"),
     libraryDependencies ++=
       (if (isDotty.value) Seq()
        else


### PR DESCRIPTION
Added in https://github.com/zio/zio/pull/2479 because `izumi-reflect` was already on sonatype, but not yet on central at the time of the PR