### PR TITLE
change hedgehog => qa.hedgehog and upgrades to 0.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,7 +356,7 @@ lazy val benchmarks = project.module
         "org.scala-lang"             % "scala-reflect"  % scalaVersion.value,
         "org.typelevel"             %% "cats-effect"    % "2.2.0",
         "org.scalacheck"            %% "scalacheck"     % "1.14.3",
-        "hedgehog"                  %% "hedgehog-core"  % "0.1.0",
+        "qa.hedgehog"               %% "hedgehog-core"  % "0.5.1",
         "com.github.japgolly.nyaya" %% "nyaya-gen"      % "0.9.2"
       ),
     unusedCompileDependenciesFilter -= libraryDependencies.value


### PR DESCRIPTION
Update Hedgehog [organization and name](https://mvnrepository.com/artifact/qa.hedgehog), as described in in [docs](https://github.com/hedgehogqa/scala-hedgehog#sbt-binary-dependency).