### PR TITLE
Generalize Dequeue Type Signature

### DIFF
--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -38,7 +38,7 @@ package object zio extends EitherCompat with PlatformSpecific with VersionSpecif
   type TaskLayer[+ROut]     = ZLayer[Any, Throwable, ROut]
 
   type Queue[A]    = ZQueue[Any, Nothing, Any, Nothing, A, A]
-  type Dequeue[+A] = ZQueue[Any, Nothing, Any, Nothing, Nothing, A]
+  type Dequeue[+A] = ZQueue[Nothing, Any, Any, Nothing, Nothing, A]
 
   type Ref[A]      = ZRef[Nothing, Nothing, A, A]
   type ERef[+E, A] = ZRef[E, E, A, A]


### PR DESCRIPTION
Since a value can never be offered to the queue we can allow it to have arbitrary environmental requirements and failure types for the offer.