### PR TITLE
Fix ZStream.toInputStream handling of signed bytes

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2010,7 +2010,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } @@ zioTag(interruption)
         ),
         testM("toInputStream") {
-          val stream = ZStream(1, 2, 3).map(_.toByte)
+          val stream = ZStream(-3, -2, -1, 0, 1, 2, 3).map(_.toByte)
           for {
             streamResult <- stream.runCollect
             inputStreamResult <- stream.toInputStream.use { inputStream =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2434,7 +2434,7 @@ abstract class ZStream[-R, +E, +O](
             if ((currChunk ne null) && nextIndex < currChunk.size) {
               val result = currChunk(nextIndex)
               nextIndex += 1
-              result.toInt
+              result & 0xFF
             } else {
               runtime.unsafeRunSync(capturedPull) match {
                 case Exit.Failure(cause) =>


### PR DESCRIPTION
- Added fix; modified test so that it will fail without the fix.
- Description: The `java.io.InputStream.read()` method should return an `Int`. A value in the range `0` to `255` inclusive represents an unsigned byte value from the `InputStream`, while a value of `-1` indicates that the end of the stream has been reached. Previously, calling `.toInt` on the raw `Byte` value was not performing the unsigned byte conversion required by `read()`.

Fixes issue #3545 