### PR TITLE
Fix Bugs In Chunk#indexWhere and Chunk#mapAccumM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -16,59 +16,21 @@ object ChunkSpec extends ZIOBaseSpec {
   def toBoolFn[R <: Random, A]: Gen[R, A => Boolean] =
     Gen.function(Gen.boolean)
 
-  def chunks[R <: Random, A](n: Int)(a: Gen[R, A]): Gen[R, Chunk[A]] = {
-
-    val empty: Gen[R, Chunk[Nothing]] =
-      Gen.const(Chunk.empty)
-
-    val single: Gen[R, Chunk[A]] =
-      a.map(Chunk.single)
-
-    def append(n: Int): Gen[R, Chunk[A]] =
-      chunks(n - 1)(a).zipWith(a)(_ :+ _)
-
-    def prepend(n: Int): Gen[R, Chunk[A]] =
-      a.zipWith(chunks(n - 1)(a))(_ +: _)
-
-    def array(n: Int): Gen[R, Chunk[A]] =
-      Gen.listOfN(n)(a).map(Chunk.fromIterable)
-
-    def vector(n: Int): Gen[R, Chunk[A]] =
-      Gen.vectorOfN(n)(a).map(Chunk.fromIterable)
-
-    def concat(n: Int): Gen[R, Chunk[A]] =
-      Gen.suspend {
-        for {
-          i <- Gen.int(0, n)
-          l <- chunks(i)(a)
-          r <- chunks(n - i)(a)
-        } yield l ++ r
-      }
-
-    Gen.suspend {
-      if (n == 0) Gen.oneOf(empty, array(n), vector(n), concat(n))
-      else Gen.oneOf(append(n), array(n), concat(n), prepend(n), single, vector(n))
-    }
-  }
-
-  def chunkOfBounded[R <: Random, A](from: Int, to: Int)(a: Gen[R, A]): Gen[R, Chunk[A]] =
-    Gen.int(from, to).flatMap(chunks(_)(a))
-
   def tinyChunks[R <: Random, A](a: Gen[R, A]): Gen[R, Chunk[A]] =
-    chunkOfBounded(0, 3)(a)
+    Gen.chunkOfBounded(0, 3)(a)
 
   def smallChunks[R <: Random, A](a: Gen[R, A]): Gen[R with Sized, Chunk[A]] =
-    Gen.small(chunks(_)(a))
+    Gen.small(Gen.chunkOfN(_)(a))
 
   def mediumChunks[R <: Random, A](a: Gen[R, A]): Gen[R with Sized, Chunk[A]] =
-    Gen.medium(chunks(_)(a))
+    Gen.medium(Gen.chunkOfN(_)(a))
 
   def largeChunks[R <: Random, A](a: Gen[R, A]): Gen[R with Sized, Chunk[A]] =
-    Gen.large(chunks(_)(a))
+    Gen.large(Gen.chunkOfN(_)(a))
 
   def chunkWithIndex[R <: Random, A](a: Gen[R, A]): Gen[R with Sized, (Chunk[A], Int)] =
     for {
-      chunk <- chunkOfBounded(1, 100)(a)
+      chunk <- Gen.chunkOfBounded(1, 100)(a)
       idx   <- Gen.int(0, chunk.length - 1)
     } yield (chunk, idx)
 
