### PR TITLE
Add UStream alias for streams that can't fail

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/package.scala
+++ b/streams/shared/src/main/scala/zio/stream/package.scala
@@ -4,6 +4,9 @@ package object stream {
   type Stream[+E, +A] = ZStream[Any, E, A]
   val Stream = ZStream
 
+  type UStream[+A] = ZStream[Any, Nothing, A]
+  val UStream = ZStream
+
   type Sink[+E, A, +L, +B] = ZSink[Any, E, A, L, B]
   val Sink = ZSink
 


### PR DESCRIPTION
I have to write `Stream[Nothing, A]` a lot so an alias would be useful. Not sure if I need to update any documentation for this, let me know if that's the case.