### PR TITLE
Add ZStream.debounce

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -7,13 +7,13 @@ import scala.concurrent.ExecutionContext
 import ZStreamGen._
 
 import zio._
+import zio.clock.Clock
 import zio.duration._
 import zio.stm.TQueue
 import zio.test.Assertion._
 import zio.test.TestAspect.flaky
 import zio.test._
 import zio.test.environment.TestClock
-import zio.clock.Clock
 
 object ZStreamSpec extends ZIOBaseSpec {
   import ZIOTag._

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -743,7 +743,7 @@ abstract class ZStream[-R, +E, +O](
 
   /**
    * Only emits elements after `waitTime` has passed. If another element in the source stream is
-   * produced before `waitTime` has passed, the previous element is will be dropped.
+   * produced before `waitTime` has passed, the previous element will be dropped.
    */
   final def debounce(waitTime: Duration): ZStream[R with Clock, E, O] =
     aggregateAsyncWithin(ZTransducer.lastOption[O], Schedule.spaced(waitTime)).collectSome

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -742,6 +742,13 @@ abstract class ZStream[-R, +E, +O](
     (self crossWith that)((_, o2) => o2)
 
   /**
+   * Only emits elements after `waitTime` has passed. If another element in the source stream is
+   * produced before `waitTime` has passed, the previous element is will be dropped.
+   */
+  final def debounce(waitTime: Duration): ZStream[R with Clock, E, O] =
+    aggregateAsyncWithin(ZTransducer.lastOption[O], Schedule.spaced(waitTime)).collectSome
+
+  /**
    * More powerful version of `ZStream#broadcast`. Allows to provide a function that determines what
    * queues should receive which elements. The decide function will receive the indices of the queues
    * in the resulting list.

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -537,6 +537,24 @@ object ZTransducer {
     ZTransducer(Managed.succeed(push))
 
   /**
+   * Creates a transducer that returns the last element of a chunk, if it exists.
+   */
+  def headOption[O]: ZTransducer[Any, Nothing, O, Option[O]] =
+    foldLeft[O, Option[O]](Option.empty[O]) {
+      case (acc, a) =>
+        acc match {
+          case Some(_) => acc
+          case None    => Some(a)
+        }
+    }
+
+  /**
+   * Creates a transducer that returns the last element of a chunk, if it exists.
+   */
+  def lastOption[O]: ZTransducer[Any, Nothing, O, Option[O]] =
+    foldLeft[O, Option[O]](Option.empty[O])((_, a) => Some(a))
+
+  /**
    * Splits strings on newlines. Handles both Windows newlines (`\r\n`) and UNIX newlines (`\n`).
    */
   val splitLines: ZTransducer[Any, Nothing, String, String] =

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -537,7 +537,7 @@ object ZTransducer {
     ZTransducer(Managed.succeed(push))
 
   /**
-   * Creates a transducer that returns the last element of a chunk, if it exists.
+   * Creates a transducer that returns the first element of a chunk, if it exists.
    */
   def headOption[O]: ZTransducer[Any, Nothing, O, Option[O]] =
     foldLeft[O, Option[O]](Option.empty[O]) {


### PR DESCRIPTION
Resolves #2565

This is my first attempt. I'm not sure if this is a reasonable implementation.

A few things about this:
- I added ZTransducer `headOption` and `lastOption`. Does it makes sense to expose these? I used `lastOption` in `debounce`.
- "Debounce" has multiple interpretations depending on how you want to handle the "leading" and "trailing" cases. I mentioned that in #2565. In any case, I went with what seems like the most common intepretation (`{leading: false, trailing: true}` in lodash terms). This seemed like the most useful default to me. If we want to support `leading = true` I guess it's just a matter of peeling the head element, returning that immediately and then `debounce` the rest as normal?
- Writing concise tests for this is hard. I believe I'm running into the same race condition problems as I did with `groupedWithin`. In the end I just took @mschuwalow's solution in #2631 and used it for `debounce` too. But it might be better to generalize that piece of code.