### PR TITLE
docs: remove unused (and shadowed) alias for Has.add

### DIFF
--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -97,7 +97,6 @@ object Has {
   }
 
   implicit final class HasSyntax[Self <: Has[_]](private val self: Self) extends AnyVal {
-    def +[B](b: B)(implicit tag: Tagged[B]): Self with Has[B] = self.add(b)
 
     def ++[B <: Has[_]](that: B)(implicit tagged: Tagged[B]): Self with B = self.union[B](that)
 

--- a/docs/howto/use_modules_and_layers.md
+++ b/docs/howto/use_modules_and_layers.md
@@ -107,7 +107,7 @@ We encountered two new data types `Has` and `ZLayer`, let's get familiar with th
 
 ### The `Has` data type
 
-`Has[A]` represents a dependency on a service of type `A`. Two `Has[_]` can be combined _horizontally_ through `+` and `++` operators, as in
+`Has[A]` represents a dependency on a service of type `A`. Two `Has[_]` can be combined _horizontally_ through `++` operator, as in
 
 ```scala mdoc:invisible
 object Repo {


### PR DESCRIPTION
Every time I was reading this part of documentation, I was confused by the aforementioned operator.

First: '+' operator doesn't exist on `ZLayer`
Second: using '+' results into `String`, which is most probably not what we want