### PR TITLE
Use short forms where it makes sense

### DIFF
--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -53,7 +53,7 @@ class FiberRefBenchmarks {
     for {
       fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.make(i))
       _         <- ZIO.foreach_(1.to(n))(_ => ZIO.yieldNow)
-      values    <- ZIO.collectAllPar(fiberRefs.map(_.get))
+      values    <- ZIO.foreachPar(fiberRefs)(_.get)
       _         <- verify(values == 1.to(n))(s"Got $values")
     } yield ()
   }

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -50,8 +50,8 @@ class QueueSequentialBenchmark {
       else task.flatMap(_ => repeat(task, max - 1))
 
     val io = for {
-      _ <- repeat(zioQ.offer(0).map(_ => ()), totalSize)
-      _ <- repeat(zioQ.take.map(_ => ()), totalSize)
+      _ <- repeat(zioQ.offer(0).unit, totalSize)
+      _ <- repeat(zioQ.take.unit, totalSize)
     } yield 0
 
     unsafeRun(io)

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -290,7 +290,7 @@ object ChunkSpec extends ZIOBaseSpec {
         checkM(mediumChunks(intGen), pfGen) { (c, pf) =>
           for {
             result   <- c.collectWhileM(pf).map(_.toList)
-            expected <- UIO.collectAll(c.toList.takeWhile(pf.isDefinedAt).map(pf.apply))
+            expected <- UIO.foreach(c.toList.takeWhile(pf.isDefinedAt))(pf.apply)
           } yield assert(result)(equalTo(expected))
         }
       },

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -168,7 +168,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           fiberRef <- FiberRef.make(initial)
           loser1   = fiberRef.set(update1) *> ZIO.fail("ups1")
           loser2   = fiberRef.set(update2) *> ZIO.fail("ups2")
-          _        <- loser1.race(loser2).catchAll(_ => ZIO.unit)
+          _        <- loser1.race(loser2).ignore
           value    <- fiberRef.get
         } yield assert(value)(equalTo(initial))
       } @@ zioTag(errors),

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1646,7 +1646,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
-        assertM(ZIO.succeed(Some(42)).someOrFailException)(equalTo(42))
+        assertM(ZIO.some(42).someOrFailException)(equalTo(42))
       },
       testM("fails when given a None") {
         val task = ZIO.succeed(Option.empty[Int]).someOrFailException
@@ -2926,8 +2926,8 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           effectRef      <- Ref.make(0)
           conditionRef   <- Ref.make(0)
-          conditionTrue  = conditionRef.update(_ + 1).map(_ => true)
-          conditionFalse = conditionRef.update(_ + 1).map(_ => false)
+          conditionTrue  = conditionRef.update(_ + 1).as(true)
+          conditionFalse = conditionRef.update(_ + 1).as(false)
           _              <- effectRef.set(1).unlessM(conditionTrue)
           val1           <- effectRef.get
           conditionVal1  <- conditionRef.get
@@ -3139,8 +3139,8 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           effectRef      <- Ref.make(0)
           conditionRef   <- Ref.make(0)
-          conditionTrue  = conditionRef.update(_ + 1).map(_ => true)
-          conditionFalse = conditionRef.update(_ + 1).map(_ => false)
+          conditionTrue  = conditionRef.update(_ + 1).as(true)
+          conditionFalse = conditionRef.update(_ + 1).as(false)
           _              <- effectRef.set(1).whenM(conditionFalse)
           val1           <- effectRef.get
           conditionVal1  <- conditionRef.get

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -921,14 +921,14 @@ object ZSTMSpec extends ZIOBaseSpec {
         for {
           it    <- UIO((1 to 100).map(TRef.make(_)))
           tvars <- STM.collectAll(it).commit
-          res   <- UIO.collectAllPar(tvars.map(_.get.commit))
+          res   <- UIO.foreachPar(tvars)(_.get.commit)
         } yield assert(res)(equalTo((1 to 100).toList))
       },
       testM("collects a chunk of transactional effects to a single transaction that produces a chunk of values") {
         for {
           it    <- UIO((1 to 100).map(TRef.make(_)))
           tvars <- STM.collectAll(Chunk.fromIterable(it)).commit
-          res   <- UIO.collectAllPar(tvars.map(_.get.commit))
+          res   <- UIO.foreachPar(tvars)(_.get.commit)
         } yield assert(res)(equalTo(Chunk.fromIterable((1 to 100).toList)))
       }
     ),

--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -68,7 +68,7 @@ private[zio] trait FiberPlatformSpecific {
               .fold(Exit.fail, Exit.succeed)
               .map(Some(_))
           } else {
-            UIO.succeed(None)
+            UIO.none
           }
         }
 

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -408,7 +408,7 @@ object Fiber extends FiberPlatformSpecific {
         name       <- self.getRef(Fiber.fiberName)
         id         <- self.id
         status     <- self.status
-        trace      <- if (withTrace) self.trace.map(Some(_)) else UIO(None)
+        trace      <- if (withTrace) self.trace.asSome else UIO.none
         ch         <- self.children
         childDumps <- ZIO.foreach(ch)(_.dumpWith(withTrace))
       } yield Fiber.Dump(id, name, status, childDumps, trace)

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -476,7 +476,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Returns an effect whose failure is mapped by the specified `f` function.
    */
   def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZManaged[R, E1, A] =
