### PR TITLE
ZIO Test: Evaluate Effects Sequentially In Gen#zipWith

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -8,6 +8,7 @@ import java.nio.{ Buffer, ByteBuffer }
 import java.util.concurrent.CountDownLatch
 
 import scala.concurrent.ExecutionContext.global
+
 import zio._
 import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.test.Assertion._

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -12,7 +12,7 @@ import java.{ util => ju }
 import scala.annotation.tailrec
 
 import zio._
-import zio.blocking.{ effectBlockingIO, Blocking }
+import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.stream.compression._
 
 trait ZSinkPlatformSpecificConstructors {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3008,7 +3008,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   def zipAllWith[R1 <: R, E1 >: E, O2, O3](
     that: ZStream[R1, E1, O2]
   )(left: O => O3, right: O2 => O3)(both: (O, O2) => O3): ZStream[R1, E1, O3] =
-    zipAllWithExec(that)(left, right)(both)(ExecutionStrategy.Parallel)
+    zipAllWithExec(that)(ExecutionStrategy.Parallel)(left, right)(both)
 
   /**
    * Zips this stream with another point-wise. The provided functions will be used to create elements
@@ -3022,7 +3022,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   def zipAllWithExec[R1 <: R, E1 >: E, O2, O3](
     that: ZStream[R1, E1, O2]
-  )(left: O => O3, right: O2 => O3)(both: (O, O2) => O3)(exec: ExecutionStrategy): ZStream[R1, E1, O3] = {
+  )(exec: ExecutionStrategy)(left: O => O3, right: O2 => O3)(both: (O, O2) => O3): ZStream[R1, E1, O3] = {
     sealed trait Status
     case object Running   extends Status
     case object LeftDone  extends Status

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3007,7 +3007,22 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   def zipAllWith[R1 <: R, E1 >: E, O2, O3](
     that: ZStream[R1, E1, O2]
-  )(left: O => O3, right: O2 => O3)(both: (O, O2) => O3): ZStream[R1, E1, O3] = {
+  )(left: O => O3, right: O2 => O3)(both: (O, O2) => O3): ZStream[R1, E1, O3] =
+    zipAllWithExec(that)(left, right)(both)(ExecutionStrategy.Parallel)
+
+  /**
+   * Zips this stream with another point-wise. The provided functions will be used to create elements
+   * for the composed stream.
+   *
+   * The functions `left` and `right` will be used if the streams have different lengths
+   * and one of the streams has ended before the other.
+   *
+   * The execution strategy `exec` will be used to determine whether to pull
+   * from the streams sequentially or in parallel.
+   */
+  def zipAllWithExec[R1 <: R, E1 >: E, O2, O3](
+    that: ZStream[R1, E1, O2]
+  )(left: O => O3, right: O2 => O3)(both: (O, O2) => O3)(exec: ExecutionStrategy): ZStream[R1, E1, O3] = {
     sealed trait Status
     case object Running   extends Status
     case object LeftDone  extends Status
@@ -3037,9 +3052,16 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
 
     combineChunks(that)((Running, Left(Chunk())): State) {
       case ((Running, excess), pullL, pullR) =>
-        pullL.optional
-          .zipWithPar(pullR.optional)(handleSuccess(_, _, excess))
-          .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        exec match {
+          case ExecutionStrategy.Sequential =>
+            pullL.optional
+              .zipWith(pullR.optional)(handleSuccess(_, _, excess))
+              .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+          case _ =>
+            pullL.optional
+              .zipWithPar(pullR.optional)(handleSuccess(_, _, excess))
+              .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        }
       case ((LeftDone, excess), _, pullR) =>
         pullR.optional
           .map(handleSuccess(None, _, excess))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -8,7 +8,7 @@ import zio.duration.{ Duration, _ }
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.GenUtils._
-import zio.test.TestAspect.{ nonFlaky, scala2Only }
+import zio.test.TestAspect.{ nonFlaky, scala2Only, setSeed }
 import zio.test.{ check => Check, checkN => CheckN }
 import zio.{ Chunk, NonEmptyChunk, ZIO }
 
@@ -596,7 +596,11 @@ object GenSpec extends ZIOBaseSpec {
             result <- shrinkWith(gen) { case (x, y) => x < m && y < n }
           } yield assert(result.reverse.headOption)(isSome(equalTo((m, 0)) || equalTo((0, n))))
         }
-      }
+      },
+      testM("determinism") {
+        val gen = Gen.anyInt <&> Gen.anyInt
+        assertM(gen.runHead)(isSome(equalTo((-1170105035, 234785527))))
+      } @@ setSeed(42) @@ nonFlaky
     ),
     testM("fromIterable constructs deterministic generators") {
       val expected   = List.range(1, 6).flatMap(x => List.range(1, 6).map(y => x + y))

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -24,7 +24,7 @@ import scala.math.Numeric.DoubleIsFractional
 
 import zio.random._
 import zio.stream.{ Stream, ZStream }
-import zio.{ Chunk, NonEmptyChunk, UIO, URIO, ZIO }
+import zio.{ Chunk, ExecutionStrategy, NonEmptyChunk, UIO, URIO, ZIO }
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires
@@ -152,11 +152,15 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
   def zipWith[R1 <: R, B, C](that: Gen[R1, B])(f: (A, B) => C): Gen[R1, C] = Gen {
     val left  = self.sample.map(Right(_)) ++ self.sample.map(Left(_)).forever
     val right = that.sample.map(Right(_)) ++ that.sample.map(Left(_)).forever
-    left.zipAllWith(right)(l => (Some(l), None), r => (None, Some(r)))((l, r) => (Some(l), Some(r))).collectWhile {
-      case (Some(Right(l)), Some(Right(r))) => l.zipWith(r)(f)
-      case (Some(Right(l)), Some(Left(r)))  => l.zipWith(r)(f)
-      case (Some(Left(l)), Some(Right(r)))  => l.zipWith(r)(f)
-    }
+    left
+      .zipAllWithExec(right)(l => (Some(l), None), r => (None, Some(r)))((l, r) => (Some(l), Some(r)))(
+        ExecutionStrategy.Sequential
+      )
+      .collectWhile {
+        case (Some(Right(l)), Some(Right(r))) => l.zipWith(r)(f)
+        case (Some(Right(l)), Some(Left(r)))  => l.zipWith(r)(f)
+        case (Some(Left(l)), Some(Right(r)))  => l.zipWith(r)(f)
+      }
   }
 }
 

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -153,9 +153,10 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
     val left  = self.sample.map(Right(_)) ++ self.sample.map(Left(_)).forever
     val right = that.sample.map(Right(_)) ++ that.sample.map(Left(_)).forever
     left
