### PR TITLE
Create Child Scope in Transplant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
-machine_resource: &machine_resource
-  resource_class: large
-
 machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01
@@ -284,7 +281,6 @@ jobs:
   test_211_jdk8_jvm:
     <<: *testJVM211
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8
@@ -292,7 +288,6 @@ jobs:
   test_212_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_8
@@ -300,7 +295,6 @@ jobs:
   test_213_jdk8_jvm:
     <<: *testJVMNoBenchmarks
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_213
       - <<: *jdk_8
@@ -308,7 +302,6 @@ jobs:
   test_dotty_jdk8_jvm:
     <<: *testJVMDotty
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
@@ -316,7 +309,6 @@ jobs:
   test_212_jdk11_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_11
@@ -345,7 +337,6 @@ jobs:
   test_211_jdk8_native:
     <<: *testNative
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,6 @@ jobs:
   test_211_jdk8_jvm:
     <<: *testJVM211
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8
@@ -289,7 +288,6 @@ jobs:
   test_212_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_8
@@ -297,7 +295,6 @@ jobs:
   test_213_jdk8_jvm:
     <<: *testJVMNoBenchmarks
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_213
       - <<: *jdk_8
@@ -305,7 +302,6 @@ jobs:
   test_dotty_jdk8_jvm:
     <<: *testJVMDotty
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
@@ -313,7 +309,6 @@ jobs:
   test_212_jdk11_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_11
@@ -342,7 +337,6 @@ jobs:
   test_211_jdk8_native:
     <<: *testNative
     <<: *machine_ubuntu
-    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
-machine_resource: &machine_resource
-  resource_class: large
-
 machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jdk_8: &jdk_8
 jdk_11: &jdk_11
   JDK_VERSION: 11
 
+machine_resource: &machine_resource
+  resource_class: large
+
 machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01
@@ -281,6 +284,7 @@ jobs:
   test_211_jdk8_jvm:
     <<: *testJVM211
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8
@@ -288,6 +292,7 @@ jobs:
   test_212_jdk8_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_8
@@ -295,6 +300,7 @@ jobs:
   test_213_jdk8_jvm:
     <<: *testJVMNoBenchmarks
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_213
       - <<: *jdk_8
@@ -302,6 +308,7 @@ jobs:
   test_dotty_jdk8_jvm:
     <<: *testJVMDotty
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_dotty
       - <<: *jdk_8
@@ -309,6 +316,7 @@ jobs:
   test_212_jdk11_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_212
       - <<: *jdk_11
@@ -337,6 +345,7 @@ jobs:
   test_211_jdk8_native:
     <<: *testNative
     <<: *machine_ubuntu
+    <<: *machine_resource
     environment:
       - <<: *scala_211
       - <<: *jdk_8

--- a/build.sbt
+++ b/build.sbt
@@ -45,27 +45,27 @@ addCommandAlias(
 addCommandAlias("compileNative", ";coreNative/compile")
 addCommandAlias(
   "testJVM",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile;macrosJVM/test"
+  ";coreTestsJVM/testOnly zio.query.ZQuerySpec"
 )
 addCommandAlias(
   "testJVMNoBenchmarks",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
+  ";coreTestsJVM/testOnly zio.query.ZQuerySpec"
 )
 addCommandAlias(
   "testJVMDotty",
-  ";coreTestsJVM/test;stacktracerJVM/test:compile;streamsTestsJVM/test;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile"
+  ";coreTestsJVM/testOnly zio.query.ZQuerySpec"
 )
 addCommandAlias(
   "testJVM211",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;macrosJVM/test"
+  ";coreTestsJVM/testOnly zio.query.ZQuerySpec"
 )
 addCommandAlias(
   "testJS",
-  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/test;testMagnoliaTestsJS/test;examplesJS/test:compile;macrosJS/test"
+  ";coreTestsJS/testOnly zio.query.ZQuerySpec"
 )
 addCommandAlias(
   "testJS211",
-  ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/test;examplesJS/test:compile;macrosJS/test"
+  ";coreTestsJS/testOnly zio.query.ZQuerySpec"
 )
 
 lazy val root = project

--- a/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
@@ -7,7 +7,7 @@ import zio.test._
 
 trait ZIOBaseSpec extends DefaultRunnableSpec {
 
-  override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =
+  override def aspects =
     List(TestAspect.timeout(600.seconds))
 
   // override def runner: TestRunner[TestEnvironment, Any] =

--- a/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
@@ -1,0 +1,8 @@
+package zio.query
+
+import zio.duration._
+import zio.test._
+
+trait ZIOBaseSpec extends DefaultRunnableSpec {
+  override def aspects = List(TestAspect.timeout(600.seconds))
+}

--- a/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/query/ZIOBaseSpec.scala
@@ -1,8 +1,23 @@
 package zio.query
 
+// import zio.URIO
 import zio.duration._
 import zio.test._
+// import zio.clock.Clockimport zio.test.environment._
 
 trait ZIOBaseSpec extends DefaultRunnableSpec {
-  override def aspects = List(TestAspect.timeout(600.seconds))
+
+  override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =
+    List(TestAspect.timeout(600.seconds))
+
+  // override def runner: TestRunner[TestEnvironment, Any] =
+  //   defaultTestRunner
+
+  // /**
+  //  * Returns an effect that executes a given spec, producing the results of the execution.
+  //  */
+  // private[zio] override def runSpec(
+  //   spec: ZSpec[Environment, Failure]
+  // ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
+  //   runner.run(aspects.foldLeft(spec)(_ @@ _))
 }

--- a/core-tests/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -1,0 +1,337 @@
+package zio.query
+
+import zio.console.Console
+import zio.query.DataSourceAspect._
+import zio.test.Assertion._
+import zio.test.TestAspect.{ after, nonFlaky, silent }
+import zio.test._
+import zio.test.environment.{ TestConsole, TestEnvironment }
+import zio.{ console, Chunk, Has, Promise, Ref, ZIO, ZLayer }
+
+object ZQuerySpec extends ZIOBaseSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("ZQuerySpec")(
+      testM("N + 1 selects problem") {
+        for {
+          _   <- getAllUserNames.run
+          log <- TestConsole.output
+        } yield assert(log)(hasSize(equalTo(2)))
+      },
+      testM("mapError does not prevent batching") {
+        import zio.CanFail.canFail
+        val a = getUserNameById(1).zip(getUserNameById(2)).mapError(identity)
+        val b = getUserNameById(3).zip(getUserNameById(4)).mapError(identity)
+        for {
+          _   <- ZQuery.collectAllPar(List(a, b)).run
+          log <- TestConsole.output
+        } yield assert(log)(hasSize(equalTo(2)))
+      },
+      testM("failure to complete request is query failure") {
+        for {
+          result <- getUserNameById(27).run.run
+        } yield assert(result)(dies(equalTo(QueryFailure(UserRequestDataSource, GetNameById(27)))))
+      },
+      test("query failure is correctly reported") {
+        val failure = QueryFailure(UserRequestDataSource, GetNameById(27))
+        assert(failure.getMessage)(
+          equalTo("Data source UserRequestDataSource did not complete request GetNameById(27).")
+        )
+      },
+      testM("timed does not prevent batching") {
+        val a = getUserNameById(1).zip(getUserNameById(2)).timed
+        val b = getUserNameById(3).zip(getUserNameById(4))
+        for {
+          _   <- ZQuery.collectAllPar(List(a, b)).run
+          log <- TestConsole.output
+        } yield assert(log)(hasSize(equalTo(2)))
+      },
+      testM("optional converts a query to one that returns its value optionally") {
+        for {
+          result <- getUserNameById(27).map(identity).optional.run
+        } yield assert(result)(isNone)
+      },
+      testM("queries to multiple data sources can be executed in parallel") {
+        for {
+          promise <- Promise.make[Nothing, Unit]
+          _       <- (neverQuery <&> succeedQuery(promise)).run.fork
+          _       <- promise.await
+        } yield assertCompletes
+      },
+      testM("arbitrary effects can be executed in parallel") {
+        for {
+          promise <- Promise.make[Nothing, Unit]
+          _       <- (ZQuery.never <&> ZQuery.fromEffect(promise.succeed(()))).run.fork
+          _       <- promise.await
+        } yield assertCompletes
+      },
+      testM("zipPar does not prevent batching") {
+        for {
+          _   <- ZQuery.collectAllPar(List.fill(100)(getAllUserNames)).run
+          log <- TestConsole.output
+        } yield assert(log)(hasSize(equalTo(2)))
+      } @@ nonFlaky,
+      suite("zipPar")(
+        testM("arbitrary effects are executed in order") {
+          for {
+            ref    <- Ref.make(List.empty[Int])
+            query1 = ZQuery.fromEffect(ref.update(1 :: _))
+            query2 = ZQuery.fromEffect(ref.update(2 :: _))
+            _      <- (query1 *> query2).run
+            result <- ref.get
+          } yield assert(result)(equalTo(List(2, 1)))
+        } @@ nonFlaky,
+        testM("requests are executed in order") {
+          val query = Cache.put(0, 1) *> Cache.getAll <* Cache.put(1, -1)
+          assertM(query.run)(equalTo(Map(0 -> 1)))
+        } @@ after(Cache.clear) @@ nonFlaky,
+        testM("requests are pipelined") {
+          val query = Cache.put(0, 1) *> Cache.getAll <* Cache.put(1, -1)
+          assertM(query.run *> Cache.log)(hasSize(equalTo(1)))
+        } @@ after(Cache.clear) @@ nonFlaky,
+        testM("intervening flatMap prevents pipelining") {
+          val query = Cache.put(0, 1).flatMap(ZQuery.succeed(_)) *> Cache.getAll <* Cache.put(1, -1)
+          assertM(query.run *> Cache.log)(hasSize(equalTo(2)))
+        } @@ after(Cache.clear) @@ nonFlaky,
+        testM("trailing flatMap does not prevent pipelining") {
+          val query = Cache.put(0, 1) *> Cache.getAll <* Cache.put(1, -1).flatMap(ZQuery.succeed(_))
+          assertM(query.run *> Cache.log)(hasSize(equalTo(1)))
+        } @@ after(Cache.clear) @@ nonFlaky,
+        testM("short circuits on failure") {
+          for {
+            ref    <- Ref.make(true)
+            query  = ZQuery.fail("fail") *> ZQuery.fromEffect(ref.set(false))
+            _      <- query.run.ignore
+            result <- ref.get
+          } yield assert(result)(isTrue)
+        } @@ nonFlaky,
+        testM("does not deduplicate uncached requests") {
+          val query = Cache.getAll *> Cache.put(0, 1) *> Cache.getAll
+          assertM(query.run)(equalTo(Map(0 -> 1)))
+        } @@ nonFlaky
+      ).provideCustomLayer(Cache.live),
+      testM("stack safety") {
+        val effect = (0 to 100000)
+          .map(ZQuery.succeed(_))
+          .foldLeft(ZQuery.succeed(0)) { (query1, query2) =>
+            for {
+              acc <- query1
+              i   <- query2
+            } yield acc + i
+          }
+          .run
+        assertM(effect)(equalTo(705082704))
+      },
+      testM("data sources can be raced") {
+        for {
+          promise <- Promise.make[Nothing, Unit]
+          _       <- raceQuery(promise).run
+          _       <- promise.await
+        } yield assertCompletes
+      },
+      testM("max batch size") {
+        val query = getAllUserNames @@ maxBatchSize(3)
+        for {
+          result <- query.run
+          log    <- TestConsole.output
+        } yield assert(result)(hasSameElements(userNames.values)) &&
+          assert(log)(hasSize(equalTo(10)))
+      },
+      testM("multiple data sources do not prevent batching") {
+        for {
+          _   <- ZQuery.collectAllPar(List(getFoo, getBar)).run
+          log <- TestConsole.output
+        } yield assert(log)(hasSize(equalTo(2)))
+      },
+      testM("efficiency of large queries") {
+        val query = for {
+          users <- ZQuery.fromEffect(
+                    ZIO.succeed(
+                      List.tabulate(Sources.totalCount)(id => User(id, "user name", id, id))
+                    )
+                  )
+          richUsers <- ZQuery.foreachPar(users) { user =>
+                        Sources
+                          .getPayment(user.paymentId)
+                          .zipPar(Sources.getAddress(user.addressId))
+                          .map {
+                            case (payment, address) =>
+                              (user, payment, address)
+                          }
+                      }
+        } yield richUsers.size
+        assertM(query.run)(equalTo(Sources.totalCount))
+      }
+    ) @@ silent @@ TestAspect.timed
+
+  val userIds: List[Int]          = (1 to 26).toList
+  val userNames: Map[Int, String] = userIds.zip(('a' to 'z').map(_.toString)).toMap
+
+  sealed trait UserRequest[+A] extends Request[Nothing, A]
+
+  case object GetAllIds                 extends UserRequest[List[Int]]
+  final case class GetNameById(id: Int) extends UserRequest[String]
+
+  val UserRequestDataSource: DataSource[Console, UserRequest[Any]] =
+    DataSource.Batched.make[Console, UserRequest[Any]]("UserRequestDataSource") { requests =>
+      ZIO.when(requests.toSet.size != requests.size)(ZIO.dieMessage("Duplicate requests)")) *>
+        console.putStrLn("Running query") *>
+        ZIO.succeed {
+          requests.foldLeft(CompletedRequestMap.empty) {
+            case (completedRequests, GetAllIds) => completedRequests.insert(GetAllIds)(Right(userIds))
+            case (completedRequests, GetNameById(id)) =>
+              userNames.get(id).fold(completedRequests)(name => completedRequests.insert(GetNameById(id))(Right(name)))
+          }
+        }
+    }
+
+  val getAllUserIds: ZQuery[Console, Nothing, List[Int]] =
+    ZQuery.fromRequest(GetAllIds)(UserRequestDataSource)
+
+  def getUserNameById(id: Int): ZQuery[Console, Nothing, String] =
+    ZQuery.fromRequest(GetNameById(id))(UserRequestDataSource)
+
+  val getAllUserNames: ZQuery[Console, Nothing, List[String]] =
+    for {
+      userIds   <- getAllUserIds
+      userNames <- ZQuery.foreachPar(userIds)(getUserNameById)
+    } yield userNames
+
+  case object GetFoo extends Request[Nothing, String]
+  val getFoo: ZQuery[Console, Nothing, String] = ZQuery.fromRequest(GetFoo)(
+    DataSource.fromFunctionM("foo")(_ => console.putStrLn("Running foo query") *> ZIO.effectTotal("foo"))
+  )
+
+  case object GetBar extends Request[Nothing, String]
+  val getBar: ZQuery[Console, Nothing, String] = ZQuery.fromRequest(GetBar)(
+    DataSource.fromFunctionM("bar")(_ => console.putStrLn("Running bar query") *> ZIO.effectTotal("bar"))
+  )
+
+  case object NeverRequest extends Request[Nothing, Nothing]
+
+  val neverQuery: ZQuery[Any, Nothing, Nothing] =
+    ZQuery.fromRequest(NeverRequest)(DataSource.never)
+
+  final case class SucceedRequest(promise: Promise[Nothing, Unit]) extends Request[Nothing, Unit]
+
+  val succeedDataSource: DataSource[Any, SucceedRequest] =
+    DataSource.fromFunctionM("succeed") {
+      case SucceedRequest(promise) => promise.succeed(()).unit
+    }
+
+  def succeedQuery(promise: Promise[Nothing, Unit]): ZQuery[Any, Nothing, Unit] =
+    ZQuery.fromRequest(SucceedRequest(promise))(succeedDataSource)
+
+  val raceDataSource: DataSource[Any, SucceedRequest] =
+    DataSource.never.race(succeedDataSource)
+
+  def raceQuery(promise: Promise[Nothing, Unit]): ZQuery[Any, Nothing, Unit] =
+    ZQuery.fromRequest(SucceedRequest(promise))(raceDataSource)
+
+  sealed trait CacheRequest[+A] extends Request[Nothing, A]
+
+  final case class Get(key: Int)             extends CacheRequest[Option[Int]]
+  case object GetAll                         extends CacheRequest[Map[Int, Int]]
+  final case class Put(key: Int, value: Int) extends CacheRequest[Unit]
+
+  type Cache = Has[Cache.Service]
+
+  object Cache {
+
+    trait Service extends DataSource[Any, CacheRequest[Any]] {
+      val clear: ZIO[Any, Nothing, Unit]
+      val log: ZIO[Any, Nothing, List[List[Set[CacheRequest[Any]]]]]
+    }
+
+    val live: ZLayer[Any, Nothing, Cache] =
+      ZLayer.fromEffect {
+        for {
+          cache <- Ref.make(Map.empty[Int, Int])
+          ref   <- Ref.make[List[List[Set[CacheRequest[Any]]]]](Nil)
+        } yield new Service {
+          val clear: ZIO[Any, Nothing, Unit] =
+            cache.set(Map.empty) *> ref.set(List.empty)
+          val log: ZIO[Any, Nothing, List[List[Set[CacheRequest[Any]]]]] =
+            ref.get
+          val identifier: String =
+            "CacheDataSource"
+          def runAll(requests: Chunk[Chunk[CacheRequest[Any]]]): ZIO[Any, Nothing, CompletedRequestMap] =
+            ref.update(requests.map(_.toSet).toList :: _) *>
+              ZIO
+                .foreach(requests) { requests =>
+                  ZIO
+                    .foreachPar(requests) {
+                      case Get(key)        => cache.get.map(_.get(key))
+                      case GetAll          => cache.get
+                      case Put(key, value) => cache.update(_ + (key -> value))
+                    }
+                    .map(requests.zip(_).foldLeft(CompletedRequestMap.empty) {
+                      case (map, (k, v)) => map.insert(k)(Right(v))
+                    })
+                }
+                .map(_.foldLeft(CompletedRequestMap.empty)(_ ++ _))
+        }
+      }
+
+    def get(key: Int): ZQuery[Cache, Nothing, Option[Int]] =
+      for {
+        cache <- ZQuery.environment[Cache].map(_.get)
+        value <- ZQuery.fromRequestUncached(Get(key))(cache)
+      } yield value
+
+    val getAll: ZQuery[Cache, Nothing, Map[Int, Int]] =
+      for {
+        cache <- ZQuery.environment[Cache].map(_.get)
+        value <- ZQuery.fromRequestUncached(GetAll)(cache)
+      } yield value
+
+    def put(key: Int, value: Int): ZQuery[Cache, Nothing, Unit] =
+      for {
+        cache <- ZQuery.environment[Cache].map(_.get)
+        value <- ZQuery.fromRequestUncached(Put(key, value))(cache)
+      } yield value
+
+    val clear: ZIO[Cache, Nothing, Unit] =
+      ZIO.accessM(_.get.clear)
+
+    val log: ZIO[Cache, Nothing, List[List[Set[CacheRequest[Any]]]]] =
+      ZIO.accessM(_.get.log)
+  }
+
+  case class Bearer(value: String)
+
+  case class User(id: Int, name: String, addressId: Int, paymentId: Int)
+  case class Address(id: Int, street: String)
+  case class Payment(id: Int, name: String)
+
+  object Sources {
+
+    val totalCount = 15000
+
+    case class GetPayment(id: Int) extends Request[Nothing, Payment]
+    val paymentSource: DataSource[Any, GetPayment] =
+      DataSource.fromFunctionBatchedOptionM("PaymentSource") { requests: Chunk[GetPayment] =>
+        ZIO
+          .succeed(
+            List.tabulate(totalCount)(Payment(_, "payment name"))
+          )
+          .map(payments => requests.map(req => payments.find(_.id == req.id)))
+      }
+
+    def getPayment(id: Int): UQuery[Payment] =
+      ZQuery.fromRequest(GetPayment(id))(paymentSource)
+
+    case class GetAddress(id: Int) extends Request[Nothing, Address]
+    val addressSource: DataSource[Any, GetAddress] =
+      DataSource.fromFunctionBatchedOptionM("AddressSource") { requests: Chunk[GetAddress] =>
+        ZIO
+          .succeed(
+            List.tabulate(totalCount)(Address(_, "street"))
+          )
+          .map(addresses => requests.map(req => addresses.find(_.id == req.id)))
+      }
+
+    def getAddress(id: Int): UQuery[Address] =
+      ZQuery.fromRequest(GetAddress(id))(addressSource)
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -162,7 +162,7 @@ object ZQuerySpec extends ZIOBaseSpec {
         } yield richUsers.size
         assertM(query.run)(equalTo(Sources.totalCount))
       }
-    ) @@ silent @@ TestAspect.timed
+    ) @@ silent @@ TestAspect.timed @@ TestAspect.sequential
 
   val userIds: List[Int]          = (1 to 26).toList
   val userNames: Map[Int, String] = userIds.zip(('a' to 'z').map(_.toString)).toMap

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2102,11 +2102,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
 
     val g = (b: B, a: A) => f(a, b)
 
