### PR TITLE
Add TestAspect.untraced

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -7,7 +7,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.TestRandom
-import zio.{ Ref, Schedule, ZIO }
+import zio.{ Ref, Schedule, TracingStatus, ZIO }
 
 object TestAspectSpec extends ZIOBaseSpec {
 
@@ -246,7 +246,10 @@ object TestAspectSpec extends ZIOBaseSpec {
         ) @@ sequential @@ verify(assertM(ref.get)(isTrue))
         result <- succeeded(spec)
       } yield assert(result)(isFalse)
-    }
+    },
+    testM("untraced disables tracing") {
+      assertM(ZIO.checkTraced(ZIO.succeed(_)))(equalTo(TracingStatus.Untraced))
+    } @@ untraced
   )
 
   def diesWithSubtypeOf[E](implicit ct: ClassTag[E]): Assertion[TestFailure[E]] =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -702,6 +702,13 @@ object TestAspect extends TimeoutVariants {
         test <* ZTest(condition)
     }
 
+  val untraced: TestAspectPoly = new PerTest[Nothing, Any, Nothing, Any] {
+    override def perTest[R >: Nothing <: Any, E >: Nothing <: Any](
+      test: ZIO[R, TestFailure[E], TestSuccess]
+    ): ZIO[R, TestFailure[E], TestSuccess] =
+      test.untraced
+  }
+
   trait PerTest[+LowerR, -UpperR, +LowerE, -UpperE] extends TestAspect[LowerR, UpperR, LowerE, UpperE] {
 
     def perTest[R >: LowerR <: UpperR, E >: LowerE <: UpperE](


### PR DESCRIPTION
When testing expected failures tracing can be noisy, especially if you have logging turned on.