### PR TITLE
Ensure ZIO#fromFutureJava runs the parameter only once (#3702)

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -21,6 +21,11 @@ object JavaSpec extends ZIOBaseSpec {
         def ftr: Future[Unit] = CompletableFuture.supplyAsync(() => evaluated = true)
         assertM(ZIO.fromFutureJava(ftr).when(false).as(evaluated))(isFalse)
       },
+      testM("execute the `Future` parameter only once") {
+        var count            = 0
+        def ftr: Future[Int] = CompletableFuture.supplyAsync { () => count += 1; count }
+        assertM(ZIO.fromFutureJava(ftr).run)(succeeds(equalTo(1)))
+      },
       testM("catch exceptions thrown by lazy block") {
         val ex                          = new Exception("no future for you!")
         lazy val noFuture: Future[Unit] = throw ex

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -83,10 +83,12 @@ private[zio] object javaz {
   /** WARNING: this uses the blocking Future#get, consider using `fromCompletionStage` */
   def fromFutureJava[A](future: => Future[A]): RIO[Blocking, A] =
     RIO.effectSuspendTotalWith { (p, _) =>
-      if (future.isDone) {
-        unwrapDone(p.fatal)(future)
+      lazy val lazyFuture: Future[A] = future
+
+      if (lazyFuture.isDone) {
+        unwrapDone(p.fatal)(lazyFuture)
       } else {
-        blocking(Task.effectSuspend(unwrapDone(p.fatal)(future)))
+        blocking(Task.effectSuspend(unwrapDone(p.fatal)(lazyFuture)))
       }
     }
 


### PR DESCRIPTION
See #3702 
