### PR TITLE
Delete Gen.usASCII

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -8,6 +8,7 @@ import java.nio.{ Buffer, ByteBuffer }
 import java.util.concurrent.CountDownLatch
 
 import scala.concurrent.ExecutionContext.global
+
 import zio._
 import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.test.Assertion._

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -746,7 +746,8 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("usASCII")(
         testM("US-ASCII strings") {
-          checkM(Gen.usASCII) { s =>
+          checkM(Gen.chunkOf(Gen.anyASCIIString)) { chunk =>
+            val s = chunk.mkString("")
             ZTransducer.usASCIIDecode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.US_ASCII))))

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -12,7 +12,7 @@ import java.{ util => ju }
 import scala.annotation.tailrec
 
 import zio._
-import zio.blocking.{ effectBlockingIO, Blocking }
+import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.stream.compression._
 
 trait ZSinkPlatformSpecificConstructors {

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -718,12 +718,6 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   val unit: Gen[Any, Unit] =
     const(())
 
-  /**
-   *  A generator of strings that can be encoded in the US-ASCII character set.
-   */
-  val usASCII: Gen[Random with Sized, String] =
-    chunkOf(anyASCIIString).map(chunk => chunk.toString)
-
   def vectorOf[R <: Random with Sized, A](g: Gen[R, A]): Gen[R, Vector[A]] =
     listOf(g).map(_.toVector)
 

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
@@ -1,7 +1,7 @@
 package zio.test.laws
 
+import zio.test.{ Gen, TestConfig, TestResult, check }
 import zio.{ URIO, ZIO }
-import zio.test.{ check, Gen, TestConfig, TestResult }
 
 object ZLawsF2 {
 


### PR DESCRIPTION
Resolves #4227.

This generator was confusing in that it generates a large ASCII string by first generating a chunk of ASCII strings and then calling `toString` on it but that resulted in the string being `Chunk(...)` instead of just the generated string. Also I don't think it is necessary to have such a specialized constructor since this can be easily implemented as `Gen.chunkOf(Gen.anyASCIIString)`. Deletes the generator and updates the one test that used it accordingly.