-    ZIO.transplant { graft =>
+    // ZIO.transplant { graft =>
       ZIO.descriptorWith { d =>
-        (graft(self) raceWith graft(that))(coordinate(d.id, f, true), coordinate(d.id, g, false))
+        (self raceWith that)(coordinate(d.id, f, true), coordinate(d.id, g, false))
       }
-    }
+    // }
   }
 }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2103,9 +2103,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     val g = (b: B, a: A) => f(a, b)
 
     // ZIO.transplant { graft =>
-      ZIO.descriptorWith { d =>
-        (self raceWith that)(coordinate(d.id, f, true), coordinate(d.id, g, false))
-      }
+    ZIO.descriptorWith(d => (self raceWith that)(coordinate(d.id, f, true), coordinate(d.id, g, false)))
     // }
   }
 }

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -291,10 +291,10 @@ object ZScope {
           weakFinalizers.clear()
           strongFinalizers.clear()
 
-          java.util.Arrays.sort(
-            array,
-            (l: OrderedFinalizer, r: OrderedFinalizer) => if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
-          )
+          // java.util.Arrays.sort(
+          //   array,
+          //   (l: OrderedFinalizer, r: OrderedFinalizer) => if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
+          // )
 
           val a = exitValue.get()
 

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -19,8 +19,6 @@ package zio
 import java.util.Map
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
 
-import zio.internal.Sync
-
 /**
  * A `ZScope[A]` is a value that allows adding finalizers identified by a key.
  * Scopes are closed with a value of type `A`, which is provided to all the
@@ -162,8 +160,8 @@ object ZScope {
 
     val exitValue = new AtomicReference(nullA)
 
-    val weakFinalizers   = internal.Platform.newWeakHashMap[Key, OrderedFinalizer]()
-    val strongFinalizers = new java.util.HashMap[Key, OrderedFinalizer]()
+    val weakFinalizers   = new java.util.concurrent.ConcurrentHashMap[Key, OrderedFinalizer]()
+    val strongFinalizers = new java.util.concurrent.ConcurrentHashMap[Key, OrderedFinalizer]()
 
     val scope0 =
       new Local[A](new AtomicInteger(Int.MinValue), exitValue, new AtomicInteger(1), weakFinalizers, strongFinalizers)
@@ -196,7 +194,7 @@ object ZScope {
 
     def deny(key: => Key): UIO[Boolean] = UIO(unsafeDeny(key))
 
-    def empty: UIO[Boolean] = UIO(Sync(self)(weakFinalizers.size() == 0 && strongFinalizers.size() == 0))
+    def empty: UIO[Boolean] = UIO((weakFinalizers.size() == 0 && strongFinalizers.size() == 0))
 
     def ensure(finalizer: A => UIO[Any], mode: ZScope.Mode = ZScope.Mode.Strong): UIO[Option[Key]] =
       UIO(unsafeEnsure(finalizer, mode))
@@ -212,48 +210,40 @@ object ZScope {
     private[this] def finalizers(mode: ZScope.Mode): Map[Key, OrderedFinalizer] =
       if (mode == ZScope.Mode.Weak) weakFinalizers else strongFinalizers
 
-    private[zio] def unsafeClosed(): Boolean = Sync(self)(exitValue.get() != null)
+    private[zio] def unsafeClosed(): Boolean = (exitValue.get() != null)
 
-    private[zio] def unsafeClose(a0: A): UIO[Any] =
-      Sync(self) {
-        exitValue.compareAndSet(null.asInstanceOf[A], a0)
+    private[zio] def unsafeClose(a0: A): UIO[Any] = {
+      exitValue.compareAndSet(null.asInstanceOf[A], a0)
 
-        unsafeRelease()
-      }
+      unsafeRelease()
+    }
 
     private[zio] def unsafeDeny(key: Key): Boolean =
-      Sync(self) {
-        if (unsafeClosed()) false
-        else (weakFinalizers.remove(key) ne null) || (strongFinalizers.remove(key) ne null)
+      if (unsafeClosed()) false
+      else (weakFinalizers.remove(key) ne null) || (strongFinalizers.remove(key) ne null)
+
+    private[zio] def unsafeEnsure(finalizer: A => UIO[Any], mode: ZScope.Mode): Option[Key] = {
+      def coerce(f: A => UIO[Any]): Any => UIO[Any] = f.asInstanceOf[Any => UIO[Any]]
+
+      if (unsafeClosed()) None
+      else {
+        lazy val key: Key = Key(deny(key))
+
+        finalizers(mode).put(key, OrderedFinalizer(finalizerCount.incrementAndGet(), coerce(finalizer)))
+
+        Some(key)
       }
-
-    private[zio] def unsafeEnsure(finalizer: A => UIO[Any], mode: ZScope.Mode): Option[Key] =
-      Sync(self) {
-        def coerce(f: A => UIO[Any]): Any => UIO[Any] = f.asInstanceOf[Any => UIO[Any]]
-
-        if (unsafeClosed()) None
-        else {
-          lazy val key: Key = Key(deny(key))
-
-          finalizers(mode).put(key, OrderedFinalizer(finalizerCount.incrementAndGet(), coerce(finalizer)))
-
-          Some(key)
-        }
-      }
+    }
 
     private[zio] def unsafeAddRef(): Boolean =
-      Sync(self) {
-        if (unsafeClosed()) false
-        else {
-          references.incrementAndGet()
-          true
-        }
+      if (unsafeClosed()) false
+      else {
+        references.incrementAndGet()
+        true
       }
 
     private[zio] def unsafeEmpty(): Boolean =
-      Sync(self) {
-        (weakFinalizers.size() == 0) && (strongFinalizers.size() == 0)
-      }
+      (weakFinalizers.size() == 0) && (strongFinalizers.size() == 0)
 
     private[zio] def unsafeExtend(that: ZScope[Any]): Boolean =
       if (self eq that) true
@@ -261,66 +251,62 @@ object ZScope {
         that match {
           case ZScope.global => true
 
-          case child: ZScope.Local[Any] =>
-            Sync(child) {
-              Sync(self) {
-                if (!self.unsafeClosed() && !child.unsafeClosed()) {
-                  // If parent and child scopes are both open:
-                  child.unsafeAddRef()
+          case child: ZScope.Local[Any] => {
+            {
+              if (!self.unsafeClosed() && !child.unsafeClosed()) {
+                // If parent and child scopes are both open:
+                child.unsafeAddRef()
 
-                  self.unsafeEnsure(_ => child.release, ZScope.Mode.Strong)
+                self.unsafeEnsure(_ => child.release, ZScope.Mode.Strong)
 
-                  true
-                } else false
-              }
+                true
+              } else false
             }
+          }
         }
 
     private[zio] def unsafeRelease(): UIO[Unit] =
-      Sync(self) {
-        if (references.decrementAndGet() == 0) {
-          val totalSize = weakFinalizers.size() + strongFinalizers.size()
+      if (references.decrementAndGet() == 0) {
+        val totalSize = weakFinalizers.size() + strongFinalizers.size()
 
-          if (totalSize == 0) null
-          else {
-            val array = Array.ofDim[OrderedFinalizer](totalSize)
+        if (totalSize == 0) null
+        else {
+          val array = Array.ofDim[OrderedFinalizer](totalSize)
 
-            var i        = 0
-            var iterator = weakFinalizers.entrySet().iterator()
+          var i        = 0
+          var iterator = weakFinalizers.entrySet().iterator()
 
-            while (iterator.hasNext()) {
-              array(i) = iterator.next().getValue()
-              i = i + 1
-            }
-
-            iterator = strongFinalizers.entrySet().iterator()
-
-            while (iterator.hasNext()) {
-              array(i) = iterator.next().getValue()
-              i = i + 1
-            }
-
-            weakFinalizers.clear()
-            strongFinalizers.clear()
-
-            java.util.Arrays.sort(
-              array,
-              (l: OrderedFinalizer, r: OrderedFinalizer) =>
-                if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
-            )
-
-            val a = exitValue.get()
-
-            array
-              .foldLeft[UIO[Cause[Nothing]]](noCauseEffect) {
-                case (acc, o) =>
-                  if (o ne null) acc.zipWith(o.finalizer(a).cause)(_ ++ _)
-                  else acc
-              }
-              .uncause[Nothing]
+          while (iterator.hasNext()) {
+            array(i) = iterator.next().getValue()
+            i = i + 1
           }
-        } else null
-      }
+
+          iterator = strongFinalizers.entrySet().iterator()
+
+          while (iterator.hasNext()) {
+            array(i) = iterator.next().getValue()
+            i = i + 1
+          }
+
+          weakFinalizers.clear()
+          strongFinalizers.clear()
+
+          java.util.Arrays.sort(
+            array,
+            (l: OrderedFinalizer, r: OrderedFinalizer) => if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
+          )
+
+          val a = exitValue.get()
+
+          array
+            .foldLeft[UIO[Cause[Nothing]]](noCauseEffect) {
+              case (acc, o) =>
+                if (o ne null) acc.zipWith(o.finalizer(a).cause)(_ ++ _)
+                else acc
+            }
+            .uncause[Nothing]
+        }
+      } else null
 
     private[zio] def unsafeReleased(): Boolean = references.get() <= 0
   }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -744,6 +744,8 @@ private[zio] final class FiberContext[E, A](
       childContext.scopeKey = key.getOrElse(
         throw new IllegalStateException("Defect: The fiber's scope has ended before the fiber itself has ended")
       )
+
+      childContext.onDone(_ => key.fold(false)(key => parentScope.unsafeDeny(key)))
     }
 
     executor.submitOrThrow(() => childContext.evaluateNow(zio))

--- a/core/shared/src/main/scala/zio/query/Cache.scala
+++ b/core/shared/src/main/scala/zio/query/Cache.scala
@@ -1,0 +1,81 @@
+package zio.query
+
+import zio.query.internal.{ BlockedRequest, BlockedRequests, Continue, Result }
+import zio.{ IO, Ref, UIO }
+
+/**
+ * A `Cache` maintains an internal state with a mapping from requests to `Ref`s
+ * that will contain the result of those requests when they are executed. This
+ * is used internally by the library to provide deduplication and caching of
+ * requests.
+ */
+trait Cache {
+
+  /**
+   * Looks up a request in the cache, failing with the unit value if the
+   * request is not in the cache, succeeding with `Ref(None)` if the request is
+   * in the cache but has not been executed yet, or `Ref(Some(value))` if the
+   * request has been executed.
+   */
+  def get[E, A](request: Request[E, A]): IO[Unit, Ref[Option[Either[E, A]]]]
+
+  /**
+   * Inserts a request and a `Ref` that will contain the result of the request
+   * when it is executed into the cache.
+   */
+  def put[E, A](request: Request[E, A], result: Ref[Option[Either[E, A]]]): UIO[Unit]
+
+  /**
+   * Looks up a request in the cache. If the request is not in the cache
+   * returns a result that is blocked on the request. If the request is in the
+   * cache but has not been executed yet returns a result that is blocked on
+   * the previous request. If the request has been executed returns a result
+   * that is done.
+   */
+  private[query] def getOrElseUpdate[R, E, A, B](request: A, dataSource: DataSource[R, A])(
+    implicit ev: A <:< Request[E, B]
+  ): UIO[Result[R, E, B]]
+}
+
+object Cache {
+
+  /**
+   * Constructs an empty cache.
+   */
+  val empty: UIO[Cache] =
+    Ref.make(Map.empty[Any, Any]).map(new Impl(_))
+
+  private final class Impl(private val state: Ref[Map[Any, Any]]) extends Cache {
+
+    def get[E, A](request: Request[E, A]): IO[Unit, Ref[Option[Either[E, A]]]] =
+      state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]]).get.orElseFail(())
+
+    def put[E, A](request: Request[E, A], result: Ref[Option[Either[E, A]]]): UIO[Unit] =
+      state.update(_ + (request -> result)).unit
+
+    private[query] def getOrElseUpdate[R, E, A, B](request: A, dataSource: DataSource[R, A])(
+      implicit ev: A <:< Request[E, B]
+    ): UIO[Result[R, E, B]] =
+      Ref.make(Option.empty[Either[E, B]]).flatMap { ref =>
+        state.modify { map =>
+          map.get(request) match {
+            case None      => (Left(ref), map + (request -> ref))
+            case Some(ref) => (Right(ref.asInstanceOf[Ref[Option[Either[E, B]]]]), map)
+          }
+        }.flatMap {
+          case Left(ref) =>
+            UIO.succeedNow(
+              Result.blocked(
+                BlockedRequests.single(dataSource, BlockedRequest(request, ref)),
+                Continue(request, dataSource, ref)
+              )
+            )
+          case Right(ref) =>
+            ref.get.map {
+              case None    => Result.blocked(BlockedRequests.empty, Continue(request, dataSource, ref))
+              case Some(b) => Result.fromEither(b)
+            }
+        }
+      }
+  }
+}

