### PR TITLE
Implement ZLayer#project

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -376,6 +376,12 @@ object ZLayerSpec extends ZIOBaseSpec {
         val layer4 = ZLayer.fromAcquireRelease(sleep)(_ => sleep)
         val env    = layer1 ++ ((layer2 ++ layer3) >+> layer4)
         assertM(ZIO.unit.provideCustomLayer(env).run)(fails(equalTo("foo")))
+      },
+      testM("project") {
+        final case class Person(name: String, age: Int)
+        val personLayer = ZLayer.succeed(Person("User", 42))
+        val ageLayer    = personLayer.project(_.age)
+        assertM(ZIO.service[Int].provideLayer(ageLayer))(equalTo(42))
       }
     )
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -2204,6 +2204,16 @@ object ZLayer {
       ZLayer.identity[RIn] ++ self
   }
 
+  implicit final class ZLayerProjectOps[R, E, A](private val self: ZLayer[R, E, Has[A]]) extends AnyVal {
+
+    /**
+     * Projects out part of one of the layers output by this layer using the
+     * specified function
+     */
+    final def project[B: Tag](f: A => B)(implicit tag: Tag[A]): ZLayer[R, E, Has[B]] =
+      self >>> ZLayer.fromFunction(r => f(r.get))
+  }
+
   /**
    * A `MemoMap` memoizes dependencies.
    */


### PR DESCRIPTION
Implements `ZLayer#project`, which allows zooming in on one part of one of the services output by a layer. Example use case: `configLayer.project(_.kafkaConfig)`.