### PR TITLE
Add Schedule#resetAfter

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import scala.concurrent.Future
+
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -5,7 +5,7 @@ import scala.language.postfixOps
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ nonFlaky, timeout }
+import zio.test.TestAspect.timeout
 import zio.test.environment.{ TestClock, TestRandom }
 import zio.test.{ assert, assertM, suite, testM, TestResult }
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,11 +1,11 @@
 package zio
 
 import scala.concurrent.Future
-
+import scala.language.postfixOps
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.timeout
+import zio.test.TestAspect.{ nonFlaky, timeout }
 import zio.test.environment.{ TestClock, TestRandom }
 import zio.test.{ assert, assertM, suite, testM, TestResult }
 
@@ -350,6 +350,31 @@ object ScheduleSpec extends ZIOBaseSpec {
         _   <- ref.getAndUpdate(_ + 1).repeat(schedule(ref))
         res <- ref.get
       } yield assert(res)(equalTo(8))
+    },
+    testM("Reset after some inactivity") {
+
+      def io(ref: Ref[Int], latch: Promise[Nothing, Unit]): ZIO[Clock, String, Unit] =
+        ref
+          .updateAndGet(_ + 1)
+          .flatMap(retries =>
+            // the 5th retry will fail after 10 seconds to let the schedule reset
+            if (retries == 5) latch.succeed(()) *> io(ref, latch).delay(10 seconds)
+            // the 10th retry will succeed, which is only possible if the schedule was reset
+            else if (retries == 10) UIO.unit
+            else ZIO.fail("Boom")
+          )
+
+      assertM {
+        for {
+          retriesCounter <- Ref.make(-1)
+          latch          <- Promise.make[Nothing, Unit]
+          fiber          <- io(retriesCounter, latch).retry(Schedule.recurs(5).resetAfter(5 seconds)).fork
+          _              <- latch.await
+          _              <- TestClock.adjust(10 seconds)
+          _              <- fiber.join
+          retries        <- retriesCounter.get
+        } yield retries
+      }(equalTo(10))
     }
   )
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,7 +1,6 @@
 package zio
 
 import scala.concurrent.Future
-import scala.language.postfixOps
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
@@ -358,7 +357,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           .updateAndGet(_ + 1)
           .flatMap(retries =>
             // the 5th retry will fail after 10 seconds to let the schedule reset
-            if (retries == 5) latch.succeed(()) *> io(ref, latch).delay(10 seconds)
+            if (retries == 5) latch.succeed(()) *> io(ref, latch).delay(10.seconds)
             // the 10th retry will succeed, which is only possible if the schedule was reset
             else if (retries == 10) UIO.unit
             else ZIO.fail("Boom")
@@ -368,9 +367,9 @@ object ScheduleSpec extends ZIOBaseSpec {
         for {
           retriesCounter <- Ref.make(-1)
           latch          <- Promise.make[Nothing, Unit]
-          fiber          <- io(retriesCounter, latch).retry(Schedule.recurs(5).resetAfter(5 seconds)).fork
+          fiber          <- io(retriesCounter, latch).retry(Schedule.recurs(5).resetAfter(5.seconds)).fork
           _              <- latch.await
-          _              <- TestClock.adjust(10 seconds)
+          _              <- TestClock.adjust(10.seconds)
           _              <- fiber.join
           retries        <- retriesCounter.get
         } yield retries

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -523,7 +523,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     fold(0)((n: Int, _: B) => n + 1)
 
   /**
-   * Return a new schedule that automatically resets the initial schedule to its initial state
+   * Return a new schedule that automatically resets the schedule to its initial state
    * after some time of inactivity defined by `duration`.
    */
   final def resetAfter(duration: Duration): Schedule[R with Clock, A, B] =


### PR DESCRIPTION
Adds a new method `Schedule#resetAfter` that resets the schedule to its initial state after some time of inactivity.
This is particularly useful when using `retry` on a never-ending task: it allows the retry policy to start fresh again.