### PR TITLE
Include source location (filename, line number) of the executing specs

### DIFF
--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -38,7 +38,7 @@ trait CompileVariants {
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  private[test] def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)(
+  private[test] def assertMImpl[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)(
     assertion: AssertionM[A]
   ): ZIO[R, E, TestResult]
 
@@ -58,16 +58,16 @@ trait CompileVariants {
   private[zio] def showExpression[A](expr: => A): String = macro Macros.showExpression_impl
 }
 
+/**
+ * Proxy methods to call package private methods from the macro
+ */
 object CompileVariants {
 
-  /**
-   * just a proxy to call package private assertRuntime from the macro
-   */
-  def assertImpl[A](value: => A, expression: String, sourceLocation: String)(assertion: Assertion[A]): TestResult =
+  def assertProxy[A](value: => A, expression: String, sourceLocation: String)(assertion: Assertion[A]): TestResult =
     zio.test.assertImpl(value, Some(expression), Some(sourceLocation))(assertion)
 
-  def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)(
+  def assertMProxy[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)(
     assertion: AssertionM[A]
   ): ZIO[R, E, TestResult] =
-    zio.test.assertMInternal(effect, Some(sourceLocation))(assertion)
+    zio.test.assertMImpl(effect, Some(sourceLocation))(assertion)
 }

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -56,6 +56,12 @@ private[test] object Macros {
     q"_root_.zio.test.CompileVariants.assertProxy($expr, $code, $srcLocation)($assertion)"
   }
 
+  def sourceLocation_impl(c: blackbox.Context): c.Expr[SourceLocation] = {
+    import c.universe._
+    val (path, line) = location(c)
+    c.Expr[SourceLocation](q"""${c.prefix}($path, $line)""")
+  }
+
   def sourcePath_impl(c: blackbox.Context): c.Tree = {
     import c.universe._
     q"${c.enclosingPosition.source.path}"

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -41,14 +41,11 @@ private[test] object Macros {
     (path, line)
   }
 
-  def assertImpl[A](value: => A, label: String, location: String)(assertion: Assertion[A]): TestResult =
-    zio.test.assertImpl(value, Some(label), Some(location))(assertion)
-
   def assertM_impl(c: blackbox.Context)(effect: c.Tree)(assertion: c.Tree): c.Tree = {
     import c.universe._
     val (fileName, line) = location(c)
     val srcLocation      = s"$fileName:$line"
-    q"_root_.zio.test.CompileVariants.assertMInternal($effect, $srcLocation)($assertion)"
+    q"_root_.zio.test.CompileVariants.assertMProxy($effect, $srcLocation)($assertion)"
   }
 
   def assert_impl(c: blackbox.Context)(expr: c.Tree)(assertion: c.Tree): c.Tree = {
@@ -56,7 +53,7 @@ private[test] object Macros {
     val (fileName, line) = location(c)
     val srcLocation      = s"$fileName:$line"
     val code             = CleanCodePrinter.show(c)(expr)
-    q"_root_.zio.test.CompileVariants.assertImpl($expr, $code, $srcLocation)($assertion)"
+    q"_root_.zio.test.CompileVariants.assertProxy($expr, $code, $srcLocation)($assertion)"
   }
 
   def sourcePath_impl(c: blackbox.Context): c.Tree = {

--- a/test/shared/src/main/scala-2.x/zio/test/SourceLocationVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/SourceLocationVariants.scala
@@ -1,0 +1,5 @@
+package zio.test
+
+trait SourceLocationVariants {
+  implicit def generate: SourceLocation = macro Macros.sourceLocation_impl
+}

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -72,5 +72,5 @@ object CompileVariants {
 
   def assertMProxy[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)
                               (assertion: AssertionM[A]): ZIO[R, E, TestResult] =
-    zio.test.assertMInternal(effect, Some(sourceLocation))(assertion)
+    zio.test.assertMImpl(effect, Some(sourceLocation))(assertion)
 }

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -49,7 +49,7 @@ trait CompileVariants {
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  private[test] def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)
+  private[test] def assertMImpl[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)
                                             (assertion: AssertionM[A]): ZIO[R, E, TestResult]
 
 
@@ -62,55 +62,15 @@ trait CompileVariants {
   private[zio] inline def showExpression[A](inline value: => A): String = ${Macros.showExpression_impl('value)}
 }
 
+/**
+ * Proxy methods to call package private methods from the macro
+ */
 object CompileVariants {
-  /**
-   * just a proxy to call package private assertRuntime from the macro
-   */
-  def assertImpl[A](value: => A, expression: String, sourceLocation: String)(assertion: Assertion[A]): TestResult =
+
+  def assertProxy[A](value: => A, expression: String, sourceLocation: String)(assertion: Assertion[A]): TestResult =
     zio.test.assertImpl(value, Some(expression), Some(sourceLocation))(assertion)
 
-  def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)
+  def assertMProxy[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)
                               (assertion: AssertionM[A]): ZIO[R, E, TestResult] =
     zio.test.assertMInternal(effect, Some(sourceLocation))(assertion)
-}
-
-object Macros {
-  import scala.quoted._
-
-  private def location(ctx: Quotes): (String, Int) = {
-    import ctx.reflect._
-    val path = Position.ofMacroExpansion.sourceFile.jpath.toString
-    val line = Position.ofMacroExpansion.startLine + 1
-    (path, line)
-  }
-
-  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: Quotes, tp: Type[A]): Expr[TestResult] = {
-    import quotes.reflect._
-    val (path, line) = location(ctx)
-    val code = showExpr(value)
-    val srcLocation = s"$path:$line"
-    '{_root_.zio.test.CompileVariants.assertImpl[A]($value, ${Expr(code)}, ${Expr(srcLocation)})($assertion)}
-  }
-
-  def assertM_impl[R: Type, E: Type, A: Type](effect: Expr[ZIO[R, E, A]])(assertion: Expr[AssertionM[A]])
-                           (using ctx: Quotes): Expr[ZIO[R, E, TestResult]] = {
-    import quotes.reflect._
-    val (path, line) = location(ctx)
-    val srcLocation = s"$path:$line"
-    '{_root_.zio.test.CompileVariants.assertMInternal($effect, ${Expr(srcLocation)})($assertion)}
-  }
-
-  private def showExpr[A](expr: Expr[A])(using ctx: Quotes): String = {
-    import quotes.reflect._
-    expr.asTerm.pos.sourceCode.get
-  }
-
-  def sourcePath_impl(using ctx: Quotes): Expr[String] = {
-    import quotes.reflect._
-    Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
-  }
-  def showExpression_impl[A](value: Expr[A])(using ctx: Quotes): Expr[String] = {
-    import quotes.reflect._
-    Expr(showExpr(value))
-  }
 }

--- a/test/shared/src/main/scala-dotty/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/Macros.scala
@@ -49,7 +49,7 @@ object Macros {
     expr.asTerm.pos.sourceCode.get
   }
 
-  def sourceLocation_impl(using ctx: QuoteContext): Expr[SourceLocation] = {
+  def sourceLocation_impl(using ctx: Quotes): Expr[SourceLocation] = {
     import quotes.reflect._
     val (path, line) = location(ctx)
     '{SourceLocation(${Expr(path)}, ${Expr(line)})}
@@ -59,6 +59,7 @@ object Macros {
     import quotes.reflect._
     Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
   }
+
   def showExpression_impl[A](value: Expr[A])(using ctx: Quotes): Expr[String] = {
     import quotes.reflect._
     Expr(showExpr(value))

--- a/test/shared/src/main/scala-dotty/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/Macros.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.{UIO, ZIO}
+
+object Macros {
+  import scala.quoted._
+
+  private def location(ctx: Quotes): (String, Int) = {
+    import ctx.reflect._
+    val path = Position.ofMacroExpansion.sourceFile.jpath.toString
+    val line = Position.ofMacroExpansion.startLine + 1
+    (path, line)
+  }
+
+  def assertM_impl[R: Type, E: Type, A: Type](effect: Expr[ZIO[R, E, A]])(assertion: Expr[AssertionM[A]])
+                                             (using ctx: Quotes): Expr[ZIO[R, E, TestResult]] = {
+    import quotes.reflect._
+    val (path, line) = location(ctx)
+    val srcLocation = s"$path:$line"
+    '{_root_.zio.test.CompileVariants.assertMProxy($effect, ${Expr(srcLocation)})($assertion)}
+  }
+
+  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: Quotes, tp: Type[A]): Expr[TestResult] = {
+    import quotes.reflect._
+    val (path, line) = location(ctx)
+    val code = showExpr(value)
+    val srcLocation = s"$path:$line"
+    '{_root_.zio.test.CompileVariants.assertProxy($value, ${Expr(code)}, ${Expr(srcLocation)})($assertion)}
+  }
+
+  private def showExpr[A](expr: Expr[A])(using ctx: Quotes): String = {
+    import quotes.reflect._
+    expr.asTerm.pos.sourceCode.get
+  }
+
+  def sourceLocation_impl(using ctx: QuoteContext): Expr[SourceLocation] = {
+    import quotes.reflect._
+    val (path, line) = location(ctx)
+    '{SourceLocation(${Expr(path)}, ${Expr(line)})}
+  }
+
+  def sourcePath_impl(using ctx: Quotes): Expr[String] = {
+    import quotes.reflect._
+    Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
+  }
+  def showExpression_impl[A](value: Expr[A])(using ctx: Quotes): Expr[String] = {
+    import quotes.reflect._
+    Expr(showExpr(value))
+  }
+}

--- a/test/shared/src/main/scala-dotty/zio/test/SourceLocationVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/SourceLocationVariants.scala
@@ -1,0 +1,5 @@
+package zio.test
+
+trait SourceLocationVariants {
+  inline given SourceLocation = ${Macros.sourceLocation_impl}
+}

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -44,5 +44,6 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
   /**
    * Builds a spec with a single pure test.
    */
-  def test(label: String)(assertion: => TestResult): ZSpec[Any, Nothing] = zio.test.test(label)(assertion)
+  def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =
+    zio.test.test(label)(assertion)
 }

--- a/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
@@ -102,7 +102,7 @@ class MutableRunnableSpec[R <: Has[_]](layer: ZLayer[TestEnvironment, Throwable,
   /**
    * Builds a spec with a single pure test.
    */
-  final def test(label: String)(assertion: => TestResult): TestBuilder = {
+  final def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): TestBuilder = {
     if (specBuilt)
       throw new InAnotherTestException("Test", label)
     val test    = zio.test.test(label)(assertion)
@@ -114,7 +114,9 @@ class MutableRunnableSpec[R <: Has[_]](layer: ZLayer[TestEnvironment, Throwable,
   /**
    * Builds a spec with a single effectful test.
    */
-  final def testM(label: String)(assertion: => ZIO[R, Failure, TestResult]): TestBuilder = {
+  final def testM(
+    label: String
+  )(assertion: => ZIO[R, Failure, TestResult])(implicit loc: SourceLocation): TestBuilder = {
     if (specBuilt)
       throw new InAnotherTestException("Test", label)
     val test    = zio.test.testM(label)(assertion)

--- a/test/shared/src/main/scala/zio/test/SourceLocation.scala
+++ b/test/shared/src/main/scala/zio/test/SourceLocation.scala
@@ -1,0 +1,4 @@
+package zio.test
+
+private[test] final case class SourceLocation(path: String, line: Int)
+object SourceLocation extends SourceLocationVariants

--- a/test/shared/src/main/scala/zio/test/SourceLocation.scala
+++ b/test/shared/src/main/scala/zio/test/SourceLocation.scala
@@ -1,4 +1,4 @@
 package zio.test
 
-private[test] final case class SourceLocation(path: String, line: Int)
+private[zio] final case class SourceLocation(path: String, line: Int)
 object SourceLocation extends SourceLocationVariants

--- a/test/shared/src/main/scala/zio/test/SourceLocation.scala
+++ b/test/shared/src/main/scala/zio/test/SourceLocation.scala
@@ -1,4 +1,4 @@
 package zio.test
 
-private[zio] final case class SourceLocation(path: String, line: Int)
+final case class SourceLocation(path: String, line: Int)
 object SourceLocation extends SourceLocationVariants

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -70,6 +70,12 @@ object TestAnnotation {
   val timing: TestAnnotation[Duration] =
     TestAnnotation("timing", Duration.Zero, _ + _)
 
+  /**
+   * An annotation for capturing the source location (file name and line number) of the calling test.
+   */
+  val location: TestAnnotation[List[SourceLocation]] =
+    TestAnnotation("location", List.empty, _ ++ _)
+
   import scala.collection.immutable.SortedSet
 
   import zio.Ref

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -174,7 +174,7 @@ package object test extends CompileVariants {
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  override private[test] def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)(
+  override private[test] def assertMImpl[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)(
     assertion: AssertionM[A]
   ): ZIO[R, E, TestResult] =
     for {

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -554,14 +554,16 @@ package object test extends CompileVariants {
   /**
    * Builds a spec with a single pure test.
    */
-  def test(label: String)(assertion: => TestResult): ZSpec[Any, Nothing] =
+  def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =
     testM(label)(ZIO.effectTotal(assertion))
 
   /**
    * Builds a spec with a single effectful test.
    */
-  def testM[R, E](label: String)(assertion: => ZIO[R, E, TestResult]): ZSpec[R, E] =
-    Spec.test(label, ZTest(assertion), TestAnnotationMap.empty)
+  def testM[R, E](label: String)(assertion: => ZIO[R, E, TestResult])(implicit loc: SourceLocation): ZSpec[R, E] =
+    Spec
+      .test(label, ZTest(assertion), TestAnnotationMap.empty)
+      .annotate(TestAnnotation.location, loc :: Nil)
 
   /**
    * Passes version specific information to the specified function, which will


### PR DESCRIPTION
Fixes #3152

This PR adds source information of the currently executing `test`/`testM`, and storing it inside a test annotation.
This is done with a small macro, without any external libraries!

![image](https://user-images.githubusercontent.com/601206/94318060-584c7280-ff90-11ea-9ee9-a02607147088.png)

Result (with `location` rendering enabled):
```
+ Source location - location: "(/Users/hmemcpy/.../test/SourceLocationSpec.scala,5)"
  + Tests report their source location - location: "(/Users/hmemcpy/.../test/SourceLocationSpec.scala,5)"
Ran 1 test in 433 ms: 1 succeeded, 0 ignored, 0 failed
```

This functionality is required in order to provide external tooling support with better navigation to the location of the test, for instance, from IntelliJ's test runner window - double clicking on the test entry can take you to the file.
To achieve this, IntelliJ expects test runners to provide "location hints" in form of a `filename:lineNumber` URL. This URL can be constructed externally, but only if this information is available from ZIO Test.

I was, unfortunately, not able to extract the exact information I required from ZIO's stack traces.

I welcome a discussion/alternative implementation suggestions!

Related: #3911