### PR TITLE
Try To Identify Source Of CI Flakiness

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1343,10 +1343,10 @@ object ZManaged extends ZManagedPlatformSpecific {
                       Exited(nextKey, exit)
                     )
 
-                  case ExecutionStrategy.ParallelN(n) =>
+                  case ExecutionStrategy.ParallelN(_) =>
                     (
                       ZIO
-                        .foreachParN(n)(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
+                        .foreachPar(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
                           finalizer(exit).run
                         }
                         .flatMap(results => ZIO.done(Exit.collectAllPar(results) getOrElse Exit.unit)),

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -26,9 +26,10 @@ abstract class BaseTestTask(
 
   protected def run(eventHandler: EventHandler): ZIO[TestLogger with Clock, Throwable, Unit] =
     for {
-      spec <- specInstance.runSpec(FilteredSpec(specInstance.spec, args)).timeout(5.minutes).flatMap {
+      spec <- specInstance.runSpec(FilteredSpec(specInstance.spec, args)).disconnect.timeout(5.minutes).flatMap {
                 case Some(result) => ZIO.succeed(result)
-                case None         => UIO(println(s"${taskDef.fullyQualifiedName} timed out!")) *> UIO.die(new Exception("die"))
+                case None =>
+                  UIO(println(s"${taskDef.fullyQualifiedName()} timed out!")) *> UIO.die(new Exception("die"))
               }
       summary = SummaryBuilder.buildSummary(spec)
       _      <- sendSummary.provide(summary)

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -39,7 +39,7 @@ final case class TestRunner[R <: Has[_], E](
    * Runs the spec, producing the execution results.
    */
   def run(spec: ZSpec[R, E]): URIO[TestLogger with Clock, ExecutedSpec[E]] =
-    executor.run(spec, ExecutionStrategy.ParallelN(4)).timed.flatMap { case (duration, results) =>
+    executor.run(spec, ExecutionStrategy.Parallel).timed.flatMap { case (duration, results) =>
       reporter(duration, results).as(results)
     }
 

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -39,7 +39,7 @@ final case class TestRunner[R <: Has[_], E](
    * Runs the spec, producing the execution results.
    */
   def run(spec: ZSpec[R, E]): URIO[TestLogger with Clock, ExecutedSpec[E]] =
-    executor.run(spec, ExecutionStrategy.Parallel).timed.flatMap { case (duration, results) =>
+    executor.run(spec, ExecutionStrategy.ParallelN(4)).timed.flatMap { case (duration, results) =>
       reporter(duration, results).as(results)
     }
 


### PR DESCRIPTION
We are seeing some builds fail on CI with a message that no output has been received for 10 minutes. This indicates that something is going wrong but it is not simply a test timing out since that should be caught by the test framework and reported as a test failure. Initial work to identify the underlying cause.