### PR TITLE
NonEmptyChunk as newtype

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.random.Random
 import zio.test.Assertion._

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -1,10 +1,11 @@
 package zio
 
+import NonEmptyChunk._
+
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.TestAspect.exceptScala211
 import zio.test._
-import NonEmptyChunk._
 
 object ChunkSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -4,6 +4,7 @@ import zio.random.Random
 import zio.test.Assertion._
 import zio.test.TestAspect.exceptScala211
 import zio.test._
+import NonEmptyChunk._
 
 object ChunkSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.test.Assertion._
 import zio.test._
+import NonEmptyChunk._
 
 object NonEmptyChunkSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
@@ -1,8 +1,9 @@
 package zio
 
+import NonEmptyChunk._
+
 import zio.test.Assertion._
 import zio.test._
-import NonEmptyChunk._
 
 object NonEmptyChunkSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.test.Assertion._
 import zio.test._

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.Builder
 import scala.reflect.{ classTag, ClassTag }
+import NonEmptyChunk._
+import zio.NonEmptyChunk.NonEmptyChunkSyntax
 
 /**
  * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed
@@ -470,54 +472,6 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
 
       dest.map((_, builder.result()))
     }
-
-  /**
-   * Effectfully maps the elements of this chunk.
-   */
-  final def mapM[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Chunk[B]] = ZIO.effectSuspendTotal {
-    val len     = self.length
-    val builder = ChunkBuilder.make[B]()
-    builder.sizeHint(len)
-    var dest: ZIO[R, E, ChunkBuilder[B]] = IO.succeedNow(builder)
-
-    var i = 0
-    while (i < len) {
-      val j = i
-      dest = dest.zipWith(f(self(j)))(_ += _)
-      i += 1
-    }
-
-    dest.map(_.result())
-  }
-
-  /**
-   * Effectfully maps the elements of this chunk in parallel.
-   */
-  final def mapMPar[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Chunk[B]] = {
-    val len                        = self.length
-    var array: ZIO[R, E, Array[B]] = IO.succeedNow(null.asInstanceOf[Array[B]])
-    var i                          = 0
-
-    while (i < len) {
-      val j = i
-      array = array.zipWithPar(f(self(j))) { (array, b) =>
-        val array2 = if (array == null) {
-          implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
-          Array.ofDim[B](len)
-        } else array
-
-        array2(j) = b
-        array2
-      }
-
-      i += 1
-    }
-
-    array.map(array =>
-      if (array == null) Chunk.empty
-      else Chunk.fromArray(array)
-    )
-  }
 
   /**
    * Effectfully maps the elements of this chunk in parallel purely for the effects.
@@ -1447,4 +1401,56 @@ object Chunk {
   final case class BooleanArray(array: Array[Boolean]) extends Arr[Boolean] {
     override def boolean(index: Int)(implicit ev: Boolean <:< Boolean): Boolean = array(index)
   }
+
+  implicit class ChunkSyntax[+A](private val self: Chunk[A]) extends AnyVal {
+
+    /**
+     * Effectfully maps the elements of this chunk.
+     */
+    final def mapM[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Chunk[B]] = ZIO.effectSuspendTotal {
+      val len     = self.length
+      val builder = ChunkBuilder.make[B]()
+      builder.sizeHint(len)
+      var dest: ZIO[R, E, ChunkBuilder[B]] = IO.succeedNow(builder)
+
+      var i = 0
+      while (i < len) {
+        val j = i
+        dest = dest.zipWith(f(self(j)))(_ += _)
+        i += 1
+      }
+
+      dest.map(_.result())
+    }
+
+    /**
+     * Effectfully maps the elements of this chunk in parallel.
+     */
+    final def mapMPar[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Chunk[B]] = {
+      val len                        = self.length
+      var array: ZIO[R, E, Array[B]] = IO.succeedNow(null.asInstanceOf[Array[B]])
+      var i                          = 0
+
+      while (i < len) {
+        val j = i
+        array = array.zipWithPar(f(self(j))) { (array, b) =>
+          val array2 = if (array == null) {
+            implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+            Array.ofDim[B](len)
+          } else array
+
+          array2(j) = b
+          array2
+        }
+
+        i += 1
+      }
+
+      array.map(array =>
+        if (array == null) Chunk.empty
+        else Chunk.fromArray(array)
+      )
+    }
+  }
+
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -24,8 +24,6 @@ import scala.reflect.{ classTag, ClassTag }
 
 import NonemptyChunkModule._
 
