### PR TITLE
Java Time Dependency for ScalaJS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -395,7 +395,8 @@ lazy val docs = project.module
     coreJVM,
     streamsJVM,
     testJVM,
-    testMagnoliaJVM
+    testMagnoliaJVM,
+    coreJS
   )
   .enablePlugins(MdocPlugin, DocusaurusPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-// shadow sbt-scalajs' crossProject from Scala.js 0.6.x
 import BuildHelper._
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
+// shadow sbt-scalajs' crossProject from Scala.js 0.6.x
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "zio"
@@ -357,6 +357,11 @@ lazy val benchmarks = project.module
     )
   )
 
+lazy val jsdocs = project
+  .settings(
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.0.0"
+  )
+  .enablePlugins(ScalaJSPlugin)
 lazy val docs = project.module
   .in(file("zio-docs"))
   .settings(
@@ -385,6 +390,7 @@ lazy val docs = project.module
     )
   )
   .settings(macroExpansionSettings)
+  .settings(mdocJS := Some(jsdocs))
   .dependsOn(
     coreJVM,
     streamsJVM,

--- a/build.sbt
+++ b/build.sbt
@@ -390,13 +390,13 @@ lazy val docs = project.module
     )
   )
   .settings(macroExpansionSettings)
-  .settings(mdocJS := Some(jsdocs))
+  //.settings(mdocJS := Some(jsdocs)) // Disabled until mdoc supports ScalaJS 1.1
   .dependsOn(
     coreJVM,
     streamsJVM,
     testJVM,
-    testMagnoliaJVM,
-    coreJS
+    testMagnoliaJVM
+    // , coreJS // Disabled until mdoc supports ScalaJS 1.1
   )
   .enablePlugins(MdocPlugin, DocusaurusPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val coreJVM = core.jvm
   .settings(replSettings)
 
 lazy val coreJS = core.js
+  .settings(jsSettings)
 
 lazy val coreNative = core.native
   .settings(scalaVersion := "2.11.12")
@@ -152,7 +153,7 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings(replSettings)
 
 lazy val coreTestsJS = coreTests.js
-  .settings(testJsSettings)
+  .settings(jsSettings)
 
 lazy val macros = crossProject(JSPlatform, JVMPlatform)
   .in(file("macros"))
@@ -165,7 +166,7 @@ lazy val macros = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(testRunner)
 
 lazy val macrosJVM = macros.jvm.settings(dottySettings)
-lazy val macrosJS  = macros.js.settings(testJsSettings)
+lazy val macrosJS  = macros.js.settings(jsSettings)
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .in(file("streams"))
@@ -197,7 +198,7 @@ lazy val streamsTestsJVM = streamsTests.jvm
   .settings(dottySettings)
 
 lazy val streamsTestsJS = streamsTests.js
-  .settings(testJsSettings)
+  .settings(jsSettings)
 
 lazy val test = crossProject(JSPlatform, JVMPlatform)
   .in(file("test"))
@@ -228,7 +229,7 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testTestsJVM = testTests.jvm.settings(dottySettings)
-lazy val testTestsJS  = testTests.js.settings(testJsSettings)
+lazy val testTestsJS  = testTests.js.settings(jsSettings)
 
 lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-magnolia"))
@@ -256,7 +257,7 @@ lazy val testMagnoliaTests = crossProject(JVMPlatform, JSPlatform)
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testMagnoliaTestsJVM = testMagnoliaTests.jvm
-lazy val testMagnoliaTestsJS  = testMagnoliaTests.js.settings(testJsSettings)
+lazy val testMagnoliaTestsJS  = testMagnoliaTests.js.settings(jsSettings)
 
 lazy val stacktracer = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("stacktracer"))
@@ -294,7 +295,7 @@ lazy val testJunitRunner = crossProject(JVMPlatform)
 lazy val testJunitRunnerJVM = testJunitRunner.jvm.settings(dottySettings)
 
 lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
