### PR TITLE
Avoid Recomputing Hash Code In ZLayer

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -146,6 +146,12 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
     ZLayer.Fresh(self)
 
   /**
+    * Returns the hash code of this layer.
+    */
+  override final lazy val hashCode: Int =
+    super.hashCode
+
+  /**
    * Builds this layer and uses it until it is interrupted. This is useful when
    * your entire application is a layer, such as an HTTP server.
    */


### PR DESCRIPTION
Resolves #4126.

When constructing extremely large layers performance can be negatively impacted because layers are used as keys in the `MemoMap` and the hash codes of layers are recomputed each time, which can require having to recursively compute the hash codes of all layers composed into the layer. With this PR we store the hash code of a layer once it has been computed to avoid this, resulting in dramatic improvements in time to construct complex layers (from ~3seconds to ~200ms for me locally using the example from the original issue).