--- a/core/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/core/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -1,0 +1,47 @@
+package zio.query
+
+/**
+ * A `CompletedRequestMap` is a universally quantified mapping from requests
+ * of type `Request[E, A]` to results of type `Either[E, A[` for all types `E`
+ * and `A`. The guarantee is that for any request of type `Request[E, A]`, if
+ * there is a corresponding value in the map, that value is of type
+ * `Either[E, A]`. This is used by the library to support data sources that
+ * return different result types for different requests while guaranteeing that
+ * results will be of the type requested.
+ */
+final class CompletedRequestMap private (private val map: Map[Any, Either[Any, Any]]) { self =>
+
+  def ++(that: CompletedRequestMap): CompletedRequestMap =
+    new CompletedRequestMap(self.map ++ that.map)
+
+  /**
+   * Appends the specified result to the completed requests map.
+   */
+  def insert[E, A](request: Request[E, A])(result: Either[E, A]): CompletedRequestMap =
+    new CompletedRequestMap(self.map + (request -> result))
+
+  /**
+   * Appends the specified optional result to the completed request map.
+   */
+  def insertOption[E, A](request: Request[E, A])(result: Either[E, Option[A]]): CompletedRequestMap =
+    result match {
+      case Left(e)        => insert(request)(Left(e))
+      case Right(Some(a)) => insert(request)(Right(a))
+      case Right(None)    => self
+    }
+
+  /**
+   * Retrieves the result of the specified request if it exists.
+   */
+  def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =
+    map.get(request).asInstanceOf[Option[Either[E, A]]]
+}
+
+object CompletedRequestMap {
+
+  /**
+   * An empty completed requests map.
+   */
+  val empty: CompletedRequestMap =
+    new CompletedRequestMap(Map.empty)
+}

