### PR TITLE
Fixing JUnit test runner failure reporting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import BuildHelper._
 import MimaSettings.mimaSettings
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
+import sbt.Keys
 // shadow sbt-scalajs' crossProject from Scala.js 0.6.x
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
@@ -102,6 +103,7 @@ lazy val root = project
     testRunnerJS,
     testRunnerJVM,
     testJunitRunnerJVM,
+    testJunitRunnerTestsJVM,
     testMagnoliaJVM,
     testMagnoliaJS
   )
@@ -346,6 +348,45 @@ lazy val testJunitRunnerJVM = testJunitRunner.jvm.settings(dottySettings)
 
 lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
 lazy val testRunnerJS  = testRunner.js.settings(jsSettings)
+
+lazy val testJunitRunnerTests = crossProject(JVMPlatform)
+  .in(file("test-junit-tests"))
+  .settings(stdSettings("test-junit-tests"))
+  .settings(fork in Test := true)
+  .settings(javaOptions in Test ++= {
+    Seq(s"-Dproject.dir=${baseDirectory.value}", s"-Dproject.version=${version.value}")
+  })
+  .settings(skip in publish := true)
+  .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "junit"                   % "junit"     % "4.13"  % Test,
+      "org.scala-lang.modules" %% "scala-xml" % "1.3.0" % Test,
+      // required to run embedded maven in the tests
+      "org.apache.maven"       % "maven-embedder"         % "3.6.3"  % Test,
+      "org.apache.maven"       % "maven-compat"           % "3.6.3"  % Test,
+      "org.apache.maven.wagon" % "wagon-http"             % "3.3.4"  % Test,
+      "org.eclipse.aether"     % "aether-connector-basic" % "1.1.0"  % Test,
+      "org.eclipse.aether"     % "aether-transport-wagon" % "1.1.0"  % Test,
+      "org.slf4j"              % "slf4j-simple"           % "1.7.30" % Test
+    )
+  )
+  .dependsOn(test)
+  .dependsOn(testRunner)
+
+lazy val testJunitRunnerTestsJVM = testJunitRunnerTests.jvm
+  .settings(dottySettings)
+  // publish locally so embedded maven runs against locally compiled zio
+  .settings(
+    Keys.test in Test :=
+      (Keys.test in Test)
+        .dependsOn(Keys.publishM2 in testJunitRunnerJVM)
+        .dependsOn(Keys.publishM2 in testJVM)
+        .dependsOn(Keys.publishM2 in coreJVM)
+        .dependsOn(Keys.publishM2 in streamsJVM)
+        .dependsOn(Keys.publishM2 in stacktracerJVM)
+        .value
+  )
 
 /**
  * Examples sub-project that is not included in the root project.

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ addCommandAlias(
 addCommandAlias("compileNative", ";coreNative/compile;streamsNative/compile;testNative/compile")
 addCommandAlias(
   "testJVM",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile;macrosJVM/test"
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;benchmarks/test:compile;macrosJVM/test;testJunitRunnerTestsJVM/test"
 )
 addCommandAlias(
   "testJVMNoBenchmarks",

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -82,7 +82,7 @@ object MavenJunitSpec extends DefaultRunnableSpec {
 
   }
 
-  def containsSuccess(label: String) = containsResult(label, error = None)
+  def containsSuccess(label: String)                = containsResult(label, error = None)
   def containsFailure(label: String, error: String) = containsResult(label, Some(error))
   def containsResult(label: String, error: Option[String]): Assertion[Iterable[TestCase]] =
     contains(TestCase(label, error.map(TestError(_, "zio.test.junit.TestFailed"))))

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -7,10 +7,10 @@ import scala.xml.XML
 
 import org.apache.maven.cli.MavenCli
 
-import zio.blocking.{Blocking, effectBlocking}
+import zio.blocking.{ Blocking, effectBlocking }
 import zio.test.Assertion._
-import zio.test.{DefaultRunnableSpec, ZSpec, _}
-import zio.{RIO, ZIO}
+import zio.test.{ DefaultRunnableSpec, ZSpec, _ }
+import zio.{ RIO, ZIO }
 
 /**
  * when running from IDE run `sbt publishM2`, copy the snapshot version the artifacts were published under (something like: `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`)
@@ -70,7 +70,7 @@ object MavenJunitSpec extends DefaultRunnableSpec {
       cli.doMain(command.toArray, mvnRoot, System.out, System.err)
     )
 
-    def parseSurefireReport(testFQN: String): ZIO[Blocking,Throwable,immutable.Seq[TestCase]] =
+    def parseSurefireReport(testFQN: String): ZIO[Blocking, Throwable, immutable.Seq[TestCase]] =
       effectBlocking(
         XML.load(scala.xml.Source.fromFile(new File(s"$mvnRoot/target/surefire-reports/TEST-$testFQN.xml")))
       ).map { report =>

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -1,0 +1,92 @@
+package zio.test.junit
+
+import java.io.File
+
+import org.apache.maven.cli.MavenCli
+import zio.blocking.{ Blocking, effectBlocking }
+import zio.test.Assertion._
+import zio.test.{ DefaultRunnableSpec, _ }
+import zio.{ RIO, ZIO }
+
+import scala.xml.XML
+
+/**
+ * when running from IDE run `sbt publishM2`, copy the snapshot version the artifacts were published under (something like: `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`)
+ * and put this into `VM Parameters`: `-Dproject.dir=$PROJECT_DIR$/test-junit-tests/jvm -Dproject.version=$snapshotVersion`
+ */
+object MavenJunitSpec extends DefaultRunnableSpec {
+
+  def spec = suite("MavenJunitSpec")(
+    testM("FailingSpec results are properly reported") {
+      for {
+        mvn       <- makeMaven
+        mvnResult <- mvn.clean() *> mvn.test()
+        report    <- mvn.parseSurefireReport("zio.test.junit.maven.FailingSpec")
+      } yield {
+        assert(mvnResult)(not(equalTo(0))) &&
+        assert(report)(
+          containsFailure("should fail", "zio.test.junit.TestFailed: 11 did not satisfy equalTo(12)") &&
+            containsFailure(
+              "should fail - isSome",
+              "zio.test.junit.TestFailed: \n11 did not satisfy equalTo(12)\nSome(11) did not satisfy isSome(equalTo(12))"
+            ) &&
+            containsSuccess("should succeed")
+        )
+      }
+    }
+  ) @@ TestAspect.sequential
+
+  def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
+    projectDir <-
+      ZIO
+        .fromOption(sys.props.get("project.dir"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.dir system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.dir=$PROJECT_DIR$/test-junit-tests/jvm`"
+          )
+        )
+    projectVer <-
+      ZIO
+        .fromOption(sys.props.get("project.version"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.version system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.dir=<current zio version>`"
+          )
+        )
+  } yield new MavenDriver(projectDir, projectVer)
+
+  class MavenDriver(projectDir: String, projectVersion: String) {
+    private val mvnRoot = new File(s"$projectDir/../maven").getCanonicalPath
+    private val cli     = new MavenCli
+    System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
+
+    def clean(): RIO[Blocking, Int] = run("clean")
+    def test(): RIO[Blocking, Int]  = run("test", s"-Dzio.version=${projectVersion}", s"-ssettings.xml")
+    def run(command: String*): RIO[Blocking, Int] = effectBlocking(
+      cli.doMain(command.toArray, mvnRoot, System.out, System.err)
+    )
+
+    def parseSurefireReport(testFQN: String) =
+      effectBlocking(
+        XML.load(scala.xml.Source.fromFile(new File(s"$mvnRoot/target/surefire-reports/TEST-$testFQN.xml")))
+      ).map { report =>
+        (report \ "testcase").map { tcNode =>
+          TestCase(
+            tcNode \@ "name",
+            (tcNode \ "error").headOption.map(error => TestError(error.text.trim, error \@ "type"))
+          )
+        }
+      }
+
+  }
+
+  def containsSuccess(label: String) = containsResult(label, error = None)
+  def containsFailure(label: String, error: String) = containsResult(label, Some(error))
+  def containsResult(label: String, error: Option[String]): Assertion[Iterable[TestCase]] =
+    contains(TestCase(label, error.map(TestError(_, "zio.test.junit.TestFailed"))))
+
+  case class TestCase(name: String, error: Option[TestError])
+  case class TestError(message: String, `type`: String)
+}

