### PR TITLE
Fix MatchError in `zio.Has.equals`

### DIFF
--- a/core/shared/src/main/scala/zio/Has.scala
+++ b/core/shared/src/main/scala/zio/Has.scala
@@ -37,6 +37,7 @@ final class Has[A] private (
 ) extends Serializable {
   override def equals(that: Any): Boolean = that match {
     case that: Has[_] => map == that.map
+    case _            => false
   }
 
   override def hashCode: Int = map.hashCode


### PR DESCRIPTION
Odds are no one has ever compared Has[_] to other types, but I guess it should be fixed anyway.