### PR TITLE
Use SetRemoveOnCanceledPolicy In Scheduler To Prevent Memory Leaks

### DIFF
--- a/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
@@ -33,7 +33,6 @@ private[clock] trait PlatformSpecific {
     override def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
       case Duration.Infinity => ConstFalse
       case Duration.Finite(_) =>
-        println(service)
         val future = service.schedule(
           new Runnable {
             def run: Unit =

--- a/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
@@ -26,13 +26,14 @@ private[clock] trait PlatformSpecific {
 
   private[clock] val globalScheduler = new Scheduler {
 
-    private[this] val service = Executors.newScheduledThreadPool(1, new NamedThreadFactory("zio-timer", true))
+    private[this] val service = makeService()
 
     private[this] val ConstFalse = () => false
 
     override def schedule(task: Runnable, duration: Duration): CancelToken = duration match {
       case Duration.Infinity => ConstFalse
       case Duration.Finite(_) =>
+        println(service)
         val future = service.schedule(
           new Runnable {
             def run: Unit =
@@ -48,5 +49,11 @@ private[clock] trait PlatformSpecific {
           canceled
         }
     }
+  }
+
+  private[this] def makeService(): ScheduledExecutorService = {
+    val service = new ScheduledThreadPoolExecutor(1, new NamedThreadFactory("zio-timer", true))
+    service.setRemoveOnCancelPolicy(true)
+    service
   }
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -8,6 +8,7 @@ import java.nio.{ Buffer, ByteBuffer }
 import java.util.concurrent.CountDownLatch
 
 import scala.concurrent.ExecutionContext.global
+
 import zio._
 import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.test.Assertion._

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -12,7 +12,7 @@ import java.{ util => ju }
 import scala.annotation.tailrec
 
 import zio._
-import zio.blocking.{ effectBlockingIO, Blocking }
+import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.stream.compression._
 
 trait ZSinkPlatformSpecificConstructors {

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
@@ -1,7 +1,7 @@
 package zio.test.laws
 
+import zio.test.{ Gen, TestConfig, TestResult, check }
 import zio.{ URIO, ZIO }
-import zio.test.{ check, Gen, TestConfig, TestResult }
 
 object ZLawsF2 {
 


### PR DESCRIPTION
Resolves #4208.

We need to set the remove on canceled policy in the scheduler to true so that tasks get immediately removed from the task queue when canceled to prevent a memory leak.

Thanks to @tusharmath for reporting!