### PR TITLE
foreachParN_ should not use more than 'n' fibers 

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3055,21 +3055,19 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Unlike `foreachPar_`, this method will use at most up to `n` fibers.
    */
   def foreachParN_[R, E, A](n: Int)(as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] = {
-    def worker(q: Queue[A], result: Promise[E, Unit], ref: Ref[Int]): URIO[R, Unit] =
-      ref.modify(n => (n > 0, n - 1)).flatMap {
-        case true  => q.take.flatMap(a => f(a).foldCauseM(result.halt(_).unit, _ => worker(q, result, ref)))
-        case false => result.succeed(()).unit
+    def worker(q: Queue[A], ref: Ref[Int]): ZIO[R, E, Unit] =
+      ZIO.whenM(ref.modify(n => (n > 0, n - 1))) {
+        q.take.flatMap(f) *> worker(q, ref)
       }
 
     Queue
       .bounded[A](n.toInt)
       .bracket(_.shutdown) { q =>
         for {
-          ref <- Ref.make(as.size)
-          p   <- Promise.make[E, Unit]
-          _   <- ZIO.foreach_(as)(q.offer).fork
-          _   <- ZIO.collectAll_(List.fill(n.toInt)(worker(q, p, ref).fork))
-          _   <- p.await
+          ref    <- Ref.make(as.size)
+          _      <- ZIO.foreach_(as)(q.offer).fork
+          fibers <- ZIO.collectAll(List.fill(n.toInt)(worker(q, ref).fork))
+          _      <- ZIO.foreach_(fibers)(_.await)
         } yield ()
       }
       .refailWithTrace


### PR DESCRIPTION
In https://github.com/zio/zio/pull/1187, `foreachParN` was fixed to avoid creating 'n' fibers all sharing a semaphore, but `foreachParN_` was left with the old behavior, leading to dramatic performance with large collections.

I reused the implementation of `foreachParN` but simplified it since we don't need to collect results.