### PR TITLE
Prevent Fibers From Being Terminated Prematurely In ZIO#foreachPar

### DIFF
--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -137,8 +137,8 @@ object StackTracesSpec extends DefaultRunnableSpec {
         .uploadUsers(List(new fiberAncestryUploadExample.User)) causeMust { cause =>
         assert(cause.traces.head.stackTrace.size)(equalTo(7)) &&
         assert(cause.traces.head.stackTrace(4).prettyPrint.contains("uploadUsers"))(isTrue) &&
-        assert(cause.traces(1).stackTrace.size)(equalTo(4)) &&
-        assert(cause.traces(1).executionTrace.size)(equalTo(4)) &&
+        assert(cause.traces(1).stackTrace.size)(equalTo(6)) &&
+        assert(cause.traces(1).executionTrace.size)(equalTo(6)) &&
         assert(cause.traces(1).executionTrace.head.prettyPrint.contains("uploadTo"))(isTrue) &&
         assert(cause.traces(1).parentTrace.isEmpty)(isFalse) &&
         assert(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -761,7 +761,15 @@ object ZIOSpec extends ZIOBaseSpec {
           e <- ZIO.foreachPar(actions)(a => a).flip
           v <- ref.get
         } yield assert(e)(equalTo("C")) && assert(v)(isFalse)
-      } @@ zioTag(interruption)
+      } @@ zioTag(interruption),
+      testM("does not kill fiber when forked on the parent scope") {
+        for {
+          ref    <- Ref.make(0)
+          fibers <- ZIO.foreachPar(1 to 100)(_ => ref.update(_ + 1).fork)
+          _      <- ZIO.foreach(fibers)(_.await)
+          value  <- ref.get
+        } yield assert(value)(equalTo(100))
+      }
     ),
     suite("foreachPar_")(
       testM("accumulates errors") {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3007,7 +3007,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
                    .uninterruptible
                )
 
-        fibers <- ZIO.foreach(as)(a => task(a).fork)
+        fibers <- ZIO.transplant(graft => ZIO.foreach(as)(a => graft(task(a)).fork))
         interrupter = result.await
                         .catchAll(_ => ZIO.foreach(fibers)(_.interruptAs(parentId).fork) >>= Fiber.joinAll)
                         .forkManaged


### PR DESCRIPTION
Currently code like this will not work:

```scala
for {
  ref    <- Ref.make(0)
  fibers <- ZIO.foreachPar(1 to 100)(_ => ref.update(_ + 1).fork)
  _      <- ZIO.foreach(fibers)(_.await)
  value  <- ref.get
} yield assert(value)(equalTo(100))
```

The issue is that `foreachPar` forks a fiber to perform each of the effects and under the supervision model when that fiber terminates it terminates the fibers in its scope, including the fiber that is updating the `Ref` in this case.

The fix is to use the `transplant` operator similar to how we did with `zipWithPar` to make sure that when fibers are forked within one of the effects in `foreachPar` they are forked on the original scope and not the scope of the fiber internally created by `foreachPar`. Conceptually this is the same issue as with `zipWithPar`, it looks like we just didn't push the change through to `foreachPar`.