--- a/core/shared/src/main/scala/zio/query/DataSource.scala
+++ b/core/shared/src/main/scala/zio/query/DataSource.scala
@@ -1,0 +1,341 @@
+package zio.query
+
+import zio.{ Chunk, NeedsEnv, ZIO }
+
+/**
+ * A `DataSource[R, A]` requires an environment `R` and is capable of executing
+ * requests of type `A`.
+ *
+ * Data sources must implement the method `runAll` which takes a collection of
+ * requests and returns an effect with a `CompletedRequestMap` containing a
+ * mapping from requests to results. The type of the collection of requests is
+ * a `Chunk[Chunk[A]]`. The outer `Chunk` represents batches of requests that
+ * must be performed sequentially. The inner `Chunk` represents a batch of
+ * requests that can be performed in parallel. This allows data sources to
+ * introspect on all the requests being executed and optimize the query.
+ *
+ * Data sources will typically be parameterized on a subtype of `Request[A]`,
+ * though that is not strictly necessarily as long as the data source can map
+ * the request type to a `Request[A]`. Data sources can then pattern match on
+ * the collection of requests to determine the information requested, execute
+ * the query, and place the results into the `CompletedRequestsMap` using
+ * [[CompletedRequestMap.empty]] and [[CompletedRequestMap.insert]]. Data
+ * sources must provide results for all requests received. Failure to do so
+ * will cause a query to die with a `QueryFailure` when run.
+ */
+trait DataSource[-R, -A] { self =>
+
+  /**
+   * The data source's identifier.
+   */
+  val identifier: String
+
+  /**
+   * Execute a collection of requests. The outer `Chunk` represents batches
+   * of requests that must be performed sequentially. The inner `Chunk`
+   * represents a batch of requests that can be performed in parallel.
+   */
+  def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap]
+
+  /**
+   * Returns a data source that executes at most `n` requests in parallel.
+   */
+  def batchN(n: Int): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier = s"${self}.batchN($n)"
+      def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+        if (n < 1)
+          ZIO.die(new IllegalArgumentException("batchN: n must be at least 1"))
+        else
+          self.runAll(requests.foldLeft[Chunk[Chunk[A]]](Chunk.empty)(_ ++ _.grouped(n)))
+    }
+
+  /**
+   * Returns a new data source that executes requests of type `B` using the
+   * specified function to transform `B` requests into requests that this data
+   * source can execute.
+   */
+  final def contramap[B](f: Described[B => A]): DataSource[R, B] =
+    new DataSource[R, B] {
+      val identifier = s"${self.identifier}.contramap(${f.description})"
+      def runAll(requests: Chunk[Chunk[B]]): ZIO[R, Nothing, CompletedRequestMap] =
+        self.runAll(requests.map(_.map(f.value)))
+    }
+
+  /**
+   * Returns a new data source that executes requests of type `B` using the
+   * specified effectual function to transform `B` requests into requests that
+   * this data source can execute.
+   */
+  final def contramapM[R1 <: R, B](f: Described[B => ZIO[R1, Nothing, A]]): DataSource[R1, B] =
+    new DataSource[R1, B] {
+      val identifier = s"${self.identifier}.contramapM(${f.description})"
+      def runAll(requests: Chunk[Chunk[B]]): ZIO[R1, Nothing, CompletedRequestMap] =
+        ZIO.foreach(requests)(ZIO.foreachPar(_)(f.value)).flatMap(self.runAll)
+    }
+
+  /**
+   * Returns a new data source that executes requests of type `C` using the
+   * specified function to transform `C` requests into requests that either
+   * this data source or that data source can execute.
+   */
+  final def eitherWith[R1 <: R, B, C](
+    that: DataSource[R1, B]
+  )(f: Described[C => Either[A, B]]): DataSource[R1, C] =
+    new DataSource[R1, C] {
+      val identifier = s"${self.identifier}.eitherWith(${that.identifier})(${f.description})"
+      def runAll(requests: Chunk[Chunk[C]]): ZIO[R1, Nothing, CompletedRequestMap] =
+        ZIO
+          .foreach(requests) { requests =>
+            val (as, bs) = requests.partitionMap(f.value)
+            self.runAll(Chunk(as)).zipWithPar(that.runAll(Chunk(bs)))(_ ++ _)
+          }
+          .map(_.foldLeft(CompletedRequestMap.empty)(_ ++ _))
+
+    }
+
+  override final def equals(that: Any): Boolean =
+    that match {
+      case that: DataSource[_, _] => this.identifier == that.identifier
+    }
+
+  override final def hashCode: Int =
+    identifier.hashCode
+
+  /**
+   * Provides this data source with its required environment.
+   */
+  final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): DataSource[Any, A] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
+
+  /**
+   * Provides this data source with part of its required environment.
+   */
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): DataSource[R0, A] =
+    new DataSource[R0, A] {
+      val identifier = s"${self.identifier}.provideSome(${f.description})"
+      def runAll(requests: Chunk[Chunk[A]]): ZIO[R0, Nothing, CompletedRequestMap] =
+        self.runAll(requests).provideSome(f.value)
+    }
+
+  /**
+   * Returns a new data source that executes requests by sending them to this
+   * data source and that data source, returning the results from the first
+   * data source to complete and safely interrupting the loser.
+   */
+  final def race[R1 <: R, A1 <: A](that: DataSource[R1, A1]): DataSource[R1, A1] =
+    new DataSource[R1, A1] {
+      val identifier = s"${self.identifier}.race(${that.identifier})"
+      def runAll(requests: Chunk[Chunk[A1]]): ZIO[R1, Nothing, CompletedRequestMap] =
+        self.runAll(requests).race(that.runAll(requests))
+    }
+
+  override final def toString: String =
+    identifier
+}
+
+object DataSource {
+
+  /**
+   * A data source that executes requests that can be performed in parallel in
+   * batches but does not further optimize batches of requests that must be
+   * performed sequentially.
+   */
+  trait Batched[-R, -A] extends DataSource[R, A] {
+    def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap]
+    final def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+      ZIO.foreach(requests)(run).map(_.foldLeft(CompletedRequestMap.empty)(_ ++ _))
+  }
+
+  object Batched {
+
+    /**
+     * Constructs a data source from a function taking a collection of requests
+     * and returning a `CompletedRequestMap`.
+     */
+    def make[R, A](name: String)(f: Chunk[A] => ZIO[R, Nothing, CompletedRequestMap]): DataSource[R, A] =
+      new DataSource.Batched[R, A] {
+        val identifier: String = name
+        def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+          f(requests)
+      }
+  }
+
+  /**
+   * Constructs a data source from a pure function.
+   */
+  def fromFunction[A, B](
+    name: String
+  )(f: A => B)(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    new DataSource.Batched[Any, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[Any, Nothing, CompletedRequestMap] =
+        ZIO.succeedNow(requests.foldLeft(CompletedRequestMap.empty)((map, k) => map.insert(k)(Right(f(k)))))
+    }
+
+  /**
+   * Constructs a data source from a pure function that takes a list of
+   * requests and returns a list of results of the same size. Each item in the
+   * result list must correspond to the item at the same index in the request
+   * list.
+   */
+  def fromFunctionBatched[A, B](
+    name: String
+  )(f: Chunk[A] => Chunk[B])(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    fromFunctionBatchedM(name)(as => ZIO.succeedNow(f(as)))
+
+  /**
+   * Constructs a data source from an effectual function that takes a list of
+   * requests and returns a list of results of the same size. Each item in the
+   * result list must correspond to the item at the same index in the request
+   * list.
+   */
+  def fromFunctionBatchedM[R, E, A, B](
+    name: String
+  )(f: Chunk[A] => ZIO[R, E, Chunk[B]])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource.Batched[R, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests)
+          .fold(
+            e => requests.map((_, Left(e))),
+            bs => requests.zip(bs.map(Right(_)))
+          )
+          .map(_.foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insert(k)(v)
+          })
+    }
+
+  /**
+   * Constructs a data source from a pure function that takes a list of
+   * requests and returns a list of optional results of the same size. Each
+   * item in the result list must correspond to the item at the same index in
+   * the request list.
+   */
+  def fromFunctionBatchedOption[A, B](
+    name: String
+  )(f: Chunk[A] => Chunk[Option[B]])(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    fromFunctionBatchedOptionM(name)(as => ZIO.succeedNow(f(as)))
+
+  /**
+   * Constructs a data source from an effectual function that takes a list of
+   * requests and returns a list of optional results of the same size. Each
+   * item in the result list must correspond to the item at the same index in
+   * the request list.
+   */
+  def fromFunctionBatchedOptionM[R, E, A, B](
+    name: String
+  )(f: Chunk[A] => ZIO[R, E, Chunk[Option[B]]])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource.Batched[R, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests)
+          .fold(
+            e => requests.map((_, Left(e))),
+            bs => requests.zip(bs.map(Right(_)))
+          )
+          .map(_.foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insertOption(k)(v)
+          })
+    }
+
+  /**
+   * Constructs a data source from a function that takes a list of requests and
+   * returns a list of results of the same size. Uses the specified function to
+   * associate each result with the corresponding effect, allowing the function
+   * to return the list of results in a different order than the list of
+   * requests.
+   */
+  def fromFunctionBatchedWith[A, B](
+    name: String
+  )(f: Chunk[A] => Chunk[B], g: B => Request[Nothing, B])(
+    implicit ev: A <:< Request[Nothing, B]
+  ): DataSource[Any, A] =
+    fromFunctionBatchedWithM(name)(as => ZIO.succeedNow(f(as)), g)
+
+  /**
+   * Constructs a data source from an effectual function that takes a list of
+   * requests and returns a list of results of the same size. Uses the
+   * specified function to associate each result with the corresponding effect,
+   * allowing the function to return the list of results in a different order
+   * than the list of requests.
+   */
+  def fromFunctionBatchedWithM[R, E, A, B](
+    name: String
+  )(f: Chunk[A] => ZIO[R, E, Chunk[B]], g: B => Request[E, B])(
+    implicit ev: A <:< Request[E, B]
+  ): DataSource[R, A] =
+    new DataSource.Batched[R, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests)
+          .fold(
+            e => requests.map(a => (ev(a), Left(e))),
+            bs => bs.map(b => (g(b), Right(b)))
+          )
+          .map(_.foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insert(k)(v)
+          })
+    }
+
+  /**
+   * Constructs a data source from an effectual function.
+   */
+  def fromFunctionM[R, E, A, B](
+    name: String
+  )(f: A => ZIO[R, E, B])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource.Batched[R, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        ZIO
+          .foreachPar(requests)(a => f(a).either.map((a, _)))
+          .map(_.foldLeft(CompletedRequestMap.empty) { case (map, (k, v)) => map.insert(k)(v) })
+    }
+
+  /**
+   * Constructs a data source from a pure function that may not provide results
+   * for all requests received.
+   */
+  def fromFunctionOption[A, B](
+    name: String
+  )(f: A => Option[B])(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    fromFunctionOptionM(name)(a => ZIO.succeedNow(f(a)))
+
+  /**
+   * Constructs a data source from an effectual function that may not provide
+   * results for all requests received.
+   */
+  def fromFunctionOptionM[R, E, A, B](
+    name: String
+  )(f: A => ZIO[R, E, Option[B]])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource.Batched[R, A] {
+      val identifier: String = name
+      def run(requests: Chunk[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        ZIO
+          .foreachPar(requests)(a => f(a).either.map((a, _)))
+          .map(_.foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insertOption(k)(v)
+          })
+    }
+
+  /**
+   * Constructs a data source from a function taking a collection of requests
+   * and returning a `CompletedRequestMap`.
+   */
+  def make[R, A](name: String)(f: Chunk[Chunk[A]] => ZIO[R, Nothing, CompletedRequestMap]): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier: String = name
+      def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests)
+    }
+
+  /**
+   * A data source that never executes requests.
+   */
+  val never: DataSource[Any, Any] =
+    new DataSource[Any, Any] {
+      val identifier = "never"
+      def runAll(requests: Chunk[Chunk[Any]]): ZIO[Any, Nothing, CompletedRequestMap] =
+        ZIO.never
+    }
+}

--- a/core/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/core/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -1,0 +1,61 @@
+package zio.query
+
+import zio.{ Chunk, ZIO }
+
+/**
+ * A `DataSourceAspect` is an aspect that can be weaved into queries. You can
+ * think of an aspect as a polymorphic function, capable of transforming one
+ * data source into another, possibly enlarging the environment type.
+ */
+trait DataSourceAspect[-R] { self =>
+
+  /**
+   * Applies the aspect to a data source.
+   */
+  def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A]
+
+  /**
+   * A symbolic alias for `andThen`.
+   */
+  final def >>>[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
+    andThen(that)
+
+  /**
+   * Returns a new aspect that represents the sequential composition of this
+   * aspect with the specified one.
+   */
+  final def andThen[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
+    new DataSourceAspect[R1] {
+      def apply[R2 <: R1, A](dataSource: DataSource[R2, A]): DataSource[R2, A] =
+        that(self(dataSource))
+    }
+}
+
+object DataSourceAspect {
+
+  /**
+   * A data source aspect that executes requests between two effects, `before`
+   * and `after`, where the result of `before` can be used by `after`.
+   */
+  def around[R, A](
+    before: Described[ZIO[R, Nothing, A]]
+  )(after: Described[A => ZIO[R, Nothing, Any]]): DataSourceAspect[R] =
+    new DataSourceAspect[R] {
+      def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A] =
+        new DataSource[R, A] {
+          val identifier = s"${dataSource.identifier} @@ around(${before.description})(${after.description})"
+          def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+            before.value.bracket(after.value)(_ => runAll(requests))
+        }
+    }
+
+  /**
+   * A data source aspect that limits data sources to executing at most `n`
+   * requests in parallel.
+   */
+  def maxBatchSize(n: Int): DataSourceAspect[Any] =
+    new DataSourceAspect[Any] {
+      def apply[R, A](dataSource: DataSource[R, A]): DataSource[R, A] =
+        dataSource.batchN(n)
+    }
+}

--- a/core/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/core/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -1,6 +1,6 @@
 package zio.query
 
