### PR TITLE
Suspend Evaluation Of By Name Parameter In Schedule#unfold

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1040,7 +1040,7 @@ object Schedule {
     def loop(a: A): StepFunction[Any, Any, A] =
       (now, _) => ZIO.succeed(Decision.Continue(a, now, loop(f(a))))
 
-    Schedule(loop(a))
+    Schedule((now, _) => ZIO.effectTotal(a).map(a => Decision.Continue(a, now, loop(f(a)))))
   }
 
   /**


### PR DESCRIPTION
Minor follow up to #4064 to suspend evaluation of by name parameter.