### PR TITLE
Implement ZManaged#release

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -725,14 +725,6 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     new ZManaged.ProvideSomeLayer[R0, R, E, A](self)
 
   /**
-   * Runs the acquire and release actions and returns the result of this
-   * managed effect. Note that this is only safe if the result of this managed
-   * effect is valid outside its scope.
-   */
-  def release: ZIO[R, E, A] =
-    use(ZIO.succeedNow)
-
-  /**
    * Gives access to wrapped [[Reservation]].
    */
   def reserve: ZIO[R, E, Reservation[R, E, A]] = reservation
@@ -1024,6 +1016,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    * Useful for resources that you want to acquire and use as long as the application is running, like a HTTP server.
    */
   val useForever: ZIO[R, E, Nothing] = use(_ => ZIO.never)
+
+  /**
+   * Runs the acquire and release actions and returns the result of this
+   * managed effect. Note that this is only safe if the result of this managed
+   * effect is valid outside its scope.
+   */
+  def useNow: ZIO[R, E, A] =
+    use(ZIO.succeedNow)
 
   /**
    * The moral equivalent of `if (p) exp`

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -725,6 +725,14 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     new ZManaged.ProvideSomeLayer[R0, R, E, A](self)
 
   /**
+   * Runs the acquire and release actions and returns the result of this
+   * managed effect. Note that this is only safe if the result of this managed
+   * effect is valid outside its scope.
+   */
+  def release: ZIO[R, E, A] =
+    use(ZIO.succeedNow)
+
+  /**
    * Gives access to wrapped [[Reservation]].
    */
   def reserve: ZIO[R, E, Reservation[R, E, A]] = reservation


### PR DESCRIPTION
Following up on discussion on Discord, implements `Managed#release`, which is equivalent to `managed.use(ZIO.succeed)` and lets you go back from `ZManaged` to a `ZIO` by describing running the acquire and release actions and returning the result. This is only safe if the result is valid outside the scope in the same way that the user needs to not leak the resource in the `use` action of `bracket` but can be useful if we have already converted the resource into a result in the context of the managed.