### PR TITLE
Implement Fast Single Element Prepend for Chunk

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
@@ -9,7 +9,7 @@ import zio.Chunk
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-class ChunkAddBenchmarks {
+class ChunkAppendBenchmarks {
 
   val chunk  = Chunk(1)
   val vector = Vector(1)
@@ -18,12 +18,12 @@ class ChunkAddBenchmarks {
   var size: Int = _
 
   @Benchmark
-  def chunkAdd(): Chunk[Int] = {
+  def chunkAppend(): Chunk[Int] = {
     var i       = 0
     var current = chunk
 
     while (i < size) {
-      current = current :+ 2
+      current = current :+ i
       i += 1
     }
 
@@ -31,12 +31,12 @@ class ChunkAddBenchmarks {
   }
 
   @Benchmark
-  def vectorAdd(): Vector[Int] = {
+  def vectorAppend(): Vector[Int] = {
     var i       = 0
     var current = vector
 
     while (i < size) {
-      current = current :+ 2
+      current = current :+ i
       i += 1
     }
 

--- a/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
@@ -1,0 +1,45 @@
+package zio.chunks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.Chunk
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ChunkPrependBenchmarks {
+
+  val chunk  = Chunk(1)
+  val vector = Vector(1)
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def chunkPrepend(): Chunk[Int] = {
+    var i       = 0
+    var current = chunk
+
+    while (i < size) {
+      current = i +: current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def vectorPrepend(): Vector[Int] = {
+    var i       = 0
+    var current = vector
+
+    while (i < size) {
+      current = i +: current
+      i += 1
+    }
+
+    current
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -57,7 +57,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(chunk.size)(equalTo(chunk.length))
       }
     ),
-    suite("add")(
+    suite("append")(
       testM("apply") {
         val chunksWithIndex: Gen[Random with Sized, (Chunk[Int], Chunk[Int], Int)] =
           for {
@@ -99,6 +99,53 @@ object ChunkSpec extends ZIOBaseSpec {
       testM("length") {
         check(Gen.chunkOf(Gen.anyInt), smallChunks(Gen.anyInt)) { (as, bs) =>
           val actual   = bs.foldLeft(as)(_ :+ _).length
+          val expected = (as ++ bs).length
+          assert(actual)(equalTo(expected))
+        }
+      }
+    ),
+    suite("prepend")(
+      testM("apply") {
+        val chunksWithIndex: Gen[Random with Sized, (Chunk[Int], Chunk[Int], Int)] =
+          for {
+            p  <- Gen.boolean
+            as <- Gen.chunkOf(Gen.anyInt)
+            bs <- Gen.chunkOf1(Gen.anyInt)
+            n  <- Gen.int(0, as.length + bs.length - 1)
+          } yield if (p) (as, bs, n) else (bs, as, n)
+        check(chunksWithIndex) {
+          case (as, bs, n) =>
+            val actual   = as.foldRight(bs)(_ +: _).apply(n)
+            val expected = (as ++ bs).apply(n)
+            assert(actual)(equalTo(expected))
+        }
+      },
+      testM("buffer full") {
+        check(Gen.chunkOf(Gen.anyInt), Gen.chunkOf(Gen.anyInt)) { (as, bs) =>
+          def addAll[A](l: Chunk[A], r: Chunk[A]): Chunk[A] = l.foldRight(r)(_ +: _)
+          val actual                                        = List.fill(100)(as).foldRight(bs)(addAll)
+          val expected                                      = List.fill(100)(as).foldRight(bs)(_ ++ _)
+          assert(actual)(equalTo(expected))
+        }
+      },
+      testM("buffer used") {
+        checkM(Gen.chunkOf(Gen.anyInt), Gen.chunkOf(Gen.anyInt)) { (as, bs) =>
+          val effect   = ZIO.succeed(as.foldRight(bs)(_ +: _))
+          val actual   = ZIO.collectAllPar(ZIO.replicate(100)(effect))
+          val expected = (as ++ bs)
+          assertM(actual)(forall(equalTo(expected)))
+        }
+      },
+      testM("equals") {
+        check(Gen.chunkOf(Gen.anyInt), Gen.chunkOf(Gen.anyInt)) { (as, bs) =>
+          val actual   = as.foldRight(bs)(_ +: _)
+          val expected = (as ++ bs)
+          assert(actual)(equalTo(expected))
+        }
+      },
+      testM("length") {
+        check(Gen.chunkOf(Gen.anyInt), smallChunks(Gen.anyInt)) { (as, bs) =>
+          val actual   = as.foldRight(bs)(_ +: _).length
           val expected = (as ++ bs).length
           assert(actual)(equalTo(expected))
         }

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -876,9 +876,9 @@ object ZManagedSpec extends ZIOBaseSpec {
         val expected = Chunk("acquiring a", "acquiring b", "releasing b", "acquiring c", "releasing c", "releasing a")
         for {
           ref     <- Ref.make[Chunk[String]](Chunk.empty)
-          a       = Managed.make(ref.update(_ + "acquiring a"))(_ => ref.update(_ + "releasing a"))
-          b       = Managed.make(ref.update(_ + "acquiring b"))(_ => ref.update(_ + "releasing b"))
-          c       = Managed.make(ref.update(_ + "acquiring c"))(_ => ref.update(_ + "releasing c"))
+          a       = Managed.make(ref.update(_ :+ "acquiring a"))(_ => ref.update(_ :+ "releasing a"))
+          b       = Managed.make(ref.update(_ :+ "acquiring b"))(_ => ref.update(_ :+ "releasing b"))
+          c       = Managed.make(ref.update(_ :+ "acquiring c"))(_ => ref.update(_ :+ "releasing c"))
           managed = a *> b.release *> c
           _       <- managed.useNow
           log     <- ref.get

--- a/core/shared/src/main/scala-2.11-2.12/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.11-2.12/ChunkLike.scala
@@ -44,6 +44,12 @@ private[zio] trait ChunkLike[+A] extends IndexedSeq[A] with IndexedSeqLike[A, Ch
       case _                        => super.:+(a1)
     }
 
+  override final def +:[A1 >: A, That](a1: A1)(implicit bf: CanBuildFrom[Chunk[A], A1, That]): That =
+    bf match {
+      case _: ChunkCanBuildFrom[A1] => prepend(a1)
+      case _                        => super.:+(a1)
+    }
+
   /**
    * Returns a filtered, mapped subset of the elements of this chunk.
    */

--- a/core/shared/src/main/scala-2.13+/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/ChunkLike.scala
@@ -44,6 +44,9 @@ trait ChunkLike[+A]
   override final def appended[A1 >: A](a1: A1): Chunk[A1] =
     append(a1)
 
+  override final def prepended[A1 >: A](a1: A1): Chunk[A1] =
+    prepend(a1)
+
   /**
    * Returns a filtered, mapped subset of the elements of this `Chunk`.
    */

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -35,6 +35,13 @@ import scala.reflect.{ classTag, ClassTag }
 sealed trait Chunk[+A] extends ChunkLike[A] { self =>
 
   /**
+   * Appends an element to the chunk
+   */
+  @deprecated("use :+", "1.0.0")
+  final def +[A1 >: A](a: A1): Chunk[A1] =
+    self :+ a
+
+  /**
    * Returns the concatenation of this chunk with the specified chunk.
    */
   final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] =

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -234,7 +234,7 @@ object ZTransducer {
             if (contFn(o))
               (os0, o, true)
             else
-              (os0 + o, z, false)
+              (os0 :+ o, z, false)
         }
 
       ZRef.makeManaged[Option[O]](Some(z)).map { state =>
@@ -280,7 +280,7 @@ object ZTransducer {
               if (contFn(o))
                 (os0, o, true)
               else
-                (os0 + o, z, false)
+                (os0 :+ o, z, false)
             }
         }
 
@@ -388,14 +388,14 @@ object ZTransducer {
                 // If `i` cannot be decomposed, we need to cross the `max` threshold. To
                 // minimize "injury", we only allow this when we haven't added anything else
                 // to the aggregate (dirty = false).
-                (os0 + f(state.result, if (is.nonEmpty) is(0) else i), initial, false)
+                (os0 :+ f(state.result, if (is.nonEmpty) is(0) else i), initial, false)
               else if (is.length <= 1 && dirty) {
                 // If the state is dirty and `i` cannot be decomposed, we close the current
                 // aggregate and a create new one from `is`. We're not adding `f(initial, i)` to
                 // the results immediately because it could be that `i` by itself does not
                 // cross the threshold, so we can attempt to aggregate it with subsequent elements.
                 val elem = if (is.nonEmpty) is(0) else i
-                (os0 + state.result, FoldWeightedState(f(initial.result, elem), costFn(initial.result, elem)), true)
+                (os0 :+ state.result, FoldWeightedState(f(initial.result, elem), costFn(initial.result, elem)), true)
               } else
                 // `i` got decomposed, so we will recurse and see whether the decomposition
                 // can be aggregated without crossing `max`.
@@ -470,12 +470,12 @@ object ZTransducer {
                 decompose(i).flatMap(is =>
                   // See comments on `foldWeightedDecompose` for details on every case here.
                   if (is.length <= 1 && !dirty)
-                    f(state.result, if (is.nonEmpty) is(0) else i).map(o => ((os + o), initial, false))
+                    f(state.result, if (is.nonEmpty) is(0) else i).map(o => ((os :+ o), initial, false))
                   else if (is.length <= 1 && dirty) {
                     val elem = if (is.nonEmpty) is(0) else i
 
                     f(initial.result, elem).zipWith(costFn(initial.result, elem)) { (s, cost) =>
-                      (os + state.result, FoldWeightedState(s, cost), true)
+                      (os :+ state.result, FoldWeightedState(s, cost), true)
                     }
                   } else go(is, os, state, dirty)
                 )


### PR DESCRIPTION
```scala
[info] Benchmark                             (size)   Mode  Cnt     Score    Error  Units
[info] ChunkPrependBenchmarks.chunkPrepend    10000  thrpt   25  7788.576 ± 35.149  ops/s
[info] ChunkPrependBenchmarks.vectorPrepend   10000  thrpt   25  4383.454 ± 14.474  ops/s
```