### PR TITLE
Trigger auto-approve-action on pull_request_target

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,7 +1,7 @@
 name: Auto approve
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   auto-approve:


### PR DESCRIPTION
I would actually like to experiment with `pull_request_target` once more.
This time, we will have to patently wait for Scala Steward to open a PR, so that `github.actor == 'scala-steward'` holds and the action actually runs.
:crossed_fingers: 
/cc @adamgfraser 

---
We can safely conclude, that `auto-approve-action` on `pull_request` doesn't work, it fails with `Resource not accessible by integration`.
Just to make sure, we don't have any _cusom_ token in Secrets with the name `GITHUB_TOKEN` that would alias with the token GitHub automatically creates for each repo, right?