### PR TITLE
add link to zio-dotty-quickstart.g8 template

### DIFF
--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -56,6 +56,7 @@ If you know a useful library that has direct support for ZIO, please consider [s
 - [ZIO IntelliJ](https://github.com/zio/zio-intellij): A complimentary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects
 - [zio-shield](https://github.com/zio/zio-shield): Enforce best coding practices with ZIO
 - [zio-akka-quickstart.g8](https://github.com/ScalaConsultants/zio-akka-quickstart.g8): A Giter8 template for a basic Scala application build using ZIO, Akka HTTP and Slick
+- [zio-dotty-quickstart.g8](https://github.com/ScalaConsultants/zio-dotty-quickstart.g8): A Giter8 template for a basic Dotty application build using ZIO
 
 
 ## ZIO Interoperability Libraries


### PR DESCRIPTION
Add link to template for Dotty application build using ZIO [ScalaConsultants/zio-dotty-quickstart.g8](https://github.com/ScalaConsultants/zio-dotty-quickstart.g8)