### PR TITLE
NonEmptyChunk usability

### DIFF
--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -188,6 +188,12 @@ object NonEmptyChunk {
     nonEmpty(Chunk(a) ++ Chunk.fromIterable(as))
 
   /**
+   * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
+   */
+  def fromChunk[A](chunk: Chunk[A]): Option[NonEmptyChunk[A]] =
+    if (chunk.isEmpty) None else Some(nonEmpty(chunk))
+
+  /**
    * Constructs a `NonEmptyChunk` from the `::` case of a `List`.
    */
   def fromCons[A](as: ::[A]): NonEmptyChunk[A] =
@@ -217,6 +223,6 @@ object NonEmptyChunk {
    * when it is statically known that the `Chunk` must have at least one
    * element.
    */
-  private def nonEmpty[A](chunk: Chunk[A]): NonEmptyChunk[A] =
+  private[zio] def nonEmpty[A](chunk: Chunk[A]): NonEmptyChunk[A] =
     new NonEmptyChunk(chunk)
 }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2659,8 +2659,8 @@ abstract class ZStream[-R, +E, +O](
   )(f: (O, O2) => O3): ZStream[R1, E1, O3] = {
     sealed trait State[+W1, +W2]
     case class Running[W1, W2](excess: Either[Chunk[W1], Chunk[W2]]) extends State[W1, W2]
-    case class LeftDone[W1](nonEmptyExcessL: Chunk[W1])              extends State[W1, Nothing]
-    case class RightDone[W2](nonEmptyExcess: Chunk[W2])              extends State[Nothing, W2]
+    case class LeftDone[W1](excessL: NonEmptyChunk[W1])              extends State[W1, Nothing]
+    case class RightDone[W2](excessR: NonEmptyChunk[W2])             extends State[Nothing, W2]
     case object End                                                  extends State[Nothing, Nothing]
 
     def zipSides(cl: Chunk[O], cr: Chunk[O2]): (Chunk[O3], Either[Chunk[O], Chunk[O2]]) =
@@ -2686,8 +2686,8 @@ abstract class ZStream[-R, +E, +O](
         case (false, false) => Exit.fail(None)
         case _ => {
           val newState = newExcess match {
-            case Left(l)  => if (l.isEmpty) End else LeftDone(l)
-            case Right(r) => if (r.isEmpty) End else RightDone(r)
+            case Left(l)  => NonEmptyChunk.fromChunk(l).fold[State[O, O2]](End)(LeftDone(_))
+            case Right(r) => NonEmptyChunk.fromChunk(r).fold[State[O, O2]](End)(RightDone(_))
           }
           Exit.succeed((emit, newState))
         }


### PR DESCRIPTION
1) Added `Chunk[A] => Option[NonEmptyChunk[A]]` constructor
2) Expand visibility of unsafe `NonEmptyChunk.nonEmpty` constructor to `zio` package
3) Tiny refactoring using (1)