-import zio.{ Chunk, ZIO }
+import zio.ZIO
 
 /**
  * A `DataSourceAspect` is an aspect that can be weaved into queries. You can
@@ -44,7 +44,7 @@ object DataSourceAspect {
       def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A] =
         new DataSource[R, A] {
           val identifier = s"${dataSource.identifier} @@ around(${before.description})(${after.description})"
-          def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+          def runAll(requests: Vector[Vector[A]]): ZIO[R, Nothing, CompletedRequestMap] =
             before.value.bracket(after.value)(_ => runAll(requests))
         }
     }

--- a/core/shared/src/main/scala/zio/query/Described.scala
+++ b/core/shared/src/main/scala/zio/query/Described.scala
@@ -1,0 +1,17 @@
+package zio.query
+
+/**
+ * A `Described[A]` is a value of type `A` along with a string description of
+ * that value. The description may be used to generate a hash associated with
+ * the value, so values that are equal should have the same description and
+ * values that are not equal should have different descriptions.
+ */
+final case class Described[+A](value: A, description: String)
+
+object Described {
+
+  implicit class AnySyntax[A](private val value: A) extends AnyVal {
+    def ?(description: String): Described[A] =
+      Described(value, description)
+  }
+}

--- a/core/shared/src/main/scala/zio/query/QueryFailure.scala
+++ b/core/shared/src/main/scala/zio/query/QueryFailure.scala
@@ -1,0 +1,10 @@
+package zio.query
+
+/**
+ * `QueryFailure` keeps track of details relevant to query failures.
+ */
+final case class QueryFailure(dataSource: DataSource[Nothing, Nothing], request: Request[Any, Any])
+    extends Throwable(null, null, true, false) {
+  override def getMessage: String =
+    s"Data source ${dataSource.identifier} did not complete request ${request.toString}."
+}

--- a/core/shared/src/main/scala/zio/query/Request.scala
+++ b/core/shared/src/main/scala/zio/query/Request.scala
@@ -1,0 +1,15 @@
+package zio.query
+
+/**
+ * A `Request[E, A]` is a request from a data source for a value of type `A`
+ * that may fail with an `E`.
+ *
+ * {{{
+ * sealed trait UserRequest[+A] extends Request[Nothing, A]
+ *
+ * case object GetAllIds                 extends UserRequest[List[Int]]
+ * final case class GetNameById(id: Int) extends UserRequest[String]
+ *
+ * }}}
+ */
+trait Request[+E, +A]

