### PR TITLE
Add Schedule noDelay and run

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -115,6 +115,20 @@ object ScheduleSpec extends ZIOBaseSpec {
         } yield assert(v)(equalTo(6)) && assert(finalizerV.isDefined)(equalTo(true))
       }
     ),
+    suite("Simulate a schedule")(
+      testM("without timing out") {
+        val schedule  = Schedule.exponential(1.minute)
+        val scheduled = schedule.simulate(List.fill(5)(()))
+        val expected  = List(1.minute, 2.minute, 4.minute, 8.minute, 16.minute)
+        assertM(scheduled)(equalTo(expected))
+      },
+      testM("respect Schedule.recurs even if more input is provided than needed") {
+        val schedule  = Schedule.recurs(2) && Schedule.exponential(1.minute)
+        val scheduled = schedule.simulate(1 to 10)
+        val expected  = List((0, 1.minute), (1, 2.minute), (2, 4.minute))
+        assertM(scheduled)(equalTo(expected))
+      }
+    ),
     suite("Retry on failure according to a provided strategy")(
       testM("retry 0 time for `once` when first time succeeds") {
         implicit val canFail = CanFail

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -122,13 +122,13 @@ object ScheduleSpec extends ZIOBaseSpec {
         val scheduled = schedule.noDelay.run(List.fill(5)(()))
         val expected  = List(1.minute, 2.minute, 4.minute, 8.minute, 16.minute)
         assertM(scheduled)(equalTo(expected))
-      },
+      } @@ timeout(1.seconds),
       testM("respect Schedule.recurs even if more input is provided than needed") {
         val schedule  = Schedule.recurs(2) && Schedule.exponential(1.minute)
         val scheduled = schedule.noDelay.run(1 to 10)
         val expected  = List((0, 1.minute), (1, 2.minute), (2, 4.minute))
         assertM(scheduled)(equalTo(expected))
-      } @@ timeout(1.seconds)
+      }
     ),
     suite("Retry on failure according to a provided strategy")(
       testM("retry 0 time for `once` when first time succeeds") {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
+import zio.test.TestAspect.timeout
 import zio.test.environment.{ TestClock, TestRandom }
 import zio.test.{ assert, assertM, suite, testM, TestResult }
 
@@ -118,16 +119,16 @@ object ScheduleSpec extends ZIOBaseSpec {
     suite("Simulate a schedule")(
       testM("without timing out") {
         val schedule  = Schedule.exponential(1.minute)
-        val scheduled = schedule.simulate(List.fill(5)(()))
+        val scheduled = schedule.noDelay.run(List.fill(5)(()))
         val expected  = List(1.minute, 2.minute, 4.minute, 8.minute, 16.minute)
         assertM(scheduled)(equalTo(expected))
       },
       testM("respect Schedule.recurs even if more input is provided than needed") {
         val schedule  = Schedule.recurs(2) && Schedule.exponential(1.minute)
-        val scheduled = schedule.simulate(1 to 10)
+        val scheduled = schedule.noDelay.run(1 to 10)
         val expected  = List((0, 1.minute), (1, 2.minute), (2, 4.minute))
         assertM(scheduled)(equalTo(expected))
-      }
+      } @@ timeout(1.seconds)
     ),
     suite("Retry on failure according to a provided strategy")(
       testM("retry 0 time for `once` when first time succeeds") {
@@ -170,19 +171,19 @@ object ScheduleSpec extends ZIOBaseSpec {
       },
       testM("for a given number of times with random jitter in (0, 1)") {
         val schedule  = Schedule.spaced(500.millis).jittered(0, 1)
-        val scheduled = TestClock.runAll *> run(schedule >>> testElapsed)(List.fill(5)(()))
+        val scheduled = TestClock.runAll *> (schedule >>> testElapsed).run(List.fill(5)(()))
         val expected  = List(0.millis, 250.millis, 500.millis, 750.millis, 1000.millis)
         assertM(TestRandom.feedDoubles(0.5, 0.5, 0.5, 0.5, 0.5) *> scheduled)(equalTo(expected))
       },
       testM("for a given number of times with random jitter in custom interval") {
         val schedule  = Schedule.spaced(500.millis).jittered(2, 4)
-        val scheduled = TestClock.runAll *> run(schedule >>> testElapsed)((List.fill(5)(())))
+        val scheduled = TestClock.runAll *> (schedule >>> testElapsed).run((List.fill(5)(())))
         val expected  = List(0, 1500, 3000, 5000, 7000).map(_.millis)
         assertM(TestRandom.feedDoubles(0.5, 0.5, 1, 1, 0.5) *> scheduled)(equalTo(expected))
       },
       testM("for a given number of times with random delay in custom interval") {
         val schedule  = Schedule.randomDelay(2.nanos, 4.nanos)
-        val scheduled = TestClock.runAll *> run(schedule >>> testElapsed)((List.fill(5)(())))
+        val scheduled = TestClock.runAll *> (schedule >>> testElapsed).run((List.fill(5)(())))
         val expected  = List(0, 3, 6, 10, 14).map(_.nanos)
         assertM(TestRandom.feedLongs(1, 1, 2, 2, 1) *> scheduled)(equalTo(expected))
       },
@@ -199,37 +200,35 @@ object ScheduleSpec extends ZIOBaseSpec {
       testM("fibonacci delay") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.fibonacci(100.millis) >>> testElapsed)(List.fill(5)(()))
+            .setTime(Duration.Infinity) *> (Schedule.fibonacci(100.millis) >>> testElapsed).run(List.fill(5)(()))
         )(equalTo(List(0, 1, 2, 4, 7).map(i => (i * 100).millis)))
       },
       testM("linear delay") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.linear(100.millis) >>> testElapsed)(List.fill(5)(()))
+            .setTime(Duration.Infinity) *> (Schedule.linear(100.millis) >>> testElapsed).run(List.fill(5)(()))
         )(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 100).millis)))
       },
       testM("modified linear delay") {
-        assertM(TestClock.runAll *> run(Schedule.linear(100.millis).modifyDelay {
+        assertM(TestClock.runAll *> (Schedule.linear(100.millis).modifyDelay {
           case (_, d) => ZIO.succeed(d * 2)
-        } >>> testElapsed)(List.fill(5)(())))(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 200).millis)))
+        } >>> testElapsed).run(List.fill(5)(())))(equalTo(List(0, 1, 3, 6, 10).map(i => (i * 200).millis)))
       },
       testM("exponential delay with default factor") {
         assertM(
           TestClock
-            .setTime(Duration.Infinity) *> run(Schedule.exponential(100.millis) >>> testElapsed)(List.fill(5)(()))
+            .setTime(Duration.Infinity) *> (Schedule.exponential(100.millis) >>> testElapsed).run(List.fill(5)(()))
         )(equalTo(List(0, 1, 3, 7, 15).map(i => (i * 100).millis)))
       },
       testM("exponential delay with other factor") {
         assertM(
-          TestClock.runAll *> run(Schedule.exponential(100.millis, 3.0) >>> testElapsed)(
-            List.fill(5)(())
-          )
+          TestClock.runAll *> (Schedule.exponential(100.millis, 3.0) >>> testElapsed).run(List.fill(5)(()))
         )(equalTo(List(0, 1, 4, 13, 40).map(i => (i * 100).millis)))
       },
       testM("fromDurations") {
         val schedule = Schedule.fromDurations(4.seconds, 7.seconds, 12.seconds, 19.seconds)
         val expected = List(0.seconds, 4.seconds, 11.seconds, 23.seconds, 42.seconds)
-        val actual   = TestClock.runAll *> run(schedule >>> testElapsed)(List.fill(5)(()))
+        val actual   = TestClock.runAll *> (schedule >>> testElapsed).run(List.fill(5)(()))
         assertM(actual)(equalTo(expected))
       }
     ) @@ zioTag(errors),
