### PR TITLE
Fix handling of zero probability values in Gen.weighted

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -360,6 +360,10 @@ object GenSpec extends ZIOBaseSpec {
       testM("weighted generates weighted distribution") {
         val weighted = Gen.weighted((Gen.const(true), 10), (Gen.const(false), 90))
         checkSample(weighted)(isTrue, ps => ps.count(!_) > ps.count(identity))
+      },
+      testM("weighted never chooses a generator with zero probability") {
+        val weighted = Gen.weighted((Gen.const(true), 1), (Gen.const(false), 0))
+        checkSample(weighted)(isTrue, ps => ps.forall(identity))
       }
     ),
     suite("shrinks")(


### PR DESCRIPTION
Gen.weighted can't currently handle generators with zero weight because it builds a map from the the cumulative probability to the generator, but a probability of zero doesn't change the cumulative probability, overwriting the initial value for that probability.

For example, when making a map of `(Gen.const(true), 1), (Gen.const(false), 0)`, first `true` gets added to the map, yielding `Map(1 -> Gen.const(true)`. Then `false` gets added, resulting in `Map(1 -> Gen.const(true), (1 + 0) -> Gen.const(false))`. So `false` overwrites the earlier value, since adding zero doesn't change the probability.

The first commit creates a failing test, the second one adds a fix. The fix also works when the added double isn't zero, but is so small that the cumulative probability wouldn't change, which can (in theory) happen, since doubles are not indefinitely precise (and have their precision distributed unevenly). For example, `weighted(("a", 100000000000.0),  ("b", 0.000007))` now drops "b" completely instead of overwriting "a", even though "b" doesn't have zero probability.
It can (again, in theory) still fail when the values don't add up to exactly one.

I've also added a small example to the documentation of `weighted`.