### PR TITLE
Fix ZStream#takeWhile stopping on empty chunks

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
@@ -53,7 +53,7 @@ object ZStreamGen extends GenZIO {
   val pureStreamOfInts: Gen[Random with Sized, ZStream[Any, Nothing, Int]] =
     Gen.bounded(0, 5)(pureStreamGen(Gen.anyInt, _)).zipWith(Gen.function(Gen.boolean))(injectEmptyChunks)
 
-  def injectEmptyChunks[R, E, A](stream: ZStream[R, E, A], predicate: Chunk[A] => Boolean) =
+  def injectEmptyChunks[R, E, A](stream: ZStream[R, E, A], predicate: Chunk[A] => Boolean): ZStream[R, E, A] =
     stream.mapChunks { chunk =>
       if (predicate(chunk)) chunk
       else Chunk.empty

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
@@ -47,11 +47,15 @@ object ZStreamGen extends GenZIO {
   def nPulls[R, E, A](pull: ZIO[R, Option[E], A], n: Int): ZIO[R, Nothing, Iterable[Either[Option[E], A]]] =
     ZIO.foreach(1 to n)(_ => pull.either)
 
-  val streamOfBytes: Gen[Random with Sized, ZStream[Any, String, Byte]] = Gen.bounded(0, 5)(streamGen(Gen.anyByte, _))
-  val streamOfInts: Gen[Random with Sized, ZStream[Any, String, Int]]   = Gen.bounded(0, 5)(streamGen(Gen.anyInt, _))
+  val streamOfInts: Gen[Random with Sized, ZStream[Any, String, Int]] =
+    Gen.bounded(0, 5)(streamGen(Gen.anyInt, _)).zipWith(Gen.function(Gen.boolean))(injectEmptyChunks)
 
-  val pureStreamOfBytes: Gen[Random with Sized, ZStream[Any, Nothing, Byte]] =
-    Gen.bounded(0, 5)(pureStreamGen(Gen.anyByte, _))
   val pureStreamOfInts: Gen[Random with Sized, ZStream[Any, Nothing, Int]] =
-    Gen.bounded(0, 5)(pureStreamGen(Gen.anyInt, _))
+    Gen.bounded(0, 5)(pureStreamGen(Gen.anyInt, _)).zipWith(Gen.function(Gen.boolean))(injectEmptyChunks)
+
+  def injectEmptyChunks[R, E, A](stream: ZStream[R, E, A], predicate: Chunk[A] => Boolean) =
+    stream.mapChunks { chunk =>
+      if (predicate(chunk)) chunk
+      else Chunk.empty
+    }
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -824,7 +824,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } @@ zioTag(errors)
         ),
         suite("concat")(
-          testM("concat")(checkM(streamOfBytes, streamOfBytes) { (s1, s2) =>
+          testM("concat")(checkM(streamOfInts, streamOfInts) { (s1, s2) =>
             for {
               chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
               streamConcat <- (s1 ++ s2).runCollect.run
@@ -904,7 +904,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(ZStream.never.drainFork(ZStream.die(ex)).runDrain.run)(dies(equalTo(ex)))
           } @@ zioTag(errors)
         ),
-        testM("drop")(checkM(streamOfBytes, Gen.anyInt) { (s: ZStream[Any, String, Byte], n: Int) =>
+        testM("drop")(checkM(streamOfInts, Gen.anyInt) { (s, n) =>
           for {
             dropStreamResult <- s.drop(n.toLong).runCollect.run
             dropListResult   <- s.runCollect.map(_.drop(n)).run
@@ -913,7 +913,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         }),
         testM("dropUntil") {
-          checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+          checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.dropUntil(p).runCollect
               res2 <- s.runCollect.map(_.dropWhile(!p(_)).drop(1))
@@ -922,12 +922,11 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("dropWhile")(
           testM("dropWhile")(
-            checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) {
-              (s: ZStream[Any, String, Byte], p: Byte => Boolean) =>
-                for {
-                  res1 <- s.dropWhile(p).runCollect
-                  res2 <- s.runCollect.map(_.dropWhile(p))
-                } yield assert(res1)(equalTo(res2))
+            checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+              for {
+                res1 <- s.dropWhile(p).runCollect
+                res2 <- s.runCollect.map(_.dropWhile(p))
+              } yield assert(res1)(equalTo(res2))
             }
           ),
           testM("short circuits") {
@@ -965,14 +964,14 @@ object ZStreamSpec extends ZIOBaseSpec {
             execution <- log.get
           } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
         },
-        testM("filter")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+        testM("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             res1 <- s.filter(p).runCollect
             res2 <- s.runCollect.map(_.filter(p))
           } yield assert(res1)(equalTo(res2))
         }),
         suite("filterM")(
-          testM("filterM")(checkM(pureStreamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+          testM("filterM")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.filterM(s => IO.succeed(p(s))).runCollect
               res2 <- s.runCollect.map(_.filter(p))
@@ -1843,7 +1842,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(uninterruptible)(isSome(equalTo(InterruptStatus.Uninterruptible)))
           }
         ),
-        testM("map")(checkM(pureStreamOfBytes, Gen.function(Gen.anyInt)) { (s, f) =>
+        testM("map")(checkM(pureStreamOfInts, Gen.function(Gen.anyInt)) { (s, f) =>
           for {
             res1 <- s.map(f).runCollect
             res2 <- s.runCollect.map(_.map(f))
@@ -1881,13 +1880,13 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        testM("mapConcat")(checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+        testM("mapConcat")(checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
           for {
             res1 <- s.mapConcat(f).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
           } yield assert(res1)(equalTo(res2))
         }),
-        testM("mapConcatChunk")(checkM(pureStreamOfBytes, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
+        testM("mapConcatChunk")(checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
           for {
             res1 <- s.mapConcatChunk(f).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -1895,7 +1894,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         }),
         suite("mapConcatChunkM")(
           testM("mapConcatChunkM happy path") {
-            checkM(pureStreamOfBytes, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
+            checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
               for {
                 res1 <- s.mapConcatChunkM(b => UIO.succeedNow(f(b))).runCollect
                 res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -1912,7 +1911,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("mapConcatM")(
           testM("mapConcatM happy path") {
-            checkM(pureStreamOfBytes, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+            checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
               for {
                 res1 <- s.mapConcatM(b => UIO.succeedNow(f(b))).runCollect
                 res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2431,7 +2430,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           s1.someOrFail(-1).runCollect.either.map(assert(_)(isLeft(equalTo(-1))))
         },
         suite("take")(
-          testM("take")(checkM(streamOfBytes, Gen.anyInt) { (s: ZStream[Any, String, Byte], n: Int) =>
+          testM("take")(checkM(streamOfInts, Gen.anyInt) { (s, n) =>
             for {
               takeStreamResult <- s.take(n.toLong).runCollect.run
               takeListResult   <- s.runCollect.map(_.take(n)).run
@@ -2467,7 +2466,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         testM("takeUntil") {
-          checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+          checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeUntil <- s.takeUntil(p).runCollect.run
               chunkTakeUntil <- s.runCollect
@@ -2479,7 +2478,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         testM("takeUntilM") {
-          checkM(streamOfBytes, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
+          checkM(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
             for {
               streamTakeUntilM <- s.takeUntilM(p).runCollect.run
               chunkTakeUntilM <- s.runCollect
@@ -2494,7 +2493,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         suite("takeWhile")(
-          testM("takeWhile")(checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
+          testM("takeWhile")(checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.run
               chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).run
@@ -3148,7 +3147,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(isLeft(equalTo("Ouch")))
           }
         ),
-        testM("zipWithIndex")(checkM(pureStreamOfBytes) { s =>
+        testM("zipWithIndex")(checkM(pureStreamOfInts) { s =>
           for {
             res1 <- (s.zipWithIndex.runCollect)
             res2 <- (s.runCollect.map(_.zipWithIndex.map(t => (t._1, t._2.toLong))))

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2494,13 +2494,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         suite("takeWhile")(
-          testM("takeWhile")(checkM(tinyListOf(tinyChunkOf(Gen.anyInt)), Gen.function(Gen.boolean)) { (chunks, p) =>
-            val s = ZStream.fromChunks(chunks: _*)
-
+          testM("takeWhile")(checkM(streamOfBytes, Gen.function(Gen.boolean)) { (s, p) =>
             for {
-              streamTakeWhile <- s.takeWhile(p).runCollect
-              chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p))
-            } yield assert(streamTakeWhile)(equalTo(chunkTakeWhile))
+              streamTakeWhile <- s.takeWhile(p).runCollect.run
+              chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).run
+            } yield assert(chunkTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
           }),
           testM("takeWhile doesn't stop when hitting an empty chunk (#4272)") {
             ZStream

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2626,8 +2626,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
                    for {
                      chunk <- chunks
                      taken  = chunk.takeWhile(pred)
-                     _     <- doneRef.set(true).when(taken.length < chunk.length || chunk.length == 0)
-                     _     <- Pull.end.when(taken.length == 0)
+                     _     <- doneRef.set(true).when(taken.length < chunk.length)
                    } yield taken
                }
       } yield pull


### PR DESCRIPTION
We go out of our way to drop empty chunks in most
constructors/combinators but some combinators might still emit empty
chunks - namely, ZStream#collect.

I'm not sure why it was implemented this way, but ZStream#takeWhile would stop when encountering an
empty chunk. This fixes the logic there.

Resolves #4272.

Also hardens some of the property checks by enhancing the stream generator to inject empty chunks into the generated streams.