### PR TITLE
Split the badges table to make it more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 ![ZIO Logo](./ZIO.png)
 
-| CI | Release | Snapshot | Issues | Scaladoc | Scaladex | Discord | Twitter | Gitpod |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| [![Build Status][Badge-Circle]][Link-Circle] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Snapshot Artifacts][Badge-SonatypeSnapshots]][Link-SonatypeSnapshots] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladoc]][Link-Scaladoc] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] | [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/zio/zio) |
+| CI | Release | Snapshot | Issues | Scaladoc |
+| --- | --- | --- | --- | --- |
+| [![Build Status][Badge-Circle]][Link-Circle] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Snapshot Artifacts][Badge-SonatypeSnapshots]][Link-SonatypeSnapshots] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] | [![Badge-Scaladoc]][Link-Scaladoc] |
 
+| Scaladex | Discord | Twitter | Gitpod |
+| --- | --- | --- | --- |
+| [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] | [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/zio/zio) |
 
 # Welcome to ZIO
 


### PR DESCRIPTION
Currently, the badges table is too wide and makes the badges pretty hard to read:

![image](https://user-images.githubusercontent.com/666504/86204665-a4a73280-bb9a-11ea-95f2-e68e27d66002.png)


I have split the table into two to make it more readable.