### PR TITLE
Don't transform to Chunks when using foreach in ZManaged

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1337,7 +1337,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                   case ExecutionStrategy.Sequential =>
                     (
                       ZIO
-                        .foreach(Chunk.fromIterable(fins)) {
+                        .foreach(fins: Iterable[(Long, Finalizer)]) {
                           case (_, fin) => fin.apply(exit).run
                         }
                         .flatMap(results => ZIO.done(Exit.collectAll(results) getOrElse Exit.unit)),
@@ -1347,7 +1347,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                   case ExecutionStrategy.Parallel =>
                     (
                       ZIO
-                        .foreachPar(Chunk.fromIterable(fins)) {
+                        .foreachPar(fins: Iterable[(Long, Finalizer)]) {
                           case (_, finalizer) =>
                             finalizer(exit).run
                         }
@@ -1358,7 +1358,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                   case ExecutionStrategy.ParallelN(n) =>
                     (
                       ZIO
-                        .foreachParN(n)(Chunk.fromIterable(fins)) {
+                        .foreachParN(n)(fins: Iterable[(Long, Finalizer)]) {
                           case (_, finalizer) =>
                             finalizer(exit).run
                         }


### PR DESCRIPTION
I had a case with a large map and was seeing unnecessary time spent in `Chunk.fromIterable` in the profiler.