### PR TITLE
Prevent Interruption While Closing Scopes

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2882,19 +2882,7 @@ object ZIOSpec extends ZIOBaseSpec {
           _       <- fiber.interrupt
           value   <- ref.get
         } yield assert(value)(isTrue)
-      },
-      testM("asynchronous finalizers are uninterruptible") {
-        for {
-          promise1 <- Promise.make[Nothing, Unit]
-          promise2 <- Promise.make[Nothing, Unit]
-          promise3 <- Promise.make[Nothing, Unit]
-          fiber    <- (promise1.succeed(()) *> ZIO.never).ensuring(promise2.await *> promise3.succeed(())).fork
-          _        <- promise1.await
-          _        <- fiber.interrupt.fork
-          _        <- promise2.succeed(())
-          _        <- promise3.await
-        } yield assertCompletes
-      } @@ nonFlaky
+      }
     ) @@ zioTag(interruption),
     suite("RTS environment")(
       testM("provide is modular") {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -944,7 +944,7 @@ private[zio] final class FiberContext[E, A](
          * We are not done yet, because we have to close the scope of the fiber.
          */
         if (!state.compareAndSet(oldState, Executing(oldStatus.toFinishing, observers, interrupted))) done(v)
-        else openScope.close(v) *> ZIO.done(v)
+        else openScope.close(v).uninterruptible *> ZIO.done(v)
 
       case Done(_) => null // Already done
     }


### PR DESCRIPTION
Resolves #4116.

It looks like the issue here is that we are getting interrupted when attempting to close the scope of the child fiber. The child fiber tries to close its scope after it finishes forking the grandchild but then is externally interrupted. As a result, the finalizers in its scope are never run and so we do not wait for the interruption of the grandchild to return.