### PR TITLE
WIP: try Alex encoding of ZSink

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
@@ -6,7 +6,7 @@ import zio.{ IO, UIO }
 
 object SinkUtils {
 
-  def findSink[A](a: A): ZSink[Any, Unit, A, A, A] =
+  def findSink[A](a: A): ZSink[Any, Unit, A, A] =
     ZSink.fold[A, Option[A]](None)(_.isEmpty)((_, v) => if (a == v) Some(a) else None).mapM {
       case Some(v) => IO.succeedNow(v)
       case None    => IO.fail(())

--- a/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
@@ -1,3 +1,4 @@
+/*
 package zio.stream
 
 import zio.test.Assertion.equalTo
@@ -50,3 +51,4 @@ object SinkUtils {
     }
 
 }
+*/

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -12,7 +12,6 @@ import zio._
 import zio.clock.Clock
 import zio.duration._
 import zio.stm.TQueue
-import zio.stream.ZSink.Push
 import zio.test.Assertion._
 import zio.test.TestAspect.{ exceptDotty, exceptJS, flaky, nonFlaky, timeout }
 import zio.test._
@@ -1363,8 +1362,8 @@ object ZStreamSpec extends ZIOBaseSpec {
             )
           }
         ),
-        suite("foreach")(
-          testM("foreach") {
+       // suite("foreach")(
+ /*         testM("foreach") {
             for {
               ref <- Ref.make(0)
               _   <- ZStream(1, 1, 1, 1, 1).foreach[Any, Nothing](a => ref.update(_ + a))
@@ -1400,7 +1399,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 )
             sum <- ref.get
           } yield assert(sum)(equalTo(10))
-        },
+        },*/
         suite("groupBy")(
           testM("values") {
             val words = List.fill(1000)(0 to 100).flatten.map(_.toString())
@@ -2137,7 +2136,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               }
           }
         ),
-        testM("peel") {
+     /*   testM("peel") {
           val sink: ZSink[Any, Nothing, Int, Nothing, Chunk[Int]] = ZSink {
             ZManaged.succeed {
               case Some(inputs) => Push.emit(inputs, Chunk.empty)
@@ -2152,7 +2151,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 assert(rest)(equalTo(Chunk(4, 5, 6)))
               }
           }
-        },
+        },*/
         testM("orElse") {
           val s1 = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
           val s2 = ZStream(4, 5, 6)

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -383,7 +383,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
      *
      * The sink will yield the count of bytes written.
      */
-    def write: Sink[Throwable, Byte, Nothing, Int] =
+    def write: Sink[Throwable, Byte, Int] =
       ZSink.foldLeftChunksM(0) {
         case (nbBytesWritten, c) =>
           IO.effectAsync[Throwable, Int] { callback =>

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -53,7 +53,7 @@ trait ZSinkPlatformSpecificConstructors { self: ZSink.type =>
     path: => Path,
     position: Long = 0L,
     options: Set[OpenOption] = Set(WRITE, TRUNCATE_EXISTING, CREATE)
-  ): ZSink[Blocking, Throwable, Byte, Byte, Long] = {
+  ): ZSink[Blocking, Throwable, Byte, Long] = {
     val managedChannel = ZManaged.make(
       blocking
         .effectBlockingInterrupt(
@@ -68,7 +68,7 @@ trait ZSinkPlatformSpecificConstructors { self: ZSink.type =>
         )
     )(chan => blocking.effectBlocking(chan.close()).orDie)
 
-    val writer: ZSink[Blocking, Throwable, Byte, Byte, Unit] = ZSink.managed(managedChannel) { chan =>
+    val writer: ZSink[Blocking, Throwable, Byte, Unit] = ZSink.managed(managedChannel) { chan =>
       ZSink.foreachChunk[Blocking, Throwable, Byte](byteChunk =>
         blocking.effectBlockingInterrupt {
           chan.write(ByteBuffer.wrap(byteChunk.toArray))

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -22,7 +22,7 @@ trait ZSinkPlatformSpecificConstructors { self: ZSink.type =>
    */
   final def fromOutputStream(
     os: OutputStream
-  ): ZSink[Blocking, IOException, Byte, Byte, Long] = fromOutputStreamManaged(ZManaged.succeedNow(os))
+  ): ZSink[Blocking, IOException, Byte, Long] = fromOutputStreamManaged(ZManaged.succeedNow(os))
 
   /**
    * Uses the provided `OutputStream` resource to create a [[ZSink]] that consumes byte chunks
@@ -32,7 +32,7 @@ trait ZSinkPlatformSpecificConstructors { self: ZSink.type =>
    */
   final def fromOutputStreamManaged(
     os: ZManaged[Blocking, IOException, OutputStream]
-  ): ZSink[Blocking, IOException, Byte, Byte, Long] =
+  ): ZSink[Blocking, IOException, Byte, Long] =
     ZSink.managed(os) { out =>
       ZSink.foldLeftChunksM(0L) { (bytesWritten, byteChunk: Chunk[Byte]) =>
         blocking.effectBlockingInterrupt {

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -34,13 +34,17 @@ abstract class ZSink[-R, +E, -I, +Z] { self =>
   )(implicit ev: L <:< I1): ZSink[R1, E1, I1, L1, (Z, Z1)] =
     zip(that)
 
+
+  */
   /**
    * Operator alias for [[zipPar]].
    */
-  final def <&>[R1 <: R, E1 >: E, I1 <: I, L1 >: L, Z1](
-    that: ZSink[R1, E1, I1, L1, Z1]
-  ): ZSink[R1, E1, I1, L1, (Z, Z1)] =
+  final def <&>[R1 <: R, E1 >: E, I1 <: I, Z1](
+    that: ZSink[R1, E1, I1, Z1]
+  ): ZSink[R1, E1, I1, (Z, Z1)] =
     self.zipPar(that)
+
+  /*
 
   /**
    * Operator alias for [[zipRight]].
@@ -50,11 +54,14 @@ abstract class ZSink[-R, +E, -I, +Z] { self =>
   )(implicit ev: L <:< I1): ZSink[R1, E1, I1, L1, Z1] =
     zipRight(that)
 
+
+   */
   /**
    * Operator alias for [[zipParRight]].
    */
-  final def &>[R1 <: R, E1 >: E, I1 <: I, L1 >: L, Z1](that: ZSink[R1, E1, I1, L1, Z1]): ZSink[R1, E1, I1, L1, Z1] =
+  final def &>[R1 <: R, E1 >: E, I1 <: I, Z1](that: ZSink[R1, E1, I1, Z1]): ZSink[R1, E1, I1, Z1] =
     self.zipParRight(that)
+/*
 
   /**
    * Operator alias for [[zipLeft]].
@@ -354,30 +361,33 @@ abstract class ZSink[-R, +E, -I, +Z] { self =>
   )(implicit ev: L <:< I1): ZSink[R1, E1, I1, L1, Z] =
     zipWith(that)((z, _) => z)
 
+
+  */
   /**
    * Runs both sinks in parallel on the input and combines the results in a tuple.
    */
-  final def zipPar[R1 <: R, E1 >: E, I1 <: I, L1 >: L, Z1](
-    that: ZSink[R1, E1, I1, L1, Z1]
-  ): ZSink[R1, E1, I1, L1, (Z, Z1)] =
+  final def zipPar[R1 <: R, E1 >: E, I1 <: I, Z1](
+    that: ZSink[R1, E1, I1, Z1]
+  ): ZSink[R1, E1, I1, (Z, Z1)] =
     zipWithPar(that)((_, _))
 
   /**
    * Like [[zipPar]], but keeps only the result from this sink.
    */
-  final def zipParLeft[R1 <: R, E1 >: E, I1 <: I, L1 >: L](
-    that: ZSink[R1, E1, I1, L1, Any]
-  ): ZSink[R1, E1, I1, L1, Z] =
+  final def zipParLeft[R1 <: R, E1 >: E, I1 <: I](
+    that: ZSink[R1, E1, I1, Any]
+  ): ZSink[R1, E1, I1, Z] =
     zipWithPar(that)((b, _) => b)
 
   /**
    * Like [[zipPar]], but keeps only the result from the `that` sink.
    */
-  final def zipParRight[R1 <: R, E1 >: E, I1 <: I, Z1, L1 >: L](
-    that: ZSink[R1, E1, I1, L1, Z1]
-  ): ZSink[R1, E1, I1, L1, Z1] =
+  final def zipParRight[R1 <: R, E1 >: E, I1 <: I, Z1](
+    that: ZSink[R1, E1, I1,Z1]
+  ): ZSink[R1, E1, I1, Z1] =
     zipWithPar(that)((_, c) => c)
 
+  /*
   /**
    * Like [[zip]], but keeps only the result from this sink.
    */
@@ -588,12 +598,15 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
   def collectAllToSet[A]: ZSink[Any, Nothing, A, Nothing, Set[A]] =
     foldLeftChunks(Set[A]())((acc, as) => as.foldLeft(acc)(_ + _))
 
+
+ */
   /**
    * A sink that counts the number of elements fed to it.
    */
-  val count: ZSink[Any, Nothing, Any, Nothing, Long] =
+  val count: ZSink[Any, Nothing, Any, Long] =
     foldLeft(0L)((s, _) => s + 1)
 
+  /*
   /**
    * Creates a sink halting with the specified `Throwable`.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -572,13 +572,13 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
       } yield push
     }
   }
-/*
+
   /**
    * A sink that collects all of its inputs into a map. The keys are extracted from inputs
    * using the keying function `key`; if multiple inputs use the same key, they are merged
    * using the `f` function.
    */
-  def collectAllToMap[A, K](key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, A, Nothing, Map[K, A]] =
+  def collectAllToMap[A, K](key: A => K)(f: (A, A) => A): ZSink[Any, Nothing, A, Map[K, A]] =
     foldLeftChunks(Map[K, A]()) { (acc, as) =>
       as.foldLeft(acc) { (acc, a) =>
         val k = key(a)
@@ -595,11 +595,11 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
   /**
    * A sink that collects all of its inputs into a set.
    */
-  def collectAllToSet[A]: ZSink[Any, Nothing, A, Nothing, Set[A]] =
+  def collectAllToSet[A]: ZSink[Any, Nothing, A, Set[A]] =
     foldLeftChunks(Set[A]())((acc, as) => as.foldLeft(acc)(_ + _))
 
 
- */
+
   /**
    * A sink that counts the number of elements fed to it.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -236,34 +236,6 @@ abstract class ZSink[-R, +E, -I, +Z] { self =>
         } yield push
       }
     }
-    /*ZSink {
-      for {
-        switched     <- Ref.make(false).toManaged_
-        thisPush     <- self.push
-        thatPush     <- Ref.make[Push[R1, E2, I2, L2, Z2]](_ => ZIO.unit).toManaged_
-        openThatPush <- ZManaged.switchable[R1, Nothing, Push[R1, E2, I2, L2, Z2]]
-        push = (in: Option[Chunk[I2]]) => {
-          switched.get.flatMap { sw =>
-            if (!sw) {
-              thisPush(in).catchAll { v =>
-                val leftover = v._2
-                val nextSink = v._1.fold(failure, success)
-                openThatPush(nextSink.push).tap(thatPush.set).flatMap { p =>
-                  switched.set(true) *> {
-                    if (in.isDefined)
-                      p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty)
-                    else
-                      p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty) *> p(None)
-                  }
-                }
-              }
-            } else {
-              thatPush.get.flatMap(p => p(in))
-            }
-          }
-        }
-      } yield push
-    }*/
 
   /**
    * Transforms this sink's result.

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -606,26 +606,26 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
   val count: ZSink[Any, Nothing, Any, Long] =
     foldLeft(0L)((s, _) => s + 1)
 
-  /*
+
   /**
    * Creates a sink halting with the specified `Throwable`.
    */
-  def die(e: => Throwable): ZSink[Any, Nothing, Any, Nothing, Nothing] =
+  def die(e: => Throwable): ZSink[Any, Nothing, Any, Nothing] =
     ZSink.halt(Cause.die(e))
 
   /**
    * Creates a sink halting with the specified message, wrapped in a
    * `RuntimeException`.
    */
-  def dieMessage(m: => String): ZSink[Any, Nothing, Any, Nothing, Nothing] =
+  def dieMessage(m: => String): ZSink[Any, Nothing, Any, Nothing] =
     ZSink.halt(Cause.die(new RuntimeException(m)))
 
   /**
    * A sink that ignores its inputs.
    */
-  val drain: ZSink[Any, Nothing, Any, Nothing, Unit] =
+  val drain: ZSink[Any, Nothing, Any, Unit] =
     foreach[Any, Nothing, Any](_ => ZIO.unit).dropLeftover
-*/
+
   /**
    * A sink that always fails with the specified error.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -109,7 +109,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    * Symbolic alias for [[[zio.stream.ZStream!.run[R1<:R,E1>:E,B]*]]].
    */
-  def >>>[R1 <: R, E1 >: E, O2 >: O, Z](sink: ZSink[R1, E1, O2, Any, Z]): ZIO[R1, E1, Z] =
+  def >>>[R1 <: R, E1 >: E, O2 >: O, Z](sink: ZSink[R1, E1, O2, Z]): ZIO[R1, E1, Z] =
     self.run(sink)
 
   /**
@@ -1198,15 +1198,15 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Consumes elements of the stream, passing them to the specified callback,
    * and terminating consumption when the callback returns `false`.
    */
-  final def foreachWhile[R1 <: R, E1 >: E](f: O => ZIO[R1, E1, Boolean]): ZIO[R1, E1, Unit] =
-    run(ZSink.foreachWhile(f))
+ // final def foreachWhile[R1 <: R, E1 >: E](f: O => ZIO[R1, E1, Boolean]): ZIO[R1, E1, Unit] =
+ //   run(ZSink.foreachWhile(f))
 
   /**
    * Like [[ZStream#foreachWhile]], but returns a `ZManaged` so the finalization order
    * can be controlled.
    */
-  final def foreachWhileManaged[R1 <: R, E1 >: E](f: O => ZIO[R1, E1, Boolean]): ZManaged[R1, E1, Unit] =
-    runManaged(ZSink.foreachWhile(f))
+//  final def foreachWhileManaged[R1 <: R, E1 >: E](f: O => ZIO[R1, E1, Boolean]): ZManaged[R1, E1, Unit] =
+  //  runManaged(ZSink.foreachWhile(f))
 
   /**
    * Repeats this stream forever.
@@ -2137,14 +2137,14 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * [[ZStream]] in a managed resource. Like all [[ZManaged]] values, the provided
    * stream is valid only within the scope of [[ZManaged]].
    */
-  def peel[R1 <: R, E1 >: E, O1 >: O, Z, J](
+  /*def peel[R1 <: R, E1 >: E, O1 >: O, Z, J](
     sink: ZSink[R1, E1, O1, O1, Z]
   ): ZManaged[R1, E1, (Z, ZStream[R1, E1, O1])] =
     self.process.flatMap { pull =>
       val stream = ZStream.repeatEffectChunkOption(pull)
       val s      = sink.exposeLeftover
       stream.run(s).toManaged_.map(e => (e._1, ZStream.fromChunk(e._2) ++ stream))
-    }
+    }*/
 
   /**
    * Provides the stream with its required environment, which eliminates
@@ -2305,11 +2305,11 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    * Runs the sink on the stream to produce either the sink's result or an error.
    */
-  def run[R1 <: R, E1 >: E, B](sink: ZSink[R1, E1, O, Any, B]): ZIO[R1, E1, B] =
+  def run[R1 <: R, E1 >: E, B](sink: ZSink[R1, E1, O, B]): ZIO[R1, E1, B] =
     runManaged(sink).useNow
 
-  def runManaged[R1 <: R, E1 >: E, B](sink: ZSink[R1, E1, O, Any, B]): ZManaged[R1, E1, B] =
-    (process <*> sink.push).mapM {
+  def runManaged[R1 <: R, E1 >: E, B](sink: ZSink[R1, E1, O, B]): ZManaged[R1, E1, B] =
+    (process <*> sink.push(identity[O])).mapM {
       case (pull, push) =>
         def go: ZIO[R1, E1, B] = pull.foldCauseM(
           Cause
@@ -2331,14 +2331,14 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    * Runs the stream and collects all of its elements to a list.
    */
-  def runCollect: ZIO[R, E, Chunk[O]] = run(ZSink.collectAll[O])
+ // def runCollect: ZIO[R, E, Chunk[O]] = run(ZSink.collectAll[O])
 
   /**
    * Runs the stream and emits the number of elements processed
    *
    * Equivalent to `run(ZSink.count)`
    */
-  final def runCount: ZIO[R, E, Long] = self.run(ZSink.count)
+ // final def runCount: ZIO[R, E, Long] = self.run(ZSink.count)
 
   /**
    * Runs the stream only for its effects. The emitted elements are discarded.
@@ -2350,22 +2350,22 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Runs the stream to completion and yields the first value emitted by it,
    * discarding the rest of the elements.
    */
-  def runHead: ZIO[R, E, Option[O]] =
-    run(ZSink.head)
+//  def runHead: ZIO[R, E, Option[O]] =
+//    run(ZSink.head)
 
   /**
    * Runs the stream to completion and yields the last value emitted by it,
    * discarding the rest of the elements.
    */
-  def runLast: ZIO[R, E, Option[O]] =
-    run(ZSink.last)
+ // def runLast: ZIO[R, E, Option[O]] =
+ //   run(ZSink.last)
 
   /**
    * Runs the stream to a sink which sums elements, provided they are Numeric.
    *
    * Equivalent to `run(Sink.sum[A])`
    */
-  final def runSum[O1 >: O](implicit ev: Numeric[O1]): ZIO[R, E, O1] = run(ZSink.sum[O1])
+ // final def runSum[O1 >: O](implicit ev: Numeric[O1]): ZIO[R, E, O1] = run(ZSink.sum[O1])
 
   /**
    * Schedules the output of the stream using the provided `schedule`.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2331,7 +2331,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    * Runs the stream and collects all of its elements to a list.
    */
- // def runCollect: ZIO[R, E, Chunk[O]] = run(ZSink.collectAll[O])
+  def runCollect: ZIO[R, E, Chunk[O]] = run(ZSink.collectAll[O])
 
   /**
    * Runs the stream and emits the number of elements processed
@@ -2350,15 +2350,15 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Runs the stream to completion and yields the first value emitted by it,
    * discarding the rest of the elements.
    */
-//  def runHead: ZIO[R, E, Option[O]] =
-//    run(ZSink.head)
+  def runHead: ZIO[R, E, Option[O]] =
+    run(ZSink.head)
 
   /**
    * Runs the stream to completion and yields the last value emitted by it,
    * discarding the rest of the elements.
    */
- // def runLast: ZIO[R, E, Option[O]] =
- //   run(ZSink.last)
+  def runLast: ZIO[R, E, Option[O]] =
+    run(ZSink.last)
 
   /**
    * Runs the stream to a sink which sums elements, provided they are Numeric.

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -35,7 +35,8 @@ abstract class ZTransducer[-R, +E, -I, +O](val push: ZManaged[R, Nothing, Option
    * Compose this transducer with a sink, resulting in a sink that processes elements by piping
    * them through this transducer and piping the results into the sink.
    */
-  def >>>[R1 <: R, E1 >: E, O2 >: O, I1 <: I, L, Z](that: ZSink[R1, E1, O2, L, Z]): ZSink[R1, E1, I1, L, Z] =
+  //TODO:
+  /*def >>>[R1 <: R, E1 >: E, O2 >: O, I1 <: I, L, Z](that: ZSink[R1, E1, O2, L, Z]): ZSink[R1, E1, I1, L, Z] =
     ZSink[R1, E1, I1, L, Z] {
       self.push.zipWith(that.push) { (pushSelf, pushThat) =>
         {
@@ -49,7 +50,7 @@ abstract class ZTransducer[-R, +E, -I, +O](val push: ZManaged[R, Nothing, Option
               .flatMap(chunk => pushThat(Some(chunk)))
         }
       }
-    }
+    }*/
 
   final def contramap[J](f: J => I): ZTransducer[R, E, J, O] =
     ZTransducer(self.push.map(push => is => push(is.map(_.map(f)))))

--- a/streams/shared/src/main/scala/zio/stream/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/package.scala
@@ -4,7 +4,7 @@ package object stream {
   type Stream[+E, +A] = ZStream[Any, E, A]
   val Stream = ZStream
 
-  type Sink[+E, A, +L, +B] = ZSink[Any, E, A, L, B]
+  type Sink[+E, A, +B] = ZSink[Any, E, A, B]
   val Sink = ZSink
 
   type Transducer[+E, -A, +B] = ZTransducer[Any, E, A, B]

--- a/streams/shared/src/main/scala/zio/stream/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/package.scala
@@ -4,7 +4,7 @@ package object stream {
   type Stream[+E, +A] = ZStream[Any, E, A]
   val Stream = ZStream
 
-  type Sink[+E, A, +B] = ZSink[Any, E, A, B]
+  type Sink[+E, -A, +B] = ZSink[Any, E, A, B]
   val Sink = ZSink
 
   type Transducer[+E, -A, +B] = ZTransducer[Any, E, A, B]

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -17,7 +17,7 @@
 package zio.test.mock
 
 import zio.internal.Executor
-import zio.stream.{ ZSink, ZStream }
+import zio.stream.{ ZStream }
 import zio.test.TestPlatform
 import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO }
 
@@ -43,7 +43,7 @@ abstract class Mock[R <: Has[_]: Tag] { self =>
 
   abstract class Effect[I: Tag, E: Tag, A: Tag]               extends Capability[R, I, E, A](self)
   abstract class Method[I: Tag, E <: Throwable: Tag, A: Tag]  extends Capability[R, I, E, A](self)
-  abstract class Sink[I: Tag, E: Tag, A: Tag, L: Tag, B: Tag] extends Capability[R, I, E, ZSink[Any, E, A, L, B]](self)
+  //abstract class Sink[I: Tag, E: Tag, A: Tag, L: Tag, B: Tag] extends Capability[R, I, E, ZSink[Any, E, A, L, B]](self)
   abstract class Stream[I: Tag, E: Tag, A: Tag]               extends Capability[R, I, Nothing, ZStream[Any, E, A]](self)
 
   object Poly {


### PR DESCRIPTION
Based on: https://scalafiddle.io/sf/mY7Svca/0
Very early stage.

Problems faced so far: 
1) Can't declare a sink from lambda: no more `ZSink.apply` and `ZSink.fromPush`. Too much polymorphism.
2) Seems that effectful `ZSink.contramapM` will not work as well (not sure)
3) Should `invert` operate on chunks or on single values?
4) in vast majority of cases `invert` will be `identity`. Can it be optimized?