### PR TITLE
Fix ZStream.grouped to produce correct group size

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1555,6 +1555,9 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("sanity") {
             assertM(ZStream(1, 2, 3, 4, 5).grouped(2).runCollect)(equalTo(Chunk(Chunk(1, 2), Chunk(3, 4), Chunk(5))))
           },
+          testM("group size is correct") {
+            assertM(ZStream.range(0, 100).grouped(10).map(_.size).runCollect)(equalTo(Chunk.fill(10)(10)))
+          },
           testM("doesn't emit empty chunks") {
             assertM(ZStream.fromIterable(List.empty[Int]).grouped(5).runCollect)(equalTo(Chunk.empty))
           }

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -196,7 +196,7 @@ object ZTransducer extends ZTransducerPlatformSpecificConstructors {
         if (leftover.size + left.size < n) outBuilder.result() -> (leftover ++ left)
         else {
           val nextOutBuilder =
-            if (leftover.nonEmpty) outBuilder += leftover += left
+            if (leftover.nonEmpty) outBuilder += (leftover ++ left)
             else outBuilder += left
           go(nextIn, Chunk.empty, nextOutBuilder)
         }


### PR DESCRIPTION
Currently, with this test:

```scalla
assertM(ZStream.range(0, 100).grouped(10).map(_.size).runCollect)(equalTo(Chunk.fill(10)(10)))
```

```
[info] - ZStreamSpec
[info]   - Combinators
[info]     - grouped
[info]       - group size is correct
[info]         Chunk(9,1,9,1,9,1,9,1,9,1,9,1,9,1,9,1,9,1,9,1) did not satisfy equalTo(Chunk(10,10,10,10,10,10,10,10,10,10))
```