### PR TITLE
Make Chunk#append and Chunk#prepend Stack Safe

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -525,9 +525,19 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(bs)(equalTo(Chunk(0, 2, 4, 6, 8))) &&
       assert(cs)(equalTo(Chunk(1, 3, 5, 7, 9)))
     },
-    zio.test.test("stack safety") {
-      val n  = 100000
+    zio.test.test("stack safety concat") {
+      val n  = 1000000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => Chunk(a) ++ as)
+      assert(as.toArray)(equalTo(Array.range(0, n)))
+    },
+    zio.test.test("stack safety append") {
+      val n  = 1000000
+      val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => as :+ a)
+      assert(as.toArray)(equalTo(Array.range(0, n).reverse))
+    },
+    zio.test.test("stack safety prepend") {
+      val n  = 1000000
+      val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => a +: as)
       assert(as.toArray)(equalTo(Array.range(0, n)))
     },
     zio.test.test("toArray does not throw ClassCastException") {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1238,7 +1238,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       } else {
         val buffer = Array.ofDim[AnyRef](BufferSize)
         buffer(0) = a1.asInstanceOf[AnyRef]
-        AppendN(self, buffer, 1, new AtomicInteger(1))
+        val chunk = Chunk.fromArray(self.buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
+        AppendN(start ++ chunk, buffer, 1, new AtomicInteger(1))
       }
 
     def apply(n: Int): A =
@@ -1265,7 +1266,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       } else {
         val buffer = Array.ofDim[AnyRef](BufferSize)
         buffer(BufferSize - 1) = a1.asInstanceOf[AnyRef]
-        PrependN(self, buffer, 1, new AtomicInteger(1))
+        val chunk = Chunk.fromArray(self.buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
+        PrependN(chunk ++ end, buffer, 1, new AtomicInteger(1))
       }
 
     def apply(n: Int): A =


### PR DESCRIPTION
Resolves #4065.

The problem is basically that right now there is nothing stopping us from from building deeply left or right leaning trees of `Append` or `Prepend` nodes.

To address this, I think we need to leverage our existing infrastructure for balanced concatenation. When we are done with an `Append` or `Prepend` node, we now take the buffer, treat it as its own chunk, and concatenate it onto the start or end chunk. This maintains the balanced property and ensures there is at most one of a `Append` or `Prepend` node at a time.