### PR TITLE
Revert debounce

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -742,13 +742,6 @@ abstract class ZStream[-R, +E, +O](
     (self crossWith that)((_, o2) => o2)
 
   /**
-   * Only emits elements after `waitTime` has passed. If another element in the source stream is
-   * produced before `waitTime` has passed, the previous element will be dropped.
-   */
-  final def debounce(waitTime: Duration): ZStream[R with Clock, E, O] =
-    aggregateAsyncWithin(ZTransducer.lastOption[O], Schedule.spaced(waitTime)).collectSome
-
-  /**
    * More powerful version of `ZStream#broadcast`. Allows to provide a function that determines what
    * queues should receive which elements. The decide function will receive the indices of the queues
    * in the resulting list.

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -539,7 +539,7 @@ object ZTransducer {
   /**
    * Creates a transducer that returns the first element of a chunk, if it exists.
    */
-  def headOption[O]: ZTransducer[Any, Nothing, O, Option[O]] =
+  def head[O]: ZTransducer[Any, Nothing, O, Option[O]] =
     foldLeft[O, Option[O]](Option.empty[O]) {
       case (acc, a) =>
         acc match {
@@ -551,7 +551,7 @@ object ZTransducer {
   /**
    * Creates a transducer that returns the last element of a chunk, if it exists.
    */
-  def lastOption[O]: ZTransducer[Any, Nothing, O, Option[O]] =
+  def last[O]: ZTransducer[Any, Nothing, O, Option[O]] =
     foldLeft[O, Option[O]](Option.empty[O])((_, a) => Some(a))
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -537,7 +537,7 @@ object ZTransducer {
     ZTransducer(Managed.succeed(push))
 
   /**
-   * Creates a transducer that returns the first element of a chunk, if it exists.
+   * Creates a transducer that returns the first element of the stream, if it exists.
    */
   def head[O]: ZTransducer[Any, Nothing, O, Option[O]] =
     foldLeft[O, Option[O]](Option.empty[O]) {
@@ -549,7 +549,7 @@ object ZTransducer {
     }
 
   /**
-   * Creates a transducer that returns the last element of a chunk, if it exists.
+   * Creates a transducer that returns the last element of the stream, if it exists.
    */
   def last[O]: ZTransducer[Any, Nothing, O, Option[O]] =
     foldLeft[O, Option[O]](Option.empty[O])((_, a) => Some(a))


### PR DESCRIPTION
Reverting the debounce implementation since it isn't quite right (needs to reset `waitTime` when new elements arrive). I'll submit another PR with the new implementation. It's not possible to do this with ZTransducer.

I also renamed ZTransducer headOption and lastOption to be consistent with ZSink.