### PR TITLE
Fix ZTransducer.splitLines

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -362,6 +362,14 @@ object ZTransducerSpec extends ZIOBaseSpec {
             )(equalTo("bc"))
           }
         },
+        testM("handles leftovers 2") {
+          assertM(
+            ZStream
+              .fromChunks(Chunk("aa", "bb"), Chunk("\nbbc\n", "ddb", "bd"), Chunk("abc", "\n"), Chunk("abc"))
+              .transduce(ZTransducer.splitLines)
+              .runCollect
+          )(equalTo(List("aabb", "bbc", "ddbbdabc", "abc")))
+        },
         testM("aggregates chunks") {
           ZTransducer.splitLines.push.use { push =>
             for {

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -631,7 +631,7 @@ object ZTransducer {
                 var inCRLF = wasSplitCRLF
                 var carry  = leftover getOrElse ""
 
-                (Chunk.fromIterable(leftover) ++ strings).foreach { string =>
+                strings.foreach { string =>
                   val concat = carry + string
 
                   if (concat.length() > 0) {
@@ -775,8 +775,8 @@ object ZTransducer {
 
               val (toConvert, newLeftovers) = concat.splitAt(computeSplit(concat))
 
-              if (toConvert.isEmpty) (Chunk.empty, newLeftovers)
-              else (Chunk.single(new String(toConvert.toArray[Byte], "UTF-8")), newLeftovers)
+              if (toConvert.isEmpty) (Chunk.empty, newLeftovers.materialize)
+              else (Chunk.single(new String(toConvert.toArray[Byte], "UTF-8")), newLeftovers.materialize)
             }
         }
       }


### PR DESCRIPTION
Fixes #3659.

We were already pulling the leftover into the `carry`, so concatenating it to the chunk was redundant.

I was going to write a smarter generator to catch this, but ran out of time.