### PR TITLE
Tune maxShrinks for small checks count

### DIFF
--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -616,7 +616,7 @@ package object test extends CompileVariants {
 
     final class CheckNM(private val n: Int) extends AnyVal {
       def apply[R, R1 <: R, E, A](rv: Gen[R, A])(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(test)
+        checkStream(rv.sample.forever.take(n.toLong), maxShrinks = n * 5)(test)
       def apply[R, R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =


### PR DESCRIPTION
Currently `maxShrinks` always equal to 1000, even for `checkN(1)`.
With this change `maxShrinks` will correlate with checks count. 
So with long failing test it will not timeout on shrinking phase.
Default values not changed: `check(...)` == `checkN(200)(...)`

Better control over `maxShrinks` covered in #4007