-    ZManaged(reserve.mapError(f).map(r => Reservation(r.acquire.mapError(f), r.release)))
+    ZManaged(reserve.bimap(f, r => Reservation(r.acquire.mapError(f), r.release)))
 
   /**
    * Returns an effect whose full failure is mapped by the specified `f` function.

--- a/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/SinkUtils.scala
@@ -43,7 +43,7 @@ trait SinkUtils {
           case None        => (default, Chunk.empty)
         })
 
-      def initial = UIO.succeed(None)
+      def initial = UIO.none
 
       def step(state: State, a: A) =
         state match {
@@ -54,7 +54,7 @@ trait SinkUtils {
             if (acc.length >= accumulateAfterMet)
               UIO.succeed(state)
             else
-              UIO.succeed(Some(acc :+ a))
+              UIO.some(acc :+ a)
         }
 
       def cont(state: State) = state.map(_.length < accumulateAfterMet).getOrElse(true)

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamEffectAsyncSpec.scala
@@ -83,8 +83,7 @@ object StreamEffectAsyncSpec extends ZIOBaseSpec {
                       inParallel {
                         list.foreach(a => k(Task.succeed(a)))
                       }(global)
-                      latch.succeed(()) *>
-                        Task.unit
+                      latch.succeed(()).unit
                     }
                     .take(list.size.toLong)
                     .run(Sink.collectAll[Int])

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1493,7 +1493,7 @@ object StreamSpec extends ZIOBaseSpec {
           .partitionEither(i => ZIO.succeed(if (i % 2 == 0) Left(i) else Right(i)))
           .map { case (evens, odds) => evens.mergeEither(odds) }
           .use(_.runCollect)
-        assertM(ZIO.collectAll(Range(0, 100).toList.map(_ => stream)).map(_ => 0))(equalTo(0))
+        assertM(ZIO.collectAll(Range(0, 100).toList.map(_ => stream)).as(0))(equalTo(0))
       },
       testM("values") {
         Stream
@@ -1747,7 +1747,7 @@ object StreamSpec extends ZIOBaseSpec {
             .runDrain
             .sandbox
             .ignore
-            .map(_ => true)
+            .as(true)
         )(isTrue)
       } @@ zioTag(interruption)
     ),
@@ -1863,7 +1863,7 @@ object StreamSpec extends ZIOBaseSpec {
       assertM(
         Stream
           .unfoldM(0) { i =>
-            if (i < 10) IO.succeed(Some((i, i + 1)))
+            if (i < 10) IO.some((i, i + 1))
             else IO.succeed(None)
           }
           .runCollect

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamSpec.scala
@@ -1864,7 +1864,7 @@ object StreamSpec extends ZIOBaseSpec {
         Stream
           .unfoldM(0) { i =>
             if (i < 10) IO.some((i, i + 1))
-            else IO.succeed(None)
+            else IO.none
           }
           .runCollect
       )(equalTo((0 to 9).toList))

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamUtils.scala
@@ -34,7 +34,7 @@ trait StreamUtils extends GenZIO {
               it <- Gen.listOfN(n)(a)
             } yield ZStream.unfoldM((i, it)) {
               case (_, Nil) | (0, _) => IO.fail("fail-case")
-              case (n, head :: rest) => IO.succeed(Some((head, (n - 1, rest))))
+              case (n, head :: rest) => IO.some((head, (n - 1, rest)))
             }
           )
     }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -36,9 +36,7 @@ abstract class BaseTestTask(
   protected def sbtTestLayer(loggers: Array[Logger]): Layer[Nothing, TestLogger with Clock] =
     ZLayer.succeed[TestLogger.Service](new TestLogger.Service {
       def logLine(line: String): UIO[Unit] =
-        ZIO
-          .effect(loggers.foreach(_.info(colored(line))))
-          .catchAll(_ => ZIO.unit)
+        ZIO.effect(loggers.foreach(_.info(colored(line)))).ignore
     }) ++ Clock.live
 
   override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] =

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -90,7 +90,7 @@ object GenUtils {
     gen: Gen[Random with Sized, ZIO[Random with Sized, E, A]],
     size: Int = 100
   ): ZIO[Random, Nothing, List[Exit[E, A]]] =
-    provideSize(sample100(gen).flatMap(effects => ZIO.collectAll(effects.map(_.run))))(size)
+    provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.run)))(size)
 
   def shrink[R, A](gen: Gen[R, A]): ZIO[R, Nothing, A] =
     gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(1000).runLast.map(_.get)

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -651,7 +651,7 @@ package object environment extends PlatformSpecific {
         for {
           input <- consoleState.get.flatMap(d =>
                     IO.fromOption(d.input.headOption)
-                      .mapError(_ => new EOFException("There is no more input left to read"))
+                      .orElseFail(new EOFException("There is no more input left to read"))
                   )
           _ <- consoleState.update(data => Data(data.input.tail, data.output))
         } yield input


### PR DESCRIPTION
I ran zio-intellij inspections across the project to see what would come up.

There are some I didn't change because they were specifically testing things like `*>`. I also didn't touch the tracing tests because I assume there might be subtle differences if I use different methods. Not sure.

I also didn't change certain things (like using ZIO.when) as micro optimizations. I figure this is the same reason why some longer forms are used throughout the ZIO codebase.

Changes like using `ZIO.some` and so on should actually be faster than the old code because internally it uses `succeedNow`.