### PR TITLE
add resurrect and resurrectWith

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3285,10 +3285,10 @@ object ZIOSpec extends ZIOBaseSpec {
         val e1: UIO[Unit]                 = ZIO.fail(error1).unit.orDieWith(new Exception(_))
         val t1: IO[String, Unit]          = e1
         val e2: IO[String, Unit]          = t1.orElse(ZIO.fail(error2))
-        val res: Task[Unit]               = e2.resurrectWith(new Exception(_))
-        val e3: UIO[Either[String, Unit]] = res.mapError(_.getMessage).either
+        val e3: IO[String, Unit]          = e2.resurrectWith(_.getMessage)
+        val e4: UIO[Either[String, Unit]] = e3.either
 
-        assertM(e3)(isLeft(equalTo(error1)))
+        assertM(e4)(isLeft(equalTo(error1)))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3282,8 +3282,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val error1 = "msg1"
         val error2 = "msg2"
 
-        val e1: UIO[Unit]                 = ZIO.fail(error1).unit.orDieWith(new Exception(_))
-        val t1: IO[String, Unit]          = e1
+        val e1: UIO[Unit]                 = ZIO.fail(error1).unit.orDieWith(msg => new Exception(msg))
+        val t1: Task[Unit]                = e1
         val e2: IO[String, Unit]          = t1.orElse(ZIO.fail(error2))
         val e3: IO[String, Unit]          = e2.resurrectWith(_.getMessage)
         val e4: UIO[Either[String, Unit]] = e3.either

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1062,7 +1062,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    *   val f3: IO[String, Unit] = f2.resurrectWith(_.getMessage)
    * }}}
    */
-  final def resurrectWith[E1 >: E](f: Throwable => E1)(implicit ev: CanFail[E]): ZIO[R, E1, A] =
+  final def resurrectWith[E1 >: E](f: Throwable => E1): ZIO[R, E1, A] =
     self.sandbox.mapError(_.failureOrCause.map(c => f(c.squash)).merge)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1042,6 +1042,30 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     (self mapError f) catchAll (IO.die(_))
 
   /**
+   * Unearth the unchecked failure of the effect. (opposite of `orDie`)
+   * {{{
+   *  val f0: Task[Unit] = ZIO.fail(new Exception("failing")).unit
+   *  val f1: UIO[Unit]  = f0.orDie
+   *  val f2: Task[Unit] = f1.resurrect
+   * }}}
+   */
+  final def resurrect(implicit ev1: E <:< Throwable): RIO[R, A] =
+    sandbox.mapError(_.squash)
+
+  /**
+   * Unearth the unchecked failure of the effect. (symmetrical with `orDieWith`)
+   * {{{
+   *   val f0: IO[String, Unit] = ZIO.fail("err 0").unit
+   *   val f1: UIO[Unit]        = f0.orDieWith(msg => new Exception(msg))
+   *   val ft: Task[Unit]       = ft
+   *   val f2: IO[String, Unit] = ft.orElse(ZIO.fail("err 1"))
+   *   val f3: Task[Unit]       = f2.resurrectWith(msg => new Exception(msg))
+   * }}}
+   */
+  final def resurrectWith(f: E => Throwable)(implicit ev: CanFail[E]): RIO[R, A] =
+    self.mapError(f).resurrect
+
+  /**
    * Executes this effect and returns its value, if it succeeds, but
    * otherwise executes the specified effect.
    */


### PR DESCRIPTION
Symmetrical to orDie and orDieWith:
```scala
ZIO.fail(new Exception("msg")).orDie.resurrect
```