### PR TITLE
Fix Schedule.unfold causing stack overflow

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -128,6 +128,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val scheduled = clock.currentDateTime.orDie.flatMap(schedule.run(_, 1 to 10))
         val expected  = Chunk((0L, 1.minute), (1L, 2.minute), (2L, 4.minute))
         assertM(scheduled)(equalTo(expected))
+      },
+      testM("free from stack overflow") {
+        assertM(run(Schedule.forever *> Schedule.recurs(10000000))(List.fill(1000000)(())))(
+          equalTo(Chunk.range(0L, 1000000L))
+        )
       }
     ),
     suite("Retry on failure according to a provided strategy")(

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,9 +1,9 @@
 package zio
 
 import scala.concurrent.Future
-
 import zio.clock.Clock
 import zio.duration._
+import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect.timeout
 import zio.test.environment.{ TestClock, TestRandom }
@@ -130,8 +130,8 @@ object ScheduleSpec extends ZIOBaseSpec {
         assertM(scheduled)(equalTo(expected))
       },
       testM("free from stack overflow") {
-        assertM(run(Schedule.forever *> Schedule.recurs(10000000))(List.fill(1000000)(())))(
-          equalTo(Chunk.range(0L, 1000000L))
+        assertM(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(1000000)).runCount)(
+          equalTo(1000000L)
         )
       }
     ),

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1037,7 +1037,7 @@ object Schedule {
    * Unfolds a schedule that repeats one time from the specified state and iterator.
    */
   def unfold[A](a: => A)(f: A => A): Schedule[Any, Any, A] = {
-    def loop(a: => A): StepFunction[Any, Any, A] =
+    def loop(a: A): StepFunction[Any, Any, A] =
       (now, _) => ZIO.succeed(Decision.Continue(a, now, loop(f(a))))
 
     Schedule(loop(a))


### PR DESCRIPTION
This test

```scala
testM("free from stack overflow") {
  assertM(run(Schedule.forever *> Schedule.recurs(10000000))(List.fill(1000000)(())))(
    equalTo(Chunk.range(0L, 1000000L))
  )
}
```

causes

```
java.lang.StackOverflowError
at zio.Schedule$.$anonfun$unfold$3(Schedule.scala:1041)
```

After the fix, it takes around 5-7 seconds to execute on my machine. Not sure if it's good to leave it in.