### PR TITLE
Implement Balanced Concatenation for Chunk

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -1,0 +1,54 @@
+package zio.chunks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.Chunk
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ChunkConcatBenchmarks {
+
+  val chunk: Chunk[Int] = Chunk.empty
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  def concatBalanced(n: Int): Chunk[Int] =
+    if (n == 0) Chunk.empty
+    else if (n == 1) Chunk(1)
+    else concatBalanced(n / 2) ++ concatBalanced(n / 2)
+
+  @Benchmark
+  def leftConcat(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk
+
+    while (i < size) {
+      current = Chunk(i) ++ current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk
+
+    while (i < size) {
+      current = current ++ Chunk(i)
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def balancedConcat(): Chunk[Int] = {
+    concatBalanced(size)
+  }
+}

--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -48,7 +48,6 @@ class ChunkConcatBenchmarks {
   }
 
   @Benchmark
-  def balancedConcat(): Chunk[Int] = {
+  def balancedConcat(): Chunk[Int] =
     concatBalanced(size)
-  }
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -480,6 +480,11 @@ object ChunkSpec extends ZIOBaseSpec {
       val (bs, cs) = as.partitionMap(n => if (n % 2 == 0) Left(n) else Right(n))
       assert(bs)(equalTo(Chunk(0, 2, 4, 6, 8))) &&
       assert(cs)(equalTo(Chunk(1, 3, 5, 7, 9)))
+    },
+    zio.test.test("stack safety") {
+      val n  = 100000
+      val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => Chunk(a) ++ as)
+      assert(as.toArray)(equalTo(Array.range(0, n)))
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -28,6 +28,11 @@ import scala.reflect.{ classTag, ClassTag }
  * to the underlying elements, and they become lazy on operations that would be
  * costly with arrays, such as repeated concatenation.
  *
+ * The implementation of balanced concatenation is based on the one for
+ * Conc-Trees in "Conc-Trees for Functional and Parallel Programming" by
+ * Aleksandar Prokopec and Martin Odersky.
+ * [[http://aleksandar-prokopec.com/resources/docs/lcpc-conc-trees.pdf]]
+ *
  * NOTE: For performance reasons `Chunk` does not box primitive types. As a
  * result, it is not safe to construct chunks from heteregenous primitive
  * types.
@@ -44,10 +49,39 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
   /**
    * Returns the concatenation of this chunk with the specified chunk.
    */
-  final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] =
-    if (self.length == 0) that
-    else if (that.length == 0) self
-    else Chunk.Concat(self, that)
+  final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] = {
+    val diff = that.depth - self.depth
+    if (math.abs(diff) <= 1) Chunk.Concat(self, that)
+    else if (diff < -1) {
+      if (self.left.depth >= self.right.depth) {
+        val nr = self.right ++ that
+        Chunk.Concat(self.left, nr)
+      } else {
+        val nrr = self.right.right ++ that
+        if (nrr.depth == self.depth - 3) {
+          val nr = Chunk.Concat(self.right.left, nrr)
+          Chunk.Concat(self.left, nr)
+        } else {
+          val nl = Chunk.Concat(self.left, self.right.left)
+          Chunk.Concat(nl, nrr)
+        }
+      }
+    } else {
+      if (that.right.depth >= that.left.depth) {
+        val nl = self ++ that.left
+        Chunk.Concat(nl, that.right)
+      } else {
+        val nll = self ++ that.left.left
+        if (nll.depth == that.depth - 3) {
+          val nl = Chunk.Concat(nll, that.left.right)
+          Chunk.Concat(nl, that.right)
+        } else {
+          val nr = Chunk.Concat(that.left.right, that.right)
+          Chunk.Concat(nll, nr)
+        }
+      }
+    }
+  }
 
   final def ++[A1 >: A](that: NonEmptyChunk[A1]): NonEmptyChunk[A1] =
     that.prepend(self)
@@ -725,22 +759,32 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
   /**
    * Appends an element to the chunk.
    */
-  protected def append[A1 >: A](a: A1): Chunk[A1] =
-    if (self.length == 0) Chunk.single(a)
-    else Chunk.Concat(self, Chunk.single(a))
+  protected def append[A1 >: A](a1: A1): Chunk[A1] = {
+    val buffer = Array.ofDim[AnyRef](Chunk.BufferSize)
+    buffer(0) = a1.asInstanceOf[AnyRef]
+    Chunk.AppendN(self, buffer, 1, new AtomicInteger(1))
+  }
 
   /**
    * Prepends an element to the chunk.
    */
-  protected def prepend[A1 >: A](a: A1): Chunk[A1] =
-    if (self.length == 0) Chunk.single(a)
-    else Chunk.Concat(Chunk.single(a), self)
+  protected def prepend[A1 >: A](a1: A1): Chunk[A1] = {
+    val buffer = Array.ofDim[AnyRef](Chunk.BufferSize)
+    buffer(Chunk.BufferSize - 1) = a1.asInstanceOf[AnyRef]
+    Chunk.PrependN(self, buffer, 1, new AtomicInteger(1))
+  }
 
   /**
    * Returns a filtered, mapped subset of the elements of this chunk.
    */
   protected def collectChunk[B](pf: PartialFunction[A, B]): Chunk[B] =
     if (isEmpty) Chunk.empty else self.materialize.collectChunk(pf)
+
+  protected def depth: Int =
+    0
+
+  protected def left: Chunk[A] =
+    Chunk.empty
 
   /**
    * Returns a chunk with the elements mapped by the specified function.
@@ -757,6 +801,9 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
 
     builder.result()
   }
+
+  protected def right: Chunk[A] =
+    Chunk.empty
 
   private final def fromBuilder[A1 >: A, B[_]](builder: Builder[A1, B[A1]]): B[A1] = {
     val c   = materialize
@@ -1162,18 +1209,6 @@ object Chunk {
     override def materialize[A1 >: A]: Chunk[A1] =
       self
 
-    override protected def append[A1 >: A](a1: A1): Chunk[A] = {
-      val buffer = Array.ofDim[AnyRef](BufferSize)
-      buffer(0) = a1.asInstanceOf[AnyRef]
-      AppendN(self, buffer, 1, new AtomicInteger(1))
-    }
-
-    override protected def prepend[A1 >: A](a1: A1): Chunk[A] = {
-      val buffer = Array.ofDim[AnyRef](BufferSize)
-      buffer(BufferSize - 1) = a1.asInstanceOf[AnyRef]
-      PrependN(self, buffer, 1, new AtomicInteger(1))
-    }
-
     /**
      * Takes all elements so long as the predicate returns true.
      */
@@ -1227,31 +1262,33 @@ object Chunk {
     }
   }
 
-  private final case class Concat[A](l: Chunk[A], r: Chunk[A]) extends Chunk[A] { self =>
+  private final case class Concat[A](override protected val left: Chunk[A], override protected val right: Chunk[A])
+      extends Chunk[A] {
+    self =>
 
     implicit val classTag: ClassTag[A] =
-      l match {
-        case Empty => classTagOf(r)
-        case _     => classTagOf(l)
+      left match {
+        case Empty => classTagOf(right)
+        case _     => classTagOf(left)
       }
 
-    override val length: Int =
-      l.length + r.length
+    override val depth: Int =
+      1 + math.max(left.depth, right.depth)
 
-    override protected def append[A1 >: A](a1: A1): Chunk[A1] =
-      Concat(l, r :+ a1)
+    override val length: Int =
+      left.length + right.length
 
     override def apply(n: Int): A =
-      if (n < l.length) l(n) else r(n - l.length)
+      if (n < left.length) left(n) else right(n - left.length)
 
     override def foreach[B](f: A => B): Unit = {
-      l.foreach(f)
-      r.foreach(f)
+      left.foreach(f)
+      right.foreach(f)
     }
 
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = {
-      l.toArray(n, dest)
-      r.toArray(n + l.length, dest)
+      left.toArray(n, dest)
+      right.toArray(n + left.length, dest)
     }
   }
 


### PR DESCRIPTION
Resolves #3238. Resolves #3753.

Implements balanced concatenation for Chunk based on the algorithm used in Conc-Trees. This also addresses the stack overflow issue.