### PR TITLE
Fix BufferedPull#pullChunk

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3999,7 +3999,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         cursor.modify {
           case (chunk, idx) =>
             if (idx >= chunk.size) (update *> pullChunk, (Chunk.empty, 0))
-            else (update.as(chunk.drop(idx)), (Chunk.empty, 0))
+            else (UIO.succeedNow(chunk.drop(idx)), (Chunk.empty, 0))
         }.flatten
       }
 


### PR DESCRIPTION
Currently the last element is lost due to `update` signaling end via failing with `None`