### PR TITLE
Fixed #4127 - Fix typo UnexpectedCallExpection => UnexpectedCallException

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -207,7 +207,7 @@ object ReportingTestUtils {
   )
 
   val mock3 = zio.test.test("Extra calls") {
-    throw UnexpectedCallExpection(PureModuleMock.ManyParams, (2, "3", 4L))
+    throw UnexpectedCallException(PureModuleMock.ManyParams, (2, "3", 4L))
   }
 
   val mock3Expected = Vector(

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
@@ -41,13 +41,13 @@ object AdvancedEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule]
   }
 
   def hasUnexpectedCall[I, E, A](capability: Capability[PureModule, I, E, A], args: I): Assertion[Throwable] =
-    isSubtype[UnexpectedCallExpection[PureModule, I, E, A]](
-      hasField[UnexpectedCallExpection[PureModule, I, E, A], Capability[PureModule, I, E, A]](
+    isSubtype[UnexpectedCallException[PureModule, I, E, A]](
+      hasField[UnexpectedCallException[PureModule, I, E, A], Capability[PureModule, I, E, A]](
         "capability",
         _.capability,
         equalTo(capability)
       ) &&
-        hasField[UnexpectedCallExpection[PureModule, I, E, A], Any]("args", _.args, equalTo(args))
+        hasField[UnexpectedCallException[PureModule, I, E, A], Any]("args", _.args, equalTo(args))
     )
 
   def hasUnsatisfiedExpectations: Assertion[Throwable] =

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
@@ -41,13 +41,13 @@ object AdvancedMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModul
   }
 
   def hasUnexpectedCall[I, E, A](capability: Capability[ImpureModule, I, E, A], args: I): Assertion[Throwable] =
-    isSubtype[UnexpectedCallExpection[ImpureModule, I, E, A]](
-      hasField[UnexpectedCallExpection[ImpureModule, I, E, A], Capability[ImpureModule, I, E, A]](
+    isSubtype[UnexpectedCallException[ImpureModule, I, E, A]](
+      hasField[UnexpectedCallException[ImpureModule, I, E, A], Capability[ImpureModule, I, E, A]](
         "capability",
         _.capability,
         equalTo(capability)
       ) &&
-        hasField[UnexpectedCallExpection[ImpureModule, I, E, A], Any]("args", _.args, equalTo(args))
+        hasField[UnexpectedCallException[ImpureModule, I, E, A], Any]("args", _.args, equalTo(args))
     )
 
   def hasUnsatisfiedExpectations: Assertion[Throwable] =

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
@@ -467,7 +467,7 @@ object BasicEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
         )
       }, {
         type M = Capability[PureModule, (Int, String, Long), String, String]
-        type X = UnexpectedCallExpection[PureModule, (Int, String, Long), String, String]
+        type X = UnexpectedCallException[PureModule, (Int, String, Long), String, String]
 
         testDied("unexpected call")(
           PureModuleMock.SingleParam(equalTo(1), value("foo")),

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
@@ -467,7 +467,7 @@ object BasicMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] 
           )
         }, {
           type M = Capability[ImpureModule, (Int, String, Long), Throwable, String]
-          type X = UnexpectedCallExpection[ImpureModule, (Int, String, Long), Throwable, String]
+          type X = UnexpectedCallException[ImpureModule, (Int, String, Long), Throwable, String]
 
           testDied("unexpected call")(
             ImpureModuleMock.SingleParam(equalTo(1), value("foo")),

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -334,7 +334,7 @@ object FailureRenderer {
         val header = red(s"- unsatisfied expectations").toLine
         header +: renderUnsatisfiedExpectations(expectation)
 
-      case MockException.UnexpectedCallExpection(method, args) =>
+      case MockException.UnexpectedCallException(method, args) =>
         Message(
           Seq(
             red(s"- unexpected call to $method with arguments").toLine,

--- a/test/shared/src/main/scala/zio/test/mock/internal/MockException.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/MockException.scala
@@ -31,7 +31,7 @@ object MockException {
     expectation: Expectation[R]
   ) extends MockException
 
-  final case class UnexpectedCallExpection[R <: Has[_], I >: Nothing, E >: Nothing, A >: Nothing](
+  final case class UnexpectedCallException[R <: Has[_], I >: Nothing, E >: Nothing, A >: Nothing](
     capability: Capability[R, I, E, A],
     args: Any
   ) extends MockException

--- a/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
@@ -39,7 +39,7 @@ object ProxyFactory {
         def findMatching(scopes: List[Scope[R]]): UIO[Matched[R, E, A]] = {
           debug(s"::: invoked $invoked\n${prettify(scopes)}")
           scopes match {
-            case Nil => ZIO.die(UnexpectedCallExpection(invoked, args))
+            case Nil => ZIO.die(UnexpectedCallException(invoked, args))
             case Scope(expectation, id, update0) :: nextScopes =>
               val update: Expectation[R] => Expectation[R] = updated => {
                 debug(s"::: updated state to: ${updated.state}")


### PR DESCRIPTION
This pull request replaces all occurrences of `UnexpectedCallExpection` as `UnexpectedCallException`.