### PR TITLE
Implement ZStream#intersperse

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1438,12 +1438,26 @@ object ZStreamSpec extends ZIOBaseSpec {
               .runCollect
               .map(result => assert(result)(equalTo(List("1", "@", "2", "@", "3", "@", "4"))))
           },
+          testM("intersperse several with begin and end") {
+            Stream(1, 2, 3, 4)
+              .map(_.toString)
+              .intersperse("[", "@", "]")
+              .runCollect
+              .map(result => assert(result)(equalTo(List("[", "1", "@", "2", "@", "3", "@", "4", "]"))))
+          },
           testM("intersperse single") {
             Stream(1)
               .map(_.toString)
               .intersperse("@")
               .runCollect
               .map(result => assert(result)(equalTo(List("1"))))
+          },
+          testM("intersperse single with begin and end") {
+            Stream(1)
+              .map(_.toString)
+              .intersperse("[", "@", "]")
+              .runCollect
+              .map(result => assert(result)(equalTo(List("[", "1", "]"))))
           }
         ),
         suite("interruptWhen")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1430,6 +1430,22 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(interleavedStream)(equalTo(interleavedLists))
           }
         },
+        suite("Stream.intersperse")(
+          testM("intersperse several") {
+            Stream(1, 2, 3, 4)
+              .map(_.toString)
+              .intersperse("@")
+              .runCollect
+              .map(result => assert(result)(equalTo(List("1", "@", "2", "@", "3", "@", "4"))))
+          },
+          testM("intersperse single") {
+            Stream(1)
+              .map(_.toString)
+              .intersperse("@")
+              .runCollect
+              .map(result => assert(result)(equalTo(List("1"))))
+          }
+        ),
         suite("interruptWhen")(
           suite("interruptWhen(Promise)")(
             testM("interrupts the current element") {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1527,6 +1527,25 @@ abstract class ZStream[-R, +E, +O](
   }
 
   /**
+   * Intersperse stream with provided element similar to <code>List.mkString</code>.
+   */
+  final def intersperse[O1 >: O](middle: O1): ZStream[R, E, O1] =
+    ZStream {
+      for {
+        state  <- ZRef.makeManaged(false)
+        chunks <- self.process
+        pull = chunks.flatMap { os =>
+          state.modify { flag =>
+            os.foldRight(List.empty[O1] -> flag) {
+              case (o, (Nil, curr)) => List(o)              -> !curr
+              case (o, (out, curr)) => (o :: middle :: out) -> !curr
+            }
+          }.map(e => Chunk.fromIterable(e))
+        }
+      } yield pull
+    }
+
+  /**
    * Interrupts the evaluation of this stream when the provided IO completes. The given
    * IO will be forked as part of this stream, and its success will be discarded. This
    * combinator will also interrupt any in-progress element being pulled from upstream.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1546,6 +1546,12 @@ abstract class ZStream[-R, +E, +O](
     }
 
   /**
+   * Intersperse and also add a prefix and a suffix
+   */
+  final def intersperse[O1 >: O](start: O1, middle: O1, end: O1): ZStream[R, E, O1] =
+    ZStream(start) ++ intersperse(middle) ++ ZStream(end)
+
+  /**
    * Interrupts the evaluation of this stream when the provided IO completes. The given
    * IO will be forked as part of this stream, and its success will be discarded. This
    * combinator will also interrupt any in-progress element being pulled from upstream.


### PR DESCRIPTION
This is an implementation for `intersperse` (https://github.com/zio/zio/issues/3440).

For example:

```scala
Stream(1, 2, 3, 4).map(_.toString).intersperse("@")
//  "1", "@", "2", "@", "3", "@", "4"
```

