### PR TITLE
Add ZQueue.takeBetween

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -273,7 +273,6 @@ object ZQueueSpec extends ZIOBaseSpec {
         } yield assert(count > 5)(isTrue)
       }
     ),
-
     testM("offerAll with takeAll") {
       for {
         queue  <- Queue.bounded[Int](10)

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -234,6 +234,46 @@ object ZQueueSpec extends ZIOBaseSpec {
         _      <- f.interrupt
       } yield assert(l)(equalTo(List(1, 2, 3, 4)))
     },
+    suite("takeBetween")(
+      testM("returns immediately if there is enough elements") {
+        for {
+          queue <- Queue.bounded[Int](100)
+          _     <- queue.offer(10)
+          _     <- queue.offer(20)
+          _     <- queue.offer(30)
+          res   <- queue.takeBetween(2, 5)
+        } yield assert(res)(equalTo(List(10, 20, 30)))
+      },
+      testM("returns an empty list if boundaries are inverted") {
+        for {
+          queue <- Queue.bounded[Int](100)
+          _     <- queue.offer(10)
+          _     <- queue.offer(20)
+          _     <- queue.offer(30)
+          res   <- queue.takeBetween(5, 2)
+        } yield assert(res)(isEmpty)
+      },
+      testM("returns an empty list if boundaries are negative") {
+        for {
+          queue <- Queue.bounded[Int](100)
+          _     <- queue.offer(10)
+          _     <- queue.offer(20)
+          _     <- queue.offer(30)
+          res   <- queue.takeBetween(-5, -2)
+        } yield assert(res)(isEmpty)
+      },
+      testM("blocks until a required minimum of elements is collected") {
+        for {
+          queue   <- Queue.bounded[Int](100)
+          counter <- Ref.make(0)
+          updater = (queue.offer(10) *> counter.update(_ + 1)).forever
+          getter  = queue.takeBetween(5, 10)
+          _       <- getter.race(updater)
+          count   <- counter.get
+        } yield assert(count > 5)(isTrue)
+      }
+    ),
+
     testM("offerAll with takeAll") {
       for {
         queue  <- Queue.bounded[Int](10)

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -109,7 +109,7 @@ trait ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { self =>
    * collected.
    */
   final def takeBetween(min: Int, max: Int): ZIO[RB, EB, List[B]] =
-    if (max < min) ZIO.succeedNow(Nil)
+    if (max < min) UIO.succeedNow(Nil)
     else
       takeUpTo(max).flatMap { bs =>
         val remaining = min - bs.length


### PR DESCRIPTION
This PR is related to #3489.

I have implemented `takeBetween` via repeated invocations of `takeUpTo`. While this approach isn't the optimal one, it is the simplest one. The "optimal" solution would probably require some form of "smart" takers, i.e., promises aware of requested `min` and `max` values, which would require significant refactoring of queue internals.

Besides efficiency, this implementation might suffer from interruption-related issues.