### PR TITLE
Set status to interrupting before closing scope

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -427,6 +427,8 @@ private[zio] final class FiberContext[E, A](
                         else causeAndInterrupt
                       }
 
+                      setInterrupting(true)
+
                       curZio = done(Exit.halt(cause))
                     } else {
                       setInterrupting(false)


### PR DESCRIPTION
I expect the following code to preserve the thrown errors in the interrupt output:

```scala
package demo

import zio.App
import zio._
import zio.duration._
import zio.console._

object HelloWorld extends App {

  def run(args: List[String]) =
    for {
      f <- interruptWithError.fork
      _ <- f.interrupt
      _ <- f.join
    } yield (ExitCode.success)

  val interruptWithError =
    ZIO
      .sleep(1.seconds)
      .onInterrupt(for {
        _ <- putStrLn("on interrupt executed")
        _ <- ZIO.die(new Throwable("interruption"))
      } yield ())
}
```

The current behaviour is:

```
[info] running demo.HelloWorld 
on interrupt executed
[error] (run-main-0) zio.FiberFailure: Fiber failed.
[error] An interrupt was produced by #1.
[error] No ZIO Trace available.
[error] zio.FiberFailure: Fiber failed.
[error] An interrupt was produced by #1.
[error] No ZIO Trace available.
[error] stack trace is suppressed; run 'last demoJVM / Compile / bgRun' for the full output
[error] Nonzero exit code: 1
[error] (demoJVM / Compile / run) Nonzero exit code: 1
[error] Total time: 1 s, completed Jun 26, 2020 6:30:34 PM
```

After this change:

```
[info] running demo.HelloWorld 
on interrupt executed
[error] (run-main-0) zio.FiberFailure: Fiber failed.
[error] ╥
[error] ╠─An unchecked error was produced.
[error] ║ java.lang.Throwable: interruption
[error] ║ 	at demo.HelloWorld$.$anonfun$interruptWithError$7(HelloWorld.scala:23)
[error] ║ 	at zio.ZIO$.$anonfun$die$1(ZIO.scala:2413)
[error] ║ 	at zio.internal.FiberContext.evaluateNow(FiberContext.scala:406)
[error] ║ 	at zio.internal.FiberContext.$anonfun$fork$11(FiberContext.scala:749)
[error] ║ 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] ║ 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] ║ 	at java.lang.Thread.run(Thread.java:748)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) was supposed to continue to:
[error] ║   a future continuation at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) execution trace:
[error] ║   at demo.HelloWorld$.interruptWithError(HelloWorld.scala:23)
[error] ║   at zio.console.package$Console$Service$$anon$1.putStrLn(package.scala:57)
[error] ║   at zio.console.package$.putStrLn(package.scala:101)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO$.effectSuspendTotal(ZIO.scala:2556)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2489)
[error] ║   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2489)
[error] ║   at zio.clock.package$.sleep(package.scala:92)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) was spawned by:
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) was supposed to continue to:
[error] ║   a future continuation at demo.HelloWorld$.run(HelloWorld.scala:13)
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) ZIO Execution trace: <empty trace>
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) was spawned by:
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) was supposed to continue to:
[error] ║   a future continuation at zio.App.main(App.scala:57)
[error] ║   a future continuation at zio.App.main(App.scala:56)
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) ZIO Execution trace: <empty trace>
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) was spawned by: <empty trace>
[error] ║
[error] ╠─An interrupt was produced by #1.
[error] ║ No ZIO Trace available.
[error] ▼
[error] zio.FiberFailure: Fiber failed.
[error] ╥
[error] ╠─An unchecked error was produced.
[error] ║ java.lang.Throwable: interruption
[error] ║ 	at demo.HelloWorld$.$anonfun$interruptWithError$7(HelloWorld.scala:23)
[error] ║ 	at zio.ZIO$.$anonfun$die$1(ZIO.scala:2413)
[error] ║ 	at zio.internal.FiberContext.evaluateNow(FiberContext.scala:406)
[error] ║ 	at zio.internal.FiberContext.$anonfun$fork$11(FiberContext.scala:749)
[error] ║ 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] ║ 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] ║ 	at java.lang.Thread.run(Thread.java:748)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) was supposed to continue to:
[error] ║   a future continuation at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) execution trace:
[error] ║   at demo.HelloWorld$.interruptWithError(HelloWorld.scala:23)
[error] ║   at zio.console.package$Console$Service$$anon$1.putStrLn(package.scala:57)
[error] ║   at zio.console.package$.putStrLn(package.scala:101)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO$.effectSuspendTotal(ZIO.scala:2556)
[error] ║   at zio.ZIO.onInterrupt(ZIO.scala:1001)
[error] ║   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2489)
[error] ║   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2489)
[error] ║   at zio.clock.package$.sleep(package.scala:92)
[error] ║ 
[error] ║ Fiber:Id(1593192770808,2) was spawned by:
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) was supposed to continue to:
[error] ║   a future continuation at demo.HelloWorld$.run(HelloWorld.scala:13)
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) ZIO Execution trace: <empty trace>
[error] ║ 
[error] ║ Fiber:Id(1593192770796,1) was spawned by:
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) was supposed to continue to:
[error] ║   a future continuation at zio.App.main(App.scala:57)
[error] ║   a future continuation at zio.App.main(App.scala:56)
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) ZIO Execution trace: <empty trace>
[error] ║ 
[error] ║ Fiber:Id(1593192770743,0) was spawned by: <empty trace>
[error] ║
[error] ╠─An interrupt was produced by #1.
[error] ║ No ZIO Trace available.
[error] ▼
[error] stack trace is suppressed; run 'last demoJVM / Compile / bgRun' for the full output
[error] Nonzero exit code: 1
[error] (demoJVM / Compile / run) Nonzero exit code: 1
[error] Total time: 5 s, completed Jun 26, 2020 6:32:51 PM
```

The reason for this behaviour is that the first time the interruption cause hits the fiber here:
https://github.com/zio/zio/blob/master/core/shared/src/main/scala/zio/internal/FiberContext.scala#L430

The actual status becomes interrupted and the next op (next cycle in the while loop) follows to:
https://github.com/zio/zio/blob/master/core/shared/src/main/scala/zio/internal/FiberContext.scala#L629

That again set the status to interrupting in order to run the finalizers but without preserving the original exit.