### PR TITLE
Correct type in Scaladoc

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2723,7 +2723,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     }
 
   /**
-   * Applies the function `f` to each element of the `Iterable[A]` and runs
+   * Applies the function `f` to each element of the `Chunk[A]` and runs
    * produced effects in parallel, discarding the results.
    *
    * For a sequential version of this method, see `foreach_`.


### PR DESCRIPTION
Looks like a tiny copy-paste artefact.