### PR TITLE
Keep chunk structure in distributedWithDynamic

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -84,7 +84,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def groupByBenchmark: Chunk[Unit] = {
-    val chunks = (1 to chunkCount).map(_ => Chunk.fromIterable(1 to chunkSize))
+    val chunks = (1 to chunkCount).map(_ => Chunk.fromIterable(1 to (chunkSize / 10)))
     val result = ZStream
       .fromChunks(chunks: _*)
       .groupByKey(_ % 10)((_, s) => s.drain)

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -81,6 +81,17 @@ class StreamBenchmarks {
       .map(_.toLong)
       .fold(0L)(_ + _)
   }
+
+  @Benchmark
+  def groupByBenchmark: Chunk[Unit] = {
+    val chunks = (1 to chunkCount).map(_ => Chunk.fromIterable(1 to chunkSize))
+    val result = ZStream
+      .fromChunks(chunks: _*)
+      .groupByKey(_ % 10)((_, s) => s.drain)
+      .runCollect
+    unsafeRun(result)
+  }
+
 }
 
 @State(Scope.Thread)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -823,6 +823,36 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(execution)(equalTo(List("First", "Second")))
           }
         ),
+        suite("cursor")(
+          testM("should produce correct results for simple example") {
+            val s = Stream.fromIterable(0 to 10)
+            assertM(s.cursor.use(_.stream.runSum))(equalTo(55))
+          },
+          testM("should allow traversing a stream twice") {
+            checkM(streamOfInts) { s =>
+              s.cursor.use { cursor =>
+                for {
+                  copied <- cursor.split
+                  r1 <- cursor.stream.runSum.run
+                  r2 <- copied.stream.runSum.run
+                } yield assert(r1)(equalTo(r2))
+              }
+            }
+          },
+          testM("should allow traversing a stream in parallel") {
+            checkM(streamOfInts) { s =>
+              s.cursor.use { cursor =>
+                for {
+                  copied <- cursor.split
+                  f1 <- cursor.stream.runSum.fork
+                  f2 <- copied.stream.runSum.fork
+                  r1 <- f1.await
+                  r2 <- f2.await
+                } yield assert(r1)(equalTo(r2))
+              }
+            }
+          } @@ nonFlaky
+        ),
         suite("distributedWithDynamic")(
           testM("ensures no race between subscription and stream end") {
             ZStream.empty.distributedWithDynamic(1, _ => UIO.succeedNow(_ => true)).use { add =>
@@ -1452,7 +1482,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(
               ZStream
                 .fromIterable(words)
-                .groupByKey(identity, 8192) { case (k, s) =>
+                .groupByKey(identity) { case (k, s) =>
                   ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
                 }
                 .runCollect
@@ -1464,7 +1494,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(
               ZStream
                 .fromIterable(words)
-                .groupByKey(identity, 1050)
+                .groupByKey(identity)
                 .first(2) { case (k, s) =>
                   ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
                 }
@@ -1477,7 +1507,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(
               ZStream
                 .fromIterable(words)
-                .groupByKey(identity, 1050)
+                .groupByKey(identity)
                 .filter(_ <= 5) { case (k, s) =>
                   ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
                 }

--- a/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
@@ -1,9 +1,0 @@
-package zio.stream
-
-import zio._
-
-trait StreamCursor[-R, +E, +A] {
-  val next: ZIO[R, Option[E], Chunk[A]]
-  val split: UIO[StreamCursor[R, E, A]]
-  final lazy val stream: ZStream[R, E, A] = ZStream(ZManaged.succeedNow(next))
-}

--- a/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
@@ -1,0 +1,9 @@
+package zio.stream
+
+import zio._
+
+trait StreamCursor[-R, +E, +A] {
+  val next: ZIO[R, Option[E], Chunk[A]]
+  val split: UIO[StreamCursor[R, E, A]]
+  final lazy val stream: ZStream[R, E, A] = ZStream(ZManaged.succeedNow(next))
+}


### PR DESCRIPTION
Resolves #4191

For the groupBy benchmark preserving chunks in `distributedWithDynamic` actually decreased performance significantly. The new implementation increased performance from 0.02 ops/s to 0.03 ops/s on my machine. If we have a specific stream / chunk size combination we want to test against I'm happy to adjust.

I believe we are still not guaranteeing API stability for `ZStream`, so I updated some methods to use `Take` instead of `Exit[Option[E], A]`.