### PR TITLE
Improve Efficiency Of Chunk

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
@@ -10,6 +10,8 @@ import zio.Chunk
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
 class ChainBenchmarks {
 
   val largeChain: Chain[Int] =

--- a/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
@@ -1,0 +1,52 @@
+package zio.chunks
+
+import java.util.concurrent.TimeUnit
+
+import cats.data.Chain
+import org.openjdk.jmh.annotations._
+
+import zio.Chunk
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ChainBenchmarks {
+
+  val largeChain: Chain[Int] =
+    (0 to 1000).foldLeft(Chain.empty[Int])((acc, _) => acc ++ Chain.fromSeq(0 to 1000))
+
+  val largeChunk =
+    (0 to 1000).foldLeft[Chunk[Int]](Chunk.empty)((acc, _) => acc ++ Chunk.fromIterable(0 to 1000))
+
+  val largeVector: Vector[Int] =
+    (0 to 1000000).toVector
+
+  val largeList: List[Int] =
+    (0 to 1000000).toList
+
+  @Benchmark
+  def foldLeftLargeChain: Int =
+    largeChain.foldLeft(0)(_ + _)
+  @Benchmark
+  def foldLeftLargeChunk: Int =
+    largeChunk.foldLeft(0)(_ + _)
+  @Benchmark
+  def foldLeftLargeVector: Int =
+    largeVector.foldLeft(0)(_ + _)
+  @Benchmark
+  def foldLeftLargeList: Int =
+    largeList.foldLeft(0)(_ + _)
+
+  @Benchmark
+  def mapLargeChain: Chain[Int] =
+    largeChain.map(_ + 1)
+  @Benchmark
+  def mapLargeChunk: Chunk[Int] =
+    largeChunk.map(_ + 1)
+  @Benchmark
+  def mapLargeVector: Vector[Int] =
+    largeVector.map(_ + 1)
+  @Benchmark
+  def mapLargeList: List[Int] =
+    largeList.map(_ + 1)
+}

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -319,15 +319,8 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
    * Folds over the elements in this chunk from the left.
    */
   override def foldLeft[S](s0: S)(f: (S, A) => S): S = {
-    val len = self.length
-    var s   = s0
-
-    var i = 0
-    while (i < len) {
-      s = f(s, self(i))
-      i += 1
-    }
-
+    var s = s0
+    foreach(a => s = f(s, a))
     s
   }
 
@@ -814,15 +807,9 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
    * Returns a chunk with the elements mapped by the specified function.
    */
   protected def mapChunk[B](f: A => B): Chunk[B] = {
-    val len     = self.length
     val builder = ChunkBuilder.make[B]()
-
-    var i = 0
-    while (i < len) {
-      builder += f(self(i))
-      i += 1
-    }
-
+    builder.sizeHint(length)
+    foreach(a => builder += f(a))
     builder.result()
   }
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3291,7 +3291,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           )(equalTo(Chunk(0, 1, 2, 3)))
         },
         testM("range") {
-          assertM(ZStream.range(0, 10).runCollect)(equalTo(Chunk.fromIterable(Range(0, 10))))
+          val right = Chunk.fromIterable(Range(0, 10))
+          println(right)
+          val left = UIO(println("Starting")) *> ZStream.range(0, 10).runCollect <* UIO(println("Done"))
+          assertM(left)(equalTo(right))
+          //assertM(ZStream.range(0, 10).runCollect)(equalTo(Chunk.fromIterable(Range(0, 10))))
         },
         testM("repeatEffect")(
           assertM(


### PR DESCRIPTION
Following up on discussion on Discord, this PR improves the efficiency of operations on concatenated chunks. The basic problem is that right now almost all chunk operations are implemented in terms of accessing each index of the chunk. Indexed access is relatively efficient because of balanced concatenation and using underlying arrays, but because the data structure is not actually a flat array indexed access is not nearly as efficient as direct iteration, resulting in terrible performance when iterating over concatenated chunks.

We can address this in many cases by just using `foreach` instead of accessing each index. For example, here is a comparison with `Chunk` and other data types for `map` and `foldLeft` on concatenated chunks (created by repeatedly concatenating 1,000 chunks of 1,000 elements each). The first set of results is for the current implementation. The second set of results is for a fully materialized chunk. The third set of results is using `foreach` instead of indexed access.

The current implementation is orders of magnitude slower than other collections versus just using `foreach` is as fast or faster than other collections. Right now I have only done this for `map` and `foldLeft` but I think we need to go through and make sure no operations on `Chunk`, as opposed to the `Arr` subtype are doing indexed access and instead are all iterating using `foreach` or `iterator`.

**Current Chunk**

```
[info] Benchmark                            Mode  Cnt          Score         Error  Units
[info] ChainBenchmarks.foldLeftLargeChain   avgt    5    7394179.877 ± 2400522.803  ns/op
[info] ChainBenchmarks.foldLeftLargeChunk   avgt    5  152564062.429 ± 3453030.056  ns/op
[info] ChainBenchmarks.foldLeftLargeList    avgt    5    4015942.091 ±  297741.459  ns/op
[info] ChainBenchmarks.foldLeftLargeVector  avgt    5    8167982.583 ±  968383.806  ns/op
[info] ChainBenchmarks.mapLargeChain        avgt    5   12212584.229 ± 1688755.027  ns/op
[info] ChainBenchmarks.mapLargeChunk        avgt    5  154922038.625 ± 3936423.265  ns/op
[info] ChainBenchmarks.mapLargeList         avgt    5   10110147.776 ± 2062606.153  ns/op
[info] ChainBenchmarks.mapLargeVector       avgt    5    6808899.183 ±  861057.070  ns/op
```

**Materialized Chunk**

```
[info] Benchmark                            Mode  Cnt         Score         Error  Units
[info] ChainBenchmarks.foldLeftLargeChain   avgt    5   6954098.879 ±  110454.185  ns/op
[info] ChainBenchmarks.foldLeftLargeChunk   avgt    5   4920782.436 ±  597549.698  ns/op
[info] ChainBenchmarks.foldLeftLargeList    avgt    5   4542490.441 ± 1471651.374  ns/op
[info] ChainBenchmarks.foldLeftLargeVector  avgt    5   8054089.991 ±  244988.236  ns/op
[info] ChainBenchmarks.mapLargeChain        avgt    5  10515048.826 ±  701132.081  ns/op
[info] ChainBenchmarks.mapLargeChunk        avgt    5   4884269.707 ±   54435.301  ns/op
[info] ChainBenchmarks.mapLargeList         avgt    5  11663339.345 ± 2032071.560  ns/op
[info] ChainBenchmarks.mapLargeVector       avgt    5   6777173.856 ±  515598.245  ns/op
```

**Iteration Instead of Indexed Access**

```
[info] Benchmark                            Mode  Cnt         Score         Error  Units
[info] ChainBenchmarks.foldLeftLargeChain   avgt    5   7669070.957 ± 2548209.118  ns/op
[info] ChainBenchmarks.foldLeftLargeChunk   avgt    5   7239030.095 ±  675284.379  ns/op
[info] ChainBenchmarks.foldLeftLargeList    avgt    5   4289477.864 ±  185167.759  ns/op
[info] ChainBenchmarks.foldLeftLargeVector  avgt    5   8532388.157 ±  223626.941  ns/op
[info] ChainBenchmarks.mapLargeChain        avgt    5  12319347.622 ± 3136106.030  ns/op
[info] ChainBenchmarks.mapLargeChunk        avgt    5   5711082.159 ±  565630.752  ns/op
[info] ChainBenchmarks.mapLargeList         avgt    5  11124514.568 ± 1431372.665  ns/op
[info] ChainBenchmarks.mapLargeVector       avgt    5   7067995.506 ±  376664.129  ns/op
```

The current implementation is orders of magnitude slower than other collection types