### PR TITLE
add someOrElseM method to ZIO, ZManaged and ZSTM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2881,6 +2881,17 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.fail(ExampleError).someOrElse(42).run)(fails(equalTo(ExampleError)))
       } @@ zioTag(errors)
     ),
+    suite("someOrElseM")(
+      testM("extracts the value from Some") {
+        assertM(UIO.succeed(Some(1)).someOrElseM(UIO.succeed(2)))(equalTo(1))
+      },
+      testM("falls back to the default effect if None") {
+        assertM(UIO.succeed(None).someOrElseM(UIO.succeed(42)))(equalTo(42))
+      },
+      testM("does not change failed state") {
+        assertM(ZIO.fail(ExampleError).someOrElseM(UIO.succeed(42)).run)(fails(equalTo(ExampleError)))
+      } @@ zioTag(errors)
+    ),
     suite("someOrFail")(
       testM("extracts the optional value") {
         val task: Task[Int] = UIO(Some(42)).someOrFail(exampleError)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -789,6 +789,20 @@ object ZManagedSpec extends ZIOBaseSpec {
         managed.run.use(res => ZIO.succeed(assert(res)(fails(equalTo(ExampleError)))))
       } @@ zioTag(errors)
     ),
+    suite("someOrElseM")(
+      testM("extracts the value from Some") {
+        val managed: TaskManaged[Int] = Managed.succeed(Some(1)).someOrElseM(Managed.succeed(2))
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(1))))
+      },
+      testM("falls back to the default value if None") {
+        val managed: TaskManaged[Int] = Managed.succeed(None).someOrElseM(Managed.succeed(42))
+        managed.use(res => ZIO.succeed(assert(res)(equalTo(42))))
+      },
+      testM("does not change failed state") {
+        val managed: TaskManaged[Int] = Managed.fail(ExampleError).someOrElseM(Managed.succeed(42))
+        managed.run.use(res => ZIO.succeed(assert(res)(fails(equalTo(ExampleError)))))
+      } @@ zioTag(errors)
+    ),
     suite("someOrFailException")(
       testM("extracts the optional value") {
         val managed = Managed.succeed(Some(42)).someOrFailException

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -608,6 +608,17 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertM(STM.fail(ExampleError).someOrElse(42).commit.run)(fails(equalTo(ExampleError)))
         } @@ zioTag(errors)
       ),
+      suite("someOrElseM")(
+        testM("extracts the value from Some") {
+          assertM(STM.succeed(Some(1)).someOrElseM(STM.succeed(2)).commit)(equalTo(1))
+        },
+        testM("falls back to the default value if None") {
+          assertM(STM.succeed(None).someOrElseM(STM.succeed(42)).commit)(equalTo(42))
+        },
+        testM("does not change failed state") {
+          assertM(STM.fail(ExampleError).someOrElseM(STM.succeed(42)).commit.run)(fails(equalTo(ExampleError)))
+        } @@ zioTag(errors)
+      ),
       suite("someOrFail")(
         testM("extracts the value from Some") {
           assertM(STM.succeed(Some(1)).someOrFail(ExampleError).commit)(equalTo(1))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1654,6 +1654,15 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     map(_.getOrElse(default))
 
   /**
+   * Extracts the optional value, or executes the effect 'default'.
+   */
+  final def someOrElseM[B, R1 <: R, E1 >: E](default: ZIO[R1, E1, B])(implicit ev: A <:< Option[B]): ZIO[R1, E1, B] =
+    self.flatMap(ev(_) match {
+      case Some(value) => ZIO.succeedNow(value)
+      case None        => default
+    })
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZIO[R, E1, B] =

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -838,6 +838,17 @@ final class ZManaged[-R, +E, +A] private (val zio: ZIO[(R, ZManaged.ReleaseMap),
     map(_.getOrElse(default))
 
   /**
+   * Extracts the optional value, or executes the effect 'default'.
+   */
+  final def someOrElseM[B, R1 <: R, E1 >: E](
+    default: ZManaged[R1, E1, B]
+  )(implicit ev: A <:< Option[B]): ZManaged[R1, E1, B] =
+    self.flatMap(ev(_) match {
+      case Some(value) => ZManaged.succeedNow(value)
+      case None        => default
+    })
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZManaged[R, E1, B] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -776,6 +776,15 @@ final class ZSTM[-R, +E, +A] private[stm] (
     map(_.getOrElse(default))
 
   /**
+   * Extracts the optional value, or executes the effect 'default'.
+   */
+  def someOrElseM[B, R1 <: R, E1 >: E](default: ZSTM[R1, E1, B])(implicit ev: A <:< Option[B]): ZSTM[R1, E1, B] =
+    self.flatMap(ev(_) match {
+      case Some(value) => ZSTM.succeedNow(value)
+      case None        => default
+    })
+
+  /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
   def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A <:< Option[B]): ZSTM[R, E1, B] =


### PR DESCRIPTION
This PR adds new `someOrElseM` method  to `ZIO`, `ZManaged` and `ZSTM` - similar to `someOrElse` but with effect as default. I found this helper quite useful when working with `some` / `asSomeError` / `optional` combinators. Of course this can be achieved  with `flatMap` doing pattern matching or folding, but new helper looks cleaner.
    