-import zio.NonemptyChunkModule.NonEmptyChunk
-
 /**
  * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed
  * are usually backed by arrays, but expose a purely functional, safe interface

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -22,9 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable.Builder
 import scala.reflect.{ classTag, ClassTag }
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
-import zio.NonEmptyChunk.NonEmptyChunkSyntax
+import zio.NonemptyChunkModule.NonEmptyChunk
 
 /**
  * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.Builder
 import scala.reflect.{ classTag, ClassTag }
+
 import NonEmptyChunk._
+
 import zio.NonEmptyChunk.NonEmptyChunkSyntax
 
 /**

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1,6 +1,7 @@
 package zio
 
 import scala.concurrent.ExecutionContext
+import NonEmptyChunk._
 
 import zio.internal.{ Executor, Platform }
 

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1,6 +1,7 @@
 package zio
 
 import scala.concurrent.ExecutionContext
+
 import NonEmptyChunk._
 
 import zio.internal.{ Executor, Platform }

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -2,7 +2,7 @@ package zio
 
 import scala.concurrent.ExecutionContext
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.internal.{ Executor, Platform }
 

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -16,9 +16,7 @@
 
 package zio
 
-import scala.language.implicitConversions
-
-import zio.NonEmptyChunk._
+import zio.NonEmptyChunk.{ NonEmptyChunk, NonEmptyChunkSyntax }
 
 /**
  * A `NonEmptyChunk` is a `Chunk` that is guaranteed to contain at least one
@@ -27,196 +25,28 @@ import zio.NonEmptyChunk._
  * `NonEmptyChunk`. Operations on `NonEmptyChunk` which could potentially
  * return an empty chunk will return a `Chunk` instead.
  */
