### PR TITLE
Optimize Chunk.Tags.fromValue

### DIFF
--- a/core/jvm/src/main/scala/zio/ChunkPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ChunkPlatformSpecific.scala
@@ -5,52 +5,55 @@ import scala.reflect.{ ClassTag, classTag }
 private[zio] trait ChunkPlatformSpecific {
 
   private[zio] object Tags {
-    def fromValue[A](a: A): ClassTag[A] =
-      unbox(ClassTag(a.getClass))
+    def fromValue[A](a: A): ClassTag[A] = {
+      val c = a.getClass
+      val unboxedClass =
+        if (isBoolean(c)) BooleanClass.asInstanceOf[Class[A]]
+        else if (isByte(c)) ByteClass.asInstanceOf[Class[A]]
+        else if (isShort(c)) ShortClass.asInstanceOf[Class[A]]
+        else if (isInt(c)) IntClass.asInstanceOf[Class[A]]
+        else if (isLong(c)) LongClass.asInstanceOf[Class[A]]
+        else if (isFloat(c)) FloatClass.asInstanceOf[Class[A]]
+        else if (isDouble(c)) DoubleClass.asInstanceOf[Class[A]]
+        else if (isChar(c)) CharClass.asInstanceOf[Class[A]]
+        else null
 
-    private def unbox[A](c: ClassTag[A]): ClassTag[A] =
-      if (isBoolean(c)) BooleanClass.asInstanceOf[ClassTag[A]]
-      else if (isByte(c)) ByteClass.asInstanceOf[ClassTag[A]]
-      else if (isShort(c)) ShortClass.asInstanceOf[ClassTag[A]]
-      else if (isInt(c)) IntClass.asInstanceOf[ClassTag[A]]
-      else if (isLong(c)) LongClass.asInstanceOf[ClassTag[A]]
-      else if (isFloat(c)) FloatClass.asInstanceOf[ClassTag[A]]
-      else if (isDouble(c)) DoubleClass.asInstanceOf[ClassTag[A]]
-      else if (isChar(c)) CharClass.asInstanceOf[ClassTag[A]]
-      else classTag[AnyRef].asInstanceOf[ClassTag[A]] // TODO: Find a better way
+      if (unboxedClass eq null) classTag[AnyRef].asInstanceOf[ClassTag[A]]
+      else ClassTag(unboxedClass).asInstanceOf[ClassTag[A]]
+    }
 
-    private def isBoolean(c: ClassTag[_]): Boolean =
+    private def isBoolean(c: Class[_]): Boolean =
       c == BooleanClass || c == BooleanClassBox
-    private def isByte(c: ClassTag[_]): Boolean =
+    private def isByte(c: Class[_]): Boolean =
       c == ByteClass || c == ByteClassBox
-    private def isShort(c: ClassTag[_]): Boolean =
+    private def isShort(c: Class[_]): Boolean =
       c == ShortClass || c == ShortClassBox
-    private def isInt(c: ClassTag[_]): Boolean =
+    private def isInt(c: Class[_]): Boolean =
       c == IntClass || c == IntClassBox
-    private def isLong(c: ClassTag[_]): Boolean =
+    private def isLong(c: Class[_]): Boolean =
       c == LongClass || c == LongClassBox
-    private def isFloat(c: ClassTag[_]): Boolean =
+    private def isFloat(c: Class[_]): Boolean =
       c == FloatClass || c == FloatClassBox
-    private def isDouble(c: ClassTag[_]): Boolean =
+    private def isDouble(c: Class[_]): Boolean =
       c == DoubleClass || c == DoubleClassBox
-    private def isChar(c: ClassTag[_]): Boolean =
+    private def isChar(c: Class[_]): Boolean =
       c == CharClass || c == CharClassBox
 
-    private val BooleanClass    = classTag[Boolean]
-    private val BooleanClassBox = classTag[java.lang.Boolean]
-    private val ByteClass       = classTag[Byte]
-    private val ByteClassBox    = classTag[java.lang.Byte]
-    private val ShortClass      = classTag[Short]
-    private val ShortClassBox   = classTag[java.lang.Short]
-    private val IntClass        = classTag[Int]
-    private val IntClassBox     = classTag[java.lang.Integer]
-    private val LongClass       = classTag[Long]
-    private val LongClassBox    = classTag[java.lang.Long]
-    private val FloatClass      = classTag[Float]
-    private val FloatClassBox   = classTag[java.lang.Float]
-    private val DoubleClass     = classTag[Double]
-    private val DoubleClassBox  = classTag[java.lang.Double]
-    private val CharClass       = classTag[Char]
-    private val CharClassBox    = classTag[java.lang.Character]
+    private val BooleanClass    = classOf[Boolean]
+    private val BooleanClassBox = classOf[java.lang.Boolean]
+    private val ByteClass       = classOf[Byte]
+    private val ByteClassBox    = classOf[java.lang.Byte]
+    private val ShortClass      = classOf[Short]
+    private val ShortClassBox   = classOf[java.lang.Short]
+    private val IntClass        = classOf[Int]
+    private val IntClassBox     = classOf[java.lang.Integer]
+    private val LongClass       = classOf[Long]
+    private val LongClassBox    = classOf[java.lang.Long]
+    private val FloatClass      = classOf[Float]
+    private val FloatClassBox   = classOf[java.lang.Float]
+    private val DoubleClass     = classOf[Double]
+    private val DoubleClassBox  = classOf[java.lang.Double]
+    private val CharClass       = classOf[Char]
+    private val CharClassBox    = classOf[java.lang.Character]
   }
 }


### PR DESCRIPTION
Been looking at some profiles of the stream benchmarks and noticed
that ClassTag equality showed up pretty noticeably on profiles from
`Tags.fromValue`. Replacing the comparisons by `java.lang.Class`
comparisons speeds that up considerably (15-20%).