### PR TITLE
Add ZStream#cursor

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
@@ -1,0 +1,30 @@
+package zio.stream
+
+import zio._
+
+/**
+ * A cursor that allows effectful iteration over a stream. Usage is similar to
+ * [[ZStream#Pull]], but additionally offers the option to traverse a stream multiple
+ * times.
+ */
+trait StreamCursor[-R, +E, +A] {
+
+  /**
+   * Pull the next value of the stream. As with [[ZStream#Pull]], `fail(None)` signals end of stream.
+   * If any cursor has advanced past this point already, the effect will not be reevaluated.
+   */
+  val next: ZIO[R, Option[E], Chunk[A]]
+
+  /**
+   * Creates a new cursor at the current position in the stream. The new cursor is guranteed to
+   * see the same elements as the original cursor when advancing.
+   */
+  val split: UIO[StreamCursor[Any, E, A]]
+
+  /**
+   * Create a stream backed by this cursor.
+   */
+  final lazy val stream: ZStream[R, E, A] =
+    ZStream(ZManaged.succeedNow(next))
+
+}

--- a/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
+++ b/streams/shared/src/main/scala/zio/stream/StreamCursor.scala
@@ -7,24 +7,87 @@ import zio._
  * [[ZStream#Pull]], but additionally offers the option to traverse a stream multiple
  * times.
  */
-trait StreamCursor[-R, +E, +A] {
+trait StreamCursor[-R, +E, +O] {
 
   /**
-   * Pull the next value of the stream. As with [[ZStream#Pull]], `fail(None)` signals end of stream.
+   * Pull the next chunk of the stream. As with [[ZStream#Pull]], `fail(None)` signals end of stream.
    * If any cursor has advanced past this point already, the effect will not be reevaluated.
    */
-  val next: ZIO[R, Option[E], Chunk[A]]
+  val next: ZIO[R, Option[E], Chunk[O]]
 
   /**
    * Creates a new cursor at the current position in the stream. The new cursor is guranteed to
    * see the same elements as the original cursor when advancing.
    */
-  val split: UIO[StreamCursor[Any, E, A]]
+  val split: UIO[StreamCursor[R, E, O]]
 
   /**
    * Create a stream backed by this cursor.
    */
-  final lazy val stream: ZStream[R, E, A] =
+  final lazy val stream: ZStream[R, E, O] =
     ZStream(ZManaged.succeedNow(next))
 
+}
+
+object StreamCursor {
+
+  def fromPull[R, E, O](pull: ZStream.Pull[R, E, O]): UIO[StreamCursor[R, E, O]] = {
+    final case class Node(
+      chunk: Chunk[O],
+      next: ZIO[R, Option[E], Node]
+    )
+
+    sealed trait State
+    object State {
+      case object NotStarted                             extends State
+      final case class Done(exit: Exit[Option[E], Node]) extends State
+    }
+
+    def makeCursor(getNode: ZIO[R, Option[E], Node]): UIO[StreamCursor[R, E, O]] =
+      Ref.make(getNode).map { ref =>
+        new StreamCursor[R, E, O] { self =>
+          def nextNode: ZIO[R, Option[E], Node] =
+            ref.get.flatten.flatMap { node =>
+              ref.set(node.next).as(node)
+            }
+          val next: ZIO[R, Option[E], Chunk[O]] =
+            nextNode.map(_.chunk)
+          val split: UIO[StreamCursor[R, E, O]] =
+            ref.get.flatMap(makeCursor)
+        }
+      }
+
+    def makeGetNode(pull: ZIO[R, Option[E], Chunk[O]], sema: Semaphore): UIO[ZIO[R, Option[E], Node]] =
+      Ref.make[State](State.NotStarted).map { ref =>
+        ref.get.flatMap {
+          case State.NotStarted =>
+            sema.withPermit {
+              ref.get.flatMap {
+                case State.NotStarted =>
+                  ZIO.uninterruptibleMask { restore =>
+                    for {
+                      exit <- restore(pull).run
+                      result <- exit.foldM(
+                                  cause => ZIO.succeedNow(Exit.halt(cause)),
+                                  chunk => makeGetNode(pull, sema).map(Node(chunk, _)).run
+                                )
+                      _    <- ref.set(State.Done(result))
+                      node <- ZIO.done(result)
+                    } yield node
+                  }
+                case State.Done(exit) =>
+                  ZIO.done(exit)
+              }
+            }
+          case State.Done(exit) =>
+            ZIO.done(exit)
+        }
+      }
+
+    for {
+      sema    <- Semaphore.make(1)
+      getNode <- makeGetNode(pull, sema)
+      cursor  <- makeCursor(getNode)
+    } yield cursor
+  }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -845,21 +845,21 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    *  Creates a [[StreamCursor]] that allows effectful iteration over the stream.
    */
   val cursor: ZManaged[R, Nothing, StreamCursor[Any, E, O]] = {
-    final case class Node(
+    final case class Node[E1 <: E](
       chunk: Chunk[O],
-      next: IO[Option[E], Node]
+      next: IO[Option[E1], Node[E1]]
     )
 
     sealed trait State
     object State {
-      case object NotStarted                             extends State
-      final case class Done(exit: Exit[Option[E], Node]) extends State
+      case object NotStarted                                extends State
+      final case class Done(exit: Exit[Option[E], Node[E]]) extends State
     }
 
-    def makeCursor(getNode: IO[Option[E], Node]): UIO[StreamCursor[Any, E, O]] =
+    def makeCursor(getNode: IO[Option[E], Node[E]]): UIO[StreamCursor[Any, E, O]] =
       Ref.make(getNode).map { ref =>
         new StreamCursor[Any, E, O] { self =>
-          def nextNode: IO[Option[E], Node] =
+          def nextNode: IO[Option[E], Node[E]] =
             ref.get.flatten.flatMap { node =>
               ref.set(node.next).as(node)
             }
@@ -870,7 +870,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
         }
       }
 
-    def makeNode(pull: IO[Option[E], Chunk[O]], sema: Semaphore): UIO[IO[Option[E], Node]] =
+    def makeNode(pull: IO[Option[E], Chunk[O]], sema: Semaphore): UIO[IO[Option[E], Node[E]]] =
       Ref.make[State](State.NotStarted).map { ref =>
         ref.get.flatMap {
           case State.NotStarted =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -844,67 +844,8 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   /**
    *  Creates a [[StreamCursor]] that allows effectful iteration over the stream.
    */
-  val cursor: ZManaged[R, Nothing, StreamCursor[Any, E, O]] = {
-    final case class Node[+E1, +O1](
-      chunk: Chunk[O1],
-      next: IO[Option[E1], Node[E1, O1]]
-    )
-
-    sealed trait State
-    object State {
-      case object NotStarted                                   extends State
-      final case class Done(exit: Exit[Option[E], Node[E, O]]) extends State
-    }
-
-    def makeCursor(getNode: IO[Option[E], Node[E, O]]): UIO[StreamCursor[Any, E, O]] =
-      Ref.make(getNode).map { ref =>
-        new StreamCursor[Any, E, O] { self =>
-          def nextNode: IO[Option[E], Node[E, O]] =
-            ref.get.flatten.flatMap { node =>
-              ref.set(node.next).as(node)
-            }
-          val next: IO[Option[E], Chunk[O]] =
-            nextNode.map(_.chunk)
-          val split: UIO[StreamCursor[Any, E, O]] =
-            ref.get.flatMap(makeCursor)
-        }
-      }
-
-    def makeNode(pull: IO[Option[E], Chunk[O]], sema: Semaphore): UIO[IO[Option[E], Node[E, O]]] =
-      Ref.make[State](State.NotStarted).map { ref =>
-        ref.get.flatMap {
-          case State.NotStarted =>
-            sema.withPermit {
-              ref.get.flatMap {
-                case State.NotStarted =>
-                  ZIO.uninterruptibleMask { restore =>
-                    for {
-                      exit <- restore(pull).run
-                      result <- exit.foldM(
-                                  cause => ZIO.succeedNow(Exit.halt(cause)),
-                                  chunk => makeNode(pull, sema).map(Node(chunk, _)).run
-                                )
-                      _    <- ref.set(State.Done(result))
-                      node <- ZIO.done(result)
-                    } yield node
-                  }
-                case State.Done(exit) =>
-                  ZIO.done(exit)
-              }
-            }
-          case State.Done(exit) =>
-            ZIO.done(exit)
-        }
-      }
-
-    for {
-      pull        <- process
-      env         <- ZManaged.environment[R]
-      sema        <- Semaphore.make(1).toManaged_
-      initialNode <- makeNode(pull.provide(env), sema).toManaged_
-      cursor      <- makeCursor(initialNode).toManaged_
-    } yield cursor
-  }
+  val cursor: ZManaged[R, Nothing, StreamCursor[R, E, O]] =
+    process.mapM(StreamCursor.fromPull)
 
   /**
    * More powerful version of `ZStream#broadcast`. Allows to provide a function that determines what


### PR DESCRIPTION
Something I played around with.

I don't know how widely useful it is, but I think the option to traverse a stream twice / have lookahead can come in handy.