### PR TITLE
fix ZStream.grouped

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1540,8 +1540,13 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(result)(equalTo(Chunk(1)))
           }
         ),
-        testM("grouped")(
-          assertM(ZStream(1, 2, 3, 4).grouped(2).runCollect)(equalTo(Chunk(List(1, 2), List(3, 4))))
+        suite("grouped")(
+          testM("sanity") {
+            assertM(ZStream(1, 2, 3, 4, 5).grouped(2).runCollect)(equalTo(Chunk(List(1, 2), List(3, 4), List(5))))
+          },
+          testM("doesn't emit empty chunks") {
+            assertM(ZStream.fromIterable(List.empty[Int]).grouped(5).runCollect)(equalTo(Chunk.empty))
+          }
         ),
         suite("groupedWithin")(
           testM("group based on time passed") {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1589,7 +1589,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * @param chunkSize size of the chunk
    */
   def grouped(chunkSize: Long): ZStream[R, E, List[O]] =
-    aggregate(ZTransducer.collectAllN(chunkSize))
+    aggregate(ZTransducer.collectAllN(chunkSize)).filter(_.nonEmpty)
 
   /**
    * Partitions the stream with the specified chunkSize or until the specified


### PR DESCRIPTION
Closes #3818 
This fix looks like a dirty hack but this is fine.
`grouped` is implemented using Transducer. 
Empty output is a valid output of the transducer (it has to emit something).
So we have to filter-out empty chunks explicitly.