### PR TITLE
Add Console support for printing to standard error

### DIFF
--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -28,7 +28,11 @@ package object console {
     trait Service extends Serializable {
       def putStr(line: String): UIO[Unit]
 
+      def putStrErr(line: String): UIO[Unit]
+
       def putStrLn(line: String): UIO[Unit]
+
+      def putStrLnErr(line: String): UIO[Unit]
 
       def getStrLn: IO[IOException, String]
     }
@@ -42,10 +46,22 @@ package object console {
         final def putStr(line: String): UIO[Unit] =
           putStr(SConsole.out)(line)
 
+        /**
+         * Prints text to the standard error console.
+         */
+        override def putStrErr(line: String): UIO[Unit] =
+          putStrLn(SConsole.err)(line)
+
         final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream) {
             SConsole.print(line)
           })
+
+        /**
+         * Prints a line of text to the standard error console, including a newline character.
+         */
+        override def putStrLnErr(line: String): UIO[Unit] =
+          putStrLn(SConsole.err)(line)
 
         /**
          * Prints a line of text to the console, including a newline character.
@@ -95,10 +111,22 @@ package object console {
     ZIO.accessM(_.get putStr line)
 
   /**
+   * Prints text to the standard error console.
+   */
+  def putStrErr(line: => String): URIO[Console, Unit] =
+    ZIO.accessM(_.get putStrErr line)
+
+  /**
    * Prints a line of text to the console, including a newline character.
    */
   def putStrLn(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrLn line)
