### PR TITLE
Add ZSink#mapError

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -49,6 +49,9 @@ object ZSinkSpec extends ZIOBaseSpec {
           } yield assert(xs)(equalTo(ys))
         }
       ),
+      testM("mapError")(
+        assertM(ZStream.range(1, 10).run(ZSink.fail("fail").mapError(s => s + "!")).either)(equalTo(Left("fail!")))
+      ),
       suite("fold")(
         testM("termination in the middle")(
           assertM(ZStream.range(1, 10).run(ZSink.fold(0)(_ <= 5)((a, b) => a + b)))(equalTo(6))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -231,6 +231,12 @@ abstract class ZSink[-R, +E, -I, +Z] private (
     ZSink(self.push.map(sink => (inputs: Option[Chunk[I]]) => sink(inputs).mapError(_.map(f))))
 
   /**
+   * Transforms the errors emitted by this sink using `f`.
+   */
+  def mapError[E2](f: E => E2): ZSink[R, E2, I, Z] =
+    ZSink(self.push.map(p => in => p(in).mapError(e => e.left.map(f))))
+
+  /**
    * Effectfully transforms this sink's result.
    */
   def mapM[R1 <: R, E1 >: E, Z2](f: Z => ZIO[R1, E1, Z2]): ZSink[R1, E1, I, Z2] =


### PR DESCRIPTION
Closes #3485 (and perhaps  #2431)

Originally I wanted to add `mapError` to `ZConduit` but it doesn't work because of inheritance:
`ZSink#mapError` must return `ZSink`, not `ZConduit`