### PR TITLE
STM internals overhaul

### DIFF
--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -81,7 +81,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Find the first element in the array matching a predicate.
    */
   def find(p: A => Boolean): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       var i   = 0
       var res = Option.empty[A]
 
@@ -95,13 +95,13 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
       }
 
       TExit.Succeed(res)
-    })
+    }
 
   /**
    * Find the last element in the array matching a predicate.
    */
   def findLast(p: A => Boolean): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       var i   = array.length - 1
       var res = Option.empty[A]
 
@@ -115,7 +115,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
       }
 
       TExit.Succeed(res)
-    })
+    }
 
   /**
    * Find the last element in the array matching a transactional predicate.
@@ -157,7 +157,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically folds using a pure function.
    */
   def fold[Z](zero: Z)(op: (Z, A) => Z): USTM[Z] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       var res = zero
       var i   = 0
 
@@ -168,7 +168,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
       }
 
       TExit.Succeed(res)
-    })
+    }
 
   /**
    * Atomically folds using a transactional function.
@@ -220,7 +220,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (from < 0)
       STM.succeedNow(-1)
     else
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         var i     = from
         var found = false
 
@@ -231,7 +231,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         }
 
         if (found) TExit.Succeed(i - 1) else TExit.Succeed(-1)
-      })
+      }
 
   /**
    * Get the index of the first entry in the array matching a transactional
@@ -267,7 +267,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (end >= array.length)
       STM.succeedNow(-1)
     else
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         var i     = end
         var found = false
 
@@ -277,7 +277,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         }
 
         if (found) TExit.Succeed(i + 1) else TExit.Succeed(-1)
-      })
+      }
 
   /**
    * The last entry in the array, if it exists.
@@ -301,7 +301,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically reduce the array, if non-empty, by a binary operator.
    */
   def reduceOption(op: (A, A) => A): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       var i   = 0
       var res = null.asInstanceOf[A]
 
@@ -317,7 +317,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
       }
 
       TExit.Succeed(Option(res))
-    })
+    }
 
   /**
    * Atomically reduce the non-empty array using a transactional binary operator.
@@ -352,7 +352,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically updates all elements using a pure function.
    */
   def transform(f: A => A): USTM[Unit] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       var i = 0
 
       while (i < array.length) {
@@ -362,14 +362,14 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
       }
 
       TExit.Succeed(())
-    })
+    }
 
   /**
    * Atomically updates all elements using a transactional effect.
    */
   def transformM[E](f: A => STM[E, A]): STM[E, Unit] =
     STM.foreach(Chunk.fromArray(array))(_.get.flatMap(f)).flatMap { newData =>
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         var i  = 0
         val it = newData.iterator
 
@@ -379,7 +379,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         }
 
         TExit.Succeed(())
-      })
+      }
     }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -81,7 +81,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Find the first element in the array matching a predicate.
    */
   def find(p: A => Boolean): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var i   = 0
       var res = Option.empty[A]
 
@@ -101,7 +101,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Find the last element in the array matching a predicate.
    */
   def findLast(p: A => Boolean): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var i   = array.length - 1
       var res = Option.empty[A]
 
@@ -157,7 +157,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically folds using a pure function.
    */
   def fold[Z](zero: Z)(op: (Z, A) => Z): USTM[Z] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var res = zero
       var i   = 0
 
@@ -220,7 +220,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (from < 0)
       STM.succeedNow(-1)
     else
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         var i     = from
         var found = false
 
@@ -267,7 +267,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (end >= array.length)
       STM.succeedNow(-1)
     else
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         var i     = end
         var found = false
 
@@ -301,7 +301,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically reduce the array, if non-empty, by a binary operator.
    */
   def reduceOption(op: (A, A) => A): USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var i   = 0
       var res = null.asInstanceOf[A]
 
