### PR TITLE
Fix the behavior of `*` method in the Duration in some corner cases

### DIFF
--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -78,6 +78,23 @@ object DurationSpec extends ZIOBaseSpec {
       test("* with overflow to negative results in Infinity") {
         assert(Duration.fromNanos(Long.MaxValue) * 2)(equalTo(Duration.Infinity: Duration))
       },
+      test("* with factor equal to 0 results in zero") {
+        assert(Duration.fromNanos(42) * 0)(equalTo(Duration.Zero: Duration))
+      },
+      test("* with positive factor less than 1 results in Finite Duration") {
+        assert(Duration.fromNanos(42) * 0.5)(equalTo(Duration.fromNanos(21)))
+      },
+      test("* with factor equal to 1 results in Finite Duration in case of small duration") {
+        assert(Duration.fromNanos(42) * 1)(equalTo(Duration.fromNanos(42)))
+      },
+      test("* with factor equal to 1 results in Finite Duration in case of large duration") {
+        assert(Duration.fromNanos(Long.MaxValue) * 1)(equalTo(Duration.fromNanos(Long.MaxValue)))
+      },
+      test("* results in Finite Duration if the multiplication result is close to max FiniteDuration value") {
+        val factor = 1.5
+        val nanos  = (Long.MaxValue / 1.9).round
+        assert(Duration.fromNanos(nanos) * factor)(isSubtype[Duration.Finite](Assertion.anything))
+      },
       test("Folding picks up the correct value") {
         assert(Duration.fromNanos(Long.MaxValue).fold("Infinity", _ => "Finite"))(equalTo("Finite"))
       },
@@ -130,6 +147,9 @@ object DurationSpec extends ZIOBaseSpec {
       },
       test("Infinity * -10 = Zero") {
         assert(Duration.Infinity * -10)(equalTo(Duration.Zero: Duration))
+      },
+      test("Infinity * 0 = Zero") {
+        assert(Duration.Infinity * 0)(equalTo(Duration.Zero: Duration))
       }
     ),
     suite("Make a Scala stdlib s.c.d.Duration and check that: ")(

--- a/core/shared/src/main/scala/zio/duration/Duration.scala
+++ b/core/shared/src/main/scala/zio/duration/Duration.scala
@@ -89,11 +89,10 @@ object Duration {
 
     def *(factor: Double): Duration =
       if (factor <= 0 || nanos <= 0) Zero
-      else if (factor < 1) Finite((nanos * factor).round)
-      else if (factor < Long.MaxValue / nanos) Finite((nanos * factor).round)
+      else if (factor <= Long.MaxValue / nanos.toDouble) Finite((nanos * factor).round)
       else Infinity
 
-    def compare(other: Duration) = other match {
+    def compare(other: Duration): Int = other match {
       case Finite(otherNanos) => nanos compare otherNanos
       case Infinity           => -1
     }
@@ -140,9 +139,9 @@ object Duration {
     def +(other: Duration): Duration = Infinity
 
     def *(factor: Double): Duration =
-      if (factor < 0) Duration.Zero else Infinity
+      if (factor <= 0) Duration.Zero else Infinity
 
-    def compare(other: Duration) = if (other == this) 0 else 1
+    def compare(other: Duration): Int = if (other == this) 0 else 1
 
     val toMillis: Long = TimeUnit.NANOSECONDS.toMillis(Long.MaxValue)
 


### PR DESCRIPTION
There are some issues with the current implementation of `*` method in `zio.duration.Duration`.

- `Duration.Infinity * 0` results in `Duration.Infinity` instead of `Duration.Finite(0)`.
- `Duration.fromNanos(Long.MaxValue)` results in `Duration.Finite(Long.MaxValue)` , while `Duration.fromNanos(Long.MaxValue) * 1`  results in `Duration.Infinity`.
- `Duration.fromNanos(5500000000000000000L) * 1.5` results in `Duration.Infinitiy`, instead of `Duration.Finite(8250000000000000000)`.

This PR fixes these issues.