@@ -281,14 +243,15 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("mapAccumM")(
       testM("mapAccumM happy path") {
-        checkM(smallChunks(Gen.anyInt), Gen.anyInt, Gen.function2(Gen.anyInt <*> Gen.anyInt)) { (as, s, f) =>
-          val actual = as.mapAccumM[Any, Nothing, Int, Int](s)((s, a) => UIO.succeed(f(s, a)))
-          val expected = as.foldLeft[(Int, Chunk[Int])]((s, Chunk.empty)) {
-            case ((s0, bs), a) =>
-              val (s1, b) = f(s0, a)
-              (s1, bs :+ b)
-          }
-          assertM(actual)(equalTo(expected))
+        checkM(smallChunks(Gen.anyInt), smallChunks(Gen.anyInt), Gen.anyInt, Gen.function2(Gen.anyInt <*> Gen.anyInt)) {
+          (left, right, s, f) =>
+            val actual = (left ++ right).mapAccumM[Any, Nothing, Int, Int](s)((s, a) => UIO.succeed(f(s, a)))
+            val expected = (left ++ right).foldLeft[(Int, Chunk[Int])]((s, Chunk.empty)) {
+              case ((s0, bs), a) =>
+                val (s1, b) = f(s0, a)
+                (s1, bs :+ b)
+            }
+            assertM(actual)(equalTo(expected))
         }
       },
       testM("mapAccumM error") {
@@ -321,8 +284,10 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     testM("indexWhere") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
-      check(mediumChunks(intGen), fn, intGen) { (chunk, p, from) =>
-        assert(chunk.indexWhere(p, from))(equalTo(chunk.toList.indexWhere(p, from)))
+      check(smallChunks(intGen), smallChunks(intGen), fn, intGen) { (left, right, p, from) =>
+        val actual   = (left ++ right).indexWhere(p, from)
+        val expected = (left.toVector ++ right.toVector).indexWhere(p, from)
+        assert(actual)(equalTo(expected))
       }
     } @@ exceptScala211,
     testM("exists") {
@@ -549,28 +514,10 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(a.zipAll(b))(equalTo(d)) &&
       assert(b.zipAll(a))(equalTo(e))
     },
-    testM("zipAllWith") {
-      check(
-        smallChunks(Gen.anyInt),
-        smallChunks(Gen.anyInt),
-        Gen.function(Gen.anyInt),
-        Gen.function(Gen.anyInt),
-        Gen.function2(Gen.anyInt)
-      ) { (as, bs, left, right, both) =>
-        val actual = as.zipAllWith(bs)(left, right)(both).toList
-        val expected =
-          if (as.length > bs.length)
-            (as.toList).zip(bs.toList).map(both.tupled) ::: as.toList.drop(bs.toList.length).map(left)
-          else (as.toList).zip(bs.toList).map(both.tupled) ::: bs.toList.drop(as.toList.length).map(right)
-        assert(actual)(equalTo(expected))
-      }
-    },
-    testM("zipWith") {
-      check(smallChunks(Gen.anyInt), smallChunks(Gen.anyInt), Gen.function2(Gen.anyInt)) { (as, bs, f) =>
-        val actual   = as.zipWith(bs)(f).toList
-        val expected = as.toList.zip(bs.toList).map(f.tupled)
-        assert(actual)(equalTo(expected))
-      }
+    zio.test.test("zipAllWith") {
+      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 4))) &&
+      assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0))) &&
+      assert(Chunk(1, 2).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0)))
     },
     zio.test.test("partitionMap") {
       val as       = Chunk(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -591,14 +591,14 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
       val iterator = arrayIterator
       val builder  = ChunkBuilder.make[B]()
       builder.sizeHint(length)
-      var zio: ZIO[R, E, S1] = UIO.succeedNow(s1)
+      var dest: ZIO[R, E, S1] = UIO.succeedNow(s1)
       while (iterator.hasNext) {
         val array  = iterator.next()
         val length = array.length
         var i      = 0
         while (i < length) {
           val a = array(i)
-          zio = zio.flatMap { state =>
+          dest = dest.flatMap { state =>
             f1(state, a).map {
               case (state2, b) =>
                 builder += b
@@ -608,7 +608,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] { self =>
           i += 1
         }
       }
-      zio.map((_, builder.result()))
+      dest.map((_, builder.result()))
     }
 
   /**


### PR DESCRIPTION
Resolves #4032. Fixes a bug in `Chunk#mapM` that could lead to incorrect results with concatenated chunks. Hardens tests.
