### PR TITLE
Fixed #3806: Update AccessibleMacro to properly handle ZManaged

### DIFF
--- a/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
+++ b/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
@@ -94,6 +94,29 @@ object AccessibleSpec extends DefaultRunnableSpec {
           """
         })(isRight(anything))
       },
+      testM("generates accessors for members returning ZManaged") {
+        assertM(typeCheck {
+          """
+            @accessible
+            object Module {
+              trait Service {
+                def umanaged(s: String): UManaged[Int]
+                def urmanaged(s: String): URManaged[Has[String], Int]
+                def zmanaged(s: String): ZManaged[Has[String], String, Int]
+              }
+            }
+
+            object Check {
+              def umanaged(s: String): ZManaged[Has[Module.Service], Nothing, Int] =
+                Module.umanaged(s)
+              def urmanaged(s: String): ZManaged[Has[String] with Has[Module.Service], Nothing, Int] =
+                Module.urmanaged(s)
+              def zmanaged(s: String): ZManaged[Has[String] with Has[Module.Service], String, Int] =
+                Module.zmanaged(s)
+            }
+          """
+        })(isRight(anything))
+      },
       testM("generates accessors for all capabilities") {
         assertM(typeCheck {
           """
@@ -110,6 +133,19 @@ object AccessibleSpec extends DefaultRunnableSpec {
                 def command(arg1: Int)                     : UIO[Unit]
                 def overloaded(arg1: Int)                  : UIO[String]
                 def overloaded(arg1: Long)                 : UIO[String]
+
+                val staticManaged                                 : UManaged[String]
+                def zeroArgsManaged                               : UManaged[Int]
+                def zeroArgsTypedManaged[T]                       : UManaged[T]
+                def zeroArgsWithParensManaged()                   : UManaged[Long]
+                def singleArgManaged(arg1: Int)                   : UManaged[String]
+                def multiArgsManaged(arg1: Int, arg2: Long)       : UManaged[String]
+                def multiParamListsManaged(arg1: Int)(arg2: Long) : UManaged[String]
+                def typedVarargsManaged[T](arg1: Int, arg2: T*)   : UManaged[T]
+                def commandManaged(arg1: Int)                     : UManaged[Unit]
+                def overloadedManaged(arg1: Int)                  : UManaged[String]
+                def overloadedManaged(arg1: Long)                 : UManaged[String]
+
                 def function(arg1: Int)                    : String
                 def sink(arg1: Int)                        : ZSink[Any, Nothing, Int, Int, List[Int]]
                 def stream(arg1: Int)                      : ZStream[Any, Nothing, Int]
@@ -127,6 +163,19 @@ object AccessibleSpec extends DefaultRunnableSpec {
               def command(arg1: Int)                     : ZIO[Has[Module.Service], Nothing, Unit]   = Module.command(arg1)
               def overloaded(arg1: Int)                  : ZIO[Has[Module.Service], Nothing, String] = Module.overloaded(arg1)
               def overloaded(arg1: Long)                 : ZIO[Has[Module.Service], Nothing, String] = Module.overloaded(arg1)
+
+              val staticManaged                                 : ZManaged[Has[Module.Service], Nothing, String] = Module.staticManaged
+              def zeroArgsManaged                               : ZManaged[Has[Module.Service], Nothing, Int]    = Module.zeroArgsManaged
+              def zeroArgsTypedManaged[T]                       : ZManaged[Has[Module.Service], Nothing, T]      = Module.zeroArgsTypedManaged[T]
+              def zeroArgsWithParensManaged()                   : ZManaged[Has[Module.Service], Nothing, Long]   = Module.zeroArgsWithParensManaged()
+              def singleArgManaged(arg1: Int)                   : ZManaged[Has[Module.Service], Nothing, String] = Module.singleArgManaged(arg1)
+              def multiArgsManaged(arg1: Int, arg2: Long)       : ZManaged[Has[Module.Service], Nothing, String] = Module.multiArgsManaged(arg1, arg2)
+              def multiParamListsManaged(arg1: Int)(arg2: Long) : ZManaged[Has[Module.Service], Nothing, String] = Module.multiParamListsManaged(arg1)(arg2)
+              def typedVarargsManaged[T](arg1: Int, arg2: T*)   : ZManaged[Has[Module.Service], Nothing, T]      = Module.typedVarargsManaged[T](arg1, arg2: _*)
+              def commandManaged(arg1: Int)                     : ZManaged[Has[Module.Service], Nothing, Unit]   = Module.commandManaged(arg1)
+              def overloadedManaged(arg1: Int)                  : ZManaged[Has[Module.Service], Nothing, String] = Module.overloadedManaged(arg1)
+              def overloadedManaged(arg1: Long)                 : ZManaged[Has[Module.Service], Nothing, String] = Module.overloadedManaged(arg1)
+
               def function(arg1: Int)                    : ZIO[Has[Module.Service], Throwable, String] = Module.function(arg1)
               def sink(arg1: Int)                        : ZIO[Has[Module.Service], Nothing, ZSink[Any, Nothing, Int, Int, List[Int]]] = Module.sink(arg1)
               def stream(arg1: Int)                      : ZIO[Has[Module.Service], Nothing, ZStream[Any, Nothing, Int]] = Module.stream(arg1)


### PR DESCRIPTION
First off, this is my first PR to zio, so please let me know if I am not following proper procedures or if there is anything else I should have done to be a better contributor. I am also only a week or so into using zio, so feedback about better ways to accomplish my goals is also very welcome.

When a module has a member with a return type of `ZManaged[R, E, A]`, I think the expected accessor generated by @accessible would be `ZManaged[R with Has[Service], E, A]`, but the current implementation seems to fall back to treating it as a method and generates an accessor with return type `ZIO[Has[Service], Throwable, ZManaged[R, E, A]]` which is more difficult to work with and doesn't match the API provided by the other ZIO classes.

This PR addresses the issue by adding in specific handling for `ZManaged` in `AccessibleMacro`, in a way that mostly mirrors the way `ZIO` itself is handled (though `ZManaged.accessM` doesn't compose the same way, so I had to use a slightly different approach there.) I was mostly just following the example of the surrounding code, which was fairly easy to follow, especially for macro code. I added tests to verify the new behavior and make sure that it had coverage similar to the level of the effect types.

Let me know if anything looks improper and I am happy to fix it. Thanks!