### PR TITLE
ZManagedSpec: Tag: timeout, remove extraneous call

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1208,7 +1208,6 @@ object ZManagedSpec extends ZIOBaseSpec {
           releaseLatch <- Promise.make[Nothing, Unit]
           managed       = ZManaged.reserve(Reservation(reserveLatch.await, _ => releaseLatch.succeed(())))
           res          <- managed.timeout(Duration.Zero).use(ZIO.succeed(_))
-          _            <- reserveLatch.succeed(())
           _            <- releaseLatch.await
         } yield assert(res)(isNone)
       },


### PR DESCRIPTION
Motivation: 

While go through [ZManagedSpec](https://github.com/zio/zio/blob/master/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala) I noticed there was an extraneous call `reserveLatch.succeed(())` at [L1211](https://github.com/zio/zio/blob/master/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala#L1211)
When [Reservation](https://github.com/zio/zio/blob/master/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala#L1209) is defined, `release` is already set to an expression where `releaseLatch` will be completed with ().  This PR addresses this issue. 