### PR TITLE
Add Operators

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -32,7 +32,7 @@ object FiberSpec extends ZIOBaseSpec {
           } yield assert(value)(equalTo(update))
         },
         testM("`orElse`") {
-          import zio.CanFail.canFail
+          implicit val canFail = CanFail
           for {
             fiberRef <- FiberRef.make(initial)
             latch1   <- Promise.make[Nothing, Unit]

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -32,6 +32,7 @@ object FiberSpec extends ZIOBaseSpec {
           } yield assert(value)(equalTo(update))
         },
         testM("`orElse`") {
+          import zio.CanFail.canFail
           for {
             fiberRef <- FiberRef.make(initial)
             latch1   <- Promise.make[Nothing, Unit]

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -47,24 +47,6 @@ import zio.internal.{ Executor, FiberRenderer }
 sealed trait Fiber[+E, +A] { self =>
 
   /**
-   * Zips this fiber and the specified fiber together, producing a tuple of their
-   * output.
-   *
-   * @param that fiber to be zipped
-   * @tparam E1 error type
-   * @tparam B type of that fiber
-   * @return `Fiber[E1, (A, B)]` combined fiber
-   */
-  final def <*>[E1 >: E, B](that: => Fiber[E1, B]): Fiber.Synthetic[E1, (A, B)] =
-    (self zipWith that)((a, b) => (a, b))
-
-  /**
-   * A symbolic alias for `orElseEither`.
-   */
-  final def <+>[E1 >: E, B](that: => Fiber[E1, B])(implicit ev: CanFail[E]): Fiber.Synthetic[E1, Either[A, B]] =
-    self.orElseEither(that)
-
-  /**
    * Same as `zip` but discards the output of the left hand side.
    *
    * @param that fiber to be zipped
@@ -85,6 +67,30 @@ sealed trait Fiber[+E, +A] { self =>
    */
   final def <*[E1 >: E, B](that: Fiber[E1, B]): Fiber.Synthetic[E1, A] =
     (self zipWith that)((a, _) => a)
+
+  /**
+   * Zips this fiber and the specified fiber together, producing a tuple of their
+   * output.
+   *
+   * @param that fiber to be zipped
+   * @tparam E1 error type
+   * @tparam B type of that fiber
+   * @return `Fiber[E1, (A, B)]` combined fiber
+   */
+  final def <*>[E1 >: E, B](that: => Fiber[E1, B]): Fiber.Synthetic[E1, (A, B)] =
+    (self zipWith that)((a, b) => (a, b))
+
+  /**
+   * A symbolic alias for `orElseEither`.
+   */
+  final def <+>[E1 >: E, B](that: => Fiber[E1, B])(implicit ev: CanFail[E]): Fiber.Synthetic[E1, Either[A, B]] =
+    self.orElseEither(that)
+
+  /**
+   * A symbolic alias for `orElse`.
+   */
+  def <>[E1, A1 >: A](that: => Fiber[E1, A1])(implicit ev: CanFail[E]): Fiber.Synthetic[E1, A1] =
+    self.orElse(that)
 
   /**
    * Maps the output of this fiber to the specified constant.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -114,6 +114,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     self &&& that
 
   /**
+   * A symbolic alias for `orElseEither`.
+   */
+  final def <+>[R1 <: R, E1, B](that: => ZIO[R1, E1, B])(implicit ev: CanFail[E]): ZIO[R1, E1, Either[A, B]] =
+    self.orElseEither(that)
+
+  /**
    * Operator alias for `compose`.
    */
   final def <<<[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] =
@@ -124,6 +130,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def <>[R1 <: R, E2, A1 >: A](that: => ZIO[R1, E2, A1])(implicit ev: CanFail[E]): ZIO[R1, E2, A1] =
     orElse(that)
+
+  /**
+   * A symbolic alias for `raceEither`.
+   */
+  final def <|>[R1 <: R, E1 >: E, B](that: ZIO[R1, E1, B]): ZIO[R1, E1, Either[A, B]] =
+    self.raceEither(that)
 
   /**
    * Alias for `flatMap`.

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -50,6 +50,12 @@ final class ZLayer[-RIn, +E, +ROut] private (
     self.zipWithPar(that)(ev.union[ROut1, ROut2])
 
   /**
+   * A symbolic alias for `orElse`.
+   */
+  def <>[RIn1 <: RIn, E1, ROut1 >: ROut](that: => ZLayer[RIn1, E1, ROut1])(implicit ev: CanFail[E]): ZLayer[RIn1, E1, ROut1] =
+    self.orElse(that)
+
+  /**
    * Feeds the output services of this layer into the input of the specified
    * layer, resulting in a new layer with the inputs of this layer, and the
    * outputs of both this layer and the specified layer.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -117,6 +117,12 @@ final class ZSTM[-R, +E, +A] private[stm] (
     self zip that
 
   /**
+   * A symbolic alias for `orElseEither`.
+   */
+  def <+>[R1 <: R, E1, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, Either[A, B]] =
+    self.orElseEither(that)
+
+  /**
    * Propagates self environment to that.
    */
   def <<<[R1, E1 >: E](that: ZSTM[R1, E1, R]): ZSTM[R1, E1, A] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -75,6 +75,12 @@ abstract class ZStream[-R, +E, +O](
     self concat that
 
   /**
+   * Symbolic alias for [[ZStream#orElse]].
+   */
+  final def <>[R1 <: R, E2, O1 >: O](that: => ZStream[R1, E2, O1])(implicit ev: CanFail[E]): ZStream[R1, E2, O1] =
+    self orElse that
+
+  /**
    * Returns a stream that submerges the error case of an `Either` into the `ZStream`.
    */
   final def absolve[R1 <: R, E1, O1](


### PR DESCRIPTION
Resolves #3538. Resolves #3539. Note that I think there was an error with the type signature of `Fiber#orElse` where it was requiring the error type of the right hand side to be a super type of the error type of the left hand side instead of allowing it to be independent.