### PR TITLE
Handle Possibility that Parent Scope is Closed

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -855,6 +855,18 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(name)(isNone)
       }
     ),
+    suite("forkIn") {
+      testM("fiber forked in a closed scope does not run") {
+        for {
+          ref   <- Ref.make(false)
+          open  <- ZScope.make[Exit[Any, Any]]
+          _     <- open.close(Exit.unit)
+          fiber <- ref.set(true).forkIn(open.scope)
+          exit  <- fiber.await
+          value <- ref.get
+        } yield assert(exit)(isInterrupted) && assert(value)(isFalse)
+      }
+    },
     suite("forkWithErrorHandler")(
       testM("calls provided function when task fails") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZScopeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZScopeSpec.scala
@@ -43,7 +43,7 @@ object ZScopeSpec extends ZIOBaseSpec {
         open  <- ZScope.make[Unit]
         value <- open.scope.ensure(_ => IO.unit)
         empty <- open.scope.empty
-      } yield assert(empty)(isFalse) && assert(value)(isSome(anything))
+      } yield assert(empty)(isFalse) && assert(value)(isRight(anything))
     },
     testM("ensure on closed scope returns false") {
       for {
@@ -51,7 +51,7 @@ object ZScopeSpec extends ZIOBaseSpec {
         _     <- open.close(())
         value <- open.scope.ensure(_ => IO.unit)
         empty <- open.scope.empty
-      } yield assert(empty)(isTrue) && assert(value)(isNone)
+      } yield assert(empty)(isTrue) && assert(value)(isLeft(anything))
     },
     testScope("one finalizer", 0)((ref, scope) => scope.ensure(_ => ref.update(_ + 1)) as 1),
     suite("finalizer removal")(
@@ -60,7 +60,7 @@ object ZScopeSpec extends ZIOBaseSpec {
           ref  <- Ref.make[Int](0)
           open <- ZScope.make[Unit]
           key  <- open.scope.ensure(_ => ref.update(_ + 1))
-          _    <- key.fold[UIO[Any]](IO.unit)(_.remove)
+          _    <- key.fold[UIO[Any]](_ => IO.unit, _.remove)
           _    <- open.close(())
           v    <- ref.get
         } yield assert(v)(equalTo(0))

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -741,9 +741,7 @@ private[zio] final class FiberContext[E, A](
 
       // Add the finalizer key to the child fiber, so that if it happens to be
       // garbage collected, then its finalizer will be garbage collected too:
-      childContext.scopeKey = key.getOrElse(
-        throw new IllegalStateException("Defect: The fiber's scope has ended before the fiber itself has ended")
-      )
+      key.foreach(childContext.scopeKey = _)
 
       // Remove the finalizer key from the parent scope when the child fiber
       // terminates:


### PR DESCRIPTION
Resolves #3910.

In `FiberContext#fork` there is an implicit assumption that `unsafeEnsure` will always succeed in adding a finalizer to the parent scope. However, that does not appear to always be the case. In particular, after `fork` is called but before `unsafeEnsure` obtains a lock, a concurrent process could close the parent scope. Right now this causes a defect which this PR removes.

In addition to this, I think we have a risk of not propagating interruption, because if the parent scope has already been closed we want to immediately interrupt the child fiber or possibly not begin executing it at all.