### PR TITLE
Generalize Has.AreHas to Has.Union

### DIFF
--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -81,17 +81,78 @@ object Has {
       "operator, you must ensure the service produced by your layer is " +
       "wrapped in Has."
   )
-  trait AreHas[-R, -R1] {
-    def union[R0 <: R, R00 <: R1: Tag](r: R0, r1: R00): R0 with R00
-    def unionAll[R0 <: R, R00 <: R1](r: R0, r1: R00): R0 with R00
+  trait Union[R, R1] {
+    def union(r: R, r1: R1): R with R1
   }
-  object AreHas {
-    implicit def ImplicitAre[R <: Has[_], R1 <: Has[_]]: AreHas[R, R1] =
-      new AreHas[R, R1] {
-        def union[R0 <: R, R00 <: R1: Tag](r: R0, r1: R00): R0 with R00 =
-          r.union[R00](r1)
-        def unionAll[R0 <: R, R00 <: R1](r: R0, r1: R00): R0 with R00 =
-          r.unionAll[R00](r1)
+  object Union extends LowPriorityUnionImplicits {
+    implicit def HasHasUnion[R <: Has[_], R1 <: Has[_]: Tag]: Union[R, R1] =
+      new Union[R, R1] {
+        def union(r: R, r1: R1): R with R1 =
+          r.union[R1](r1)
+      }
+  }
+  trait LowPriorityUnionImplicits {
+    implicit def HasAnyUnion[R <: Has[_]]: Union[R, Any] =
+      new Union[R, Any] {
+        def union(r: R, r1: Any): R = {
+          val _ = r1
+          r
+        }
+      }
+    implicit def AnyHasUnion[R1 <: Has[_]]: Union[Any, R1] =
+      new Union[Any, R1] {
+        def union(r: Any, r1: R1): R1 = {
+          val _ = r
+          r1
+        }
+      }
+    implicit val AnyAnyUnion: Union[Any, Any] =
+      new Union[Any, Any] {
+        def union(r: Any, r1: Any): Any = {
+          val _ = (r, r1)
+          ()
+        }
+      }
+  }
+
+  @implicitNotFound(
+    "The ZLayer operator you are trying to use needs to combine multiple " +
+      "services. While services cannot directly be combined, they can be " +
+      "combined if first wrapped in the Has data type. Before you use this " +
+      "operator, you must ensure the service produced by your layer is " +
+      "wrapped in Has."
+  )
+  trait UnionAll[R, R1] {
+    def unionAll(r: R, r1: R1): R with R1
+  }
+  object UnionAll extends LowPriorityUnionAllImplicits {
+    implicit def HasHasUnionAll[R <: Has[_], R1 <: Has[_]: Tag]: UnionAll[R, R1] =
+      new UnionAll[R, R1] {
+        def unionAll(r: R, r1: R1): R with R1 =
+          r.unionAll[R1](r1)
+      }
+  }
+  trait LowPriorityUnionAllImplicits {
+   implicit def HasAnyUnionAll[R <: Has[_]]: UnionAll[R, Any] =
+      new UnionAll[R, Any] {
+        def unionAll(r: R, r1: Any): R = {
+          val _ = r1
+          r
+        }
+      }
+    implicit def AnyHasUnionAll[R1 <: Has[_]]: UnionAll[Any, R1] =
+      new UnionAll[Any, R1] {
+        def unionAll(r: Any, r1: R1): R1 = {
+          val _ = r
+          r1
+        }
+      }
+    implicit val AnyAnyUnionAll: UnionAll[Any, Any] =
+      new UnionAll[Any, Any] {
+        def unionAll(r: Any, r1: Any): Any = {
+          val _ = (r, r1)
+          ()
+        }
       }
   }
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -74,7 +74,7 @@ sealed trait ZLayer[-RIn, +E, +ROut] { self =>
   final def >+>[E1 >: E, RIn2 >: ROut, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
   )(implicit ev: Has.Union[ROut1, ROut2], tagged: Tag[ROut2]): ZLayer[RIn, E1, ROut1 with ROut2] =
-    self ++[E1, RIn, ROut1, ROut2] (self >>> that)
+    self.++[E1, RIn, ROut1, ROut2](self >>> that)
 
   /**
    * Feeds the output services of this layer into the input of the specified
@@ -90,7 +90,7 @@ sealed trait ZLayer[-RIn, +E, +ROut] { self =>
   final def and[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
   )(implicit ev: Has.Union[ROut1, ROut2], tagged: Tag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
-    self ++[E1, RIn2, ROut1, ROut2] that
+    self.++[E1, RIn2, ROut1, ROut2](that)
 
   /**
    * A named alias for `>+>`.
@@ -98,7 +98,7 @@ sealed trait ZLayer[-RIn, +E, +ROut] { self =>
   final def andTo[E1 >: E, RIn2 >: ROut, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
   )(implicit ev: Has.Union[ROut1, ROut2], tagged: Tag[ROut2]): ZLayer[RIn, E1, ROut1 with ROut2] =
-    self >+>[E1, RIn2, ROut1, ROut2] that
+    self.>+>[E1, RIn2, ROut1, ROut2](that)
 
   /**
    * Builds a layer into a managed value.


### PR DESCRIPTION
Resolves #3997.

There has been a desire by library authors to generalize over the types `_ <: Has[_]` and `Any` to describe conceptually "the set of all environmental requirements that can be combined generically".

This PR changes the encoding of `Has.AreHas`, which describes the capability to combine two types to form their intersection, from:

```scala
  trait AreHas[-R, -R1] {
    def union[R0 <: R, R00 <: R1: Tag](r: R0, r1: R00): R0 with R00
```

to:

```scala
  trait Union[R, R1] {
    def union(r: R, r1: R1): R with R1
  }
```

Instances are then provided for combinations of `Has` with `Has`, `Has` with `Any`, `Any` with `Has`, and `Any` with `Any`.

The biggest disadvantage of this proposal I can see is we lose the contravariance on the type parameters of `R` and `R1`. Previously, we could say that if `R` and `R1` are subtypes of `Has`, then `R0 <: R` and `R00 <: R1` are also subtypes of `Has` and so can be combined generically. But now if `R` is `Any` it is not the case that we can combine subtypes of `R` generically. This requires type annotations in the implementation of a couple of additional `ZLayer` combinators, but it only required one change to the API (adding an additional `ROut1 >: ROut` parameter in `+!+` for variance) and no additional type annotations in any of the tests, so I think the impact will be limited to library authors who are writing their own combinators to combine environment types generically.

We don't gain a lot from this capability in our own library but it avoids the need for libraries like `zio-grpc` to implement it themselves and potentially provides them with a common way to do so.

Copying @thesamet.