### PR TITLE
Harden TestClock Implementation

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -22,7 +22,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- adjust(11.hours)
         result <- ref.get
       } yield assert(result)(isTrue)
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("sleep delays effect until time is adjusted") {
       for {
         ref    <- Ref.make(false)
@@ -30,7 +30,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- adjust(9.hours)
         result <- ref.get
       } yield assert(result)(isFalse)
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("sleep correctly handles multiple sleeps") {
       for {
         ref    <- Ref.make("")
@@ -39,7 +39,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- adjust(4.hours)
         result <- ref.get
       } yield assert(result)(equalTo("Hello, World!"))
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("sleep correctly handles new set time") {
       for {
         ref    <- Ref.make(false)
@@ -47,7 +47,7 @@ object ClockSpec extends ZIOBaseSpec {
         _      <- setTime(11.hours)
         result <- ref.get
       } yield assert(result)(isTrue)
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("adjust correctly advances nanotime") {
       for {
         time1 <- nanoTime
@@ -121,7 +121,7 @@ object ClockSpec extends ZIOBaseSpec {
         result <- fiber.join
       } yield result == None
       assertM(example)(isTrue)
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("recurrence example from TestClock documentation works correctly") {
       val example = for {
         q <- Queue.unbounded[Unit]
@@ -135,14 +135,14 @@ object ClockSpec extends ZIOBaseSpec {
         e <- q.poll.map(_.isEmpty)
       } yield a && b && c && d && e
       assertM(example)(isTrue)
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky,
     testM("clock time is always 0 at the start of a test that repeats")(
       for {
         clockTime <- currentTime(TimeUnit.NANOSECONDS)
         _         <- sleep(2.nanos).fork
         _         <- adjust(3.nanos)
       } yield assert(clockTime)(equalTo(0.millis.toNanos))
-    ) @@ nonFlaky(3),
+    ) @@ forked @@ nonFlaky(3),
     testM("TestClock interacts correctly with Scheduled.fixed") {
       for {
         latch     <- Promise.make[Nothing, Unit]
@@ -152,7 +152,7 @@ object ClockSpec extends ZIOBaseSpec {
         _         <- TestClock.adjust(5.seconds)
         _         <- latch.await
       } yield assertCompletes
-    } @@ nonFlaky,
+    } @@ forked @@ nonFlaky(100),
     testM("adjustments to time are visible on other fibers") {
       for {
         promise <- Promise.make[Nothing, Unit]

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -424,7 +424,7 @@ package object environment extends PlatformSpecific {
        * Returns whether all descendants of this fiber are done or suspended.
        */
       private lazy val suspended: UIO[Boolean] =
-        freeze.zipWith(ZIO.yieldNow *> freeze)(_ == _).orElseSucceed(false)
+        freeze.zipWith(live.provide(ZIO.sleep(1.millisecond)) *> freeze)(_ == _).orElseSucceed(false)
 
       /**
        * Constructs an `OffsetDateTime` from a `Duration` and a `ZoneId`.

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -365,6 +365,13 @@ package object environment extends PlatformSpecific {
         }.unit
 
       /**
+       * Delays for a short period of time.
+       */
+      private lazy val delay: UIO[Unit] =
+        if (TestPlatform.isJS) ZIO.yieldNow
+        else live.provide(ZIO.sleep(1.millisecond))
+
+      /**
        * Provides access to the list of descendants of this fiber (children and
        * their children, recursively).
        */
@@ -424,7 +431,7 @@ package object environment extends PlatformSpecific {
        * Returns whether all descendants of this fiber are done or suspended.
        */
       private lazy val suspended: UIO[Boolean] =
-        freeze.zipWith(live.provide(ZIO.sleep(1.millisecond)) *> freeze)(_ == _).orElseSucceed(false)
+        freeze.zipWith(delay *> freeze)(_ == _).orElseSucceed(false)
 
       /**
        * Constructs an `OffsetDateTime` from a `Duration` and a `ZoneId`.


### PR DESCRIPTION
In the implementation of `TestClock` we are relying on taking two consecutive "snapshots" of the status of descendent fibers and concluding that an effect is indefinitely suspended if all fibers are done / suspended in each snapshot and the snapshots are identical. In general this seems to be working quite well but we are seeing rare flakiness that seems to be related to situations where the two snapshots are the same but we actually aren't done yet. I am trying to resolve by adding a 1 millisecond delay between the snapshots.