### PR TITLE
Implement Schedule#unionWith

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -384,6 +384,12 @@ object ScheduleSpec extends ZIOBaseSpec {
           retries        <- retriesCounter.get
         } yield retries
       }(equalTo(10))
+    },
+    testM("union of two schedules should continue as long as either wants to continue") {
+      val schedule = Schedule.recurWhile[Boolean](_ == true) || Schedule.fixed(1.second)
+      assertM(run(schedule >>> Schedule.elapsed)(List(true, false, false, false, false)))(
+        equalTo(Chunk(0, 0, 1, 2, 3).map(_.seconds))
+      )
     }
   )
 


### PR DESCRIPTION
Resolves #4101.

`combineWith` takes a function to specify how to merge the intervals of two schedules, but it is always done if either schedule is done so to a certain extent it already embodies intersection semantics in that one schedule can no longer continue if the other one doesn't want to.

This PR renames `combineWith` to `unionWith` and implements a new combinator `intersectWith` that still takes a merge function but now continues as long as either schedule wants to continue. `||` can then be implements in terms of `unionWith` to make use cases like `Schedule.recurWhile[Boolean](_ == true) || Schedule.fixed(1.second)` work.