-      .zipAllWithExec(right)(l => (Some(l), None), r => (None, Some(r)))((l, r) => (Some(l), Some(r)))(
-        ExecutionStrategy.Sequential
-      )
+      .zipAllWithExec(right)(ExecutionStrategy.Sequential)(
+        l => (Some(l), None),
+        r => (None, Some(r))
+      )((l, r) => (Some(l), Some(r)))
       .collectWhile {
         case (Some(Right(l)), Some(Right(r))) => l.zipWith(r)(f)
         case (Some(Right(l)), Some(Left(r)))  => l.zipWith(r)(f)

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -98,7 +98,7 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
     val shrink = self.shrink
       .combine[R1, Nothing, State, Sample[R1, B], Sample[R1, C]](that.shrink)((false, false, None, None)) {
         case ((leftDone, rightDone, s1, s2), left, right) =>
-          left.run.zipWithPar(right.run) {
+          left.run.zipWith(right.run) {
             case (Exit.Success(l), Exit.Success(r)) =>
               Exit.succeed((zipWith(r)(f), (leftDone, rightDone, Some(l), Some(r))))
 

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
@@ -1,7 +1,7 @@
 package zio.test.laws
 
+import zio.test.{ Gen, TestConfig, TestResult, check }
 import zio.{ URIO, ZIO }
-import zio.test.{ check, Gen, TestConfig, TestResult }
 
 object ZLawsF2 {
 


### PR DESCRIPTION
`Gen#zipWith` describes combining two generators in a pairwise fashion. We ran into an issue where doing so was leading to generated values not being deterministic because in `ZStream#zipAllWith` we pull from the two streams in parallel so we could potentially evaluate the random effect in the second stream before the first stream. It would be nice to be able to describe combining streams point wise while evaluating the effects of pulling from the two streams sequentially versus in parallel.

To support this I added a new `zipAllWithExec` operator that takes an execution strategy and implemented `zipAllWith` in terms of that. Then we can call `zipAllWithExec` from `Gen#zipWith` to regain deterministic generated values.