### PR TITLE
Add ZStream#runManaged

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -125,6 +125,15 @@ object ZSinkSpec extends ZIOBaseSpec {
           }
         }
       ),
+      suite("foreachWhile")(
+        testM("handles leftovers") {
+          val leftover = ZStream
+            .fromIterable(1 to 5)
+            .run(ZSink.foreachWhile((n: Int) => ZIO.succeed(n <= 3)).exposeLeftover)
+            .map(_._2)
+          assertM(leftover)(equalTo(Chunk(4, 5)))
+        }
+      ),
       suite("fromEffect")(
         testM("handles leftovers (happy)") {
           val s = ZSink.fromEffect[Any, Nothing, Int, String](ZIO.succeed("ok"))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -714,6 +714,35 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
   }
 
   /**
+   * A sink that executes the provided effectful function for every chunk fed to it.
+   */
+  def foreachChunk[R, E, I](f: Chunk[I] => ZIO[R, E, Any]): ZSink[R, E, I, I, Unit] =
+    ZSink.fromPush[R, E, I, I, Unit] {
+      case Some(is) => f(is).mapError(e => (Left(e), Chunk.empty)) *> Push.more
+      case None     => Push.emit((), Chunk.empty)
+    }
+
+  /**
+   * A sink that executes the provided effectful function for every element fed to it
+   * until `f` evaluates to `false`.
+   */
+  final def foreachWhile[R, E, I](f: I => ZIO[R, E, Boolean]): ZSink[R, E, I, I, Unit] = {
+    def go(chunk: Chunk[I], idx: Int, len: Int): ZIO[R, (Either[E, Unit], Chunk[I]), Unit] =
+      if (idx == len)
+        Push.more
+      else
+        f(chunk(idx)).foldM(
+          e => Push.fail(e, chunk.drop(idx + 1)),
+          b => if (b) go(chunk, idx + 1, len) else Push.emit((), chunk.drop(idx))
+        )
+
+    ZSink.fromPush[R, E, I, I, Unit] {
+      case Some(is) => go(is, 0, is.length)
+      case None     => Push.emit((), Chunk.empty)
+    }
+  }
+
+  /**
    * Creates a single-value sink produced from an effect
    */
   def fromEffect[R, E, I, Z](b: => ZIO[R, E, Z]): ZSink[R, E, I, I, Z] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2297,7 +2297,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     runManaged(sink).useNow
 
   def runManaged[R1 <: R, E1 >: E, B](sink: ZSink[R1, E1, O, Any, B]): ZManaged[R1, E1, B] =
-    (process <*> sink.push).flatMap {
+    (process <*> sink.push).mapM {
       case (pull, push) =>
         def go: ZIO[R1, E1, B] = pull.foldCauseM(
           Cause
@@ -2313,7 +2313,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
               .foldCauseM(c => Cause.sequenceCauseEither(c.map(_._1)).fold(IO.halt(_), ZIO.succeedNow), _ => go)
         )
 
-        go.toManaged_
+        go
     }
 
   /**


### PR DESCRIPTION
Closes #3758

After adding `ZStream#runManaged` all other `ZStream#.....Managed` methods become redundant. 
~~I left the following methods~~
~~1) that spark joy~~
~~2) that are used internally~~
~~3) that have tests~~

I kept all existing methods, made them delegating to appropriate sink