### PR TITLE
Add ZStream.onError

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2169,6 +2169,13 @@ object ZStreamSpec extends ZIOBaseSpec {
               }
           }
         },
+        testM("onError") {
+          for {
+            flag   <- Ref.make(false)
+            exit   <- ZStream.fail("Boom").onError(_ => flag.set(true)).runDrain.run
+            called <- flag.get
+          } yield assert(called)(isTrue) && assert(exit)(fails(equalTo("Boom")))
+        } @@ zioTag(errors),
         testM("orElse") {
           val s1 = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
           val s2 = ZStream(4, 5, 6)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2063,6 +2063,14 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     }
 
   /**
+   * Runs the specified effect if this stream fails, providing the error to the effect if it exists.
+   *
+   * Note: Unlike [[ZIO.onError]], there is no guarantee that the provided effect will not be interrupted.
+   */
+  final def onError[R1 <: R](cleanup: Cause[E] => URIO[R1, Any]): ZStream[R1, E, O] =
+    catchAllCause(cause => ZStream.fromEffect(cleanup(cause) *> ZIO.halt(cause)))
+
+  /**
    * Switches to the provided stream in case this one fails with a typed error.
    *
    * See also [[ZStream#catchAll]].


### PR DESCRIPTION
Use case: forward a stream from storage to HTTP server, but log errors.