### PR TITLE
Add example of testing layered effects with Clock

### DIFF
--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -315,7 +315,7 @@ The above code creates a write once cell that will be set to "1" after 10 second
 
 A more complex example leveraging layers and multiple services is shown below. 
 
-```
+```scala mdoc:reset
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._


### PR DESCRIPTION
This is a more complex test example using layers and TestClock. I had to spend some time to have it working, hopefully this will help other people too 👍 

Unfortunately, I cannot make it compilable under mdoc even though it compiles in [scastie](https://scastie.scala-lang.org/d1gkSoQzSSSwev3j2aISMA). 

```
error: /Users/lgr/projects/opensource/zio/docs/howto/test_effects.md:342:63: type mismatch;
 found   : repl.MdocSession.App1.ZIO[Any,Exception,Unit]
 required: zio.ZIO[?,?,Any]
        (ZIO.sleep(10.seconds) *> promise.succeed(1).tap(b => logger.log(b.toString)))
                                                              ^^^^^^^^^^^^^^^^^^^^^^
error: /Users/lgr/projects/opensource/zio/docs/howto/test_effects.md:349:64: type mismatch;
 found   : zio.IO[Exception,Nothing]
    (which expands to)  zio.ZIO[Any,Exception,Nothing]
 required: repl.MdocSession.App1.ZIO[Any,Exception,Unit]
    override def log(msg: String): ZIO[Any, Exception, Unit] = ZIO.fail(new Exception("BOOM"))
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: /Users/lgr/projects/opensource/zio/docs/howto/test_effects.md:357:57: type mismatch;
 found   : repl.MdocSession.App1.ZIO[Any,Exception,Boolean]
 required: zio.ZIO[?,?,?]
      result  <- ZIO.service[SchedulingService].flatMap(_.schedule(promise)).run.fork
                                                        ^^^^^^^^^^^^^^^^^^^
error: /Users/lgr/projects/opensource/zio/docs/howto/test_effects.md:362:45: This operation assumes that your effect requires an environment. However, your effect has Any for the environment type, which means it has no requirement, so there is no need to provide the environment.
  testCase.provideSomeLayer[TestEnvironment](partialLayer)
                                            ^
```

Any idea how to solve it?