--- a/core/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/core/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1,0 +1,566 @@
+package zio.query
+
+import zio._
+import zio.clock._
+import zio.duration._
+import zio.query.internal._
+
+/**
+ * A `ZQuery[R, E, A]` is a purely functional description of an effectual query
+ * that may contain requests from one or more data sources, requires an
+ * environment `R`, and may fail with an `E` or succeed with an `A`.
+ *
+ * Requests that can be performed in parallel, as expressed by `zipWithPar` and
+ * combinators derived from it, will automatically be batched. Requests that
+ * must be performed sequentially, as expressed by `zipWith` and combinators
+ * derived from it, will automatically be pipelined. This allows for aggressive
+ * data source specific optimizations. Requests can also be deduplicated and
+ * cached.
+ *
+ * This allows for writing queries in a high level, compositional style, with
+ * confidence that they will automatically be optimized. For example, consider
+ * the following query from a user service.
+ *
+ * {{{
+ * val getAllUserIds: ZQuery[Any, Nothing, List[Int]]         = ???
+ * def getUserNameById(id: Int): ZQuery[Any, Nothing, String] = ???
+ *
+ * for {
+ *   userIds   <- getAllUserIds
+ *   userNames <- ZQuery.foreachPar(userIds)(getUserNameById)
+ * } yield userNames
+ * }}}
+ *
+ * This would normally require N + 1 queries, one for `getAllUserIds` and one
+ * for each call to `getUserNameById`. In contrast, `ZQuery` will automatically
+ * optimize this to two queries, one for `userIds` and one for `userNames`,
+ * assuming an implementation of the user service that supports batching.
+ *
+ * Based on "There is no Fork: an Abstraction for Efficient, Concurrent, and
+ * Concise Data Access" by Simon Marlow, Louis Brandy, Jonathan Coens, and Jon
+ * Purdy. [[http://simonmar.github.io/bib/papers/haxl-icfp14.pdf]]
+ */
+final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, QueryContext), Nothing, Result[R, E, A]]) { self =>
+
+  /**
+   * Syntax for adding aspects.
+   */
+  final def @@[R1 <: R](aspect: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+    mapDataSources(aspect)
+
+  /**
+   * A symbolic alias for `zipParRight`.
+   */
+  final def &>[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    zipParRight(that)
+
+  /**
+   * A symbolic alias for `zipRight`.
+   */
+  final def *>[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    zipRight(that)
+
+  /**
+   * A symbolic alias for `zipParLeft`.
+   */
+  final def <&[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, A] =
+    zipParLeft(that)
+
+  /**
+   * A symbolic alias for `zipPar`.
+   */
+  final def <&>[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, (A, B)] =
+    zipPar(that)
+
+  /**
+   * A symbolic alias for `zipLeft`.
+   */
+  final def <*[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, A] =
+    zipLeft(that)
+
+  /**
+   * A symbolic alias for `zip`.
+   */
+  final def <*>[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, (A, B)] =
+    zip(that)
+
+  /**
+   * A symbolic alias for `flatMap`.
+   */
+  final def >>=[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    flatMap(f)
+
+  /**
+   * Maps the success value of this query to the specified constant value.
+   */
+  final def as[B](b: => B): ZQuery[R, E, B] =
+    map(_ => b)
+
+  /**
+   * Returns a query whose failure and success channels have been mapped by the
+   * specified pair of functions, `f` and `g`.
+   */
+  final def bimap[E1, B](f: E => E1, g: A => B)(implicit ev: CanFail[E]): ZQuery[R, E1, B] =
+    foldM(e => ZQuery.fail(f(e)), a => ZQuery.succeed(g(a)))
+
+  /**
+   * Returns a query whose failure and success have been lifted into an
+   * `Either`. The resulting query cannot fail, because the failure case has
+   * been exposed as part of the `Either` success case.
+   */
+  final def either(implicit ev: CanFail[E]): ZQuery[R, Nothing, Either[E, A]] =
+    fold(Left(_), Right(_))
+
+  /**
+   * Returns a query that models execution of this query, followed by passing
+   * its result to the specified function that returns a query. Requests
+   * composed with `flatMap` or combinators derived from it will be executed
+   * sequentially and will not be pipelined, though deduplication and caching of
+   * requests may still be applied.
+   */
+  final def flatMap[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    ZQuery {
+      step.flatMap {
+        case Result.Blocked(br, c) => ZIO.succeedNow(Result.blocked(br, c.mapM(f)))
+        case Result.Done(a)        => f(a).step
+        case Result.Fail(e)        => ZIO.succeedNow(Result.fail(e))
+      }
+    }
+
+  /**
+   * Folds over the failed or successful result of this query to yield a query
+   * that does not fail, but succeeds with the value returned by the left or
+   * right function passed to `fold`.
+   */
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZQuery[R, Nothing, B] =
+    foldM(e => ZQuery.succeed(failure(e)), a => ZQuery.succeed(success(a)))
+
+  /**
+   * A more powerful version of `foldM` that allows recovering from any type
+   * of failure except interruptions.
+   */
+  final def foldCauseM[R1 <: R, E1, B](
+    failure: Cause[E] => ZQuery[R1, E1, B],
+    success: A => ZQuery[R1, E1, B]
+  ): ZQuery[R1, E1, B] =
+    ZQuery {
+      step.foldCauseM(
+        failure(_).step, {
+          case Result.Blocked(br, c) => ZIO.succeedNow(Result.blocked(br, c.foldCauseM(failure, success)))
+          case Result.Done(a)        => success(a).step
+          case Result.Fail(e)        => failure(e).step
+        }
+      )
+    }
+
+  /**
+   * Recovers from errors by accepting one query to execute for the case of an
+   * error, and one query to execute for the case of success.
+   */
+  final def foldM[R1 <: R, E1, B](failure: E => ZQuery[R1, E1, B], success: A => ZQuery[R1, E1, B])(
+    implicit ev: CanFail[E]
+  ): ZQuery[R1, E1, B] =
+    foldCauseM(_.failureOrCause.fold(failure, ZQuery.halt(_)), success)
+
+  /**
+   * Maps the specified function over the successful result of this query.
+   */
+  final def map[B](f: A => B): ZQuery[R, E, B] =
+    ZQuery(step.map(_.map(f)))
+
+  /**
+   * Transforms all data sources with the specified data source aspect.
+   */
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+    ZQuery(step.map(_.mapDataSources(f)))
+
+  /**
+   * Maps the specified function over the failed result of this query.
+   */
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZQuery[R, E1, A] =
+    bimap(f, identity)
+
+  /**
+   * Converts this query to one that returns `Some` if data sources return
+   * results for all requests received and `None` otherwise.
+   */
+  final def optional: ZQuery[R, E, Option[A]] =
+    foldCauseM(
+      _.stripSomeDefects { case _: QueryFailure => () }.fold[ZQuery[R, E, Option[A]]](ZQuery.none)(ZQuery.halt(_)),
+      ZQuery.some(_)
+    )
+
+  /**
+   * Converts this query to one that dies if a query failure occurs.
+   */
+  final def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZQuery[R, Nothing, A] =
+    orDieWith(ev1)
+
+  /**
+   * Converts this query to one that dies if a query failure occurs, using the
+   * specified function to map the error to a `Throwable`.
+   */
+  final def orDieWith(f: E => Throwable)(implicit ev: CanFail[E]): ZQuery[R, Nothing, A] =
+    foldM(e => ZQuery.die(f(e)), a => ZQuery.succeed(a))
+
+  /**
+   * Provides this query with its required environment.
+   */
+  final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): ZQuery[Any, E, A] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
+
+  /**
+   * Provides the part of the environment that is not part of the `ZEnv`,
+   * leaving a query that only depends on the `ZEnv`.
+   */
+  final def provideCustomLayer[E1 >: E, R1 <: Has[_]](
+    layer: Described[ZLayer[ZEnv, E1, R1]]
+  )(implicit ev: ZEnv with R1 <:< R, tag: Tag[R1]): ZQuery[ZEnv, E1, A] =
+    provideSomeLayer(layer)
+
+  /**
+   * Provides a layer to this query, which translates it to another level.
+   */
+  final def provideLayer[E1 >: E, R0, R1 <: Has[_]](
+    layer: Described[ZLayer[R0, E1, R1]]
+  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZQuery[R0, E1, A] =
+    ZQuery {
+      layer.value.build.provideSome[(R0, QueryContext)](_._1).run.use {
+        case Exit.Failure(e) => ZIO.succeedNow(Result.fail(e))
+        case Exit.Success(r) => self.provide(Described(r, layer.description)).step
+      }
+    }
+
+  /**
+   * Provides this query with part of its required environment.
+   */
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): ZQuery[R0, E, A] =
+    ZQuery(step.map(_.provideSome(f)).provideSome(r => (f.value(r._1), r._2)))
+
+  /**
+   * Splits the environment into two parts, providing one part using the
+   * specified layer and leaving the remainder `R0`.
+   */
+  final def provideSomeLayer[R0 <: Has[_]]: ZQuery.ProvideSomeLayer[R0, R, E, A] =
+    new ZQuery.ProvideSomeLayer(self)
+
+  /**
+   * Returns an effect that models executing this query.
+   */
+  final val run: ZIO[R, E, A] =
+    runLog.map(_._2)
+
+  /**
+   * Returns an effect that models executing this query with the specified
+   * cache.
+   */
+  final def runCache(cache: Cache): ZIO[R, E, A] =
+    step.provideSome[R]((_, QueryContext(cache))).flatMap {
+      case Result.Blocked(br, c) => br.run *> c.runCache(cache)
+      case Result.Done(a)        => ZIO.succeedNow(a)
+      case Result.Fail(e)        => ZIO.halt(e)
+    }
+
+  /**
+   * Returns an effect that models executing this query, returning the query
+   * result along with the cache.
+   */
+  final def runLog: ZIO[R, E, (Cache, A)] =
+    for {
+      cache <- Cache.empty
+      a     <- runCache(cache)
+    } yield (cache, a)
+
+  /**
+   * Summarizes a query by computing some value before and after execution,
+   * and then combining the values to produce a summary, together with the
+   * result of execution.
+   */
+  final def summarized[R1 <: R, E1 >: E, B, C](summary: ZIO[R1, E1, B])(f: (B, B) => C): ZQuery[R1, E1, (C, A)] =
+    for {
+      start <- ZQuery.fromEffect(summary)
+      value <- self
+      end   <- ZQuery.fromEffect(summary)
+    } yield (f(start, end), value)
+
+  /**
+   * Returns a new query that executes this one and times the execution.
+   */
+  final def timed: ZQuery[R with Clock, E, (Duration, A)] =
+    summarized(clock.nanoTime)((start, end) => Duration.fromNanos(end - start))
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query sequentially, combining their results into a tuple.
+   */
+  final def zip[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, (A, B)] =
+    zipWith(that)((_, _))
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query sequentially, returning the result of this query.
+   */
+  final def zipLeft[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, A] =
+    zipWith(that)((a, _) => a)
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query in parallel, combining their results into a tuple.
+   */
+  final def zipPar[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, (A, B)] =
+    zipWithPar(that)((_, _))
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query in parallel, returning the result of this query.
+   */
+  final def zipParLeft[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, A] =
+    zipWithPar(that)((a, _) => a)
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query in parallel, returning the result of the specified query.
+   */
+  final def zipParRight[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    zipWithPar(that)((_, b) => b)
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query sequentially, returning the result of the specified query.
+   */
+  final def zipRight[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
+    zipWith(that)((_, b) => b)
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query sequentially, combining their results with the specified function.
+   * Requests composed with `zipWith` or combinators derived from it will
+   * automatically be pipelined.
+   */
+  final def zipWith[R1 <: R, E1 >: E, B, C](that: ZQuery[R1, E1, B])(f: (A, B) => C): ZQuery[R1, E1, C] =
+    ZQuery {
+      self.step.flatMap {
+        case Result.Blocked(br, Continue.Effect(c)) =>
+          ZIO.succeedNow(Result.blocked(br, Continue.effect(c.zipWith(that)(f))))
+        case Result.Blocked(br1, c1) =>
+          that.step.map {
+            case Result.Blocked(br2, c2) => Result.blocked(br1 ++ br2, c1.zipWith(c2)(f))
+            case Result.Done(b)          => Result.blocked(br1, c1.map(a => f(a, b)))
+            case Result.Fail(e)          => Result.fail(e)
+          }
+        case Result.Done(a) =>
+          that.step.map {
+            case Result.Blocked(br, c) => Result.blocked(br, c.map(b => f(a, b)))
+            case Result.Done(b)        => Result.done(f(a, b))
+            case Result.Fail(e)        => Result.fail(e)
+          }
+        case Result.Fail(e) => ZIO.succeedNow(Result.fail(e))
+      }
+    }
+
+  /**
+   * Returns a query that models the execution of this query and the specified
+   * query in parallel, combining their results with the specified function.
+   * Requests composed with `zipWithPar` or combinators derived from it will
+   * automatically be batched.
+   */
+  final def zipWithPar[R1 <: R, E1 >: E, B, C](that: ZQuery[R1, E1, B])(f: (A, B) => C): ZQuery[R1, E1, C] =
+    ZQuery {
+      self.step.zipWithPar(that.step) {
+        case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 && br2, c1.zipWithPar(c2)(f))
+        case (Result.Blocked(br, c), Result.Done(b))            => Result.blocked(br, c.map(a => f(a, b)))
+        case (Result.Done(a), Result.Blocked(br, c))            => Result.blocked(br, c.map(b => f(a, b)))
+        case (Result.Done(a), Result.Done(b))                   => Result.done(f(a, b))
+        case (Result.Fail(e1), Result.Fail(e2))                 => Result.fail(Cause.Both(e1, e2))
+        case (Result.Fail(e), _)                                => Result.fail(e)
+        case (_, Result.Fail(e))                                => Result.fail(e)
+      }
+    }
+}
+
+object ZQuery {
+
+  /**
+   * Accesses the environment of the effect.
+   * {{{
+   * val portNumber = effect.access(_.config.portNumber)
+   * }}}
+   */
+  final def access[R]: AccessPartiallyApplied[R] =
+    new AccessPartiallyApplied[R]
+
+  /**
+   * Effectfully accesses the environment of the effect.
+   */
+  final def accessM[R]: AccessMPartiallyApplied[R] =
+    new AccessMPartiallyApplied[R]
+
+  /**
+   * Collects a collection of queries into a query returning a collection of
+   * their results. Requests will be executed sequentially and will be
+   * pipelined.
+   */
+  def collectAll[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
+    foreach(as)(identity)
+
+  /**
+   * Collects a collection of queries into a query returning a collection of
+   * their results. Requests will be executed in parallel and will be batched.
+   */
+  def collectAllPar[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
+    foreachPar(as)(identity)
+
+  /**
+   * Constructs a query that dies with the specified error.
+   */
+  def die(t: => Throwable): ZQuery[Any, Nothing, Nothing] =
+    ZQuery(ZIO.die(t))
+
+  /**
+   * Accesses the whole environment of the query.
+   */
+  def environment[R]: ZQuery[R, Nothing, R] =
+    ZQuery.fromEffect(ZIO.environment)
+
+  /**
+   * Constructs a query that fails with the specified error.
+   */
+  def fail[E](error: => E): ZQuery[Any, E, Nothing] =
+    ZQuery(ZIO.succeed(Result.fail(Cause.fail(error))))
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a query returning a collection of their results. Requests will be
+   * executed sequentially and will be pipelined.
+   */
+  def foreach[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
+    as.foldRight[ZQuery[R, E, List[B]]](ZQuery.succeed(Nil))((a, bs) => f(a).zipWith(bs)(_ :: _))
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a query returning a collection of their results. Requests will be
+   * executed in parallel and will be batched.
+   */
+  def foreachPar[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
+    as.foldRight[ZQuery[R, E, List[B]]](ZQuery.succeed(Nil))((a, bs) => f(a).zipWithPar(bs)(_ :: _))
+
+  /**
+   * Constructs a query from an effect.
+   */
+  def fromEffect[R, E, A](effect: ZIO[R, E, A]): ZQuery[R, E, A] =
+    ZQuery(effect.foldCause(Result.fail, Result.done).provideSome(_._1))
+
+  /**
+   * Constructs a query from a request and a data source. Queries will die with
+   * a `QueryFailure` when run if the data source does not provide results for
+   * all requests received. Queries must be constructed with `fromRequest` or
+   * one of its variants for optimizations to be applied.
+   */
+  def fromRequest[R, E, A, B](
+    request: A
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
+    ZQuery(ZIO.accessM(_._2.cache.getOrElseUpdate(request, dataSource)))
+
+  /**
+   * Constructs a query from a request and a data source but does not apply
+   * caching to the query.
+   */
+  def fromRequestUncached[R, E, A, B](
+    request: A
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
+    ZQuery {
+      Ref.make(Option.empty[Either[E, B]]).map { ref =>
+        Result.blocked(
+          BlockedRequests.single(dataSource, BlockedRequest(request, ref)),
+          Continue(request, dataSource, ref)
+        )
+      }
+    }
+
+  /**
+   * Constructs a query that fails with the specified cause.
+   */
+  def halt[E](cause: => Cause[E]): ZQuery[Any, E, Nothing] =
+    ZQuery(ZIO.succeed(Result.fail(cause)))
+
+  /**
+   * Constructs a query that never completes.
+   */
+  val never: ZQuery[Any, Nothing, Nothing] =
+    ZQuery.fromEffect(ZIO.never)
+
+  /**
+   * Constructs a query that succeds with the empty value.
+   */
+  val none: ZQuery[Any, Nothing, Option[Nothing]] =
+    succeed(None)
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a collection of failed results and a collection of successful
+   * results. Requests will be executed sequentially and will be pipelined.
+   */
+  def partitionM[R, E, A, B](
+    as: Iterable[A]
+  )(f: A => ZQuery[R, E, B])(implicit ev: CanFail[E]): ZQuery[R, Nothing, (List[E], List[B])] =
+    ZQuery.foreach(as)(f(_).either).map(partitionMap(_)(identity))
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a collection of failed results and a collection of successful
+   * results. Requests will be executed in parallel and will be batched.
+   */
+  def partitionMPar[R, E, A, B](
+    as: Iterable[A]
+  )(f: A => ZQuery[R, E, B])(implicit ev: CanFail[E]): ZQuery[R, Nothing, (List[E], List[B])] =
+    ZQuery.foreachPar(as)(f(_).either).map(partitionMap(_)(identity))
+
+  /**
+   * Constructs a query that succeeds with the optional value.
+   */
+  def some[A](a: => A): ZQuery[Any, Nothing, Option[A]] =
+    succeed(Some(a))
+
+  /**
+   *  Constructs a query that succeeds with the specified value.
+   */
+  def succeed[A](value: => A): ZQuery[Any, Nothing, A] =
+    ZQuery(ZIO.succeed(Result.done(value)))
+
+  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZQuery[R, E, A]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: Described[ZLayer[R0, E1, R1]]
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tag: Tag[R1]): ZQuery[R0, E1, A] =
+      self.provideLayer[E1, R0, R0 with R1](Described(ZLayer.identity[R0] ++ layer.value, layer.description))
+  }
+
+  /**
+   * Constructs a query from an effect that returns a result.
+   */
+  private def apply[R, E, A](step: ZIO[(R, QueryContext), Nothing, Result[R, E, A]]): ZQuery[R, E, A] =
+    new ZQuery(step)
+
+  /**
+   * Partitions the elements of a collection using the specified function.
+   */
+  private def partitionMap[E, A, B](
+    as: Iterable[A]
+  )(f: A => Either[E, B])(implicit ev: CanFail[E]): (List[E], List[B]) =
+    as.foldRight((List.empty[E], List.empty[B])) {
+      case (a, (es, bs)) =>
+        f(a).fold(
+          e => (e :: es, bs),
+          b => (es, b :: bs)
+        )
+    }
+
+  final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[A](f: R => A): ZQuery[R, Nothing, A] =
+      environment[R].map(f)
+  }
+
+  final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: R => ZQuery[R, E, A]): ZQuery[R, E, A] =
+      environment[R].flatMap(f)
+  }
+}

--- a/core/shared/src/main/scala/zio/query/internal/BlockedRequest.scala
+++ b/core/shared/src/main/scala/zio/query/internal/BlockedRequest.scala
@@ -1,0 +1,38 @@
+package zio.query.internal
+
+import zio.Ref
+import zio.query.Request
+
+/**
+ * A `BlockedRequest[A]` keeps track of a request of type `A` along with a
+ * `Ref` containing the result of the request, existentially hiding the result
+ * type. This is used internally by the library to support data sources that
+ * return different result types for different requests while guaranteeing that
+ * results will be of the type requested.
+ */
+private[query] sealed trait BlockedRequest[+A] {
+  type Failure
+  type Success
+
+  def request: Request[Failure, Success]
+
+  def result: Ref[Option[Either[Failure, Success]]]
+
+  override final def toString =
+    s"BlockedRequest($request, $result)"
+}
+
+private[query] object BlockedRequest {
+
+  def apply[E, A, B](request0: A, result0: Ref[Option[Either[E, B]]])(
+    implicit ev: A <:< Request[E, B]
+  ): BlockedRequest[A] =
+    new BlockedRequest[A] {
+      type Failure = E
+      type Success = B
+
+      val request = ev(request0)
+
+      val result = result0
+    }
+}

--- a/core/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/core/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -1,0 +1,181 @@
+package zio.query.internal
+
+import scala.annotation.tailrec
+
+import zio.ZIO
+import zio.query.internal.BlockedRequests._
+import zio.query.{ DataSource, DataSourceAspect, Described }
+
+/**
+ * `BlockedRequests` captures a collection of blocked requests as a data
+ * structure. By doing this the library is able to preserve information about
+ * which requests must be performed sequentially and which can be performed in
+ * parallel, allowing for maximum possible batching and pipelining while
+ * preserving ordering guarantees.
+ */
+private[query] sealed trait BlockedRequests[-R] { self =>
+
+  /**
+   * Combines this collection of blocked requests with the specified collection
+   * of blocked requests, in parallel.
+   */
+  final def &&[R1 <: R](that: BlockedRequests[R1]): BlockedRequests[R1] =
+    Both(self, that)
+
+  /**
+   * Combines this collection of blocked requests with the specified collection
+   * of blocked requests, in sequence.
+   */
+  final def ++[R1 <: R](that: BlockedRequests[R1]): BlockedRequests[R1] =
+    Then(self, that)
+
+  /**
+   * Transforms all data sources with the specified data source aspect, which
+   * can change the environment type of data sources but must preserve the
+   * request type of each data source.
+   */
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): BlockedRequests[R1] =
+    self match {
+      case Empty          => Empty
+      case Both(l, r)     => Both(l.mapDataSources(f), r.mapDataSources(f))
+      case Then(l, r)     => Then(l.mapDataSources(f), r.mapDataSources(f))
+      case Single(ds, br) => Single(f(ds), br)
+    }
+
+  /**
+   * Provides each data source with part of its required environment.
+   */
+  final def provideSome[R0](f: Described[R0 => R]): BlockedRequests[R0] =
+    self match {
+      case Empty          => Empty
+      case Both(l, r)     => Both(l.provideSome(f), r.provideSome(f))
+      case Then(l, r)     => Then(l.provideSome(f), r.provideSome(f))
+      case Single(ds, br) => Single(ds.provideSome(f), br)
+    }
+
+  /**
+   * Executes all requests, submitting requests to each data source in
+   * parallel.
+   */
+  val run: ZIO[R, Nothing, Unit] =
+    ZIO.effectSuspendTotal {
+      ZIO.foreach_(BlockedRequests.flatten(self)) { requestsByDataSource =>
+        ZIO.foreachPar_(requestsByDataSource.toIterable) {
+          case (dataSource, sequential) =>
+            for {
+              completedRequests <- dataSource.runAll(sequential.map(_.map(_.request)))
+              _ <- ZIO.foreach_(sequential) { parallel =>
+                    ZIO.foreach_(parallel) { blockedRequest =>
+                      blockedRequest.result.set(completedRequests.lookup(blockedRequest.request))
+                    }
+                  }
+            } yield ()
+        }
+      }
+    }
+}
+
+private[query] object BlockedRequests {
+
+  /**
+   * The empty collection of blocked requests.
+   */
+  val empty: BlockedRequests[Any] =
+    Empty
+
+  /**
+   * Constructs a collection of blocked requests from the specified blocked
+   * request and data source.
+   */
+  def single[R, K](dataSource: DataSource[R, K], blockedRequest: BlockedRequest[K]): BlockedRequests[R] =
+    Single(dataSource, blockedRequest)
+
+  final case class Both[-R](left: BlockedRequests[R], right: BlockedRequests[R]) extends BlockedRequests[R]
+
+  case object Empty extends BlockedRequests[Any]
+
+  final case class Single[-R, A](dataSource: DataSource[R, A], blockedRequest: BlockedRequest[A])
+      extends BlockedRequests[R]
+
+  final case class Then[-R](left: BlockedRequests[R], right: BlockedRequests[R]) extends BlockedRequests[R]
+
+  /**
+   * Flattens a collection of blocked requests into a collection of pipelined
+   * and batched requests that can be submitted for execution.
+   */
+  private def flatten[R](
+    blockedRequests: BlockedRequests[R]
+  ): List[Sequential[R]] = {
+
+    @tailrec
+    def loop[R](
+      blockedRequests: List[BlockedRequests[R]],
+      flattened: List[Sequential[R]]
+    ): List[Sequential[R]] = {
+      val (parallel, sequential) =
+        blockedRequests.foldLeft[(Parallel[R], List[BlockedRequests[R]])]((Parallel.empty, List.empty)) {
+          case ((parallel, sequential), blockedRequest) =>
+            val (par, seq) = step(blockedRequest)
+            (parallel ++ par, sequential ++ seq)
+        }
+      val updated = merge(flattened, parallel)
+      if (sequential.isEmpty) updated.reverse
+      else loop(sequential, updated)
+    }
+
+    loop(List(blockedRequests), List.empty)
+  }
+
+  /**
+   * Takes one step in evaluating a collection of blocked requests, returning a
+   * collection of blocked requests that can be performed in parallel and a
+   * list of blocked requests that must be performed sequentially after those
+   * requests.
+   */
+  private def step[R](
+    c: BlockedRequests[R]
+  ): (Parallel[R], List[BlockedRequests[R]]) = {
+
+    @tailrec
+    def loop[R](
+      blockedRequests: BlockedRequests[R],
+      stack: List[BlockedRequests[R]],
+      parallel: Parallel[R],
+      sequential: List[BlockedRequests[R]]
+    ): (Parallel[R], List[BlockedRequests[R]]) =
+      blockedRequests match {
+        case Empty =>
+          if (stack.isEmpty) (parallel, sequential)
+          else loop(stack.head, stack.tail, parallel, sequential)
+        case Then(left, right) =>
+          left match {
+            case Empty      => loop(right, stack, parallel, sequential)
+            case Then(l, r) => loop(Then(l, Then(r, right)), stack, parallel, sequential)
+            case Both(l, r) => loop(Both(Then(l, right), Then(r, right)), stack, parallel, sequential)
+            case o          => loop(o, stack, parallel, right :: sequential)
+          }
+        case Both(left, right) => loop(left, right :: stack, parallel, sequential)
+        case Single(dataSource, request) =>
+          if (stack.isEmpty) (parallel ++ Parallel(dataSource, request), sequential)
+          else loop(stack.head, stack.tail, parallel ++ Parallel(dataSource, request), sequential)
+      }
+
+    loop(c, List.empty, Parallel.empty, List.empty)
+  }
+
+  /**
+   * Merges a collection of requests that must be executed sequentially with a
+   * collection of requests that can be executed in parallel. If the
+   * collections are both from the same single data source then the requests
+   * can be pipelined while preserving ordering guarantees.
+   */
+  private def merge[R](sequential: List[Sequential[R]], parallel: Parallel[R]): List[Sequential[R]] =
+    if (sequential.isEmpty)
+      List(parallel.sequential)
+    else if (parallel.isEmpty)
+      sequential
+    else if (sequential.head.keys.size == 1 && parallel.keys.size == 1 && sequential.head.keys == parallel.keys)
+      (sequential.head ++ parallel.sequential) :: sequential.tail
+    else
+      parallel.sequential :: sequential
+}

--- a/core/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -1,0 +1,155 @@
+package zio.query.internal
+
+import zio.query._
+import zio.query.internal.Continue._
+import zio.{ CanFail, Cause, IO, NeedsEnv, Ref, ZIO }
+
+/**
+ * A `Continue[R, E, A]` models a continuation of a blocked request that
+ * requires an environment `R` and may either fail with an `E` or succeed with
+ * an `A`. A continuation may either be a `Get` that merely gets the result of
+ * a blocked request (potentially transforming it with pure functions) or an
+ * `Effect` that may perform arbitrary effects. This is used by the library
+ * internally to determine whether it is safe to pipeline two requests that
+ * must be executed sequentially.
+ */
+private[query] sealed trait Continue[-R, +E, +A] { self =>
+
+  /**
+   * Purely folds over the failure and success types of this continuation.
+   */
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): Continue[R, Nothing, B] =
+    self match {
+      case Effect(query) => effect(query.fold(failure, success))
+      case Get(io)       => get(io.fold(failure, success))
+
+    }
+
+  /**
+   * Effectually folds over the failure and success types of this continuation.
+   */
+  final def foldCauseM[R1 <: R, E1, B](
+    failure: Cause[E] => ZQuery[R1, E1, B],
+    success: A => ZQuery[R1, E1, B]
+  ): Continue[R1, E1, B] =
+    self match {
+      case Effect(query) => effect(query.foldCauseM(failure, success))
+      case Get(io)       => effect(ZQuery.fromEffect(io).foldCauseM(failure, success))
+    }
+
+  /**
+   * Purely maps over the success type of this continuation.
+   */
+  final def map[B](f: A => B): Continue[R, E, B] =
+    self match {
+      case Effect(query) => effect(query.map(f))
+      case Get(io)       => get(io.map(f))
+
+    }
+
+  /**
+   * Transforms all data sources with the specified data source aspect.
+   */
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): Continue[R1, E, A] =
+    self match {
+      case Effect(query) => effect(query.mapDataSources(f))
+      case Get(io)       => get(io)
+
+    }
+
+  /**
+   * Purely maps over the failure type of this continuation.
+   */
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): Continue[R, E1, A] =
+    self match {
+      case Effect(query) => effect(query.mapError(f))
+      case Get(io)       => get(io.mapError(f))
+
+    }
+
+  /**
+   * Effectually maps over the success type of this continuation.
+   */
+  final def mapM[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): Continue[R1, E1, B] =
+    self match {
+      case Effect(query) => effect(query.flatMap(f))
+      case Get(io)       => effect(ZQuery.fromEffect(io).flatMap(f))
+    }
+
+  /**
+   * Purely contramaps over the environment type of this continuation.
+   */
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): Continue[R0, E, A] =
+    self match {
+      case Effect(query) => effect(query.provideSome(f))
+      case Get(io)       => get(io)
+
+    }
+
+  /**
+   * Runs this continuation..
+   */
+  final def runCache(cache: Cache): ZIO[R, E, A] =
+    self match {
+      case Effect(query) => query.runCache(cache)
+      case Get(io)       => io
+    }
+
+  /**
+   * Combines this continuation with that continuation using the specified
+   * function, in sequence.
+   */
+  final def zipWith[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
+    (self, that) match {
+      case (Effect(l), Effect(r)) => effect(l.zipWith(r)(f))
+      case (Effect(l), Get(r))    => effect(l.zipWith(ZQuery.fromEffect(r))(f))
+      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWith(r)(f))
+      case (Get(l), Get(r))       => get(l.zipWith(r)(f))
+    }
+
+  /**
+   * Combines this continuation with that continuation using the specified
+   * function, in parallel.
+   */
+  final def zipWithPar[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
+    (self, that) match {
+      case (Effect(l), Effect(r)) => effect(l.zipWithPar(r)(f))
+      case (Effect(l), Get(r))    => effect(l.zipWithPar(ZQuery.fromEffect(r))(f))
+      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWithPar(r)(f))
+      case (Get(l), Get(r))       => get(l.zipWithPar(r)(f))
+    }
+
+}
+
+private[query] object Continue {
+
+  /**
+   * Constructs a continuation from a request, a data source, and a `Ref` that
+   * will contain the result of the request when it is executed.
+   */
+  def apply[R, E, A, B](request: A, dataSource: DataSource[R, A], ref: Ref[Option[Either[E, B]]])(
+    implicit ev: A <:< Request[E, B]
+  ): Continue[R, E, B] =
+    Continue.get {
+      ref.get.flatMap {
+        case None    => IO.die(QueryFailure(dataSource, request))
+        case Some(b) => IO.fromEither(b)
+      }
+    }
+
+  /**
+   * Constructs a continuation that may perform arbitrary effects.
+   */
+  def effect[R, E, A](query: ZQuery[R, E, A]): Continue[R, E, A] =
+    Effect(query)
+
+  /**
+   * Constructs a continuation that merely gets the result of a blocked request
+   * (potentially transforming it with pure functions).
+   */
+  def get[E, A](io: IO[E, A]): Continue[Any, E, A] =
+    Get(io)
+
+  final case class Effect[R, E, A](query: ZQuery[R, E, A]) extends Continue[R, E, A]
+  final case class Get[E, A](io: IO[E, A])                 extends Continue[Any, E, A]
+}

--- a/core/shared/src/main/scala/zio/query/internal/Parallel.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Parallel.scala
@@ -1,0 +1,70 @@
+package zio.query.internal
+
+import zio.Chunk
+import zio.query.DataSource
+
+/**
+ * A `Parallel[R]` maintains a mapping from data sources to requests from
+ * those data sources that can be executed in parallel.
+ */
+private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any], Chunk[BlockedRequest[Any]]]) {
+  self =>
+
+  /**
+   * Combines this collection of requests that can be executed in parallel
+   * with that collection of requests that can be executed in parallel to
+   * return a new collection of requests that can be executed in parallel.
+   */
+  def ++[R1 <: R](that: Parallel[R1]): Parallel[R1] =
+    new Parallel(
+      self.map.foldLeft(that.map) {
+        case (map, (k, v)) =>
+          map + (k -> map.get(k).fold[Chunk[BlockedRequest[Any]]](v)(_ ++ v))
+      }
+    )
+
+  /**
+   * Returns whether this collection of requests is empty.
+   */
+  def isEmpty: Boolean =
+    map.isEmpty
+
+  /**
+   * Returns a collection of the data sources that the requests in this
+   * collection are from.
+   */
+  def keys: Iterable[DataSource[R, Any]] =
+    map.keys
+
+  /**
+   * Converts this collection of requests that can be executed in parallel to
+   * a batch of requests in a collection of requests that must be executed
+   * sequentially.
+   */
+  def sequential: Sequential[R] =
+    new Sequential(map.map { case (k, v) => (k, Chunk(v)) })
+
+  /**
+   * Converts this collection of requests that can be executed in parallel to
+   * an `Iterable` containing mappings from data sources to requests from
+   * those data sources.
+   */
+  def toIterable: Iterable[(DataSource[R, Any], Chunk[BlockedRequest[Any]])] =
+    map
+}
+
+private[query] object Parallel {
+
+  /**
+   * Constructs a new collection of requests containing a mapping from the
+   * specified data source to the specified request.
+   */
+  def apply[R, E, A](dataSource: DataSource[R, A], blockedRequest: BlockedRequest[A]): Parallel[R] =
+    new Parallel(Map(dataSource.asInstanceOf[DataSource[Any, Any]] -> Chunk(blockedRequest)))
+
+  /**
+   * The empty collection of requests.
+   */
+  val empty: Parallel[Any] =
+    new Parallel(Map.empty)
+}

