### PR TITLE
Fix: ZStream.repeatEffectWith delays its outputs

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3523,7 +3523,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               ref      <- Ref.make(0)
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())
-              schedule = Schedule.identity[Int].whileOutput(_ <= length)
+              schedule = Schedule.identity[Int].whileOutput(_ < length)
               result   <- ZStream.repeatEffectWith(effect, schedule).runCollect
             } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
           })

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3535,7 +3535,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               equalTo(Chunk(1))
             )
           },
-          testM("emits before delaying according to the schedule"){
+          testM("emits before delaying according to the schedule") {
             val interval = 1.second
 
             for {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3461,9 +3461,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )(equalTo(Chunk(0, 1, 2, 3, 4, 5)))
         },
         testM("range") {
-          val right = Chunk.fromIterable(Range(0, 10))
-          val left  = ZStream.range(0, 10).runCollect
-          assertM(left)(equalTo(right))
+          assertM(ZStream.range(0, 10).runCollect)(equalTo(Chunk.fromIterable(Range(0, 10))))
         },
         testM("repeatEffect")(
           assertM(
@@ -3526,7 +3524,17 @@ object ZStreamSpec extends ZIOBaseSpec {
               schedule = Schedule.identity[Int].whileOutput(_ < length)
               result   <- ZStream.repeatEffectWith(effect, schedule).runCollect
             } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
-          })
+          }),
+          testM("should perform repetitions in addition to the first execution (one repetition)") {
+            assertM(ZStream.repeatEffectWith(UIO(1), Schedule.once).runCollect)(
+              equalTo(Chunk(1, 1))
+            )
+          },
+          testM("should perform repetitions in addition to the first execution (zero repetitions)") {
+            assertM(ZStream.repeatEffectWith(UIO(1), Schedule.stop).runCollect)(
+              equalTo(Chunk(1))
+            )
+          }
         ),
         testM("unfold") {
           assertM(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3697,9 +3697,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an effect producing a value of type `A` which repeats using the specified schedule
    */
   def repeatEffectWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, _]): ZStream[R, E, A] =
-    fromEffect(schedule.initial).flatMap { initial =>
-      unfoldM(initial) { state =>
-        effect.flatMap(value => schedule.update(value, state).fold(_ => None, state => Some((value, state))))
+    ZStream.fromEffect(schedule.initial).flatMap { initialScheduleState =>
+      ZStream.fromEffect(effect).flatMap { value =>
+        ZStream.succeed(value) ++ ZStream.unfoldM((initialScheduleState, value)) {
+          case (state, lastValue) =>
+            schedule
+              .update(lastValue, state)
+              .foldM(_ => ZIO.succeed(Option.empty), newState => effect.map(value => Some((value, (newState, value)))))
+        }
       }
     }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3695,17 +3695,19 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats using the specified schedule
+   *
+   * The first `A` is emitted immediately. Subsequent `A`s are delayed according to `schedule`, which takes as input
+   * the previous `A`.
    */
   def repeatEffectWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, _]): ZStream[R, E, A] =
-    ZStream.fromEffect(schedule.initial).flatMap { initialScheduleState =>
-      ZStream.fromEffect(effect).flatMap { value =>
+    ZStream.fromEffect(schedule.initial zip effect).flatMap {
+      case (initialScheduleState, value) =>
         ZStream.succeed(value) ++ ZStream.unfoldM((initialScheduleState, value)) {
           case (state, lastValue) =>
             schedule
               .update(lastValue, state)
               .foldM(_ => ZIO.succeed(Option.empty), newState => effect.map(value => Some((value, (newState, value)))))
         }
-      }
     }
 
   /**


### PR DESCRIPTION
Resolves #3863 

In the current implementation every element is unnecessarily delayed by the updating of the schedule. The new implementation updates the schedule as part of the next pull. 

One consequence when using `Schedule.never` is that in the new version, the stream emits at least 1 element, while in the old version it would not, although the effect was evaluated.

The new version has the same semantics as `ZIO(..).repeat(schedule)`, which is to evaluate the effect once and then use the schedule to repeat.