+
+  /**
+   * Prints a line of text to the standard error console, including a newline character.
+   */
+  def putStrLnErr(line: => String): URIO[Console, Unit] =
+    ZIO.accessM(_.get putStrLnErr line)
 
   /**
    * Retrieves a line of input from the console.

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -25,6 +25,13 @@ object EnvironmentSpec extends ZIOBaseSpec {
         output <- TestConsole.output
       } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
     } @@ silent,
+    testM("Console writes error line to error console") {
+      for {
+        _      <- console.putStrLnErr("First line")
+        _      <- console.putStrLnErr("Second line")
+        output <- TestConsole.outputErr
+      } yield assert(output)(equalTo(Vector("First line\n", "Second line\n")))
+    } @@ silent,
     testM("Console reads line from input") {
       for {
         _      <- TestConsole.feedLines("Input 1", "Input 2")

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -642,6 +642,7 @@ package object environment extends PlatformSpecific {
       def debug[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A]
       def feedLines(lines: String*): UIO[Unit]
       def output: UIO[Vector[String]]
+      def outputErr: UIO[Vector[String]]
       def silent[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A]
     }
 
@@ -691,7 +692,7 @@ package object environment extends PlatformSpecific {
                     IO.fromOption(d.input.headOption)
                       .orElseFail(new EOFException("There is no more input left to read"))
                   )
-          _ <- consoleState.update(data => Data(data.input.tail, data.output))
+          _ <- consoleState.update(data => Data(data.input.tail, data.output, data.errOutput))
         } yield input
       }
 
@@ -703,11 +704,26 @@ package object environment extends PlatformSpecific {
         consoleState.get.map(_.output)
 
       /**
+       * Returns the contents of the error output buffer. The first value written to
+       * the error output buffer will be the first in the sequence.
+       */
+      val outputErr: UIO[Vector[String]] =
+        consoleState.get.map(_.errOutput)
+
+      /**
        * Writes the specified string to the output buffer.
        */
       override def putStr(line: String): UIO[Unit] =
         consoleState.update { data =>
-          Data(data.input, data.output :+ line)
+          Data(data.input, data.output :+ line, data.errOutput)
+        } *> live.provide(console.putStr(line)).whenM(debugState.get)
+
+      /**
+       * Writes the specified string to the error buffer.
+       */
+      override def putStrErr(line: String): UIO[Unit] =
+        consoleState.update { data =>
+          Data(data.input, data.output, data.errOutput :+ line)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
 
       /**
@@ -716,7 +732,16 @@ package object environment extends PlatformSpecific {
        */
       override def putStrLn(line: String): UIO[Unit] =
         consoleState.update { data =>
-          Data(data.input, data.output :+ s"$line\n")
+          Data(data.input, data.output :+ s"$line\n", data.errOutput)
+        } *> live.provide(console.putStrLn(line)).whenM(debugState.get)
+
+      /**
+       * Writes the specified string to the error buffer followed by a newline
+       * character.
+       */
+      override def putStrLnErr(line: String): UIO[Unit] =
+        consoleState.update { data =>
+          Data(data.input, data.output, data.errOutput :+ s"$line\n")
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)
 
       /**
@@ -798,6 +823,13 @@ package object environment extends PlatformSpecific {
       ZIO.accessM(_.get.output)
 
     /**
+     * Accesses a `TestConsole` instance in the environment and returns the
+     * contents of the error buffer.
+     */
+    val outputErr: ZIO[TestConsole, Nothing, Vector[String]] =
+      ZIO.accessM(_.get.outputErr)
+
+    /**
      * Accesses a `TestConsole` instance in the environment and saves the
      * console state in an effect which, when run, will restore the
      * `TestConsole` to the saved state.
@@ -817,7 +849,11 @@ package object environment extends PlatformSpecific {
     /**
      * The state of the `TestConsole`.
      */
-    final case class Data(input: List[String] = List.empty, output: Vector[String] = Vector.empty)
+    final case class Data(
+      input: List[String] = List.empty,
+      output: Vector[String] = Vector.empty,
+      errOutput: Vector[String] = Vector.empty
+    )
   }
 
   /**

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -23,16 +23,20 @@ import zio.{ Has, IO, UIO, URLayer, ZLayer }
 
 object MockConsole extends Mock[Console] {
 
-  object PutStr   extends Effect[String, Nothing, Unit]
-  object PutStrLn extends Effect[String, Nothing, Unit]
-  object GetStrLn extends Effect[Unit, IOException, String]
+  object PutStr      extends Effect[String, Nothing, Unit]
+  object PutStrErr   extends Effect[String, Nothing, Unit]
+  object PutStrLn    extends Effect[String, Nothing, Unit]
+  object PutStrLnErr extends Effect[String, Nothing, Unit]
+  object GetStrLn    extends Effect[Unit, IOException, String]
 
   val compose: URLayer[Has[Proxy], Console] =
     ZLayer.fromService(proxy =>
       new Console.Service {
-        def putStr(line: String): UIO[Unit]   = proxy(PutStr, line)
-        def putStrLn(line: String): UIO[Unit] = proxy(PutStrLn, line)
-        val getStrLn: IO[IOException, String] = proxy(GetStrLn)
+        def putStr(line: String): UIO[Unit]      = proxy(PutStr, line)
+        def putStrErr(line: String): UIO[Unit]   = proxy(PutStrErr, line)
+        def putStrLn(line: String): UIO[Unit]    = proxy(PutStrLn, line)
+        def putStrLnErr(line: String): UIO[Unit] = proxy(PutStrLnErr, line)
+        val getStrLn: IO[IOException, String]    = proxy(GetStrLn)
       }
     )
 }


### PR DESCRIPTION
Since I had a need for printing to the standard error in a little console application, I thought I'd try adding support upstream :). I might be missing something, but it seems like a small little win to add it.

I'm not exactly in love with the naming here, but OTOH I couldn't come up with anything much better. I considered using simply 'E' as the suffix, but that might be a little bit too opaque. Prefixing seems a bit odd because you then get different cases for the 'p' in errPutStrLn and putStrLn which might be annoying.

EDIT: I also tried to see if there was precedent in Haskell, but they only have putStr/putStrLn and hPutStr/hPutStrLn (which is the generalized handle version which already exists in the "live" scala implementation, but isn't exposed -- presumably because of a lack of safety for arbitrary PrintStreams).