--- a/core/shared/src/main/scala/zio/query/internal/Parallel.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Parallel.scala
@@ -1,13 +1,12 @@
 package zio.query.internal
 
-import zio.Chunk
 import zio.query.DataSource
 
 /**
  * A `Parallel[R]` maintains a mapping from data sources to requests from
  * those data sources that can be executed in parallel.
  */
-private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any], Chunk[BlockedRequest[Any]]]) {
+private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any], Vector[BlockedRequest[Any]]]) {
   self =>
 
   /**
@@ -19,7 +18,7 @@ private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any
     new Parallel(
       self.map.foldLeft(that.map) {
         case (map, (k, v)) =>
-          map + (k -> map.get(k).fold[Chunk[BlockedRequest[Any]]](v)(_ ++ v))
+          map + (k -> map.get(k).fold[Vector[BlockedRequest[Any]]](v)(_ ++ v))
       }
     )
 
@@ -42,14 +41,14 @@ private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any
    * sequentially.
    */
   def sequential: Sequential[R] =
-    new Sequential(map.map { case (k, v) => (k, Chunk(v)) })
+    new Sequential(map.map { case (k, v) => (k, Vector(v)) })
 
   /**
    * Converts this collection of requests that can be executed in parallel to
    * an `Iterable` containing mappings from data sources to requests from
    * those data sources.
    */
-  def toIterable: Iterable[(DataSource[R, Any], Chunk[BlockedRequest[Any]])] =
+  def toIterable: Iterable[(DataSource[R, Any], Vector[BlockedRequest[Any]])] =
     map
 }
 
