### PR TITLE
Fix passphrase reading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ inThisBuild(
         url("http://degoes.net")
       )
     ),
-    pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
+    pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(


### PR DESCRIPTION
`PGP_PASSWORD` was used in our old Sonatype context. Since we moved to Sonatype2, we're using a different env variable.