-lazy val testRunnerJS  = testRunner.js.settings(testJsSettings)
+lazy val testRunnerJS  = testRunner.js.settings(jsSettings)
 
 /**
  * Examples sub-project that is not included in the root project.
@@ -309,7 +310,7 @@ lazy val examples = crossProject(JVMPlatform, JSPlatform)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .dependsOn(macros, testRunner)
 
-lazy val examplesJS = examples.js.settings(testJsSettings)
+lazy val examplesJS = examples.js.settings(jsSettings)
 lazy val examplesJVM = examples.jvm
   .settings(dottySettings)
   .dependsOn(testJunitRunnerJVM)

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -13,10 +13,6 @@ println(s"""libraryDependencies += "dev.zio" %%% "zio" % "${zio.BuildInfo.versio
 println(s"""```""")
 ```
 
-For Java Time API which is not a part of ScalaJS, you might have to add dependency that provides `java.time` package to
-avoid linker errors when using `Clock`. ZIO uses [scala-java-time](https://github.com/cquiroz/scala-java-time) for
-running it's test.
-
 ## Example
 
 Your main function can extend `App` as follows.
@@ -31,11 +27,11 @@ object MyApp extends App {
 
   def run(args: List[String]): IO[Nothing, Int] =
     for {
-      p <- IO.effectSuspendTotal(document.createElement("p"))
-      t <- IO.effectSuspendTotal(document.createTextNode("Hello World"))
-      _ <- IO.effectSuspendTotal(p.appendChild(t))
-      _ <- IO.effectSuspendTotal(document.body.appendChild(p))
-    } yield 0
+      p <- IO.effectTotal(document.createElement("p"))
+      t <- IO.effectTotal(document.createTextNode("Hello World"))
+      _ <- IO.effectTotal(p.appendChild(t))
+      _ <- IO.effectTotal(document.body.appendChild(p))
+    } yield ExitCode.success
 }
 
 ```

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -19,7 +19,7 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
-```scala mdoc:js
+```scala
 import org.scalajs.dom.{document, raw}
 import zio._
 import zio.duration._

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -19,7 +19,7 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
-```scala
+```scala mdoc:silent
 import org.scalajs.dom.document
 import zio.{App, IO}
 

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -29,9 +29,10 @@ object Main extends App {
 
   def run(args: List[String]) = {
     for {
+      _      <- putStrLn("Starting progress bar demo.")  // Outputs on browser console log.
       target <- IO.effectTotal(document.createElement("pre"))
       _      <- update(target).repeat(Schedule.spaced(1.seconds))
-      _      <- IO.effectTotal(node.appendChild(target))
+      _      <- IO.effectTotal(node.appendChild(target)) // "node" is provided in this page by mdoc.
     } yield ExitCode.success
   }
 

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -19,19 +19,42 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
+<<<<<<< HEAD
 ```scala mdoc:silent
 import org.scalajs.dom.document
 import zio.{App, IO}
+=======
+```scala mdoc:js
+import org.scalajs.dom.{document, raw}
+import zio._
+import zio.duration._
+import zio.clock._
+>>>>>>> Added Scala.JS example that uses ZIO and should render with mdoc in the browser.
 
-object MyApp extends App {
+object Main extends App {
 
-  def run(args: List[String]): IO[Nothing, Int] =
+  def run(args: List[String]) = {
     for {
-      p <- IO.effectTotal(document.createElement("p"))
-      t <- IO.effectTotal(document.createTextNode("Hello World"))
-      _ <- IO.effectTotal(p.appendChild(t))
-      _ <- IO.effectTotal(document.body.appendChild(p))
+      target <- IO.effectTotal(document.createElement("pre"))
+      _      <- update(target).repeat(Schedule.spaced(1.seconds))
+      _      <- IO.effectTotal(node.appendChild(target))
     } yield ExitCode.success
-}
+  }
 
+  def update(target: raw.Element) = {
+      for {
+        time   <- currentTime(TimeUnit.SECONDS)
+        output <- UIO.effectTotal(progress((time % 11).toInt, 10))
+        _      <- UIO.effectTotal(target.innerHTML = output)
+      } yield ()
+  }
+
+  def progress(tick: Int, size: Int) = {
+      val bar_length = tick
+      val empty_length = size - tick
+      val bar = "#" * bar_length + " " * empty_length
+      s"$bar $bar_length%"
+  }
+
+}
 ```

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -19,17 +19,11 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
-<<<<<<< HEAD
-```scala mdoc:silent
-import org.scalajs.dom.document
-import zio.{App, IO}
-=======
 ```scala mdoc:js
 import org.scalajs.dom.{document, raw}
 import zio._
 import zio.duration._
 import zio.clock._
->>>>>>> Added Scala.JS example that uses ZIO and should render with mdoc in the browser.
 
 object Main extends App {
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -328,7 +328,7 @@ object BuildHelper {
   )
 
   def jsSettings = Seq(
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0" % Test
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0"
   )
 
   def welcomeMessage = onLoadMessage := {

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -327,7 +327,7 @@ object BuildHelper {
     }
   )
 
-  def testJsSettings = Seq(
+  def jsSettings = Seq(
     libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0" % Test
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.bintrayRepo("ktosopl", "sbt-plugins/sbt-jcstress")
 
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.3.7")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.1.1")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "0.6.32")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.9.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.bintrayRepo("ktosopl", "sbt-plugins/sbt-jcstress")
 
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.3.7")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "0.6.32")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.1.1")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.9.0")


### PR DESCRIPTION
Made the java-time shim for ScalaJS always active since the default runtime includes Clock.

Resolves #3139 