### PR TITLE
Bump scalafix to 0.9.19

### DIFF
--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.18")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")


### PR DESCRIPTION
There is an important performance improvement: scalacenter/sbt-scalafix#142

I had to bump Xmx to 4g just to be able to run `sbt prepare`