### PR TITLE
Synchronize Tag typeclass naming with izumi-reflect, rename Tagged->Tag, deprecate old names

### DIFF
--- a/core-tests/shared/src/test/scala/zio/TaggedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/TaggedSpec.scala
@@ -12,8 +12,8 @@ object TaggedSpec extends ZIOBaseSpec {
         """
             trait Producer[R, K, V]
 
-            def test[R: Tagged, K: Tagged, V: Tagged]: Boolean = {
-              val _ = implicitly[Tagged[Producer[R, K, V]]]
+            def test[R: Tag, K: Tag, V: Tag]: Boolean = {
+              val _ = implicitly[Tag[Producer[R, K, V]]]
               true
             }
             """

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -598,7 +598,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
   /**
    * Converts the chunk into an array.
    */
-  override def toArray[A1 >: A](implicit tag: ClassTag[A1]): Array[A1] = {
+  override def toArray[A1 >: A: ClassTag]: Array[A1] = {
     val dest = Array.ofDim[A1](self.length)
 
     self.toArray(0, dest)
@@ -1059,7 +1059,7 @@ object Chunk {
       take(i)
     }
 
-    override def toArray[A1 >: A](implicit tag: ClassTag[A1]): Array[A1] =
+    override def toArray[A1 >: A: ClassTag]: Array[A1] =
       array.asInstanceOf[Array[A1]]
 
     override protected[zio] def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
@@ -1275,7 +1275,7 @@ object Chunk {
     override def materialize[A1]: Chunk[A1] =
       Empty
 
-    override def toArray[A1](implicit tag: ClassTag[A1]): Array[A1] =
+    override def toArray[A1: ClassTag]: Array[A1] =
       Array.empty
   }
 

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -738,26 +738,25 @@ object RIO {
   /**
    * @see See [[zio.ZIO.service]]
    */
-  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+  def service[A: Tag]: URIO[Has[A], A] =
     ZIO.service[A]
 
   /**
    * @see See [[zio.ZIO.services[A,B]*]]
    */
-  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+  def services[A: Tag, B: Tag]: URIO[Has[A] with Has[B], (A, B)] =
     ZIO.services[A, B]
 
   /**
    * @see See [[zio.ZIO.services[A,B,C]*]]
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
     ZIO.services[A, B, C]
 
   /**
    * @see See [[zio.ZIO.services[A,B,C,D]*]]
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]: URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
     ZIO.services[A, B, C, D]
 
   /**

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -657,26 +657,25 @@ object URIO {
   /**
    * @see See [[zio.ZIO.service]]
    */
-  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+  def service[A: Tag]: URIO[Has[A], A] =
     ZIO.service[A]
 
   /**
    * @see See [[zio.ZIO.services[A,B]*]]
    */
-  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+  def services[A: Tag, B: Tag]: URIO[Has[A] with Has[B], (A, B)] =
     ZIO.services[A, B]
 
   /**
    * @see See [[zio.ZIO.services[A,B,C]*]]
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
     ZIO.services[A, B, C]
 
   /**
    * @see See [[zio.ZIO.services[A,B,C,D]*]]
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]: URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
     ZIO.services[A, B, C, D]
 
   /**

--- a/core/shared/src/main/scala/zio/VersionSpecific.scala
+++ b/core/shared/src/main/scala/zio/VersionSpecific.scala
@@ -4,36 +4,44 @@ import izumi.reflect.macrortti.LightTypeTagRef
 
 private[zio] trait VersionSpecific {
 
-  type Tagged[A] = izumi.reflect.Tag[A]
-  type TagType   = izumi.reflect.macrortti.LightTypeTag
+  type Tag[A] = izumi.reflect.Tag[A]
+  lazy val Tag = izumi.reflect.Tag
 
-  type TaggedF[F[_]]                                                                  = izumi.reflect.TagK[F]
-  type TaggedF2[F[_, _]]                                                              = izumi.reflect.TagKK[F]
-  type TaggedF3[F[_, _, _]]                                                           = izumi.reflect.TagK3[F]
-  type TaggedF4[F[_, _, _, _]]                                                        = izumi.reflect.TagK4[F]
-  type TaggedF5[F[_, _, _, _, _]]                                                     = izumi.reflect.TagK5[F]
-  type TaggedF6[F[_, _, _, _, _, _]]                                                  = izumi.reflect.TagK6[F]
-  type TaggedF7[F[_, _, _, _, _, _, _]]                                               = izumi.reflect.TagK7[F]
-  type TaggedF8[F[_, _, _, _, _, _, _, _]]                                            = izumi.reflect.TagK8[F]
-  type TaggedF9[F[_, _, _, _, _, _, _, _, _]]                                         = izumi.reflect.TagK9[F]
-  type TaggedF10[F[_, _, _, _, _, _, _, _, _, _]]                                     = izumi.reflect.TagK10[F]
-  type TaggedF11[F[_, _, _, _, _, _, _, _, _, _, _]]                                  = izumi.reflect.TagK11[F]
-  type TaggedF12[F[_, _, _, _, _, _, _, _, _, _, _, _]]                               = izumi.reflect.TagK12[F]
-  type TaggedF13[F[_, _, _, _, _, _, _, _, _, _, _, _, _]]                            = izumi.reflect.TagK13[F]
-  type TaggedF14[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _]]                         = izumi.reflect.TagK14[F]
-  type TaggedF15[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                      = izumi.reflect.TagK15[F]
-  type TaggedF16[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                   = izumi.reflect.TagK16[F]
-  type TaggedF17[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                = izumi.reflect.TagK17[F]
-  type TaggedF18[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]             = izumi.reflect.TagK18[F]
-  type TaggedF19[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]          = izumi.reflect.TagK19[F]
-  type TaggedF20[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]       = izumi.reflect.TagK20[F]
-  type TaggedF21[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]    = izumi.reflect.TagK21[F]
-  type TaggedF22[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK22[F]
+  type TagK[F[_]] = izumi.reflect.TagK[F]
+  lazy val TagK = izumi.reflect.TagK
 
-  private[zio] def taggedIsSubtype(left: TagType, right: TagType): Boolean =
+  type TagKK[F[_, _]] = izumi.reflect.TagKK[F]
+  lazy val TagKK = izumi.reflect.TagKK
+
+  type TagK3[F[_, _, _]] = izumi.reflect.TagK3[F]
+  lazy val TagK3 = izumi.reflect.TagK3
+
+  type TagK4[F[_, _, _, _]]                                                        = izumi.reflect.TagK4[F]
+  type TagK5[F[_, _, _, _, _]]                                                     = izumi.reflect.TagK5[F]
+  type TagK6[F[_, _, _, _, _, _]]                                                  = izumi.reflect.TagK6[F]
+  type TagK7[F[_, _, _, _, _, _, _]]                                               = izumi.reflect.TagK7[F]
+  type TagK8[F[_, _, _, _, _, _, _, _]]                                            = izumi.reflect.TagK8[F]
+  type TagK9[F[_, _, _, _, _, _, _, _, _]]                                         = izumi.reflect.TagK9[F]
+  type TagK10[F[_, _, _, _, _, _, _, _, _, _]]                                     = izumi.reflect.TagK10[F]
+  type TagK11[F[_, _, _, _, _, _, _, _, _, _, _]]                                  = izumi.reflect.TagK11[F]
+  type TagK12[F[_, _, _, _, _, _, _, _, _, _, _, _]]                               = izumi.reflect.TagK12[F]
+  type TagK13[F[_, _, _, _, _, _, _, _, _, _, _, _, _]]                            = izumi.reflect.TagK13[F]
+  type TagK14[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _]]                         = izumi.reflect.TagK14[F]
+  type TagK15[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                      = izumi.reflect.TagK15[F]
+  type TagK16[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                   = izumi.reflect.TagK16[F]
+  type TagK17[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]                = izumi.reflect.TagK17[F]
+  type TagK18[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]             = izumi.reflect.TagK18[F]
+  type TagK19[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]          = izumi.reflect.TagK19[F]
+  type TagK20[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]       = izumi.reflect.TagK20[F]
+  type TagK21[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]]    = izumi.reflect.TagK21[F]
+  type TagK22[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK22[F]
+
+  type LightTypeTag = izumi.reflect.macrortti.LightTypeTag
+
+  private[zio] def taggedIsSubtype(left: LightTypeTag, right: LightTypeTag): Boolean =
     left <:< right
 
-  private[zio] def taggedTagType[A](tagged: Tagged[A]): TagType =
+  private[zio] def taggedTagType[A](tagged: Tag[A]): LightTypeTag =
     tagged.tag
 
   /**
@@ -42,7 +50,7 @@ private[zio] trait VersionSpecific {
    *
    * `Tag[Has[A] with Has[B]]` should produce `Set(Tag[A], Tag[B])`
    */
-  private[zio] def taggedGetHasServices[A](t: TagType): Set[TagType] =
+  private[zio] def taggedGetHasServices[A](t: LightTypeTag): Set[LightTypeTag] =
     t.decompose.map { parent =>
       parent.ref match {
         case reference: LightTypeTagRef.AppliedNamedReference if reference.typeArgs.size == 1 =>
@@ -52,4 +60,38 @@ private[zio] trait VersionSpecific {
           parent
       }
     }
+
+  @deprecated("use Tag", "1.0.0") type Tagged[A]                                              = izumi.reflect.Tag[A]
+  @deprecated("use LightTypeTag", "1.0.0") type TypeTag                                       = izumi.reflect.macrortti.LightTypeTag
+  @deprecated("use TagK", "1.0.0") type TaggedF[F[_]]                                         = izumi.reflect.TagK[F]
+  @deprecated("use TagKK", "1.0.0") type TaggedF2[F[_, _]]                                    = izumi.reflect.TagKK[F]
+  @deprecated("use TagK3", "1.0.0") type TaggedF3[F[_, _, _]]                                 = izumi.reflect.TagK3[F]
+  @deprecated("use TagK4", "1.0.0") type TaggedF4[F[_, _, _, _]]                              = izumi.reflect.TagK4[F]
+  @deprecated("use TagK5", "1.0.0") type TaggedF5[F[_, _, _, _, _]]                           = izumi.reflect.TagK5[F]
+  @deprecated("use TagK6", "1.0.0") type TaggedF6[F[_, _, _, _, _, _]]                        = izumi.reflect.TagK6[F]
+  @deprecated("use TagK7", "1.0.0") type TaggedF7[F[_, _, _, _, _, _, _]]                     = izumi.reflect.TagK7[F]
+  @deprecated("use TagK8", "1.0.0") type TaggedF8[F[_, _, _, _, _, _, _, _]]                  = izumi.reflect.TagK8[F]
+  @deprecated("use TagK9", "1.0.0") type TaggedF9[F[_, _, _, _, _, _, _, _, _]]               = izumi.reflect.TagK9[F]
+  @deprecated("use TagK10", "1.0.0") type TaggedF10[F[_, _, _, _, _, _, _, _, _, _]]          = izumi.reflect.TagK10[F]
+  @deprecated("use TagK11", "1.0.0") type TaggedF11[F[_, _, _, _, _, _, _, _, _, _, _]]       = izumi.reflect.TagK11[F]
+  @deprecated("use TagK12", "1.0.0") type TaggedF12[F[_, _, _, _, _, _, _, _, _, _, _, _]]    = izumi.reflect.TagK12[F]
+  @deprecated("use TagK13", "1.0.0") type TaggedF13[F[_, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK13[F]
+  @deprecated("use TagK14", "1.0.0")
+  type TaggedF14[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK14[F]
+  @deprecated("use TagK15", "1.0.0")
+  type TaggedF15[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK15[F]
+  @deprecated("use TagK16", "1.0.0")
+  type TaggedF16[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK16[F]
+  @deprecated("use TagK17", "1.0.0")
+  type TaggedF17[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK17[F]
+  @deprecated("use TagK18", "1.0.0")
+  type TaggedF18[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK18[F]
+  @deprecated("use TagK19", "1.0.0")
+  type TaggedF19[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK19[F]
+  @deprecated("use TagK20", "1.0.0")
+  type TaggedF20[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK20[F]
+  @deprecated("use TagK21", "1.0.0")
+  type TaggedF21[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK21[F]
+  @deprecated("use TagK22", "1.0.0")
+  type TaggedF22[F[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]] = izumi.reflect.TagK22[F]
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -182,7 +182,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Maps the success value of this effect to a service.
    */
-  final def asService[A1 >: A](implicit tagged: Tagged[A1]): ZIO[R, E, Has[A1]] =
+  final def asService[A1 >: A: Tag]: ZIO[R, E, Has[A1]] =
     map(Has(_))
 
   /**
@@ -1094,7 +1094,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tagged[R1]): ZIO[ZEnv, E1, A] =
+  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZIO[ZEnv, E1, A] =
     provideSomeLayer[ZEnv](layer)
 
   /**
@@ -1740,7 +1740,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Constructs a layer from this effect.
    */
-  final def toLayer[A1 >: A](implicit ev: Tagged[A1]): ZLayer[R, E, Has[A1]] =
+  final def toLayer[A1 >: A](implicit ev: Tag[A1]): ZLayer[R, E, Has[A1]] =
     ZLayer.fromEffect(self)
 
   /**
@@ -3261,26 +3261,25 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Accesses the specified service in the environment of the effect.
    */
-  def service[A](implicit tagged: Tagged[A]): URIO[Has[A], A] =
+  def service[A: Tag]: URIO[Has[A], A] =
     ZIO.access(_.get[A])
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged]: URIO[Has[A] with Has[B], (A, B)] =
+  def services[A: Tag, B: Tag]: URIO[Has[A] with Has[B], (A, B)] =
     ZIO.access(r => (r.get[A], r.get[B]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: URIO[Has[A] with Has[B] with Has[C], (A, B, C)] =
     ZIO.access(r => (r.get[A], r.get[B], r.get[C]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
-    : URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]: URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
     ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
@@ -3493,7 +3492,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tagged[R1]): ZIO[R0, E1, A] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZIO[R0, E1, A] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -168,7 +168,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Maps the success value of this effect to a service.
    */
-  def asService[A1 >: A](implicit tagged: Tagged[A1]): ZManaged[R, E, Has[A1]] =
+  def asService[A1 >: A: Tag]: ZManaged[R, E, Has[A1]] =
     map(Has(_))
 
   /**
@@ -693,7 +693,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tagged[R1]): ZManaged[ZEnv, E1, A] =
+  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZManaged[ZEnv, E1, A] =
     provideSomeLayer[ZEnv](layer)
 
   /**
@@ -980,7 +980,7 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
   /**
    * Constructs a layer from this managed resource.
    */
-  def toLayer[A1 >: A](implicit tagged: Tagged[A1]): ZLayer[R, E, Has[A1]] =
+  def toLayer[A1 >: A: Tag]: ZLayer[R, E, Has[A1]] =
     ZLayer.fromManaged(self)
 
   /**
@@ -1331,7 +1331,7 @@ object ZManaged {
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZManaged[R, E, A]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tagged[R1]): ZManaged[R0, E1, A] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZManaged[R0, E1, A] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
@@ -2084,25 +2084,25 @@ object ZManaged {
   /**
    * Accesses the specified service in the environment of the effect.
    */
-  def service[A](implicit tagged: Tagged[A]): ZManaged[Has[A], Nothing, A] =
+  def service[A: Tag]: ZManaged[Has[A], Nothing, A] =
     ZManaged.access(_.get[A])
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged]: ZManaged[Has[A] with Has[B], Nothing, (A, B)] =
+  def services[A: Tag, B: Tag]: ZManaged[Has[A] with Has[B], Nothing, (A, B)] =
     ZManaged.access(r => (r.get[A], r.get[B]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: ZManaged[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: ZManaged[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
     ZManaged.access(r => (r.get[A], r.get[B], r.get[C]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]
     : ZManaged[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
     ZManaged.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1357,25 +1357,25 @@ object ZSTM {
   /**
    * Accesses the specified service in the environment of the effect.
    */
-  def service[A](implicit tagged: Tagged[A]): ZSTM[Has[A], Nothing, A] =
+  def service[A: Tag]: ZSTM[Has[A], Nothing, A] =
     ZSTM.access(_.get[A])
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged]: ZSTM[Has[A] with Has[B], Nothing, (A, B)] =
+  def services[A: Tag, B: Tag]: ZSTM[Has[A] with Has[B], Nothing, (A, B)] =
     ZSTM.access(r => (r.get[A], r.get[B]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: ZSTM[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: ZSTM[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
     ZSTM.access(r => (r.get[A], r.get[B], r.get[C]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]
     : ZSTM[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
     ZSTM.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -389,7 +389,7 @@ assertM(result)(isUnit)
 
 ## Polymorphic capabilities
 
-Mocking polymorphic methods is also supported, but the interface must require `zio.Tagged` implicit evidence for each type parameter.
+Mocking polymorphic methods is also supported, but the interface must require `zio.Tag` implicit evidence for each type parameter.
 
 ```scala mdoc:silent
 // main sources
@@ -397,10 +397,10 @@ type PolyExample = Has[PolyExample.Service]
 
 object PolyExample {
   trait Service {
-    def polyInput[I: Tagged](input: I): ZIO[Any, Throwable, String]
-    def polyError[E: Tagged](input: Int): ZIO[Any, E, String]
-    def polyOutput[A: Tagged](input: Int): ZIO[Any, Throwable, A]
-    def polyAll[I: Tagged, E: Tagged, A: Tagged](input: I): ZIO[Any, E, A]
+    def polyInput[I: Tag](input: I): ZIO[Any, Throwable, String]
+    def polyError[E: Tag](input: Int): ZIO[Any, E, String]
+    def polyOutput[A: Tag](input: Int): ZIO[Any, Throwable, A]
+    def polyAll[I: Tag, E: Tag, A: Tag](input: I): ZIO[Any, E, A]
   }
 }
 ```
@@ -422,10 +422,10 @@ object PolyExampleMock extends Mock[PolyExample] {
     ZLayer.fromServiceM { proxy =>
       withRuntime.map { rts =>
         new PolyExample.Service {
-          def polyInput[I: Tagged](input: I)                     = proxy(PolyInput.of[I], input)
-          def polyError[E: Tagged](input: Int)                   = proxy(PolyError.of[E], input)
-          def polyOutput[A: Tagged](input: Int)                  = proxy(PolyOutput.of[A], input)
-          def polyAll[I: Tagged, E: Tagged, A: Tagged](input: I) = proxy(PolyAll.of[I, E, A], input)
+          def polyInput[I: Tag](input: I)                     = proxy(PolyInput.of[I], input)
+          def polyError[E: Tag](input: Int)                   = proxy(PolyError.of[E], input)
+          def polyOutput[A: Tag](input: Int)                  = proxy(PolyOutput.of[A], input)
+          def polyAll[I: Tag, E: Tag, A: Tag](input: I) = proxy(PolyAll.of[I, E, A], input)
         }
       }
     }

--- a/examples/shared/src/main/scala-2.x/zio/examples/test/MockableMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/test/MockableMacroExample.scala
@@ -1,8 +1,8 @@
 package zio.examples.test
 
 import zio.test.mock.mockable
-import zio.{Tagged, UIO}
-import zio.{IO, Task, Tagged, UIO, URIO, ZIO}
+import zio.{ Tag, UIO }
+import zio.{ IO, Tag, Task, UIO, URIO, ZIO }
 
 object DiffrentScopeExample {
 
@@ -18,16 +18,16 @@ object DiffrentScopeExample {
     def task: Task[Long]
     def uio: UIO[Long]
     def urio: URIO[String, Long]
-    def poly1[A: Tagged](a: A): UIO[Unit]
-    def poly2[A: Tagged]: IO[A, Unit]
-    def poly3[A: Tagged]: UIO[A]
-    def poly4[A: Tagged, B: Tagged](a: A): IO[B, Unit]
-    def poly5[A: Tagged, B: Tagged](a: A): IO[Unit, B]
-    def poly6[A: Tagged, B: Tagged]: IO[A, B]
-    def poly7[A: Tagged, B: Tagged, C: Tagged](a: A): IO[B, C]
-    def poly8[A: Tagged]: UIO[(A, String)]
-    def poly9[A <: Foo: Tagged]: UIO[A]
-    def poly10[A: Tagged](a: Wrapped[A]): UIO[A]
+    def poly1[A: Tag](a: A): UIO[Unit]
+    def poly2[A: Tag]: IO[A, Unit]
+    def poly3[A: Tag]: UIO[A]
+    def poly4[A: Tag, B: Tag](a: A): IO[B, Unit]
+    def poly5[A: Tag, B: Tag](a: A): IO[Unit, B]
+    def poly6[A: Tag, B: Tag]: IO[A, B]
+    def poly7[A: Tag, B: Tag, C: Tag](a: A): IO[B, C]
+    def poly8[A: Tag]: UIO[(A, String)]
+    def poly9[A <: Foo: Tag]: UIO[A]
+    def poly10[A: Tag](a: Wrapped[A]): UIO[A]
   }
 }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1886,7 +1886,7 @@ abstract class ZStream[-R, +E, +O](
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tagged[R1]): ZStream[ZEnv, E1, O] =
+  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZStream[ZEnv, E1, O] =
     provideSomeLayer[ZEnv](layer)
 
   /**
@@ -3264,25 +3264,25 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   /**
    * Accesses the specified service in the environment of the effect.
    */
-  def service[A](implicit tagged: Tagged[A]): ZStream[Has[A], Nothing, A] =
+  def service[A: Tag]: ZStream[Has[A], Nothing, A] =
     ZStream.access(_.get[A])
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
+  def services[A: Tag, B: Tag]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
     ZStream.access(r => (r.get[A], r.get[B]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+  def services[A: Tag, B: Tag, C: Tag]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
     ZStream.access(r => (r.get[A], r.get[B], r.get[C]))
 
   /**
    * Accesses the specified services in the environment of the effect.
    */
-  def services[A: Tagged, B: Tagged, C: Tagged, D: Tagged]
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]
     : ZStream[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
     ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
@@ -3446,7 +3446,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZStream[R, E, A]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tagged[R1]): ZStream[R0, E1, A] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZStream[R0, E1, A] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 

--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -1,6 +1,6 @@
 package zio.test.mock
 
-import zio.{ Has, IO, Tagged, ZIO }
+import zio.{ Has, IO, Tag, ZIO }
 
 /**
  * https://github.com/scalamacros/paradise/issues/75
@@ -62,30 +62,30 @@ object modules {
   type PolyPureDefsModule = Has[PolyPureDefsModule.Service]
   object PolyPureDefsModule {
     trait Service {
-      def polyInput[I: Tagged](v: I): IO[String, String]
-      def polyError[E: Tagged](v: String): IO[E, String]
-      def polyOutput[A: Tagged](v: String): IO[String, A]
-      def polyInputError[I: Tagged, E: Tagged](v: I): IO[E, String]
-      def polyInputOutput[I: Tagged, A: Tagged](v: I): IO[String, A]
-      def polyErrorOutput[E: Tagged, A: Tagged](v: String): IO[E, A]
-      def polyInputErrorOutput[I: Tagged, E: Tagged, A: Tagged](v: I): IO[E, A]
-      def polyMixed[A: Tagged]: IO[String, (A, String)]
-      def polyBounded[A <: AnyVal: Tagged]: IO[String, A]
+      def polyInput[I: Tag](v: I): IO[String, String]
+      def polyError[E: Tag](v: String): IO[E, String]
+      def polyOutput[A: Tag](v: String): IO[String, A]
+      def polyInputError[I: Tag, E: Tag](v: I): IO[E, String]
+      def polyInputOutput[I: Tag, A: Tag](v: I): IO[String, A]
+      def polyErrorOutput[E: Tag, A: Tag](v: String): IO[E, A]
+      def polyInputErrorOutput[I: Tag, E: Tag, A: Tag](v: I): IO[E, A]
+      def polyMixed[A: Tag]: IO[String, (A, String)]
+      def polyBounded[A <: AnyVal: Tag]: IO[String, A]
     }
   }
 
   type PolyImpureDefsModule = Has[PolyImpureDefsModule.Service]
   object PolyImpureDefsModule {
     trait Service {
-      def polyInput[I: Tagged](v: I): String
-      def polyError[E <: Throwable: Tagged](v: String): String
-      def polyOutput[A: Tagged](v: String): A
-      def polyInputError[I: Tagged, E <: Throwable: Tagged](v: I): String
-      def polyInputOutput[I: Tagged, A: Tagged](v: I): A
-      def polyErrorOutput[E <: Throwable: Tagged, A: Tagged](v: String): A
-      def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): A
-      def polyMixed[A: Tagged]: (A, String)
-      def polyBounded[A <: AnyVal: Tagged]: A
+      def polyInput[I: Tag](v: I): String
+      def polyError[E <: Throwable: Tag](v: String): String
+      def polyOutput[A: Tag](v: String): A
+      def polyInputError[I: Tag, E <: Throwable: Tag](v: I): String
+      def polyInputOutput[I: Tag, A: Tag](v: I): A
+      def polyErrorOutput[E <: Throwable: Tag, A: Tag](v: String): A
+      def polyInputErrorOutput[I: Tag, E <: Throwable: Tag, A: Tag](v: I): A
+      def polyMixed[A: Tag]: (A, String)
+      def polyBounded[A <: AnyVal: Tag]: A
     }
   }
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -6,14 +6,14 @@ import zio.duration._
 import zio.random.Random
 import zio.system.System
 import zio.test.{ assertM, suite, testM, Assertion, ZIOBaseSpec }
-import zio.{ clock, console, random, system, Has, Tagged, ULayer, ZIO }
+import zio.{ clock, console, random, system, Has, Tag, ULayer, ZIO }
 
 object ComposedMockSpec extends ZIOBaseSpec {
 
   import Assertion._
   import Expectation._
 
-  private def testValueComposed[R1 <: Has[_]: Tagged, E, A](name: String)(
+  private def testValueComposed[R1 <: Has[_]: Tag, E, A](name: String)(
     mock: ULayer[R1],
     app: ZIO[R1, E, A],
     check: Assertion[A]

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
@@ -18,7 +18,7 @@ package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
 
-import zio.{ Tagged, URIO, ZIO }
+import zio.{ Tag, URIO, ZIO }
 
 /**
  * Example of impure module used for testing ZIO Mock framework.
@@ -37,15 +37,15 @@ object ImpureModule {
     def parameterizedCommand(a: Int): Unit
     def overloaded(n: Int): String
     def overloaded(n: Long): String
-    def polyInput[I: Tagged](v: I): String
-    def polyError[E <: Throwable: Tagged](v: String): String
-    def polyOutput[A: Tagged](v: String): A
-    def polyInputError[I: Tagged, E <: Throwable: Tagged](v: I): String
-    def polyInputOutput[I: Tagged, A: Tagged](v: I): A
-    def polyErrorOutput[E <: Throwable: Tagged, A: Tagged](v: String): A
-    def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): A
-    def polyMixed[A: Tagged]: (A, String)
-    def polyBounded[A <: AnyVal: Tagged]: A
+    def polyInput[I: Tag](v: I): String
+    def polyError[E <: Throwable: Tag](v: String): String
+    def polyOutput[A: Tag](v: String): A
+    def polyInputError[I: Tag, E <: Throwable: Tag](v: I): String
+    def polyInputOutput[I: Tag, A: Tag](v: I): A
+    def polyErrorOutput[E <: Throwable: Tag, A: Tag](v: String): A
+    def polyInputErrorOutput[I: Tag, E <: Throwable: Tag, A: Tag](v: I): A
+    def polyMixed[A: Tag]: (A, String)
+    def polyBounded[A <: AnyVal: Tag]: A
     def varargs(a: Int, b: String*): String
     def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String
     def byName(a: => Int): String
@@ -86,20 +86,20 @@ object ImpureModule {
   def parameterizedCommand(a: Int): URIO[ImpureModule, Unit] = ZIO.access[ImpureModule](_.get.parameterizedCommand(a))
   def overloaded(n: Int): URIO[ImpureModule, String]         = ZIO.access[ImpureModule](_.get.overloaded(n))
   def overloaded(n: Long): URIO[ImpureModule, String]        = ZIO.access[ImpureModule](_.get.overloaded(n))
-  def polyInput[I: Tagged](v: I): URIO[ImpureModule, String] = ZIO.access[ImpureModule](_.get.polyInput(v))
-  def polyError[E <: Throwable: Tagged](v: String): URIO[ImpureModule, String] =
+  def polyInput[I: Tag](v: I): URIO[ImpureModule, String]    = ZIO.access[ImpureModule](_.get.polyInput(v))
+  def polyError[E <: Throwable: Tag](v: String): URIO[ImpureModule, String] =
     ZIO.access[ImpureModule](_.get.polyError(v))
-  def polyOutput[A: Tagged](v: String): URIO[ImpureModule, A] = ZIO.access[ImpureModule](_.get.polyOutput(v))
-  def polyInputError[I: Tagged, E <: Throwable: Tagged](v: I): URIO[ImpureModule, String] =
+  def polyOutput[A: Tag](v: String): URIO[ImpureModule, A] = ZIO.access[ImpureModule](_.get.polyOutput(v))
+  def polyInputError[I: Tag, E <: Throwable: Tag](v: I): URIO[ImpureModule, String] =
     ZIO.access[ImpureModule](_.get.polyInputError[I, E](v))
-  def polyInputOutput[I: Tagged, A: Tagged](v: I): URIO[ImpureModule, A] =
+  def polyInputOutput[I: Tag, A: Tag](v: I): URIO[ImpureModule, A] =
     ZIO.access[ImpureModule](_.get.polyInputOutput[I, A](v))
-  def polyErrorOutput[E <: Throwable: Tagged, A: Tagged](v: String): URIO[ImpureModule, A] =
+  def polyErrorOutput[E <: Throwable: Tag, A: Tag](v: String): URIO[ImpureModule, A] =
     ZIO.access[ImpureModule](_.get.polyErrorOutput[E, A](v))
-  def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): URIO[ImpureModule, A] =
+  def polyInputErrorOutput[I: Tag, E <: Throwable: Tag, A: Tag](v: I): URIO[ImpureModule, A] =
     ZIO.access[ImpureModule](_.get.polyInputErrorOutput[I, E, A](v))
-  def polyMixed[A: Tagged]: URIO[ImpureModule, (A, String)]   = ZIO.access[ImpureModule](_.get.polyMixed[A])
-  def polyBounded[A <: AnyVal: Tagged]: URIO[ImpureModule, A] = ZIO.access[ImpureModule](_.get.polyBounded[A])
+  def polyMixed[A: Tag]: URIO[ImpureModule, (A, String)]      = ZIO.access[ImpureModule](_.get.polyMixed[A])
+  def polyBounded[A <: AnyVal: Tag]: URIO[ImpureModule, A]    = ZIO.access[ImpureModule](_.get.polyBounded[A])
   def varargs(a: Int, b: String*): URIO[ImpureModule, String] = ZIO.access[ImpureModule](_.get.varargs(a, b: _*))
   def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): URIO[ImpureModule, String] =
     ZIO.access[ImpureModule](_.get.curriedVarargs(a, b: _*)(c, d: _*))

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
@@ -19,7 +19,7 @@ package zio.test.mock.module
 import com.github.ghik.silencer.silent
 
 import zio.test.mock.{ Mock, Proxy }
-import zio.{ Has, Tagged, URLayer, ZLayer }
+import zio.{ Has, Tag, URLayer, ZLayer }
 
 /**
  * Example module used for testing ZIO Mock framework.
@@ -63,22 +63,22 @@ object ImpureModuleMock extends Mock[ImpureModule] {
           def manyParams(a: Int, b: String, c: Long): String     = rts.unsafeRunTask(proxy(ManyParams, (a, b, c)))
           def manyParamLists(a: Int)(b: String)(c: Long): String = rts.unsafeRunTask(proxy(ManyParamLists, a, b, c))
           @silent("side-effecting nullary methods")
-          def command: Unit                                        = rts.unsafeRunTask(proxy(Command))
-          def parameterizedCommand(a: Int): Unit                   = rts.unsafeRunTask(proxy(ParameterizedCommand, a))
-          def overloaded(n: Int): String                           = rts.unsafeRunTask(proxy(Overloaded._0, n))
-          def overloaded(n: Long): String                          = rts.unsafeRunTask(proxy(Overloaded._1, n))
-          def polyInput[I: Tagged](v: I): String                   = rts.unsafeRunTask(proxy(PolyInput.of[I], v))
-          def polyError[E <: Throwable: Tagged](v: String): String = rts.unsafeRunTask(proxy(PolyError.of[E], v))
-          def polyOutput[A: Tagged](v: String): A                  = rts.unsafeRunTask(proxy(PolyOutput.of[A], v))
-          def polyInputError[I: Tagged, E <: Throwable: Tagged](v: I): String =
+          def command: Unit                                     = rts.unsafeRunTask(proxy(Command))
+          def parameterizedCommand(a: Int): Unit                = rts.unsafeRunTask(proxy(ParameterizedCommand, a))
+          def overloaded(n: Int): String                        = rts.unsafeRunTask(proxy(Overloaded._0, n))
+          def overloaded(n: Long): String                       = rts.unsafeRunTask(proxy(Overloaded._1, n))
+          def polyInput[I: Tag](v: I): String                   = rts.unsafeRunTask(proxy(PolyInput.of[I], v))
+          def polyError[E <: Throwable: Tag](v: String): String = rts.unsafeRunTask(proxy(PolyError.of[E], v))
+          def polyOutput[A: Tag](v: String): A                  = rts.unsafeRunTask(proxy(PolyOutput.of[A], v))
+          def polyInputError[I: Tag, E <: Throwable: Tag](v: I): String =
             rts.unsafeRunTask(proxy(PolyInputError.of[I, E], v))
-          def polyInputOutput[I: Tagged, A: Tagged](v: I): A = rts.unsafeRunTask(proxy(PolyInputOutput.of[I, A], v))
-          def polyErrorOutput[E <: Throwable: Tagged, A: Tagged](v: String): A =
+          def polyInputOutput[I: Tag, A: Tag](v: I): A = rts.unsafeRunTask(proxy(PolyInputOutput.of[I, A], v))
+          def polyErrorOutput[E <: Throwable: Tag, A: Tag](v: String): A =
             rts.unsafeRunTask(proxy(PolyErrorOutput.of[E, A], v))
-          def polyInputErrorOutput[I: Tagged, E <: Throwable: Tagged, A: Tagged](v: I): A =
+          def polyInputErrorOutput[I: Tag, E <: Throwable: Tag, A: Tag](v: I): A =
             rts.unsafeRunTask(proxy(PolyInputErrorOutput.of[I, E, A], v))
-          def polyMixed[A: Tagged]: (A, String)   = rts.unsafeRunTask(proxy(PolyMixed.of[(A, String)]))
-          def polyBounded[A <: AnyVal: Tagged]: A = rts.unsafeRunTask(proxy(PolyBounded.of[A]))
+          def polyMixed[A: Tag]: (A, String)      = rts.unsafeRunTask(proxy(PolyMixed.of[(A, String)]))
+          def polyBounded[A <: AnyVal: Tag]: A    = rts.unsafeRunTask(proxy(PolyBounded.of[A]))
           def varargs(a: Int, b: String*): String = rts.unsafeRunTask(proxy(Varargs, (a, b)))
           def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): String =
             rts.unsafeRunTask(proxy(CurriedVarargs, (a, b, c, d)))

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
@@ -18,7 +18,7 @@ package zio.test.mock.module
 
 import scala.reflect.ClassTag
 
-import zio.{ IO, Tagged, ZIO }
+import zio.{ IO, Tag, ZIO }
 
 /**
  * Example module used for testing ZIO Mock framework.
@@ -46,15 +46,15 @@ object PureModule {
     def looped(a: Int): IO[Nothing, Nothing]
     def overloaded(n: Int): IO[String, String]
     def overloaded(n: Long): IO[String, String]
-    def polyInput[I: Tagged](v: I): IO[String, String]
-    def polyError[E: Tagged](v: String): IO[E, String]
-    def polyOutput[A: Tagged](v: String): IO[String, A]
-    def polyInputError[I: Tagged, E: Tagged](v: I): IO[E, String]
-    def polyInputOutput[I: Tagged, A: Tagged](v: I): IO[String, A]
-    def polyErrorOutput[E: Tagged, A: Tagged](v: String): IO[E, A]
-    def polyInputErrorOutput[I: Tagged, E: Tagged, A: Tagged](v: I): IO[E, A]
-    def polyMixed[A: Tagged]: IO[String, (A, String)]
-    def polyBounded[A <: AnyVal: Tagged]: IO[String, A]
+    def polyInput[I: Tag](v: I): IO[String, String]
+    def polyError[E: Tag](v: String): IO[E, String]
+    def polyOutput[A: Tag](v: String): IO[String, A]
+    def polyInputError[I: Tag, E: Tag](v: I): IO[E, String]
+    def polyInputOutput[I: Tag, A: Tag](v: I): IO[String, A]
+    def polyErrorOutput[E: Tag, A: Tag](v: String): IO[E, A]
+    def polyInputErrorOutput[I: Tag, E: Tag, A: Tag](v: I): IO[E, A]
+    def polyMixed[A: Tag]: IO[String, (A, String)]
+    def polyBounded[A <: AnyVal: Tag]: IO[String, A]
     def varargs(a: Int, b: String*): IO[String, String]
     def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String]
     def byName(a: => Int): IO[String, String]
@@ -97,25 +97,25 @@ object PureModule {
   def looped(a: Int): ZIO[PureModule, Nothing, Nothing]         = ZIO.accessM[PureModule](_.get.looped(a))
   def overloaded(n: Int): ZIO[PureModule, String, String]       = ZIO.accessM[PureModule](_.get.overloaded(n))
   def overloaded(n: Long): ZIO[PureModule, String, String]      = ZIO.accessM[PureModule](_.get.overloaded(n))
-  def polyInput[I: NotAnyKind: Tagged](v: I): ZIO[PureModule, String, String] =
+  def polyInput[I: NotAnyKind: Tag](v: I): ZIO[PureModule, String, String] =
     ZIO.accessM[PureModule](_.get.polyInput[I](v))
-  def polyError[E: NotAnyKind: Tagged](v: String): ZIO[PureModule, E, String] =
+  def polyError[E: NotAnyKind: Tag](v: String): ZIO[PureModule, E, String] =
     ZIO.accessM[PureModule](_.get.polyError[E](v))
-  def polyOutput[A: NotAnyKind: Tagged](v: String): ZIO[PureModule, String, A] =
+  def polyOutput[A: NotAnyKind: Tag](v: String): ZIO[PureModule, String, A] =
     ZIO.accessM[PureModule](_.get.polyOutput[A](v))
-  def polyInputError[I: NotAnyKind: Tagged, E: NotAnyKind: Tagged](v: I): ZIO[PureModule, E, String] =
+  def polyInputError[I: NotAnyKind: Tag, E: NotAnyKind: Tag](v: I): ZIO[PureModule, E, String] =
     ZIO.accessM[PureModule](_.get.polyInputError[I, E](v))
-  def polyInputOutput[I: NotAnyKind: Tagged, A: NotAnyKind: Tagged](v: I): ZIO[PureModule, String, A] =
+  def polyInputOutput[I: NotAnyKind: Tag, A: NotAnyKind: Tag](v: I): ZIO[PureModule, String, A] =
     ZIO.accessM[PureModule](_.get.polyInputOutput[I, A](v))
-  def polyErrorOutput[E: NotAnyKind: Tagged, A: NotAnyKind: Tagged](v: String): ZIO[PureModule, E, A] =
+  def polyErrorOutput[E: NotAnyKind: Tag, A: NotAnyKind: Tag](v: String): ZIO[PureModule, E, A] =
     ZIO.accessM[PureModule](_.get.polyErrorOutput[E, A](v))
-  def polyInputErrorOutput[I: NotAnyKind: Tagged, E: NotAnyKind: Tagged, A: NotAnyKind: Tagged](
+  def polyInputErrorOutput[I: NotAnyKind: Tag, E: NotAnyKind: Tag, A: NotAnyKind: Tag](
     v: I
   ): ZIO[PureModule, E, A] =
     ZIO.accessM[PureModule](_.get.polyInputErrorOutput[I, E, A](v))
-  def polyMixed[A: NotAnyKind: Tagged]: ZIO[PureModule, String, (A, String)] =
+  def polyMixed[A: NotAnyKind: Tag]: ZIO[PureModule, String, (A, String)] =
     ZIO.accessM[PureModule](_.get.polyMixed[A])
-  def polyBounded[A <: AnyVal: NotAnyKind: Tagged]: ZIO[PureModule, String, A] =
+  def polyBounded[A <: AnyVal: NotAnyKind: Tag]: ZIO[PureModule, String, A] =
     ZIO.accessM[PureModule](_.get.polyBounded[A])
   def varargs(a: Int, b: String*): ZIO[PureModule, String, String] = ZIO.accessM[PureModule](_.get.varargs(a, b: _*))
   def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): ZIO[PureModule, String, String] =

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
@@ -19,7 +19,7 @@ package zio.test.mock.module
 import com.github.ghik.silencer.silent
 
 import zio.test.mock.{ Mock, Proxy }
-import zio.{ Has, IO, Tagged, UIO, URLayer, ZLayer }
+import zio.{ Has, IO, Tag, UIO, URLayer, ZLayer }
 
 /**
  * Example pure module used for testing ZIO Mock framework.
@@ -71,16 +71,16 @@ object PureModuleMock extends Mock[PureModule] {
           def looped(a: Int): UIO[Nothing]                                   = proxy(Looped, a)
           def overloaded(n: Int): IO[String, String]                         = proxy(Overloaded._0, n)
           def overloaded(n: Long): IO[String, String]                        = proxy(Overloaded._1, n)
-          def polyInput[I: Tagged](v: I): IO[String, String]                 = proxy(PolyInput.of[I], v)
-          def polyError[E: Tagged](v: String): IO[E, String]                 = proxy(PolyError.of[E], v)
-          def polyOutput[A: Tagged](v: String): IO[String, A]                = proxy(PolyOutput.of[A], v)
-          def polyInputError[I: Tagged, E: Tagged](v: I): IO[E, String]      = proxy(PolyInputError.of[I, E], v)
-          def polyInputOutput[I: Tagged, A: Tagged](v: I): IO[String, A]     = proxy(PolyInputOutput.of[I, A], v)
-          def polyErrorOutput[E: Tagged, A: Tagged](v: String): IO[E, A]     = proxy(PolyErrorOutput.of[E, A], v)
-          def polyInputErrorOutput[I: Tagged, E: Tagged, A: Tagged](v: I): IO[E, A] =
+          def polyInput[I: Tag](v: I): IO[String, String]                    = proxy(PolyInput.of[I], v)
+          def polyError[E: Tag](v: String): IO[E, String]                    = proxy(PolyError.of[E], v)
+          def polyOutput[A: Tag](v: String): IO[String, A]                   = proxy(PolyOutput.of[A], v)
+          def polyInputError[I: Tag, E: Tag](v: I): IO[E, String]            = proxy(PolyInputError.of[I, E], v)
+          def polyInputOutput[I: Tag, A: Tag](v: I): IO[String, A]           = proxy(PolyInputOutput.of[I, A], v)
+          def polyErrorOutput[E: Tag, A: Tag](v: String): IO[E, A]           = proxy(PolyErrorOutput.of[E, A], v)
+          def polyInputErrorOutput[I: Tag, E: Tag, A: Tag](v: I): IO[E, A] =
             proxy(PolyInputErrorOutput.of[I, E, A], v)
-          def polyMixed[A: Tagged]: IO[String, (A, String)]   = proxy(PolyMixed.of[(A, String)])
-          def polyBounded[A <: AnyVal: Tagged]: IO[String, A] = proxy(PolyBounded.of[A])
+          def polyMixed[A: Tag]: IO[String, (A, String)]      = proxy(PolyMixed.of[(A, String)])
+          def polyBounded[A <: AnyVal: Tag]: IO[String, A]    = proxy(PolyBounded.of[A])
           def varargs(a: Int, b: String*): IO[String, String] = proxy(Varargs, (a, b))
           def curriedVarargs(a: Int, b: String*)(c: Long, d: Char*): IO[String, String] =
             proxy(CurriedVarargs, (a, b, c, d))

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -345,7 +345,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[TestEnvironment, E1, R1]
-  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tagged[R1]): Spec[TestEnvironment, E1, T] =
+  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
     provideSomeLayer[TestEnvironment](layer)
 
   /**
@@ -363,7 +363,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    */
   def provideCustomLayerShared[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[TestEnvironment, E1, R1]
-  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tagged[R1]): Spec[TestEnvironment, E1, T] =
+  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
     provideSomeLayerShared[TestEnvironment](layer)
 
   /**
@@ -542,14 +542,14 @@ object Spec {
   final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tagged[R1]): Spec[R0, E1, T] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): Spec[R0, E1, T] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 
   final class ProvideSomeLayerShared[R0 <: Has[_], -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
     def apply[E1 >: E, R1 <: Has[_]](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tagged[R1]): Spec[R0, E1, T] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): Spec[R0, E1, T] =
       self.caseValue match {
         case SuiteCase(label, specs, exec) =>
           Spec.suite(

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.Tagged
+import zio.Tag
 import zio.duration._
 
 /**
@@ -26,7 +26,7 @@ final class TestAnnotation[V] private (
   val identifier: String,
   val initial: V,
   val combine: (V, V) => V,
-  private val tag: Tagged[V]
+  private val tag: Tag[V]
 ) extends Serializable {
   override def equals(that: Any): Boolean = that match {
     case that: TestAnnotation[_] => (identifier, tag) == ((that.identifier, that.tag))
@@ -37,9 +37,7 @@ final class TestAnnotation[V] private (
 }
 object TestAnnotation {
 
-  def apply[V](identifier: String, initial: V, combine: (V, V) => V)(
-    implicit tag: Tagged[V]
-  ): TestAnnotation[V] =
+  def apply[V](identifier: String, initial: V, combine: (V, V) => V)(implicit tag: Tag[V]): TestAnnotation[V] =
     new TestAnnotation(identifier, initial, combine, tag)
 
   /**

--- a/test/shared/src/main/scala/zio/test/mock/Capability.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Capability.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import com.github.ghik.silencer.silent
 
 import zio.test.Assertion
-import zio.{ =!=, taggedIsSubtype, taggedTagType, Has, IO, TagType, Tagged }
+import zio.{ =!=, taggedIsSubtype, taggedTagType, Has, IO, LightTypeTag, Tag }
 
 /**
  * A `Capability[R, I, E, A]` represents a capability of environment `R` that takes an input `I`
@@ -33,12 +33,12 @@ import zio.{ =!=, taggedIsSubtype, taggedTagType, Has, IO, TagType, Tagged }
  * To construct capability tags you should start by creating a `Mock[R]` and extend publicly
  * available `Effect`, `Method`, `Sink` or `Stream` type members.
  */
-protected[mock] abstract class Capability[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A: Tagged](val mock: Mock[R])
+protected[mock] abstract class Capability[R <: Has[_]: Tag, I: Tag, E: Tag, A: Tag](val mock: Mock[R])
     extends Capability.Base[R] { self =>
 
-  val inputTag: TagType  = taggedTagType(implicitly[Tagged[I]])
-  val errorTag: TagType  = taggedTagType(implicitly[Tagged[E]])
-  val outputTag: TagType = taggedTagType(implicitly[Tagged[A]])
+  val inputTag: LightTypeTag  = taggedTagType(implicitly[Tag[I]])
+  val errorTag: LightTypeTag  = taggedTagType(implicitly[Tag[E]])
+  val outputTag: LightTypeTag = taggedTagType(implicitly[Tag[A]])
 
   @silent("is never used")
   def apply()(implicit ev1: I =:= Unit, ev2: A <:< Unit): Expectation[R] =
@@ -90,188 +90,188 @@ object Capability {
 
   sealed abstract class Unknown
 
-  protected[mock] abstract class Poly[R <: Has[_]: Tagged, I, E, A] extends Base[R]
+  protected[mock] abstract class Poly[R <: Has[_]: Tag, I, E, A] extends Base[R]
 
   object Poly {
 
     /**
      * Represents capability of environment `R` polymorphic in its input type.
      */
-    protected[mock] abstract class Input[R <: Has[_]: Tagged, E: Tagged, A: Tagged](val mock: Mock[R])
+    protected[mock] abstract class Input[R <: Has[_]: Tag, E: Tag, A: Tag](val mock: Mock[R])
         extends Poly[R, Unknown, E, A] { self =>
 
-      def of[I: Tagged]: Capability[R, I, E, A] =
+      def of[I: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[I: Tagged](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
+      def of[I: Tag](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[I: Tagged](assertion: Assertion[I], result: Result[I, E, A])(implicit ev: I =!= Unit): Expectation[R] =
+      def of[I: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit ev: I =!= Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[I: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its error type.
      */
-    protected[mock] abstract class Error[R <: Has[_]: Tagged, I: Tagged, A: Tagged, E1](val mock: Mock[R])
+    protected[mock] abstract class Error[R <: Has[_]: Tag, I: Tag, A: Tag, E1](val mock: Mock[R])
         extends Poly[R, I, Unknown, A] { self =>
 
-      def of[E <: E1: Tagged]: Capability[R, I, E, A] =
+      def of[E <: E1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[E <: E1: Tagged](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
+      def of[E <: E1: Tag](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[E <: E1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[E <: E1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[E <: E1: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[E <: E1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its output type.
      */
-    protected[mock] abstract class Output[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A1](val mock: Mock[R])
+    protected[mock] abstract class Output[R <: Has[_]: Tag, I: Tag, E: Tag, A1](val mock: Mock[R])
         extends Poly[R, I, E, Unknown] { self =>
 
-      def of[A <: A1: Tagged]: Capability[R, I, E, A] =
+      def of[A <: A1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[A <: A1: Tagged](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
+      def of[A <: A1: Tag](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[A <: A1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[A <: A1: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its input and error types.
      */
-    protected[mock] abstract class InputError[R <: Has[_]: Tagged, A: Tagged, E1](val mock: Mock[R])
+    protected[mock] abstract class InputError[R <: Has[_]: Tag, A: Tag, E1](val mock: Mock[R])
         extends Poly[R, Unknown, Unknown, A] { self =>
 
-      def of[I: Tagged, E <: E1: Tagged]: Capability[R, I, E, A] =
+      def of[I: Tag, E <: E1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged](
+      def of[I: Tag, E <: E1: Tag](
         assertion: Assertion[I]
       )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[I: Tag, E <: E1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[I: Tag, E <: E1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its input and output types.
      */
-    protected[mock] abstract class InputOutput[R <: Has[_]: Tagged, E: Tagged, A1](val mock: Mock[R])
+    protected[mock] abstract class InputOutput[R <: Has[_]: Tag, E: Tag, A1](val mock: Mock[R])
         extends Poly[R, Unknown, E, Unknown] { self =>
 
-      def of[I: Tagged, A <: A1: Tagged]: Capability[R, I, E, A] =
+      def of[I: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[I: Tagged, A <: A1: Tagged](
+      def of[I: Tag, A <: A1: Tag](
         assertion: Assertion[I]
       )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[I: Tagged, A <: A1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[I: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tagged, A <: A1: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[I: Tag, A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its error and output types.
      */
-    protected[mock] abstract class ErrorOutput[R <: Has[_]: Tagged, I: Tagged, E1, A1](val mock: Mock[R])
+    protected[mock] abstract class ErrorOutput[R <: Has[_]: Tag, I: Tag, E1, A1](val mock: Mock[R])
         extends Poly[R, I, Unknown, Unknown] { self =>
 
-      def of[E <: E1: Tagged, A <: A1: Tagged]: Capability[R, I, E, A] =
+      def of[E <: E1: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[E <: E1: Tagged, A <: A1: Tagged](
+      def of[E <: E1: Tag, A <: A1: Tag](
         assertion: Assertion[I]
       )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[E <: E1: Tagged, A <: A1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[E <: E1: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[E <: E1: Tagged, A <: A1: Tagged](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
+      def of[E <: E1: Tag, A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its input, error and output types.
      */
-    protected[mock] abstract class InputErrorOutput[R <: Has[_]: Tagged, E1, A1](val mock: Mock[R])
+    protected[mock] abstract class InputErrorOutput[R <: Has[_]: Tag, E1, A1](val mock: Mock[R])
         extends Poly[R, Unknown, Unknown, Unknown] { self =>
 
-      def of[I: Tagged, E <: E1: Tagged, A <: A1: Tagged]: Capability[R, I, E, A] =
+      def of[I: Tag, E <: E1: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
         toMethod[R, I, E, A](self)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged, A <: A1: Tagged](
+      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](
         assertion: Assertion[I]
       )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged, A <: A1: Tagged](assertion: Assertion[I], result: Result[I, E, A])(
+      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(
         implicit ev: I =!= Unit
       ): Expectation[R] =
         toExpectation[R, I, E, A](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tagged, E <: E1: Tagged, A <: A1: Tagged](
+      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](
         returns: Result[I, E, A]
       )(implicit ev: I <:< Unit): Expectation[R] =
         toExpectation[R, I, E, A](self, returns)
     }
 
     @silent("is never used")
-    private def toExpectation[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A: Tagged](
+    private def toExpectation[R <: Has[_]: Tag, I: Tag, E: Tag, A: Tag](
       poly: Poly[R, _, _, _],
       assertion: Assertion[I]
     )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
@@ -282,7 +282,7 @@ object Capability {
       )
 
     @silent("is never used")
-    private def toExpectation[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A: Tagged](
+    private def toExpectation[R <: Has[_]: Tag, I: Tag, E: Tag, A: Tag](
       poly: Poly[R, _, _, _],
       assertion: Assertion[I],
       result: Result[I, E, A]
@@ -290,13 +290,13 @@ object Capability {
       Expectation.Call[R, I, E, A](toMethod[R, I, E, A](poly), assertion, result.io)
 
     @silent("is never used")
-    private def toExpectation[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A: Tagged](
+    private def toExpectation[R <: Has[_]: Tag, I: Tag, E: Tag, A: Tag](
       poly: Poly[R, _, _, _],
       returns: Result[I, E, A]
     )(implicit ev: I <:< Unit): Expectation[R] =
       Expectation.Call[R, I, E, A](toMethod[R, I, E, A](poly), Assertion.isUnit.asInstanceOf[Assertion[I]], returns.io)
 
-    private def toMethod[R <: Has[_]: Tagged, I: Tagged, E: Tagged, A: Tagged](
+    private def toMethod[R <: Has[_]: Tag, I: Tag, E: Tag, A: Tag](
       poly: Poly[R, _, _, _]
     ): Capability[R, I, E, A] = new Capability[R, I, E, A](poly.mock) {
       override val id: UUID         = poly.id

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -19,12 +19,12 @@ package zio.test.mock
 import zio.internal.Executor
 import zio.stream.{ ZSink, ZStream }
 import zio.test.TestPlatform
-import zio.{ Has, Runtime, Tagged, URIO, URLayer, ZIO }
+import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO }
 
 /**
  * A `Mock[R]` represents a mockable environenment `R`.
  */
-abstract class Mock[R <: Has[_]: Tagged] { self =>
+abstract class Mock[R <: Has[_]: Tag] { self =>
 
   protected[test] val compose: URLayer[Has[Proxy], R]
 
@@ -41,36 +41,36 @@ abstract class Mock[R <: Has[_]: Tagged] { self =>
         }
     }
 
-  abstract class Effect[I: Tagged, E: Tagged, A: Tagged]              extends Capability[R, I, E, A](self)
-  abstract class Method[I: Tagged, E <: Throwable: Tagged, A: Tagged] extends Capability[R, I, E, A](self)
-  abstract class Sink[I: Tagged, E: Tagged, A: Tagged, B: Tagged]     extends Capability[R, I, E, ZSink[Any, E, A, B]](self)
-  abstract class Stream[I: Tagged, E: Tagged, A: Tagged]              extends Capability[R, I, Nothing, ZStream[Any, E, A]](self)
+  abstract class Effect[I: Tag, E: Tag, A: Tag]              extends Capability[R, I, E, A](self)
+  abstract class Method[I: Tag, E <: Throwable: Tag, A: Tag] extends Capability[R, I, E, A](self)
+  abstract class Sink[I: Tag, E: Tag, A: Tag, B: Tag]        extends Capability[R, I, E, ZSink[Any, E, A, B]](self)
+  abstract class Stream[I: Tag, E: Tag, A: Tag]              extends Capability[R, I, Nothing, ZStream[Any, E, A]](self)
 
   object Poly {
 
     object Effect {
-      abstract class Input[E: Tagged, A: Tagged]  extends Capability.Poly.Input[R, E, A](self)
-      abstract class Error[I: Tagged, A: Tagged]  extends Capability.Poly.Error[R, I, A, Any](self)
-      abstract class Output[I: Tagged, E: Tagged] extends Capability.Poly.Output[R, I, E, Any](self)
-      abstract class InputError[A: Tagged]        extends Capability.Poly.InputError[R, A, Any](self)
-      abstract class InputOutput[E: Tagged]       extends Capability.Poly.InputOutput[R, E, Any](self)
-      abstract class ErrorOutput[I: Tagged]       extends Capability.Poly.ErrorOutput[R, I, Any, Any](self)
-      abstract class InputErrorOutput             extends Capability.Poly.InputErrorOutput[R, Any, Any](self)
+      abstract class Input[E: Tag, A: Tag]  extends Capability.Poly.Input[R, E, A](self)
+      abstract class Error[I: Tag, A: Tag]  extends Capability.Poly.Error[R, I, A, Any](self)
+      abstract class Output[I: Tag, E: Tag] extends Capability.Poly.Output[R, I, E, Any](self)
+      abstract class InputError[A: Tag]     extends Capability.Poly.InputError[R, A, Any](self)
+      abstract class InputOutput[E: Tag]    extends Capability.Poly.InputOutput[R, E, Any](self)
+      abstract class ErrorOutput[I: Tag]    extends Capability.Poly.ErrorOutput[R, I, Any, Any](self)
+      abstract class InputErrorOutput       extends Capability.Poly.InputErrorOutput[R, Any, Any](self)
     }
 
     object Method {
-      abstract class Input[E <: Throwable: Tagged, A: Tagged]  extends Capability.Poly.Input[R, E, A](self)
-      abstract class Error[I: Tagged, A: Tagged]               extends Capability.Poly.Error[R, I, A, Throwable](self)
-      abstract class Output[I: Tagged, E <: Throwable: Tagged] extends Capability.Poly.Output[R, I, E, Any](self)
-      abstract class InputError[A: Tagged]                     extends Capability.Poly.InputError[R, A, Throwable](self)
-      abstract class InputOutput[E <: Throwable: Tagged]       extends Capability.Poly.InputOutput[R, E, Any](self)
-      abstract class ErrorOutput[I: Tagged]                    extends Capability.Poly.ErrorOutput[R, I, Throwable, Any](self)
-      abstract class InputErrorOutput                          extends Capability.Poly.InputErrorOutput[R, Throwable, Any](self)
+      abstract class Input[E <: Throwable: Tag, A: Tag]  extends Capability.Poly.Input[R, E, A](self)
+      abstract class Error[I: Tag, A: Tag]               extends Capability.Poly.Error[R, I, A, Throwable](self)
+      abstract class Output[I: Tag, E <: Throwable: Tag] extends Capability.Poly.Output[R, I, E, Any](self)
+      abstract class InputError[A: Tag]                  extends Capability.Poly.InputError[R, A, Throwable](self)
+      abstract class InputOutput[E <: Throwable: Tag]    extends Capability.Poly.InputOutput[R, E, Any](self)
+      abstract class ErrorOutput[I: Tag]                 extends Capability.Poly.ErrorOutput[R, I, Throwable, Any](self)
+      abstract class InputErrorOutput                    extends Capability.Poly.InputErrorOutput[R, Throwable, Any](self)
     }
   }
 }
 
 object Mock {
 
-  private[mock] case class Composed[R <: Has[_]: Tagged](compose: URLayer[Has[Proxy], R]) extends Mock[R]
+  private[mock] case class Composed[R <: Has[_]: Tag](compose: URLayer[Has[Proxy], R]) extends Mock[R]
 }

--- a/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
@@ -20,7 +20,7 @@ import scala.util.Try
 
 import zio.test.Assertion
 import zio.test.mock.{ Capability, Expectation, Proxy }
-import zio.{ Has, IO, Tagged, UIO, ULayer, ZIO, ZLayer }
+import zio.{ Has, IO, Tag, UIO, ULayer, ZIO, ZLayer }
 
 object ProxyFactory {
 
@@ -31,7 +31,7 @@ object ProxyFactory {
   /**
    * Given initial `State[R]`, constructs a `Proxy` running that state.
    */
-  def mockProxy[R <: Has[_]: Tagged](state: State[R]): ULayer[Has[Proxy]] =
+  def mockProxy[R <: Has[_]: Tag](state: State[R]): ULayer[Has[Proxy]] =
     ZLayer.succeed(new Proxy {
       def invoke[RIn <: Has[_], ROut, I, E, A](invoked: Capability[RIn, I, E, A], args: I): ZIO[ROut, E, A] = {
         def findMatching(scopes: List[Scope[R]]): UIO[Matched[R, E, A]] =


### PR DESCRIPTION
Error messages from Tag mention `Tag`, not `Tаgged`, which adds confusion. I think it's time to synchronize naming and re-export with the same names now that all scala versions have the same implementation.