### PR TITLE
Simplify ZStream#catchAllCause

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -469,54 +469,31 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   final def catchAllCause[R1 <: R, E2, O1 >: O](f: Cause[E] => ZStream[R1, E2, O1]): ZStream[R1, E2, O1] = {
     sealed abstract class State
-    object State {
-      case object NotStarted                         extends State
-      case class Self(finalizer: ZManaged.Finalizer) extends State
-      case object Other                              extends State
-    }
+    case object NotStarted                                              extends State
+    case class Self(finalizer: ZManaged.Finalizer, pull: Pull[R, E, O]) extends State
+    case class Other(pull: Pull[R1, E2, O1])                            extends State
 
     ZStream {
       for {
         finalizers <- ZManaged.releaseMap
-        selfPull   <- Ref.make[ZIO[R, Option[E], Chunk[O]]](Pull.end).toManaged_
-        otherPull  <- Ref.make[ZIO[R1, Option[E2], Chunk[O1]]](Pull.end).toManaged_
-        stateRef   <- Ref.make[State](State.NotStarted).toManaged_
+        ref        <- Ref.make[State](NotStarted).toManaged_
         pull = {
-          def switch(releasePrev: ZManaged.Finalizer, e: Cause[Option[E]]): ZIO[R1, Option[E2], Chunk[O1]] = {
-            def next(e: Cause[E]) = ZIO.uninterruptible {
-              for {
-                _             <- releasePrev(Exit.fail(e))
-                tp            <- f(e).process.zio.provideSome[R1]((_, finalizers))
-                (release, as) = tp
-                _             <- otherPull.set(as)
-                _             <- stateRef.set(State.Other)
-                a             <- as
-              } yield a
-            }
+          def use[R, E, O](stream: ZStream[R, E, O])(state: (ZManaged.Finalizer, Pull[R, E, O]) => State) =
+            stream.process.zio
+              .provideSome[R]((_, finalizers))
+              .flatMap { case (release, pull) => ref.set(state(release, pull)) *> pull }
+              .uninterruptible
 
-            Cause.sequenceCauseOption(e) match {
-              case None    => Pull.end
-              case Some(c) => next(c)
-            }
-          }
+          def switch(release: ZManaged.Finalizer, e: Cause[Option[E]]): Pull[R1, E2, O1] =
+            Cause
+              .sequenceCauseOption(e)
+              .map(cause => release(Exit.fail(e)) *> use(f(cause))((_, pull) => Other(pull)))
+              .getOrElse(Pull.end)
 
-          stateRef.get.flatMap {
-            case State.NotStarted =>
-              ZIO.uninterruptible {
-                for {
-                  tp            <- self.process.zio.provideSome[R1]((_, finalizers))
-                  (release, as) = tp
-                  _             <- selfPull.set(as)
-                  _             <- stateRef.set(State.Self(release))
-                  a             <- as
-                } yield a
-              }.catchAllCause(switch(ZManaged.Finalizer.noop, _))
-
-            case State.Self(release) =>
-              selfPull.get.flatten.catchAllCause(switch(release, _))
-
-            case State.Other =>
-              otherPull.get.flatten
+          ref.get.flatMap {
+            case NotStarted          => use(self)(Self(_, _)).catchAllCause(switch(ZManaged.Finalizer.noop, _))
+            case Self(release, pull) => pull.catchAllCause(switch(release, _))
+            case Other(pull)         => pull
           }
         }
       } yield pull
@@ -3684,6 +3661,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZStream[R0, E1, A] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
+
+  type Pull[-R, +E, +O] = ZIO[R, Option[E], Chunk[O]]
 
   private[zio] object Pull {
     def emit[A](a: A): IO[Nothing, Chunk[A]]                               = UIO(Chunk.single(a))


### PR DESCRIPTION
- Remove two atomic references
- Abstract over usage of stream