### PR TITLE
Add some Schedule constructors for cron-like functionality: dayOfMonth + bugfix

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import java.time.temporal.ChronoField
+import java.time.temporal.{ ChronoField, ChronoUnit }
 import java.time.{ Instant, OffsetDateTime, ZoneId }
 
 import zio.clock.Clock
@@ -359,9 +359,7 @@ object ScheduleSpec extends ZIOBaseSpec {
 
         val originOffset = OffsetDateTime
           .now()
-          .withMinute(0)
-          .withSecond(0)
-          .withNano(0)
+          .truncatedTo(ChronoUnit.HOURS)
 
         val inTimeHourSecond = originOffset.withHour(1).withSecond(1)
         val inTimeHour       = originOffset.withHour(1)
@@ -388,10 +386,7 @@ object ScheduleSpec extends ZIOBaseSpec {
 
         val originOffset = OffsetDateTime
           .now()
-          .withHour(0)
-          .withMinute(0)
-          .withSecond(0)
-          .withNano(0)
+          .truncatedTo(ChronoUnit.DAYS)
 
         val tuesdayHour = originOffset.`with`(ChronoField.DAY_OF_WEEK, 2).withHour(1)
         val tuesday     = originOffset.`with`(ChronoField.DAY_OF_WEEK, 2)
@@ -420,10 +415,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           .now()
           .withYear(2020)
           .withMonth(1)
-          .withHour(0)
-          .withMinute(0)
-          .withSecond(0)
-          .withNano(0)
+          .truncatedTo(ChronoUnit.DAYS)
 
         val inTimeDate1 = originOffset.withDayOfMonth(2).withHour(1)
         val inTimeDate2 = originOffset.withDayOfMonth(2)
@@ -449,10 +441,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           .withYear(2020)
           .withMonth(1)
           .withDayOfMonth(31)
-          .withHour(0)
-          .withMinute(0)
-          .withSecond(0)
-          .withNano(0)
+          .truncatedTo(ChronoUnit.DAYS)
 
         val input = List(originOffset).map((_, ()))
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -447,8 +447,8 @@ object ScheduleSpec extends ZIOBaseSpec {
         val originOffset = OffsetDateTime
           .now()
           .withYear(2020)
-          .withMonth(2)
-          .withDayOfMonth(1)
+          .withMonth(1)
+          .withDayOfMonth(31)
           .withHour(0)
           .withMinute(0)
           .withSecond(0)
@@ -456,8 +456,8 @@ object ScheduleSpec extends ZIOBaseSpec {
 
         val input = List(originOffset).map((_, ()))
 
-        assertM(runManually(Schedule.dayOfMonth(31), input).map(toOffsetDateTime)) {
-          val expected = originOffset.withMonth(3).withDayOfMonth(31)
+        assertM(runManually(Schedule.dayOfMonth(30), input).map(toOffsetDateTime)) {
+          val expected = originOffset.withMonth(3).withDayOfMonth(30)
           equalTo(List(expected))
         }
       },


### PR DESCRIPTION
Resolves #4043

I added remaining `dayOfMonth` method and also fixed bug causing infinite loop in the cron-like methods introduced earlier in a scope of #4043 