### PR TITLE
ZSink.collectAll and Zstream.runAll use chunk

### DIFF
--- a/docs/datatypes/sink.md
+++ b/docs/datatypes/sink.md
@@ -25,7 +25,7 @@ stream.run(sink)
 
 The `zio.stream` provides numerous kinds of sinks to use.
 
-Collecting all elements into `List[A]`:
+Collecting all elements into `Chunk[A]`:
 
 ```scala mdoc:silent
 ZSink.collectAll[Int]
@@ -80,5 +80,5 @@ Sink.collectAll[String].contramap[Int](_.toString + "id")
 A `dimap` is an extended `contramap` that additionally transforms sink's output:
 
 ```scala mdoc:silent
-Sink.collectAll[String].dimap[Int, List[String]](_.toString + "id", _.take(10))
+Sink.collectAll[String].dimap[Int, Chunk[String]](_.toString + "id", _.take(10))
 ```

--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -1,8 +1,8 @@
 package zio.examples.macros
 
-import zio.{ random, Has, IO, UIO, URIO, ZIO, ZLayer }
+import zio.{Chunk, Has, IO, UIO, URIO, ZIO, ZLayer, random}
 import zio.console.Console
-import zio.stream.{ ZSink, ZStream }
+import zio.stream.{ZSink, ZStream}
 import zio.random.Random
 import zio.macros.accessible
 
@@ -26,7 +26,7 @@ object AccessibleMacroExample {
     val value: String
     def function(n: Int): String
     def stream(n: Int): ZStream[Any, String, Int]
-    def sink(n: Int): ZSink[Any, Nothing, Int, List[Int]]
+    def sink(n: Int): ZSink[Any, Nothing, Int, Chunk[Int]]
   }
 
   val live: ZLayer[Console, Nothing, Has[Service]] =
@@ -40,11 +40,11 @@ object AccessibleMacroExample {
       val value: String                                              = "foo"
       def function(n: Int): String                                   = s"foo $n"
       def stream(n: Int): ZStream[Any, String, Int]                  = ZStream.fromIterable(List(1, 2, 3))
-      def sink(n: Int): ZSink[Any, Nothing, Int, List[Int]] = ZSink.collectAll
+      def sink(n: Int): ZSink[Any, Nothing, Int, Chunk[Int]] = ZSink.collectAll
     })
 
   // can use accessors even in the same compilation unit
-  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, ZStream[Any, String, Int], ZSink[Any, Nothing, Int, List[Int]])] =
+  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, ZStream[Any, String, Int], ZSink[Any, Nothing, Int, Chunk[Int]])] =
     for {
       _  <- AccessibleMacroExample.foo
       _  <- AccessibleMacroExample.bar(1)
@@ -69,7 +69,7 @@ object AccessibleMacroExample {
   def _value                          : ZIO[AccessibleMacroExample, Throwable, String]                                     = AccessibleMacroExample.value
   def _function(n: Int)               : ZIO[AccessibleMacroExample, Throwable, String]                                     = AccessibleMacroExample.function(n)
   def _stream(n: Int)                 : ZIO[AccessibleMacroExample, Nothing, ZStream[Any, String, Int]]                    = AccessibleMacroExample.stream(n)
-  def _sink(n: Int)                   : ZIO[AccessibleMacroExample, Nothing, ZSink[Any, Nothing, Int, List[Int]]] = AccessibleMacroExample.sink(n)
+  def _sink(n: Int)                   : ZIO[AccessibleMacroExample, Nothing, ZSink[Any, Nothing, Int, Chunk[Int]]] = AccessibleMacroExample.sink(n)
 
   // macro autogenerates accessors for `foo`, `bar`, `baz`, `poly`, `poly2`, `value` and `function` below
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -7,7 +7,7 @@ import zio._
 import zio.stream.SinkUtils.{ findSink, sinkRaceLaw }
 import zio.stream.ZStreamGen._
 import zio.test.Assertion.{ equalTo, isTrue, succeeds }
-import zio.test._
+import zio.test.{ assertM, _ }
 
 object ZSinkSpec extends ZIOBaseSpec {
   def spec = suite("ZSinkSpec")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
@@ -8,6 +8,9 @@ object ZStreamGen extends GenZIO {
   def tinyListOf[R <: Random, A](g: Gen[R, A]): Gen[R, List[A]] =
     Gen.listOfBounded(0, 5)(g)
 
+  def tinyChunkOf[R <: Random, A](g: Gen[R, A]): Gen[R, Chunk[A]] =
+    Gen.chunkOfBounded(0, 5)(g)
+
   def streamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, ZStream[Any, String, A]] =
     Gen.oneOf(failingStreamGen(a, max), pureStreamGen(a, max))
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1868,7 +1868,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("interrupts pulling on finish") {
             val s1 = ZStream(1, 2, 3)
             val s2 = ZStream.fromEffect(clock.sleep(5.seconds).as(4))
-            assertM(s1.mergeTerminateLeft(s2).runCollect)(equalTo(List(1, 2, 3)))
+            assertM(s1.mergeTerminateLeft(s2).runCollect)(equalTo(Chunk(1, 2, 3)))
           }
         ),
         suite("mergeTerminateRight")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -26,15 +26,15 @@ object ZStreamSpec extends ZIOBaseSpec {
     suite("ZStreamSpec")(
       suite("Combinators")(
         suite("absolve")(
-          testM("happy path")(checkM(tinyListOf(Gen.anyInt)) { xs =>
+          testM("happy path")(checkM(tinyChunkOf(Gen.anyInt)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_)))
             assertM(stream.absolve.runCollect)(equalTo(xs))
           }),
-          testM("failure")(checkM(tinyListOf(Gen.anyInt)) { xs =>
+          testM("failure")(checkM(tinyChunkOf(Gen.anyInt)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
             assertM(stream.absolve.runCollect.run)(fails(equalTo("Ouch")))
           }),
-          testM("round-trip #1")(checkM(tinyListOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
+          testM("round-trip #1")(checkM(tinyChunkOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs.map(Right(_)))
             val stream = xss ++ ZStream(Left(s)) ++ xss
             for {
@@ -42,7 +42,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               res2 <- stream.absolve.either.runCollect
             } yield assert(res1)(startsWith(res2))
           }),
-          testM("round-trip #2")(checkM(tinyListOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
+          testM("round-trip #2")(checkM(tinyChunkOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs)
             val stream = xss ++ ZStream.fail(s)
             for {
@@ -87,7 +87,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               .aggregateAsync(ZTransducer.foldUntil(List[Int](), 3)((acc, el) => el :: acc))
               .runCollect
               .map { result =>
-                assert(result.flatten)(equalTo(List(1, 1, 1, 1))) &&
+                assert(result.toList.flatten)(equalTo(List(1, 1, 1, 1))) &&
                 assert(result.forall(_.length <= 3))(isTrue)
               }
           },
@@ -149,7 +149,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 )
                 .map(_.reverse)
                 .runCollect
-                .map(_.flatten)
+                .map(_.toList.flatten)
             )(equalTo(data))
           }
         ),
@@ -160,21 +160,21 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .aggregate(ZTransducer.collectAllWhile(_.isDigit))
                 .map(_.mkString.toInt)
                 .runCollect
-            )(equalTo(List(12, 34)))
+            )(equalTo(Chunk(12, 34)))
           },
           testM("no remainder") {
             assertM(
               ZStream(1, 2, 3, 4)
                 .aggregate(ZTransducer.fold(100)(_ % 2 == 0)(_ + _))
                 .runCollect
-            )(equalTo(List(101, 105, 104)))
+            )(equalTo(Chunk(101, 105, 104)))
           },
           testM("with a sink that always signals more") {
             assertM(
               ZStream(1, 2, 3)
                 .aggregate(ZTransducer.fold(0)(_ => true)(_ + _))
                 .runCollect
-            )(equalTo(List(1 + 2 + 3)))
+            )(equalTo(Chunk(1 + 2 + 3)))
           },
           // testM("managed") {
           //   final class TestSink(ref: Ref[Int]) extends ZSink[Any, Throwable, Int, Int, List[Int]] {
@@ -201,7 +201,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           //     result   <- stream.aggregateManaged(sink).runCollect
           //     i        <- resource.get
           //     _        <- if (i != 2000) IO.fail(new IllegalStateException(i.toString)) else IO.unit
-          //   } yield assert(result)(equalTo(List(List(1, 1), List(2, 2), List(3, 3), List(4, 4))))
+          //   } yield assert(result)(equalTo(Chunk(List(1, 1), List(2, 2), List(3, 3), List(4, 4))))
           // },
           testM("propagate managed error") {
             val fail = "I'm such a failure!"
@@ -225,7 +225,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 )
                 .runCollect
             )(
-              equalTo(List(Right(List(2, 1, 1, 1, 1)), Right(List(2))))
+              equalTo(Chunk(Right(List(2, 1, 1, 1, 1)), Right(List(2))))
             )
           },
           testM("error propagation 1") {
@@ -303,7 +303,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         case Right(v) => v
                       }
                       .runCollect
-                      .map(_.flatten))
+                      .map(_.toList.flatten))
                       .fork
                 _      <- TestClock.adjust(31.minutes)
                 result <- f.join
@@ -326,7 +326,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   Schedule.spaced(30.minutes)
                 )
                 .runCollect
-            )(equalTo(List(List(2, 1, 1, 1, 1), List(2))))
+            )(equalTo(Chunk(List(2, 1, 1, 1, 1), List(2))))
           }
         ),
         suite("bracket")(
@@ -336,7 +336,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               iteratorStream = ZStream.bracket(UIO(0 to 2))(_ => done.set(true)).flatMap(ZStream.fromIterable(_))
               result         <- iteratorStream.runCollect
               released       <- done.get
-            } yield assert(result)(equalTo(List(0, 1, 2))) && assert(released)(isTrue)
+            } yield assert(result)(equalTo(Chunk(0, 1, 2))) && assert(released)(isTrue)
           ),
           testM("bracket short circuits")(
             for {
@@ -347,7 +347,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .take(2)
               result   <- iteratorStream.runCollect
               released <- done.get
-            } yield assert(result)(equalTo(List(0, 1))) && assert(released)(isTrue)
+            } yield assert(result)(equalTo(Chunk(0, 1))) && assert(released)(isTrue)
           ),
           testM("no acquisition when short circuiting")(
             for {
@@ -394,7 +394,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   for {
                     out1     <- s1.runCollect
                     out2     <- s2.runCollect
-                    expected = Range(0, 5).toList
+                    expected = Chunk.fromIterable(Range(0, 5))
                   } yield assert(out1)(equalTo(expected)) && assert(out2)(equalTo(expected))
                 case _ =>
                   UIO(assert(())(Assertion.nothing))
@@ -440,20 +440,20 @@ object ZStreamSpec extends ZIOBaseSpec {
                 for {
                   _    <- s1.process.use_(ZIO.unit).ignore
                   out2 <- s2.runCollect
-                } yield assert(out2)(equalTo(Range(0, 5).toList))
+                } yield assert(out2)(equalTo(Chunk.fromIterable(Range(0, 5))))
               case _ =>
                 UIO(assert(())(Assertion.nothing))
             }
           }
         ),
         suite("buffer")(
-          testM("maintains elements and ordering")(checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { list =>
+          testM("maintains elements and ordering")(checkM(tinyChunkOf(Gen.chunkOf(Gen.anyInt))) { chunk =>
             assertM(
               ZStream
-                .fromChunks(list: _*)
+                .fromChunks(chunk: _*)
                 .buffer(2)
                 .runCollect
-            )(equalTo(Chunk.fromIterable(list).flatten.toList))
+            )(equalTo(chunk.flatten))
           }),
           testM("buffer the Stream with Error") {
             val e = new RuntimeException("boom")
@@ -566,13 +566,13 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("bufferUnbounded")(
-          testM("buffer the Stream")(checkM(Gen.listOf(Gen.anyInt)) { list =>
+          testM("buffer the Stream")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
             assertM(
               ZStream
-                .fromIterable(list)
+                .fromIterable(chunk)
                 .bufferUnbounded
                 .runCollect
-            )(equalTo(list))
+            )(equalTo(chunk))
           }),
           testM("buffer the Stream with Error") {
             val e = new RuntimeException("boom")
@@ -600,17 +600,17 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("recovery from errors") {
             val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
             val s2 = ZStream(3, 4)
-            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
           },
           testM("recovery from defects") {
             val s1 = ZStream(1, 2) ++ ZStream.dieMessage("Boom")
             val s2 = ZStream(3, 4)
-            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
           },
           testM("happy path") {
             val s1 = ZStream(1, 2)
             val s2 = ZStream(3, 4)
-            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(List(1, 2))))
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
           },
           testM("executes finalizers") {
             for {
@@ -623,13 +623,13 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           testM("releases all resources by the time the failover stream has started") {
             for {
-              fins <- Ref.make(List[Int]())
-              s = ZStream.finalizer(fins.update(1 :: _)) *>
-                ZStream.finalizer(fins.update(2 :: _)) *>
-                ZStream.finalizer(fins.update(3 :: _)) *>
+              fins <- Ref.make(Chunk[Int]())
+              s = ZStream.finalizer(fins.update(1 +: _)) *>
+                ZStream.finalizer(fins.update(2 +: _)) *>
+                ZStream.finalizer(fins.update(3 +: _)) *>
                 ZStream.fail("boom")
               result <- s.drain.catchAllCause(_ => ZStream.fromEffect(fins.get)).runCollect
-            } yield assert(result.flatten)(equalTo(List(1, 2, 3)))
+            } yield assert(result.flatten)(equalTo(Chunk(1, 2, 3)))
           },
           testM("propagates the right Exit value to the failing stream (#3609)") {
             for {
@@ -648,7 +648,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("recovery from some errors") {
             val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
             val s2 = ZStream(3, 4)
-            s1.catchSome { case "Boom" => s2 }.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
+            s1.catchSome { case "Boom" => s2 }.runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
           },
           testM("fails stream when partial function does not match") {
             val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
@@ -660,7 +660,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("recovery from some errors") {
             val s1 = ZStream(1, 2) ++ ZStream.halt(Cause.Fail("Boom"))
             val s2 = ZStream(3, 4)
-            s1.catchSomeCause { case Cause.Fail("Boom") => s2 }.runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4))))
+            s1.catchSomeCause { case Cause.Fail("Boom") => s2 }.runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
           },
           testM("halts stream when partial function does not match") {
             val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
@@ -671,7 +671,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         testM("collect") {
           assertM(ZStream(Left(1), Right(2), Left(3)).collect {
             case Right(n) => n
-          }.runCollect)(equalTo(List(2)))
+          }.runCollect)(equalTo(Chunk(2)))
         },
         suite("collectM")(
           testM("collectM") {
@@ -679,7 +679,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(Left(1), Right(2), Left(3)).collectM {
                 case Right(n) => ZIO(n * 2)
               }.runCollect
-            )(equalTo(List(4)))
+            )(equalTo(Chunk(4)))
           },
           testM("collectM fails") {
             assertM(
@@ -694,20 +694,20 @@ object ZStreamSpec extends ZIOBaseSpec {
                 case 3 => ZIO.fail("boom")
                 case x => UIO.succeed(x)
               }.either.runCollect
-            )(equalTo(List(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         testM("collectSome")(checkM(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.anyInt), _))) { s =>
           for {
             res1 <- (s.collectSome.runCollect)
-            res2 <- (s.runCollect.map(_.flatten))
+            res2 <- (s.runCollect.map(_.collect { case Some(x) => x }))
           } yield assert(res1)(equalTo(res2))
         }),
         suite("collectWhile")(
           testM("collectWhile") {
             assertM(ZStream(Some(1), Some(2), Some(3), None, Some(4)).collectWhile {
               case Some(v) => v
-            }.runCollect)(equalTo(List(1, 2, 3)))
+            }.runCollect)(equalTo(Chunk(1, 2, 3)))
           },
           testM("collectWhile short circuits") {
             assertM((ZStream(Option(1)) ++ ZStream.fail("Ouch")).collectWhile {
@@ -721,7 +721,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(Some(1), Some(2), Some(3), None, Some(4)).collectWhileM {
                 case Some(v) => ZIO(v * 2)
               }.runCollect
-            )(equalTo(List(2, 4, 6)))
+            )(equalTo(Chunk(2, 4, 6)))
           },
           testM("collectWhileM short circuits") {
             assertM(
@@ -746,7 +746,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 case 3 => ZIO.fail("boom")
                 case x => UIO.succeed(x)
               }.either.runCollect
-            )(equalTo(List(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         suite("collectWhileSuccess")(
@@ -757,7 +757,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .toQueue(1)
                 .use(q => ZStream.fromQueue(q).map(_.exit).collectWhileSuccess.runCollect)
                 .map(_.flatMap(_.toList))
-            )(equalTo(Range(0, 10).toList))
+            )(equalTo(Chunk.fromIterable(Range(0, 10))))
           },
           testM("errors") {
             val e = new RuntimeException("boom")
@@ -772,10 +772,10 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("concat")(
           testM("concat")(checkM(streamOfBytes, streamOfBytes) { (s1, s2) =>
             for {
-              listConcat   <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
+              chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
               streamConcat <- (s1 ++ s2).runCollect.run
-            } yield assert(streamConcat.succeeded && listConcat.succeeded)(isTrue) implies assert(streamConcat)(
-              equalTo(listConcat)
+            } yield assert(streamConcat.succeeded && chunkConcat.succeeded)(isTrue) implies assert(streamConcat)(
+              equalTo(chunkConcat)
             )
           }),
           testM("finalizer order") {
@@ -881,7 +881,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         testM("either") {
           val s = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
-          s.either.runCollect.map(assert(_)(equalTo(List(Right(1), Right(2), Right(3), Left("Boom")))))
+          s.either.runCollect.map(assert(_)(equalTo(Chunk(Right(1), Right(2), Right(3), Left("Boom")))))
         },
         testM("ensuring") {
           for {
@@ -922,7 +922,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 case 3 => ZIO.fail("boom")
                 case _ => UIO.succeed(true)
               }.either.runCollect
-            )(equalTo(List(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         suite("flatMap")(
@@ -935,7 +935,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             val stream   = fib(20)
             val expected = 6765
 
-            assertM(stream.runCollect)(equalTo(List(expected)))
+            assertM(stream.runCollect)(equalTo(Chunk(expected)))
           } @@ TestAspect.jvmOnly, // Too slow on Scala.js
           testM("left identity")(checkM(Gen.anyInt, Gen.function(pureStreamOfInts)) { (x, f) =>
             for {
@@ -1072,7 +1072,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 )
                 .take(1)
                 .runCollect
-            )(equalTo(List(1)))
+            )(equalTo(Chunk(1)))
           },
           testM("interruption propagation") {
             for {
@@ -1200,7 +1200,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .flatMapParSwitch(2)(identity)
                 .take(1)
                 .runCollect
-            )(equalTo(List(1)))
+            )(equalTo(Chunk(1)))
           },
           testM("interruption propagation") {
             for {
@@ -1301,7 +1301,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .mapChunks(chunk => Chunk.single(Take.chunk(chunk)))
                 .flattenTake
                 .runCollect
-            )(equalTo(chunks.fold(Chunk.empty)(_ ++ _).toList))
+            )(equalTo(chunks.fold(Chunk.empty)(_ ++ _)))
           }),
           testM("stop collecting on Exit.Failure") {
             assertM(
@@ -1310,7 +1310,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 Take.single(3),
                 Take.end
               ).flattenTake.runCollect
-            )(equalTo(List(1, 2, 3)))
+            )(equalTo(Chunk(1, 2, 3)))
           },
           testM("work with empty chunks") {
             assertM(ZStream(Take.chunk(Chunk.empty), Take.chunk(Chunk.empty)).flattenTake.runCollect)(isEmpty)
@@ -1484,7 +1484,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                     _      <- c.offer
                     result <- fiber.join
                   } yield result
-                )(equalTo(List(Chunk(1), Chunk(2), Chunk(3))))
+                )(equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3))))
             }
           },
           testM("will process first chunk") {
@@ -1494,11 +1494,11 @@ object ZStreamSpec extends ZIOBaseSpec {
               _      <- TestClock.adjust(6.seconds)
               _      <- queue.offer(1)
               result <- fiber.join
-            } yield assert(result)(equalTo(List(1)))
+            } yield assert(result)(equalTo(Chunk(1)))
           }
         ),
         testM("grouped")(
-          assertM(ZStream(1, 2, 3, 4).grouped(2).runCollect)(equalTo(List(List(1, 2), List(3, 4))))
+          assertM(ZStream(1, 2, 3, 4).grouped(2).runCollect)(equalTo(Chunk(List(1, 2), List(3, 4))))
         ),
         suite("groupedWithin")(
           testM("group based on time passed") {
@@ -1516,38 +1516,38 @@ object ZStreamSpec extends ZIOBaseSpec {
                 _      <- c.offer *> TestClock.adjust(2.seconds) *> c.awaitNext
                 _      <- c.offer
                 result <- f.join
-              } yield result)(equalTo(List(List(1, 2), List(3, 4), List(5))))
+              } yield result)(equalTo(Chunk(List(1, 2), List(3, 4), List(5))))
             }
           } @@ timeout(10.seconds) @@ flaky,
           testM("group immediately when chunk size is reached") {
-            assertM(ZStream(1, 2, 3, 4).groupedWithin(2, 10.seconds).runCollect)(equalTo(List(List(1, 2), List(3, 4))))
+            assertM(ZStream(1, 2, 3, 4).groupedWithin(2, 10.seconds).runCollect)(equalTo(Chunk(List(1, 2), List(3, 4))))
           }
         ),
         testM("interleave") {
           val s1 = ZStream(2, 3)
           val s2 = ZStream(5, 6, 7)
 
-          assertM(s1.interleave(s2).runCollect)(equalTo(List(2, 5, 3, 6, 7)))
+          assertM(s1.interleave(s2).runCollect)(equalTo(Chunk(2, 5, 3, 6, 7)))
         },
         testM("interleaveWith") {
-          def interleave(b: List[Boolean], s1: => List[Int], s2: => List[Int]): List[Int] =
+          def interleave(b: Chunk[Boolean], s1: => Chunk[Int], s2: => Chunk[Int]): Chunk[Int] =
             b.headOption.map { hd =>
               if (hd) s1 match {
-                case h :: t =>
-                  h :: interleave(b.tail, t, s2)
+                case h +: t =>
+                  h +: interleave(b.tail, t, s2)
                 case _ =>
-                  if (s2.isEmpty) List.empty
-                  else interleave(b.tail, List.empty, s2)
+                  if (s2.isEmpty) Chunk.empty
+                  else interleave(b.tail, Chunk.empty, s2)
               }
               else
                 s2 match {
-                  case h :: t =>
-                    h :: interleave(b.tail, s1, t)
+                  case h +: t =>
+                    h +: interleave(b.tail, s1, t)
                   case _ =>
-                    if (s1.isEmpty) List.empty
-                    else interleave(b.tail, s1, List.empty)
+                    if (s1.isEmpty) Chunk.empty
+                    else interleave(b.tail, s1, Chunk.empty)
                 }
-            }.getOrElse(List.empty)
+            }.getOrElse(Chunk.empty)
 
           val int = Gen.int(0, 5)
 
@@ -1571,28 +1571,28 @@ object ZStreamSpec extends ZIOBaseSpec {
               .map(_.toString)
               .intersperse("@")
               .runCollect
-              .map(result => assert(result)(equalTo(List("1", "@", "2", "@", "3", "@", "4"))))
+              .map(result => assert(result)(equalTo(Chunk("1", "@", "2", "@", "3", "@", "4"))))
           },
           testM("intersperse several with begin and end") {
             Stream(1, 2, 3, 4)
               .map(_.toString)
               .intersperse("[", "@", "]")
               .runCollect
-              .map(result => assert(result)(equalTo(List("[", "1", "@", "2", "@", "3", "@", "4", "]"))))
+              .map(result => assert(result)(equalTo(Chunk("[", "1", "@", "2", "@", "3", "@", "4", "]"))))
           },
           testM("intersperse single") {
             Stream(1)
               .map(_.toString)
               .intersperse("@")
               .runCollect
-              .map(result => assert(result)(equalTo(List("1"))))
+              .map(result => assert(result)(equalTo(Chunk("1"))))
           },
           testM("intersperse single with begin and end") {
             Stream(1)
               .map(_.toString)
               .intersperse("[", "@", "]")
               .runCollect
-              .map(result => assert(result)(equalTo(List("[", "1", "]"))))
+              .map(result => assert(result)(equalTo(Chunk("[", "1", "]"))))
           }
         ),
         suite("interruptWhen")(
@@ -1670,7 +1670,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   _      <- c.offer
                   result <- fiber.join
                 } yield result
-              )(equalTo(List(Chunk(1), Chunk(2))))
+              )(equalTo(Chunk(Chunk(1), Chunk(2))))
             }
           },
           testM("interrupts before first chunk") {
@@ -1701,7 +1701,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assert(res1)(equalTo(res2))
         }),
         testM("mapAccum") {
-          assertM(ZStream(1, 1, 1).mapAccum(0)((acc, el) => (acc + el, acc + el)).runCollect)(equalTo(List(1, 2, 3)))
+          assertM(ZStream(1, 1, 1).mapAccum(0)((acc, el) => (acc + el, acc + el)).runCollect)(equalTo(Chunk(1, 2, 3)))
         },
         suite("mapAccumM")(
           testM("mapAccumM happy path") {
@@ -1709,7 +1709,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(1, 1, 1)
                 .mapAccumM[Any, Nothing, Int, Int](0)((acc, el) => IO.succeed((acc + el, acc + el)))
                 .runCollect
-            )(equalTo(List(1, 2, 3)))
+            )(equalTo(Chunk(1, 2, 3)))
           },
           testM("mapAccumM error") {
             ZStream(1, 1, 1)
@@ -1727,7 +1727,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 }
                 .either
                 .runCollect
-            )(equalTo(List(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         testM("mapConcat")(checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
@@ -1800,7 +1800,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               for {
                 l <- s.mapM(f).runCollect
                 r <- IO.foreach(data)(f)
-              } yield assert(l)(equalTo(r))
+              } yield assert(l.toList)(equalTo(r))
             }
           },
           testM("laziness on chunks") {
@@ -1809,7 +1809,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 case 3 => ZIO.fail("boom")
                 case x => UIO.succeed(x)
               }.either.runCollect
-            )(equalTo(List(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         suite("mapMPar")(
@@ -1820,7 +1820,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               for {
                 l <- s.mapMPar(8)(f).runCollect
                 r <- IO.foreachParN(8)(data)(f)
-              } yield assert(l)(equalTo(r))
+              } yield assert(l.toList)(equalTo(r))
             }
           },
           testM("order when n = 1") {
@@ -1863,7 +1863,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               _       <- queue1.shutdown *> TestClock.adjust(1.second)
               _       <- queue2.offer(3)
               result  <- fiber.join
-            } yield assert(result)(equalTo(List(1, 2)))
+            } yield assert(result)(equalTo(Chunk(1, 2)))
           },
           testM("interrupts pulling on finish") {
             val s1 = ZStream(1, 2, 3)
@@ -1884,7 +1884,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               _       <- queue2.shutdown *> TestClock.adjust(1.second)
               _       <- queue1.offer(1)
               result  <- fiber.join
-            } yield assert(result)(equalTo(List(2, 3)))
+            } yield assert(result)(equalTo(Chunk(2, 3)))
           }
         ),
         suite("mergeTerminateEither")(
@@ -1946,7 +1946,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   for {
                     out1 <- s1.runCollect
                     out2 <- s2.runCollect
-                  } yield assert(out1)(equalTo(List(0, 2, 4))) && assert(out2)(equalTo(List(1, 3, 5)))
+                  } yield assert(out1)(equalTo(Chunk(0, 2, 4))) && assert(out2)(equalTo(Chunk(1, 3, 5)))
               }
           },
           testM("errors") {
@@ -1985,7 +1985,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                     other
                   )(
                     equalTo(
-                      List(
+                      Chunk(
                         1,
                         3,
                         5
@@ -2007,19 +2007,19 @@ object ZStreamSpec extends ZIOBaseSpec {
             case (chunk, rest) =>
               rest.runCollect.map { rest =>
                 assert(chunk)(equalTo(Chunk(1, 2, 3))) &&
-                assert(rest)(equalTo(List(4, 5, 6)))
+                assert(rest)(equalTo(Chunk(4, 5, 6)))
               }
           }
         },
         testM("orElse") {
           val s1 = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
           val s2 = ZStream(4, 5, 6)
-          s1.orElse(s2).runCollect.map(assert(_)(equalTo(List(1, 2, 3, 4, 5, 6))))
+          s1.orElse(s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
         },
         testM("orElseEither") {
           val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
           val s2 = ZStream.succeed(2)
-          s1.orElseEither(s2).runCollect.map(assert(_)(equalTo(List(Left(1), Right(2)))))
+          s1.orElseEither(s2).runCollect.map(assert(_)(equalTo(Chunk(Left(1), Right(2)))))
         },
         testM("orElseFail") {
           val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
@@ -2028,11 +2028,11 @@ object ZStreamSpec extends ZIOBaseSpec {
         testM("orElseOptional") {
           val s1 = ZStream.succeed(1) ++ ZStream.fail(None)
           val s2 = ZStream.succeed(2)
-          s1.orElseOptional(s2).runCollect.map(assert(_)(equalTo(List(1, 2))))
+          s1.orElseOptional(s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
         },
         testM("orElseSucceed") {
           val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
-          s1.orElseSucceed(2).runCollect.map(assert(_)(equalTo(List(1, 2))))
+          s1.orElseSucceed(2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
         },
         suite("repeat")(
           testM("repeat")(
@@ -2040,7 +2040,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(1)
                 .repeat(Schedule.recurs(4))
                 .runCollect
-            )(equalTo(List(1, 1, 1, 1, 1)))
+            )(equalTo(Chunk(1, 1, 1, 1, 1)))
           ),
           testM("short circuits")(
             for {
@@ -2065,7 +2065,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .runCollect
             )(
               equalTo(
-                List(
+                Chunk(
                   Right(1),
                   Right(1),
                   Left(1),
@@ -2124,14 +2124,14 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream("A", "B", "C", "A", "B", "C")
                 .scheduleWith(Schedule.recurs(2) *> Schedule.fromFunction((_) => "Done"))(_.toLowerCase, identity)
                 .runCollect
-            )(equalTo(List("a", "b", "c", "Done", "a", "b", "c", "Done")))
+            )(equalTo(Chunk("a", "b", "c", "Done", "a", "b", "c", "Done")))
           ),
           testM("scheduleEither")(
             assertM(
               ZStream("A", "B", "C")
                 .scheduleEither(Schedule.recurs(2) *> Schedule.fromFunction((_) => "!"))
                 .runCollect
-            )(equalTo(List(Right("A"), Right("B"), Right("C"), Left("!"))))
+            )(equalTo(Chunk(Right("A"), Right("B"), Right("C"), Left("!"))))
           )
         ),
         suite("scheduleElements")(
@@ -2140,21 +2140,21 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream("A", "B", "C")
                 .scheduleElementsWith(Schedule.recurs(0) *> Schedule.fromFunction((_) => 123))(identity, _.toString)
                 .runCollect
-            )(equalTo(List("A", "123", "B", "123", "C", "123")))
+            )(equalTo(Chunk("A", "123", "B", "123", "C", "123")))
           ),
           testM("scheduleElementsEither")(
             assertM(
               ZStream("A", "B", "C")
                 .scheduleElementsEither(Schedule.recurs(0) *> Schedule.fromFunction((_) => 123))
                 .runCollect
-            )(equalTo(List(Right("A"), Left(123), Right("B"), Left(123), Right("C"), Left(123))))
+            )(equalTo(Chunk(Right("A"), Left(123), Right("B"), Left(123), Right("C"), Left(123))))
           ),
           testM("repeated && assertspaced")(
             assertM(
               ZStream("A", "B", "C")
                 .scheduleElements(Schedule.once)
                 .runCollect
-            )(equalTo(List("A", "A", "B", "B", "C", "C")))
+            )(equalTo(Chunk("A", "A", "B", "B", "C", "C")))
           ),
           testM("short circuits in schedule")(
             assertM(
@@ -2162,7 +2162,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .scheduleElements(Schedule.once)
                 .take(4)
                 .runCollect
-            )(equalTo(List("A", "A", "B", "B")))
+            )(equalTo(Chunk("A", "A", "B", "B")))
           ),
           testM("short circuits after schedule")(
             assertM(
@@ -2170,7 +2170,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .scheduleElements(Schedule.once)
                 .take(3)
                 .runCollect
-            )(equalTo(List("A", "A", "B")))
+            )(equalTo(Chunk("A", "A", "B")))
           )
         ),
         testM("some") {
@@ -2179,7 +2179,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         testM("someOrElse") {
           val s1 = ZStream.succeed(Some(1)) ++ ZStream.succeed(None)
-          s1.someOrElse(-1).runCollect.map(assert(_)(equalTo(List(1, -1))))
+          s1.someOrElse(-1).runCollect.map(assert(_)(equalTo(Chunk(1, -1))))
         },
         testM("someOrFail") {
           val s1 = ZStream.succeed(Some(1)) ++ ZStream.succeed(None)
@@ -2203,28 +2203,28 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("take(0) short circuits")(
             for {
               units <- ZStream.never.take(0).runCollect
-            } yield assert(units)(equalTo(Nil))
+            } yield assert(units)(equalTo(Chunk.empty))
           ),
           testM("take(1) short circuits")(
             for {
               ints <- (ZStream(1) ++ ZStream.never).take(1).runCollect
-            } yield assert(ints)(equalTo(List(1)))
+            } yield assert(ints)(equalTo(Chunk(1)))
           )
         ),
         testM("takeUntil") {
           checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeUntil <- s.takeUntil(p).runCollect.run
-              listTakeUntil   <- s.runCollect.map(as => as.takeWhile(!p(_)) ++ as.dropWhile(!p(_)).take(1)).run
-            } yield assert(listTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(equalTo(listTakeUntil))
+              chunkTakeUntil  <- s.runCollect.map(as => as.takeWhile(!p(_)) ++ as.dropWhile(!p(_)).take(1)).run
+            } yield assert(chunkTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(equalTo(chunkTakeUntil))
           }
         },
         suite("takeWhile")(
           testM("takeWhile")(checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.run
-              listTakeWhile   <- s.runCollect.map(_.takeWhile(p)).run
-            } yield assert(listTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(listTakeWhile))
+              chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).run
+            } yield assert(chunkTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
           }),
           testM("takeWhile short circuits")(
             assertM(
@@ -2241,11 +2241,11 @@ object ZStreamSpec extends ZIOBaseSpec {
               ref <- Ref.make(0)
               res <- ZStream(1, 1).tap[Any, Nothing](a => ref.update(_ + a)).runCollect
               sum <- ref.get
-            } yield assert(res)(equalTo(List(1, 1))) && assert(sum)(equalTo(2))
+            } yield assert(res)(equalTo(Chunk(1, 1))) && assert(sum)(equalTo(2))
           },
           testM("laziness on chunks") {
             assertM(Stream(1, 2, 3).tap(x => IO.when(x == 3)(IO.fail("error"))).either.runCollect)(
-              equalTo(List(Right(1), Right(2), Left("error")))
+              equalTo(Chunk(Right(1), Right(2), Left("error")))
             )
           }
         ),
@@ -2255,14 +2255,14 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(1, 2, 3, 4)
                 .throttleEnforce(0, Duration.Infinity)(_ => 0)
                 .runCollect
-            )(equalTo(List(1, 2, 3, 4)))
+            )(equalTo(Chunk(1, 2, 3, 4)))
           },
           testM("no bandwidth") {
             assertM(
               ZStream(1, 2, 3, 4)
                 .throttleEnforce(0, Duration.Infinity)(_ => 1)
                 .runCollect
-            )(equalTo(Nil))
+            )(equalTo(Chunk.empty))
           }
         ),
         suite("throttleShape")(
@@ -2281,7 +2281,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                                 _    <- clock.sleep(4.seconds)
                                 _    <- queue.offer(3)
                                 res3 <- pull
-                              } yield assert(List(res1, res2, res3))(equalTo(List(Chunk(1), Chunk(2), Chunk(3))))
+                              } yield assert(Chunk(res1, res2, res3))(equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3))))
                           }
                         }
                         .fork
@@ -2298,7 +2298,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   _       <- queue.offer(2)
                   res2    <- pull
                   elapsed <- clock.currentTime(TimeUnit.SECONDS)
-                } yield assert(elapsed)(equalTo(0L)) && assert(List(res1, res2))(equalTo(List(Chunk(1), Chunk(2))))
+                } yield assert(elapsed)(equalTo(0L)) && assert(Chunk(res1, res2))(equalTo(Chunk(Chunk(1), Chunk(2))))
               }
             }
           },
@@ -2318,7 +2318,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                                 _    <- TestClock.adjust(4.seconds)
                                 _    <- queue.offer(3)
                                 res3 <- pull
-                              } yield assert(List(res1, res2, res3))(equalTo(List(Chunk(1), Chunk(2), Chunk(3))))
+                              } yield assert(Chunk(res1, res2, res3))(equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3))))
                           }
                         }
                         .fork
@@ -2330,7 +2330,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream(1, 2, 3, 4)
                 .throttleShape(1, Duration.Infinity)(_ => 0)
                 .runCollect
-            )(equalTo(List(1, 2, 3, 4)))
+            )(equalTo(Chunk(1, 2, 3, 4)))
           }
         ),
         suite("debounce")(
@@ -2351,7 +2351,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   _      <- (clock.sleep(2500.millis) *> c.offer).fork
                   _      <- TestClock.adjust(3500.millis)
                   result <- fiber.join
-                } yield result)(equalTo(List(Chunk(3, 4), Chunk(6, 7))))
+                } yield result)(equalTo(Chunk(Chunk(3, 4), Chunk(6, 7))))
             }
           },
           testM("should take latest chunk within waitTime") {
@@ -2367,7 +2367,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 _      <- c.offer *> c.offer *> c.offer
                 _      <- TestClock.adjust(1.second)
                 result <- fiber.join
-              } yield result)(equalTo(List(Chunk(5, 6))))
+              } yield result)(equalTo(Chunk(Chunk(5, 6))))
             }
           },
           testM("should work properly with parallelization") {
@@ -2391,7 +2391,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               fiber  <- ZStream(1, 2, 3).fixed[Any](500.millis).debounce(1.second).runCollect.fork
               _      <- TestClock.adjust(3.seconds)
               result <- fiber.join
-            } yield assert(result)(equalTo(List(3)))
+            } yield assert(result)(equalTo(Chunk(3)))
           },
           testM("should fail immediately") {
             val stream = ZStream.fromEffect(IO.fail(None)).debounce(Duration.Infinity)
@@ -2406,7 +2406,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               fiber  <- ZStream(1, 2, 3).debounce(1.second).runCollect.fork
               _      <- TestClock.adjust(1.second)
               result <- fiber.join
-            } yield result)(equalTo(List(3)))
+            } yield result)(equalTo(Chunk(3)))
           }
         ),
         suite("timeout")(
@@ -2416,7 +2416,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .succeed(1)
                 .timeout(Duration.Infinity)
                 .runCollect
-            )(equalTo(List(1)))
+            )(equalTo(Chunk(1)))
           },
           testM("should end stream") {
             assertM(
@@ -2459,7 +2459,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .range(0, 5)
                 .timeoutTo(Duration.Infinity)(ZStream.succeed(-1))
                 .runCollect
-            )(equalTo(List(0, 1, 2, 3, 4)))
+            )(equalTo(Chunk(0, 1, 2, 3, 4)))
           },
           testM("should switch stream") {
             assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
@@ -2478,7 +2478,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   _      <- c.offer
                   result <- fiber.join
                 } yield result
-              )(equalTo(List(1, 2, 4)))
+              )(equalTo(Chunk(1, 2, 4)))
             }
           },
           testM("should not apply timeout after switch") {
@@ -2494,7 +2494,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               _       <- queue2.offer(4) *> TestClock.adjust(3.second)
               _       <- queue2.offer(5) *> queue2.shutdown
               result  <- fiber.join
-            } yield assert(result)(equalTo(List(1, 2, 4, 5)))
+            } yield assert(result)(equalTo(Chunk(1, 2, 4, 5)))
           }
         ),
         suite("toInputStream")(
@@ -2602,7 +2602,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                     .take(n.toLong)
                     .runCollect
                     .toManaged_
-          } yield assert(out)(equalTo((1 to n).toList))).use(ZIO.succeed(_))
+          } yield assert(out)(equalTo(Chunk.fromIterable(1 to n)))).use(ZIO.succeed(_))
         } @@ TestAspect.jvmOnly, // Until #3360 is solved
         suite("toQueue")(
           testM("toQueue")(checkM(Gen.chunkOfBounded(0, 3)(Gen.anyInt)) { (c: Chunk[Int]) =>
@@ -2627,7 +2627,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("zip doesn't pull too much when one of the streams is done") {
             val l = ZStream.fromChunks(Chunk(1, 2), Chunk(3, 4), Chunk(5)) ++ ZStream.fail("Nothing to see here")
             val r = ZStream.fromChunks(Chunk("a", "b"), Chunk("c"))
-            assertM(l.zip(r).runCollect)(equalTo(List((1, "a"), (2, "b"), (3, "c"))))
+            assertM(l.zip(r).runCollect)(equalTo(Chunk((1, "a"), (2, "b"), (3, "c"))))
           },
           testM("zip equivalence with Chunk#zipWith") {
             checkM(
@@ -2635,7 +2635,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               tinyListOf(Gen.chunkOf(Gen.anyInt))
             ) { (l, r) =>
               val expected = Chunk.fromIterable(l).flatten.zip(Chunk.fromIterable(r).flatten)
-              assertM(ZStream.fromChunks(l: _*).zip(ZStream.fromChunks(r: _*)).runCollect)(equalTo(expected.toList))
+              assertM(ZStream.fromChunks(l: _*).zip(ZStream.fromChunks(r: _*)).runCollect)(equalTo(expected))
             }
           },
           testM("zipWith prioritizes failure") {
@@ -2669,7 +2669,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   .map(Option(_))
                   .zipAll(ZStream.fromChunks(r: _*).map(Option(_)))(None, None)
                   .runCollect
-              )(equalTo(expected.toList))
+              )(equalTo(expected))
             }
           },
           testM("zipAllWith prioritizes failure") {
@@ -2698,18 +2698,18 @@ object ZStreamSpec extends ZIOBaseSpec {
             fiber <- s3.take(4).runCollect.fork
             _     <- TestClock.setTime(210.milliseconds)
             value <- fiber.join
-          } yield assert(value)(equalTo(List(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2)))
+          } yield assert(value)(equalTo(Chunk(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2)))
         },
         suite("zipWithNext")(
           testM("should zip with next element for a single chunk") {
             for {
               result <- ZStream(1, 2, 3).zipWithNext.runCollect
-            } yield assert(result)(equalTo(List(1 -> Some(2), 2 -> Some(3), 3 -> None)))
+            } yield assert(result)(equalTo(Chunk(1 -> Some(2), 2 -> Some(3), 3 -> None)))
           },
           testM("should work with multiple chunks") {
             for {
               result <- ZStream.fromChunks(Chunk(1), Chunk(2), Chunk(3)).zipWithNext.runCollect
-            } yield assert(result)(equalTo(List(1 -> Some(2), 2 -> Some(3), 3 -> None)))
+            } yield assert(result)(equalTo(Chunk(1 -> Some(2), 2 -> Some(3), 3 -> None)))
           },
           testM("should play well with empty streams") {
             assertM(ZStream.empty.zipWithNext.runCollect)(isEmpty)
@@ -2728,12 +2728,12 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("should zip with previous element for a single chunk") {
             for {
               result <- ZStream(1, 2, 3).zipWithPrevious.runCollect
-            } yield assert(result)(equalTo(List(None -> 1, Some(1) -> 2, Some(2) -> 3)))
+            } yield assert(result)(equalTo(Chunk(None -> 1, Some(1) -> 2, Some(2) -> 3)))
           },
           testM("should work with multiple chunks") {
             for {
               result <- ZStream.fromChunks(Chunk(1), Chunk(2), Chunk(3)).zipWithPrevious.runCollect
-            } yield assert(result)(equalTo(List(None -> 1, Some(1) -> 2, Some(2) -> 3)))
+            } yield assert(result)(equalTo(Chunk(None -> 1, Some(1) -> 2, Some(2) -> 3)))
           },
           testM("should play well with empty streams") {
             assertM(ZStream.empty.zipWithPrevious.runCollect)(isEmpty)
@@ -2751,9 +2751,8 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("zipWithPreviousAndNext")(
           testM("succeed") {
             for {
-              result0 <- ZStream(1, 2, 3).zipWithPreviousAndNext.runCollect
-              result  = List((None, 1, Some(2)), (Some(1), 2, Some(3)), (Some(2), 3, None))
-            } yield assert(result0)(equalTo(result))
+              result <- ZStream(1, 2, 3).zipWithPreviousAndNext.runCollect
+            } yield assert(result)(equalTo(Chunk((None, 1, Some(2)), (Some(1), 2, Some(3)), (Some(2), 3, None))))
           },
           testM("should output same values as zipping with both previous and next element") {
             checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
@@ -2799,14 +2798,14 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         testM("chunkN") {
-          checkM(tinyListOf(Gen.chunkOf(Gen.anyInt)) <*> (Gen.int(1, 100))) {
-            case (list, n) =>
-              val expected = list.flatten.grouped(n).toList
+          checkM(tinyChunkOf(Gen.chunkOf(Gen.anyInt)) <*> (Gen.int(1, 100))) {
+            case (chunk, n) =>
+              val expected = Chunk.fromIterable(chunk.flatten.grouped(n).toList)
               assertM(
                 ZStream
-                  .fromChunks(list: _*)
+                  .fromChunks(chunk: _*)
                   .chunkN(n)
-                  .mapChunks(ch => Chunk(ch.toList))
+                  .mapChunks(ch => Chunk(ch))
                   .runCollect
               )(equalTo(expected))
           }
@@ -2814,7 +2813,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         testM("concatAll") {
           checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
             assertM(ZStream.concatAll(Chunk.fromIterable(chunks.map(ZStream.fromChunk(_)))).runCollect)(
-              equalTo(Chunk.fromIterable(chunks).flatten.toList)
+              equalTo(Chunk.fromIterable(chunks).flatten)
             )
           }
         },
@@ -2843,14 +2842,12 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         testM("fromChunk") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))(c =>
-            assertM(ZStream.fromChunk(c).runCollect)(equalTo(c.toList))
-          )
+          checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
         },
         suite("fromChunks")(
           testM("fromChunks") {
             checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { cs =>
-              assertM(ZStream.fromChunks(cs: _*).runCollect)(equalTo(Chunk.fromIterable(cs).flatten.toList))
+              assertM(ZStream.fromChunks(cs: _*).runCollect)(equalTo(Chunk.fromIterable(cs).flatten))
             }
           },
           testM("discards empty chunks") {
@@ -2862,7 +2859,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("fromEffectOption")(
           testM("emit one element with success") {
             val fa: ZIO[Any, Option[Int], Int] = ZIO.succeed(5)
-            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(List(5)))
+            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(Chunk(5)))
           },
           testM("emit one element with failure") {
             val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(Some(5))
@@ -2870,7 +2867,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } @@ zioTag(errors),
           testM("do not emit any element") {
             val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(None)
-            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(List()))
+            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(Chunk()))
           }
         ),
         suite("fromInputStream")(
@@ -2881,24 +2878,24 @@ object ZStreamSpec extends ZIOBaseSpec {
             ZStream.fromInputStream(is, chunkSize).runCollect map { bytes => assert(bytes.toArray)(equalTo(data)) }
           },
           testM("example 2") {
-            checkM(Gen.small(Gen.listOfN(_)(Gen.anyByte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
+            checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyByte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
               val is = new ByteArrayInputStream(bytes.toArray)
               ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
             }
           }
         ),
-        testM("fromIterable")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
+        testM("fromIterable")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
           def lazyL = l
           assertM(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))
         }),
-        testM("fromIterableM")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
+        testM("fromIterableM")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
           assertM(ZStream.fromIterableM(UIO.effectTotal(l)).runCollect)(equalTo(l))
         }),
-        testM("fromIterator")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
+        testM("fromIterator")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
           def lazyIt = l.iterator
           assertM(ZStream.fromIterator(lazyIt).runCollect)(equalTo(l))
         }),
-        testM("fromIteratorTotal")(checkM(Gen.small(Gen.listOfN(_)(Gen.anyInt))) { l =>
+        testM("fromIteratorTotal")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
           def lazyIt = l.iterator
           assertM(ZStream.fromIteratorTotal(lazyIt).runCollect)(equalTo(l))
         }),
@@ -2973,7 +2970,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             _     <- TestClock.adjust(62.seconds)
             value <- fiber.join
           } yield value
-          val expected = List(1.seconds, 2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds)
+          val expected = Chunk(1.seconds, 2.seconds, 4.seconds, 8.seconds, 16.seconds, 32.seconds)
           assertM(zio)(equalTo(expected))
         },
         testM("fromQueue") {
@@ -2988,7 +2985,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         .fork
               _      <- c.offer
               result <- fiber.join
-            } yield result)(equalTo(List(1, 2)))
+            } yield result)(equalTo(Chunk(1, 2)))
           }
         },
         testM("fromTQueue") {
@@ -2999,13 +2996,13 @@ object ZStreamSpec extends ZIOBaseSpec {
                 first  <- ZStream.fromQueue(queue).take(3).runCollect
                 _      <- tqueue.offerAll(List(4, 5)).commit
                 second <- ZStream.fromQueue(queue).take(2).runCollect
-              } yield assert(first)(equalTo(List(1, 2, 3).map(Take.single))) &&
-                assert(second)(equalTo(List(4, 5).map(Take.single)))
+              } yield assert(first)(equalTo(Chunk(1, 2, 3).map(Take.single))) &&
+                assert(second)(equalTo(Chunk(4, 5).map(Take.single)))
             }
           }
         } @@ flaky,
         testM("iterate")(
-          assertM(ZStream.iterate(1)(_ + 1).take(10).runCollect)(equalTo((1 to 10).toList))
+          assertM(ZStream.iterate(1)(_ + 1).take(10).runCollect)(equalTo(Chunk.fromIterable(1 to 10)))
         ),
         testM("paginate") {
           val s = (0, List(1, 2, 3))
@@ -3016,7 +3013,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               case (x, x0 :: xs) => x -> Some(x0 -> xs)
             }
             .runCollect
-            .map(assert(_)(equalTo(List(0, 1, 2, 3))))
+            .map(assert(_)(equalTo(Chunk(0, 1, 2, 3))))
         },
         testM("paginateM") {
           val s = (0, List(1, 2, 3))
@@ -3028,10 +3025,10 @@ object ZStreamSpec extends ZIOBaseSpec {
                 case (x, x0 :: xs) => ZIO.succeed(x -> Some(x0 -> xs))
               }
               .runCollect
-          )(equalTo(List(0, 1, 2, 3)))
+          )(equalTo(Chunk(0, 1, 2, 3)))
         },
         testM("range") {
-          assertM(ZStream.range(0, 10).runCollect)(equalTo(Range(0, 10).toList))
+          assertM(ZStream.range(0, 10).runCollect)(equalTo(Chunk.fromIterable(Range(0, 10))))
         },
         testM("repeatEffect")(
           assertM(
@@ -3039,7 +3036,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               .repeatEffect(IO.succeed(1))
               .take(2)
               .runCollect
-          )(equalTo(List(1, 1)))
+          )(equalTo(Chunk(1, 1)))
         ),
         suite("repeatEffectOption")(
           testM("emit elements")(
@@ -3048,7 +3045,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .repeatEffectOption(IO.succeed(1))
                 .take(2)
                 .runCollect
-            )(equalTo(List(1, 1)))
+            )(equalTo(Chunk(1, 1)))
           ),
           testM("emit elements until pull fails with None")(
             for {
@@ -3061,7 +3058,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                       .repeatEffectOption(fa)
                       .take(10)
                       .runCollect
-            } yield assert(res)(equalTo(List(1, 2, 3, 4)))
+            } yield assert(res)(equalTo(Chunk(1, 2, 3, 4)))
           )
         ),
         suite("repeatEffectWith")(
@@ -3084,7 +3081,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())
               schedule = Schedule.identity[Int].whileOutput(_ <= length)
               result   <- ZStream.repeatEffectWith(effect, schedule).runCollect
-            } yield assert(result)(equalTo((0 to length).toList))
+            } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
           })
         ),
         testM("unfold") {
@@ -3095,7 +3092,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 else None
               }
               .runCollect
-          )(equalTo((0 to 9).toList))
+          )(equalTo(Chunk.fromIterable(0 to 9)))
         },
         testM("unfoldM") {
           assertM(
@@ -3105,7 +3102,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 else IO.succeed(None)
               }
               .runCollect
-          )(equalTo((0 to 9).toList))
+          )(equalTo(Chunk.fromIterable(0 to 9)))
         }
       )
     ) @@ TestAspect.timed

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -11,7 +11,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
 
   val initErrorParser = ZTransducer.fromEffect(IO.fail("Ouch"))
 
-  def run[R, E, I, O](parser: ZTransducer[R, E, I, O], input: List[Chunk[I]]): ZIO[R, E, List[O]] =
+  def run[R, E, I, O](parser: ZTransducer[R, E, I, O], input: List[Chunk[I]]): ZIO[R, E, Chunk[O]] =
     ZStream.fromChunks(input: _*).transduce(parser).runCollect
 
   def spec = suite("ZTransducerSpec")(
@@ -19,7 +19,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       suite("contramap")(
         testM("happy path") {
           val parser = ZTransducer.identity[Int].contramap[String](_.toInt)
-          assertM(run(parser, List(Chunk("1"))))(equalTo(List(1)))
+          assertM(run(parser, List(Chunk("1"))))(equalTo(Chunk(1)))
         },
         testM("error") {
           val parser = initErrorParser.contramap[String](_.toInt)
@@ -29,7 +29,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       suite("contramapM")(
         testM("happy path") {
           val parser = ZTransducer.identity[Int].contramapM[Any, Unit, String](s => UIO.succeed(s.toInt))
-          assertM(run(parser, List(Chunk("1"))))(equalTo(List(1)))
+          assertM(run(parser, List(Chunk("1"))))(equalTo(Chunk(1)))
         },
         testM("error") {
           val parser = initErrorParser.contramapM[Any, String, String](s => UIO.succeed(s.toInt))
@@ -39,7 +39,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       suite("map")(
         testM("happy path") {
           val parser = ZTransducer.identity[Int].map(_.toString)
-          assertM(run(parser, List(Chunk(1))))(equalTo(List("1")))
+          assertM(run(parser, List(Chunk(1))))(equalTo(Chunk("1")))
         },
         testM("error") {
           val parser = initErrorParser.map(_.toString)
@@ -55,7 +55,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       suite("mapM")(
         testM("happy path") {
           val parser = ZTransducer.identity[Int].mapM[Any, Unit, String](n => UIO.succeed(n.toString))
-          assertM(run(parser, List(Chunk(1))))(equalTo(List("1")))
+          assertM(run(parser, List(Chunk(1))))(equalTo(Chunk("1")))
         },
         testM("error") {
           val parser = initErrorParser.mapM[Any, String, String](n => UIO.succeed(n.toString))
@@ -82,11 +82,11 @@ object ZTransducerSpec extends ZIOBaseSpec {
       suite("collectAllN")(
         testM("happy path") {
           val parser = ZTransducer.collectAllN[Int](3)
-          assertM(run(parser, List(Chunk(1, 2, 3, 4))))(equalTo(List(List(1, 2, 3), List(4))))
+          assertM(run(parser, List(Chunk(1, 2, 3, 4))))(equalTo(Chunk(List(1, 2, 3), List(4))))
         },
         testM("empty list") {
           val parser = ZTransducer.collectAllN[Int](0)
-          assertM(run(parser, List()))(equalTo(List(List())))
+          assertM(run(parser, List()))(equalTo(Chunk(List())))
         }
       ),
       suite("collectAllToMapN")(
@@ -96,7 +96,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
               ZTransducer.collectAllToMapN[Int, Int](2)(_ % 3)(_ + _),
               List(Chunk(0, 1, 2))
             )
-          )(equalTo(List(Map(0 -> 0, 1 -> 1), Map(2 -> 2))))
+          )(equalTo(Chunk(Map(0 -> 0, 1 -> 1), Map(2 -> 2))))
         ),
         testM("keep collecting as long as map size does not exceed the limit")(
           assertM(
@@ -108,19 +108,19 @@ object ZTransducerSpec extends ZIOBaseSpec {
                 Chunk(6, 7, 8, 9)
               )
             )
-          )(equalTo(List(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))))
+          )(equalTo(Chunk(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15))))
         )
       ),
       testM("collectAllToSetN")(
         assertM(
           run(ZTransducer.collectAllToSetN[Int](3), List(Chunk(1, 2, 1), Chunk(2, 3, 3, 4)))
-        )(equalTo(List(Set(1, 2, 3), Set(4))))
+        )(equalTo(Chunk(Set(1, 2, 3), Set(4))))
       ),
       testM("collectAllWhile") {
         val parser = ZTransducer.collectAllWhile[Int](_ < 5)
         val input  = List(Chunk(3, 4, 5, 6, 7, 2), Chunk.empty, Chunk(3, 4, 5, 6, 5, 4, 3, 2), Chunk.empty)
         val result = run(parser, input)
-        assertM(result)(equalTo(List(List(3, 4), List(2, 3, 4), List(4, 3, 2))))
+        assertM(result)(equalTo(Chunk(List(3, 4), List(2, 3, 4), List(4, 3, 2))))
       },
       suite("fold")(
         testM("empty")(
@@ -128,7 +128,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
             ZStream.empty
               .aggregate(ZTransducer.fold[Int, Int](0)(_ => true)(_ + _))
               .runCollect
-          )(equalTo(List(0)))
+          )(equalTo(Chunk(0)))
         ),
         testM("short circuits") {
           val empty: ZStream[Any, Nothing, Int]     = ZStream.empty
@@ -147,9 +147,9 @@ object ZTransducerSpec extends ZIOBaseSpec {
               result <- effects.get
             } yield (exit, result)).run
 
-          (assertM(run(empty))(succeeds(equalTo((List(0), Nil)))) <*>
-            assertM(run(single))(succeeds(equalTo((List(30), List(1))))) <*>
-            assertM(run(double))(succeeds(equalTo((List(30), List(2, 1))))) <*>
+          (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
+            assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
+            assertM(run(double))(succeeds(equalTo((Chunk(30), List(2, 1))))) <*>
             assertM(run(failed))(fails(equalTo("Ouch")))).map {
             case (((r1, r2), r3), r4) => r1 && r2 && r3 && r4
           }
@@ -163,7 +163,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                 ZTransducer.foldM(0)(_ => true)((x, y: Int) => ZIO.succeed(x + y))
               )
               .runCollect
-          )(equalTo(List(0)))
+          )(equalTo(Chunk(0)))
         ),
         testM("short circuits") {
           val empty: ZStream[Any, Nothing, Int]     = ZStream.empty
@@ -182,9 +182,9 @@ object ZTransducerSpec extends ZIOBaseSpec {
               result <- effects.get
             } yield exit -> result).run
 
-          (assertM(run(empty))(succeeds(equalTo((List(0), Nil)))) <*>
-            assertM(run(single))(succeeds(equalTo((List(30), List(1))))) <*>
-            assertM(run(double))(succeeds(equalTo((List(30), List(2, 1))))) <*>
+          (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
+            assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
+            assertM(run(double))(succeeds(equalTo((Chunk(30), List(2, 1))))) <*>
             assertM(run(failed))(fails(equalTo("Ouch")))).map {
             case (((r1, r2), r3), r4) => r1 && r2 && r3 && r4
           }
@@ -198,7 +198,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                 ZTransducer.foldWeighted(List[Long]())((_, x: Long) => x * 2, 12)((acc, el) => el :: acc).map(_.reverse)
               )
               .runCollect
-          )(equalTo(List(List(1L, 5L), List(2L, 3L))))
+          )(equalTo(Chunk(List(1L, 5L), List(2L, 3L))))
         ),
         suite("foldWeightedDecompose")(
           testM("foldWeightedDecompose")(
@@ -216,7 +216,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                     .map(_.reverse)
                 )
                 .runCollect
-            )(equalTo(List(List(1, 3), List(1, 1, 1))))
+            )(equalTo(Chunk(List(1, 3), List(1, 1, 1))))
           ),
           testM("empty")(
             assertM(
@@ -225,7 +225,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   ZTransducer.foldWeightedDecompose[Int, Int](0)((_, x) => x.toLong, 1000, Chunk.single(_))(_ + _)
                 )
                 .runCollect
-            )(equalTo(List(0)))
+            )(equalTo(Chunk(0)))
           )
         ),
         testM("foldWeightedM")(
@@ -239,7 +239,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   .map(_.reverse)
               )
               .runCollect
-          )(equalTo(List(List(1L, 5L), List(2L, 3L))))
+          )(equalTo(Chunk(List(1L, 5L), List(2L, 3L))))
         ),
         suite("foldWeightedDecomposeM")(
           testM("foldWeightedDecomposeM")(
@@ -255,7 +255,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                     .map(_.reverse)
                 )
                 .runCollect
-            )(equalTo(List(List(1, 3), List(1, 1, 1))))
+            )(equalTo(Chunk(List(1, 3), List(1, 1, 1))))
           ),
           testM("empty")(
             assertM(
@@ -268,7 +268,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   )((x, y) => ZIO.succeed(x + y))
                 )
                 .runCollect
-            )(equalTo(List(0)))
+            )(equalTo(Chunk(0)))
           )
         ),
         testM("foldUntil")(
@@ -276,14 +276,14 @@ object ZTransducerSpec extends ZIOBaseSpec {
             ZStream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(ZTransducer.foldUntil(0L, 3)(_ + _))
               .runCollect
-          )(equalTo(List(3L, 3L)))
+          )(equalTo(Chunk(3L, 3L)))
         ),
         testM("foldUntilM")(
           assertM(
             ZStream[Long](1, 1, 1, 1, 1, 1)
               .aggregate(ZTransducer.foldUntilM(0L, 3)((s, a) => UIO.succeedNow(s + a)))
               .runCollect
-          )(equalTo(List(3L, 3L)))
+          )(equalTo(Chunk(3L, 3L)))
         )
       ),
       testM("dropWhile")(
@@ -291,7 +291,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           ZStream(1, 2, 3, 4, 5, 1, 2, 3, 4, 5)
             .aggregate(ZTransducer.dropWhile(_ < 3))
             .runCollect
-        )(equalTo(List(3, 4, 5, 1, 2, 3, 4, 5)))
+        )(equalTo(Chunk(3, 4, 5, 1, 2, 3, 4, 5)))
       ),
       suite("dropWhileM")(
         testM("happy path")(
@@ -299,7 +299,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
             ZStream(1, 2, 3, 4, 5, 1, 2, 3, 4, 5)
               .aggregate(ZTransducer.dropWhileM(x => UIO(x < 3)))
               .runCollect
-          )(equalTo(List(3, 4, 5, 1, 2, 3, 4, 5)))
+          )(equalTo(Chunk(3, 4, 5, 1, 2, 3, 4, 5)))
         )
         // testM("error")(
         //   assertM {
@@ -307,7 +307,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
         //       .aggregate(ZTransducer.dropWhileM(x => UIO(x < 3)))
         //       .either
         //       .runCollect
-        //   }(equalTo(List(Right(3),Left("Aie"),Right(5),Right(1),Right(2),Right(3),Right(4),Right(5))))
+        //   }(equalTo(Chunk(Right(3),Left("Aie"),Right(5),Right(1),Right(2),Right(3),Right(4),Right(5))))
         // )
       ),
       testM("fromFunction")(
@@ -315,14 +315,14 @@ object ZTransducerSpec extends ZIOBaseSpec {
           ZStream(1, 2, 3, 4, 5)
             .aggregate(ZTransducer.fromFunction[Int, String](_.toString))
             .runCollect
-        )(equalTo(List("1", "2", "3", "4", "5")))
+        )(equalTo(Chunk("1", "2", "3", "4", "5")))
       ),
       testM("fromFunctionM")(
         assertM(
           ZStream("1", "2", "3", "4", "5")
             .transduce(ZTransducer.fromFunctionM[Any, Throwable, String, Int](s => Task(s.toInt)))
             .runCollect
-        )(equalTo(List(1, 2, 3, 4, 5)))
+        )(equalTo(Chunk(1, 2, 3, 4, 5)))
       ),
       suite("splitLines")(
         testM("preserves data")(
@@ -368,7 +368,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
               .fromChunks(Chunk("aa", "bb"), Chunk("\nbbc\n", "ddb", "bd"), Chunk("abc", "\n"), Chunk("abc"))
               .transduce(ZTransducer.splitLines)
               .runCollect
-          )(equalTo(List("aabb", "bbc", "ddbbdabc", "abc")))
+          )(equalTo(Chunk("aabb", "bbc", "ddbbdabc", "abc")))
         },
         testM("aggregates chunks") {
           ZTransducer.splitLines.push.use { push =>
@@ -404,42 +404,43 @@ object ZTransducerSpec extends ZIOBaseSpec {
         }
       ),
       suite("splitOn")(
-        testM("preserves data")(checkM(Gen.listOf(Gen.anyString.filter(!_.contains("|")).filter(_.nonEmpty))) { lines =>
-          val data   = lines.mkString("|")
-          val parser = ZTransducer.splitOn("|")
-          assertM(run(parser, List(Chunk.single(data))))(equalTo(lines))
+        testM("preserves data")(checkM(Gen.chunkOf(Gen.anyString.filter(!_.contains("|")).filter(_.nonEmpty))) {
+          lines =>
+            val data   = lines.mkString("|")
+            val parser = ZTransducer.splitOn("|")
+            assertM(run(parser, List(Chunk.single(data))))(equalTo(lines))
         }),
         testM("handles leftovers") {
           val parser = ZTransducer.splitOn("\n")
-          assertM(run(parser, List(Chunk("ab", "c\nb"), Chunk("c"))))(equalTo(List("abc", "bc")))
+          assertM(run(parser, List(Chunk("ab", "c\nb"), Chunk("c"))))(equalTo(Chunk("abc", "bc")))
         },
         testM("aggregates") {
           assertM(
             Stream("abc", "delimiter", "bc", "delimiter", "bcd", "bcd")
               .aggregate(ZTransducer.splitOn("delimiter"))
               .runCollect
-          )(equalTo(List("abc", "bc", "bcdbcd")))
+          )(equalTo(Chunk("abc", "bc", "bcdbcd")))
         },
         testM("single newline edgecase") {
           assertM(
             Stream("test")
               .aggregate(ZTransducer.splitOn("test"))
               .runCollect
-          )(equalTo(List("")))
+          )(equalTo(Chunk("")))
         },
         testM("no delimiter in data") {
           assertM(
             Stream("abc", "abc", "abc")
               .aggregate(ZTransducer.splitOn("hello"))
               .runCollect
-          )(equalTo(List("abcabcabc")))
+          )(equalTo(Chunk("abcabcabc")))
         },
         testM("delimiter on the boundary") {
           assertM(
             Stream("abc<", ">abc")
               .aggregate(ZTransducer.splitOn("<>"))
               .runCollect
-          )(equalTo(List("abc", "abc")))
+          )(equalTo(Chunk("abc", "abc")))
         }
       ),
       suite("utf8DecodeChunk")(

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -36,7 +36,9 @@ abstract class ZSink[-R, +E, -I, +Z] private (
   /**
    * Operator alias for [[zipPar]].
    */
-  final def <&>[R1 <: R, E1 >: E, I1 <: I, Z1](that: ZSink[R1, E1, I1, Z1]): ZSink[R1, E1, I1, (Z, Z1)] =
+  final def <&>[R1 <: R, E1 >: E, I1 <: I, Z1](
+    that: ZSink[R1, E1, I1, Z1]
+  ): ZSink[R1, E1, I1, (Z, Z1)] =
     self.zipPar(that)
 
   /**
@@ -64,7 +66,8 @@ abstract class ZSink[-R, +E, -I, +Z] private (
   /**
    * Operator alias for [[zipParLeft]].
    */
-  final def <&[R1 <: R, E1 >: E, I1 <: I](that: ZSink[R1, E1, I1, Any]): ZSink[R1, E1, I1, Z] = self.zipParLeft(that)
+  final def <&[R1 <: R, E1 >: E, I1 <: I](that: ZSink[R1, E1, I1, Any]): ZSink[R1, E1, I1, Z] =
+    self.zipParLeft(that)
 
   /**
    * Replaces this sink's result with the provided value.
@@ -107,7 +110,9 @@ abstract class ZSink[-R, +E, -I, +Z] private (
   /**
    * Effectfully transforms this sink's input chunks.
    */
-  def contramapChunksM[R1 <: R, E1 >: E, I2](f: Chunk[I2] => ZIO[R1, E1, Chunk[I]]): ZSink[R1, E1, I2, Z] =
+  def contramapChunksM[R1 <: R, E1 >: E, I2](
+    f: Chunk[I2] => ZIO[R1, E1, Chunk[I]]
+  ): ZSink[R1, E1, I2, Z] =
     ZSink[R1, E1, I2, Z](
       self.push.map(push =>
         input =>
@@ -190,8 +195,10 @@ abstract class ZSink[-R, +E, -I, +Z] private (
                   // to terminate.
                   thisPush(None).catchAllCause { cause =>
                     val switchToNextPush = Cause.sequenceCauseEither(cause) match {
-                      case Left(e)  => openThatPush(failure(e).push).tap(thatPush.set) <* switched.set(true)
-                      case Right(z) => openThatPush(success(z).push).tap(thatPush.set) <* switched.set(true)
+                      case Left(e) =>
+                        openThatPush(failure(e).push).tap(thatPush.set) <* switched.set(true)
+                      case Right(z) =>
+                        openThatPush(success(z).push).tap(thatPush.set) <* switched.set(true)
                     }
 
                     switchToNextPush.flatMap(_.apply(None))
@@ -200,8 +207,10 @@ abstract class ZSink[-R, +E, -I, +Z] private (
                 case is @ Some(_) =>
                   thisPush(is).catchAllCause {
                     Cause.sequenceCauseEither(_) match {
-                      case Left(e)  => openThatPush(failure(e).push).flatMap(thatPush.set) *> switched.set(true)
-                      case Right(z) => openThatPush(success(z).push).flatMap(thatPush.set) *> switched.set(true)
+                      case Left(e) =>
+                        openThatPush(failure(e).push).flatMap(thatPush.set) *> switched.set(true)
+                      case Right(z) =>
+                        openThatPush(success(z).push).flatMap(thatPush.set) *> switched.set(true)
                     }
                   }
               }
@@ -279,9 +288,15 @@ abstract class ZSink[-R, +E, -I, +Z] private (
         p1(in).raceWith(p2(in))(
           (res1, fib2) =>
             res1
-              .foldM(f => fib2.interrupt *> ZIO.halt(f.map(_.map(Left(_)))), _ => fib2.join.mapError(_.map(Right(_)))),
+              .foldM(
+                f => fib2.interrupt *> ZIO.halt(f.map(_.map(Left(_)))),
+                _ => fib2.join.mapError(_.map(Right(_)))
+              ),
           (res2, fib1) =>
-            res2.foldM(f => fib1.interrupt *> ZIO.halt(f.map(_.map(Right(_)))), _ => fib1.join.mapError(_.map(Left(_))))
+            res2.foldM(
+              f => fib1.interrupt *> ZIO.halt(f.map(_.map(Right(_)))),
+              _ => fib1.join.mapError(_.map(Left(_)))
+            )
         )
       }
     } yield push)
@@ -341,7 +356,9 @@ abstract class ZSink[-R, +E, -I, +Z] private (
    */
   final def zipWith[R1 <: R, E1 >: E, I1 <: I, Z1, Z2](
     that: ZSink[R1, E1, I1, Z1]
-  )(f: (Z, Z1) => Z2): ZSink[R1, E1, I1, Z2] =
+  )(
+    f: (Z, Z1) => Z2
+  ): ZSink[R1, E1, I1, Z2] =
     flatMap(z => that.map(f(z, _)))
 
   /**
@@ -350,7 +367,9 @@ abstract class ZSink[-R, +E, -I, +Z] private (
    */
   final def zipWithPar[R1 <: R, E1 >: E, I1 <: I, Z1, Z2](
     that: ZSink[R1, E1, I1, Z1]
-  )(f: (Z, Z1) => Z2): ZSink[R1, E1, I1, Z2] = {
+  )(
+    f: (Z, Z1) => Z2
+  ): ZSink[R1, E1, I1, Z2] = {
 
     sealed trait State[+Z, +Z1]
     case object BothRunning          extends State[Nothing, Nothing]
@@ -467,10 +486,11 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
     new ZSink(push) {}
 
   /**
-   * A sink that collects all of its inputs into a list.
+   * A sink that collects all of its inputs into a chunk.
    */
-  def collectAll[A]: ZSink[Any, Nothing, A, List[A]] =
-    foldLeftChunks(Chunk[A]())(_ ++ (_: Chunk[A])).map(_.toList)
+  def collectAll[A]: ZSink[Any, Nothing, A, Chunk[A]] =
+    foldLeftChunks[A, ChunkBuilder[A]](ChunkBuilder.make[A]())((b, chunk) => b ++= chunk)
+      .map(_.result())
 
   /**
    * A sink that collects all of its inputs into a map. The keys are extracted from inputs
@@ -537,7 +557,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
   /**
    * A sink that folds its input chunks with the provided function, termination predicate and initial state.
    */
-  def foldChunks[I, S](z: S)(contFn: S => Boolean)(f: (S, Chunk[I]) => S): ZSink[Any, Nothing, I, S] =
+  def foldChunks[I, S](
+    z: S
+  )(
+    contFn: S => Boolean
+  )(
+    f: (S, Chunk[I]) => S
+  ): ZSink[Any, Nothing, I, S] =
     foldChunksM(z)(contFn)((s, is) => UIO.succeedNow(f(s, is)))
 
   /**
@@ -546,7 +572,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
    * This sink may terminate in the middle of a chunk and discard the rest of it. See the discussion on the
    * ZSink class scaladoc on sinks vs. transducers.
    */
-  def foldChunksM[R, E, I, S](z: S)(contFn: S => Boolean)(f: (S, Chunk[I]) => ZIO[R, E, S]): ZSink[R, E, I, S] =
+  def foldChunksM[R, E, I, S](
+    z: S
+  )(
+    contFn: S => Boolean
+  )(
+    f: (S, Chunk[I]) => ZIO[R, E, S]
+  ): ZSink[R, E, I, S] =
     if (contFn(z))
       ZSink {
         for {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2295,7 +2295,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    * Runs the stream and collects all of its elements to a list.
    */
-  def runCollect: ZIO[R, E, List[O]] = run(ZSink.collectAll[O])
+  def runCollect: ZIO[R, E, Chunk[O]] = run(ZSink.collectAll[O])
 
   /**
    * Runs the stream and emits the number of elements processed

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
@@ -1,5 +1,6 @@
 package zio.test.mock
 
+import zio.Chunk
 import zio.stream.{ ZSink, ZStream }
 import zio.test.mock.module.{ StreamModule, StreamModuleMock }
 import zio.test.{ suite, Assertion, TestAspect, ZIOBaseSpec }
@@ -17,7 +18,7 @@ object BasicStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] 
       suite("capabilities")(
         suite("sink")(
           testValue("success")(
-            StreamModuleMock.Sink(equalTo(1), value(ZSink.collectAll)),
+            StreamModuleMock.Sink(equalTo(1), value(ZSink.collectAll.map(_.toList))),
             StreamModule.sink(1).flatMap(A.run(_)),
             equalTo(List(1, 2, 3))
           ),
@@ -31,7 +32,7 @@ object BasicStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] 
           testValue("success")(
             StreamModuleMock.Stream(equalTo(1), value(A)),
             StreamModule.stream(1).flatMap(_.runCollect),
-            equalTo(List(1, 2, 3))
+            equalTo(Chunk(1, 2, 3))
           )
         )
       )

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -120,14 +120,14 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect: ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect
+    sample.map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect
+    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.


### PR DESCRIPTION
Change ZSink.collectAll to return Chunk
Change Zstream.runAll to return Chunk

I think i left one todo for the ZIO.foreach that returns a list as well but it would make this PR too big.

There was on inconvenience with the current test system i only had 1 compilation error left 
but because it didn't check all test cases i had to compile many times with only a single error reported.

#3575