### PR TITLE
Chunk.foldWhileM should not advance iterator twice

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -515,6 +515,17 @@ object ChunkSpec extends ZIOBaseSpec {
       val chunk = Chunk("a")
       val array = chunk.toArray
       assert(array)(anything)
+    },
+    testM("foldWhileM") {
+      assertM(
+        Chunk
+          .fromIterable(List(2))
+          .foldWhileM(0)(i => i <= 2) {
+            case (i: Int, i1: Int) =>
+              if (i < 2) IO.succeed(i + i1)
+              else IO.succeed(i)
+          }
+      )(equalTo(2))
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -473,7 +473,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
     if (iterator.hasNext) {
       val array  = iterator.next()
       val length = array.length
-      loop(z, iterator, iterator.next(), 0, length)
+      loop(z, iterator, array, 0, length)
     } else {
       ZIO.succeedNow(z)
     }


### PR DESCRIPTION
Fixes #3968 

Small bug in Chunk.foldWhileM iterates the iterable twice while only checking once:

```scala
if (iterator.hasNext) {
  val array  = iterator.next()
  val length = array.length
  loop(z, iterator, iterator.next(), 0, length)
} else {
  ZIO.succeedNow(z)
}
```