### PR TITLE
refineToOrDie for ZStream.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1556,8 +1556,10 @@ object ZManagedSpec extends ZIOBaseSpec {
       testM("does not compile when refine type is not a subtype of error type") {
         val result = typeCheck {
           """
-            |ZManaged.fail(new RuntimeException("KABOOM!"))
-            | .refineToOrDie[Error]""".stripMargin
+          ZIO
+            .fail(new RuntimeException("BOO!"))
+            .refineToOrDie[Error]
+            """
         }
         val expected =
           "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -6,7 +6,7 @@ import zio.Cause.Interrupt
 import zio.Exit.Failure
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.nonFlaky
+import zio.test.TestAspect.{ nonFlaky, scala2Only }
 import zio.test._
 import zio.test.environment._
 
@@ -1551,6 +1551,18 @@ object ZManagedSpec extends ZIOBaseSpec {
             ref.get.map(assert(_)(equalTo(List(1, 3))))
         }
       }
+    ),
+    suite("refineToOrDie")(
+      testM("does not compile when refine type is not a subtype of error type") {
+        val result = typeCheck {
+          """
+            |ZManaged.fail(new RuntimeException("KABOOM!"))
+            | .refineToOrDie[Error]""".stripMargin
+        }
+        val expected =
+          "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"
+        assertM(result)(isLeft(equalTo(expected)))
+      } @@ scala2Only
     )
   )
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -740,12 +740,6 @@ final class ZManaged[-R, +E, +A] private (val zio: ZIO[(R, ZManaged.ReleaseMap),
     refineOrDieWith(pf)(ev1)
 
   /**
-   * Keeps some of the errors, and terminates the fiber with the rest.
-   */
-  def refineToOrDie[E1: ClassTag](implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
-    refineOrDieWith { case e: E1 => e }(ev1)
-
-  /**
    * Keeps some of the errors, and terminates the fiber with the rest, using
    * the specified function to convert the `E` into a `Throwable`.
    */
@@ -2291,4 +2285,14 @@ object ZManaged extends ZManagedPlatformSpecific {
 
   private[zio] def succeedNow[A](r: A): ZManaged[Any, Nothing, A] =
     ZManaged(IO.succeedNow((Finalizer.noop, r)))
+
+  implicit final class RefineToOrDieOps[R, E <: Throwable, A](private val self: ZManaged[R, E, A]) extends AnyVal {
+
+    /**
+     * Keeps some of the errors, and terminates the fiber with the rest.
+     */
+    def refineToOrDie[E1 <: E: ClassTag](implicit ev: CanFail[E]): ZManaged[R, E1, A] =
+      self.refineOrDie { case e: E1 => e }
+  }
+
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3153,8 +3153,10 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("does not compile when refine type is not a subtype of error type") {
             val result = typeCheck {
               """
-                |ZStream.fail(new RuntimeException("KABOOM!"))
-                | .refineToOrDie[Error]""".stripMargin
+              ZIO
+                .fail(new RuntimeException("BOO!"))
+                .refineToOrDie[Error]
+                """
             }
             val expected =
               "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -14,7 +14,7 @@ import zio.duration._
 import zio.stm.TQueue
 import zio.stream.ZSink.Push
 import zio.test.Assertion._
-import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, timeout }
+import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, scala2Only, timeout }
 import zio.test._
 import zio.test.environment.TestClock
 
@@ -3148,6 +3148,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               } yield assert(result0)(equalTo(result1))
             }
           }
+        ),
+        suite("refineToOrDie")(
+          testM("does not compile when refine type is not a subtype of error type") {
+            val result = typeCheck {
+              """
+                |ZStream.fail(new RuntimeException("KABOOM!"))
+                | .refineToOrDie[Error]""".stripMargin
+            }
+            val expected =
+              "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"
+            assertM(result)(isLeft(equalTo(expected)))
+          } @@ scala2Only
         )
       ),
       suite("Constructors")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2,6 +2,8 @@ package zio.stream
 
 import java.{ util => ju }
 
+import scala.reflect.ClassTag
+
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
@@ -9,8 +11,6 @@ import zio.internal.UniqueKey
 import zio.stm.TQueue
 import zio.stream.internal.Utils.zipChunks
 import zio.stream.internal.{ ZInputStream, ZReader }
-
-import scala.reflect.ClassTag
 
 /**
  * A `ZStream[R, E, O]` is a description of a program that, when evaluated,

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -10,6 +10,8 @@ import zio.stm.TQueue
 import zio.stream.internal.Utils.zipChunks
 import zio.stream.internal.{ ZInputStream, ZReader }
 
+import scala.reflect.ClassTag
+
 /**
  * A `ZStream[R, E, O]` is a description of a program that, when evaluated,
  * may emit 0 or more values of type `O`, may fail with errors of type `E`
@@ -4046,4 +4048,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     case object Both   extends TerminationStrategy
     case object Either extends TerminationStrategy
   }
+
+  implicit final class RefineToOrDieOps[R, E <: Throwable, A](private val self: ZStream[R, E, A]) extends AnyVal {
+
+    /**
+     * Keeps some of the errors, and terminates the fiber with the rest.
+     */
+    def refineToOrDie[E1 <: E: ClassTag](implicit ev: CanFail[E]): ZStream[R, E1, A] =
+      self.refineOrDie { case e: E1 => e }
+  }
+
 }


### PR DESCRIPTION
Implement `ZStream#refineToOrDie`.

Also implement `ZManaged#refineToOrDie` in the same way as for ZIO, for type safety.