### PR TITLE
Add a new `fromOptionError` operator

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -264,8 +264,8 @@ object ZSTMSpec extends ZIOBaseSpec {
         testM("extracts the value from Some") {
           assertM(STM.succeed(Some(1)).get.commit)(equalTo(1))
         },
-        testM("fails with Unit on None") {
-          assertM(STM.succeed(None).get.commit.run)(fails(isUnit))
+        testM("fails with None on None") {
+          assertM(STM.succeed(None).get.commit.run)(fails(isNone))
         }
       ),
       suite("head")(

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -490,7 +490,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.fromOption]]
    */
-  def fromOption[A](v: => Option[A]): IO[Unit, A] = ZIO.fromOption(v)
+  def fromOption[A](v: => Option[A]): IO[Option[Nothing], A] = ZIO.fromOption(v)
 
   /**
    * @see See [[zio.ZIO.fromTry]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -776,7 +776,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     self.mapError(e => ev(e).getOrElse(default))
 
   /**
-   * Unwraps the optional success of this effect, but can fail with unit value.
+   * Unwraps the optional success of this effect, but can fail with an None value.
    */
   final def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZIO[R, Option[Nothing], B] =
     ZIO.absolve(self.mapError(ev1)(CanFail).map(ev2(_).toRight(None)))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2981,6 +2981,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     effectTotal(v).flatMap(_.fold[IO[Unit, A]](fail(()))(succeedNow))
 
   /**
+   * Lifts an `Option` into a `ZIO` but preserves the error as an option in the error channel, making it easier to compose
+   * in some scenarios.
+   */
+  def fromOptionError[A](v: => Option[A]): IO[Option[Nothing], A] =
+    effectTotal(v).flatMap(_.fold[IO[Option[Nothing], A]](fail(None))(succeedNow))
+
+  /**
    * Lifts a `Try` into a `ZIO`.
    */
   def fromTry[A](value: => scala.util.Try[A]): Task[A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2975,16 +2975,10 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     }
 
   /**
-   * Lifts an `Option` into a `ZIO`.
-   */
-  def fromOption[A](v: => Option[A]): IO[Unit, A] =
-    effectTotal(v).flatMap(_.fold[IO[Unit, A]](fail(()))(succeedNow))
-
-  /**
    * Lifts an `Option` into a `ZIO` but preserves the error as an option in the error channel, making it easier to compose
    * in some scenarios.
    */
-  def fromOptionError[A](v: => Option[A]): IO[Option[Nothing], A] =
+  def fromOption[A](v: => Option[A]): IO[Option[Nothing], A] =
     effectTotal(v).flatMap(_.fold[IO[Option[Nothing], A]](fail(None))(succeedNow))
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -778,8 +778,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Unwraps the optional success of this effect, but can fail with unit value.
    */
