### PR TITLE
Implement ZIO#schedule

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1668,17 +1668,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Runs this effect according to the specified schedule.
    *
-   * See [[scheduleWith]] for a variant that allows the schedule's decision to
+   * See [[scheduleFrom]] for a variant that allows the schedule's decision to
    * depend on the rsult of this effect.
    */
   final def schedule[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZIO[R1 with Clock, E, B] =
-    scheduleWith(())(schedule)
+    scheduleFrom(())(schedule)
 
   /**
-   * Runs this effect according to the specified schedule with the specified
-   * initial input to the schedule.
+   * Runs this effect according to the specified schedule starting from the
+   * specified input value.
    */
-  final def scheduleWith[R1 <: R, A1 >: A, B](a: A1)(schedule: Schedule[R1, A1, B]): ZIO[R1 with Clock, E, B] =
+  final def scheduleFrom[R1 <: R, A1 >: A, B](a: A1)(schedule: Schedule[R1, A1, B]): ZIO[R1 with Clock, E, B] =
     schedule.driver.flatMap { driver =>
       def loop(a: A1): ZIO[R1 with Clock, E, B] =
         driver.next(a).foldM(_ => driver.last.orDie, _ => self.flatMap(loop))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1667,13 +1667,23 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
 
   /**
    * Runs this effect according to the specified schedule.
+   *
+   * See [[scheduleWith]] for a variant that allows the schedule's decision to
+   * depend on the rsult of this effect.
    */
   final def schedule[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZIO[R1 with Clock, E, B] =
-    schedule.driver.flatMap { driver =>
-      def loop: ZIO[R1 with Clock, E, B] =
-        driver.next(()).foldM(_ => driver.last.orDie, _ => self *> loop)
+    scheduleWith(())(schedule)
 
-      loop
+  /**
+   * Runs this effect according to the specified schedule with the specified
+   * initial input to the schedule.
+   */
+  final def scheduleWith[R1 <: R, A1 >: A, B](a: A1)(schedule: Schedule[R1, A1, B]): ZIO[R1 with Clock, E, B] =
+    schedule.driver.flatMap { driver =>
+      def loop(a: A1): ZIO[R1 with Clock, E, B] =
+        driver.next(a).foldM(_ => driver.last.orDie, _ => self.flatMap(loop))
+
+      loop(a)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1666,6 +1666,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def sandbox: ZIO[R, Cause[E], A] = foldCauseM(ZIO.fail(_), ZIO.succeedNow)
 
   /**
+   * Runs this effect according to the specified schedule.
+   */
+  final def schedule[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZIO[R1 with Clock, E, B] =
+    schedule.driver.flatMap { driver =>
+      def loop: ZIO[R1 with Clock, E, B] =
+        driver.next(()).foldM(_ => driver.last.orDie, _ => self *> loop)
+
+      loop
+    }
+
+  /**
    * Converts an option on values into an option on errors.
    */
   final def some[B](implicit ev: A <:< Option[B]): ZIO[R, Option[E], B] =


### PR DESCRIPTION
Resolves #4218.

The main problem with this is that since we have to run the schedule before the effect we don't have an `A` value to provide to the `Schedule` initially so we need a `Schedule` with an input type of `Any`, which works for time based recurrence but doesn't allow the schedule to continue to depend on the prior result of running the effect. Potentially we could have a variant that accepts an initial `A` value to kick off the schedule though that is not ideal because we would like the schedule to completely describe the pattern of recurrence.