### PR TITLE
Prevent Potential Deadlock in ZIO#foreachPar

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -143,7 +143,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
           assert(cause.traces.head.stackTrace.size)(equalTo(7)) &&
           assert(cause.traces.head.stackTrace(4).prettyPrint.contains("uploadUsers"))(isTrue) &&
           assert(cause.traces(1).stackTrace.size)(equalTo(4)) &&
-          assert(cause.traces(1).executionTrace.size)(equalTo(3)) &&
+          assert(cause.traces(1).executionTrace.size)(equalTo(4)) &&
           assert(cause.traces(1).executionTrace.head.prettyPrint.contains("uploadTo"))(isTrue) &&
           assert(cause.traces(1).parentTrace.isEmpty)(isFalse) &&
           assert(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -682,6 +682,12 @@ object ZIOSpec extends ZIOBaseSpec {
           .run
         assertM(results)(isInterrupted)
       } @@ zioTag(interruption),
+      testM("runs a task that throws an unsuspended exception") {
+        def f(i: Int): Task[Int] = throw new Exception(i.toString)
+        for {
+          _ <- IO.foreachPar(1 to 1)(f).run
+        } yield assertCompletes
+      },
       testM("returns results in the same order") {
         val list = List("1", "2", "3")
         val res  = IO.foreachPar(list)(x => IO.effectTotal[Int](x.toInt))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2834,7 +2834,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
         task = ZIOFn(f)((a: A) =>
           ZIO
             .whenM[R, E](startTask) {
-              f(a).interruptible
+              ZIO
+                .effectSuspendTotal(f(a))
+                .interruptible
                 .tapCause(c => causes.update(_ && c) *> startFailure)
                 .ensuring {
                   val isComplete = status.modify {


### PR DESCRIPTION
Resolves #3940.

The issue is that in our optimized implementation of `foreachPar_` we are forking a fiber for each task and waiting for it to signal success or failure. But if an exception is thrown during the construction of the task this logic is never executed so we suspend indefinitely waiting for the signal.

This PR addresses by using `effectSuspendTotal` to convert thrown exceptions in constructing the task to fiber failures. 

One slightly unfortunate thing is that now there is a slight asymmetry between `foreach` and `foreachPar` in that `ZIO.foreach(as)(f).run` will fail with a fiber failure if `f` throws` but `ZIO.foreachPar(as)(f).run` will return an exit with a die failure..