### PR TITLE
@accessible accessors for ZStream/ZSink (#4223)

### DIFF
--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -46,7 +46,7 @@ object AccessibleMacroExample {
     )
 
   // can use accessors even in the same compilation unit
-  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, ZStream[Any, String, Int], ZSink[Any, Nothing, Int, Nothing, Chunk[Int]])] =
+  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, Chunk[Int], ZSink[Any, Nothing, Int, Nothing, Chunk[Int]])] =
     for {
       _  <- AccessibleMacroExample.foo
       _  <- AccessibleMacroExample.bar(1)
@@ -57,7 +57,7 @@ object AccessibleMacroExample {
       v5 <- AccessibleMacroExample.dependent(5).orDieWith(_ => new Exception)
       v6 <- AccessibleMacroExample.value.orDie
       v7 <- AccessibleMacroExample.function(6).orDie
-      v8 <- AccessibleMacroExample.stream(7)
+      v8 <- AccessibleMacroExample.stream(7).run(ZSink.collectAll).orDieWith(_ => new Exception)
       v9 <- AccessibleMacroExample.sink(8)
     } yield (v1, v2, v3, v4, v5, v6, v7, v8, v9)
 
@@ -70,7 +70,7 @@ object AccessibleMacroExample {
   def _dependent(n: Int)              : ZIO[AccessibleMacroExample with Random, Long, Int]                         = AccessibleMacroExample.dependent(n)
   def _value                          : RIO[AccessibleMacroExample, String]                                        = AccessibleMacroExample.value
   def _function(n: Int)               : RIO[AccessibleMacroExample, String]                                        = AccessibleMacroExample.function(n)
-  def _stream(n: Int)                 : ZIO[AccessibleMacroExample, Nothing, ZStream[Any, String, Int]]            = AccessibleMacroExample.stream(n)
+  def _stream(n: Int)                 : ZStream[AccessibleMacroExample, String, Int]                               = AccessibleMacroExample.stream(n)
   def _sink(n: Int)                   : ZIO[AccessibleMacroExample, Nothing, ZSink[Any, Nothing, Int, Nothing, Chunk[Int]]] = AccessibleMacroExample.sink(n)
 
   // macro autogenerates accessors for `foo`, `bar`, `baz`, `poly`, `poly2`, `value` and `function` below

--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -46,7 +46,7 @@ object AccessibleMacroExample {
     )
 
   // can use accessors even in the same compilation unit
-  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, Chunk[Int], ZSink[Any, Nothing, Int, Nothing, Chunk[Int]])] =
+  val program: URIO[AccessibleMacroExample with Random, (Int, String, Long, List[Foo], Int, String, String, Chunk[Int], Chunk[Int])] =
     for {
       _  <- AccessibleMacroExample.foo
       _  <- AccessibleMacroExample.bar(1)
@@ -57,8 +57,8 @@ object AccessibleMacroExample {
       v5 <- AccessibleMacroExample.dependent(5).orDieWith(_ => new Exception)
       v6 <- AccessibleMacroExample.value.orDie
       v7 <- AccessibleMacroExample.function(6).orDie
-      v8 <- AccessibleMacroExample.stream(7).run(ZSink.collectAll).orDieWith(_ => new Exception)
-      v9 <- AccessibleMacroExample.sink(8)
+      v8 <- AccessibleMacroExample.stream(7).runCollect.orDieWith(_ => new Exception)
+      v9 <- ZStream(0).run(AccessibleMacroExample.sink(8))
     } yield (v1, v2, v3, v4, v5, v6, v7, v8, v9)
 
   // sanity check
@@ -71,7 +71,7 @@ object AccessibleMacroExample {
   def _value                          : RIO[AccessibleMacroExample, String]                                        = AccessibleMacroExample.value
   def _function(n: Int)               : RIO[AccessibleMacroExample, String]                                        = AccessibleMacroExample.function(n)
   def _stream(n: Int)                 : ZStream[AccessibleMacroExample, String, Int]                               = AccessibleMacroExample.stream(n)
-  def _sink(n: Int)                   : ZIO[AccessibleMacroExample, Nothing, ZSink[Any, Nothing, Int, Nothing, Chunk[Int]]] = AccessibleMacroExample.sink(n)
+  def _sink(n: Int)                   : ZSink[AccessibleMacroExample, Nothing, Int, Nothing, Chunk[Int]]           = AccessibleMacroExample.sink(n)
 
   // macro autogenerates accessors for `foo`, `bar`, `baz`, `poly`, `poly2`, `value` and `function` below
 }

--- a/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacro.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacro.scala
@@ -131,9 +131,8 @@ private[macros] class AccessibleMacro(val c: whitebox.Context) {
           if (r != any) tq"_root_.zio.stream.ZStream[_root_.zio.Has[Service[..$serviceTypeArgs]] with $r, $e, $a]"
           else tq"_root_.zio.stream.ZStream[_root_.zio.Has[Service[..$serviceTypeArgs]], $e, $a]"
         case Capability.Sink(r, e, a, l, b) =>
-          val value = tq"_root_.zio.stream.ZSink[$r, $e, $a, $l, $b]"
-          if (r != any) tq"_root_.zio.ZIO[_root_.zio.Has[Service[..$serviceTypeArgs]] with $r, $e, $value]"
-          else tq"_root_.zio.ZIO[_root_.zio.Has[Service[..$serviceTypeArgs]], $e, $value]"
+          if (r != any) tq"_root_.zio.stream.ZSink[_root_.zio.Has[Service[..$serviceTypeArgs]] with $r, $e, $a, $l, $b]"
+          else tq"_root_.zio.stream.ZSink[_root_.zio.Has[Service[..$serviceTypeArgs]], $e, $a, $l, $b]"
         case Capability.Method(a) =>
           tq"_root_.zio.ZIO[_root_.zio.Has[Service[..$serviceTypeArgs]], $throwable, $a]"
       }
@@ -163,6 +162,10 @@ private[macros] class AccessibleMacro(val c: whitebox.Context) {
           q"_root_.zio.stream.ZStream.accessStream(_.get[Service[..$serviceTypeArgs]].$name[..$typeArgs](...$argNames))"
         case (_: Capability.Stream, _) =>
           q"_root_.zio.stream.ZStream.accessStream(_.get[Service[..$serviceTypeArgs]].$name)"
+        case (_: Capability.Sink, argLists) if argLists.flatten.nonEmpty =>
+          q"_root_.zio.stream.ZSink.accessSink(_.get[Service[..$serviceTypeArgs]].$name[..$typeArgs](...$argNames))"
+        case (_: Capability.Sink, _) =>
+          q"_root_.zio.stream.ZSink.accessSink(_.get[Service[..$serviceTypeArgs]].$name)"
         case (_, argLists) if argLists.flatten.nonEmpty =>
           val argNames = argLists.map(_.map(_.name))
           q"_root_.zio.ZIO.access(_.get[Service[..$serviceTypeArgs]].$name[..$typeArgs](...$argNames))"

--- a/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
+++ b/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
@@ -281,7 +281,7 @@ object AccessibleSpec extends DefaultRunnableSpec {
 
               def function(arg1: Int)                    : ZIO[Has[Module.Service], Throwable, String] = Module.function(arg1)
               def sink(arg1: Int)                        : ZIO[Has[Module.Service], Nothing, ZSink[Any, Nothing, Int, Int, List[Int]]] = Module.sink(arg1)
-              def stream(arg1: Int)                      : ZIO[Has[Module.Service], Nothing, ZStream[Any, Nothing, Int]] = Module.stream(arg1)
+              def stream(arg1: Int)                      : ZStream[Has[Module.Service], Nothing, Int] = Module.stream(arg1)
             }
           """
         })(isRight(anything))

--- a/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
+++ b/macros/shared/src/test/scala-2.x/zio/macros/AccessibleSpec.scala
@@ -280,7 +280,7 @@ object AccessibleSpec extends DefaultRunnableSpec {
               def overloadedManaged(arg1: Long)                 : ZManaged[Has[Module.Service], Nothing, String] = Module.overloadedManaged(arg1)
 
               def function(arg1: Int)                    : ZIO[Has[Module.Service], Throwable, String] = Module.function(arg1)
-              def sink(arg1: Int)                        : ZIO[Has[Module.Service], Nothing, ZSink[Any, Nothing, Int, Int, List[Int]]] = Module.sink(arg1)
+              def sink(arg1: Int)                        : ZSink[Has[Module.Service], Nothing, Int, Int, List[Int]] = Module.sink(arg1)
               def stream(arg1: Int)                      : ZStream[Has[Module.Service], Nothing, Int] = Module.stream(arg1)
             }
           """

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -26,6 +26,14 @@ object ZSinkSpec extends ZIOBaseSpec {
             .run(ZSink.collectAllToMap((_: Int) % 3)(_ + _))
         )(equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15)))
       ),
+      suite("accessSink")(
+        testM("accessSink") {
+          assertM(
+            ZStream("ignore this")
+              .run(ZSink.accessSink[String](ZSink.succeed[String, String](_)).provide("use this"))
+          )(equalTo("use this"))
+        }
+      ),
       suite("collectAllWhileWith")(
         testM("example 1") {
           ZIO


### PR DESCRIPTION
- Generated Stream accessors use `ZStream.accessStream` rather than wrapping the stream in a ZIO using `ZIO.access`
- Added `ZSink.provide` and `ZSink.accessSink`
- Generated Sink accessors use `ZSink.accessSink` rather than wrapping the stream in a ZIO using `ZIO.access`