### PR TITLE
WIP: more simple `zio.App`

### DIFF
--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -37,7 +37,7 @@ package zio
  * }
  * }}}
  */
-trait App extends BootstrapRuntime {
+trait App extends BootstrapRuntime with AppOps {
 
   /**
    * The main function of the application, which will be passed the command-line

--- a/core/jvm/src/main/scala/zio/AppExample.scala
+++ b/core/jvm/src/main/scala/zio/AppExample.scala
@@ -1,0 +1,9 @@
+package zio
+
+object AppExample extends App {
+  override def run(args: List[String]): ZIO[Any, Nothing, Int] = {
+    ZIO.succeed("xxx").tap(e => {
+      zio.console.putStrLn(e)
+    }).createValueForBusiness
+  }
+}


### PR DESCRIPTION
closes #2153

People (me including) complain about messing with exit codes and environments.
Here is yet another attempt to solve it.

As far as I understand, problem with approaches in the linked ticket is that we don't want to pollute `ZIO` api with helper methods which don't make sense outside of the main class.