### PR TITLE
[WIP] zio-mock: support no calls

### DIFF
--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -227,6 +227,14 @@ object Expectation {
     }
   }
 
+  private[test] case class NoCalls[R <: Has[_]: Tag](mock: Mock[R]) extends Expectation[R] {
+
+    override private[test] val invocations: List[Int] = Nil
+
+    override private[test] val state: ExpectationState = Satisfied
+
+  }
+
   /**
    * Models expectations disjunction on environment `R`. Expectations are checked in the order they are provided,
    * meaning that earlier expectations may shadow later ones.

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -19,7 +19,7 @@ package zio.test.mock
 import zio.internal.Executor
 import zio.stream.{ ZSink, ZStream }
 import zio.test.TestPlatform
-import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO }
+import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO, ULayer }
 
 /**
  * A `Mock[R]` represents a mockable environment `R`.
@@ -27,6 +27,8 @@ import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO }
 abstract class Mock[R <: Has[_]: Tag] { self =>
 
   protected[test] val compose: URLayer[Has[Proxy], R]
+
+  def empty: ULayer[R] = Expectation.NoCalls(self)
 
   /**
    * Replaces Runtime on JS platform to one with unyielding executor.

--- a/test/shared/src/main/scala/zio/test/mock/internal/Debug.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/Debug.scala
@@ -56,6 +56,7 @@ private[mock] object Debug {
         renderRoot("Chain", children)
       case Expectation.Or(children, _, _, _) =>
         renderRoot("Or", children)
+      case Expectation.NoCalls(_) => renderRoot("NoCalls", Nil)
       case Expectation.Repeated(child, range, _, _, started, completed) =>
         val progress = s"progress = $started out of $completed,"
         ("Repeated(" :: state :: s"range = $range," :: progress :: invoked :: prettify(child, 1) :: ")" :: Nil)

--- a/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
@@ -51,6 +51,8 @@ object ProxyFactory {
                   debug("::: skipping saturated expectation")
                   findMatching(nextScopes)
 
+                case NoCalls(_) =>
+                  findMatching(nextScopes)
                 case call @ Call(capability, assertion, returns, _, invocations) if invoked isEqual capability =>
                   debug(s"::: matched call $capability")
                   assertion.asInstanceOf[Assertion[I]].test(args) match {
@@ -259,6 +261,7 @@ object ProxyFactory {
                 children = self.children.map(resetTree),
                 state = Unsatisfied
               )
+            case self: NoCalls[R] => self
             case self: Repeated[R] =>
               self.copy(
                 child = resetTree(self.child),


### PR DESCRIPTION
As discussed on #3115 this is updated implementation for https://github.com/zio/zio/pull/3641/files

The goal here is to be able to check that no calls are made to a specific method inside a service, this is currently a missing feature and is pretty hard/ugly to emulate with the current tools available in the lib.

The decision that was taken in the issue was to extend the Expectation with another case allowing to disallow certain calls (or all calls in extreme case).

This is my first try to implement this, I would love to have some pointers and remarks on this. For instance, I'm not sure that i got the purpose of the `invocations` list in the `Expectation` class, could someone clarify its usage ?

Please note that one of the two tests added in the `exampleJVM` project is expected to fail, but from what I understood, it should not be an issue as this is a project containing only examples, and not actual tests.


I'm also not sure at all on the behavior we should implement in the `Debug` class and how to use it.
When everything else is fine, I'll take care of the documentation for this feature as well.

Thanks