### PR TITLE
fix ZSink#collectAllWhileWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -78,27 +78,7 @@ abstract class ZSink[-R, +E, -I, +Z] private (
    * using the stepping function `f`.
    */
   def collectAllWhileWith[S](z: S)(p: Z => Boolean)(f: (S, Z) => S): ZSink[R, E, I, S] =
-    ZSink {
-      Push.restartable(push).flatMap {
-        case (push, restart) =>
-          Ref.make(z).toManaged_.map { state => (input: Option[Chunk[I]]) =>
-            input match {
-              case None => state.get.map(Right(_)).flip
-              case is @ Some(_) =>
-                push(is).catchAll {
-                  case Left(e) => ZIO.fail(Left(e))
-                  case Right(z) =>
-                    state
-                      .updateAndGet(f(_, z))
-                      .flatMap(s =>
-                        if (p(z)) restart
-                        else ZIO.fail(Right(s))
-                      )
-                }
-            }
-          }
-      }
-    }
+    self.toTransducer >>> ZTransducer.identity[Z].filter(p) >>> ZSink.foldLeft(z)(f)
 
   /**
    * Transforms this sink's input elements.


### PR DESCRIPTION
Closes #3657

Not sure how useful this combinator is with the new encoding.
- Its implementation is shorter than the declaration
- it uses ZSink as a Transducer without a huge disclaimer
- (consequently) it has no meaningful laws

FWIW, here is the fix