@@ -329,9 +328,9 @@ object ScheduleSpec extends ZIOBaseSpec {
     testM("either should not wait if neither schedule wants to continue") {
       assertM(
         TestClock
-          .setTime(Duration.Infinity) *> run(
+          .setTime(Duration.Infinity) *> (
           (Schedule.stop || (Schedule.spaced(2.seconds) && Schedule.stop)) >>> testElapsed
-        )(List.fill(5)(()))
+        ).run(List.fill(5)(()))
       )(equalTo(List(Duration.Zero)))
     },
     testM("perform log for each recurrence of effect") {
@@ -361,25 +360,6 @@ object ScheduleSpec extends ZIOBaseSpec {
       ref <- Ref.make(0)
       res <- ref.updateAndGet(_ + 1).repeat(schedule)
     } yield res
-
-  /**
-   * Run a schedule using the provided input and collect all outputs
-   */
-  def run[R, A, B](
-    sched: Schedule[R, A, B]
-  )(xs: Iterable[A]): ZIO[R, Nothing, List[B]] = {
-    def loop(xs: List[A], state: sched.State, acc: List[B]): ZIO[R, Nothing, List[B]] = xs match {
-      case Nil => ZIO.succeed(acc)
-      case x :: xs =>
-        sched
-          .update(x, state)
-          .foldM(
-            _ => ZIO.succeed(sched.extract(x, state) :: acc),
-            s => loop(xs, s, sched.extract(x, state) :: acc)
-          )
-    }
-    sched.initial.flatMap(loop(xs.toList, _, Nil)).map(_.reverse)
-  }
 
   def checkRepeat[B](schedule: Schedule[Any, Int, B], expected: B): ZIO[Any with Clock, Nothing, TestResult] =
     assertM(repeat(schedule))(equalTo(expected))

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -455,6 +455,20 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
   }
 
   /**
+   * Returns a new schedule that will not perform any sleep calls between recurrences.
+   */
+  final def noDelay[R1 <: R](implicit ev1: Has.IsHas[R1], ev2: R1 <:< Clock): Schedule[R1, A, B] = {
+    def proxy(clock0: Clock.Service): Clock.Service = new Clock.Service {
+      def currentTime(unit: TimeUnit) = clock0.currentTime(unit)
+      def currentDateTime             = clock0.currentDateTime
+      val nanoTime                    = clock0.nanoTime
+      def sleep(duration: Duration)   = ZIO.unit
+    }
+
+    provideSome[R1](env => ev1.update[R1, Clock.Service](env, proxy(_)))
+  }
+
+  /**
    * A new schedule that applies the current one but runs the specified effect
    * for every decision of this schedule. This can be used to create schedules
    * that log failures, decisions, or computed values.
@@ -515,26 +529,10 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
   final def right[C]: Schedule[R, Either[C, A], Either[C, B]] = Schedule.identity[C] +++ self
 
   /**
-   * Puts this schedule into the second element of a tuple, and passes along
-   * another value unchanged as the first element of the tuple.
+   * Run a schedule using the provided input and collect all outputs.
    */
-  final def second[C]: Schedule[R, (C, A), (C, B)] = Schedule.identity[C] *** self
-
-  /**
-   * Simulates a schedule by generating its output given the specified input.
-   * This function skips any sleep calls.
-   */
-  final def simulate[R1 <: R](
-    input: Iterable[A]
-  )(implicit ev1: Has.IsHas[R1], ev2: R1 <:< Clock): ZIO[R1, Nothing, List[B]] = {
-    def proxy(clock0: Clock.Service): Clock.Service = new Clock.Service {
-      def currentTime(unit: TimeUnit) = clock0.currentTime(unit)
-      def currentDateTime             = clock0.currentDateTime
-      val nanoTime                    = clock0.nanoTime
-      def sleep(duration: Duration)   = ZIO.unit
-    }
-
-    def loop(xs: List[A], state: State, acc: List[B]): ZIO[R1, Nothing, List[B]] = xs match {
+  final def run(input: Iterable[A]): ZIO[R, Nothing, List[B]] = {
+    def loop(xs: List[A], state: State, acc: List[B]): ZIO[R, Nothing, List[B]] = xs match {
       case Nil => ZIO.succeedNow(acc)
       case x :: xs =>
         update(x, state)
@@ -547,8 +545,13 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     initial
       .flatMap(loop(input.toList, _, Nil))
       .map(_.reverse)
-      .provideSome[R1](env => ev1.update[R1, Clock.Service](env, proxy(_)))
   }
+
+  /**
+   * Puts this schedule into the second element of a tuple, and passes along
+   * another value unchanged as the first element of the tuple.
+   */
+  final def second[C]: Schedule[R, (C, A), (C, B)] = Schedule.identity[C] *** self
 
   /**
    * Sends every input value to the specified sink.


### PR DESCRIPTION
Resolves #3468

This skips any sleep calls so that we can simulate a schedule and get its output instantaneously.

One thing I was considering was making `input` a LazyList so that passing in infinite input was possible if you wanted to (in that case you would solely rely on your Schedule's end condition). Not sure whether that's needed or not though.