### PR TITLE
Add provideCustom

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1442,6 +1442,14 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(zio2)(anything)
       }
     ),
+    suite("provideCustom")(
+      testM("provides the part ot the environment that is not part of the `ZEnv`") {
+        val logging: Logging                           = Has(new Logging.Service {})
+        val zio: ZIO[ZEnv with Logging, Nothing, Unit] = ZIO.unit
+        val zio2: ZIO[ZEnv, Nothing, Unit]             = zio.provideCustom(logging)
+        assertM(zio2)(anything)
+      }
+    ),
     suite("provideSomeLayer")(
       testM("can split environment into two parts") {
         val clockLayer: ZLayer[Any, Nothing, Clock]    = Clock.live

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1104,6 +1104,26 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * leaving an effect that only depends on the `ZEnv`.
    *
    * {{{
+   * val logging: Logging = ???
+   *
+   * val zio: ZIO[ZEnv with Logging, Nothing, Unit] = ???
+   *
+   * val zio2 = zio.provideCustom(logging)
+   * }}}
+   */
+  final def provideCustom[R1 <: Has[_]](
+    r1: R1
+  )(implicit ev: zio.ZEnv with R1 <:< R, tagged: Tag[R1]): ZIO[zio.ZEnv, E, A] =
+    provideSome[zio.ZEnv] { zenv =>
+      val all = zenv ++ r1
+      ev(all)
+    }
+
+  /**
+   * Provides the part of the environment that is not part of the `ZEnv`,
+   * leaving an effect that only depends on the `ZEnv`.
+   *
+   * {{{
    * val loggingLayer: ZLayer[Any, Nothing, Logging] = ???
    *
    * val zio: ZIO[ZEnv with Logging, Nothing, Unit] = ???


### PR DESCRIPTION
to improve parity between provide and provideLayer, this PR add :

```scala
  /**
   * Provides the part of the environment that is not part of the `ZEnv`,
   * leaving an effect that only depends on the `ZEnv`.
   *
   * {{{
   * val logging: Logging = ???
   *
   * val zio: ZIO[ZEnv with Logging, Nothing, Unit] = ???
   *
   * val zio2 = zio.provideCustom(logging)
   * }}}
   */
  final def provideCustom[R1 <: Has[_]](
    r1: R1
  )(implicit ev: zio.ZEnv with R1 <:< R, tagged: Tag[R1]): ZIO[zio.ZEnv, E, A] =
    provideSome[zio.ZEnv] { zenv =>
      val all = zenv ++ r1
      ev(all)
    }
```