--- a/test-junit-tests/maven/pom.xml
+++ b/test-junit-tests/maven/pom.xml
@@ -1,0 +1,113 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.zio</groupId>
+    <version>1.0</version>
+    <artifactId>zio_test_junit_test</artifactId>
+    <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
+    <description>Testing ZIO Test Junit runner test project</description>
+    <inceptionYear>2020</inceptionYear>
+
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <encoding>UTF-8</encoding>
+        <scala.version>2.12.8</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
+        <zio.version>1.0.0</zio.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio-test_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio-test-junit_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.0.0-M5</version>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- see http://davidb.github.com/scala-maven-plugin -->
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <!--<arg>-make:transitive</arg>-->
+                                <arg>-dependencyfile</arg>
+                                <arg>${project.build.directory}/.scala_dependencies</arg>
+                                <arg>-Ywarn-value-discard</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <goal>test</goal>
+                    <parallel>methods</parallel>
+                    <threadCount>10</threadCount>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>
+

--- a/test-junit-tests/maven/settings.xml
+++ b/test-junit-tests/maven/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+</settings>

--- a/test-junit-tests/maven/src/test/scala/zio/test/junit/maven/FailingSpec.scala
+++ b/test-junit-tests/maven/src/test/scala/zio/test/junit/maven/FailingSpec.scala
@@ -1,0 +1,19 @@
+package zio.test.junit.maven
+
+import zio.test.junit._
+import zio.test._
+import zio.test.Assertion._
+
+class FailingSpec extends JUnitRunnableSpec {
+  override def spec = suite("FailingSpec")(
+    test("should fail") {
+      assert(11)(equalTo(12))
+    },
+    test("should fail - isSome") {
+      assert(Some(11))(isSome(equalTo(12)))
+    },
+    test("should succeed") {
+      assert(12)(equalTo(12))
+    }
+  )
+}

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -4,6 +4,7 @@ import com.github.ghik.silencer.silent
 import org.junit.runner.manipulation.{ Filter, Filterable }
 import org.junit.runner.notification.{ Failure, RunNotifier }
 import org.junit.runner.{ Description, RunWith, Runner }
+
 import zio.ZIO.effectTotal
 import zio._
 import zio.test.FailureRenderer.FailureMessage.Message


### PR DESCRIPTION
Test failure details are currently not reported to external tools like maven surefire plugin.
This PR also adds an E2E test for JUnit test runner under maven (and surefire)

Related issue #4092