-  final def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZIO[R, Unit, B] =
-    ZIO.absolve(self.mapError(ev1)(CanFail).map(ev2(_).toRight(())))
+  final def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZIO[R, Option[Nothing], B] =
+    ZIO.absolve(self.mapError(ev1)(CanFail).map(ev2(_).toRight(None)))
 
   /**
    * Returns a new effect that, on exit of this effect, invokes the specified

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -406,7 +406,7 @@ final class ZManaged[-R, +E, +A] private (val zio: ZIO[(R, ZManaged.ReleaseMap),
     }
 
   /**
-   * Unwraps the optional success of this effect, but can fail with unit value.
+   * Unwraps the optional success of this effect, but can fail with None value.
    */
   def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZManaged[R, Option[Nothing], B] =
     ZManaged.absolve(mapError(ev1)(CanFail).map(ev2(_).toRight(None)))

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -408,8 +408,8 @@ final class ZManaged[-R, +E, +A] private (val zio: ZIO[(R, ZManaged.ReleaseMap),
   /**
    * Unwraps the optional success of this effect, but can fail with unit value.
    */
-  def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZManaged[R, Unit, B] =
-    ZManaged.absolve(mapError(ev1)(CanFail).map(ev2(_).toRight(())))
+  def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZManaged[R, Option[Nothing], B] =
+    ZManaged.absolve(mapError(ev1)(CanFail).map(ev2(_).toRight(None)))
 
   /**
    * Returns a new effect that ignores the success or failure of this effect.

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -168,7 +168,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.fromOption]]
    */
-  def fromOption[A](v: => Option[A]): STM[Unit, A] =
+  def fromOption[A](v: => Option[A]): STM[Option[Nothing], A] =
     ZSTM.fromOption(v)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -385,10 +385,10 @@ final class ZSTM[-R, +E, +A] private[stm] (
   /**
    * Unwraps the optional success of this effect, but can fail with unit value.
    */
-  def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZSTM[R, Unit, B] =
+  def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZSTM[R, Option[Nothing], B] =
     foldM(
       ev1,
-      ev2(_).fold[ZSTM[R, Unit, B]](ZSTM.fail(()))(ZSTM.succeedNow(_))
+      ev2(_).fold[ZSTM[R, Option[Nothing], B]](ZSTM.fail(None))(ZSTM.succeedNow(_))
     )(CanFail)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -383,7 +383,7 @@ final class ZSTM[-R, +E, +A] private[stm] (
   def forever: ZSTM[R, E, Nothing] = self *> self.forever
 
   /**
-   * Unwraps the optional success of this effect, but can fail with unit value.
+   * Unwraps the optional success of this effect, but can fail with None value.
    */
   def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZSTM[R, Option[Nothing], B] =
     foldM(

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1180,8 +1180,8 @@ object ZSTM {
   /**
    * Lifts an `Option` into a `STM`.
    */
-  def fromOption[A](v: => Option[A]): STM[Unit, A] =
-    STM.suspend(v.fold[STM[Unit, A]](STM.fail(()))(STM.succeedNow))
+  def fromOption[A](v: => Option[A]): STM[Option[Nothing], A] =
+    STM.suspend(v.fold[STM[Option[Nothing], A]](STM.fail(None))(STM.succeedNow))
 
   /**
    * Lifts a `Try` into a `STM`.

--- a/docs/datatypes/promise.md
+++ b/docs/datatypes/promise.md
@@ -79,7 +79,7 @@ you can use `poll`:
 ```scala mdoc:silent
 val ioPromise4: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
 val ioIsItDone: UIO[Option[IO[Exception, String]]] = ioPromise4.flatMap(p => p.poll)
-val ioIsItDone2: IO[Unit, IO[Exception, String]] = ioPromise4.flatMap(p => p.poll.get)
+val ioIsItDone2: IO[Option[Nothing], IO[Exception, String]] = ioPromise4.flatMap(p => p.poll.get)
 ```
 
 If the Promise was not completed when you called `poll` then the IO will fail with the `Unit` value otherwise,

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -58,7 +58,7 @@ Scala's standard library contains a number of data types that can be converted i
 An `Option` can be converted into a ZIO effect using `ZIO.fromOption`:
 
 ```scala mdoc:silent
-val zoption: IO[Unit, Int] = ZIO.fromOption(Some(2))
+val zoption: IO[Option[Nothing], Int] = ZIO.fromOption(Some(2))
 ```
 
 The error type of the resulting effect is `Unit`, because the `None` case of `Option` provides no information on why the value is not there. You can change the `Unit` into a more specific error type using `ZIO#mapError`:

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -69,6 +69,10 @@ val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
 
 You can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
 
+```scala mdoc:invisible
+trait Team
+```
+
 ```scala mdoc:silent
 val maybeId: IO[Option[Nothing], String] = ZIO.fromOption(Some("abc123"))
 def getUser(userId: String): IO[Throwable, Option[User]] = ???
@@ -176,7 +180,9 @@ val getStrLn2: IO[IOException, String] =
 An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.effectAsync`:
 
 ```scala mdoc:invisible
-trait User
+trait User { 
+  def teamId: String
+}
 trait AuthError
 ```
 

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -61,10 +61,25 @@ An `Option` can be converted into a ZIO effect using `ZIO.fromOption`:
 val zoption: IO[Option[Nothing], Int] = ZIO.fromOption(Some(2))
 ```
 
-The error type of the resulting effect is `Unit`, because the `None` case of `Option` provides no information on why the value is not there. You can change the `Unit` into a more specific error type using `ZIO#mapError`:
+The error type of the resulting effect is `Option[Nothing]`, because the `None` case of `Option` provides no information on why the value is not there. You can change the `Option[Nothing]` into a more specific error type using `ZIO#mapError`:
 
 ```scala mdoc:silent
 val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
+```
+
+You can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
+
+```scala mdoc:silent
+val maybeId: IO[Option[Nothing], String] = ZIO.fromOption(Some("abc123"))
+def getUser(userId: String): IO[Throwable, Option[User]] = ???
+def getTeam(teamId: String): IO[Throwable, Team] = ???
+
+
+val result: IO[Throwable, Option[(User, Team)] = (for {
+  id   <- maybeId
+  user <- getUser(id).some
+  team <- getTeam(user.teamId).asSomeError 
+} yield (user, team)).optional 
 ```
 
 ### Either

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -61,7 +61,7 @@ An `Option` can be converted into a ZIO effect using `ZIO.fromOption`:
 val zoption: IO[Option[Nothing], Int] = ZIO.fromOption(Some(2))
 ```
 
-The error type of the resulting effect is `Option[Nothing]`, because the `None` case of `Option` provides no information on why the value is not there. You can change the `Option[Nothing]` into a more specific error type using `ZIO#mapError`:
+The error type of the resulting effect is `Option[Nothing]`, which provides no information on why the value is not there. You can change the `Option[Nothing]` into a more specific error type using `ZIO#mapError`:
 
 ```scala mdoc:silent
 val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -75,7 +75,7 @@ def getUser(userId: String): IO[Throwable, Option[User]] = ???
 def getTeam(teamId: String): IO[Throwable, Team] = ???
 
 
-val result: IO[Throwable, Option[(User, Team)] = (for {
+val result: IO[Throwable, Option[(User, Team)]] = (for {
   id   <- maybeId
   user <- getUser(id).some
   team <- getTeam(user.teamId).asSomeError 


### PR DESCRIPTION
Adds a new `fromOptionError` operator which has better composability with the existing `some`/`optional`/`asSomeError` combinators.