@@ -352,7 +352,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically updates all elements using a pure function.
    */
   def transform(f: A => A): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var i = 0
 
       while (i < array.length) {
@@ -369,7 +369,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    */
   def transformM[E](f: A => STM[E, A]): STM[E, Unit] =
     STM.foreach(Chunk.fromArray(array))(_.get.flatMap(f)).flatMap { newData =>
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         var i  = 0
         val it = newData.iterator
 

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -17,7 +17,6 @@
 package zio.stm
 
 import zio.Chunk
-import zio.stm.ZSTM.internal._
 
 /**
  * Wraps array of [[TRef]] and adds methods for convenience.
@@ -94,7 +93,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         i += 1
       }
 
-      TExit.Succeed(res)
+      res
     }
 
   /**
@@ -114,7 +113,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         i -= 1
       }
 
-      TExit.Succeed(res)
+      res
     }
 
   /**
@@ -167,7 +166,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         i += 1
       }
 
-      TExit.Succeed(res)
+      res
     }
 
   /**
@@ -230,7 +229,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
           i += 1
         }
 
-        if (found) TExit.Succeed(i - 1) else TExit.Succeed(-1)
+        if (found) i - 1 else -1
       }
 
   /**
@@ -276,7 +275,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
           i -= 1
         }
 
-        if (found) TExit.Succeed(i + 1) else TExit.Succeed(-1)
+        if (found) i + 1 else -1
       }
 
   /**
@@ -316,7 +315,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         i += 1
       }
 
-      TExit.Succeed(Option(res))
+      Option(res)
     }
 
   /**
@@ -361,7 +360,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
         i += 1
       }
 
-      TExit.Succeed(())
+      ()
     }
 
   /**
@@ -378,7 +377,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
           i += 1
         }
 
-        TExit.Succeed(())
+        ()
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/TArray.scala
+++ b/core/shared/src/main/scala/zio/stm/TArray.scala
@@ -81,7 +81,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Find the first element in the array matching a predicate.
    */
   def find(p: A => Boolean): USTM[Option[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var i   = 0
       var res = Option.empty[A]
 
@@ -101,7 +101,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Find the last element in the array matching a predicate.
    */
   def findLast(p: A => Boolean): USTM[Option[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var i   = array.length - 1
       var res = Option.empty[A]
 
@@ -157,7 +157,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically folds using a pure function.
    */
   def fold[Z](zero: Z)(op: (Z, A) => Z): USTM[Z] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var res = zero
       var i   = 0
 
@@ -220,7 +220,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (from < 0)
       STM.succeedNow(-1)
     else
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         var i     = from
         var found = false
 
@@ -267,7 +267,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
     if (end >= array.length)
       STM.succeedNow(-1)
     else
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         var i     = end
         var found = false
 
@@ -301,7 +301,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically reduce the array, if non-empty, by a binary operator.
    */
   def reduceOption(op: (A, A) => A): USTM[Option[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var i   = 0
       var res = null.asInstanceOf[A]
 
@@ -352,7 +352,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    * Atomically updates all elements using a pure function.
    */
   def transform(f: A => A): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var i = 0
 
       while (i < array.length) {
@@ -369,7 +369,7 @@ final class TArray[A] private[stm] (private[stm] val array: Array[TRef[A]]) exte
    */
   def transformM[E](f: A => STM[E, A]): STM[E, Unit] =
     STM.foreach(Chunk.fromArray(array))(_.get.flatMap(f)).flatMap { newData =>
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         var i  = 0
         val it = newData.iterator
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -435,8 +435,6 @@ object TMap {
    */
   def make[K, V](data: (K, V)*): USTM[TMap[K, V]] = fromIterable(data)
 
-  private final case class UpdateResult(stm: STM[Nothing, Unit])
-
   private def allocate[K, V](capacity: Int, data: List[(K, V)]): USTM[TMap[K, V]] = {
     val buckets  = Array.fill[List[(K, V)]](capacity)(Nil)
     val distinct = data.toMap

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -44,7 +44,7 @@ final class TMap[K, V] private (
    * Removes binding for given key.
    */
   def delete(k: K): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
@@ -64,7 +64,7 @@ final class TMap[K, V] private (
    * Atomically folds using a pure function.
    */
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       var res     = zero
       var i       = 0
@@ -97,7 +97,7 @@ final class TMap[K, V] private (
    * Retrieves value associated with given key.
    */
   def get(k: K): USTM[Option[V]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
@@ -167,7 +167,7 @@ final class TMap[K, V] private (
       tBuckets.unsafeSet(journal, new TArray(newArray))
     }
 
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val buckets      = tBuckets.unsafeGet(journal)
       val capacity     = buckets.array.length
       val idx          = TMap.indexOf(k, capacity)
@@ -203,7 +203,7 @@ final class TMap[K, V] private (
    * Removes bindings matching predicate.
    */
   def removeIf(p: (K, V) => Boolean): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -237,7 +237,7 @@ final class TMap[K, V] private (
    * Retains bindings matching predicate.
    */
   def retainIf(p: (K, V) => Boolean): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -283,7 +283,7 @@ final class TMap[K, V] private (
    * Collects all bindings into a chunk.
    */
   def toChunk: USTM[Chunk[(K, V)]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
       val size     = tSize.unsafeGet(journal)
@@ -317,7 +317,7 @@ final class TMap[K, V] private (
    * Atomically updates all bindings using a pure function.
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val g        = f.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -365,7 +365,7 @@ final class TMap[K, V] private (
       val g = f.tupled
 
       STM.foreach(data)(g).flatMap { newData =>
-        ZSTM.Effect((journal, _, _, _) => {
+        ZSTM.Effect((journal, _, _) => {
           val buckets    = tBuckets.unsafeGet(journal)
           val capacity   = buckets.array.length
           val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -44,7 +44,7 @@ final class TMap[K, V] private (
    * Removes binding for given key.
    */
   def delete(k: K): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
@@ -64,7 +64,7 @@ final class TMap[K, V] private (
    * Atomically folds using a pure function.
    */
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       var res     = zero
       var i       = 0
@@ -97,7 +97,7 @@ final class TMap[K, V] private (
    * Retrieves value associated with given key.
    */
   def get(k: K): USTM[Option[V]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
@@ -167,7 +167,7 @@ final class TMap[K, V] private (
       tBuckets.unsafeSet(journal, new TArray(newArray))
     }
 
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val buckets      = tBuckets.unsafeGet(journal)
       val capacity     = buckets.array.length
       val idx          = TMap.indexOf(k, capacity)
@@ -203,7 +203,7 @@ final class TMap[K, V] private (
    * Removes bindings matching predicate.
    */
   def removeIf(p: (K, V) => Boolean): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -237,7 +237,7 @@ final class TMap[K, V] private (
    * Retains bindings matching predicate.
    */
   def retainIf(p: (K, V) => Boolean): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -283,7 +283,7 @@ final class TMap[K, V] private (
    * Collects all bindings into a chunk.
    */
   def toChunk: USTM[Chunk[(K, V)]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
       val size     = tSize.unsafeGet(journal)
@@ -317,7 +317,7 @@ final class TMap[K, V] private (
    * Atomically updates all bindings using a pure function.
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val g        = f.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -365,7 +365,7 @@ final class TMap[K, V] private (
       val g = f.tupled
 
       STM.foreach(data)(g).flatMap { newData =>
-        new ZSTM((journal, _, _, _) => {
+        ZSTM.Effect((journal, _, _, _) => {
           val buckets    = tBuckets.unsafeGet(journal)
           val capacity   = buckets.array.length
           val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -57,7 +57,7 @@ final class TMap[K, V] private (
         tSize.unsafeSet(journal, currSize - 1)
       }
 
-      TExit.unit
+      ()
     }
 
   /**
@@ -78,7 +78,7 @@ final class TMap[K, V] private (
         i += 1
       }
 
-      TExit.Succeed(res)
+      res
     }
 
   /**
@@ -102,7 +102,7 @@ final class TMap[K, V] private (
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
 
-      TExit.Succeed(bucket.find(_._1 == k).map(_._2))
+      bucket.find(_._1 == k).map(_._2)
     }
 
   /**
@@ -189,7 +189,7 @@ final class TMap[K, V] private (
         }
       }
 
-      TExit.unit
+      ()
     }
   }
 
@@ -230,7 +230,7 @@ final class TMap[K, V] private (
 
       tSize.unsafeSet(journal, newSize)
 
-      TExit.unit
+      ()
     }
 
   /**
@@ -264,7 +264,7 @@ final class TMap[K, V] private (
 
       tSize.unsafeSet(journal, newSize)
 
-      TExit.unit
+      ()
     }
 
   /**
@@ -304,7 +304,7 @@ final class TMap[K, V] private (
         i += 1
       }
 
-      TExit.Succeed(Chunk.fromArray(data))
+      Chunk.fromArray(data)
     }
 
   /**
@@ -354,7 +354,7 @@ final class TMap[K, V] private (
 
       tSize.unsafeSet(journal, newSize)
 
-      TExit.unit
+      ()
     }
 
   /**
@@ -390,7 +390,7 @@ final class TMap[K, V] private (
           }
 
           tSize.unsafeSet(journal, newSize)
-          TExit.unit
+          ()
         }
       }
     }

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -44,7 +44,7 @@ final class TMap[K, V] private (
    * Removes binding for given key.
    */
   def delete(k: K): USTM[Unit] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
@@ -58,13 +58,13 @@ final class TMap[K, V] private (
       }
 
       TExit.unit
-    })
+    }
 
   /**
    * Atomically folds using a pure function.
    */
   def fold[A](zero: A)(op: (A, (K, V)) => A): USTM[A] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val buckets = tBuckets.unsafeGet(journal)
       var res     = zero
       var i       = 0
@@ -79,7 +79,7 @@ final class TMap[K, V] private (
       }
 
       TExit.Succeed(res)
-    })
+    }
 
   /**
    * Atomically folds using a transactional function.
@@ -97,13 +97,13 @@ final class TMap[K, V] private (
    * Retrieves value associated with given key.
    */
   def get(k: K): USTM[Option[V]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val buckets = tBuckets.unsafeGet(journal)
       val idx     = TMap.indexOf(k, buckets.array.length)
       val bucket  = buckets.array(idx).unsafeGet(journal)
 
       TExit.Succeed(bucket.find(_._1 == k).map(_._2))
-    })
+    }
 
   /**
    * Retrieves value associated with given key or default value, in case the
@@ -167,7 +167,7 @@ final class TMap[K, V] private (
       tBuckets.unsafeSet(journal, new TArray(newArray))
     }
 
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val buckets      = tBuckets.unsafeGet(journal)
       val capacity     = buckets.array.length
       val idx          = TMap.indexOf(k, capacity)
@@ -190,7 +190,7 @@ final class TMap[K, V] private (
       }
 
       TExit.unit
-    })
+    }
   }
 
   /**
@@ -203,7 +203,7 @@ final class TMap[K, V] private (
    * Removes bindings matching predicate.
    */
   def removeIf(p: (K, V) => Boolean): USTM[Unit] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -231,13 +231,13 @@ final class TMap[K, V] private (
       tSize.unsafeSet(journal, newSize)
 
       TExit.unit
-    })
+    }
 
   /**
    * Retains bindings matching predicate.
    */
   def retainIf(p: (K, V) => Boolean): USTM[Unit] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val f        = p.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -265,7 +265,7 @@ final class TMap[K, V] private (
       tSize.unsafeSet(journal, newSize)
 
       TExit.unit
-    })
+    }
 
   /**
    * Returns the number of bindings.
@@ -283,7 +283,7 @@ final class TMap[K, V] private (
    * Collects all bindings into a chunk.
    */
   def toChunk: USTM[Chunk[(K, V)]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
       val size     = tSize.unsafeGet(journal)
@@ -305,7 +305,7 @@ final class TMap[K, V] private (
       }
 
       TExit.Succeed(Chunk.fromArray(data))
-    })
+    }
 
   /**
    * Collects all bindings into a map.
@@ -317,7 +317,7 @@ final class TMap[K, V] private (
    * Atomically updates all bindings using a pure function.
    */
   def transform(f: (K, V) => (K, V)): USTM[Unit] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val g        = f.tupled
       val buckets  = tBuckets.unsafeGet(journal)
       val capacity = buckets.array.length
@@ -355,7 +355,7 @@ final class TMap[K, V] private (
       tSize.unsafeSet(journal, newSize)
 
       TExit.unit
-    })
+    }
 
   /**
    * Atomically updates all bindings using a transactional function.
@@ -365,7 +365,7 @@ final class TMap[K, V] private (
       val g = f.tupled
 
       STM.foreach(data)(g).flatMap { newData =>
-        ZSTM.Effect((journal, _, _) => {
+        ZSTM.Effect { (journal, _, _) =>
           val buckets    = tBuckets.unsafeGet(journal)
           val capacity   = buckets.array.length
           val newBuckets = Array.fill[List[(K, V)]](capacity)(Nil)
@@ -391,7 +391,7 @@ final class TMap[K, V] private (
 
           tSize.unsafeSet(journal, newSize)
           TExit.unit
-        })
+        }
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -47,7 +47,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * a value is in the queue.
    */
   def peek: USTM[A] =
-    new ZSTM((journal, _, _, _) =>
+    ZSTM.Effect((journal, _, _, _) =>
       ref.unsafeGet(journal).headOption match {
         case None          => TExit.Retry
         case Some((_, as)) => TExit.Succeed(as.head)
@@ -90,7 +90,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * Takes a value from the queue, retrying until a value is in the queue.
    */
   def take: USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Retry
@@ -143,7 +143,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * the queue.
    */
   def takeOption: USTM[Option[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Succeed(None)

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -48,7 +48,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
   def peek: USTM[A] =
     ZSTM.Effect((journal, _, _) =>
       ref.unsafeGet(journal).headOption match {
-        case None          => throw ZSTM.RetryException()
+        case None          => throw ZSTM.RetryException
         case Some((_, as)) => as.head
       }
     )
@@ -92,7 +92,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
     ZSTM.Effect { (journal, _, _) =>
       val map = ref.unsafeGet(journal)
       map.headOption match {
-        case None => throw ZSTM.RetryException()
+        case None => throw ZSTM.RetryException
         case Some((a, as)) =>
           ref.unsafeSet(
             journal,

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -90,7 +90,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * Takes a value from the queue, retrying until a value is in the queue.
    */
   def take: USTM[A] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Retry
@@ -104,7 +104,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
           )
           TExit.Succeed(as.head)
       }
-    })
+    }
 
   /**
    * Takes all values from the queue.
@@ -143,7 +143,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * the queue.
    */
   def takeOption: USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Succeed(None)
@@ -157,7 +157,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
           )
           TExit.Succeed(Some(as.head))
       }
-    })
+    }
 
   /**
    * Collects all values into a chunk.

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -48,7 +48,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
   def peek: USTM[A] =
     ZSTM.Effect((journal, _, _) =>
       ref.unsafeGet(journal).headOption match {
-        case None          => throw ZSTM.RetryException
+        case None          => throw ZSTM.RetryException()
         case Some((_, as)) => as.head
       }
     )
@@ -92,7 +92,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
     ZSTM.Effect { (journal, _, _) =>
       val map = ref.unsafeGet(journal)
       map.headOption match {
-        case None => throw ZSTM.RetryException
+        case None => throw ZSTM.RetryException()
         case Some((a, as)) =>
           ref.unsafeSet(
             journal,

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -47,7 +47,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * a value is in the queue.
    */
   def peek: USTM[A] =
-    ZSTM.Effect((journal, _, _, _) =>
+    ZSTM.Effect((journal, _, _) =>
       ref.unsafeGet(journal).headOption match {
         case None          => TExit.Retry
         case Some((_, as)) => TExit.Succeed(as.head)
@@ -90,7 +90,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * Takes a value from the queue, retrying until a value is in the queue.
    */
   def take: USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Retry
@@ -143,7 +143,7 @@ final class TPriorityQueue[A] private (private val ref: TRef[SortedMap[A, ::[A]]
    * the queue.
    */
   def takeOption: USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val map = ref.unsafeGet(journal)
       map.headOption match {
         case None => TExit.Succeed(None)

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -40,7 +40,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     ZSTM.Effect { (journal, _, _) =>
       ref.unsafeGet(journal).lastOption match {
         case Some(a) => a
-        case None    => throw ZSTM.RetryException()
+        case None    => throw ZSTM.RetryException
       }
     }
 
@@ -55,7 +55,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       if (q.length < capacity)
         ref.unsafeSet(journal, q.enqueue(a))
       else
-        throw ZSTM.RetryException()
+        throw ZSTM.RetryException
     }
 
   /**
@@ -70,7 +70,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
       val q = ref.unsafeGet(journal)
 
-      if (forQueue.size > capacity - q.length) throw ZSTM.RetryException()
+      if (forQueue.size > capacity - q.length) throw ZSTM.RetryException
       else {
         ref.unsafeSet(journal, q ++ forQueue)
         remaining
@@ -85,7 +85,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     ZSTM.Effect { (journal, _, _) =>
       ref.unsafeGet(journal).headOption match {
         case Some(a) => a
-        case None    => throw ZSTM.RetryException()
+        case None    => throw ZSTM.RetryException
       }
     }
 
@@ -130,7 +130,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       }
 
       res match {
-        case null => throw ZSTM.RetryException()
+        case null => throw ZSTM.RetryException
         case a    => a
       }
     }
@@ -151,7 +151,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
           ref.unsafeSet(journal, as)
           a
         case None =>
-          throw ZSTM.RetryException()
+          throw ZSTM.RetryException
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -40,7 +40,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     ZSTM.Effect { (journal, _, _) =>
       ref.unsafeGet(journal).lastOption match {
         case Some(a) => a
-        case None    => throw ZSTM.RetryException
+        case None    => throw ZSTM.RetryException()
       }
     }
 
@@ -55,7 +55,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       if (q.length < capacity)
         ref.unsafeSet(journal, q.enqueue(a))
       else
-        throw ZSTM.RetryException
+        throw ZSTM.RetryException()
     }
 
   /**
@@ -70,7 +70,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
       val q = ref.unsafeGet(journal)
 
-      if (forQueue.size > capacity - q.length) throw ZSTM.RetryException
+      if (forQueue.size > capacity - q.length) throw ZSTM.RetryException()
       else {
         ref.unsafeSet(journal, q ++ forQueue)
         remaining
@@ -85,7 +85,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     ZSTM.Effect { (journal, _, _) =>
       ref.unsafeGet(journal).headOption match {
         case Some(a) => a
-        case None    => throw ZSTM.RetryException
+        case None    => throw ZSTM.RetryException()
       }
     }
 
@@ -130,7 +130,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       }
 
       res match {
-        case null => throw ZSTM.RetryException
+        case null => throw ZSTM.RetryException()
         case a    => a
       }
     }
@@ -151,7 +151,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
           ref.unsafeSet(journal, as)
           a
         case None =>
-          throw ZSTM.RetryException
+          throw ZSTM.RetryException()
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -26,7 +26,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Checks if the queue is empty.
    */
   def isEmpty: USTM[Boolean] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.isEmpty)
     })
@@ -35,7 +35,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Checks if the queue is at capacity.
    */
   def isFull: USTM[Boolean] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.size == capacity)
     })
@@ -45,7 +45,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * empty.
    */
   def last: USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.lastOption match {
@@ -59,7 +59,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * capacity.
    */
   def offer(a: A): USTM[Unit] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
 
       if (q.length < capacity)
@@ -75,7 +75,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * specified collection.
    */
   def offerAll(as: Iterable[A]): USTM[Iterable[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val (forQueue, remaining) = as.splitAt(capacity)
 
       val q = ref.unsafeGet(journal)
@@ -92,7 +92,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * queue is empty.
    */
   def peek: USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.headOption match {
@@ -106,7 +106,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * if the queue is empty.
    */
   def peekOption: USTM[Option[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.headOption)
     })
@@ -124,7 +124,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Retries if no elements satisfy the predicate.
    */
   def seek(f: A => Boolean): USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       var q    = ref.unsafeGet(journal)
       var loop = true
       var res  = null.asInstanceOf[A]
@@ -154,7 +154,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Returns the number of elements currently in the queue.
    */
   def size: USTM[Int] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.length)
     })
@@ -163,7 +163,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes a single element from the queue, retrying if the queue is empty.
    */
   def take: USTM[A] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.dequeueOption match {
@@ -179,7 +179,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes all elements from the queue.
    */
   def takeAll: USTM[List[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q = ref.unsafeGet(journal)
       ref.unsafeSet(journal, ScalaQueue.empty[A])
       TExit.Succeed(q.toList)
@@ -189,7 +189,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes up to the specified maximum number of elements from the queue.
    */
   def takeUpTo(max: Int): USTM[List[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val q     = ref.unsafeGet(journal)
       val split = q.splitAt(max)
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -18,27 +18,19 @@ package zio.stm
 
 import scala.collection.immutable.{ Queue => ScalaQueue }
 
-import zio.stm.ZSTM.internal._
-
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
   /**
    * Checks if the queue is empty.
    */
   def isEmpty: USTM[Boolean] =
-    ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-      TExit.Succeed(q.isEmpty)
-    }
+    ZSTM.Effect((journal, _, _) => ref.unsafeGet(journal).isEmpty)
 
   /**
    * Checks if the queue is at capacity.
    */
   def isFull: USTM[Boolean] =
-    ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-      TExit.Succeed(q.size == capacity)
-    }
+    ZSTM.Effect((journal, _, _) => ref.unsafeGet(journal).size == capacity)
 
   /**
    * Views the last element inserted into the queue, retrying if the queue is
@@ -46,11 +38,9 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    */
   def last: USTM[A] =
     ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-
-      q.lastOption match {
-        case Some(a) => TExit.Succeed(a)
-        case None    => TExit.Retry
+      ref.unsafeGet(journal).lastOption match {
+        case Some(a) => a
+        case None    => throw ZSTM.RetryException
       }
     }
 
@@ -63,9 +53,9 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       val q = ref.unsafeGet(journal)
 
       if (q.length < capacity)
-        TExit.Succeed(ref.unsafeSet(journal, q.enqueue(a)))
+        ref.unsafeSet(journal, q.enqueue(a))
       else
-        TExit.Retry
+        throw ZSTM.RetryException
     }
 
   /**
@@ -80,10 +70,10 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
       val q = ref.unsafeGet(journal)
 
-      if (forQueue.size > capacity - q.length) TExit.Retry
+      if (forQueue.size > capacity - q.length) throw ZSTM.RetryException
       else {
         ref.unsafeSet(journal, q ++ forQueue)
-        TExit.Succeed(remaining)
+        remaining
       }
     }
 
@@ -93,11 +83,9 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    */
   def peek: USTM[A] =
     ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-
-      q.headOption match {
-        case Some(a) => TExit.Succeed(a)
-        case None    => TExit.Retry
+      ref.unsafeGet(journal).headOption match {
+        case Some(a) => a
+        case None    => throw ZSTM.RetryException
       }
     }
 
@@ -106,10 +94,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * if the queue is empty.
    */
   def peekOption: USTM[Option[A]] =
-    ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-      TExit.Succeed(q.headOption)
-    }
+    ZSTM.Effect((journal, _, _) => ref.unsafeGet(journal).headOption)
 
   /**
    * Takes a single element from the queue, returning `None` if the queue is
@@ -145,8 +130,8 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
       }
 
       res match {
-        case null => TExit.Retry
-        case a    => TExit.Succeed(a)
+        case null => throw ZSTM.RetryException
+        case a    => a
       }
     }
 
@@ -154,24 +139,19 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Returns the number of elements currently in the queue.
    */
   def size: USTM[Int] =
-    ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-      TExit.Succeed(q.length)
-    }
+    ZSTM.Effect((journal, _, _) => ref.unsafeGet(journal).length)
 
   /**
    * Takes a single element from the queue, retrying if the queue is empty.
    */
   def take: USTM[A] =
     ZSTM.Effect { (journal, _, _) =>
-      val q = ref.unsafeGet(journal)
-
-      q.dequeueOption match {
+      ref.unsafeGet(journal).dequeueOption match {
         case Some((a, as)) =>
           ref.unsafeSet(journal, as)
-          TExit.Succeed(a)
+          a
         case None =>
-          TExit.Retry
+          throw ZSTM.RetryException
       }
     }
 
@@ -182,7 +162,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     ZSTM.Effect { (journal, _, _) =>
       val q = ref.unsafeGet(journal)
       ref.unsafeSet(journal, ScalaQueue.empty[A])
-      TExit.Succeed(q.toList)
+      q.toList
     }
 
   /**
@@ -190,11 +170,10 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    */
   def takeUpTo(max: Int): USTM[List[A]] =
     ZSTM.Effect { (journal, _, _) =>
-      val q     = ref.unsafeGet(journal)
-      val split = q.splitAt(max)
+      val split = ref.unsafeGet(journal).splitAt(max)
 
       ref.unsafeSet(journal, split._2)
-      TExit.Succeed(split._1.toList)
+      split._1.toList
     }
 }
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -26,7 +26,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Checks if the queue is empty.
    */
   def isEmpty: USTM[Boolean] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.isEmpty)
     })
@@ -35,7 +35,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Checks if the queue is at capacity.
    */
   def isFull: USTM[Boolean] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.size == capacity)
     })
@@ -45,7 +45,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * empty.
    */
   def last: USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.lastOption match {
@@ -59,7 +59,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * capacity.
    */
   def offer(a: A): USTM[Unit] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
 
       if (q.length < capacity)
@@ -75,7 +75,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * specified collection.
    */
   def offerAll(as: Iterable[A]): USTM[Iterable[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val (forQueue, remaining) = as.splitAt(capacity)
 
       val q = ref.unsafeGet(journal)
@@ -92,7 +92,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * queue is empty.
    */
   def peek: USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.headOption match {
@@ -106,7 +106,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * if the queue is empty.
    */
   def peekOption: USTM[Option[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.headOption)
     })
@@ -124,7 +124,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Retries if no elements satisfy the predicate.
    */
   def seek(f: A => Boolean): USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       var q    = ref.unsafeGet(journal)
       var loop = true
       var res  = null.asInstanceOf[A]
@@ -154,7 +154,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Returns the number of elements currently in the queue.
    */
   def size: USTM[Int] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
       TExit.Succeed(q.length)
     })
@@ -163,7 +163,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes a single element from the queue, retrying if the queue is empty.
    */
   def take: USTM[A] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
 
       q.dequeueOption match {
@@ -179,7 +179,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes all elements from the queue.
    */
   def takeAll: USTM[List[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q = ref.unsafeGet(journal)
       ref.unsafeSet(journal, ScalaQueue.empty[A])
       TExit.Succeed(q.toList)
@@ -189,7 +189,7 @@ final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
    * Takes up to the specified maximum number of elements from the queue.
    */
   def takeUpTo(max: Int): USTM[List[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val q     = ref.unsafeGet(journal)
       val split = q.splitAt(max)
 

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -60,7 +60,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
           data.unsafeSet(journal, WriteLock(n + 1, m, fiberId))
           n + 1
 
-        case _ => throw ZSTM.RetryException
+        case _ => throw ZSTM.RetryException()
       }
     )
 
@@ -161,7 +161,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
 
           newTotal
 
-        case _ => throw ZSTM.RetryException //another fiber is holding a write lock
+        case _ => throw ZSTM.RetryException() //another fiber is holding a write lock
       }
     )
 }

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -52,7 +52,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
    * write locks held by this fiber.
    */
   lazy val acquireWrite: USTM[Int] =
-    ZSTM.Effect((journal, fiberId, _, _) =>
+    ZSTM.Effect((journal, fiberId, _) =>
       data.unsafeGet(journal) match {
 
         case readLock: ReadLock if readLock.noOtherHolder(fiberId) =>
@@ -96,13 +96,13 @@ final class TReentrantLock private (data: TRef[LockState]) {
    * Retrieves the number of acquired read locks for this fiber.
    */
   def fiberReadLocks: USTM[Int] =
-    ZSTM.Effect((journal, fiberId, _, _) => TExit.Succeed(data.unsafeGet(journal).readLocks(fiberId)))
+    ZSTM.Effect((journal, fiberId, _) => TExit.Succeed(data.unsafeGet(journal).readLocks(fiberId)))
 
   /**
    * Retrieves the number of acquired write locks for this fiber.
    */
   def fiberWriteLocks: USTM[Int] =
-    ZSTM.Effect((journal, fiberId, _, _) => TExit.Succeed(data.unsafeGet(journal).writeLocks(fiberId)))
+    ZSTM.Effect((journal, fiberId, _) => TExit.Succeed(data.unsafeGet(journal).writeLocks(fiberId)))
 
   /**
    * Determines if any fiber has a read lock.
@@ -120,7 +120,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
    * number of write locks held by this fiber.
    */
   lazy val releaseWrite: USTM[Int] =
-    ZSTM.Effect { (journal, fiberId, _, _) =>
+    ZSTM.Effect { (journal, fiberId, _) =>
       val res = data.unsafeGet(journal) match {
         case WriteLock(1, m, `fiberId`) => ReadLock(fiberId, m)
         case WriteLock(n, m, `fiberId`) if n > 1 =>
@@ -148,7 +148,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
   def writeLocks: USTM[Int] = data.get.map(_.writeLocks)
 
   private def adjustRead(delta: Int): USTM[Int] =
-    ZSTM.Effect((journal, fiberId, _, _) =>
+    ZSTM.Effect((journal, fiberId, _) =>
       data.unsafeGet(journal) match {
         case readLock: ReadLock =>
           val res = readLock.adjust(fiberId, delta)

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -60,7 +60,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
           data.unsafeSet(journal, WriteLock(n + 1, m, fiberId))
           n + 1
 
-        case _ => throw ZSTM.RetryException()
+        case _ => throw ZSTM.RetryException
       }
     )
 
@@ -161,7 +161,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
 
           newTotal
 
-        case _ => throw ZSTM.RetryException() //another fiber is holding a write lock
+        case _ => throw ZSTM.RetryException //another fiber is holding a write lock
       }
     )
 }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -567,9 +567,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * in left side, unless it fails or retries, in which case, it will produce the value
    * of the specified effect in right side.
    */
-  def orElseEither[R1 <: R, E1, B](
-    that: => ZSTM[R1, E1, B]
-  ): ZSTM[R1, E1, Either[A, B]] =
+  def orElseEither[R1 <: R, E1, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, Either[A, B]] =
     (self map (Left[A, B](_))) orElse (that map (Right[A, B](_)))
 
   /**
@@ -583,9 +581,9 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * fails with the `None` value, in which case it will produce the value of
    * the specified effect.
    */
-  def orElseOptional[R1 <: R, E1, A1 >: A](
-    that: => ZSTM[R1, Option[E1], A1]
-  )(implicit ev: E <:< Option[E1]): ZSTM[R1, Option[E1], A1] =
+  def orElseOptional[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, Option[E1], A1])(implicit
+    ev: E <:< Option[E1]
+  ): ZSTM[R1, Option[E1], A1] =
     catchAll(ev(_).fold(that)(e => ZSTM.fail(Some(e))))
 
   /**
@@ -617,9 +615,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  def refineOrDie[E1](
-    pf: PartialFunction[E, E1]
-  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
+  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -933,10 +933,6 @@ object ZSTM {
     ifRetry: () => ZSTM[R, E2, B]
   ) extends ZSTM[R, E2, B]
 
-  final case class Fail[+E](value: E)    extends ZSTM[Any, E, Nothing]
-  final case class Succeed[+A](value: A) extends ZSTM[Any, Nothing, A]
-  case object Retry                      extends ZSTM[Any, Nothing, Nothing]
-
   final case class Effect[-R, +E, +A](f: (Journal, Fiber.Id, AtomicLong, R) => TExit[E, A]) extends ZSTM[R, E, A]
 
   private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -633,21 +633,8 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  def provideSome[R0](f: R0 => R): ZSTM[R0, E, A] = ???
-  // new ZSTM((journal, fiberId, stackSize, r0) => {
-
-  //   val framesCount = stackSize.incrementAndGet()
-
-  //   if (framesCount > ZSTM.MaxFrames) {
-  //     throw new ZSTM.Resumable(
-  //       new ZSTM((journal, fiberId, stackSize, _) => self.exec(journal, fiberId, stackSize, f(r0))),
-  //       Stack[TExit[E, A] => STM[E, A]]()
-  //     )
-  //   } else {
-  //     // no need to catch resumable here
-  //     self.exec(journal, fiberId, stackSize, f(r0))
-  //   }
-  // })
+  def provideSome[R0](f: R0 => R): ZSTM[R0, E, A] = 
+    Effect((journal, fiberId, r) => self.run(journal, fiberId, f(r)))
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -556,7 +556,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     FoldCauseM[R1, Nothing, E1, () => Any, A1](
       Effect((journal, _, _) => prepareResetJournal(journal)),
       nothing => nothing,
-      reset => self.foldCauseM(_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that),
+      reset => self.foldCauseM(_ => ZSTM.succeed(reset()) *> that, ZSTM.succeedNow, ZSTM.succeed(reset()) *> that),
       ZSTM.retry
     )
 
@@ -600,7 +600,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     FoldCauseM[R1, Nothing, E1, () => Any, A1](
       Effect((journal, _, _) => prepareResetJournal(journal)),
       ZSTM.failFn,
-      reset => self.foldCauseM(ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self)),
+      reset => self.foldCauseM(ZSTM.failFn, ZSTM.succeedNow(_), ZSTM.succeed(reset()) *> that.orTry(self)),
       ZSTM.retry
     )
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -880,14 +880,14 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
                 val k = contStack.pop()
 
                 k match {
-                  case FoldCauseM(_, onFailure, _, _) => curr = onFailure(e)
-                  case _                              => exit = TExit.Fail(e)
+                  case FoldCauseM(_, onFailure: Cont, _, _) => curr = onFailure(e)
+                  case _                                    => exit = TExit.Fail(e)
                 }
               }
           }
 
         case fc @ FoldCauseM(stm, _, _, _) =>
-          contStack.push(fc)
+          contStack.push(fc.asInstanceOf[Cont])
           curr = stm
 
         case ProvideSome(stm, f) =>
@@ -895,7 +895,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 
           val cleanup = ZSTM.succeed(envStack.pop())
 
-          curr = stm.ensuring(cleanup)
+          curr = stm.ensuring(cleanup).asInstanceOf[Erased]
       }
     }
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -907,28 +907,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  private[stm] final case class FailException[E](e: E) extends Throwable(null, null, false, false)
-
-  private[stm] case object RetryException extends Throwable(null, null, false, false)
-
-  private[stm] final case class FoldCauseM[R, E1, E2, A, B](
-    self: ZSTM[R, E1, A],
-    onFailure: E1 => ZSTM[R, E2, B],
-    onSuccess: A => ZSTM[R, E2, B],
-    onRetry: ZSTM[R, E2, B]
-  ) extends ZSTM[R, E2, B]
-      with Function[A, ZSTM[R, E2, B]] {
-    def apply(a: A): ZSTM[R, E2, B] = onSuccess(a)
-  }
-
-  private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => A) extends ZSTM[R, E, A]
-
-  private[stm] final case class ProvideSome[R1, R2, E, A](effect: ZSTM[R1, E, A], f: R2 => R1) extends ZSTM[R2, E, A]
-
-  private val _FailFn: Any => ZSTM[Any, Any, Nothing] = ZSTM.fail(_)
-
-  private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
-
   /**
    * Submerges the error case of an `Either` into the `STM`. The inverse
    * operation of `STM.either`.
@@ -1451,9 +1429,6 @@ object ZSTM {
   def whenM[R, E](b: ZSTM[R, E, Boolean]): ZSTM.WhenM[R, E] =
     new ZSTM.WhenM(b)
 
-  private[zio] def succeedNow[A](a: A): USTM[A] =
-    succeed(a)
-
   final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: R => A): ZSTM[R, Nothing, A] =
       ZSTM.environment.map(f)
@@ -1483,6 +1458,30 @@ object ZSTM {
     def apply[R1 <: R, E1 >: E](stm: => ZSTM[R1, E1, Any]): ZSTM[R1, E1, Unit] =
       b.flatMap(b => if (b) stm.unit else unit)
   }
+
+  private[stm] final case class FailException[E](e: E) extends Throwable(null, null, false, false)
+
+  private[stm] case object RetryException extends Throwable(null, null, false, false)
+
+  private[stm] final case class FoldCauseM[R, E1, E2, A, B](
+    self: ZSTM[R, E1, A],
+    onFailure: E1 => ZSTM[R, E2, B],
+    onSuccess: A => ZSTM[R, E2, B],
+    onRetry: ZSTM[R, E2, B]
+  ) extends ZSTM[R, E2, B]
+      with Function[A, ZSTM[R, E2, B]] {
+    def apply(a: A): ZSTM[R, E2, B] = onSuccess(a)
+  }
+
+  private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => A) extends ZSTM[R, E, A]
+
+  private[stm] final case class ProvideSome[R1, R2, E, A](effect: ZSTM[R1, E, A], f: R2 => R1) extends ZSTM[R2, E, A]
+
+  private val _FailFn: Any => ZSTM[Any, Any, Nothing] = ZSTM.fail(_)
+
+  private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
+
+  private[zio] def succeedNow[A](a: A): USTM[A] = succeed(a)
 
   private[stm] object internal {
     val DefaultJournalSize = 4

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -72,7 +72,7 @@ import zio.internal.{ Platform, Stack, Sync }
  *  [[https://www.microsoft.com/en-us/research/publication/lock-free-data-structures-using-stms-in-haskell/]]
  */
 sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
-  import ZSTM.internal.{ prepareResetJournal, TExit }
+  import ZSTM.internal.{ prepareResetJournal, Journal, TExit }
   import ZSTM._
 
   /**
@@ -221,7 +221,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Continues on the effect returned from pf.
    */
   def collectM[R1 <: R, E1 >: E, B](pf: PartialFunction[A, ZSTM[R1, E1, B]]): ZSTM[R1, E1, B] =
-    foldM(ZSTM.fail(_), (a: A) => if (pf.isDefinedAt(a)) pf(a) else ZSTM.retry) 
+    foldM(ZSTM.fail(_), (a: A) => if (pf.isDefinedAt(a)) pf(a) else ZSTM.retry)
 
   /**
    * Named alias for `<<<`.
@@ -366,8 +366,8 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Effectfully folds over the `STM` effect, handling both failure and
    * success.
    */
-  def foldM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B])(
-    implicit ev: CanFail[E]
+  def foldM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B])(implicit
+    ev: CanFail[E]
   ): ZSTM[R1, E1, B] = FoldM(self, f, g, () => ZSTM.retry)
 
   /**
@@ -916,6 +916,29 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   //   }
   //   result.asInstanceOf[TExit[E, A]]
   // }
+
+  private def run(journal: Journal, fiberId: Fiber.Id, r: R): TExit[E, A] = {
+    type Erased = ZSTM[R, Any, Any]
+    type Cont   = Any => Erased
+
+    val stack = new Stack[Cont]()
+
+    def loop(stm: Erased): Any =
+      stm match {
+        case Continue(_, _)    => TExit.Retry
+
+        case Effect(f)         => f(journal, fiberId, new AtomicLong(0), r)
+
+        case FlatMap(t, f)     =>
+          stack.push(f.asInstanceOf[Cont])
+          loop(t.asInstanceOf[Erased])
+
+        case FoldM(_, _, _, _) => TExit.Retry
+      }
+
+    loop(self.asInstanceOf[Erased]).asInstanceOf[TExit[E, A]]
+  }
+
 }
 
 object ZSTM {
@@ -935,10 +958,8 @@ object ZSTM {
 
   final case class Effect[-R, +E, +A](f: (Journal, Fiber.Id, AtomicLong, R) => TExit[E, A]) extends ZSTM[R, E, A]
 
-  private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =
-    Continue(stm, f)
-
-  private def run[R, E, A](stm: ZSTM[R, E, A]): TExit[E, A] = ???
+  // private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =
+  //   Continue(stm, f)
 
   /**
    * Submerges the error case of an `Either` into the `STM`. The inverse
@@ -1494,13 +1515,6 @@ object ZSTM {
     def apply[R1 <: R, E1 >: E](stm: => ZSTM[R1, E1, Any]): ZSTM[R1, E1, Unit] =
       b.flatMap(b => if (b) stm.unit else unit)
   }
-
-  private final class Resumable[E, E1, A, B](
-    val stm: STM[E, A],
-    val ks: Stack[internal.TExit[E, A] => STM[E1, B]]
-  ) extends Throwable(null, null, false, false)
-
-  private val MaxFrames = 200
 
   private[stm] object internal {
     val DefaultJournalSize = 4

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -866,7 +866,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
               }
             }
           } catch {
-            case ZSTM.RetryException() =>
+            case ZSTM.RetryException =>
               if (contStack.isEmpty) exit = TExit.Retry
               else {
                 val k = contStack.pop()
@@ -916,7 +916,7 @@ object ZSTM {
 
   private[stm] final case class FailException[E](e: E) extends Throwable(null, null, false, false)
 
-  private[stm] final case class RetryException() extends Throwable(null, null, false, false)
+  private[stm] case object RetryException extends Throwable(null, null, false, false)
 
   private[stm] final case class FoldCauseM[R, E1, E2, A, B](
     self: ZSTM[R, E1, A],
@@ -1326,7 +1326,7 @@ object ZSTM {
    * Abort and retry the whole transaction when any of the underlying
    * transactional variables have changed.
    */
-  val retry: USTM[Nothing] = Effect((_, _, _) => throw RetryException())
+  val retry: USTM[Nothing] = Effect((_, _, _) => throw RetryException)
 
   /**
    * Returns an effect with the value on the right part.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -910,10 +910,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  private val _FailFn: Any => ZSTM[Any, Any, Nothing] = ZSTM.fail(_)
-
-  private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
-
   private[stm] final case class FailException[E](e: E) extends Throwable(null, null, false, false)
 
   private[stm] case object RetryException extends Throwable(null, null, false, false)
@@ -931,6 +927,10 @@ object ZSTM {
   private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => A) extends ZSTM[R, E, A]
 
   private[stm] final case class ProvideSome[R1, R2, E, A](effect: ZSTM[R1, E, A], f: R2 => R1) extends ZSTM[R2, E, A]
+
+  private val _FailFn: Any => ZSTM[Any, Any, Nothing] = ZSTM.fail(_)
+
+  private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
 
   /**
    * Submerges the error case of an `Either` into the `STM`. The inverse

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -320,7 +320,15 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Feeds the value produced by this effect to the specified function,
    * and then runs the returned effect as well to produce its results.
    */
-  def flatMap[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] = FlatMap(self, f)
+  def flatMap[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
+    FlatMap[R1, E, E1, A, B](
+      self,
+      {
+        case TExit.Succeed(value) => f(value)
+        case TExit.Fail(error)    => ZSTM.fail(error)
+        case TExit.Retry          => ZSTM.retry
+      }
+    )
 
   /**
    * Creates a composite effect that represents this effect followed by another
@@ -368,7 +376,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    */
   def foldM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B])(implicit
     ev: CanFail[E]
-  ): ZSTM[R1, E1, B] = FoldM(self, f, g, () => ZSTM.retry)
+  ): ZSTM[R1, E1, B] = foldAllM(f, g, ZSTM.retry)
 
   /**
    * Repeats this effect forever (until the first error).
@@ -552,15 +560,15 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Named alias for `<>`.
    */
   def orElse[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
-    Effect { (journal, fiberId, r) =>
-      val reset = prepareResetJournal(journal)
-
-      self.run(journal, fiberId, r) match {
-        case TExit.Succeed(a) => TExit.Succeed(a)
-        case TExit.Fail(_)    => { reset(); that.run(journal, fiberId, r) }
-        case TExit.Retry      => { reset(); that.run(journal, fiberId, r) }
+    FlatMap[R1, Nothing, E1, () => Any, A1](
+      Effect((journal, _, _) => TExit.Succeed(prepareResetJournal(journal))),
+      {
+        case TExit.Succeed(reset) =>
+          self.foldAllM[R1, E1, A1](_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that)
+        case TExit.Fail(nothing) => nothing
+        case TExit.Retry         => ZSTM.retry
       }
-    }
+    )
 
   /**
    * Returns a transactional effect that will produce the value of this effect
@@ -599,15 +607,15 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Named alias for `<|>`.
    */
   def orTry[R1 <: R, E1 >: E, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
-    Effect { (journal, fiberId, r) =>
-      val reset = prepareResetJournal(journal)
-
-      self.run(journal, fiberId, r) match {
-        case TExit.Succeed(a) => TExit.Succeed(a)
-        case TExit.Fail(e)    => TExit.Fail(e)
-        case TExit.Retry      => { reset(); that.orTry(self).run(journal, fiberId, r) }
+    FlatMap[R1, Nothing, E1, () => Any, A1](
+      Effect((journal, _, _) => TExit.Succeed(prepareResetJournal(journal))),
+      {
+        case TExit.Succeed(reset) =>
+          self.foldAllM[R1, E1, A1](ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self))
+        case TExit.Fail(nothing) => nothing
+        case TExit.Retry         => ZSTM.retry
       }
-    }
+    )
 
   /**
    * Provides the transaction its required environment, which eliminates
@@ -620,8 +628,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Provides some of the environment required to run this effect,
    * leaving the remainder `R0`.
    */
-  def provideSome[R0](f: R0 => R): ZSTM[R0, E, A] =
-    Effect((journal, fiberId, r) => self.run(journal, fiberId, f(r)))
+  def provideSome[R0](f: R0 => R): ZSTM[R0, E, A] = ProvideSome(self, f)
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
@@ -843,69 +850,43 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   def zipWith[R1 <: R, E1 >: E, B, C](that: => ZSTM[R1, E1, B])(f: (A, B) => C): ZSTM[R1, E1, C] =
     self flatMap (a => that map (b => f(a, b)))
 
-  // private def continueWithM[R1 <: R, E1, B](continueM: TExit[E, A] => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
-  //   new ZSTM((journal, fiberId, stackSize, r) => {
-  //     val framesCount = stackSize.incrementAndGet()
+  private def foldAllM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B], h: => ZSTM[R1, E1, B])(implicit
+    ev: CanFail[E]
+  ): ZSTM[R1, E1, B] =
+    FlatMap[R1, E, E1, A, B](
+      self,
+      {
+        case TExit.Fail(error)    => f(error)
+        case TExit.Succeed(value) => g(value)
+        case TExit.Retry          => h
+      }
+    )
 
-  //     if (framesCount > ZSTM.MaxFrames) {
-  //       throw new ZSTM.Resumable(self.provide(r), Stack(continueM.andThen(_.provide(r))))
-  //     } else {
-  //       val continued =
-  //         try {
-  //           continueM(self.exec(journal, fiberId, stackSize, r))
-  //         } catch {
-  //           case res: ZSTM.Resumable[e, e1, a, b] =>
-  //             res.ks.push(continueM.asInstanceOf[TExit[e, a] => STM[e1, b]])
-  //             throw res
-  //         }
+  private def run(journal: Journal, fiberId: Fiber.Id, r0: R): TExit[E, A] = {
+    type Erased = ZSTM[Any, Any, Any]
+    type Cont   = TExit[Any, Any] => Erased
 
-  //       continued.exec(journal, fiberId, stackSize, r)
-  //     }
-  //   })
+    val contStack = Stack[Cont]()
+    val envStack  = Stack[AnyRef](r0.asInstanceOf[AnyRef])
 
-  // private def run(journal: ZSTM.internal.Journal, fiberId: Fiber.Id, r: R): TExit[E, A] = {
-  //   type Cont = ZSTM.internal.TExit[Any, Any] => STM[Any, Any]
+    @tailrec
+    def loop(self: Erased): TExit[Any, Any] =
+      self match {
+        case Effect(f) =>
+          val exit = f(journal, fiberId, envStack.peek())
+          if (contStack.isEmpty) exit
+          else loop(contStack.pop()(exit))
 
-  //   val stackSize = new AtomicLong()
-  //   val stack     = new Stack[Cont]()
-  //   var current   = self.asInstanceOf[ZSTM[R, Any, Any]]
-  //   var result    = null: TExit[Any, Any]
+        case FlatMap(stm, k) =>
+          contStack.push(k)
+          loop(stm)
 
-  //   while (result eq null) {
-  //     try {
-  //       val v = current.exec(journal, fiberId, stackSize, r)
+        case ProvideSome(stm, f) =>
+          envStack.push(f.asInstanceOf[AnyRef => AnyRef](envStack.peek()))
 
-  //       if (stack.isEmpty)
-  //         result = v
-  //       else {
-  //         val next = stack.pop()
-  //         current = next(v)
-  //       }
-  //     } catch {
-  //       case cont: ZSTM.Resumable[_, _, _, _] =>
-  //         current = cont.stm
-  //         while (!cont.ks.isEmpty) stack.push(cont.ks.pop().asInstanceOf[Cont])
-  //         stackSize.set(0)
-  //     }
-  //   }
-  //   result.asInstanceOf[TExit[E, A]]
-  // }
+          val cleanup = ZSTM.succeed(envStack.pop())
 
-  private def run(journal: Journal, fiberId: Fiber.Id, r: R): TExit[E, A] = {
-    type Erased = ZSTM[R, Any, Any]
-    type Cont   = Any => Erased
-
-    val stack = new Stack[Cont]()
-
-    def loop(stm: Erased): Any =
-      stm match {
-        case Effect(f) => f(journal, fiberId, r)
-
-        case FlatMap(t, f) =>
-          stack.push(f.asInstanceOf[Cont])
-          loop(t.asInstanceOf[Erased])
-
-        case FoldM(_, _, _, _) => TExit.Retry
+          loop(stm.ensuring(cleanup))
       }
 
     loop(self.asInstanceOf[Erased]).asInstanceOf[TExit[E, A]]
@@ -916,16 +897,12 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  final case class FlatMap[R, E, A, B](self: ZSTM[R, E, A], f: A => ZSTM[R, E, B]) extends ZSTM[R, E, B]
+  private[stm] final case class FlatMap[R, E1, E2, A, B](self: ZSTM[R, E1, A], f: TExit[E1, A] => ZSTM[R, E2, B])
+      extends ZSTM[R, E2, B]
 
-  final case class FoldM[R, E1, E2, A, B](
-    self: ZSTM[R, E1, A],
-    ifError: E1 => ZSTM[R, E2, B],
-    ifSuccess: A => ZSTM[R, E2, B],
-    ifRetry: () => ZSTM[R, E2, B]
-  ) extends ZSTM[R, E2, B]
+  private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => TExit[E, A]) extends ZSTM[R, E, A]
 
-  final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => TExit[E, A]) extends ZSTM[R, E, A]
+  private[stm] final case class ProvideSome[R1, R2, E, A](effect: ZSTM[R1, E, A], f: R2 => R1) extends ZSTM[R2, E, A]
 
   /**
    * Submerges the error case of an `Either` into the `STM`. The inverse

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -321,14 +321,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * and then runs the returned effect as well to produce its results.
    */
   def flatMap[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
-    FlatMap[R1, E, E1, A, B](
-      self,
-      {
-        case TExit.Succeed(value) => f(value)
-        case TExit.Fail(error)    => ZSTM.fail(error)
-        case TExit.Retry          => ZSTM.retry
-      }
-    )
+    foldCauseM(ZSTM.failFn, f, ZSTM.retry)
 
   /**
    * Creates a composite effect that represents this effect followed by another
@@ -376,7 +369,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    */
   def foldM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B])(implicit
     ev: CanFail[E]
-  ): ZSTM[R1, E1, B] = foldAllM(f, g, ZSTM.retry)
+  ): ZSTM[R1, E1, B] = foldCauseM(f, g, ZSTM.retry)
 
   /**
    * Repeats this effect forever (until the first error).
@@ -560,14 +553,11 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Named alias for `<>`.
    */
   def orElse[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
-    FlatMap[R1, Nothing, E1, () => Any, A1](
-      Effect((journal, _, _) => TExit.Succeed(prepareResetJournal(journal))),
-      {
-        case TExit.Succeed(reset) =>
-          self.foldAllM[R1, E1, A1](_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that)
-        case TExit.Fail(nothing) => nothing
-        case TExit.Retry         => ZSTM.retry
-      }
+    FoldCauseM[R1, Nothing, E1, () => Any, A1](
+      Effect((journal, _, _) => prepareResetJournal(journal)),
+      reset => self.foldCauseM(_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that),
+      nothing => nothing,
+      ZSTM.retry
     )
 
   /**
@@ -607,14 +597,11 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Named alias for `<|>`.
    */
   def orTry[R1 <: R, E1 >: E, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
-    FlatMap[R1, Nothing, E1, () => Any, A1](
-      Effect((journal, _, _) => TExit.Succeed(prepareResetJournal(journal))),
-      {
-        case TExit.Succeed(reset) =>
-          self.foldAllM[R1, E1, A1](ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self))
-        case TExit.Fail(nothing) => nothing
-        case TExit.Retry         => ZSTM.retry
-      }
+    FoldCauseM[R1, Nothing, E1, () => Any, A1](
+      Effect((journal, _, _) => prepareResetJournal(journal)),
+      reset => self.foldCauseM(ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self)),
+      ZSTM.failFn,
+      ZSTM.retry
     )
 
   /**
@@ -850,35 +837,59 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   def zipWith[R1 <: R, E1 >: E, B, C](that: => ZSTM[R1, E1, B])(f: (A, B) => C): ZSTM[R1, E1, C] =
     self flatMap (a => that map (b => f(a, b)))
 
-  private def foldAllM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B], h: => ZSTM[R1, E1, B])(implicit
-    ev: CanFail[E]
-  ): ZSTM[R1, E1, B] =
-    FlatMap[R1, E, E1, A, B](
-      self,
-      {
-        case TExit.Fail(error)    => f(error)
-        case TExit.Succeed(value) => g(value)
-        case TExit.Retry          => h
-      }
-    )
+  private def foldCauseM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B], h: => ZSTM[R1, E1, B])(
+    implicit ev: CanFail[E]
+  ): ZSTM[R1, E1, B] = FoldCauseM(self, g, f, h)
 
   private def run(journal: Journal, fiberId: Fiber.Id, r0: R): TExit[E, A] = {
     type Erased = ZSTM[Any, Any, Any]
-    type Cont   = TExit[Any, Any] => Erased
+    type Cont   = Any => Erased
 
     val contStack = Stack[Cont]()
     val envStack  = Stack[AnyRef](r0.asInstanceOf[AnyRef])
 
-    @tailrec
+    // @tailrec
     def loop(self: Erased): TExit[Any, Any] =
       self match {
         case Effect(f) =>
-          val exit = f(journal, fiberId, envStack.peek())
-          if (contStack.isEmpty) exit
-          else loop(contStack.pop()(exit))
+          try {
+            val a = f(journal, fiberId, envStack.peek())
 
-        case FlatMap(stm, k) =>
-          contStack.push(k)
+            if (contStack.isEmpty) TExit.Succeed(a)
+            else {
+              val k = contStack.pop()
+
+              k match {
+                case FoldCauseM(_, onSuccess, _, _) => loop(onSuccess(a))
+                case _                              => loop(k(a))
+              }
+            }
+          } catch {
+            case ZSTM.RetryException =>
+              if (contStack.isEmpty) TExit.Retry
+              else {
+                val k = contStack.pop()
+
+                k match {
+                  case FoldCauseM(_, _, _, onRetry) => loop(onRetry)
+                  case _                            => TExit.Retry
+                }
+              }
+
+            case ZSTM.FailException(e) =>
+              if (contStack.isEmpty) TExit.Fail(e)
+              else {
+                val k = contStack.pop()
+
+                k match {
+                  case FoldCauseM(_, _, onFailure, _) => loop(onFailure(e))
+                  case _                              => TExit.Fail(e)
+                }
+              }
+          }
+
+        case fc @ FoldCauseM(stm, _, _, _) =>
+          contStack.push(fc)
           loop(stm)
 
         case ProvideSome(stm, f) =>
@@ -897,10 +908,25 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  private[stm] final case class FlatMap[R, E1, E2, A, B](self: ZSTM[R, E1, A], f: TExit[E1, A] => ZSTM[R, E2, B])
-      extends ZSTM[R, E2, B]
+  private val _FailFn: Any => ZSTM[Any, Any, Nothing] = ZSTM.fail(_)
 
-  private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => TExit[E, A]) extends ZSTM[R, E, A]
+  private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
+
+  private[stm] case class FailException[E](e: E) extends Throwable(null, null, false, false)
+
+  private[stm] case object RetryException extends Throwable(null, null, false, false)
+
+  private[stm] final case class FoldCauseM[R, E1, E2, A, B](
+    self: ZSTM[R, E1, A],
+    onSuccess: A => ZSTM[R, E2, B],
+    onFailure: E1 => ZSTM[R, E2, B],
+    onRetry: ZSTM[R, E2, B]
+  ) extends ZSTM[R, E2, B]
+      with Function[A, ZSTM[R, E2, B]] {
+    def apply(a: A): ZSTM[R, E2, B] = onSuccess(a)
+  }
+
+  private[stm] final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => A) extends ZSTM[R, E, A]
 
   private[stm] final case class ProvideSome[R1, R2, E, A](effect: ZSTM[R1, E, A], f: R2 => R1) extends ZSTM[R2, E, A]
 
@@ -1005,17 +1031,17 @@ object ZSTM {
   /**
    * Retrieves the environment inside an stm.
    */
-  def environment[R]: URSTM[R, R] = Effect((_, _, r) => TExit.Succeed(r))
+  def environment[R]: URSTM[R, R] = Effect((_, _, r) => r)
 
   /**
    * Returns a value that models failure in the transaction.
    */
-  def fail[E](e: => E): STM[E, Nothing] = Effect((_, _, _) => TExit.Fail(e))
+  def fail[E](e: => E): STM[E, Nothing] = Effect((_, _, _) => throw FailException(e))
 
   /**
    * Returns the fiber id of the fiber committing the transaction.
    */
-  val fiberId: USTM[Fiber.Id] = Effect((_, fiberId, _) => TExit.Succeed(fiberId))
+  val fiberId: USTM[Fiber.Id] = Effect((_, fiberId, _) => fiberId)
 
   /**
    * Filters the collection using the specified effectual predicate.
@@ -1298,7 +1324,7 @@ object ZSTM {
    * Abort and retry the whole transaction when any of the underlying
    * transactional variables have changed.
    */
-  val retry: USTM[Nothing] = Effect((_, _, _) => TExit.Retry)
+  val retry: USTM[Nothing] = Effect((_, _, _) => throw RetryException)
 
   /**
    * Returns an effect with the value on the right part.
@@ -1347,7 +1373,7 @@ object ZSTM {
   /**
    * Returns an `STM` effect that succeeds with the specified value.
    */
-  def succeed[A](a: => A): USTM[A] = Effect((_, _, _) => TExit.Succeed(a))
+  def succeed[A](a: => A): USTM[A] = Effect((_, _, _) => a)
 
   /**
    * Suspends creation of the specified transaction lazily.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -899,8 +899,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 
     def loop(stm: Erased): Any =
       stm match {
-        case Continue(_, _) => TExit.Retry
-
         case Effect(f) => f(journal, fiberId, r)
 
         case FlatMap(t, f) =>
@@ -918,8 +916,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  final case class Continue[R, E, E2, A, B](self: ZSTM[R, E, A], f: TExit[E, A] => TExit[E2, B]) extends ZSTM[R, E2, B]
-
   final case class FlatMap[R, E, A, B](self: ZSTM[R, E, A], f: A => ZSTM[R, E, B]) extends ZSTM[R, E, B]
 
   final case class FoldM[R, E1, E2, A, B](
@@ -930,9 +926,6 @@ object ZSTM {
   ) extends ZSTM[R, E2, B]
 
   final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => TExit[E, A]) extends ZSTM[R, E, A]
-
-  // private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =
-  //   Continue(stm, f)
 
   /**
    * Submerges the error case of an `Either` into the `STM`. The inverse

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -555,8 +555,8 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   def orElse[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
     FoldCauseM[R1, Nothing, E1, () => Any, A1](
       Effect((journal, _, _) => prepareResetJournal(journal)),
-      reset => self.foldCauseM(_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that),
       nothing => nothing,
+      reset => self.foldCauseM(_ => ZSTM.succeed(reset()) *> that, ZSTM.succeed(_), ZSTM.succeed(reset()) *> that),
       ZSTM.retry
     )
 
@@ -599,8 +599,8 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   def orTry[R1 <: R, E1 >: E, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
     FoldCauseM[R1, Nothing, E1, () => Any, A1](
       Effect((journal, _, _) => prepareResetJournal(journal)),
-      reset => self.foldCauseM(ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self)),
       ZSTM.failFn,
+      reset => self.foldCauseM(ZSTM.fail(_), ZSTM.succeed(_), ZSTM.succeed(reset()) *> that.orTry(self)),
       ZSTM.retry
     )
 
@@ -837,9 +837,11 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   def zipWith[R1 <: R, E1 >: E, B, C](that: => ZSTM[R1, E1, B])(f: (A, B) => C): ZSTM[R1, E1, C] =
     self flatMap (a => that map (b => f(a, b)))
 
-  private def foldCauseM[R1 <: R, E1, B](f: E => ZSTM[R1, E1, B], g: A => ZSTM[R1, E1, B], h: => ZSTM[R1, E1, B])(
-    implicit ev: CanFail[E]
-  ): ZSTM[R1, E1, B] = FoldCauseM(self, g, f, h)
+  private def foldCauseM[R1 <: R, E1, B](
+    onFailure: E => ZSTM[R1, E1, B],
+    onSuccess: A => ZSTM[R1, E1, B],
+    onRetry: => ZSTM[R1, E1, B]
+  )(implicit ev: CanFail[E]): ZSTM[R1, E1, B] = FoldCauseM(self, onFailure, onSuccess, onRetry)
 
   private def run(journal: Journal, fiberId: Fiber.Id, r0: R): TExit[E, A] = {
     type Erased = ZSTM[Any, Any, Any]
@@ -861,7 +863,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
               val k = contStack.pop()
 
               curr = k match {
-                case FoldCauseM(_, onSuccess, _, _) => onSuccess(a)
+                case FoldCauseM(_, _, onSuccess, _) => onSuccess(a)
                 case _                              => k(a)
               }
             }
@@ -883,7 +885,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
                 val k = contStack.pop()
 
                 k match {
-                  case FoldCauseM(_, _, onFailure, _) => curr = onFailure(e)
+                  case FoldCauseM(_, onFailure, _, _) => curr = onFailure(e)
                   case _                              => exit = TExit.Fail(e)
                 }
               }
@@ -916,8 +918,8 @@ object ZSTM {
 
   private[stm] final case class FoldCauseM[R, E1, E2, A, B](
     self: ZSTM[R, E1, A],
-    onSuccess: A => ZSTM[R, E2, B],
     onFailure: E1 => ZSTM[R, E2, B],
+    onSuccess: A => ZSTM[R, E2, B],
     onRetry: ZSTM[R, E2, B]
   ) extends ZSTM[R, E2, B]
       with Function[A, ZSTM[R, E2, B]] {

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -912,7 +912,7 @@ object ZSTM {
 
   private def failFn[E]: E => ZSTM[Any, E, Nothing] = _FailFn.asInstanceOf[E => ZSTM[Any, E, Nothing]]
 
-  private[stm] case class FailException[E](e: E) extends Throwable(null, null, false, false)
+  private[stm] final case class FailException[E](e: E) extends Throwable(null, null, false, false)
 
   private[stm] case object RetryException extends Throwable(null, null, false, false)
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -944,19 +944,19 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
 object ZSTM {
   import internal._
 
-  final case class Continue[-R, +E, +E2, +A, +B](self: ZSTM[R, E, A], f: TExit[E, A] => TExit[E2, B])
+  final case class Continue[R, E, E2, A, B](self: ZSTM[R, E, A], f: TExit[E, A] => TExit[E2, B])
       extends ZSTM[R, E2, B]
 
-  final case class FlatMap[-R, +E, +A, +B](self: ZSTM[R, E, A], f: A => ZSTM[R, E, B]) extends ZSTM[R, E, B]
+  final case class FlatMap[R, E, A, B](self: ZSTM[R, E, A], f: A => ZSTM[R, E, B]) extends ZSTM[R, E, B]
 
-  final case class FoldM[-R, +E1, +E2, +A, +B](
+  final case class FoldM[R, E1, E2, A, B](
     self: ZSTM[R, E1, A],
     ifError: E1 => ZSTM[R, E2, B],
     ifSuccess: A => ZSTM[R, E2, B],
     ifRetry: () => ZSTM[R, E2, B]
   ) extends ZSTM[R, E2, B]
 
-  final case class Effect[-R, +E, +A](f: (Journal, Fiber.Id, AtomicLong, R) => TExit[E, A]) extends ZSTM[R, E, A]
+  final case class Effect[R, E, A](f: (Journal, Fiber.Id, AtomicLong, R) => TExit[E, A]) extends ZSTM[R, E, A]
 
   // private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =
   //   Continue(stm, f)

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -927,7 +927,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
       stm match {
         case Continue(_, _)    => TExit.Retry
 
-        case Effect(f)         => f(journal, fiberId, new AtomicLong(0), r)
+        case Effect(f)         => f(journal, fiberId, r)
 
         case FlatMap(t, f)     =>
           stack.push(f.asInstanceOf[Cont])
@@ -956,7 +956,7 @@ object ZSTM {
     ifRetry: () => ZSTM[R, E2, B]
   ) extends ZSTM[R, E2, B]
 
-  final case class Effect[R, E, A](f: (Journal, Fiber.Id, AtomicLong, R) => TExit[E, A]) extends ZSTM[R, E, A]
+  final case class Effect[R, E, A](f: (Journal, Fiber.Id, R) => TExit[E, A]) extends ZSTM[R, E, A]
 
   // private def continue[R, E, E2, A, B](stm: ZSTM[R, E, A])(f: TExit[E, A] => TExit[E2, B]): ZSTM[R, E2, B] =
   //   Continue(stm, f)
@@ -1062,17 +1062,17 @@ object ZSTM {
   /**
    * Retrieves the environment inside an stm.
    */
-  def environment[R]: URSTM[R, R] = Effect((_, _, _, r) => TExit.Succeed(r))
+  def environment[R]: URSTM[R, R] = Effect((_, _, r) => TExit.Succeed(r))
 
   /**
    * Returns a value that models failure in the transaction.
    */
-  def fail[E](e: => E): STM[E, Nothing] = Effect((_, _, _, _) => TExit.Fail(e))
+  def fail[E](e: => E): STM[E, Nothing] = Effect((_, _, _) => TExit.Fail(e))
 
   /**
    * Returns the fiber id of the fiber committing the transaction.
    */
-  val fiberId: USTM[Fiber.Id] = Effect((_, fiberId, _, _) => TExit.Succeed(fiberId))
+  val fiberId: USTM[Fiber.Id] = Effect((_, fiberId, _) => TExit.Succeed(fiberId))
 
   /**
    * Filters the collection using the specified effectual predicate.
@@ -1355,7 +1355,7 @@ object ZSTM {
    * Abort and retry the whole transaction when any of the underlying
    * transactional variables have changed.
    */
-  val retry: USTM[Nothing] = Effect((_, _, _, _) => TExit.Retry)
+  val retry: USTM[Nothing] = Effect((_, _, _) => TExit.Retry)
 
   /**
    * Returns an effect with the value on the right part.
@@ -1404,7 +1404,7 @@ object ZSTM {
   /**
    * Returns an `STM` effect that succeeds with the specified value.
    */
-  def succeed[A](a: => A): USTM[A] = Effect((_, _, _, _) => TExit.Succeed(a))
+  def succeed[A](a: => A): USTM[A] = Effect((_, _, _) => TExit.Succeed(a))
 
   /**
    * Suspends creation of the specified transaction lazily.

--- a/core/shared/src/main/scala/zio/stm/ZTRef.scala
+++ b/core/shared/src/main/scala/zio/stm/ZTRef.scala
@@ -206,13 +206,13 @@ object ZTRef {
       }
 
     def get: USTM[A] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry = getOrMakeEntry(journal)
         TExit.Succeed(entry.unsafeGet[A])
       })
 
     def set(a: A): USTM[Unit] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry = getOrMakeEntry(journal)
         entry.unsafeSet(a)
         TExit.unit
@@ -222,7 +222,7 @@ object ZTRef {
      * Sets the value of the `ZTRef` and returns the old value.
      */
     def getAndSet(a: A): USTM[A] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(a)
@@ -233,7 +233,7 @@ object ZTRef {
      * Updates the value of the variable and returns the old value.
      */
     def getAndUpdate(f: A => A): USTM[A] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(f(oldValue))
@@ -252,7 +252,7 @@ object ZTRef {
      * value.
      */
     def modify[B](f: A => (B, A)): USTM[B] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry                = getOrMakeEntry(journal)
         val (retValue, newValue) = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -273,7 +273,7 @@ object ZTRef {
      * Updates the value of the variable.
      */
     def update(f: A => A): USTM[Unit] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -284,7 +284,7 @@ object ZTRef {
      * Updates the value of the variable and returns the new value.
      */
     def updateAndGet(f: A => A): USTM[A] =
-      ZSTM.Effect((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -533,7 +533,7 @@ object ZTRef {
    * Makes a new `ZTRef` that is initialized to the specified value.
    */
   def make[A](a: => A): USTM[TRef[A]] =
-    ZSTM.Effect((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _) => {
       val value     = a
       val versioned = new Versioned(value)
       val todo      = new AtomicReference[Map[TxnId, Todo]](Map())

--- a/core/shared/src/main/scala/zio/stm/ZTRef.scala
+++ b/core/shared/src/main/scala/zio/stm/ZTRef.scala
@@ -206,16 +206,13 @@ object ZTRef {
       }
 
     def get: USTM[A] =
-      ZSTM.Effect { (journal, _, _) =>
-        val entry = getOrMakeEntry(journal)
-        TExit.Succeed(entry.unsafeGet[A])
-      }
+      ZSTM.Effect((journal, _, _) => getOrMakeEntry(journal).unsafeGet[A])
 
     def set(a: A): USTM[Unit] =
       ZSTM.Effect { (journal, _, _) =>
         val entry = getOrMakeEntry(journal)
         entry.unsafeSet(a)
-        TExit.unit
+        ()
       }
 
     /**
@@ -226,7 +223,7 @@ object ZTRef {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(a)
-        TExit.Succeed(oldValue)
+        oldValue
       }
 
     /**
@@ -237,7 +234,7 @@ object ZTRef {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(f(oldValue))
-        TExit.Succeed(oldValue)
+        oldValue
       }
 
     /**
@@ -256,7 +253,7 @@ object ZTRef {
         val entry                = getOrMakeEntry(journal)
         val (retValue, newValue) = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
-        TExit.Succeed(retValue)
+        retValue
       }
 
     /**
@@ -277,7 +274,7 @@ object ZTRef {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
-        TExit.unit
+        ()
       }
 
     /**
@@ -288,7 +285,7 @@ object ZTRef {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
-        TExit.Succeed(newValue)
+        newValue
       }
 
     /**
@@ -539,7 +536,7 @@ object ZTRef {
       val todo      = new AtomicReference[Map[TxnId, Todo]](Map())
       val tref      = new Atomic(versioned, todo)
       journal.put(tref, Entry(tref, true))
-      TExit.Succeed(tref)
+      tref
     }
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZTRef.scala
+++ b/core/shared/src/main/scala/zio/stm/ZTRef.scala
@@ -206,39 +206,39 @@ object ZTRef {
       }
 
     def get: USTM[A] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry = getOrMakeEntry(journal)
         TExit.Succeed(entry.unsafeGet[A])
-      })
+      }
 
     def set(a: A): USTM[Unit] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry = getOrMakeEntry(journal)
         entry.unsafeSet(a)
         TExit.unit
-      })
+      }
 
     /**
      * Sets the value of the `ZTRef` and returns the old value.
      */
     def getAndSet(a: A): USTM[A] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(a)
         TExit.Succeed(oldValue)
-      })
+      }
 
     /**
      * Updates the value of the variable and returns the old value.
      */
     def getAndUpdate(f: A => A): USTM[A] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(f(oldValue))
         TExit.Succeed(oldValue)
-      })
+      }
 
     /**
      * Updates some values of the variable but leaves others alone, returning the
@@ -252,12 +252,12 @@ object ZTRef {
      * value.
      */
     def modify[B](f: A => (B, A)): USTM[B] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry                = getOrMakeEntry(journal)
         val (retValue, newValue) = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
         TExit.Succeed(retValue)
-      })
+      }
 
     /**
      * Updates the value of the variable, returning a function of the specified
@@ -273,23 +273,23 @@ object ZTRef {
      * Updates the value of the variable.
      */
     def update(f: A => A): USTM[Unit] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
         TExit.unit
-      })
+      }
 
     /**
      * Updates the value of the variable and returns the new value.
      */
     def updateAndGet(f: A => A): USTM[A] =
-      ZSTM.Effect((journal, _, _) => {
+      ZSTM.Effect { (journal, _, _) =>
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
         TExit.Succeed(newValue)
-      })
+      }
 
     /**
      * Updates some values of the variable but leaves others alone.
@@ -533,14 +533,14 @@ object ZTRef {
    * Makes a new `ZTRef` that is initialized to the specified value.
    */
   def make[A](a: => A): USTM[TRef[A]] =
-    ZSTM.Effect((journal, _, _) => {
+    ZSTM.Effect { (journal, _, _) =>
       val value     = a
       val versioned = new Versioned(value)
       val todo      = new AtomicReference[Map[TxnId, Todo]](Map())
       val tref      = new Atomic(versioned, todo)
       journal.put(tref, Entry(tref, true))
       TExit.Succeed(tref)
-    })
+    }
 
   /**
    * A convenience method that makes a `ZTRef` and immediately commits the

--- a/core/shared/src/main/scala/zio/stm/ZTRef.scala
+++ b/core/shared/src/main/scala/zio/stm/ZTRef.scala
@@ -206,13 +206,13 @@ object ZTRef {
       }
 
     def get: USTM[A] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry = getOrMakeEntry(journal)
         TExit.Succeed(entry.unsafeGet[A])
       })
 
     def set(a: A): USTM[Unit] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry = getOrMakeEntry(journal)
         entry.unsafeSet(a)
         TExit.unit
@@ -222,7 +222,7 @@ object ZTRef {
      * Sets the value of the `ZTRef` and returns the old value.
      */
     def getAndSet(a: A): USTM[A] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(a)
@@ -233,7 +233,7 @@ object ZTRef {
      * Updates the value of the variable and returns the old value.
      */
     def getAndUpdate(f: A => A): USTM[A] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val oldValue = entry.unsafeGet[A]
         entry.unsafeSet(f(oldValue))
@@ -252,7 +252,7 @@ object ZTRef {
      * value.
      */
     def modify[B](f: A => (B, A)): USTM[B] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry                = getOrMakeEntry(journal)
         val (retValue, newValue) = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -273,7 +273,7 @@ object ZTRef {
      * Updates the value of the variable.
      */
     def update(f: A => A): USTM[Unit] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -284,7 +284,7 @@ object ZTRef {
      * Updates the value of the variable and returns the new value.
      */
     def updateAndGet(f: A => A): USTM[A] =
-      new ZSTM((journal, _, _, _) => {
+      ZSTM.Effect((journal, _, _, _) => {
         val entry    = getOrMakeEntry(journal)
         val newValue = f(entry.unsafeGet[A])
         entry.unsafeSet(newValue)
@@ -533,7 +533,7 @@ object ZTRef {
    * Makes a new `ZTRef` that is initialized to the specified value.
    */
   def make[A](a: => A): USTM[TRef[A]] =
-    new ZSTM((journal, _, _, _) => {
+    ZSTM.Effect((journal, _, _, _) => {
       val value     = a
       val versioned = new Versioned(value)
       val todo      = new AtomicReference[Map[TxnId, Todo]](Map())

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -13,6 +13,7 @@ object MimaSettings {
       mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
       mimaBinaryIssueFilters ++= Seq(
         exclude[Problem]("zio.internal.*"),
+        exclude[Problem]("zio.stm.*"),
         exclude[DirectMissingMethodProblem]("zio.ZManaged.reserve"),
         exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this")
       ),


### PR DESCRIPTION
This pull request changes the encoding of ZSTM to a declarative one, similar to the one used in ZIO, intending to improve its performance.

The following sections contain benchmark results. The latest version from master - 590c24c0f9ceaf14c337367fbf8d2fb39542212d, is used as baseline.

### TArray

#### Before

```
Benchmark                          (size)   Mode  Cnt       Score        Error  Units
TArrayOpsBenchmarks.find               10  thrpt   15  179549.856 ±   2254.001  ops/s
TArrayOpsBenchmarks.find              100  thrpt   15  100904.365 ±  36388.462  ops/s
TArrayOpsBenchmarks.find             1000  thrpt   15    3776.653 ±     35.453  ops/s
TArrayOpsBenchmarks.find            10000  thrpt   15     238.890 ±      3.947  ops/s
TArrayOpsBenchmarks.find           100000  thrpt   15      23.592 ±      4.625  ops/s
TArrayOpsBenchmarks.findM              10  thrpt   15   94526.589 ±   1375.946  ops/s
TArrayOpsBenchmarks.findM             100  thrpt   15   11963.031 ±    511.167  ops/s
TArrayOpsBenchmarks.findM            1000  thrpt   15    3010.418 ±      8.302  ops/s
TArrayOpsBenchmarks.findM           10000  thrpt   15      91.556 ±      3.066  ops/s
TArrayOpsBenchmarks.findM          100000  thrpt   15       3.150 ±      0.053  ops/s
TArrayOpsBenchmarks.fold               10  thrpt   15  478163.249 ±    407.561  ops/s
TArrayOpsBenchmarks.fold              100  thrpt   15   46480.346 ±    692.277  ops/s
TArrayOpsBenchmarks.fold             1000  thrpt   15    3525.044 ±     37.371  ops/s
TArrayOpsBenchmarks.fold            10000  thrpt   15     520.609 ±    207.883  ops/s
TArrayOpsBenchmarks.fold           100000  thrpt   15       6.033 ±      0.298  ops/s
TArrayOpsBenchmarks.foldM              10  thrpt   15   91136.232 ±    924.846  ops/s
TArrayOpsBenchmarks.foldM             100  thrpt   15   15872.687 ±   8841.261  ops/s
TArrayOpsBenchmarks.foldM            1000  thrpt   15     817.120 ±    414.170  ops/s
TArrayOpsBenchmarks.foldM           10000  thrpt   15      38.311 ±      1.422  ops/s
TArrayOpsBenchmarks.foldM          100000  thrpt   15       2.894 ±      1.578  ops/s
TArrayOpsBenchmarks.indexWhere         10  thrpt   15  282897.341 ± 146569.141  ops/s
TArrayOpsBenchmarks.indexWhere        100  thrpt   15   47112.732 ±    554.623  ops/s
TArrayOpsBenchmarks.indexWhere       1000  thrpt   15    3581.373 ±     47.226  ops/s
TArrayOpsBenchmarks.indexWhere      10000  thrpt   15     524.009 ±    205.139  ops/s
TArrayOpsBenchmarks.indexWhere     100000  thrpt   15       6.425 ±      0.234  ops/s
TArrayOpsBenchmarks.indexWhereM        10  thrpt   15  128710.757 ±   1720.708  ops/s
TArrayOpsBenchmarks.indexWhereM       100  thrpt   15   56104.418 ±  13148.243  ops/s
TArrayOpsBenchmarks.indexWhereM      1000  thrpt   15    1460.726 ±     28.721  ops/s
TArrayOpsBenchmarks.indexWhereM     10000  thrpt   15     111.934 ±      4.932  ops/s
TArrayOpsBenchmarks.indexWhereM    100000  thrpt   15      10.479 ±      0.290  ops/s
TArrayOpsBenchmarks.lookup             10  thrpt   15    2898.011 ±     39.818  ops/s
TArrayOpsBenchmarks.lookup            100  thrpt   15    2899.231 ±     34.567  ops/s
TArrayOpsBenchmarks.lookup           1000  thrpt   15    7742.991 ±     17.094  ops/s
TArrayOpsBenchmarks.lookup          10000  thrpt   15    2152.589 ±     31.201  ops/s
TArrayOpsBenchmarks.lookup         100000  thrpt   15    2822.675 ±     23.449  ops/s
TArrayOpsBenchmarks.reduceOption       10  thrpt   15  410328.927 ± 135850.986  ops/s
TArrayOpsBenchmarks.reduceOption      100  thrpt   15   45997.991 ±    875.609  ops/s
TArrayOpsBenchmarks.reduceOption     1000  thrpt   15    3169.543 ±     32.357  ops/s
TArrayOpsBenchmarks.reduceOption    10000  thrpt   15     396.042 ±    215.278  ops/s
TArrayOpsBenchmarks.reduceOption   100000  thrpt   15       7.680 ±      4.748  ops/s
TArrayOpsBenchmarks.reduceOptionM      10  thrpt   15   81335.803 ±   1007.464  ops/s
TArrayOpsBenchmarks.reduceOptionM     100  thrpt   15    8976.763 ±    405.668  ops/s
TArrayOpsBenchmarks.reduceOptionM    1000  thrpt   15    1087.285 ±    516.888  ops/s
TArrayOpsBenchmarks.reduceOptionM   10000  thrpt   15      37.012 ±      1.442  ops/s
TArrayOpsBenchmarks.reduceOptionM  100000  thrpt   15       2.223 ±      0.048  ops/s
TArrayOpsBenchmarks.transform          10  thrpt   15  322845.421 ± 134588.203  ops/s
TArrayOpsBenchmarks.transform         100  thrpt   15   34240.216 ±    355.018  ops/s
TArrayOpsBenchmarks.transform        1000  thrpt   15    2451.817 ±     20.586  ops/s
TArrayOpsBenchmarks.transform       10000  thrpt   15     438.771 ±     55.657  ops/s
TArrayOpsBenchmarks.transform      100000  thrpt   15       3.904 ±      0.130  ops/s
TArrayOpsBenchmarks.transformM         10  thrpt   15   78933.497 ±    858.017  ops/s
TArrayOpsBenchmarks.transformM        100  thrpt   15   25735.062 ±    214.456  ops/s
TArrayOpsBenchmarks.transformM       1000  thrpt   15     751.115 ±     12.811  ops/s
TArrayOpsBenchmarks.transformM      10000  thrpt   15      58.295 ±      1.522  ops/s
TArrayOpsBenchmarks.transformM     100000  thrpt   15       6.224 ±      0.195  ops/s
TArrayOpsBenchmarks.update             10  thrpt   15    2723.976 ±     25.886  ops/s
TArrayOpsBenchmarks.update            100  thrpt   15    2706.516 ±     19.234  ops/s
TArrayOpsBenchmarks.update           1000  thrpt   15    6601.722 ±   1623.339  ops/s
TArrayOpsBenchmarks.update          10000  thrpt   15    2531.806 ±     20.980  ops/s
TArrayOpsBenchmarks.update         100000  thrpt   15    2560.499 ±     21.071  ops/s
TArrayOpsBenchmarks.updateM            10  thrpt   15    3252.176 ±   1572.536  ops/s
TArrayOpsBenchmarks.updateM           100  thrpt   15    1632.590 ±     19.241  ops/s
TArrayOpsBenchmarks.updateM          1000  thrpt   15    1741.424 ±     18.927  ops/s
TArrayOpsBenchmarks.updateM         10000  thrpt   15    2035.552 ±   1036.124  ops/s
TArrayOpsBenchmarks.updateM        100000  thrpt   15    2494.702 ±   1313.301  ops/s
```

#### After

```
Benchmark                          (size)   Mode  Cnt       Score       Error  Units
TArrayOpsBenchmarks.find               10  thrpt   15  479496.180 ±   615.206  ops/s
TArrayOpsBenchmarks.find              100  thrpt   15  124181.092 ±   150.847  ops/s
TArrayOpsBenchmarks.find             1000  thrpt   15    9857.831 ±    28.309  ops/s
TArrayOpsBenchmarks.find            10000  thrpt   15     656.120 ±     3.308  ops/s
TArrayOpsBenchmarks.find           100000  thrpt   15      24.073 ±     1.174  ops/s
TArrayOpsBenchmarks.findM              10  thrpt   15  303843.483 ±   377.320  ops/s
TArrayOpsBenchmarks.findM             100  thrpt   15   51237.792 ±    99.112  ops/s
TArrayOpsBenchmarks.findM            1000  thrpt   15    3967.423 ±     6.453  ops/s
TArrayOpsBenchmarks.findM           10000  thrpt   15     348.757 ±     3.058  ops/s
TArrayOpsBenchmarks.findM          100000  thrpt   15      12.566 ±     0.673  ops/s
TArrayOpsBenchmarks.fold               10  thrpt   15  477514.963 ±   593.632  ops/s
TArrayOpsBenchmarks.fold              100  thrpt   15  121218.496 ±   184.899  ops/s
TArrayOpsBenchmarks.fold             1000  thrpt   15    9703.641 ±    31.260  ops/s
TArrayOpsBenchmarks.fold            10000  thrpt   15     645.616 ±     5.220  ops/s
TArrayOpsBenchmarks.fold           100000  thrpt   15      22.138 ±     1.600  ops/s
TArrayOpsBenchmarks.foldM              10  thrpt   15  265368.275 ±   706.619  ops/s
TArrayOpsBenchmarks.foldM             100  thrpt   15   42409.511 ±    60.470  ops/s
TArrayOpsBenchmarks.foldM            1000  thrpt   15    3444.914 ±     8.487  ops/s
TArrayOpsBenchmarks.foldM           10000  thrpt   15     325.850 ±     1.557  ops/s
TArrayOpsBenchmarks.foldM          100000  thrpt   15      10.549 ±     0.254  ops/s
TArrayOpsBenchmarks.indexWhere         10  thrpt   15  475493.516 ±   857.737  ops/s
TArrayOpsBenchmarks.indexWhere        100  thrpt   15  126688.685 ±    93.029  ops/s
TArrayOpsBenchmarks.indexWhere       1000  thrpt   15   10011.308 ±    43.110  ops/s
TArrayOpsBenchmarks.indexWhere      10000  thrpt   15     673.131 ±     5.321  ops/s
TArrayOpsBenchmarks.indexWhere     100000  thrpt   15      22.505 ±     2.022  ops/s
TArrayOpsBenchmarks.indexWhereM        10  thrpt   15  377975.967 ±   353.525  ops/s
TArrayOpsBenchmarks.indexWhereM       100  thrpt   15   73549.969 ±   115.304  ops/s
TArrayOpsBenchmarks.indexWhereM      1000  thrpt   15    5298.496 ±     7.691  ops/s
TArrayOpsBenchmarks.indexWhereM     10000  thrpt   15     459.579 ±    11.128  ops/s
TArrayOpsBenchmarks.indexWhereM    100000  thrpt   15      12.882 ±     0.379  ops/s
TArrayOpsBenchmarks.lookup             10  thrpt   15    7352.442 ±    51.625  ops/s
TArrayOpsBenchmarks.lookup            100  thrpt   15    7491.974 ±    10.985  ops/s
TArrayOpsBenchmarks.lookup           1000  thrpt   15    7470.940 ±     7.828  ops/s
TArrayOpsBenchmarks.lookup          10000  thrpt   15    7262.242 ±     8.449  ops/s
TArrayOpsBenchmarks.lookup         100000  thrpt   15    5777.528 ±    20.192  ops/s
TArrayOpsBenchmarks.reduceOption       10  thrpt   15  473261.824 ±  3670.340  ops/s
TArrayOpsBenchmarks.reduceOption      100  thrpt   15  120809.769 ±   117.493  ops/s
TArrayOpsBenchmarks.reduceOption     1000  thrpt   15    9564.268 ±    27.791  ops/s
TArrayOpsBenchmarks.reduceOption    10000  thrpt   15     656.598 ±     3.985  ops/s
TArrayOpsBenchmarks.reduceOption   100000  thrpt   15      22.356 ±     1.177  ops/s
TArrayOpsBenchmarks.reduceOptionM      10  thrpt   15  221073.968 ±  1132.185  ops/s
TArrayOpsBenchmarks.reduceOptionM     100  thrpt   15   33960.814 ±    40.824  ops/s
TArrayOpsBenchmarks.reduceOptionM    1000  thrpt   15    2939.036 ±     6.406  ops/s
TArrayOpsBenchmarks.reduceOptionM   10000  thrpt   15     265.613 ±     1.284  ops/s
TArrayOpsBenchmarks.reduceOptionM  100000  thrpt   15      10.741 ±     0.358  ops/s
TArrayOpsBenchmarks.transform          10  thrpt   15  414375.899 ±   344.412  ops/s
TArrayOpsBenchmarks.transform         100  thrpt   15   33895.537 ±   332.888  ops/s
TArrayOpsBenchmarks.transform        1000  thrpt   15    5615.220 ±  2085.861  ops/s
TArrayOpsBenchmarks.transform       10000  thrpt   15     178.360 ±     2.509  ops/s
TArrayOpsBenchmarks.transform      100000  thrpt   15       4.146 ±     0.134  ops/s
TArrayOpsBenchmarks.transformM         10  thrpt   15  158099.269 ± 82096.536  ops/s
TArrayOpsBenchmarks.transformM        100  thrpt   15   13277.839 ±  4559.803  ops/s
TArrayOpsBenchmarks.transformM       1000  thrpt   15    1110.351 ±    22.878  ops/s
TArrayOpsBenchmarks.transformM      10000  thrpt   15     100.314 ±    46.059  ops/s
TArrayOpsBenchmarks.transformM     100000  thrpt   15       3.567 ±     1.987  ops/s
TArrayOpsBenchmarks.update             10  thrpt   15    2660.324 ±    49.534  ops/s
TArrayOpsBenchmarks.update            100  thrpt   15    2668.692 ±    37.798  ops/s
TArrayOpsBenchmarks.update           1000  thrpt   15    5387.682 ±  2169.463  ops/s
TArrayOpsBenchmarks.update          10000  thrpt   15    2641.401 ±    27.150  ops/s
TArrayOpsBenchmarks.update         100000  thrpt   15    2431.362 ±    29.276  ops/s
TArrayOpsBenchmarks.updateM            10  thrpt   15    4346.987 ±   794.557  ops/s
TArrayOpsBenchmarks.updateM           100  thrpt   15    1776.712 ±    36.313  ops/s
TArrayOpsBenchmarks.updateM          1000  thrpt   15    1666.502 ±    19.049  ops/s
TArrayOpsBenchmarks.updateM         10000  thrpt   15    4333.688 ±     2.518  ops/s
TArrayOpsBenchmarks.updateM        100000  thrpt   15    1582.372 ±    12.367  ops/s
```

### TReentrantLock

#### Before

```
Benchmark                                                              Mode  Cnt        Score         Error  Units
TReentrantLockBenchmark.JavaLockBasic                                 thrpt   20   668079.294 ±    8563.079  ops/s
TReentrantLockBenchmark.JavaLockBasic:javaLockReadGroup               thrpt   20    48466.025 ±    6825.909  ops/s
TReentrantLockBenchmark.JavaLockBasic:javaLockWriteGroup              thrpt   20   619613.269 ±    6481.720  ops/s
TReentrantLockBenchmark.JavaLockHighContention                        thrpt   20  2543805.382 ± 1495997.146  ops/s
TReentrantLockBenchmark.JavaLockHighContention:javaLockReadGroup3     thrpt   20  1577175.953 ±  998734.499  ops/s
TReentrantLockBenchmark.JavaLockHighContention:javaLockWriteGroup3    thrpt   20   966629.429 ±  523226.595  ops/s
TReentrantLockBenchmark.JavaLockLowContention                         thrpt   20  1720706.097 ±  898311.791  ops/s
TReentrantLockBenchmark.JavaLockLowContention:javaLockReadGroup1      thrpt   20  1420807.187 ±  752032.037  ops/s
TReentrantLockBenchmark.JavaLockLowContention:javaLockWriteGroup1     thrpt   20   299898.910 ±  156663.955  ops/s
TReentrantLockBenchmark.JavaLockMediumContention                      thrpt   20  2371901.528 ± 1527448.086  ops/s
TReentrantLockBenchmark.JavaLockMediumContention:javaLockReadGroup2   thrpt   20  1712245.750 ± 1120002.331  ops/s
TReentrantLockBenchmark.JavaLockMediumContention:javaLockWriteGroup2  thrpt   20   659655.777 ±  412053.850  ops/s
TReentrantLockBenchmark.ZioLockBasic                                  thrpt   20    80724.832 ±   60831.806  ops/s
TReentrantLockBenchmark.ZioLockBasic:zioLockReadGroup                 thrpt   20    40427.531 ±   30476.993  ops/s
TReentrantLockBenchmark.ZioLockBasic:zioLockWriteGroup                thrpt   20    40297.301 ±   30354.957  ops/s
TReentrantLockBenchmark.ZioLockHighContention                         thrpt   20    43918.724 ±    1555.958  ops/s
TReentrantLockBenchmark.ZioLockHighContention:zioLockReadGroup3       thrpt   20    21886.606 ±     868.890  ops/s
TReentrantLockBenchmark.ZioLockHighContention:zioLockWriteGroup3      thrpt   20    22032.119 ±     891.499  ops/s
TReentrantLockBenchmark.ZioLockLowContention                          thrpt   20    80485.318 ±   60173.781  ops/s
TReentrantLockBenchmark.ZioLockLowContention:zioLockReadGroup1        thrpt   20    64304.512 ±   48103.124  ops/s
TReentrantLockBenchmark.ZioLockLowContention:zioLockWriteGroup1       thrpt   20    16180.806 ±   12078.240  ops/s
TReentrantLockBenchmark.ZioLockMediumContention                       thrpt   20    43722.252 ±    1982.662  ops/s
TReentrantLockBenchmark.ZioLockMediumContention:zioLockReadGroup2     thrpt   20    29248.573 ±    1393.106  ops/s
TReentrantLockBenchmark.ZioLockMediumContention:zioLockWriteGroup2    thrpt   20    14473.680 ±     854.821  ops/s
```

#### After

```
Benchmark                                                              Mode  Cnt        Score         Error  Units
TReentrantLockBenchmark.JavaLockBasic                                 thrpt   20  1014183.922 ±  707157.803  ops/s
TReentrantLockBenchmark.JavaLockBasic:javaLockReadGroup               thrpt   20    51750.570 ±    8973.856  ops/s
TReentrantLockBenchmark.JavaLockBasic:javaLockWriteGroup              thrpt   20   962433.353 ±  701791.603  ops/s
TReentrantLockBenchmark.JavaLockHighContention                        thrpt   20  2479245.548 ± 1432173.674  ops/s
TReentrantLockBenchmark.JavaLockHighContention:javaLockReadGroup3     thrpt   20  1448461.354 ±  882274.533  ops/s
TReentrantLockBenchmark.JavaLockHighContention:javaLockWriteGroup3    thrpt   20  1030784.194 ±  588351.655  ops/s
TReentrantLockBenchmark.JavaLockLowContention                         thrpt   20  1427840.896 ±   52057.474  ops/s
TReentrantLockBenchmark.JavaLockLowContention:javaLockReadGroup1      thrpt   20  1138802.500 ±   83655.569  ops/s
TReentrantLockBenchmark.JavaLockLowContention:javaLockWriteGroup1     thrpt   20   289038.397 ±   34764.968  ops/s
TReentrantLockBenchmark.JavaLockMediumContention                      thrpt   20  2703598.607 ± 1609031.234  ops/s
TReentrantLockBenchmark.JavaLockMediumContention:javaLockReadGroup2   thrpt   20  1903896.382 ± 1150230.796  ops/s
TReentrantLockBenchmark.JavaLockMediumContention:javaLockWriteGroup2  thrpt   20   799702.225 ±  462236.764  ops/s
TReentrantLockBenchmark.ZioLockBasic                                  thrpt   20    61323.795 ±   43116.090  ops/s
TReentrantLockBenchmark.ZioLockBasic:zioLockReadGroup                 thrpt   20    30502.052 ±   21484.410  ops/s
TReentrantLockBenchmark.ZioLockBasic:zioLockWriteGroup                thrpt   20    30821.742 ±   21632.236  ops/s
TReentrantLockBenchmark.ZioLockHighContention                         thrpt   20    74381.605 ±   57956.523  ops/s
TReentrantLockBenchmark.ZioLockHighContention:zioLockReadGroup3       thrpt   20    37415.115 ±   28950.419  ops/s
TReentrantLockBenchmark.ZioLockHighContention:zioLockWriteGroup3      thrpt   20    36966.490 ±   29019.289  ops/s
TReentrantLockBenchmark.ZioLockLowContention                          thrpt   20    74221.771 ±   60545.223  ops/s
TReentrantLockBenchmark.ZioLockLowContention:zioLockReadGroup1        thrpt   20    59258.412 ±   48443.790  ops/s
TReentrantLockBenchmark.ZioLockLowContention:zioLockWriteGroup1       thrpt   20    14963.359 ±   12113.298  ops/s
TReentrantLockBenchmark.ZioLockMediumContention                       thrpt   20    69202.718 ±   56326.866  ops/s
TReentrantLockBenchmark.ZioLockMediumContention:zioLockReadGroup2     thrpt   20    46234.532 ±   37646.704  ops/s
TReentrantLockBenchmark.ZioLockMediumContention:zioLockWriteGroup2    thrpt   20    22968.186 ±   18688.454  ops/s
```

### TMap vs TRef contention

#### Before

```
Benchmark                               (repeatedUpdates)   Mode  Cnt    Score   Error  Units
TMapContentionBenchmarks.contentionMap                100  thrpt   15  141.378 ± 0.533  ops/s
TMapContentionBenchmarks.contentionMap               1000  thrpt   15   14.696 ± 0.080  ops/s
TMapContentionBenchmarks.contentionMap              10000  thrpt   15    1.514 ± 0.016  ops/s
TMapContentionBenchmarks.contentionRef                100  thrpt   15  155.414 ± 0.831  ops/s
TMapContentionBenchmarks.contentionRef               1000  thrpt   15   16.956 ± 0.052  ops/s
TMapContentionBenchmarks.contentionRef              10000  thrpt   15    1.705 ± 0.007  ops/s
```

#### After

```
Benchmark                               (repeatedUpdates)   Mode  Cnt    Score   Error  Units
TMapContentionBenchmarks.contentionMap                100  thrpt   15  139.635 ± 0.450  ops/s
TMapContentionBenchmarks.contentionMap               1000  thrpt   15   14.376 ± 0.039  ops/s
TMapContentionBenchmarks.contentionMap              10000  thrpt   15    1.469 ± 0.011  ops/s
TMapContentionBenchmarks.contentionRef                100  thrpt   15  152.830 ± 0.535  ops/s
TMapContentionBenchmarks.contentionRef               1000  thrpt   15    9.040 ± 5.913  ops/s
TMapContentionBenchmarks.contentionRef              10000  thrpt   15    0.532 ± 0.092  ops/s
```

### TMap

#### Before

```
Benchmark                     (size)   Mode  Cnt       Score        Error  Units
TMapOpsBenchmarks.fold             0  thrpt   15  266643.523 ± 135525.766  ops/s
TMapOpsBenchmarks.fold            10  thrpt   15  260146.778 ± 125049.286  ops/s
TMapOpsBenchmarks.fold           100  thrpt   15   66289.916 ±  33957.553  ops/s
TMapOpsBenchmarks.fold          1000  thrpt   15    5517.232 ±   2884.312  ops/s
TMapOpsBenchmarks.fold         10000  thrpt   15     212.703 ±    124.214  ops/s
TMapOpsBenchmarks.fold        100000  thrpt   15       7.675 ±      5.359  ops/s
TMapOpsBenchmarks.foldM            0  thrpt   15  195224.560 ± 107673.762  ops/s
TMapOpsBenchmarks.foldM           10  thrpt   15  152904.102 ±  80814.611  ops/s
TMapOpsBenchmarks.foldM          100  thrpt   15   28840.842 ±  15308.443  ops/s
TMapOpsBenchmarks.foldM         1000  thrpt   15    1701.679 ±    846.569  ops/s
TMapOpsBenchmarks.foldM        10000  thrpt   15      87.202 ±     43.281  ops/s
TMapOpsBenchmarks.foldM       100000  thrpt   15       3.425 ±      0.863  ops/s
TMapOpsBenchmarks.lookup           0  thrpt   15    2498.407 ±     26.104  ops/s
TMapOpsBenchmarks.lookup          10  thrpt   15    2463.507 ±     16.625  ops/s
TMapOpsBenchmarks.lookup         100  thrpt   15    2363.047 ±     13.906  ops/s
TMapOpsBenchmarks.lookup        1000  thrpt   15    2241.823 ±     19.667  ops/s
TMapOpsBenchmarks.lookup       10000  thrpt   15    2240.942 ±     21.191  ops/s
TMapOpsBenchmarks.lookup      100000  thrpt   15    2154.594 ±     17.272  ops/s
TMapOpsBenchmarks.removal          0  thrpt   15    2281.933 ±     15.861  ops/s
TMapOpsBenchmarks.removal         10  thrpt   15    2349.618 ±     16.106  ops/s
TMapOpsBenchmarks.removal        100  thrpt   15    2174.145 ±     11.742  ops/s
TMapOpsBenchmarks.removal       1000  thrpt   15    2198.926 ±     14.884  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15    2113.325 ±      8.153  ops/s
TMapOpsBenchmarks.removal     100000  thrpt   15    2060.277 ±      8.777  ops/s
TMapOpsBenchmarks.transform        0  thrpt   15  116952.686 ±    935.262  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  113310.522 ±   1147.105  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   23976.429 ±   1732.954  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    1907.304 ±    236.981  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15      81.380 ±     19.194  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       2.462 ±      1.060  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  125215.213 ±  52393.540  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   73208.339 ±  31817.912  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15    9785.501 ±   4451.760  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15     850.610 ±    407.747  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      45.859 ±     27.175  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       3.075 ±      2.215  ops/s
TMapOpsBenchmarks.update           0  thrpt   15    2668.573 ±   1456.795  ops/s
TMapOpsBenchmarks.update          10  thrpt   15    2675.247 ±   1456.032  ops/s
TMapOpsBenchmarks.update         100  thrpt   15    2664.858 ±   1423.056  ops/s
TMapOpsBenchmarks.update        1000  thrpt   15    2617.346 ±   1390.733  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15    2616.528 ±   1390.342  ops/s
TMapOpsBenchmarks.update      100000  thrpt   15    2627.150 ±   1416.048  ops/s
```

#### After

```
Benchmark                     (size)   Mode  Cnt       Score       Error  Units
TMapOpsBenchmarks.fold             0  thrpt   15  403615.212 ±  1334.439  ops/s
TMapOpsBenchmarks.fold            10  thrpt   15  380009.231 ±  1678.816  ops/s
TMapOpsBenchmarks.fold           100  thrpt   15   98053.509 ±    82.584  ops/s
TMapOpsBenchmarks.fold          1000  thrpt   15    9239.869 ±    14.139  ops/s
TMapOpsBenchmarks.fold         10000  thrpt   15     351.151 ±     1.762  ops/s
TMapOpsBenchmarks.fold        100000  thrpt   15      13.998 ±     1.161  ops/s
TMapOpsBenchmarks.foldM            0  thrpt   15  367729.735 ±  1854.472  ops/s
TMapOpsBenchmarks.foldM           10  thrpt   15  313868.580 ±   250.869  ops/s
TMapOpsBenchmarks.foldM          100  thrpt   15   68697.043 ±   543.179  ops/s
TMapOpsBenchmarks.foldM         1000  thrpt   15    6137.676 ±    10.762  ops/s
TMapOpsBenchmarks.foldM        10000  thrpt   15     301.891 ±     1.255  ops/s
TMapOpsBenchmarks.foldM       100000  thrpt   15      14.576 ±     0.751  ops/s
TMapOpsBenchmarks.lookup           0  thrpt   15    6053.302 ±    22.806  ops/s
TMapOpsBenchmarks.lookup          10  thrpt   15    4405.417 ±  1966.376  ops/s
TMapOpsBenchmarks.lookup         101  thrpt   15    2340.165 ±   447.210  ops/s
TMapOpsBenchmarks.lookup        1000  thrpt   15    2350.204 ±   568.947  ops/s
TMapOpsBenchmarks.lookup       10000  thrpt   15    2281.929 ±   683.208  ops/s
TMapOpsBenchmarks.lookup      100000  thrpt   15    2313.773 ±   886.662  ops/s
TMapOpsBenchmarks.removal          0  thrpt   15    2403.079 ±   968.797  ops/s
TMapOpsBenchmarks.removal         10  thrpt   15    2448.843 ±   996.663  ops/s
TMapOpsBenchmarks.removal        100  thrpt   15    2470.043 ±  1018.782  ops/s
TMapOpsBenchmarks.removal       1000  thrpt   15    2472.411 ±  1038.648  ops/s
TMapOpsBenchmarks.removal      10000  thrpt   15    2467.976 ±  1083.045  ops/s
TMapOpsBenchmarks.removal     100000  thrpt   15    2384.007 ±  1132.032  ops/s
TMapOpsBenchmarks.transform        0  thrpt   15  140876.812 ± 69495.871  ops/s
TMapOpsBenchmarks.transform       10  thrpt   15  132015.543 ± 66139.415  ops/s
TMapOpsBenchmarks.transform      100  thrpt   15   28787.338 ± 14445.552  ops/s
TMapOpsBenchmarks.transform     1000  thrpt   15    2374.359 ±  1182.982  ops/s
TMapOpsBenchmarks.transform    10000  thrpt   15     100.198 ±    60.994  ops/s
TMapOpsBenchmarks.transform   100000  thrpt   15       3.283 ±     2.084  ops/s
TMapOpsBenchmarks.transformM       0  thrpt   15  148086.296 ± 78515.921  ops/s
TMapOpsBenchmarks.transformM      10  thrpt   15   94625.375 ± 50368.144  ops/s
TMapOpsBenchmarks.transformM     100  thrpt   15   14950.445 ±  8038.146  ops/s
TMapOpsBenchmarks.transformM    1000  thrpt   15    1395.947 ±   766.284  ops/s
TMapOpsBenchmarks.transformM   10000  thrpt   15      77.457 ±    52.776  ops/s
TMapOpsBenchmarks.transformM  100000  thrpt   15       4.273 ±     3.072  ops/s
TMapOpsBenchmarks.update           0  thrpt   15    2973.290 ±  1625.814  ops/s
TMapOpsBenchmarks.update          10  thrpt   15    3052.530 ±  1699.489  ops/s
TMapOpsBenchmarks.update         100  thrpt   15    3020.253 ±  1648.689  ops/s
TMapOpsBenchmarks.update        1000  thrpt   15    2910.121 ±  1563.392  ops/s
TMapOpsBenchmarks.update       10000  thrpt   15    2848.660 ±  1516.351  ops/s
TMapOpsBenchmarks.update      100000  thrpt   15    2882.974 ±  1531.583  ops/s
```

### TSemaphore

#### Before

```
Benchmark                                   (fibers)  (ops)   Mode  Cnt   Score    Error  Units
SemaphoreBenchmark.semaphoreCatsContention        10   1000  thrpt   15  64.186 ± 54.230  ops/s
SemaphoreBenchmark.semaphoreContention            10   1000  thrpt   15  53.450 ± 42.670  ops/s
SemaphoreBenchmark.tsemaphoreContention           10   1000  thrpt   15  44.071 ± 31.329  ops/s
```

#### After

```
Benchmark                                   (fibers)  (ops)   Mode  Cnt   Score    Error  Units
SemaphoreBenchmark.semaphoreCatsContention        10   1000  thrpt   15  38.694 ± 13.844  ops/s
SemaphoreBenchmark.semaphoreContention            10   1000  thrpt   15  30.573 ± 13.970  ops/s
SemaphoreBenchmark.tsemaphoreContention           10   1000  thrpt   15  26.500 ± 12.138  ops/s
```

### TSet

#### Before

```
Benchmark                (size)   Mode  Cnt      Score     Error  Units
TSetOpsBenchmarks.union      10  thrpt   15  88600.603 ± 748.730  ops/s
TSetOpsBenchmarks.union     100  thrpt   15  14698.743 ± 140.735  ops/s
TSetOpsBenchmarks.union   10000  thrpt   15     45.005 ±   0.672  ops/s
TSetOpsBenchmarks.union  100000  thrpt   15      2.196 ±   0.036  ops/s
```

#### After

```
Benchmark                (size)   Mode  Cnt      Score     Error  Units
TSetOpsBenchmarks.union      10  thrpt   15  90131.591 ± 848.745  ops/s
TSetOpsBenchmarks.union     100  thrpt   15  16133.921 ± 120.840  ops/s
TSetOpsBenchmarks.union   10000  thrpt   15     76.785 ±   1.480  ops/s
TSetOpsBenchmarks.union  100000  thrpt   15      3.626 ±   0.139  ops/s
```

### TQueue parallel

#### Before

```
Benchmark                          Mode  Cnt   Score   Error  Units
QueueParallelBenchmark.zioTQueue  thrpt   45  66.473 ± 1.000  ops/s
```

#### After

```
Benchmark                          Mode  Cnt    Score   Error  Units
QueueParallelBenchmark.zioTQueue  thrpt   45  290.123 ± 1.463  ops/s
```

### TQueue sequential

#### Before

```
Benchmark                            Mode  Cnt    Score    Error  Units
QueueSequentialBenchmark.zioTQueue  thrpt   45  180.374 ± 45.000  ops/s
```

#### After

```
Benchmark                            Mode  Cnt    Score   Error  Units
QueueSequentialBenchmark.zioTQueue  thrpt   45  288.901 ± 0.995  ops/s
```

### TQueue backpressure

#### Before

```
Benchmark                              Mode  Cnt    Score    Error  Units
QueueBackPressureBenchmark.zioTQueue  thrpt   45  173.648 ± 58.865  ops/s
```

#### After

```
Benchmark                              Mode  Cnt    Score   Error  Units
QueueBackPressureBenchmark.zioTQueue  thrpt   45  290.346 ± 4.517  ops/s
```

### Ref vs TRef contention

#### Before

```
Benchmark                          (fibers)  (ops)   Mode  Cnt    Score    Error  Units
SingleRefBenchmark.refContention         10   1000  thrpt   15  661.969 ±  2.458  ops/s
SingleRefBenchmark.trefContention        10   1000  thrpt   15  194.940 ± 92.439  ops/s
```

#### After

```
Benchmark                          (fibers)  (ops)   Mode  Cnt    Score   Error  Units
SingleRefBenchmark.refContention         10   1000  thrpt   15  655.976 ± 2.042  ops/s
SingleRefBenchmark.trefContention        10   1000  thrpt   15  233.359 ± 1.236  ops/s
```

### STM retry

#### Before

```
Benchmark                             Mode  Cnt    Score    Error  Units
STMRetryBenchmark.mixedTransactions  thrpt   15  816.582 ± 13.739  ops/s
```

#### After

```
Benchmark                             Mode  Cnt    Score    Error  Units
STMRetryBenchmark.mixedTransactions  thrpt   15  833.764 ± 39.690  ops/s
```

### STM deep flatMap

#### Before

```
Benchmark                        (depth)   Mode  Cnt    Score   Error  Units
STMFlatMapBenchmark.deepFlatMap       20  thrpt   15  761.928 ± 1.250  ops/s
```

#### After

```
Benchmark                        (depth)   Mode  Cnt    Score   Error  Units
STMFlatMapBenchmark.deepFlatMap       20  thrpt   15  968.079 ± 6.283  ops/s
```