@@ -60,7 +59,7 @@ private[query] object Parallel {
    * specified data source to the specified request.
    */
   def apply[R, E, A](dataSource: DataSource[R, A], blockedRequest: BlockedRequest[A]): Parallel[R] =
-    new Parallel(Map(dataSource.asInstanceOf[DataSource[Any, Any]] -> Chunk(blockedRequest)))
+    new Parallel(Map(dataSource.asInstanceOf[DataSource[Any, Any]] -> Vector(blockedRequest)))
 
   /**
    * The empty collection of requests.

--- a/core/shared/src/main/scala/zio/query/internal/QueryContext.scala
+++ b/core/shared/src/main/scala/zio/query/internal/QueryContext.scala
@@ -1,0 +1,11 @@
+package zio.query.internal
+
+import zio.query.Cache
+
+/**
+ * `QueryContext` maintains the context of a query. Currently `QueryContext`
+ * simply maintains a `Cache` of requests and results but this will be
+ * augmented with other functionality such as logging and metrics in the
+ * future.
+ */
+private[query] final case class QueryContext(cache: Cache)

--- a/core/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Result.scala
@@ -1,0 +1,104 @@
+package zio.query.internal
+
+import zio.query.internal.Result._
+import zio.query.{ DataSourceAspect, Described }
+import zio.{ CanFail, Cause, NeedsEnv }
+
+/**
+ * A `Result[R, E, A]` is the result of running one step of a `ZQuery`. A
+ * result may either by done with a value `A`, blocked on a set of requests
+ * to data sources that require an environment `R`, or failed with an `E`.
+ */
+private[query] sealed trait Result[-R, +E, +A] { self =>
+
+  /**
+   * Folds over the successful or failed result.
+   */
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): Result[R, Nothing, B] =
+    self match {
+      case Blocked(br, c) => blocked(br, c.fold(failure, success))
+      case Done(a)        => done(success(a))
+      case Fail(e)        => e.failureOrCause.fold(e => done(failure(e)), c => fail(c))
+    }
+
+  /**
+   * Maps the specified function over the successful value of this result.
+   */
+  final def map[B](f: A => B): Result[R, E, B] =
+    self match {
+      case Blocked(br, c) => blocked(br, c.map(f))
+      case Done(a)        => done(f(a))
+      case Fail(e)        => fail(e)
+    }
+
+  /**
+   * Transforms all data sources with the specified data source aspect.
+   */
+  def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): Result[R1, E, A] =
+    self match {
+      case Blocked(br, c) => Result.blocked(br.mapDataSources(f), c.mapDataSources(f))
+      case Done(a)        => Result.done(a)
+      case Fail(e)        => Result.fail(e)
+    }
+
+  /**
+   * Maps the specified function over the failed value of this result.
+   */
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): Result[R, E1, A] =
+    self match {
+      case Blocked(br, c) => blocked(br, c.mapError(f))
+      case Done(a)        => done(a)
+      case Fail(e)        => fail(e.map(f))
+    }
+
+  /**
+   * Provides this result with its required environment.
+   */
+  final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): Result[Any, E, A] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
+
+  /**
+   * Provides this result with part of its required environment.
+   */
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): Result[R0, E, A] =
+    self match {
+      case Blocked(br, c) => blocked(br.provideSome(f), c.provideSome(f))
+      case Done(a)        => done(a)
+      case Fail(e)        => fail(e)
+    }
+}
+
+private[query] object Result {
+
+  /**
+   * Constructs a result that is blocked on the specified requests with the
+   * specified continuation.
+   */
+  def blocked[R, E, A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A]): Result[R, E, A] =
+    Blocked(blockedRequests, continue)
+
+  /**
+   * Constructs a result that is done with the specified value.
+   */
+  def done[A](value: A): Result[Any, Nothing, A] =
+    Done(value)
+
+  /**
+   * Constructs a result that is failed with the specified `Cause`.
+   */
+  def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
+    Fail(cause)
+
+  /**
+   * Lifts an `Either` into a result.
+   */
+  def fromEither[E, A](either: Either[E, A]): Result[Any, E, A] =
+    either.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a))
+
+  final case class Blocked[-R, +E, +A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A])
+      extends Result[R, E, A]
+
+  final case class Done[+A](value: A) extends Result[Any, Nothing, A]
+
+  final case class Fail[+E](cause: Cause[E]) extends Result[Any, E, Nothing]
+}

--- a/core/shared/src/main/scala/zio/query/internal/Sequential.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Sequential.scala
@@ -1,0 +1,48 @@
+package zio.query.internal
+
+import zio.Chunk
+import zio.query.DataSource
+
+/**
+ * A `Sequential[R]` maintains a mapping from data sources to batches of
+ * requests from those data sources that must be executed sequentially.
+ */
+private[query] final class Sequential[-R](
+  private val map: Map[DataSource[Any, Any], Chunk[Chunk[BlockedRequest[Any]]]]
+) { self =>
+
+  /**
+   * Combines this collection of batches of requests that must be executed
+   * sequentially with that collection of batches of requests that must be
+   * executed sequentially to return a new collection of batches of requests
+   * that must be executed sequentially.
+   */
+  def ++[R1 <: R](that: Sequential[R1]): Sequential[R1] =
+    new Sequential(
+      that.map.foldLeft(self.map) {
+        case (map, (k, v)) =>
+          map + (k -> map.get(k).fold[Chunk[Chunk[BlockedRequest[Any]]]](Chunk.empty)(_ ++ v))
+      }
+    )
+
+  /**
+   * Returns whether this collection of batches of requests is empty.
+   */
+  def isEmpty: Boolean =
+    map.isEmpty
+
+  /**
+   * Returns a collection of the data sources that the batches of requests in
+   * this collection are from.
+   */
+  def keys: Iterable[DataSource[R, Any]] =
+    map.keys
+
+  /**
+   * Converts this collection of batches requests that must be executed
+   * sequentially to an `Iterable` containing mappings from data sources to
+   * batches of requests from those data sources.
+   */
+  def toIterable: Iterable[(DataSource[R, Any], Chunk[Chunk[BlockedRequest[Any]]])] =
+    map
+}

--- a/core/shared/src/main/scala/zio/query/internal/Sequential.scala
+++ b/core/shared/src/main/scala/zio/query/internal/Sequential.scala
@@ -1,6 +1,5 @@
 package zio.query.internal
 
-import zio.Chunk
 import zio.query.DataSource
 
 /**
@@ -8,7 +7,7 @@ import zio.query.DataSource
  * requests from those data sources that must be executed sequentially.
  */
 private[query] final class Sequential[-R](
-  private val map: Map[DataSource[Any, Any], Chunk[Chunk[BlockedRequest[Any]]]]
+  private val map: Map[DataSource[Any, Any], Vector[Vector[BlockedRequest[Any]]]]
 ) { self =>
 
   /**
@@ -21,7 +20,7 @@ private[query] final class Sequential[-R](
     new Sequential(
       that.map.foldLeft(self.map) {
         case (map, (k, v)) =>
-          map + (k -> map.get(k).fold[Chunk[Chunk[BlockedRequest[Any]]]](Chunk.empty)(_ ++ v))
+          map + (k -> map.get(k).fold[Vector[Vector[BlockedRequest[Any]]]](Vector.empty)(_ ++ v))
       }
     )
 
@@ -43,6 +42,6 @@ private[query] final class Sequential[-R](
    * sequentially to an `Iterable` containing mappings from data sources to
    * batches of requests from those data sources.
    */
-  def toIterable: Iterable[(DataSource[R, Any], Chunk[Chunk[BlockedRequest[Any]]])] =
+  def toIterable: Iterable[(DataSource[R, Any], Vector[Vector[BlockedRequest[Any]]])] =
     map
 }

--- a/core/shared/src/main/scala/zio/query/package.scala
+++ b/core/shared/src/main/scala/zio/query/package.scala
@@ -1,0 +1,10 @@
+package zio
+
+package object query {
+
+  type RQuery[-R, +A]  = ZQuery[R, Throwable, A]
+  type URQuery[-R, +A] = ZQuery[R, Nothing, A]
+  type Query[+E, +A]   = ZQuery[Any, E, A]
+  type UQuery[+A]      = ZQuery[Any, Nothing, A]
+  type TaskQuery[+A]   = ZQuery[Any, Throwable, A]
+}

--- a/core/shared/src/main/scala/zio/query/package.scala
+++ b/core/shared/src/main/scala/zio/query/package.scala
@@ -7,4 +7,18 @@ package object query {
   type Query[+E, +A]   = ZQuery[Any, E, A]
   type UQuery[+A]      = ZQuery[Any, Nothing, A]
   type TaskQuery[+A]   = ZQuery[Any, Throwable, A]
+
+  implicit class VectorSytanx[A](private val self: Vector[A]) extends AnyVal {
+    def partitionMap[B, C](f: A => Either[B, C]): (Vector[B], Vector[C]) = {
+      val bs = Vector.newBuilder[B]
+      val cs = Vector.newBuilder[C]
+      self.foreach { a =>
+        f(a) match {
+          case Left(b)  => bs += b
+          case Right(c) => cs += c
+        }
+      }
+      (bs.result(), cs.result())
+    }
+  }
 }

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -39,5 +39,5 @@ trait DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
   private[zio] override def runSpec(
     spec: ZSpec[Environment, Failure]
   ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
-    runner.run(aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers)
+    runner.run(aspects.foldLeft(spec)(_ @@ _))
 }

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -39,5 +39,5 @@ trait DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
   private[zio] override def runSpec(
     spec: ZSpec[Environment, Failure]
   ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
-    runner.run(aspects.foldLeft(spec)(_ @@ _))
+    runner.run(aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers)
 }


### PR DESCRIPTION
Explores an alternative approach to resolving #3851. The problem there is basically that when we transplant in zipPar we are moving everything up to the parent scope in `zipPar` so when we build very large parallel programs we are creating this one piece of shared state that is accessed by all the fibers. Instead we can create a new child scope in transplant, attach the child scope to the parent scope, and graft the forked fibers in zipPar onto that. This builds a tree like structure of scopes instead of one giant scope. At least for the ZQuery use case this seems to perform very well and it passes all of our tests. However, it seems to create a memory leak with infinite zipPar processes like the ones in the issue. If we could resolve that it seems like this could be a good way to go.