### PR TITLE
Remove unnecessary buffering in Console.getStrLn

### DIFF
--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -39,25 +39,25 @@ package object console {
 
     object Service {
       val live: Service = new Service {
-        final def putStr(line: String): UIO[Unit] =
+        def putStr(line: String): UIO[Unit] =
           putStr(SConsole.out)(line)
 
-        final def putStrErr(line: String): UIO[Unit] =
+        def putStrErr(line: String): UIO[Unit] =
           putStr(SConsole.err)(line)
 
-        final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
+        def putStr(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
 
-        final def putStrLnErr(line: String): UIO[Unit] =
+        def putStrLnErr(line: String): UIO[Unit] =
           putStrLn(SConsole.err)(line)
 
-        final def putStrLn(line: String): UIO[Unit] =
+        def putStrLn(line: String): UIO[Unit] =
           putStrLn(SConsole.out)(line)
 
-        final def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
+        def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
 
-        final val getStrLn: IO[IOException, String] =
+        val getStrLn: IO[IOException, String] =
           IO.effect {
             val line = StdIn.readLine()
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -49,7 +49,7 @@ package object console {
         /**
          * Prints text to the standard error console.
          */
-        override def putStrErr(line: String): UIO[Unit] =
+        final def putStrErr(line: String): UIO[Unit] =
           putStrLn(SConsole.err)(line)
 
         final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
@@ -58,7 +58,7 @@ package object console {
         /**
          * Prints a line of text to the standard error console, including a newline character.
          */
-        override def putStrLnErr(line: String): UIO[Unit] =
+        final def putStrLnErr(line: String): UIO[Unit] =
           putStrLn(SConsole.err)(line)
 
         /**

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import java.io.{ EOFException, IOException, PrintStream, Reader }
+import java.io.{ EOFException, IOException, PrintStream }
 
 import scala.io.StdIn
 import scala.{ Console => SConsole }
@@ -76,23 +76,16 @@ package object console {
 
         /**
          * Retrieves a line of input from the console.
-         */
-        final val getStrLn: IO[IOException, String] =
-          getStrLn(SConsole.in)
-
-        /**
-         * Retrieves a line of input from the console.
          * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
          * returns null.
          */
-        final def getStrLn(reader: Reader): IO[IOException, String] =
-          IO.effect(SConsole.withIn(reader) {
+        final val getStrLn: IO[IOException, String] =
+          IO.effect {
             val line = StdIn.readLine()
-            if (line == null) {
-              throw new EOFException("There is no more input left to read")
-            } else line
-          }).refineToOrDie[IOException]
 
+            if (line ne null) line
+            else throw new EOFException("There is no more input left to read")
+          }.refineToOrDie[IOException]
       }
     }
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -45,17 +45,13 @@ package object console {
         IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
 
       val live: Service = new Service {
-        def putStr(line: String): UIO[Unit] =
-          Service.putStr(SConsole.out)(line)
+        def putStr(line: String): UIO[Unit] = Service.putStr(SConsole.out)(line)
 
-        def putStrErr(line: String): UIO[Unit] =
-          Service.putStr(SConsole.err)(line)
+        def putStrErr(line: String): UIO[Unit] = Service.putStr(SConsole.err)(line)
 
-        def putStrLnErr(line: String): UIO[Unit] =
-          Service.putStrLn(SConsole.err)(line)
+        def putStrLnErr(line: String): UIO[Unit] = Service.putStrLn(SConsole.err)(line)
 
-        def putStrLn(line: String): UIO[Unit] =
-          Service.putStrLn(SConsole.out)(line)
+        def putStrLn(line: String): UIO[Unit] = Service.putStrLn(SConsole.out)(line)
 
         val getStrLn: IO[IOException, String] =
           IO.effect {

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -53,9 +53,7 @@ package object console {
           putStrLn(SConsole.err)(line)
 
         final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
-          IO.effectTotal(SConsole.withOut(stream) {
-            SConsole.print(line)
-          })
+          IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
 
         /**
          * Prints a line of text to the standard error console, including a newline character.
@@ -70,9 +68,7 @@ package object console {
           putStrLn(SConsole.out)(line)
 
         final def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
-          IO.effectTotal(SConsole.withOut(stream) {
-            SConsole.println(line)
-          })
+          IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
 
         /**
          * Retrieves a line of input from the console.

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -50,7 +50,7 @@ package object console {
          * Prints text to the standard error console.
          */
         final def putStrErr(line: String): UIO[Unit] =
-          putStrLn(SConsole.err)(line)
+          putStr(SConsole.err)(line)
 
         final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -38,24 +38,24 @@ package object console {
     }
 
     object Service {
+      private def putStr(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
+
+      private def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
+
       val live: Service = new Service {
         def putStr(line: String): UIO[Unit] =
-          putStr(SConsole.out)(line)
+          Service.putStr(SConsole.out)(line)
 
         def putStrErr(line: String): UIO[Unit] =
-          putStr(SConsole.err)(line)
-
-        def putStr(stream: PrintStream)(line: String): UIO[Unit] =
-          IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
+          Service.putStr(SConsole.err)(line)
 
         def putStrLnErr(line: String): UIO[Unit] =
-          putStrLn(SConsole.err)(line)
+          Service.putStrLn(SConsole.err)(line)
 
         def putStrLn(line: String): UIO[Unit] =
-          putStrLn(SConsole.out)(line)
-
-        def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
-          IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
+          Service.putStrLn(SConsole.out)(line)
 
         val getStrLn: IO[IOException, String] =
           IO.effect {

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -39,42 +39,24 @@ package object console {
 
     object Service {
       val live: Service = new Service {
-
-        /**
-         * Prints text to the console.
-         */
         final def putStr(line: String): UIO[Unit] =
           putStr(SConsole.out)(line)
 
-        /**
-         * Prints text to the standard error console.
-         */
         final def putStrErr(line: String): UIO[Unit] =
           putStr(SConsole.err)(line)
 
         final def putStr(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
 
-        /**
-         * Prints a line of text to the standard error console, including a newline character.
-         */
         final def putStrLnErr(line: String): UIO[Unit] =
           putStrLn(SConsole.err)(line)
 
-        /**
-         * Prints a line of text to the console, including a newline character.
-         */
         final def putStrLn(line: String): UIO[Unit] =
           putStrLn(SConsole.out)(line)
 
         final def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
           IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
 
-        /**
-         * Retrieves a line of input from the console.
-         * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
-         * returns null.
-         */
         final val getStrLn: IO[IOException, String] =
           IO.effect {
             val line = StdIn.readLine()
@@ -118,6 +100,8 @@ package object console {
 
   /**
    * Retrieves a line of input from the console.
+   * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
+   * returns null.
    */
   val getStrLn: ZIO[Console, IOException, String] =
     ZIO.accessM(_.get.getStrLn)


### PR DESCRIPTION
### Background

@LouisLotter identified an issue with default console implementation using the following program:

```scala
import zio._
import zio.console._

object TestCase extends App {
  def run(args: List[String]): URIO[ZEnv, ExitCode] =
    getStrLn.flatMap(line => putStrLnErr(line)).forever.ignore.map(_ => ExitCode.success)
}
```

Once this program was "bombed" with tens of thousands of writes to STDIN, it started loosing data. Rewriting the reading part as follows fixed the issue:

```scala
import zio._
import zio.console._

object TestCase extends App {
  val readLine = ZIO.effect(scala.io.StdIn.readLine)

  def run(args: List[String]): URIO[ZEnv, ExitCode] =
    readLine.flatMap(line =>  putStrLnErr(line)).forever.ignore.map(_ => ExitCode.success)
}
```

This revealed the problem with `getStrLn` implementation - unnecessary buffering.

### Summary

- Removed unnecessary buffering.
- Fixed `putStrError` implementation (it was the same as `putStrLnError`).