### PR TITLE
sbt: Remove redundant settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -385,7 +385,6 @@ lazy val docs = project.module
     scalacOptions ~= { _ filterNot (_ startsWith "-Ywarn") },
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
     libraryDependencies ++= Seq(
-      "com.github.ghik"     % "silencer-lib"                 % "1.4.4" % Provided cross CrossVersion.full,
       "commons-io"          % "commons-io"                   % "2.7" % "provided",
       "org.jsoup"           % "jsoup"                        % "1.13.1" % "provided",
       "org.reactivestreams" % "reactive-streams-examples"    % "1.0.3" % "provided",

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -210,7 +210,6 @@ object BuildHelper {
 
   def stdSettings(prjName: String) = Seq(
     name := s"$prjName",
-    scalacOptions := stdOptions,
     crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),


### PR DESCRIPTION
+ `silencer-lib` is already added by `BuildHelper.stdSettings`
+ Remove duplicated `scalacOptions :=`