### PR TITLE
Remove Finalizer when Fibers Terminate

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -744,6 +744,10 @@ private[zio] final class FiberContext[E, A](
       childContext.scopeKey = key.getOrElse(
         throw new IllegalStateException("Defect: The fiber's scope has ended before the fiber itself has ended")
       )
+
+      // Remove the finalizer key from the parent scope when the child fiber
+      // terminates:
+      childContext.onDone(_ => key.foreach(parentScope.unsafeDeny))
     }
 
     executor.submitOrThrow(() => childContext.evaluateNow(zio))

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -14,7 +14,7 @@ import zio.duration._
 import zio.stm.TQueue
 import zio.stream.ZSink.Push
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, nonFlaky, timeout }
+import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, timeout }
 import zio.test._
 import zio.test.environment.TestClock
 
@@ -2014,7 +2014,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               _       <- queue1.offer(1)
               result  <- fiber.join
             } yield assert(result)(equalTo(Chunk(2, 3)))
-          }
+          } @@ exceptJS
         ),
         suite("mergeTerminateEither")(
           testM("terminates as soon as either stream terminates") {


### PR DESCRIPTION
After further investigation, it appears that the issue we are having with ZIO Query relates to excessive memory consumption. That is why the performance is so much worse in CI than it is locally and why changing the machine in CI from `medium` to `large` has such a performance impact. It appears that although the finalizers can be garbage collected the fact that we are creating such a large data structure with all of these finalizers (~1M in this case) and then have to copy them to an array and sort them as part of releasing them creates excessive memory pressure.

This PR removes the finalizer from the parent scope when the fiber terminates. This seems to dramatically reduce the memory consumption. There may be further optimizations to do to avoid locks but this seems to address the immediate issue.