### PR TITLE
ZIO Test: Close Resources Earlier In ProvideLayerShared

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -773,6 +773,15 @@ final class ZManaged[-R, +E, +A] private (val zio: ZIO[(R, ZManaged.ReleaseMap),
     }
 
   /**
+   * Runs all the finalizers associated with this scope. This is useful to
+   * conceptually "close" a scope when composing multiple managed effects.
+   * Note that this is only safe if the result of this managed effect is valid
+   * outside its scope.
+   */
+  def release: ZManaged[R, E, A] =
+    ZManaged.fromEffect(useNow)
+
+  /**
    * Retries with the specified retry policy.
    * Retries are done following the failure of the original `io` (up to a fixed maximum with
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -96,34 +96,18 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
     }
 
   /**
-   * Returns a new spec with only those suites and tests with annotations
-   * satisfying the specified predicate. If no annotations satisfy the
-   * specified predicate then returns `Some` with an empty suite with the root
-   * label if this is a suite or `None` otherwise.
+   * Returns a new spec with only those tests with annotations satisfying the
+   * specified predicate. If no annotations satisfy the specified predicate
+   * then returns `Some` with an empty suite if this is a suite or `None`
+   * otherwise.
    */
-  final def filterAnnotations[V](key: TestAnnotation[V])(f: V => Boolean): Option[Spec[R, E, T]] = {
-    def loop(spec: Spec[R, E, T]): ZManaged[R, Nothing, Option[Spec[R, E, T]]] =
-      spec.caseValue match {
-        case SuiteCase(label, specs, exec) =>
-          specs.foldCauseM(
-            c => ZManaged.succeedNow(Some(Spec.suite(label, ZManaged.halt(c), exec))),
-            ZManaged.foreach(_)(loop).map(_.toVector.flatten).map { specs =>
-              if (specs.isEmpty) None
-              else Some(Spec.suite(label, ZManaged.succeedNow(specs), exec))
-            }
-          )
-        case t @ TestCase(_, _, annotations) =>
-          if (f(annotations.get(key))) ZManaged.succeedNow(Some(Spec(t)))
-          else ZManaged.succeedNow(None)
-      }
+  final def filterAnnotations[V](key: TestAnnotation[V])(f: V => Boolean): Option[Spec[R, E, T]] =
     caseValue match {
       case SuiteCase(label, specs, exec) =>
-        Some(Spec.suite(label, specs.flatMap(ZManaged.foreach(_)(loop).map(_.toVector.flatten)), exec))
-      case t @ TestCase(_, _, annotations) =>
-        if (f(annotations.get(key))) Some(Spec(t))
-        else None
+        Some(Spec.suite(label, specs.map(_.flatMap(_.filterAnnotations(key)(f).toVector)), exec))
+      case TestCase(label, test, annotations) =>
+        if (f(annotations.get(key))) Some(Spec.test(label, test, annotations)) else None
     }
-  }
 
   /**
    * Returns a new spec with only those suites and tests satisfying the
@@ -131,35 +115,16 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    * suite will be included in the new spec. Otherwise only those specs in a
    * suite that satisfy the specified predicate will be included in the new
    * spec. If no labels satisfy the specified predicate then returns `Some`
-   * with an empty suite with the root label if this is a suite or `None`
-   * otherwise.
+   * with an empty suite if this is a suite or `None` otherwise.
    */
-  final def filterLabels(f: String => Boolean): Option[Spec[R, E, T]] = {
-    def loop(spec: Spec[R, E, T]): ZManaged[R, Nothing, Option[Spec[R, E, T]]] =
-      spec.caseValue match {
-        case SuiteCase(label, specs, exec) =>
-          if (f(label))
-            ZManaged.succeedNow(Some(Spec.suite(label, specs, exec)))
-          else
-            specs.foldCauseM(
-              c => ZManaged.succeedNow(Some(Spec.suite(label, ZManaged.halt(c), exec))),
-              ZManaged.foreach(_)(loop).map(_.toVector.flatten).map { specs =>
-                if (specs.isEmpty) None
-                else Some(Spec.suite(label, ZManaged.succeedNow(specs), exec))
-              }
-            )
-        case TestCase(label, test, annotations) =>
-          if (f(label)) ZManaged.succeedNow(Some(Spec.test(label, test, annotations)))
-          else ZManaged.succeedNow(None)
-      }
+  final def filterLabels(f: String => Boolean): Option[Spec[R, E, T]] =
     caseValue match {
       case SuiteCase(label, specs, exec) =>
         if (f(label)) Some(Spec.suite(label, specs, exec))
-        else Some(Spec.suite(label, specs.flatMap(ZManaged.foreach(_)(loop).map(_.toVector.flatten)), exec))
+        else Some(Spec.suite(label, specs.map(_.flatMap(_.filterLabels(f).toVector)), exec))
       case TestCase(label, test, annotations) =>
         if (f(label)) Some(Spec.test(label, test, annotations)) else None
     }
-  }
 
   /**
    * Returns a new spec with only those suites and tests with tags satisfying
@@ -191,7 +156,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
         specs.foldCauseM(
           c => f(SuiteCase(label, ZManaged.halt(c), exec)),
           ZManaged
-            .foreachExec(_)(exec.getOrElse(defExec))(_.foldM(defExec)(f))
+            .foreachExec(_)(exec.getOrElse(defExec))(_.foldM(defExec)(f).release)
             .flatMap(z => f(SuiteCase(label, ZManaged.succeedNow(z.toVector), exec)))
         )
       case t @ TestCase(_, _, _) => f(t)
@@ -285,44 +250,6 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
       case SuiteCase(label, specs, exec)      => SuiteCase(label, specs, exec)
       case TestCase(label, test, annotations) => TestCase(label, test.map(f), annotations)
     }
-
-  /**
-   * Returns a new suite with only those suites and tests tagged to be the only
-   * ones evaluated. If no tests are tagged to be the only ones evaluated then
-   * returns the spec unmodified.
-   */
-  final def only: Spec[R, E, T] = {
-    def loop(spec: Spec[R, E, T]): ZManaged[R, Nothing, Either[Spec[R, E, T], Spec[R, E, T]]] =
-      spec.caseValue match {
-        case SuiteCase(label, specs, exec) =>
-          specs.foldCauseM(
-            c => ZManaged.succeedNow(Left(Spec.suite(label, ZManaged.halt(c), exec))),
-            ZManaged.foreach(_)(loop).map { specs =>
-              val (left, right) = ZIO.partitionMap(specs)(identity)
-              if (right.nonEmpty)
-                Right(Spec.suite(label, ZManaged.succeedNow(right.toVector), exec))
-              else
-                Left(Spec.suite(label, ZManaged.succeedNow(left.toVector), exec))
-            }
-          )
-        case t @ TestCase(_, _, annotations) =>
-          if (annotations.get(TestAnnotation.only)) ZManaged.succeedNow(Right(Spec(t)))
-          else ZManaged.succeedNow(Left(Spec(t)))
-      }
-    caseValue match {
-      case SuiteCase(label, specs, exec) =>
-        Spec.suite(
-          label,
-          specs.flatMap(ZManaged.foreach(_)(loop)).map { specs =>
-            val (left, right) = ZIO.partitionMap(specs)(identity)
-            if (right.nonEmpty) right.toVector else left.toVector
-          },
-          exec
-        )
-      case TestCase(label, specs, annotations) =>
-        Spec.test(label, specs, annotations)
-    }
-  }
 
   /**
    * Provides each test in this spec with its required environment

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -47,12 +47,6 @@ object TestAnnotation {
     TestAnnotation("ignored", 0, _ + _)
 
   /**
-   * An annotation which tags tests to be the only ones evaluated.
-   */
-  val only: TestAnnotation[Boolean] =
-    TestAnnotation("only", false, _ || _)
-
-  /**
    * An annotation which counts repeated tests.
    */
   val repeated: TestAnnotation[Int] =

--- a/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotationRenderer.scala
@@ -72,7 +72,7 @@ object TestAnnotationRenderer {
    * The default test annotation renderer used by the `DefaultTestReporter`.
    */
   lazy val default: TestAnnotationRenderer =
-    CompositeRenderer(Vector(ignored, only, repeated, retried, tagged, timed))
+    CompositeRenderer(Vector(ignored, repeated, retried, tagged, timed))
 
   /**
    * A test annotation renderer that renders the number of ignored tests.
@@ -82,17 +82,6 @@ object TestAnnotationRenderer {
       case (child :: _) =>
         if (child == 0) None
         else Some(s"ignored: $child")
-    }
-
-  /**
-   * A test annotation renderer that renders tags for the only tests
-   * evaluated.
-   */
-  val only: TestAnnotationRenderer =
-    LeafRenderer(TestAnnotation.only) {
-      case (child :: _) =>
-        if (!child) None
-        else Some("only")
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -444,12 +444,6 @@ object TestAspect extends TimeoutVariants {
     before(Live.live(clock.nanoTime).flatMap(TestRandom.setSeed(_)))
 
   /**
-   * Annotates tests to be the only ones evaluated.
-   */
-  val only: TestAspectPoly =
-    annotate(TestAnnotation.only, true)
-
-  /**
    * An aspect that executes the members of a suite in parallel.
    */
   val parallel: TestAspectPoly =

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -32,7 +32,7 @@ object TestExecutor {
     env: Layer[Nothing, R]
   ): TestExecutor[R, E] = new TestExecutor[R, E] {
     def run(spec: ZSpec[R, E], defExec: ExecutionStrategy): UIO[ExecutedSpec[E]] =
-      spec.only.annotated
+      spec.annotated
         .provideLayer(environment)
         .foreachExec(defExec)(
           e =>


### PR DESCRIPTION
Right now we are keeping resources open too long with `provideLayerShared`. Basically we are building one giant `ZManaged` for all the suites and specs in a test and then running them so the result is we are closing all the shared resources at the end of the spec instead of at the end of the suite they are provided to. To address this I added a `release` combinator on `ZManaged` that conceptually "closes" the scope.

This works but looking at this the `only` combinator is quite problematic. It requires us to traverse the entire spec, which means acquiring all the resources in any nested suites, to determine whether there is any test annotated with `only`. For example if a spec is to be run sequentially we need to acquire and release the resources for suites one by one but we also need to potentially examine all of the suites and acquire their resources to determine which ones we should run. I have removed it for now though it is a very nice combinator and I would like to figure out a way to support it.