-final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
+private[zio] trait NonEmpty[F[+_]] {
+  type Type[+A] //<: F[A]
 
-  /**
-   * Apparents a single element to the end of this `NonEmptyChunk`.
-   */
-  def :+[A1 >: A](a: A1): NonEmptyChunk[A1] =
-    nonEmpty(chunk :+ a)
-
-  /**
-   * Appends the specified `Chunk` to the end of this `NonEmptyChunk`.
-   */
-  def ++[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
-    append(that)
-
-  /**
-   * A named alias for `++`.
-   */
-  def append[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
-    nonEmpty(chunk ++ that)
-
-  /**
-   * Converts this `NonEmptyChunk` of bytes to a `NonEmptyChunk` of bits.
-   */
-  def asBits(implicit ev: A <:< Byte): NonEmptyChunk[Boolean] =
-    nonEmpty(chunk.asBits)
-
-  /**
-   * Returns whether this `NonEmptyChunk` and the specified `NonEmptyChunk` are
-   * equal to each other.
-   */
-  override def equals(that: Any): Boolean =
-    that match {
-      case that: NonEmptyChunk[_] => self.chunk == that.chunk
-      case _                      => false
-    }
-
-  /**
-   * Maps each element of this `NonEmptyChunk` to a new `NonEmptyChunk` and
-   * then concatenates them together.
-   */
-  def flatMap[B](f: A => NonEmptyChunk[B]): NonEmptyChunk[B] =
-    nonEmpty(chunk.flatMap(a => f(a).chunk))
-
-  /**
-   * Flattens a `NonEmptyChunk` of `NonEmptyChunk` values to a single
-   * `NonEmptyChunk`.
-   */
-  def flatten[B](implicit ev: A <:< NonEmptyChunk[B]): NonEmptyChunk[B] =
-    flatMap(ev)
-
-  /**
-   * Returns the hashcode of this `NonEmptyChunk`.
-   */
-  override def hashCode: Int =
-    chunk.hashCode
-
-  /**
-   * Transforms the elements of this `NonEmptyChunk` with the specified
-   * function.
-   */
-  def map[B](f: A => B): NonEmptyChunk[B] =
-    nonEmpty(chunk.map(f))
-
-  /**
-   * Maps over the elements of this `NonEmptyChunk`, maintaining some state
-   * along the way.
-   */
-  def mapAccum[S, B](s: S)(f: (S, A) => (S, B)): (S, NonEmptyChunk[B]) =
-    chunk.mapAccum(s)(f) match { case (s, chunk) => (s, nonEmpty(chunk)) }
-
-  /**
-   * Effectfully maps over the elements of this `NonEmptyChunk`, maintaining
-   * some state along the way.
-   */
-  def mapAccumM[R, E, S, B](s: S)(f: (S, A) => ZIO[R, E, (S, B)]): ZIO[R, E, (S, Chunk[B])] =
-    chunk.mapAccumM(s)(f).map { case (s, chunk) => (s, nonEmpty(chunk)) }
-
-  /**
-   * Effectfully maps the elements of this `NonEmptyChunk`.
-   */
-  def mapM[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
-    chunk.mapM(f).map(nonEmpty)
-
-  /**
-   * Effectfully maps the elements of this `NonEmptyChunk` in parallel.
-   */
-  def mapMPar[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
-    chunk.mapMPar(f).map(nonEmpty)
-
-  /**
-   * Materialize the elements of this `NonEmptyChunk` into a `NonEmptyChunk`
-   * backed by an array.
-   */
-  def materialize[A1 >: A]: Chunk[A1] =
-    nonEmpty(chunk.materialize)
-
-  /**
-   * Prepends the specified `Chunk` to the beginning of this `NonEmptyChunk`.
-   */
-  def prepend[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
-    nonEmpty(that ++ chunk)
-
-  /**
-   * Converts this `NonEmptyChunk` to a `Chunk`, discarding information about
-   * it not being empty.
-   */
-  def toChunk: Chunk[A] =
-    chunk
-
-  /**
-   * Converts this `NonEmptyChunk` to the `::` case of a `List`.
-   */
-  def toCons[A1 >: A]: ::[A1] =
-    ::(chunk(0), chunk.drop(1).toList)
-
-  /**
-   * Renders this `NonEmptyChunk` as a `String`.
-   */
-  override def toString: String =
-    chunk.mkString("NonEmptyChunk(", ", ", ")")
-
-  /**
-   * Zips this `NonEmptyChunk` with the specified `Chunk`, using the specified
-   * functions to "fill in" missing values if one chunk has fewer elements
-   * than the other.
-   */
-  def zipAllWith[B, C](
-    that: Chunk[B]
-  )(left: A => C, right: B => C)(both: (A, B) => C): NonEmptyChunk[C] =
-    nonEmpty(chunk.zipAllWith(that)(left, right)(both))
-
-  /**
-   * Zips this `NonEmptyCHunk` with the specified `NonEmptyChunk`, only
-   * keeping as many elements as are in the smaller chunk.
-   */
-  final def zipWith[B, C](that: NonEmptyChunk[B])(f: (A, B) => C): Chunk[C] =
-    nonEmpty(chunk.zipWith(that)(f))
-
-  /**
-   * Annotates each element of this `NonEmptyChunk` with its index.
-   */
-  def zipWithIndex: NonEmptyChunk[(A, Int)] =
-    nonEmpty(chunk.zipWithIndex)
-
-  /**
-   * Annotates each element of this `NonEmptyChunk` with its index, with the
-   * specified offset.
-   */
-  final def zipWithIndexFrom(indexOffset: Int): Chunk[(A, Int)] =
-    nonEmpty(chunk.zipWithIndexFrom(indexOffset))
+  def wrap[A](chunk: F[A]): Type[A]
 }
 
-object NonEmptyChunk {
+private[zio] trait LowPriorityChunkImplicit {
+  import scala.language.implicitConversions
+  implicit def toChunk0[A](c: NonEmptyChunk[A]): Chunk[A] = new NonEmptyChunkSyntax[A](c).chunk
+}
 
-  /**
-   * Constructs a `NonEmptyChunk` from one or more values.
-   */
-  def apply[A](a: A, as: A*): NonEmptyChunk[A] =
-    nonEmpty(Chunk(a) ++ Chunk.fromIterable(as))
+object NonEmptyChunk extends LowPriorityChunkImplicit {
 
-  /**
-   * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
-   */
-  def fromChunk[A](chunk: Chunk[A]): Option[NonEmptyChunk[A]] =
-    if (chunk.isEmpty) None else Some(nonEmpty(chunk))
+  private[zio] val newtype: NonEmpty[Chunk] =
+    new NonEmpty[Chunk] {
+      type Type[+A] = Chunk[A]
 
-  /**
-   * Constructs a `NonEmptyChunk` from the `::` case of a `List`.
-   */
-  def fromCons[A](as: ::[A]): NonEmptyChunk[A] =
-    as match { case h :: t => fromIterable(h, t) }
+      def wrap[A](chunk: Chunk[A]): Type[A] =
+        chunk
+    }
 
-  /**
-   * Constructs a `NonEmptyChunk` from an `Iterable`.
-   */
-  def fromIterable[A](a: A, as: Iterable[A]): NonEmptyChunk[A] =
-    single(a) ++ Chunk.fromIterable(as)
-
-  /**
-   * Constructs a `NonEmptyChunk` from a single value.
-   */
-  def single[A](a: A): NonEmptyChunk[A] =
-    NonEmptyChunk(a)
-
-  /**
-   * Provides an implicit conversion from `NonEmptyChunk` to `Chunk` for
-   * methods that may not return a `NonEmptyChunk`.
-   */
-  implicit def toChunk[A](nonEmptyChunk: NonEmptyChunk[A]): Chunk[A] =
-    nonEmptyChunk.chunk
+  type NonEmptyChunk[+A] = newtype.Type[A]
 
   /**
    * Constructs a `NonEmptyChunk` from a `Chunk`. This should only be used
@@ -224,5 +54,177 @@ object NonEmptyChunk {
    * element.
    */
   private[zio] def nonEmpty[A](chunk: Chunk[A]): NonEmptyChunk[A] =
-    new NonEmptyChunk(chunk)
+    newtype.wrap(chunk)
+
+  def apply[A](a: A, as: Chunk[A]): NonEmptyChunk[A] =
+    nonEmpty(Chunk.single(a) ++ as)
+
+  def apply[A](a: A): NonEmptyChunk[A] =
+    nonEmpty(Chunk.single(a))
+
+  /**
+   * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
+   */
+  def fromChunk[A](chunk: Chunk[A]): Option[NonEmptyChunk[A]] =
+    fold[A, Option[NonEmptyChunk[A]]](chunk)(None)(Some(_))
+
+  /**
+   * Constructs a `NonEmptyChunk` from the `::` case of a `List`.
+   */
+  def fromCons[A](as: ::[A]): NonEmptyChunk[A] =
+    as match {
+      case h :: t => fromIterable(h, t)
+    }
+
+  /**
+   * Constructs a `NonEmptyChunk` from an `Iterable`.
+   */
+  def fromIterable[A](a: A, as: Iterable[A]): NonEmptyChunk[A] =
+    nonEmpty(Chunk.single(a) ++ Chunk.fromIterable(as))
+
+  def fold[A, B](chunk: Chunk[A])(ifEmpty: => B)(fn: NonEmptyChunk[A] => B): B = if(chunk.isEmpty) ifEmpty else fn(nonEmpty(chunk))
+
+  /**
+   * Constructs a `NonEmptyChunk` from a single value.
+   */
+  def single[A](a: A): NonEmptyChunk[A] =
+    nonEmpty(Chunk.single(a))
+
+  implicit class NonEmptyChunkSyntax[+A](private val self: NonEmptyChunk[A]) extends AnyVal {
+    @inline def chunk: Chunk[A] = self.asInstanceOf[Chunk[A]]
+
+    /**
+     * Apparents a single element to the end of this `NonEmptyChunk`.
+     */
+    def :+[A1 >: A](a: A1): NonEmptyChunk[A1] =
+      nonEmpty(chunk :+ a)
+
+    /**
+     * Appends the specified `Chunk` to the end of this `NonEmptyChunk`.
+     */
+    def ++[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
+      append(that)
+
+    /**
+     * A named alias for `++`.
+     */
+    def append[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
+      nonEmpty(chunk ++ that)
+
+    /**
+     * Converts this `NonEmptyChunk` of bytes to a `NonEmptyChunk` of bits.
+     */
+    def asBits(implicit ev: A <:< Byte): NonEmptyChunk[Boolean] =
+      nonEmpty(chunk.asBits)
+
+    /**
+     * Maps each element of this `NonEmptyChunk` to a new `NonEmptyChunk` and
+     * then concatenates them together.
+     */
+    def flatMap[B](f: A => NonEmptyChunk[B]): NonEmptyChunk[B] =
+      nonEmpty(chunk.flatMap(a => f(a).chunk))
+
+    /**
+     * Flattens a `NonEmptyChunk` of `NonEmptyChunk` values to a single
+     * `NonEmptyChunk`.
+     */
+    def flatten[B](implicit ev: A <:< NonEmptyChunk[B]): NonEmptyChunk[B] =
+      flatMap(ev)
+
+    /**
+     * Transforms the elements of this `NonEmptyChunk` with the specified
+     * function.
+     */
+    def map[B](f: A => B): NonEmptyChunk[B] =
+      nonEmpty(chunk.map(f))
+
+    /**
+     * Maps over the elements of this `NonEmptyChunk`, maintaining some state
+     * along the way.
+     */
+    def mapAccum[S, B](s: S)(f: (S, A) => (S, B)): (S, NonEmptyChunk[B]) =
+      chunk.mapAccum(s)(f) match { case (s, chunk) => (s, nonEmpty(chunk)) }
+
+    /**
+     * Effectfully maps over the elements of this `NonEmptyChunk`, maintaining
+     * some state along the way.
+     */
+    def mapAccumM[R, E, S, B](s: S)(f: (S, A) => ZIO[R, E, (S, B)]): ZIO[R, E, (S, NonEmptyChunk[B])] =
+      chunk.mapAccumM(s)(f).map { case (s, chunk) => (s, nonEmpty(chunk)) }
+
+    /**
+     * Effectfully maps the elements of this `NonEmptyChunk`.
+     */
+    def mapM[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
+      chunk.mapM(f).map(nonEmpty)
+
+    /**
+     * Effectfully maps the elements of this `NonEmptyChunk` in parallel.
+     */
+    def mapMPar[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
+      chunk.mapMPar(f).map(nonEmpty)
+
+    /**
+     * Materialize the elements of this `NonEmptyChunk` into a `NonEmptyChunk`
+     * backed by an array.
+     */
+    def materialize[A1 >: A]: NonEmptyChunk[A1] =
+      nonEmpty(chunk.materialize)
+
+    /**
+     * Prepends the specified `Chunk` to the beginning of this `NonEmptyChunk`.
+     */
+    def prepend[A1 >: A](that: Chunk[A1]): NonEmptyChunk[A1] =
+      nonEmpty(that ++ chunk)
+
+    /**
+     * Converts this `NonEmptyChunk` to a `Chunk`, discarding information about
+     * it not being empty.
+     */
+    def toChunk: Chunk[A] =
+      chunk
+
+    /**
+     * Converts this `NonEmptyChunk` to the `::` case of a `List`.
+     */
+    def toCons[A1 >: A]: ::[A1] =
+      ::(chunk(0), chunk.drop(1).toList)
+
+    /**
+     * Renders this `NonEmptyChunk` as a `String`.
+     */
+    override def toString: String =
+      chunk.mkString("NonEmptyChunk(", ", ", ")")
+
+    /**
+     * Zips this `NonEmptyChunk` with the specified `Chunk`, using the specified
+     * functions to "fill in" missing values if one chunk has fewer elements
+     * than the other.
+     */
+    def zipAllWith[B, C](
+      that: Chunk[B]
+    )(left: A => C, right: B => C)(both: (A, B) => C): NonEmptyChunk[C] =
+      nonEmpty(chunk.zipAllWith(that)(left, right)(both))
+
+    /**
+     * Zips this `NonEmptyCHunk` with the specified `NonEmptyChunk`, only
+     * keeping as many elements as are in the smaller chunk.
+     */
+    final def zipWith[B, C](that: NonEmptyChunk[B])(f: (A, B) => C): NonEmptyChunk[C] =
+      nonEmpty(chunk.zipWith(that.chunk)(f))
+
+    /**
+     * Annotates each element of this `NonEmptyChunk` with its index.
+     */
+    def zipWithIndex: NonEmptyChunk[(A, Int)] =
+      nonEmpty(chunk.zipWithIndex)
+
+    /**
+     * Annotates each element of this `NonEmptyChunk` with its index, with the
+     * specified offset.
+     */
+    final def zipWithIndexFrom(indexOffset: Int): NonEmptyChunk[(A, Int)] =
+      nonEmpty(chunk.zipWithIndexFrom(indexOffset))
+  }
+
 }

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -82,7 +82,8 @@ object NonEmptyChunk extends LowPriorityChunkImplicit {
   def fromIterable[A](a: A, as: Iterable[A]): NonEmptyChunk[A] =
     nonEmpty(Chunk.single(a) ++ Chunk.fromIterable(as))
 
-  def fold[A, B](chunk: Chunk[A])(ifEmpty: => B)(fn: NonEmptyChunk[A] => B): B = if(chunk.isEmpty) ifEmpty else fn(nonEmpty(chunk))
+  def fold[A, B](chunk: Chunk[A])(ifEmpty: => B)(fn: NonEmptyChunk[A] => B): B =
+    if (chunk.isEmpty) ifEmpty else fn(nonEmpty(chunk))
 
   /**
    * Constructs a `NonEmptyChunk` from a single value.

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -2,10 +2,11 @@ package zio
 
 import scala.concurrent.ExecutionContext
 
+import NonEmptyChunk._
+
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
-import NonEmptyChunk._
 
 object RIO {
 

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -5,6 +5,7 @@ import scala.concurrent.ExecutionContext
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
+import NonEmptyChunk._
 
 object RIO {
 

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -2,7 +2,7 @@ package zio
 
 import scala.concurrent.ExecutionContext
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.clock.Clock
 import zio.duration.Duration

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1,6 +1,7 @@
 package zio
 
 import scala.concurrent.ExecutionContext
+import NonEmptyChunk._
 
 import zio.internal.{ Executor, Platform }
 

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1,6 +1,7 @@
 package zio
 
 import scala.concurrent.ExecutionContext
+
 import NonEmptyChunk._
 
 import zio.internal.{ Executor, Platform }

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -2,7 +2,7 @@ package zio
 
 import scala.concurrent.ExecutionContext
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.internal.{ Executor, Platform }
 

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1,7 +1,8 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
 import NonEmptyChunk._
+
+import zio.internal.{ Executor, Platform }
 
 object UIO {
 

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.internal.{ Executor, Platform }
+import NonEmptyChunk._
 
 object UIO {
 

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1,6 +1,6 @@
 package zio
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.internal.{ Executor, Platform }
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -3,6 +3,7 @@ package zio
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
+import NonEmptyChunk._
 
 object URIO {
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -1,6 +1,6 @@
 package zio
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
 import zio.clock.Clock
 import zio.duration.Duration

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -1,9 +1,10 @@
 package zio
 
+import NonEmptyChunk._
+
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
-import NonEmptyChunk._
 
 object URIO {
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2650,7 +2650,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * For a sequential version of this method, see `foreach`.
    */
   final def foreachPar[R, E, A, B](as: NonEmptyChunk[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
-    new NonEmptyChunkSyntax(as).mapMPar(fn)
+    as.mapMPar(fn)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -19,7 +19,8 @@ package zio
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
-
+import NonEmptyChunk._
+import zio.NonEmptyChunk.NonEmptyChunkSyntax
 import zio.clock.Clock
 import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
@@ -2647,7 +2648,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * For a sequential version of this method, see `foreach`.
    */
   final def foreachPar[R, E, A, B](as: NonEmptyChunk[A])(fn: A => ZIO[R, E, B]): ZIO[R, E, NonEmptyChunk[B]] =
-    as.mapMPar(fn)
+    new NonEmptyChunkSyntax(as).mapMPar(fn)
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and runs

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -19,7 +19,9 @@ package zio
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
+
 import NonEmptyChunk._
+
 import zio.NonEmptyChunk.NonEmptyChunkSyntax
 import zio.clock.Clock
 import zio.duration._

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -20,9 +20,9 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
 
-import NonEmptyChunk._
+import NonemptyChunkModule._
 
-import zio.NonEmptyChunk.NonEmptyChunkSyntax
+import zio.NonemptyChunkModule.NonEmptyChunk
 import zio.clock.Clock
 import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -52,6 +52,8 @@ package object zio extends EitherCompat with PlatformSpecific with VersionSpecif
   type RefM[A]      = ZRefM[Any, Any, Nothing, Nothing, A, A]
   type ERefM[+E, A] = ZRefM[Any, Any, E, E, A, A]
 
+  //type NonEmptyChunk[A] = NonemptyChunkModule.NonEmptyChunk[A]
+
   object <*> {
     def unapply[A, B](ab: (A, B)): Some[(A, B)] =
       Some((ab._1, ab._2))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2,6 +2,7 @@ package zio.stream
 
 import java.{ util => ju }
 
+import zio.NonEmptyChunk._
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
@@ -3015,11 +3016,11 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
             }
           }.catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
         case LeftDone(excessL) => {
-            p2.optional.map(handleSuccess(None, _, Left(excessL)))
+            p2.optional.map(handleSuccess(None, _, Left((excessL).toChunk)))
           }.catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
         case RightDone(excessR) => {
           p1.optional
-            .map(handleSuccess(_, None, Right(excessR)))
+            .map(handleSuccess(_, None, Right((excessR).toChunk)))
             .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
         }
         case End => {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2,7 +2,8 @@ package zio.stream
 
 import java.{ util => ju }
 
-import zio.NonEmptyChunk._
+import zio.NonemptyChunkModule.NonEmptyChunk
+import zio.NonemptyChunkModule._
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -3,7 +3,7 @@ package zio.test
 import java.time._
 
 import scala.math.Numeric.DoubleIsFractional
-
+import zio.NonEmptyChunk._
 import zio.duration.{ Duration, _ }
 import zio.random.Random
 import zio.test.Assertion._

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -4,14 +4,14 @@ import java.time._
 
 import scala.math.Numeric.DoubleIsFractional
 
-import zio.NonEmptyChunk._
+import zio.NonemptyChunkModule._
 import zio.duration.{ Duration, _ }
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.GenUtils._
 import zio.test.TestAspect.{ nonFlaky, scala2Only }
 import zio.test.{ check => Check, checkN => CheckN }
-import zio.{ Chunk, NonEmptyChunk, ZIO }
+import zio.{ Chunk, ZIO }
 
 object GenSpec extends ZIOBaseSpec {
   implicit val localDateTimeOrdering: Ordering[LocalDateTime] = _ compareTo _

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -3,6 +3,7 @@ package zio.test
 import java.time._
 
 import scala.math.Numeric.DoubleIsFractional
+
 import zio.NonEmptyChunk._
 import zio.duration.{ Duration, _ }
 import zio.random.Random

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -18,9 +18,10 @@ package zio.test
 
 import java.util.UUID
 
+import zio.NonEmptyChunk._
+
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
-
 import zio.random._
 import zio.stream.{ Stream, ZStream }
 import zio.{ Chunk, NonEmptyChunk, UIO, ZIO }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -21,10 +21,10 @@ import java.util.UUID
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
 
-import zio.NonEmptyChunk._
+import zio.NonemptyChunkModule._
 import zio.random._
 import zio.stream.{ Stream, ZStream }
-import zio.{ Chunk, NonEmptyChunk, UIO, ZIO }
+import zio.{ Chunk, UIO, ZIO }
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -18,10 +18,10 @@ package zio.test
 
 import java.util.UUID
 
-import zio.NonEmptyChunk._
-
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
+
+import zio.NonEmptyChunk._
 import zio.random._
 import zio.stream.{ Stream, ZStream }
 import zio.{ Chunk, NonEmptyChunk, UIO, ZIO }


### PR DESCRIPTION
Thanks @adamgfraser for a newtype template.

I'm not very happy with the implementation:
-  `import NonEmptyChunk._` is required to call any method
- I had to move some methods of `Chunk` into `ChunkSyntax` extension.
And decision which method should be moved and which should stay was based on fixing compile errors rather than reasoning.