### PR TITLE
Add someOrElse to ZSTM, ZIO and ZManaged

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2857,6 +2857,17 @@ object ZIOSpec extends ZIOBaseSpec {
         io.lock(executor)
       } @@ jvm(nonFlaky(100))
     ),
+    suite("someOrElse")(
+      testM("extracts the value from Some") {
+        assertM(UIO.succeed(Some(1)).someOrElse(2))(equalTo(1))
+      },
+      testM("falls back to the default value if None") {
+        assertM(UIO.succeed(None).someOrElse(42))(equalTo(42))
+      },
+      testM("does not change failed state") {
+        assertM(ZIO.fail(ExampleError).someOrElse(42).run)(fails(equalTo(ExampleError)))
+      } @@ zioTag(errors)
+    ),
     suite("someOrFail")(
       testM("extracts the optional value") {
         val task: Task[Int] = UIO(Some(42)).someOrFail(exampleError)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -773,6 +773,20 @@ object ZManagedSpec extends ZIOBaseSpec {
         managed.run.use(res => ZIO.succeed(assert(res)(fails(isSome(equalTo(ex))))))
       } @@ zioTag(errors)
     ),
+    suite("someOrElse")(
+      testM("extracts the value from Some") {
+        val managed: TaskManaged[Int] = Managed.succeed(Some(1)).someOrElse(2)
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(1))))
+      },
+      testM("falls back to the default value if None") {
+        val managed: TaskManaged[Int] = Managed.succeed(None).someOrElse(42)
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(42))))
+      },
+      testM("does not change failed state") {
+        val managed: TaskManaged[Int] = Managed.fail(ExampleError).someOrElse(42)
+        managed.run.use(res => ZIO.succeed(assert(res)(fails(equalTo(ExampleError)))))
+      } @@ zioTag(errors)
+    ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
         val managed = Managed.succeed(Some(42)).someOrFailException

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -597,6 +597,17 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertM(STM.some(42).commit)(isSome(equalTo(42)))
         }
       ),
+      suite("someOrElse")(
+        testM("extracts the value from Some") {
+          assertM(STM.succeed(Some(1)).someOrElse(2).commit)(equalTo(1))
+        },
+        testM("falls back to the default value if None") {
+          assertM(STM.succeed(None).someOrElse(42).commit)(equalTo(42))
+        },
+        testM("does not change failed state") {
+          assertM(STM.fail(ExampleError).someOrElse(42).commit.run)(fails(equalTo(ExampleError)))
+        } @@ zioTag(errors)
+      ),
       suite("someOrFail")(
         testM("extracts the value from Some") {
           assertM(STM.succeed(Some(1)).someOrFail(ExampleError).commit)(equalTo(1))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1565,6 +1565,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     )
 
   /**
+   * Extracts the optional value, or returns the given 'default'.
+   */
+  final def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZIO[R, E, B] =
+    map(_.getOrElse(default))
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZIO[R, E1, B] =

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -858,6 +858,12 @@ final class ZManaged[-R, +E, +A] private (reservation: ZIO[R, E, Reservation[R, 
     )
 
   /**
+   * Extracts the optional value, or returns the given 'default'.
+   */
+  final def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZManaged[R, E, B] =
+    map(_.getOrElse(default))
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZManaged[R, E1, B] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -770,6 +770,12 @@ final class ZSTM[-R, +E, +A] private[stm] (
     )
 
   /**
+   * Extracts the optional value, or returns the given 'default'.
+   */
+  def someOrElse[B, B1 <: B](default: => B1)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
+    map(_.getOrElse(default))
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZSTM[R, E1, B] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -772,7 +772,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Extracts the optional value, or returns the given 'default'.
    */
-  def someOrElse[B, B1 <: B](default: => B1)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
+  def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
     map(_.getOrElse(default))
 
   /**


### PR DESCRIPTION
This PR adds `.someOrElse` which behaves similar to `.getOrElse` of `Option` but in the context of `ZSTM`, `ZIO` or `ZManaged`