### PR TITLE
Implement Package Private Unsafe Combinators On ZRef

### DIFF
--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -29,4 +29,7 @@ object Ref extends Serializable {
    */
   def makeManaged[A](a: A): UManaged[Ref[A]] =
     ZRef.makeManaged(a)
+
+  private[zio] def unsafeMake[A](a: A): Ref[A] =
+    ZRef.unsafeMake(a)
 }


### PR DESCRIPTION
When we implemented the fiber supervision changes we needed to be able to unsafely update a `Ref` in our internal implementation. At the time we just implemented a single `unsafeUpdate` method to do this and had to expose an implicit class that should have been private do to a Dotty bug. That bug is fixed in the latest version, so this PR makes that class private as well as adding package private unsafe versions of the other `Ref` combinators.