### PR TITLE
Sink.take should also emit at end of chunk.

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -1,14 +1,15 @@
 package zio.stream
 
 import scala.util.Random
+
 import zio.duration._
 import zio.stream.SinkUtils.{ findSink, sinkRaceLaw }
 import zio.stream.ZStreamGen._
 import zio.test.Assertion.{ equalTo, isFalse, isGreaterThanEqualTo, isTrue, succeeds }
+import zio.test.TestAspect.timeout
 import zio.test.environment.TestClock
 import zio.test.{ assertM, _ }
 import zio.{ ZIOBaseSpec, _ }
-import zio.test.TestAspect.timeout
 
 object ZSinkSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZSinkSpec")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -6,7 +6,6 @@ import zio.duration._
 import zio.stream.SinkUtils.{ findSink, sinkRaceLaw }
 import zio.stream.ZStreamGen._
 import zio.test.Assertion.{ equalTo, isFalse, isGreaterThanEqualTo, isTrue, succeeds }
-import zio.test.TestAspect.timeout
 import zio.test.environment.TestClock
 import zio.test.{ assertM, _ }
 import zio.{ ZIOBaseSpec, _ }
@@ -260,10 +259,10 @@ object ZSinkSpec extends ZIOBaseSpec {
       ),
       testM("take emits at end of chunk")(
         Stream(1, 2)
-          .concat(Stream.never)
+          .concat(Stream.dieMessage("should not get this far"))
           .run(Sink.take(2))
           .map(assert(_)(equalTo(Chunk(1, 2))))
-      ) @@ timeout(5.seconds),
+      ),
       testM("timed") {
         for {
           f <- ZStream.fromIterable(1 to 10).mapM(i => clock.sleep(10.millis).as(i)).run(ZSink.timed).fork

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -889,9 +889,9 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
                  state.get.flatMap { take =>
                    is match {
                      case Some(ch) =>
-                       val idx = n - take.length
-                       if (idx <= ch.length) {
-                         val (chunk, leftover) = ch.splitAt(idx)
+                       val remaining = n - take.length
+                       if (remaining <= ch.length) {
+                         val (chunk, leftover) = ch.splitAt(remaining)
                          state.set(Chunk.empty) *> Push.emit(take ++ chunk, leftover)
                        } else {
                          state.set(take ++ ch) *> Push.more

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -890,7 +890,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
                    is match {
                      case Some(ch) =>
                        val idx = n - take.length
-                       if (idx < ch.length) {
+                       if (idx <= ch.length) {
                          val (chunk, leftover) = ch.splitAt(idx)
                          state.set(Chunk.empty) *> Push.emit(take ++ chunk, leftover)
                        } else {


### PR DESCRIPTION
Currently if `Sink.take(n)` collects the nth element at the end of a chunk, it will not emit its output until the stream ends or another element is received. In this situation it should just emit immediately, with an empty left-over.

It's a one character fix, ~but I lack the knowledge and/or imagination to construct a good test for it~. I've been manually testing like this:

```scala
val s1 = Stream(1, 2) ++ Stream(3, 4)
runtime.unsafeRun(s1.run(Sink.take(2))) // emits Chunk(1, 2) immediately

val s2 = Stream(1, 2) ++ Stream(3, 4).mapChunksM(c => ZIO.sleep(15.seconds).as(c))
runtime.unsafeRun(s2.run(Sink.take(2)))  // master takes 15 seconds to emit Chunk(1, 2)
```

~Any suggestions on how to write a good test for this?~ Never mind, I had a brainwave that `Stream.never` is what I needed.
