### PR TITLE
ZIO Test: Preserve Original Failure When Shrinks Is Set To Zero

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -254,6 +254,11 @@ object TestAspectSpec extends ZIOBaseSpec {
         value <- ref.get
       } yield assert(value)(equalTo(1))
     } @@ shrinks(0),
+    testM("shrinks preserves the original failure") {
+      check(Gen.anyInt) { n =>
+        assert(n)(equalTo(n + 1))
+      }
+    } @@ shrinks(0) @@ failing,
     testM("timeout makes tests fail after given duration") {
       assertM(ZIO.never *> ZIO.unit)(equalTo(()))
     } @@ timeout(1.nanos)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -844,7 +844,7 @@ package object test extends CompileVariants {
     stream
       .dropWhile(!_.value.fold(_ => true, _.isFailure)) // Drop until we get to a failure
       .take(1)                                          // Get the first failure
-      .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks.toLong))
+      .flatMap(_.shrinkSearch(_.fold(_ => true, _.isFailure)).take(maxShrinks.toLong + 1))
       .run(ZSink.collectAll[Either[E, TestResult]]) // Collect all the shrunken values
       .flatMap { shrinks =>
         // Get the "last" failure, the smallest according to the shrinker:


### PR DESCRIPTION
In `checkStream` we need to take `maxShrinks + 1` instead of `maxShrinks` values because we need to take the original failure in addition to the shrunk values.