### PR TITLE
Fix 4358 . Assertion::equals should never throw exceptions

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -560,6 +560,15 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("throws must succeed when given assertion is correct") {
       assert(throw sampleException)(throws(equalTo(sampleException)))
+    },
+    test("should implement equals without exception") {
+      assert(nameStartsWithU.equals(new Object))(isFalse)
+    },
+    test("should never be equal to AssertionM") {
+      val assertion  = Assertion.assertionDirect[Unit]("sameName")()(_ => ???)
+      val assertionM = AssertionM.assertionDirect[Unit]("sameName")()(_ => ???)
+      assert(assertion.equals(assertionM))(isFalse ?? "assertion != assertionM") &&
+      assert(assertionM.equals(assertion))(isFalse ?? "assertionM != assertion")
     }
   )
 

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -60,8 +60,14 @@ final class Assertion[-A] private (
   def apply(a: => A): AssertResult =
     run(a)
 
+  override def canEqual(that: AssertionM[_]): Boolean = that match {
+    case _: Assertion[_] => true
+    case _               => false
+  }
+
   override def equals(that: Any): Boolean = that match {
-    case that: Assertion[_] => this.toString == that.toString
+    case that: Assertion[_] if that.canEqual(this) => this.toString == that.toString
+    case _                                         => false
   }
 
   override def hashCode: Int =

--- a/test/shared/src/main/scala/zio/test/AssertionM.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionM.scala
@@ -50,8 +50,11 @@ abstract class AssertionM[-A] { self =>
   def ||[A1 <: A](that: => AssertionM[A1]): AssertionM[A1] =
     AssertionM(infix(param(self), "||", param(that)), actual => self.runM(actual) || that.runM(actual))
 
+  def canEqual(that: AssertionM[_]): Boolean = that != null
+
   override def equals(that: Any): Boolean = that match {
-    case that: AssertionM[_] => this.toString == that.toString
+    case that: AssertionM[_] if that.canEqual(this) => this.toString == that.toString
+    case _                                          => false
   }
 
   override def hashCode: Int =


### PR DESCRIPTION
Fix #4358