### PR TITLE
Fix `ZStream#zip`

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2659,9 +2659,9 @@ abstract class ZStream[-R, +E, +O](
   )(f: (O, O2) => O3): ZStream[R1, E1, O3] = {
     sealed trait State[+W1, +W2]
     case class Running[W1, W2](excess: Either[Chunk[W1], Chunk[W2]]) extends State[W1, W2]
-    case class LeftDone[W1](nonEmptyExcessL: Chunk[W1])          extends State[W1, Nothing]
-    case class RightDone[W2](nonEmptyExcess: Chunk[W2])         extends State[Nothing, W2]
-    case object End                                         extends State[Nothing, Nothing]
+    case class LeftDone[W1](nonEmptyExcessL: Chunk[W1])              extends State[W1, Nothing]
+    case class RightDone[W2](nonEmptyExcess: Chunk[W2])              extends State[Nothing, W2]
+    case object End                                                  extends State[Nothing, Nothing]
 
     def zipSides(cl: Chunk[O], cr: Chunk[O2]): (Chunk[O3], Either[Chunk[O], Chunk[O2]]) =
       if (cl.size > cr.size)


### PR DESCRIPTION
Closes #3513

A bit messy, improvements are welcome.
There is a chance that it will be deuglified it as a part of #3495 (In case I find out how to unify `ZStream#zip` and `Ztransducer#zip`)