### PR TITLE
Fix ZStream mocks generation in @mockable macro

### DIFF
--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -1,6 +1,7 @@
 package zio.test.mock
 
-import zio.{ Has, IO, Tag, UIO }
+import zio._
+import zio.stream.Stream
 
 /**
  * https://github.com/scalamacros/paradise/issues/75
@@ -43,6 +44,18 @@ object modules {
     }
   }
 
+  type SimpleStreamDefsModule = Has[SimpleStreamDefsModule.Service]
+  object SimpleStreamDefsModule {
+    trait Service {
+      val static: Stream[String, Int]
+      def zeroParams: Stream[String, Int]
+      def zeroParamsWithParens(): Stream[String, Int]
+      def singleParam(a: Int): Stream[String, Int]
+      def manyParams(a: Int, b: String, c: Long): Stream[String, Int]
+      def manyParamLists(a: Int)(b: String)(c: Long): Stream[String, Int]
+    }
+  }
+
   type OverloadedPureDefsModule = Has[OverloadedPureDefsModule.Service]
   object OverloadedPureDefsModule {
     trait Service {
@@ -56,6 +69,14 @@ object modules {
     trait Service {
       def overloaded(n: Int): String
       def overloaded(n: Long): String
+    }
+  }
+
+  type OverloadedStreamDefsModule = Has[OverloadedStreamDefsModule.Service]
+  object OverloadedStreamDefsModule {
+    trait Service {
+      def overloaded(n: Int): Stream[String, Int]
+      def overloaded(n: Long): Stream[String, Int]
     }
   }
 
@@ -89,6 +110,21 @@ object modules {
     }
   }
 
+  type PolyStreamDefsModule = Has[PolyStreamDefsModule.Service]
+  object PolyStreamDefsModule {
+    trait Service {
+      def polyInput[I: Tag](v: I): Stream[String, Int]
+      def polyError[E: Tag](v: Long): Stream[E, Int]
+      def polyOutput[A: Tag](v: Long): Stream[String, A]
+      def polyInputError[I: Tag, E: Tag](v: I): Stream[E, Int]
+      def polyInputOutput[I: Tag, A: Tag](v: I): Stream[String, A]
+      def polyErrorOutput[E: Tag, A: Tag](v: Long): Stream[E, A]
+      def polyInputErrorOutput[I: Tag, E: Tag, A: Tag](v: I): Stream[E, A]
+      def polyMixed[A: Tag]: Stream[String, (A, Int)]
+      def polyBounded[A <: AnyVal: Tag]: Stream[String, A]
+    }
+  }
+
   type VarargsPureDefsModule = Has[VarargsPureDefsModule.Service]
   object VarargsPureDefsModule {
     trait Service {
@@ -102,6 +138,14 @@ object modules {
     trait Service {
       def simpleVarargs(a: Int, b: String*): String
       def curriedVarargs(a: Int, b: String*)(c: Long, d: Double*): String
+    }
+  }
+
+  type VarargsStreamDefsModule = Has[VarargsStreamDefsModule.Service]
+  object VarargsStreamDefsModule {
+    trait Service {
+      def simpleVarargs(a: Int, b: String*): Stream[String, Int]
+      def curriedVarargs(a: Int, b: String*)(c: Long, d: Double*): Stream[String, Int]
     }
   }
 
@@ -120,4 +164,5 @@ object modules {
       def bar(s: String): String
     }
   }
+
 }

--- a/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
+++ b/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
@@ -108,6 +108,25 @@ object MockableSpec extends DefaultRunnableSpec {
           Check
         })(anything)
       },
+      test("generates mocks for simple stream methods") {
+        assert({
+          @mockable[SimpleStreamDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[SimpleStreamDefsModule] = ModuleMock
+
+            val Static: ModuleMock.Stream[Unit, String, Int]                        = ModuleMock.Static
+            val ZeroParams: ModuleMock.Stream[Unit, String, Int]                    = ModuleMock.ZeroParams
+            val ZeroParamsWithParens: ModuleMock.Stream[Unit, String, Int]          = ModuleMock.ZeroParamsWithParens
+            val SingleParam: ModuleMock.Stream[Int, String, Int]                    = ModuleMock.SingleParam
+            val ManyParams: ModuleMock.Stream[(Int, String, Long), String, Int]     = ModuleMock.ManyParams
+            val ManyParamLists: ModuleMock.Stream[(Int, String, Long), String, Int] = ModuleMock.ManyParamLists
+          }
+
+          Check
+        })(anything)
+      },
       test("generates mocks for overloaded pure methods") {
         assert({
           @mockable[OverloadedPureDefsModule.Service]
@@ -133,6 +152,21 @@ object MockableSpec extends DefaultRunnableSpec {
 
             val Overloaded_0: ModuleMock.Method[Int, Throwable, String]  = ModuleMock.Overloaded._0
             val Overloaded_1: ModuleMock.Method[Long, Throwable, String] = ModuleMock.Overloaded._1
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for overloaded stream methods") {
+        assert({
+          @mockable[OverloadedStreamDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[OverloadedStreamDefsModule] = ModuleMock
+
+            val Overloaded_0: ModuleMock.Stream[Int, String, Int]  = ModuleMock.Overloaded._0
+            val Overloaded_1: ModuleMock.Stream[Long, String, Int] = ModuleMock.Overloaded._1
           }
 
           Check
@@ -182,6 +216,28 @@ object MockableSpec extends DefaultRunnableSpec {
           Check
         })(anything)
       },
+      test("generates mocks for poly stream methods") {
+        assert({
+          @mockable[PolyStreamDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[PolyStreamDefsModule] = ModuleMock
+
+            val PolyInput: ModuleMock.Poly.Stream.Input[String, Int]          = ModuleMock.PolyInput
+            val PolyError: ModuleMock.Poly.Stream.Error[Long, Int]            = ModuleMock.PolyError
+            val PolyOutput: ModuleMock.Poly.Stream.Output[Long, String]       = ModuleMock.PolyOutput
+            val PolyInputError: ModuleMock.Poly.Stream.InputError[Int]        = ModuleMock.PolyInputError
+            val PolyInputOutput: ModuleMock.Poly.Stream.InputOutput[String]   = ModuleMock.PolyInputOutput
+            val PolyErrorOutput: ModuleMock.Poly.Stream.ErrorOutput[Long]     = ModuleMock.PolyErrorOutput
+            val PolyInputErrorOutput: ModuleMock.Poly.Stream.InputErrorOutput = ModuleMock.PolyInputErrorOutput
+            val PolyMixed: ModuleMock.Poly.Stream.Output[Unit, String]        = ModuleMock.PolyMixed
+            val PolyBounded: ModuleMock.Poly.Stream.Output[Unit, String]      = ModuleMock.PolyBounded
+          }
+
+          Check
+        })(anything)
+      },
       test("generates mocks for varargs pure methods") {
         assert({
           @mockable[VarargsPureDefsModule.Service]
@@ -208,6 +264,22 @@ object MockableSpec extends DefaultRunnableSpec {
 
             val SimpleVarargs: ModuleMock.Method[(Int, Seq[String]), Throwable, String] = ModuleMock.SimpleVarargs
             val CurriedVarargs: ModuleMock.Method[(Int, Seq[String], Long, Seq[Double]), Throwable, String] =
+              ModuleMock.CurriedVarargs
+          }
+
+          Check
+        })(anything)
+      },
+      test("generates mocks for varargs stream methods") {
+        assert({
+          @mockable[VarargsStreamDefsModule.Service]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[VarargsStreamDefsModule] = ModuleMock
+
+            val SimpleVarargs: ModuleMock.Stream[(Int, Seq[String]), String, Int] = ModuleMock.SimpleVarargs
+            val CurriedVarargs: ModuleMock.Stream[(Int, Seq[String], Long, Seq[Double]), String, Int] =
               ModuleMock.CurriedVarargs
           }
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
@@ -33,6 +33,11 @@ object BasicStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] 
             StreamModuleMock.Stream(equalTo(1), value(A)),
             StreamModule.stream(1).flatMap(_.runCollect),
             equalTo(Chunk(1, 2, 3))
+          ),
+          testError("error")(
+            StreamModuleMock.Stream(equalTo(1), value(ZStream.fail("foo"))),
+            StreamModule.stream(1).flatMap(_.runCollect),
+            equalTo("foo")
           )
         )
       )

--- a/test-tests/shared/src/test/scala/zio/test/mock/PolyStreamMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/PolyStreamMockSpec.scala
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.mock
+
+import zio.Chunk
+import zio.stream.ZStream
+import zio.test.mock.module.{ StreamModule, StreamModuleMock }
+import zio.test.{ suite, Assertion, TestAspect, ZIOBaseSpec }
+
+object PolyStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] {
+
+  import Assertion._
+  import Expectation._
+  import TestAspect.exceptDotty
+
+  private def successfulStream[E, A](elements: A*): ZStream[Any, E, A] = ZStream.fromIterable(elements)
+  private def failedStream[E, A](error: E): ZStream[Any, E, A]         = ZStream.fail(error)
+
+  def spec = suite("PolyStreamMockSpec")(
+    suite("polymorphic input")(
+      suite("expectations met")(
+        testValue("String")(
+          StreamModuleMock.PolyInputStream
+            .of[String](equalTo("foo"), value(successfulStream[String, String]("bar", "baz"))),
+          StreamModule.polyInputStream("foo").flatMap(_.runCollect),
+          equalTo(Chunk("bar", "baz"))
+        ),
+        testValue("Int")(
+          StreamModuleMock.PolyInputStream.of[Int](equalTo(42), value(successfulStream[String, String]("bar", "baz"))),
+          StreamModule.polyInputStream(42).flatMap(_.runCollect),
+          equalTo(Chunk("bar", "baz"))
+        )
+      )
+    ),
+    suite("polymorphic error")(
+      suite("expectations met")(
+        testError("String")(
+          StreamModuleMock.PolyErrorStream.of[String](equalTo("foo"), value(failedStream[String, String]("bar"))),
+          StreamModule.polyErrorStream("foo").flatMap(_.runCollect),
+          equalTo("bar")
+        ),
+        testError("Int")(
+          StreamModuleMock.PolyErrorStream.of[Int](equalTo("foo"), value(failedStream[Int, String](42))),
+          StreamModule.polyErrorStream("foo").flatMap(_.runCollect),
+          equalTo(42)
+        )
+      )
+    ),
+    suite("polymorphic output")(
+      suite("expectations met")(
+        testValue("String")(
+          StreamModuleMock.PolyOutputStream
+            .of[String](equalTo("foo"), value(successfulStream[String, String]("bar", "baz"))),
+          StreamModule.polyOutputStream("foo").flatMap(_.runCollect),
+          equalTo(Chunk("bar", "baz"))
+        ),
+        testValue("Int")(
+          StreamModuleMock.PolyOutputStream.of[Int](equalTo("foo"), value(successfulStream[String, Int](42, 7))),
+          StreamModule.polyOutputStream("foo").flatMap(_.runCollect),
+          equalTo(Chunk(42, 7))
+        )
+      )
+    ),
+    suite("polymorphic input and error")(
+      suite("expectations met")(
+        suite("Long, Int")(
+          testValue("success")(
+            StreamModuleMock.PolyInputErrorStream
+              .of[Long, Int](equalTo(42L), value(successfulStream[Int, String]("foo", "bar"))),
+            StreamModule.polyInputErrorStream(42L).flatMap(_.runCollect),
+            equalTo(Chunk("foo", "bar"))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputErrorStream.of[Long, Int](equalTo(42L), value(failedStream[Int, String](42))),
+            StreamModule.polyInputErrorStream(42L).flatMap(_.runCollect),
+            equalTo(42)
+          )
+        ),
+        suite("String, Long")(
+          testValue("success")(
+            StreamModuleMock.PolyInputErrorStream
+              .of[String, Long](equalTo("foo"), value(successfulStream[Long, String]("bar", "baz"))),
+            StreamModule.polyInputErrorStream("foo").flatMap(_.runCollect),
+            equalTo(Chunk("bar", "baz"))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputErrorStream
+              .of[String, Long](equalTo("foo"), value(failedStream[Long, String](42L))),
+            StreamModule.polyInputErrorStream("foo").flatMap(_.runCollect),
+            equalTo(42L)
+          )
+        ),
+        testValue("combined")(
+          StreamModuleMock.PolyInputErrorStream
+            .of[Long, Int](equalTo(42L), value(successfulStream[Int, String]("foo", "bar"))) andThen
+            StreamModuleMock.PolyInputErrorStream
+              .of[Int, Long](equalTo(42), value(successfulStream[Long, String]("baz", "qux"))),
+          for {
+            v1     <- StreamModule.polyInputErrorStream[Long, Int](42L)
+            chunk1 <- v1.runCollect
+            v2     <- StreamModule.polyInputErrorStream[Int, Long](42)
+            chunk2 <- v2.runCollect
+          } yield chunk1 ++ chunk2,
+          equalTo(Chunk("foo", "bar", "baz", "qux"))
+        )
+      )
+    ),
+    suite("polymorphic input and output")(
+      suite("expectations met")(
+        suite("Long, Int")(
+          testValue("success")(
+            StreamModuleMock.PolyInputOutputStream
+              .of[Long, Int](equalTo(42L), value(successfulStream[String, Int](5, 7))),
+            StreamModule.polyInputOutputStream(42L).flatMap(_.runCollect),
+            equalTo(Chunk(5, 7))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputOutputStream.of[Long, Int](equalTo(42L), value(failedStream[String, Int]("foo"))),
+            StreamModule.polyInputOutputStream(42L).flatMap(_.runCollect),
+            equalTo("foo")
+          )
+        ),
+        suite("Int, Long")(
+          testValue("success")(
+            StreamModuleMock.PolyInputOutputStream
+              .of[Int, Long](equalTo(42), value(successfulStream[String, Long](5, 7))),
+            StreamModule.polyInputOutputStream(42).flatMap(_.runCollect),
+            equalTo(Chunk(5, 7))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputOutputStream.of[Int, Long](equalTo(42), value(failedStream[String, Long]("foo"))),
+            StreamModule.polyInputOutputStream(42).flatMap(_.runCollect),
+            equalTo("foo")
+          )
+        ),
+        testValue("combined")(
+          StreamModuleMock.PolyInputOutputStream
+            .of[Long, Int](equalTo(42L), value(successfulStream[String, Int](1, 2))) andThen
+            StreamModuleMock.PolyInputOutputStream
+              .of[Int, Long](equalTo(42), value(successfulStream[String, Long](3L, 4L))),
+          for {
+            v1     <- StreamModule.polyInputOutputStream[Long, Int](42L)
+            chunk1 <- v1.runCollect
+            v2     <- StreamModule.polyInputOutputStream[Int, Long](42)
+            chunk2 <- v2.runCollect
+          } yield (chunk1, chunk2),
+          equalTo((Chunk(1, 2), Chunk(3L, 4L)))
+        )
+      )
+    ),
+    suite("polymorphic error and output")(
+      suite("expectations met")(
+        suite("Long, Int")(
+          testValue("success")(
+            StreamModuleMock.PolyErrorOutputStream
+              .of[Long, Int](equalTo("foo"), value(successfulStream[Long, Int](1, 2))),
+            StreamModule.polyErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(Chunk(1, 2))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyErrorOutputStream.of[Long, Int](equalTo("foo"), value(failedStream[Long, Int](42L))),
+            StreamModule.polyErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(42L)
+          )
+        ),
+        suite("Int, Long")(
+          testValue("success")(
+            StreamModuleMock.PolyErrorOutputStream
+              .of[Int, Long](equalTo("foo"), value(successfulStream[Int, Long](1L, 2L))),
+            StreamModule.polyErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(Chunk(1L, 2L))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyErrorOutputStream.of[Int, Long](equalTo("foo"), value(failedStream[Int, Long](42))),
+            StreamModule.polyErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(42)
+          )
+        ),
+        testValue("combined")(
+          StreamModuleMock.PolyErrorOutputStream
+            .of[Long, Int](equalTo("foo"), value(successfulStream[Long, Int](1, 2))) andThen
+            StreamModuleMock.PolyErrorOutputStream
+              .of[Int, Long](equalTo("bar"), value(successfulStream[Int, Long](3L, 4L))),
+          for {
+            v1     <- StreamModule.polyErrorOutputStream[Long, Int]("foo")
+            chunk1 <- v1.runCollect
+            v2     <- StreamModule.polyErrorOutputStream[Int, Long]("bar")
+            chunk2 <- v2.runCollect
+          } yield (chunk1, chunk2),
+          equalTo((Chunk(1, 2), Chunk(3L, 4L)))
+        )
+      )
+    ),
+    suite("polymorphic input, error and output")(
+      suite("expectations met")(
+        suite("String, Int, Long")(
+          testValue("success")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[String, Int, Long](equalTo("foo"), value(successfulStream[Int, Long](1L, 3L, 5L))),
+            StreamModule.polyInputErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(Chunk(1L, 3L, 5L))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[String, Int, Long](equalTo("foo"), value(failedStream[Int, Long](42))),
+            StreamModule.polyInputErrorOutputStream("foo").flatMap(_.runCollect),
+            equalTo(42)
+          )
+        ),
+        suite("Int, Long, String")(
+          testValue("success")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Int, Long, String](equalTo(42), value(successfulStream[Long, String]("foo", "bar"))),
+            StreamModule.polyInputErrorOutputStream(42).flatMap(_.runCollect),
+            equalTo(Chunk("foo", "bar"))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Int, Long, String](equalTo(42), value(failedStream[Long, String](42L))),
+            StreamModule.polyInputErrorOutputStream(42).flatMap(_.runCollect),
+            equalTo(42L)
+          )
+        ),
+        suite("Long, String, Int")(
+          testValue("success")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Long, String, Int](equalTo(42L), value(successfulStream[String, Int](1, 2))),
+            StreamModule.polyInputErrorOutputStream(42L).flatMap(_.runCollect),
+            equalTo(Chunk(1, 2))
+          ),
+          testError("failure")(
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Long, String, Int](equalTo(42L), value(failedStream[String, Int]("foo"))),
+            StreamModule.polyInputErrorOutputStream(42L).flatMap(_.runCollect),
+            equalTo("foo")
+          )
+        ),
+        testValue("combined")(
+          StreamModuleMock.PolyInputErrorOutputStream
+            .of[String, Int, Long](equalTo("foo"), value(successfulStream[Int, Long](1L, 3L, 5L))) andThen
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Int, Long, String](equalTo(42), value(successfulStream[Long, String]("foo", "bar"))) andThen
+            StreamModuleMock.PolyInputErrorOutputStream
+              .of[Long, String, Int](equalTo(42L), value(successfulStream[String, Int](4, 2))),
+          for {
+            v1     <- StreamModule.polyInputErrorOutputStream[String, Int, Long]("foo")
+            chunk1 <- v1.runCollect
+            v2     <- StreamModule.polyInputErrorOutputStream[Int, Long, String](42)
+            chunk2 <- v2.runCollect
+            v3     <- StreamModule.polyInputErrorOutputStream[Long, String, Int](42L)
+            chunk3 <- v3.runCollect
+          } yield (chunk1, chunk2, chunk3),
+          equalTo((Chunk(1L, 3L, 5L), Chunk("foo", "bar"), Chunk(4, 2)))
+        )
+      )
+    ),
+    suite("polymorphic mixed output")(
+      suite("expectations met")(
+        testValue("String")(
+          StreamModuleMock.PolyMixedStream
+            .of[(String, String)](value(successfulStream[String, (String, String)]("foo" -> "bar", "baz" -> "qux"))),
+          StreamModule.polyMixedStream[String].flatMap(_.runCollect),
+          equalTo(Chunk("foo" -> "bar", "baz" -> "qux"))
+        ),
+        testValue("Int")(
+          StreamModuleMock.PolyMixedStream
+            .of[(Int, String)](value(successfulStream[String, (Int, String)](42 -> "bar"))),
+          StreamModule.polyMixedStream[Int].flatMap(_.runCollect),
+          equalTo(Chunk(42 -> "bar"))
+        ),
+        testValue("Long")(
+          StreamModuleMock.PolyMixedStream
+            .of[(Long, String)](value(successfulStream[String, (Long, String)](42L -> "bar"))),
+          StreamModule.polyMixedStream[Long].flatMap(_.runCollect),
+          equalTo(Chunk(42L -> "bar"))
+        )
+      )
+    ) @@ exceptDotty,
+    suite("polymorphic bounded output <: AnyVal")(
+      suite("expectations met")(
+        testValue("Double")(
+          StreamModuleMock.PolyBoundedStream.of[Double](value(successfulStream[String, Double](42d))),
+          StreamModule.polyBoundedStream[Double].flatMap(_.runCollect),
+          equalTo(Chunk(42d))
+        ),
+        testValue("Int")(
+          StreamModuleMock.PolyBoundedStream.of[Int](value(successfulStream[String, Int](42))),
+          StreamModule.polyBoundedStream[Int].flatMap(_.runCollect),
+          equalTo(Chunk(42))
+        ),
+        testValue("Long")(
+          StreamModuleMock.PolyBoundedStream.of[Long](value(successfulStream[String, Long](42L))),
+          StreamModule.polyBoundedStream[Long].flatMap(_.runCollect),
+          equalTo(Chunk(42L))
+        )
+      )
+    )
+  )
+
+}

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModule.scala
@@ -16,7 +16,10 @@
 
 package zio.test.mock.module
 
+import izumi.reflect.Tag
+
 import zio.stream.{ Sink, Stream }
+import zio.test.mock.module.PureModule.NotAnyKind
 import zio.{ URIO, ZIO }
 
 /**
@@ -27,8 +30,39 @@ object StreamModule {
   trait Service {
     def sink(a: Int): Sink[String, Int, Nothing, List[Int]]
     def stream(a: Int): Stream[String, Int]
+
+    def polyInputStream[I: Tag](v: I): Stream[String, String]
+    def polyErrorStream[E: Tag](v: String): Stream[E, String]
+    def polyOutputStream[A: Tag](v: String): Stream[String, A]
+    def polyInputErrorStream[I: Tag, E: Tag](v: I): Stream[E, String]
+    def polyInputOutputStream[I: Tag, A: Tag](v: I): Stream[String, A]
+    def polyErrorOutputStream[E: Tag, A: Tag](v: String): Stream[E, A]
+    def polyInputErrorOutputStream[I: Tag, E: Tag, A: Tag](v: I): Stream[E, A]
+    def polyMixedStream[A: Tag]: Stream[String, (A, String)]
+    def polyBoundedStream[A <: AnyVal: Tag]: Stream[String, A]
   }
 
   def sink(a: Int): URIO[StreamModule, Sink[String, Int, Nothing, List[Int]]] = ZIO.access[StreamModule](_.get.sink(a))
   def stream(a: Int): URIO[StreamModule, Stream[String, Int]]                 = ZIO.access[StreamModule](_.get.stream(a))
+
+  def polyInputStream[I: NotAnyKind: Tag](v: I): URIO[StreamModule, Stream[String, String]] =
+    ZIO.access[StreamModule](_.get.polyInputStream[I](v))
+  def polyErrorStream[E: NotAnyKind: Tag](v: String): URIO[StreamModule, Stream[E, String]] =
+    ZIO.access[StreamModule](_.get.polyErrorStream[E](v))
+  def polyOutputStream[A: NotAnyKind: Tag](v: String): URIO[StreamModule, Stream[String, A]] =
+    ZIO.access[StreamModule](_.get.polyOutputStream[A](v))
+  def polyInputErrorStream[I: NotAnyKind: Tag, E: NotAnyKind: Tag](v: I): URIO[StreamModule, Stream[E, String]] =
+    ZIO.access[StreamModule](_.get.polyInputErrorStream[I, E](v))
+  def polyInputOutputStream[I: NotAnyKind: Tag, A: NotAnyKind: Tag](v: I): URIO[StreamModule, Stream[String, A]] =
+    ZIO.access[StreamModule](_.get.polyInputOutputStream[I, A](v))
+  def polyErrorOutputStream[E: NotAnyKind: Tag, A: NotAnyKind: Tag](v: String): URIO[StreamModule, Stream[E, A]] =
+    ZIO.access[StreamModule](_.get.polyErrorOutputStream[E, A](v))
+  def polyInputErrorOutputStream[I: NotAnyKind: Tag, E: NotAnyKind: Tag, A: NotAnyKind: Tag](
+    v: I
+  ): URIO[StreamModule, Stream[E, A]] =
+    ZIO.access[StreamModule](_.get.polyInputErrorOutputStream[I, E, A](v))
+  def polyMixedStream[A: NotAnyKind: Tag]: URIO[StreamModule, Stream[String, (A, String)]] =
+    ZIO.access[StreamModule](_.get.polyMixedStream[A])
+  def polyBoundedStream[A <: AnyVal: NotAnyKind: Tag]: URIO[StreamModule, Stream[String, A]] =
+    ZIO.access[StreamModule](_.get.polyBoundedStream[A])
 }

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
@@ -17,8 +17,9 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
+import izumi.reflect.Tag
 
-import zio.stream.ZSink
+import zio.stream.{ ZSink, ZStream }
 import zio.test.mock.{ Mock, Proxy }
 import zio.{ Has, UIO, URLayer, ZLayer }
 
@@ -30,14 +31,43 @@ object StreamModuleMock extends Mock[StreamModule] {
   object Sink   extends Sink[Any, String, Int, Nothing, List[Int]]
   object Stream extends Stream[Any, String, Int]
 
+  object PolyInputStream            extends Poly.Stream.Input[String, String]
+  object PolyErrorStream            extends Poly.Stream.Error[String, String]
+  object PolyOutputStream           extends Poly.Stream.Output[String, String]
+  object PolyInputErrorStream       extends Poly.Stream.InputError[String]
+  object PolyInputOutputStream      extends Poly.Stream.InputOutput[String]
+  object PolyErrorOutputStream      extends Poly.Stream.ErrorOutput[String]
+  object PolyInputErrorOutputStream extends Poly.Stream.InputErrorOutput
+  object PolyMixedStream            extends Poly.Stream.Output[Unit, String]
+  object PolyBoundedStream          extends Poly.Stream.Output[Unit, String]
+
   @silent("is never used")
   val compose: URLayer[Has[Proxy], StreamModule] =
     ZLayer.fromServiceM { proxy =>
       withRuntime.map { rts =>
         new StreamModule.Service {
-          def sink(a: Int) =
+          def sink(a: Int): ZSink[Any, String, Int, Nothing, List[Int]] =
             rts.unsafeRun(proxy(Sink, a).catchAll(error => UIO(ZSink.fail[String, Int](error).dropLeftover)))
-          def stream(a: Int) = rts.unsafeRun(proxy(Stream, a))
+          def stream(a: Int): ZStream[Any, String, Int] = rts.unsafeRun(proxy(Stream, a))
+
+          def polyInputStream[I: Tag](v: I): ZStream[Any, String, String] =
+            rts.unsafeRun(proxy(PolyInputStream.of[I], v))
+          def polyErrorStream[E: Tag](v: String): ZStream[Any, E, String] =
+            rts.unsafeRun(proxy(PolyErrorStream.of[E], v))
+          def polyOutputStream[A: Tag](v: String): ZStream[Any, String, A] =
+            rts.unsafeRun(proxy(PolyOutputStream.of[A], v))
+          def polyInputErrorStream[I: Tag, E: Tag](v: I): ZStream[Any, E, String] =
+            rts.unsafeRun(proxy(PolyInputErrorStream.of[I, E], v))
+          def polyInputOutputStream[I: Tag, A: Tag](v: I): ZStream[Any, String, A] =
+            rts.unsafeRun(proxy(PolyInputOutputStream.of[I, A], v))
+          def polyErrorOutputStream[E: Tag, A: Tag](v: String): ZStream[Any, E, A] =
+            rts.unsafeRun(proxy(PolyErrorOutputStream.of[E, A], v))
+          def polyInputErrorOutputStream[I: Tag, E: Tag, A: Tag](v: I): ZStream[Any, E, A] =
+            rts.unsafeRun(proxy(PolyInputErrorOutputStream.of[I, E, A], v))
+          def polyMixedStream[A: Tag]: ZStream[Any, String, (A, String)] =
+            rts.unsafeRun(proxy(PolyMixedStream.of[(A, String)]))
+          def polyBoundedStream[A <: AnyVal: Tag]: ZStream[Any, String, A] =
+            rts.unsafeRun(proxy(PolyBoundedStream.of[A]))
         }
       }
     }

--- a/test/shared/src/main/scala/zio/test/mock/Capability.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Capability.scala
@@ -121,47 +121,59 @@ object Capability {
      */
     protected[mock] abstract class Error[R <: Has[_]: Tag, I: Tag, A: Tag, E1](val mock: Mock[R])
         extends Poly[R, I, Unknown, A] { self =>
+      type Output[Error]
 
-      def of[E <: E1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
-
-      @silent("is never used")
-      def of[E <: E1: Tag](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      def of[E <: E1: Tag](implicit outputTag: Tag[Output[E]]): Capability[R, I, E, Output[E]] =
+        toMethod[R, I, E, Output[E]](self)
 
       @silent("is never used")
-      def of[E <: E1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[E <: E1: Tag](
+        assertion: Assertion[I]
+      )(implicit ev1: I =!= Unit, ev2: Output[E] <:< Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, assertion)
 
       @silent("is never used")
-      def of[E <: E1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[E <: E1: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[E]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, assertion, result)
+
+      @silent("is never used")
+      def of[E <: E1: Tag](
+        returns: Result[I, E, Output[E]]
+      )(implicit ev: I <:< Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its output type.
      */
-    protected[mock] abstract class Output[R <: Has[_]: Tag, I: Tag, E: Tag, A1](val mock: Mock[R])
+    protected[mock] abstract class Output[R <: Has[_]: Tag, I: Tag, E: Tag](val mock: Mock[R])
         extends Poly[R, I, E, Unknown] { self =>
+      type Output[A]
 
-      def of[A <: A1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
-
-      @silent("is never used")
-      def of[A <: A1: Tag](assertion: Assertion[I])(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      def of[A: Tag](implicit outputTag: Tag[Output[A]]): Capability[R, I, E, Output[A]] =
+        toMethod[R, I, E, Output[A]](self)
 
       @silent("is never used")
-      def of[A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[A: Tag](
+        assertion: Assertion[I]
+      )(implicit ev1: I =!= Unit, ev2: Output[A] <:< Unit, outputTag: Tag[Output[A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, assertion)
 
       @silent("is never used")
-      def of[A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[A: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[A]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, assertion, result)
+
+      @silent("is never used")
+      def of[A: Tag](
+        returns: Result[I, E, Output[A]]
+      )(implicit ev: I <:< Unit, outputTag: Tag[Output[A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, returns)
     }
 
     /**
@@ -169,105 +181,117 @@ object Capability {
      */
     protected[mock] abstract class InputError[R <: Has[_]: Tag, A: Tag, E1](val mock: Mock[R])
         extends Poly[R, Unknown, Unknown, A] { self =>
+      type Output[Error]
 
-      def of[I: Tag, E <: E1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
+      def of[I: Tag, E <: E1: Tag](implicit outputTag: Tag[Output[E]]): Capability[R, I, E, Output[E]] =
+        toMethod[R, I, E, Output[E]](self)
 
       @silent("is never used")
       def of[I: Tag, E <: E1: Tag](
         assertion: Assertion[I]
-      )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      )(implicit ev1: I =!= Unit, ev2: Output[E] <:< Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, assertion)
 
       @silent("is never used")
-      def of[I: Tag, E <: E1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[I: Tag, E <: E1: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[E]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tag, E <: E1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[I: Tag, E <: E1: Tag](
+        returns: Result[I, E, Output[E]]
+      )(implicit ev: I <:< Unit, outputTag: Tag[Output[E]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E]](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its input and output types.
      */
-    protected[mock] abstract class InputOutput[R <: Has[_]: Tag, E: Tag, A1](val mock: Mock[R])
+    protected[mock] abstract class InputOutput[R <: Has[_]: Tag, E: Tag](val mock: Mock[R])
         extends Poly[R, Unknown, E, Unknown] { self =>
+      type Output[A]
 
-      def of[I: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
+      def of[I: Tag, A: Tag](implicit outputTag: Tag[Output[A]]): Capability[R, I, E, Output[A]] =
+        toMethod[R, I, E, Output[A]](self)
 
       @silent("is never used")
-      def of[I: Tag, A <: A1: Tag](
+      def of[I: Tag, A: Tag](
         assertion: Assertion[I]
-      )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      )(implicit ev1: I =!= Unit, ev2: Output[A] <:< Unit, outputTag: Tag[Output[A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, assertion)
 
       @silent("is never used")
-      def of[I: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[I: Tag, A: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[A]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tag, A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[I: Tag, A: Tag](returns: Result[I, E, Output[A]])(implicit ev: I <:< Unit): Expectation[R] =
+        toExpectation[R, I, E, Output[A]](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its error and output types.
      */
-    protected[mock] abstract class ErrorOutput[R <: Has[_]: Tag, I: Tag, E1, A1](val mock: Mock[R])
+    protected[mock] abstract class ErrorOutput[R <: Has[_]: Tag, I: Tag, E1](val mock: Mock[R])
         extends Poly[R, I, Unknown, Unknown] { self =>
+      type Output[E, A]
 
-      def of[E <: E1: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
+      def of[E <: E1: Tag, A: Tag](implicit outputTag: Tag[Output[E, A]]): Capability[R, I, E, Output[E, A]] =
+        toMethod[R, I, E, Output[E, A]](self)
 
       @silent("is never used")
-      def of[E <: E1: Tag, A <: A1: Tag](
+      def of[E <: E1: Tag, A: Tag](
         assertion: Assertion[I]
-      )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      )(implicit ev1: I =!= Unit, ev2: Output[E, A] <:< Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, assertion)
 
       @silent("is never used")
-      def of[E <: E1: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[E <: E1: Tag, A: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[E, A]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, assertion, result)
 
       @silent("is never used")
-      def of[E <: E1: Tag, A <: A1: Tag](returns: Result[I, E, A])(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[E <: E1: Tag, A: Tag](
+        returns: Result[I, E, Output[E, A]]
+      )(implicit ev: I <:< Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, returns)
     }
 
     /**
      * Represents capability of environment `R` polymorphic in its input, error and output types.
      */
-    protected[mock] abstract class InputErrorOutput[R <: Has[_]: Tag, E1, A1](val mock: Mock[R])
+    protected[mock] abstract class InputErrorOutput[R <: Has[_]: Tag, E1](val mock: Mock[R])
         extends Poly[R, Unknown, Unknown, Unknown] { self =>
+      type Output[E, A]
 
-      def of[I: Tag, E <: E1: Tag, A <: A1: Tag]: Capability[R, I, E, A] =
-        toMethod[R, I, E, A](self)
+      def of[I: Tag, E <: E1: Tag, A: Tag](implicit outputTag: Tag[Output[E, A]]): Capability[R, I, E, Output[E, A]] =
+        toMethod[R, I, E, Output[E, A]](self)
 
       @silent("is never used")
-      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](
+      def of[I: Tag, E <: E1: Tag, A: Tag](
         assertion: Assertion[I]
-      )(implicit ev1: I =!= Unit, ev2: A <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion)
+      )(implicit ev1: I =!= Unit, ev2: Output[E, A] <:< Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, assertion)
 
       @silent("is never used")
-      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](assertion: Assertion[I], result: Result[I, E, A])(implicit
-        ev: I =!= Unit
-      ): Expectation[R] =
-        toExpectation[R, I, E, A](self, assertion, result)
+      def of[I: Tag, E <: E1: Tag, A: Tag](
+        assertion: Assertion[I],
+        result: Result[I, E, Output[E, A]]
+      )(implicit ev: I =!= Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, assertion, result)
 
       @silent("is never used")
-      def of[I: Tag, E <: E1: Tag, A <: A1: Tag](
-        returns: Result[I, E, A]
-      )(implicit ev: I <:< Unit): Expectation[R] =
-        toExpectation[R, I, E, A](self, returns)
+      def of[I: Tag, E <: E1: Tag, A: Tag](
+        returns: Result[I, E, Output[E, A]]
+      )(implicit ev: I <:< Unit, outputTag: Tag[Output[E, A]]): Expectation[R] =
+        toExpectation[R, I, E, Output[E, A]](self, returns)
     }
 
     @silent("is never used")

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -49,23 +49,69 @@ abstract class Mock[R <: Has[_]: Tag] { self =>
   object Poly {
 
     object Effect {
-      abstract class Input[E: Tag, A: Tag]  extends Capability.Poly.Input[R, E, A](self)
-      abstract class Error[I: Tag, A: Tag]  extends Capability.Poly.Error[R, I, A, Any](self)
-      abstract class Output[I: Tag, E: Tag] extends Capability.Poly.Output[R, I, E, Any](self)
-      abstract class InputError[A: Tag]     extends Capability.Poly.InputError[R, A, Any](self)
-      abstract class InputOutput[E: Tag]    extends Capability.Poly.InputOutput[R, E, Any](self)
-      abstract class ErrorOutput[I: Tag]    extends Capability.Poly.ErrorOutput[R, I, Any, Any](self)
-      abstract class InputErrorOutput       extends Capability.Poly.InputErrorOutput[R, Any, Any](self)
+      abstract class Input[E: Tag, A: Tag] extends Capability.Poly.Input[R, E, A](self)
+      abstract class Error[I: Tag, A: Tag] extends Capability.Poly.Error[R, I, A, Any](self) {
+        override type Output[E] = A
+      }
+      abstract class Output[I: Tag, E: Tag] extends Capability.Poly.Output[R, I, E](self) {
+        override type Output[A] = A
+      }
+      abstract class InputError[A: Tag] extends Capability.Poly.InputError[R, A, Any](self) {
+        override type Output[E] = A
+      }
+      abstract class InputOutput[E: Tag] extends Capability.Poly.InputOutput[R, E](self) {
+        override type Output[A] = A
+      }
+      abstract class ErrorOutput[I: Tag] extends Capability.Poly.ErrorOutput[R, I, Any](self) {
+        override type Output[E, A] = A
+      }
+      abstract class InputErrorOutput extends Capability.Poly.InputErrorOutput[R, Any](self) {
+        override type Output[E, A] = A
+      }
     }
 
     object Method {
-      abstract class Input[E <: Throwable: Tag, A: Tag]  extends Capability.Poly.Input[R, E, A](self)
-      abstract class Error[I: Tag, A: Tag]               extends Capability.Poly.Error[R, I, A, Throwable](self)
-      abstract class Output[I: Tag, E <: Throwable: Tag] extends Capability.Poly.Output[R, I, E, Any](self)
-      abstract class InputError[A: Tag]                  extends Capability.Poly.InputError[R, A, Throwable](self)
-      abstract class InputOutput[E <: Throwable: Tag]    extends Capability.Poly.InputOutput[R, E, Any](self)
-      abstract class ErrorOutput[I: Tag]                 extends Capability.Poly.ErrorOutput[R, I, Throwable, Any](self)
-      abstract class InputErrorOutput                    extends Capability.Poly.InputErrorOutput[R, Throwable, Any](self)
+      abstract class Input[E <: Throwable: Tag, A: Tag] extends Capability.Poly.Input[R, E, A](self)
+      abstract class Error[I: Tag, A: Tag] extends Capability.Poly.Error[R, I, A, Throwable](self) {
+        override type Output[E] = A
+      }
+      abstract class Output[I: Tag, E <: Throwable: Tag] extends Capability.Poly.Output[R, I, E](self) {
+        override type Output[A] = A
+      }
+      abstract class InputError[A: Tag] extends Capability.Poly.InputError[R, A, Throwable](self) {
+        override type Output[E] = A
+      }
+      abstract class InputOutput[E <: Throwable: Tag] extends Capability.Poly.InputOutput[R, E](self) {
+        override type Output[A] = A
+      }
+      abstract class ErrorOutput[I: Tag] extends Capability.Poly.ErrorOutput[R, I, Throwable](self) {
+        override type Output[E, A] = A
+      }
+      abstract class InputErrorOutput extends Capability.Poly.InputErrorOutput[R, Throwable](self) {
+        override type Output[E, A] = A
+      }
+    }
+
+    object Stream {
+      abstract class Input[E: Tag, A: Tag] extends Capability.Poly.Input[R, Nothing, ZStream[Any, E, A]](self)
+      abstract class Error[I: Tag, A: Tag] extends Capability.Poly.Error[R, I, A, Any](self) {
+        override type Output[E] = ZStream[Any, E, A]
+      }
+      abstract class Output[I: Tag, E: Tag] extends Capability.Poly.Output[R, I, E](self) {
+        override type Output[A] = ZStream[Any, E, A]
+      }
+      abstract class InputError[A: Tag] extends Capability.Poly.InputError[R, A, Any](self) {
+        override type Output[E] = ZStream[Any, E, A]
+      }
+      abstract class InputOutput[E: Tag] extends Capability.Poly.InputOutput[R, E](self) {
+        override type Output[A] = ZStream[Any, E, A]
+      }
+      abstract class ErrorOutput[I: Tag] extends Capability.Poly.ErrorOutput[R, I, Any](self) {
+        override type Output[E, A] = ZStream[Any, E, A]
+      }
+      abstract class InputErrorOutput extends Capability.Poly.InputErrorOutput[R, Any](self) {
+        override type Output[E, A] = ZStream[Any, E, A]
+      }
     }
   }
 }


### PR DESCRIPTION
I've been working on the implementation of `@mockable` support in IntelliJ and stumbled across a MatchError during the generation of a Mock for service with methods returning a ZStream/ZSink.
This PR fixes generation for ZStream and adds polymorphic methods support for streams. It would be great to fix the generation of ZSink methods as well but I'm not sure how to do it yet.