### PR TITLE
Refactor ZStream#zipAllWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/internal/Utils.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/Utils.scala
@@ -1,0 +1,11 @@
+package zio.stream.internal
+
+import zio.Chunk
+
+object Utils {
+  def zipChunks[A, B, C](cl: Chunk[A], cr: Chunk[B], f: (A, B) => C): (Chunk[C], Either[Chunk[A], Chunk[B]]) =
+    if (cl.size > cr.size)
+      (cl.take(cr.size).zipWith(cr)(f), Left(cl.drop(cr.size)))
+    else
+      (cl.zipWith(cr.take(cl.size))(f), Right(cr.drop(cl.size)))
+}


### PR DESCRIPTION
1) Less representable illegal states
2) A bit less lines
3) Removed code duplication of `zipSides` in `zipAll` and `zipAllWith`.
It will be also used in ZTransducer so I extracted this function into a separate file.