### PR TITLE
ZIO Test Magnolia: Add derived generator for Instant

### DIFF
--- a/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
+++ b/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
@@ -1,6 +1,6 @@
 package zio.test.magnolia
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{Instant, LocalDate, LocalDateTime}
 import java.util.UUID
 
 import zio.random.Random
@@ -88,6 +88,7 @@ object DeriveGenSpec extends DefaultRunnableSpec {
       test("unit")(assertDeriveGen[Unit]),
       test("uuid")(assertDeriveGen[UUID]),
       test("vector")(assertDeriveGen[Vector[Int]]),
+      test("instant")(assertDeriveGen[Instant]),
       test("localDateTime")(assertDeriveGen[LocalDateTime]),
       test("localDate")(assertDeriveGen[LocalDate]),
       test("bigDecimal")(assertDeriveGen[BigDecimal])

--- a/test-magnolia/shared/src/main/scala/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala/zio/test/magnolia/DeriveGen.scala
@@ -16,7 +16,7 @@
 
 package zio.test.magnolia
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ Instant, LocalDate, LocalDateTime }
 import java.util.UUID
 
 import magnolia._
@@ -77,6 +77,7 @@ object DeriveGen {
   implicit val genString: DeriveGen[String]               = instance(Gen.anyString)
   implicit val genUnit: DeriveGen[Unit]                   = instance(Gen.unit)
   implicit val genUUID: DeriveGen[UUID]                   = instance(Gen.anyUUID)
+  implicit val genInstant: DeriveGen[Instant]             = instance(Gen.anyInstant)
   implicit val genLocalDateTime: DeriveGen[LocalDateTime] = instance(Gen.anyLocalDateTime)
   implicit val genLocalDate: DeriveGen[LocalDate]         = instance(Gen.anyLocalDateTime.map(_.toLocalDate()))
   implicit val genBigDecimal: DeriveGen[BigDecimal] = instance(


### PR DESCRIPTION
Fixes #4319

Added an implicit derived generator for Instant, just to be in sync with other time generators like `LocalDateTime` and `LocalDate`.