### PR TITLE
Add initial Gitpod support.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,15 @@
+FROM gitpod/workspace-full
+USER gitpod
+RUN brew install scala coursier/formulas/coursier sbt scalaenv ammonite-repl
+RUN sudo env "PATH=$PATH" coursier bootstrap org.scalameta:scalafmt-cli_2.12:2.4.2 \
+  -r sonatype:snapshots \
+  -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
+RUN bash -cl "set -eux \
+    version=0.9.0 \
+    coursier fetch \
+        org.scalameta:metals_2.12:$version \
+        org.scalameta:mtags_2.13.1:$version \
+        org.scalameta:mtags_2.13.0:$version \
+        org.scalameta:mtags_2.12.10:$version \
+        org.scalameta:mtags_2.12.9:$version \
+        org.scalameta:mtags_2.12.8:$version"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
 vscode:
   extensions:
     - scala-lang.scala@0.3.9:kklqw+c/dNRmtTU8B5repw==
-    - scalameta.metals@1.7.8:oixMSF1r3cXQPfOQ34+sTA==
+    - scalameta.metals@1.9.0:KNju0fLBpNiyqH8qBfFeIQ==
 ports:
   - port: 8212
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+vscode:
+  extensions:
+    - scala-lang.scala@0.3.9:kklqw+c/dNRmtTU8B5repw==
+    - scalameta.metals@1.7.8:oixMSF1r3cXQPfOQ34+sTA==
+ports:
+  - port: 8212
+    onOpen: ignore

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ![ZIO Logo](./ZIO.png)
 
-| CI | Release | Snapshot | Issues | Scaladoc | Scaladex | Discord | Twitter |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| [![Build Status][Badge-Circle]][Link-Circle] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Snapshot Artifacts][Badge-SonatypeSnapshots]][Link-SonatypeSnapshots] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladoc]][Link-Scaladoc] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] |
+| CI | Release | Snapshot | Issues | Scaladoc | Scaladex | Discord | Twitter | Gitpod |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [![Build Status][Badge-Circle]][Link-Circle] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Snapshot Artifacts][Badge-SonatypeSnapshots]][Link-SonatypeSnapshots] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladoc]][Link-Scaladoc] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] | [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/zio/zio) |
+
 
 # Welcome to ZIO
 


### PR DESCRIPTION
Resolves #3820.  This is a copy of the Gitpod Scala template with a few tweaks to remove support for old versions of Scala.