### PR TITLE
Activate mdoc on JavaScript.

### DIFF
--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -23,7 +23,7 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
-```scala
+```scala mdoc:js
 import org.scalajs.dom.document
 import zio.{App, IO}
 


### PR DESCRIPTION
Once https://github.com/scalameta/mdoc/pull/365 is complete, we can enable mdoc and demonstrate Scala.JS and ZIO compiled right into the ZIO microsite.