### PR TITLE
Fix Chunk#toArray

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -502,6 +502,11 @@ object ChunkSpec extends ZIOBaseSpec {
       val n  = 100000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => Chunk(a) ++ as)
       assert(as.toArray)(equalTo(Array.range(0, n)))
+    },
+    zio.test.test("toArray does not throw ClassCastException") {
+      val chunk = Chunk("a")
+      val array = chunk.toArray
+      assert(array)(anything)
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1464,9 +1464,6 @@ object Chunk {
       take(i)
     }
 
-    override def toArray[A1 >: A: ClassTag]: Array[A1] =
-      array.asInstanceOf[Array[A1]]
-
     override protected[zio] def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
       Array.copy(array, 0, dest, n, length)
 


### PR DESCRIPTION
Resolves #3852.

The specialized version of `toArray` for a `Chunk` backed by an `Array` was just upcasting the underlying array and returning it, which is both not safe and exposes the underlying mutable array to the caller, potentially allowing the caller to mutate the array and violating the referential transparency of `Chunk`.

This PR deletes the specialized version. The version defined on the parent class just creates a new array and then calls `toArray` to copy all of the elements to the new array, which is implemented very efficiency for an array chunk in terms of `Array.copy`.