### PR TITLE
Improve Stack Safety Of Chunk

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -540,6 +540,20 @@ object ChunkSpec extends ZIOBaseSpec {
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => a +: as)
       assert(as.toArray)(equalTo(Array.range(0, n)))
     },
+    zio.test.test("stack safety concat and append") {
+      val n = 100000
+      val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty) { (a, as) =>
+        if (a % 2 == 0) as :+ a else as ++ Chunk(a)
+      }
+      assert(as.toArray)(equalTo(Array.range(0, n).reverse))
+    },
+    zio.test.test("stack safety concat and prepend") {
+      val n = 100000
+      val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty) { (a, as) =>
+        if (a % 2 == 0) a +: as else Chunk(a) ++ as
+      }
+      assert(as.toArray)(equalTo(Array.range(0, n)))
+    },
     zio.test.test("toArray does not throw ClassCastException") {
       val chunk = Chunk("a")
       val array = chunk.toArray


### PR DESCRIPTION
Resolves #4112.

We previously made Chunk stack safe for repeated appends and prepends by concatenating previous append or prepend nodes to the starting or ending chunk to maintain the balanced property and ensure there was at most one such node at each end. However, that left open the possibility that inner append nodes could be created through appending or prepending followed by concatenation, as in `(left :+ a) ++ right`, which could again result in an unbalanced tree. In this PR we check for append and prepend nodes when concatenating to maintain the invariant that we can't have any such node in the middle of a chunk but only at the ends.