### PR TITLE
[Experiment] Use GitHub's merge branch from PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ checkout_merge_branch: &checkout_merge_branch
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
           echo FETCH
-          git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/$CIRCLE_PR_NUMBER_merge"
+          git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
           ehco CHECKOUT
-          git checkout -q -B "remotes/origin/pull/$CIRCLE_PR_NUMBER_merge"
+          git checkout -q -B "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          git checkout "origin/pull/$CIRCLE_PR_NUMBER/merge"
+          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge:pull/$CIRCLE_PR_NUMBER/merge"
+          git checkout "pull/$CIRCLE_PR_NUMBER/merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge"
-          git checkout "pull/$CIRCLE_PR_NUMBER/merge"
+          git fetch origin "refs/pull/$CIRCLE_PR_NUMBER/merge"
+          git checkout "refs/pull/$CIRCLE_PR_NUMBER/merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,8 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          echo FETCH
           git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
-          echo CHECKOUT
-          git checkout -q -B "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
+          git checkout "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ checkout_merge_branch: &checkout_merge_branch
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
           echo FETCH
-          git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/$CIRCLE_PR_NUMBER/merge"
+          git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/$CIRCLE_PR_NUMBER_merge"
           ehco CHECKOUT
-          git checkout -q -B "remotes/origin/pull/$CIRCLE_PR_NUMBER/merge"
+          git checkout -q -B "remotes/origin/pull/$CIRCLE_PR_NUMBER_merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ machine_ubuntu: &machine_ubuntu
   machine:
     image: ubuntu-1604:201903-01
 
+checkout_merge_branch: &checkout_merge_branch
+  -run:
+    if [ "$CIRCLE_PR_NUMBER" -ne "" ]; then
+      git checkout "origin/pull/$CIRCLE_PR_NUMBER/merge"
+    fi
+
 install_jdk: &install_jdk
   - run:
       name: Install JDK
@@ -102,6 +108,7 @@ filter_tags: &filter_tags
 lint: &lint
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - run:
         name: Lint code
@@ -112,6 +119,7 @@ lint: &lint
 mdoc: &mdoc
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - run:
         name: Generate documentation
@@ -124,6 +132,7 @@ mdoc: &mdoc
 mimaChecks: &mimaChecks
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - run:
@@ -135,6 +144,7 @@ mimaChecks: &mimaChecks
 testJVM: &testJVM
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - run:
@@ -148,6 +158,7 @@ testJVM: &testJVM
 testJVMNoBenchmarks: &testJVMNoBenchmarks
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - run:
@@ -161,6 +172,7 @@ testJVMNoBenchmarks: &testJVMNoBenchmarks
 testJVMDotty: &testJVMDotty
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - run:
         name: Run tests
@@ -171,6 +183,7 @@ testJVMDotty: &testJVMDotty
 testJVM211: &testJVM211
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - run:
@@ -184,6 +197,7 @@ testJVM211: &testJVM211
 testJS: &testJS
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - <<: *install_nodejs
@@ -198,6 +212,7 @@ testJS: &testJS
 testJS211: &testJS211
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - <<: *install_jdk
     - <<: *install_nodejs
@@ -212,6 +227,7 @@ testJS211: &testJS211
 testNative: &testNative
   steps:
     - checkout
+    - <<: *checkout_merge_branch
     - <<: *load_cache
     - run:
         name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ checkout_merge_branch: &checkout_merge_branch
   - run:
       name: Checkout the "merge" branch for this PR
       command: |
-        if [ "$CIRCLE_PR_NUMBER" -ne "" ]; then
+        if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
           git checkout "origin/pull/$CIRCLE_PR_NUMBER/merge"
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,12 @@ machine_ubuntu: &machine_ubuntu
     image: ubuntu-1604:201903-01
 
 checkout_merge_branch: &checkout_merge_branch
-  -run:
-    if [ "$CIRCLE_PR_NUMBER" -ne "" ]; then
-      git checkout "origin/pull/$CIRCLE_PR_NUMBER/merge"
-    fi
+  - run:
+      name: Checkout the "merge" branch for this PR
+      command: |
+        if [ "$CIRCLE_PR_NUMBER" -ne "" ]; then
+          git checkout "origin/pull/$CIRCLE_PR_NUMBER/merge"
+        fi
 
 install_jdk: &install_jdk
   - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,10 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          git fetch origin "refs/pull/$CIRCLE_PR_NUMBER/merge"
-          git checkout "refs/pull/$CIRCLE_PR_NUMBER/merge"
+          echo FETCH
+          git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/$CIRCLE_PR_NUMBER/merge"
+          ehco CHECKOUT
+          git checkout -q -B "remotes/origin/pull/$CIRCLE_PR_NUMBER/merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge:pull/$CIRCLE_PR_NUMBER/merge"
-          git checkout "pull/$CIRCLE_PR_NUMBER/merge"
+          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge:pull$CIRCLE_PR_NUMBERmerge"
+          git checkout "pull$CIRCLE_PR_NUMBERmerge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ checkout_merge_branch: &checkout_merge_branch
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
           git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
-          git checkout "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
+          git checkout -B "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ checkout_merge_branch: &checkout_merge_branch
       name: Checkout the "merge" branch for this PR
       command: |
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
-          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge:pull$CIRCLE_PR_NUMBERmerge"
-          git checkout "pull$CIRCLE_PR_NUMBERmerge"
+          git fetch origin "pull/$CIRCLE_PR_NUMBER/merge"
+          git checkout "pull/$CIRCLE_PR_NUMBER/merge"
         fi
 
 install_jdk: &install_jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ checkout_merge_branch: &checkout_merge_branch
         if [[ "$CIRCLE_PR_NUMBER" -ne "" ]]; then
           echo FETCH
           git fetch --force origin "pull/$CIRCLE_PR_NUMBER/merge:remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
-          ehco CHECKOUT
+          echo CHECKOUT
           git checkout -q -B "remotes/origin/pull/${CIRCLE_PR_NUMBER}_merge"
         fi
 


### PR DESCRIPTION
So this is what we to ideally happen: We don't want to test against the `pull/$CIRCLE_PR_NUMBER/head` branch. We want the `pull/$CIRCLE_PR_NUMBER/merge`.
What do you think?
Do you know of any easier way to achieve this in CircleCI?

/cc @softinio @mijicd
