### PR TITLE
Fix GZip compression for input >= 2^16

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
@@ -258,6 +258,12 @@ object CompressionSpec extends DefaultRunnableSpec {
             jdkGunzipped <- jdkGunzip(gzipped)
           } yield jdkGunzipped)(equalTo(longText.toList))
         ),
+        testM("input >= 2^32")(
+          assertM(for {
+            gzipped      <- Stream.fromIterable(longText).forever.take(65536).transduce(gzip()).runCollect
+            jdkGunzipped <- jdkGunzip(gzipped)
+          } yield jdkGunzipped)(hasSize(equalTo(65536)))
+        ),
         testM("transducer is re-usable")(
           assertM(for {
             gzipper       <- ZIO.effectTotal(gzip(64))

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
@@ -49,7 +49,10 @@ private[compression] class Gzipper(
     def byte(v: Long, n: Int) = ((v >> n * 8) & 0xff).toByte
 
     val v = crc.getValue
-    val s = inputSize & 0xffff
+
+    // ISIZE (Input SIZE) -- this contains the size of the original (uncompressed) input data modulo 2^32.
+    val s = inputSize & 0xffffffffL
+
     Chunk(byte(v, 0), byte(v, 1), byte(v, 2), byte(v, 3), byte(s, 0), byte(s, 1), byte(s, 2), byte(s, 3))
   }
 


### PR DESCRIPTION
Closes #4298

From [RFC 1952](https://tools.ietf.org/html/rfc1952#section-2.3.1)

>          ISIZE (Input SIZE)
>            This contains the size of the original (uncompressed) input
>            data modulo 2^32.


Tested locally with input data of around 4G≠1