### PR TITLE
Improve ZSink laws

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -210,6 +210,18 @@ object ZSinkSpec extends ZIOBaseSpec {
         }
         assertions.map(tst => tst.reduce(_ && _))
       },
+      suite("either")(
+        testM("happy path") {
+          assertM(ZStream(1, 2, 3).run(ZSink.head.either.exposeLeftover))(
+            equalTo((Right(Some(1)), Chunk(2, 3)))
+          )
+        },
+        testM("failure") {
+          assertM(ZStream(1, 2, 3).run(ZSink.fail("fail").either.exposeLeftover))(
+            equalTo((Left("fail"), Chunk(1, 2, 3)))
+          )
+        }
+      ),
       suite("flatMap")(
         testM("non-empty input") {
           assertM(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -177,16 +177,18 @@ object ZSinkSpec extends ZIOBaseSpec {
     suite("Combinators")(
       testM("raceBoth") {
         checkM(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
-          val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
-          sinkRaceLaw(ZStream.fromIterable(Random.shuffle(stream)), findSink(20), findSink(40))
+          val stream   = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+          val shuffled = Random.shuffle(stream)
+          sinkRaceLaw(ZStream.fromIterable(shuffled), findSink(20), findSink(40))
         }
       },
       suite("zipWithPar")(
         testM("coherence") {
           checkM(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
-            val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+            val stream   = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+            val shuffled = Random.shuffle(stream)
             SinkUtils
-              .zipParLaw(ZStream.fromIterable(Random.shuffle(stream)), findSink(20), findSink(40))
+              .zipParLaw(ZStream.fromIterable(shuffled), findSink(20), findSink(40))
           }
         },
         suite("zipRight (*>)")(

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -177,6 +177,19 @@ abstract class ZSink[-R, +E, -I, +L, +Z] private (
     contramapChunksM(f).mapM(g)
 
   /**
+   * Catches potential error into `Either`
+   */
+  def either: ZSink[R, Nothing, I, L, Either[E, Z]] = ZSink {
+    self.push.map(p =>
+      in => {
+        p(in).catchAll {
+          case (e, leftover) => Push.emit(e, leftover)
+        }
+      }
+    )
+  }
+
+  /**
    * Runs this sink until it yields a result, then uses that result to create another
    * sink from the provided function which will continue to run until it yields a result.
    *

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -437,7 +437,7 @@ abstract class ZSink[-R, +E, -I, +L, +Z] private (
     } yield push)
   }
 
-  def exposeLeftover: ZSink[R, E, I, Nothing, (Z, Chunk[L])] = ZSink {
+  private[zio] def exposeLeftover: ZSink[R, E, I, Nothing, (Z, Chunk[L])] = ZSink {
     self.push.map { p => (in: Option[Chunk[I]]) =>
       p(in).mapError { case (v, leftover) => (v.map(z => (z, leftover)), Chunk.empty) }
     }


### PR DESCRIPTION
Part of #3775 

1) Check leftver properties for `ZSink.zipPar` and `ZSink.race`

Collateral changes:
2) Hide `.exposeLeftover`. It is useful for testing but not lawful (drops leftovers in case of error).
3) Add `ZSink.either`