### PR TITLE
Add Additional Combinators for NonEmptyChunk

### DIFF
--- a/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
@@ -11,6 +11,8 @@ object NonEmptyChunkSpec extends ZIOBaseSpec {
 
   lazy val genIntFunction = Gen.function(genInt)
 
+  lazy val genIntFunction2 = Gen.function2(genInt)
+
   lazy val genNonEmptyChunk = Gen.chunkOf1(genInt)
 
   lazy val genNonEmptyChunkFunction = Gen.function(genNonEmptyChunk)
@@ -39,6 +41,20 @@ object NonEmptyChunkSpec extends ZIOBaseSpec {
     },
     testM("map") {
       check(genNonEmptyChunk, genIntFunction)((as, f) => assert(as.map(f).toChunk)(equalTo(as.toChunk.map(f))))
+    },
+    testM("reduceMapLeft") {
+      check(genNonEmptyChunk, genIntFunction, genIntFunction2) { (as, map, reduce) =>
+        val actual   = as.reduceMapLeft(map)(reduce)
+        val expected = as.tail.foldLeft(map(as.head))(reduce)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("reduceMapRight") {
+      check(genNonEmptyChunk, genIntFunction, genIntFunction2) { (as, map, reduce) =>
+        val actual   = as.reduceMapRight(map)(reduce)
+        val expected = as.init.foldRight(map(as.last))(reduce)
+        assert(actual)(equalTo(expected))
+      }
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -987,7 +987,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
    * `Chunk`. Note that this method is side effecting because it allocates
    * mutable state and should only be used internally.
    */
-  protected def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
+  private[zio] def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
     materialize.arrayIterator
 
   /**
@@ -1039,7 +1039,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
    * be changed.  Note that this method is side effecting because it allocates
    * mutable state and should only be used internally.
    */
-  protected def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
+  private[zio] def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
     materialize.arrayIterator
 
   protected def right: Chunk[A] =
@@ -1467,7 +1467,7 @@ object Chunk extends ChunkFactory {
     override protected[zio] def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
       Array.copy(array, 0, dest, n, length)
 
-    override protected def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    override private[zio] def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
       Iterator.single(array.asInstanceOf[Array[A1]])
 
     override protected def collectChunk[B](pf: PartialFunction[A, B]): Chunk[B] = {
@@ -1501,7 +1501,7 @@ object Chunk extends ChunkFactory {
       builder.result()
     }
 
-    override protected def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    override private[zio] def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
       Iterator.single(array.asInstanceOf[Array[A1]])
   }
 
@@ -1534,10 +1534,10 @@ object Chunk extends ChunkFactory {
       right.toArray(n + left.length, dest)
     }
 
-    override protected def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    override private[zio] def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
       (left.arrayIterator ++ right.arrayIterator).asInstanceOf[Iterator[Array[A1]]]
 
-    override protected def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    override private[zio] def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
       (right.arrayIterator ++ left.arrayIterator).asInstanceOf[Iterator[Array[A1]]]
   }
 
@@ -1560,10 +1560,10 @@ object Chunk extends ChunkFactory {
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
       dest(n) = a
 
-    protected override def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    private[zio] override def arrayIterator[A1 >: A]: Iterator[Array[A1]] =
       Iterator.single(Array(a).asInstanceOf[Array[A1]])
 
-    protected override def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
+    private[zio] override def reverseArrayIterator[A1 >: A]: Iterator[Array[A1]] =
       arrayIterator
   }
 
@@ -1680,13 +1680,13 @@ object Chunk extends ChunkFactory {
       }
     }
 
-    override protected def arrayIterator[A1 >: Boolean]: Iterator[Array[A1]] = {
+    override private[zio] def arrayIterator[A1 >: Boolean]: Iterator[Array[A1]] = {
       val array = Array.ofDim[Boolean](length)
       toArray(0, array)
       Iterator.single(array.asInstanceOf[Array[A1]])
     }
 
-    override protected def reverseArrayIterator[A1 >: Boolean]: Iterator[Array[A1]] =
+    override private[zio] def reverseArrayIterator[A1 >: Boolean]: Iterator[Array[A1]] =
       arrayIterator
 
   }
@@ -1713,10 +1713,10 @@ object Chunk extends ChunkFactory {
     override def toArray[A1: ClassTag]: Array[A1] =
       Array.empty
 
-    override protected def arrayIterator[A]: Iterator[Array[A]] =
+    override private[zio] def arrayIterator[A]: Iterator[Array[A]] =
       Iterator.empty
 
-    override protected def reverseArrayIterator[A]: Iterator[Array[A]] =
+    override private[zio] def reverseArrayIterator[A]: Iterator[Array[A]] =
       Iterator.empty
   }
 

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -130,6 +130,48 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
     nonEmpty(that ++ chunk)
 
   /**
+   * Reduces the elements of this `NonEmptyChunk` from left to right using the
+   * function `map` to transform the first value to the type `B` and then the
+   * function `reduce` to combine the `B` value with each other `A` value.
+   */
+  def reduceMapLeft[B](map: A => B)(reduce: (B, A) => B): B = {
+    val iterator = chunk.arrayIterator
+    var b: B     = null.asInstanceOf[B]
+    while (iterator.hasNext) {
+      val array  = iterator.next()
+      val length = array.length
+      var i      = 0
+      while (i < length) {
+        val a = array(i)
+        if (b == null) b = map(a) else b = reduce(b, a)
+        i += 1
+      }
+    }
+    b
+  }
+
+  /**
+   * Reduces the elements of this `NonEmptyChunk` from right to left using the
+   * function `map` to transform the first value to the type `B` and then the
+   * function `reduce` to combine the `B` value with each other `A` value.
+   */
+  def reduceMapRight[B](map: A => B)(reduce: (A, B) => B): B = {
+    val iterator = chunk.reverseArrayIterator
+    var b: B     = null.asInstanceOf[B]
+    while (iterator.hasNext) {
+      val array  = iterator.next()
+      val length = array.length
+      var i      = length - 1
+      while (i >= 0) {
+        val a = array(i)
+        if (b == null) b = map(a) else b = reduce(a, b)
+        i -= 1
+      }
+    }
+    b
+  }
+
+  /**
    * Converts this `NonEmptyChunk` to a `Chunk`, discarding information about
    * it not being empty.
    */


### PR DESCRIPTION
Implements `reduceMapLeft` and `reduceMapRight` for reducing a `NonEmptyChunk` to a summary value.