### PR TITLE
Add back ZStream.effectAsync to JS

### DIFF
--- a/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -1,0 +1,170 @@
+package zio.stream
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
+  def spec = suite("ZStream JS")(
+    testM("effectAsync")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
+      val s = ZStream.effectAsync[Any, Throwable, Int](k => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
+
+      assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))
+    }),
+    suite("effectAsyncMaybe")(
+      testM("effectAsyncMaybe signal end stream") {
+        for {
+          result <- ZStream
+                      .effectAsyncMaybe[Any, Nothing, Int] { k =>
+                        k(IO.fail(None))
+                        None
+                      }
+                      .runCollect
+        } yield assert(result)(equalTo(Chunk.empty))
+      },
+      testM("effectAsyncMaybe Some")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
+        val s = ZStream.effectAsyncMaybe[Any, Throwable, Int](_ => Some(ZStream.fromIterable(chunk)))
+
+        assertM(s.runCollect.map(_.take(chunk.size)))(equalTo(chunk))
+      }),
+      testM("effectAsyncMaybe None")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
+        val s = ZStream.effectAsyncMaybe[Any, Throwable, Int] { k =>
+          chunk.foreach(a => k(Task.succeed(Chunk.single(a))))
+          None
+        }
+
+        assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))
+      }),
+      testM("effectAsyncMaybe back pressure") {
+        for {
+          refCnt  <- Ref.make(0)
+          refDone <- Ref.make[Boolean](false)
+          stream = ZStream.effectAsyncMaybe[Any, Throwable, Int](
+                     cb => {
+                       Future
+                         .sequence(
+                           (1 to 7).map(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
+                         )
+                         .flatMap(_ => cb(refDone.set(true) *> ZIO.fail(None)))
+                       None
+                     },
+                     5
+                   )
+          run    <- stream.run(ZSink.fromEffect[Any, Nothing, Int, Nothing](ZIO.never)).fork
+          _      <- refCnt.get.repeat(Schedule.recurWhile(_ != 7))
+          isDone <- refDone.get
+          _      <- run.interrupt
+        } yield assert(isDone)(isFalse)
+      }
+    ),
+    suite("effectAsyncM")(
+      testM("effectAsyncM")(checkM(Gen.chunkOf(Gen.anyInt).filter(_.nonEmpty)) { chunk =>
+        for {
+          latch <- Promise.make[Nothing, Unit]
+          fiber <- ZStream
+                     .effectAsyncM[Any, Throwable, Int] { k =>
+                       global.execute(() => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
+                       latch.succeed(()) *>
+                         Task.unit
+                     }
+                     .take(chunk.size.toLong)
+                     .run(ZSink.collectAll[Int])
+                     .fork
+          _ <- latch.await
+          s <- fiber.join
+        } yield assert(s)(equalTo(chunk))
+      }),
+      testM("effectAsyncM signal end stream") {
+        for {
+          result <- ZStream
+                      .effectAsyncM[Any, Nothing, Int] { k =>
+                        k(IO.fail(None))
+                        UIO.unit
+                      }
+                      .runCollect
+        } yield assert(result)(equalTo(Chunk.empty))
+      },
+      testM("effectAsyncM back pressure") {
+        for {
+          refCnt  <- Ref.make(0)
+          refDone <- Ref.make[Boolean](false)
+          stream = ZStream.effectAsyncM[Any, Throwable, Int](
+                     cb => {
+                       Future
+                         .sequence(
+                           (1 to 7).map(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
+                         )
+                         .flatMap(_ => cb(refDone.set(true) *> ZIO.fail(None)))
+                       UIO.unit
+                     },
+                     5
+                   )
+          run    <- stream.run(ZSink.fromEffect[Any, Nothing, Int, Nothing](ZIO.never)).fork
+          _      <- refCnt.get.repeatWhile(_ != 7)
+          isDone <- refDone.get
+          _      <- run.interrupt
+        } yield assert(isDone)(isFalse)
+      }
+    ),
+    suite("effectAsyncInterrupt")(
+      testM("effectAsyncInterrupt Left") {
+        for {
+          cancelled <- Ref.make(false)
+          latch     <- Promise.make[Nothing, Unit]
+          fiber <- ZStream
+                     .effectAsyncInterrupt[Any, Nothing, Unit] { offer =>
+                       offer(ZIO.succeedNow(Chunk.unit))
+                       Left(cancelled.set(true))
+                     }
+                     .tap(_ => latch.succeed(()))
+                     .runDrain
+                     .fork
+          _      <- latch.await
+          _      <- fiber.interrupt
+          result <- cancelled.get
+        } yield assert(result)(isTrue)
+      },
+      testM("effectAsyncInterrupt Right")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
+        val s = ZStream.effectAsyncInterrupt[Any, Throwable, Int](_ => Right(ZStream.fromIterable(chunk)))
+
+        assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))
+      }),
+      testM("effectAsyncInterrupt signal end stream ") {
+        for {
+          result <- ZStream
+                      .effectAsyncInterrupt[Any, Nothing, Int] { k =>
+                        k(IO.fail(None))
+                        Left(UIO.succeedNow(()))
+                      }
+                      .runCollect
+        } yield assert(result)(equalTo(Chunk.empty))
+      },
+      testM("effectAsyncInterrupt back pressure") {
+        for {
+          selfId  <- ZIO.fiberId
+          refCnt  <- Ref.make(0)
+          refDone <- Ref.make[Boolean](false)
+          stream = ZStream.effectAsyncInterrupt[Any, Throwable, Int](
+                     cb => {
+                       Future
+                         .sequence(
+                           (1 to 7).map(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
+                         )
+                         .flatMap(_ => cb(refDone.set(true) *> ZIO.fail(None)))
+                       Left(UIO.unit)
+                     },
+                     5
+                   )
+          run    <- stream.run(ZSink.fromEffect[Any, Throwable, Int, Nothing](ZIO.never)).fork
+          _      <- refCnt.get.repeatWhile(_ != 7)
+          isDone <- refDone.get
+          exit   <- run.interrupt
+        } yield assert(isDone)(isFalse) &&
+          assert(exit.untraced)(failsCause(containsCause(Cause.interrupt(selfId))))
+      }
+    )
+  )
+}

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -62,13 +62,8 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
             refDone <- Ref.make[Boolean](false)
             stream = ZStream.effectAsyncMaybe[Any, Throwable, Int](
                        cb => {
-                         if (zio.internal.Platform.isJVM) {
-                           global.execute { () =>
-                             // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-                             (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
-                             cb(refDone.set(true) *> ZIO.fail(None))
-                           }
-                         } else {
+                         global.execute { () =>
+                           // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
                            (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
                            cb(refDone.set(true) *> ZIO.fail(None))
                          }

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -2,11 +2,138 @@ package zio.stream
 
 import java.io.{ IOException, InputStream }
 
+import scala.concurrent.Future
+
 import zio._
 
 trait ZSinkPlatformSpecificConstructors
 
 trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
+
+  /**
+   * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The optionality of the error type `E` can be used to signal the end of the stream,
+   * by setting it to `None`.
+   */
+  def effectAsync[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Unit,
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    effectAsyncMaybe(
+      callback => {
+        register(callback)
+        None
+      },
+      outputBuffer
+    )
+
+  /**
+   * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The registration of the callback returns either a canceler or synchronously returns a stream.
+   * The optionality of the error type `E` can be used to signal the end of the stream, by
+   * setting it to `None`.
+   */
+  def effectAsyncInterrupt[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Either[Canceler[R], ZStream[R, E, A]],
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    ZStream {
+      for {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        eitherStream <- ZManaged.effectTotal {
+                          register(k =>
+                            try {
+                              runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
+                            } catch {
+                              case FiberFailure(c) if c.interrupted =>
+                                Future.successful(false)
+                            }
+                          )
+                        }
+        pull <- eitherStream match {
+                  case Left(canceler) =>
+                    (for {
+                      done <- ZRef.makeManaged(false)
+                    } yield done.get.flatMap {
+                      if (_) Pull.end
+                      else
+                        output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+                    }).ensuring(canceler)
+                  case Right(stream) => output.shutdown.toManaged_ *> stream.process
+                }
+      } yield pull
+    }
+
+  /**
+   * Creates a stream from an asynchronous callback that can be called multiple times
+   * The registration of the callback itself returns an effect. The optionality of the
+   * error type `E` can be used to signal the end of the stream, by setting it to `None`.
+   */
+  def effectAsyncM[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => ZIO[R, E, Any],
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    managed {
+      for {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        _ <- register { k =>
+               try {
+                 runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
+               } catch {
+                 case FiberFailure(c) if c.interrupted =>
+                   Future.successful(false)
+               }
+             }.toManaged_
+        done <- ZRef.makeManaged(false)
+        pull = done.get.flatMap {
+                 if (_)
+                   Pull.end
+                 else
+                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+               }
+      } yield pull
+    }.flatMap(repeatEffectChunkOption(_))
+
+  /**
+   * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The registration of the callback can possibly return the stream synchronously.
+   * The optionality of the error type `E` can be used to signal the end of the stream,
+   * by setting it to `None`.
+   */
+  def effectAsyncMaybe[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Option[ZStream[R, E, A]],
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    ZStream {
+      for {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        maybeStream <- ZManaged.effectTotal {
+                         register { k =>
+                           try {
+                             runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
+                           } catch {
+                             case FiberFailure(c) if c.interrupted =>
+                               Future.successful(false)
+                           }
+                         }
+                       }
+        pull <- maybeStream match {
+                  case Some(stream) => output.shutdown.toManaged_ *> stream.process
+                  case None =>
+                    for {
+                      done <- ZRef.makeManaged(false)
+                    } yield done.get.flatMap {
+                      if (_)
+                        Pull.end
+                      else
+                        output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+                    }
+                }
+      } yield pull
+    }
 
   /**
    * Creates a stream from a [[java.io.InputStream]]


### PR DESCRIPTION
Closes #3490

A follow-up of #3793 with the other effectAsync variants as requested