### PR TITLE
Fix doc: creating effects succeed method description

### DIFF
--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -23,7 +23,7 @@ You can also use methods in the companion objects of the `ZIO` type aliases:
 val s2: Task[Int] = Task.succeed(42)
 ```
 
-The `succeed` method is eager, which means the value passed to `succeed` will be constructed _before_ the method is invoked. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.effectTotal` method:
+The `succeed` method takes a by-name parameter. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.effectTotal` method:
 
 ```scala mdoc:silent
 lazy val bigList = (0 to 1000000).toList

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -23,13 +23,10 @@ You can also use methods in the companion objects of the `ZIO` type aliases:
 val s2: Task[Int] = Task.succeed(42)
 ```
 
-The `succeed` method takes a by-name parameter. It is the same as the `ZIO.effectTotal` method:
+The `succeed` method takes a by-name parameter to make sure that any accidental side effects from constructing the value can be properly managed by the ZIO Runtime. However, `succeed` is intended for values which do not have any side effects. If you know that your value does have side effects consider using `ZIO.effectTotal` for clarity.
 
 ```scala mdoc:silent
-lazy val bigList = (0 to 1000000).toList
-lazy val bigString = bigList.map(_.toString).mkString("\n")
-
-val s3 = ZIO.effectTotal(bigString)
+val now = ZIO.effectTotal(System.currentTimeMillis())
 ```
 
 The value inside a successful effect constructed with `ZIO.effectTotal` will only be constructed if absolutely required.
@@ -97,7 +94,7 @@ The error type of the resulting effect will always be `Throwable`, because `Try`
 A function `A => B` can be converted into a ZIO effect with `ZIO.fromFunction`:
 
 ```scala mdoc:silent
-val zfun: ZIO[Int, Nothing, Int] = 
+val zfun: ZIO[Int, Nothing, Int] =
   ZIO.fromFunction((i: Int) => i * i)
 ```
 
@@ -112,8 +109,8 @@ import scala.concurrent.Future
 
 lazy val future = Future.successful("Hello!")
 
-val zfuture: Task[String] = 
-  ZIO.fromFuture { implicit ec => 
+val zfuture: Task[String] =
+  ZIO.fromFuture { implicit ec =>
     future.map(_ => "Goodbye!")
   }
 ```
@@ -124,7 +121,7 @@ The error type of the resulting effect will always be `Throwable`, because `Futu
 
 ## From Side-Effects
 
-ZIO can convert both synchronous and asynchronous side-effects into ZIO effects (pure values). 
+ZIO can convert both synchronous and asynchronous side-effects into ZIO effects (pure values).
 
 These functions can be used to wrap procedural code, allowing you to seamlessly use all features of ZIO with legacy Scala and Java code, as well as third-party libraries.
 
@@ -171,11 +168,11 @@ trait AuthError
 ```scala mdoc:silent
 object legacy {
   def login(
-    onSuccess: User => Unit, 
+    onSuccess: User => Unit,
     onFailure: AuthError => Unit): Unit = ???
 }
 
-val login: IO[AuthError, User] = 
+val login: IO[AuthError, User] =
   IO.effectAsync[AuthError, User] { callback =>
     legacy.login(
       user => callback(IO.succeed(user)),
@@ -197,7 +194,7 @@ A blocking side-effect can be converted directly into a ZIO effect blocking with
 ```scala mdoc:silent
 import zio.blocking._
 
-val sleeping = 
+val sleeping =
   effectBlocking(Thread.sleep(Long.MaxValue))
 ```
 
@@ -225,9 +222,9 @@ def download(url: String) =
     Source.fromURL(url)(Codec.UTF8).mkString
   }
 
-def safeDownload(url: String) = 
+def safeDownload(url: String) =
   blocking(download(url))
-``` 
+```
 
 ## Next Steps
 

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -23,7 +23,7 @@ You can also use methods in the companion objects of the `ZIO` type aliases:
 val s2: Task[Int] = Task.succeed(42)
 ```
 
-The `succeed` method takes a by-name parameter. Although this is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.effectTotal` method:
+The `succeed` method takes a by-name parameter. It is the same as the `ZIO.effectTotal` method:
 
 ```scala mdoc:silent
 lazy val bigList = (0 to 1000000).toList


### PR DESCRIPTION
Both the `ZIO.succeed` and `Task.succeed` take a by-name parameter `(a: => A)`. The parameter is not eagerly constructed.