### PR TITLE
Adding an IntelliJ page to the docs (under Ecosystem)

### DIFF
--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -21,11 +21,6 @@ These libraries are hosted in the [ZIO organization](https://github.com/zio/) on
 - [ZIO Telemetry](https://github.com/zio/zio-telemetry): A ZIO-powered OpenTelemetry library 
 
 
-## Powered by ZIO
-
-- [ZIO IntelliJ](https://github.com/zio/zio-intellij): A complimentary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects
-
-
 ## Libraries with Direct ZIO Support
 
 If you know a useful library that has direct support for ZIO, please consider [submitting a pull request](https://github.com/zio/zio/pulls) to add it to this list.
@@ -53,6 +48,12 @@ If you know a useful library that has direct support for ZIO, please consider [s
 - [zio-saga](https://github.com/VladKopanev/zio-saga): Purely functional transaction management with Saga pattern
 - [zio-slf4j](https://github.com/NeQuissimus/zio-slf4j): Referentially transparent logging with slf4j
 - [zio-slick](https://github.com/rleibman/zio-slick): Bridge library between ZIO and Slick Functional Relational Mapping Library
+
+
+## Tools for ZIO
+
+- [ZIO IntelliJ](https://github.com/zio/zio-intellij): A complimentary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects
+
 
 ## ZIO Interoperability Libraries
 

--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -21,13 +21,18 @@ These libraries are hosted in the [ZIO organization](https://github.com/zio/) on
 - [ZIO Telemetry](https://github.com/zio/zio-telemetry): A ZIO-powered OpenTelemetry library 
 
 
+## Powered by ZIO
+
+- [ZIO IntelliJ](https://github.com/zio/zio-intellij): A complimentary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects
+
+
 ## Libraries with Direct ZIO Support
 
 If you know a useful library that has direct support for ZIO, please consider [submitting a pull request](https://github.com/zio/zio/pulls) to add it to this list.
 
 - [cakeless](https://github.com/itkpi/cakeless): Wire your cakes automatically into zio environment
 - [caliban](https://github.com/ghostdogpr/caliban): Functional GraphQL backend in Scala
-- [d4s](https://github.com/PlayQ/d4s): "Dynamo DB Database done Scala way". A library that allows accessing the DynamoDB in a purely functional way.
+- [d4s](https://github.com/PlayQ/d4s): "Dynamo DB Database done Scala way". A library that allows accessing the DynamoDB in a purely functional way
 - [distage](https://github.com/7mind/izumi): Staged, transparent and debuggable runtime & compile-time Dependency Injection Framework
 - [elastic4s](https://github.com/sksamuel/elastic4s): Elasticsearch Scala Client - Reactive, Non Blocking, Type Safe, HTTP Client
 - [idealingua](https://github.com/7mind/izumi): API Definition, Data Modeling and RPC Language, optimized for fast prototyping – like gRPC, but with a human face


### PR DESCRIPTION
It's a bit of a shameless promotion, but I'd really love if the plugin could be listed in the docs, showcasing some of its functionality (with images and gifs). The full docs of the plugin are being worked on (currently, to be placed on the Wiki page of the plugin repo).