### PR TITLE
Implement ZTransducer.foldUntil using ZTransducer.fold

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -74,6 +74,11 @@ object ZTransducerSpec extends ZIOBaseSpec {
         },
         testM("doesn't emit empty trailing chunks") {
           assertM(run(ZTransducer.collectAllN[Int](3), List(Chunk(1, 2, 3))))(equalTo(Chunk(List(1, 2, 3))))
+        },
+        testM("emits chunks when exactly N elements received") {
+          ZTransducer.collectAllN[Int](4).push.use { push =>
+            push(Some(Chunk(1, 2, 3, 4))).map(result => assert(result)(equalTo(Chunk(List(1, 2, 3, 4)))))
+          }
         }
       ),
       suite("collectAllToMapN")(


### PR DESCRIPTION
The previous implementation used foldWeighted, which prevented
transducers based on it (like collectAllN) from emitting immediately
when N elements were accumulated.

Resolves #3860.