### PR TITLE
ZStream.toInputSteram: add `close`

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 import zio.Runtime
 import zio.{ Chunk, Exit, FiberFailure, ZIO }
 
-private[zio] class ZInputStream(chunks: Iterator[Chunk[Byte]]) extends java.io.InputStream {
+private[zio] class ZInputStream(private var chunks: Iterator[Chunk[Byte]]) extends java.io.InputStream {
   private var current: Chunk[Byte] = Chunk.empty
   private var currentPos: Int      = 0
   private var currentChunkLen: Int = 0
@@ -84,6 +84,11 @@ private[zio] class ZInputStream(chunks: Iterator[Chunk[Byte]]) extends java.io.I
   }
 
   override def available(): Int = availableInCurrentChunk
+
+  override def close(): Unit = {
+    chunks = Iterator.empty
+    loadNext()
+  }
 }
 
 private[zio] object ZInputStream {


### PR DESCRIPTION
When the Inputstream is closed, it's better to release the resources eagerly.