### PR TITLE
Fix Stream.mapMPar ordering issue

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1957,7 +1957,7 @@ class ZStream[-R, +E, +A] private[stream] (private[stream] val structure: ZStrea
                 p     <- Promise.make[E1, B]
                 latch <- Promise.make[Nothing, Unit]
                 _     <- out.offer(Pull.fromPromise(p))
-                _     <- permits.withPermit(latch.succeed(()) *> f(a).to(p)).fork
+                _     <- permits.withPermit(f(a).to(p) *> latch.succeed(())).fork
                 _     <- latch.await
               } yield ()
             }.foldCauseM(


### PR DESCRIPTION
Fixes #3470

- Release lock after execute effect, not before
- Tune Stream.mapMPar:"guarantee ordering" test to reproduce issue. 