### PR TITLE
Adding test_assertions docs and other misc cleanup

### DIFF
--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -10,13 +10,13 @@ import zio._
 Schedules allow you to define and compose flexible recurrence schedules, which can be used to repeat actions, or retry actions in the event of errors. Schedules are used in the following functions:
 
  * **Repetition**
-   * `IO#repeat` — Repeats an effect until the schedule is done.
+   * `IO#repeat` — Repeats an effect until the schedule is done.
    * `IO#repeatOrElse` — Repeats an effect until the schedule is done, with a fallback for errors.
    * `IO#repeatOrElse0` — Repeats an effect until the schedule is done, with a more powerful fallback for errors.
  * **Retries**
    * `IO#retry` – Retries an effect until it succeeds.
-   * `IO#retryOrElse` — Retries an effect until it succeeds, with a fallback for errors.
-   * `IO#retryOrElse0` — Retries an effect until it succeeds, with a more powerful fallback for errors.
+   * `IO#retryOrElse` — Retries an effect until it succeeds, with a fallback for errors.
+   * `IO#retryOrElse0` — Retries an effect until it succeeds, with a more powerful fallback for errors.
 
 Schedules define stateful, possibly effectful, recurring schedules of events, and compose in a variety of ways.
 

--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -37,7 +37,7 @@ If you know a useful library that has direct support for ZIO, please consider [s
 - [scanamo](https://github.com/scanamo/scanamo): Simpler DynamoDB access for Scala
 - [slf4zio](https://github.com/mlangc/slf4zio): Simple convenience layer on top of SLF4J for ZIO
 - [sttp](https://github.com/softwaremill/sttp): The Scala HTTP client you always wanted!
-- [tranzactio](https://github.com/gaelrenoux/tranzactio): ZIO wrapper for data access libraries like Doobie or Anorm
+- [tranzactio](https://github.com/gaelrenoux/tranzactio): ZIO wrapper for data access libraries like Doobie or Anorm
 - [ZIO Arrow](https://github.com/Neurodyne/zio-arrow) : Haskell Arrow meets ZIO. A deep composition and high performance applications
 - [zio-amqp](https://github.com/svroonland/zio-amqp): ZIO Streams based RabbitMQ client
 - [zio-aws](https://github.com/vigoo/zio-aws): Low-level AWS wrapper for ZIO for all AWS services using the AWS Java SDK v2

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -6,6 +6,7 @@ title: "Summary"
 Here are a few guides for common patterns with ZIO:
 
 - **[Use modules and layers](use_modules_and_layers.md)**: how to structure larger ZIO programs with the help of **ZIO environment**.
+- **[Test assertions](test_assertions.md)**: how to use **ZIO Test** assert properties in your code.
 - **[Test effects](test_effects.md)**: how to use **ZIO Test** to test effectual programs seamlessly.
 - **[Mock services](mock_services.md)**: how to test interactions between services with **mocks**.
 - **[Handle errors](handle_errors.md)**: how to deal with **errors** in ZIO (declared errors vs unforeseen defects).

--- a/docs/howto/test_assertions.md
+++ b/docs/howto/test_assertions.md
@@ -1,0 +1,286 @@
+Using the `Assertion` type effectively often involves finding the best fitting
+function for the type of assumptions you would like to verify.
+
+This list is intended to break up the available functions into groups based on
+the _Result type_. The types of the functions are included as well, to guide
+intuition.
+
+For instance, if we wanted to assert that the fourth element of a `Vector[Int]`
+was a value equal to the number `5`, we would first look at assertions that
+operate on `Seq[A]`, with the type `Assertion[Seq[A]]`.
+
+For this example, I would select `hasAt`, as it accepts both the position into
+a sequence, as well as an `Assertion[A]` to apply at that position:
+
+```scala
+Assertion.hasAt[A](pos: Int)(assertion: Assertion[A]): Assertion[Seq[A]]
+```
+
+I could start by writing:
+
+```scala mdoc:reset:invisible
+import zio.test._, zio.test.Assertion._
+```
+
+```scala mdoc
+val xs = Vector(0, 1, 2, 3)
+
+test("Fourth value is equal to 5") {
+  assert(xs)(hasAt(3)(???))
+}
+```
+
+The second parameter to `hasAt` is an `Assertion[A]` that applies to the third
+element of that sequence, so I would look for functions that operate on `A`,
+of the return type `Assertion[A]`.
+
+I could select `equalTo`, as it accepts an `A` as a parameter, allowing me to
+supply `5`:
+
+```scala mdoc:reset:invisible
+import zio.test._, zio.test.Assertion._
+```
+
+```scala mdoc
+val xs = Vector(0, 1, 2, 3)
+
+test("Fourth value is equal to 5") {
+  assert(xs)(hasAt(3)(equalTo(5)))
+}
+```
+
+Let's say this is too restrictive, and I would prefer to assert that a value is
+_near_ the number five, with a tolerance of two. This requires a little more
+knowledge of the type `A`, so I'll look for an assertion in the `Numeric`
+section. `approximatelyEquals` looks like what we want, as it permits the
+starting value `reference`, as well as a `tolerance`, for any `A` that is
+`Numeric`:
+
+```scala
+Assertion.approximatelyEquals[A: Numeric](reference: A, tolerance: A): Assertion[A]
+```
+
+Changing out `equalTo` with `approximatelyEquals` leaves us with:
+
+```scala mdoc:reset:invisible
+import zio.test._, zio.test.Assertion._
+```
+
+```scala mdoc
+val xs = Vector(0, 1, 2, 3)
+
+test("Fourth value is approximately equal to 5") {
+  assert(xs)(hasAt(3)(approximatelyEquals(5, 2)))
+}
+```
+
+Values
+======
+
+Assertions that apply to plain values.
+
+Any
+---
+
+Assertions that apply to `Any` value.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `anything`                                                                                    | `Assertion[Any]`              | Makes a new assertion that always succeeds. |
+| `isNull`                                                                                      | `Assertion[Any]`              | Makes a new assertion that requires a null value. |
+| `isSubtype[A](assertion: Assertion[A])(implicit C: ClassTag[A])`                              | `Assertion[Any]`              | Makes a new assertion that requires a value have the specified type. |
+| `nothing`                                                                                     | `Assertion[Any]`              | Makes a new assertion that always fails. |
+| `throwsA[E: ClassTag]`                                                                        | `Assertion[Any]`              | Makes a new assertion that requires the expression to throw. |
+
+A
+---
+
+Assertions that apply to specific values.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `equalTo[A](expected: A)`                                                                     | `Assertion[A]`                | Makes a new assertion that requires a value equal the specified value. |
+| `hasField[A, B](name: String, proj: A => B, assertion: Assertion[B])`                         | `Assertion[A]`                | Makes a new assertion that focuses in on a field in a case class. |
+| `isOneOf[A](values: Iterable[A])`                                                             | `Assertion[A]`                | Makes a new assertion that requires a value to be equal to one of the specified values. |
+| `not[A](assertion: Assertion[A])`                                                             | `Assertion[A]`                | Makes a new assertion that negates the specified assertion. |
+| `throws[A](assertion: Assertion[Throwable])`                                                  | `Assertion[A]`                | Makes a new assertion that requires the expression to throw. |
+
+Numeric
+-------
+
+Assertions on `Numeric` types
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `approximatelyEquals[A: Numeric](reference: A, tolerance: A)`                                 | `Assertion[A]`                | Makes a new assertion that requires a given numeric value to match a value with some tolerance. |
+| `isNegative[A](implicit num: Numeric[A])`                                                     | `Assertion[A]`                | Makes a new assertion that requires a numeric value is negative. |
+| `isPositive[A](implicit num: Numeric[A])`                                                     | `Assertion[A]`                | Makes a new assertion that requires a numeric value is positive. |
+| `isZero[A](implicit num: Numeric[A])`                                                         | `Assertion[A]`                | Makes a new assertion that requires a numeric value is zero. |
+| `nonNegative[A](implicit num: Numeric[A])`                                                    | `Assertion[A]`                | Makes a new assertion that requires a numeric value is non negative. |
+| `nonPositive[A](implicit num: Numeric[A])`                                                    | `Assertion[A]`                | Makes a new assertion that requires a numeric value is non positive. |
+
+Ordering
+--------
+
+Assertions on types that support `Ordering`
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isGreaterThan[A](reference: A)(implicit ord: Ordering[A])`                                   | `Assertion[A]`                | Makes a new assertion that requires the value be greater than the specified reference value. |
+| `isGreaterThanEqualTo[A](reference: A)(implicit ord: Ordering[A])`                            | `Assertion[A]`                | Makes a new assertion that requires the value be greater than or equal to the specified reference value. |
+| `isLessThan[A](reference: A)(implicit ord: Ordering[A])`                                      | `Assertion[A]`                | Makes a new assertion that requires the value be less than the specified reference value. |
+| `isLessThanEqualTo[A](reference: A)(implicit ord: Ordering[A])`                               | `Assertion[A]`                | Makes a new assertion that requires the value be less than or equal to the specified reference value. |
+| `isWithin[A](min: A, max: A)(implicit ord: Ordering[A])`                                      | `Assertion[A]`                | Makes a new assertion that requires a value to fall within a specified min and max (inclusive). |
+
+Iterable
+========
+
+Assertions on types that extend `Iterable`, like `List`, `Seq`, `Set`, `Map`, and many others.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `contains[A](element: A)`                                                                     | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain the specified element. See Assertion.exists if you want to require an Iterable to contain an element satisfying an assertion. |
+| `exists[A](assertion: Assertion[A])`                                                          | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain an element satisfying the given assertion. |
+| `forall[A](assertion: Assertion[A])`                                                          | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain only elements satisfying the given assertion. |
+| `hasFirst[A](assertion: Assertion[A])`                                                        | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable to contain the first element satisfying the given assertion. |
+| `hasIntersection[A](other: Iterable[A])(assertion: Assertion[Iterable[A]])`                   | `Assertion[Iterable[A]]`      | Makes a new assertion that requires the intersection of two Iterables satisfy the given assertion. |
+| `hasLast[A](assertion: Assertion[A])`                                                         | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable to contain the last element satisfying the given assertion. |
+| `hasSize[A](assertion: Assertion[Int])`                                                       | `Assertion[Iterable[A]]`      | Makes a new assertion that requires the size of an Iterable be satisfied by the specified assertion. |
+| `hasAtLeastOneOf[A](other: Iterable[A])`                                                      | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain at least one of the specified elements. |
+| `hasAtMostOneOf[A](other: Iterable[A])`                                                       | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain at most one of the specified elements. |
+| `hasNoneOf[A](other: Iterable[A])`                                                            | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain none of the specified elements. |
+| `hasOneOf[A](other: Iterable[A])`                                                             | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable contain exactly one of the specified elements. |
+| `hasSameElements[A](other: Iterable[A])`                                                      | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable to have the same elements as the specified Iterable, though not necessarily in the same order. |
+| `hasSameElementsDistinct[A](other: Iterable[A])`                                              | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable to have the same distinct elements as the other Iterable, though not necessarily in the same order. |
+| `hasSubset[A](other: Iterable[A])`                                                            | `Assertion[Iterable[A]]`      | Makes a new assertion that requires the specified Iterable to be a subset of the other Iterable. |
+| `isDistinct`                                                                                  | `Assertion[Iterable[Any]]`    | Makes a new assertion that requires an Iterable is distinct. |
+| `isEmpty`                                                                                     | `Assertion[Iterable[Any]]`    | Makes a new assertion that requires an Iterable to be empty. |
+| `isNonEmpty`                                                                                  | `Assertion[Iterable[Any]]`    | Makes a new assertion that requires an Iterable to be non empty. |
+
+Ordering
+--------
+
+Assertions that apply to ordered `Iterable`s
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isSorted[A](implicit ord: Ordering[A])`                                                      | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable is sorted. |
+| `isSortedReverse[A](implicit ord: Ordering[A])`                                               | `Assertion[Iterable[A]]`      | Makes a new assertion that requires an Iterable is sorted in reverse order. |
+
+Seq
+---
+
+Assertions that operate on sequences (`List`, `Vector`, `Map`, and many others)
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `endsWith[A](suffix: Seq[A])`                                                                 | `Assertion[Seq[A]]`           | Makes a new assertion that requires a given string to end with the specified suffix. |
+| `hasAt[A](pos: Int)(assertion: Assertion[A])`                                                 | `Assertion[Seq[A]]`           | Makes a new assertion that requires a sequence to contain an element satisfying the given assertion on the given position. |
+| `startsWith[A](prefix: Seq[A])`                                                               | `Assertion[Seq[A]]`           | Makes a new assertion that requires a given sequence to start with the specified prefix. |
+
+Either
+======
+
+Assertions for `Either` values.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isLeft[A](assertion: Assertion[A])`                                                          | `Assertion[Either[A, Any]]`   | Makes a new assertion that requires a Left value satisfying a specified assertion. |
+| `isLeft`                                                                                      | `Assertion[Either[Any, Any]]` | Makes a new assertion that requires an Either is Left. |
+| `isRight[A](assertion: Assertion[A])`                                                         | `Assertion[Either[Any, A]]`   | Makes a new assertion that requires a Right value satisfying a specified assertion. |
+| `isRight`                                                                                     | `Assertion[Either[Any, Any]]` | Makes a new assertion that requires an Either is Right. |
+
+Exit/Cause/Throwable
+==========
+
+Assertions for `Exit` or `Cause` results.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `containsCause[E](cause: Cause[E])`                                                           | `Assertion[Cause[E]]`         | Makes a new assertion that requires a Cause contain the specified cause. |
+| `dies(assertion: Assertion[Throwable])`                                                       | `Assertion[Exit[Any, Any]]`   | Makes a new assertion that requires an exit value to die. |
+| `failsCause[E](assertion: Assertion[Cause[E]])`                                               | `Assertion[Exit[E, Any]]`     | Makes a new assertion that requires an exit value to fail with a cause that meets the specified assertion. |
+| `fails[E](assertion: Assertion[E])`                                                           | `Assertion[Exit[E, Any]]`     | Makes a new assertion that requires an exit value to fail. |
+| `isInterrupted`                                                                               | `Assertion[Exit[Any, Any]]`   | Makes a new assertion that requires an exit value to be interrupted. |
+| `succeeds[A](assertion: Assertion[A])`                                                        | `Assertion[Exit[Any, A]]`     | Makes a new assertion that requires an exit value to succeed. |
+| `hasMessage(message: Assertion[String])`                                                      | `Assertion[Throwable]`        | Makes a new assertion that requires an exception to have a certain message. |
+| `hasThrowableCause(cause: Assertion[Throwable])`                                              | `Assertion[Throwable]`        | Makes a new assertion that requires an exception to have a certain cause. |
+
+Try
+===
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isFailure(assertion: Assertion[Throwable])`                                                  | `Assertion[Try[Any]]`         | Makes a new assertion that requires a Failure value satisfying the specified assertion. |
+| `isFailure`                                                                                   | `Assertion[Try[Any]]`         | Makes a new assertion that requires a Try value is Failure. |
+| `isSuccess[A](assertion: Assertion[A])`                                                       | `Assertion[Try[A]]`           | Makes a new assertion that requires a Success value satisfying the specified assertion. |
+| `isSuccess`                                                                                   | `Assertion[Try[Any]]`         | Makes a new assertion that requires a Try value is Success. |
+
+Sum type
+========
+
+An assertion that applies to some type, giving a method to transform the source
+type into another type, then assert a property on that projected type.
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isCase[Sum, Proj]( termName: String, term: Sum => Option[Proj], assertion: Assertion[Proj])` | `Assertion[Sum]`              | Makes a new assertion that requires the sum type be a specified term. |
+
+
+Map
+===
+
+Assertions for `Map[K, V]`
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `hasKey[K, V](key: K)`                                                                        | `Assertion[Map[K, V]]`        | Makes a new assertion that requires a Map to have the specified key. |
+| `hasKey[K, V](key: K, assertion: Assertion[V])`                                               | `Assertion[Map[K, V]]`        | Makes a new assertion that requires a Map to have the specified key with value satisfying the specified assertion. |
+| `hasKeys[K, V](assertion: Assertion[Iterable[K]])`                                            | `Assertion[Map[K, V]]`        | Makes a new assertion that requires a Map have keys satisfying the specified assertion. |
+| `hasValues[K, V](assertion: Assertion[Iterable[V]])`                                          | `Assertion[Map[K, V]]`        | Makes a new assertion that requires a Map have values satisfying the specified assertion. |
+
+String
+======
+
+Assertions for Strings
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `containsString(element: String)`                                                             | `Assertion[String]`           | Makes a new assertion that requires a substring to be present. |
+| `endsWithString(suffix: String)`                                                              | `Assertion[String]`           | Makes a new assertion that requires a given string to end with the specified suffix. |
+| `equalsIgnoreCase(other: String)`                                                             | `Assertion[String]`           | Makes a new assertion that requires a given string to equal another ignoring case. |
+| `hasSizeString(assertion: Assertion[Int])`                                                    | `Assertion[String]`           | Makes a new assertion that requires the size of a string be satisfied by the specified assertion. |
+| `isEmptyString`                                                                               | `Assertion[String]`           | Makes a new assertion that requires a given string to be empty. |
+| `isNonEmptyString`                                                                            | `Assertion[String]`           | Makes a new assertion that requires a given string to be non empty. |
+| `matchesRegex(regex: String)`                                                                 | `Assertion[String]`           | Makes a new assertion that requires a given string to match the specified regular expression. |
+| `startsWithString(prefix: String)`                                                            | `Assertion[String]`           | Makes a new assertion that requires a given string to start with a specified prefix. |
+
+Boolean
+=======
+
+Assertions for Booleans
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isFalse`                                                                                     | `Assertion[Boolean]`          | Makes a new assertion that requires a value be false. |
+| `isTrue`                                                                                      | `Assertion[Boolean]`          | Makes a new assertion that requires a value be true. |
+
+Option
+======
+
+Assertions for Optional values
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isNone`                                                                                      | `Assertion[Option[Any]]`      | Makes a new assertion that requires a None value. |
+| `isSome[A](assertion: Assertion[A])`                                                          | `Assertion[Option[A]]`        | Makes a new assertion that requires a Some value satisfying the specified assertion. |
+| `isSome`                                                                                      | `Assertion[Option[Any]]`      | Makes a new assertion that requires an Option is Some. |
+
+Unit
+====
+
+Assertion for Unit
+
+| Function                                                                                      | Result type                   | Description |
+| --------                                                                                      | -----------                   | ----------- |
+| `isUnit`                                                                                      | `Assertion[Unit]`             | Makes a new assertion that requires the value be unit. |

--- a/docs/interop/index.md
+++ b/docs/interop/index.md
@@ -7,8 +7,8 @@ ZIO provides the ability to interoperate with other parts of the broader ecosyst
 
  - **Future** — ZIO has built-in conversion between ZIO data types (like `ZIO` and `Fiber`) and Scala concurrent data types like `Future`.
  - **Java** — ZIO has built-in conversion between ZIO data types (like `ZIO` and `Fiber`) and Java concurrent data types like [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html), [`Future`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html) and [`CompletionHandler`](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/CompletionHandler.html).
- - **JavaScript** — ZIO has first-class support for Scala.js.
- - **Scalaz 8** — Scalaz 8 depends on ZIO, and contains instances for all ZIO data types inside the library. No additional modules are needed.
+ - **JavaScript** — ZIO has first-class support for Scala.js.
+ - **Scalaz 8** — Scalaz 8 depends on ZIO, and contains instances for all ZIO data types inside the library. No additional modules are needed.
 - [`interop-cats`](https://github.com/zio/interop-cats) has instances for the [Cats](https://typelevel.org/cats/), [Cats MTL](https://github.com/typelevel/cats-mtl) and [Cats Effect](https://typelevel.org/cats-effect/) libraries, which allow you to use ZIO with any libraries that rely on these, like [Doobie](https://github.com/tpolecat/doobie), [Http4s](https://github.com/http4s/http4s), [FS2](https://github.com/functional-streams-for-scala/fs2) or [Circe](https://github.com/circe/circe)
 - [`interop-reactive-streams`](https://github.com/zio/interop-reactive-streams) for [Reactive Streams](http://www.reactive-streams.org/), has conversion from ZIO Streams and Sinks to Reactive Streams Producers and Consumers
 - [`interop-scalaz`](https://github.com/zio/interop-scalaz) for [ScalaZ 7](https://scalaz.github.io/7/), has instances of `Monad` and other type classes for the ZIO data types

--- a/docs/overview/background.md
+++ b/docs/overview/background.md
@@ -5,15 +5,15 @@ title:  "Background"
 
 Procedural Scala programs use _procedural functions_, which are:
 
- * **Partial** — Procedures do not return values for some inputs (for example, they throw exceptions).
+ * **Partial** — Procedures do not return values for some inputs (for example, they throw exceptions).
  * **Non-Deterministic** — Procedures return different outputs for the same input.
  * **Impure** — Procedures perform side-effects, which mutate data or interact with the external world.
 
 Unlike procedural Scala programs, functional Scala programs only use _pure functions_, which are:
 
- * **Total** — Functions always return an output for every input.
- * **Deterministic** — Functions return the same output for the same input.
- * **Pure** — The only effect of providing a function an input is computing the output.
+ * **Total** — Functions always return an output for every input.
+ * **Deterministic** — Functions return the same output for the same input.
+ * **Pure** — The only effect of providing a function an input is computing the output.
 
 Pure functions only combine or transform input values into output values in a total, deterministic way. Pure functions are easier to understand, easier to test, easier to refactor, and easier to abstract over.
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -31,11 +31,11 @@ This function, which requires an `R`, might produce either an `E`, representing 
 
 The `ZIO` data type is the only effect type in ZIO. However, there are a family of type aliases and companion objects that simplify common cases:
 
- - `UIO[A]` — This is a type alias for `ZIO[Any, Nothing, A]`, which represents an effect that has no requirements, and cannot fail, but can succeed with an `A`.
+ - `UIO[A]` — This is a type alias for `ZIO[Any, Nothing, A]`, which represents an effect that has no requirements, and cannot fail, but can succeed with an `A`.
  - `URIO[R, A]` — This is a type alias for `ZIO[R, Nothing, A]`, which represents an effect that requires an `R`, and cannot fail, but can succeed with an `A`.
  - `Task[A]` — This is a type alias for `ZIO[Any, Throwable, A]`, which represents an effect that has no requirements, and may fail with a `Throwable` value, or succeed with an `A`.
  - `RIO[R, A]` — This is a type alias for `ZIO[R, Throwable, A]`, which represents an effect that requires an `R`, and may fail with a `Throwable` value, or succeed with an `A`.
- - `IO[E, A]` — This is a type alias for `ZIO[Any, E, A]`, which represents an effect that has no requirements, and may fail with an `E`, or succeed with an `A`.
+ - `IO[E, A]` — This is a type alias for `ZIO[Any, E, A]`, which represents an effect that has no requirements, and may fail with an `E`, or succeed with an `A`.
 
 These type aliases all have companion objects, and these companion objects have methods that can be used to construct values of the appropriate type.
 

--- a/docs/usecases/index.md
+++ b/docs/usecases/index.md
@@ -5,13 +5,13 @@ title:  "Summary"
 
 The ZIO library lets you easily solve problems in a variety of areas, including:
 
- - [**Asynchronous Programming**](./usecases_asynchronous) — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
- - [**Concurrent Programming**](./usecases_concurrency) — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
+ - [**Asynchronous Programming**](./usecases_asynchronous) — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
+ - [**Concurrent Programming**](./usecases_concurrency) — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
  - [**Parallelism**](./usecases_parallelism) — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
- - [**Queuing**](./usecases_queueing) — Build work processing flows and ration scarce resources with powerful asynchronous queues.
- - [**Retrying**](./usecases_retrying) — Create and test robust retry strategies that make your application resilient to transient failures.
+ - [**Queuing**](./usecases_queueing) — Build work processing flows and ration scarce resources with powerful asynchronous queues.
+ - [**Retrying**](./usecases_retrying) — Create and test robust retry strategies that make your application resilient to transient failures.
  - [**Scheduling**](./usecases_scheduling) — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
- - [**Streaming**](./usecases_streaming) — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
+ - [**Streaming**](./usecases_streaming) — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
  - [**Testing**](./usecases_testing) - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
 
 Explore the pages above and learn how the simple, powerful building blocks in ZIO help you solve problems in these critical areas.

--- a/docs/usecases/index.md
+++ b/docs/usecases/index.md
@@ -5,13 +5,13 @@ title:  "Summary"
 
 The ZIO library lets you easily solve problems in a variety of areas, including:
 
- - **Asynchronous Programming** — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
- - **Concurrent Programming** — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
+ - **Asynchronous Programming** — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
+ - **Concurrent Programming** — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
  - **Parallelism** — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
- - **Queuing** — Build work processing flows and ration scarce resources with powerful asynchronous queues.
- - **Retrying** — Create and test robust retry strategies that make your application resilient to transient failures.
+ - **Queuing** — Build work processing flows and ration scarce resources with powerful asynchronous queues.
+ - **Retrying** — Create and test robust retry strategies that make your application resilient to transient failures.
  - **Scheduling** — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
- - **Streaming** — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
+ - **Streaming** — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
  - **Testing** - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
 
 Explore the pages above and learn how the simple, powerful building blocks in ZIO help you solve problems in these critical areas.

--- a/docs/usecases/index.md
+++ b/docs/usecases/index.md
@@ -5,13 +5,13 @@ title:  "Summary"
 
 The ZIO library lets you easily solve problems in a variety of areas, including:
 
- - **Asynchronous Programming** — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
- - **Concurrent Programming** — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
- - **Parallelism** — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
- - **Queuing** — Build work processing flows and ration scarce resources with powerful asynchronous queues.
- - **Retrying** — Create and test robust retry strategies that make your application resilient to transient failures.
- - **Scheduling** — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
- - **Streaming** — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
- - **Testing** - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
+ - [**Asynchronous Programming**](./usecases_asynchronous) — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
+ - [**Concurrent Programming**](./usecases_concurrency) — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
+ - [**Parallelism**](./usecases_parallelism) — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
+ - [**Queuing**](./usecases_queueing) — Build work processing flows and ration scarce resources with powerful asynchronous queues.
+ - [**Retrying**](./usecases_retrying) — Create and test robust retry strategies that make your application resilient to transient failures.
+ - [**Scheduling**](./usecases_scheduling) — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
+ - [**Streaming**](./usecases_streaming) — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
+ - [**Testing**](./usecases_testing) - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
 
 Explore the pages above and learn how the simple, powerful building blocks in ZIO help you solve problems in these critical areas.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -229,7 +229,7 @@ object Assertion extends AssertionVariants {
     Assertion.assertion("endsWithString")(param(suffix))(_.endsWith(suffix))
 
   /**
-   * Makes a new assertion that requires a given string to equal another ignoring case
+   * Makes a new assertion that requires a given string to equal another ignoring case.
    */
   def equalsIgnoreCase(other: String): Assertion[String] =
     Assertion.assertion("equalsIgnoreCase")(param(other))(_.equalsIgnoreCase(other))
@@ -273,7 +273,7 @@ object Assertion extends AssertionVariants {
 
   /**
    * Makes a new assertion that requires an Iterable to have the same distinct elements
-   * as the other Iterable, though not necessarily in the same order
+   * as the other Iterable, though not necessarily in the same order.
    */
   def hasSameElementsDistinct[A](other: Iterable[A]): Assertion[Iterable[A]] =
     Assertion.assertion("hasSameElementsDistinct")(param(other))(actual => actual.toSet == other.toSet)
@@ -319,14 +319,14 @@ object Assertion extends AssertionVariants {
 
   /**
    * Makes a new assertion that requires an Iterable to contain the first
-   * element satisfying the given assertion
+   * element satisfying the given assertion.
    */
   def hasFirst[A](assertion: Assertion[A]): Assertion[Iterable[A]] =
     Assertion.assertionRec("hasFirst")(param(assertion))(assertion)(actual => actual.headOption)
 
   /**
    * Makes a new assertion that requires the intersection of two Iterables
-   * satisfy the given assertion
+   * satisfy the given assertion.
    */
   def hasIntersection[A](other: Iterable[A])(assertion: Assertion[Iterable[A]]): Assertion[Iterable[A]] =
     Assertion.assertionRec("hasIntersection")(param(other))(assertion) { actual =>
@@ -358,7 +358,7 @@ object Assertion extends AssertionVariants {
 
   /**
    * Makes a new assertion that requires an Iterable to contain the last
-   * element satisfying the given assertion
+   * element satisfying the given assertion.
    */
   def hasLast[A](assertion: Assertion[A]): Assertion[Iterable[A]] =
     Assertion.assertionRec("hasLast")(param(assertion))(assertion)(actual => actual.lastOption)
@@ -379,7 +379,7 @@ object Assertion extends AssertionVariants {
 
   /**
    * Makes a new assertion that requires an Iterable to have the same elements
-   * as the specified Iterable, though not necessarily in the same order
+   * as the specified Iterable, though not necessarily in the same order.
    */
   def hasSameElements[A](other: Iterable[A]): Assertion[Iterable[A]] =
     Assertion.assertion("hasSameElements")(param(other)) { actual =>
@@ -405,7 +405,7 @@ object Assertion extends AssertionVariants {
 
   /**
    * Makes a new assertion that requires the specified Iterable to be a subset of the
-   * other Iterable
+   * other Iterable.
    */
   def hasSubset[A](other: Iterable[A]): Assertion[Iterable[A]] =
     hasIntersection(other)(hasSameElements(other))
@@ -552,7 +552,7 @@ object Assertion extends AssertionVariants {
     Assertion.assertion("isNonEmpty")()(_.nonEmpty)
 
   /**
-   * Makes a new assertion that requires a given string to be non empty
+   * Makes a new assertion that requires a given string to be non empty.
    */
   val isNonEmptyString: Assertion[String] =
     Assertion.assertion("isNonEmptyString")()(_.nonEmpty)
@@ -631,7 +631,7 @@ object Assertion extends AssertionVariants {
     isSorted(ord.reverse)
 
   /**
-   * Makes an assertion that requires a value have the specified type.
+   * Makes a new assertion that requires a value have the specified type.
    *
    * Example:
    * {{{
@@ -670,7 +670,7 @@ object Assertion extends AssertionVariants {
     Assertion.assertion("isUnit")()(_ => true)
 
   /**
-   * Returns a new assertion that requires a value to fall within a
+   * Makes a new assertion that requires a value to fall within a
    * specified min and max (inclusive).
    */
   def isWithin[A](min: A, max: A)(implicit ord: Ordering[A]): Assertion[A] =
@@ -720,7 +720,7 @@ object Assertion extends AssertionVariants {
     Assertion.assertion("startsWith")(param(prefix))(_.startsWith(prefix))
 
   /**
-   * Makes a new assertion that requires a given string to start with a specified prefix
+   * Makes a new assertion that requires a given string to start with a specified prefix.
    */
   def startsWithString(prefix: String): Assertion[String] =
     Assertion.assertion("startsWithString")(param(prefix))(_.startsWith(prefix))
@@ -735,7 +735,7 @@ object Assertion extends AssertionVariants {
     }
 
   /**
-   * Returns a new assertion that requires the expression to throw.
+   * Makes a new assertion that requires the expression to throw.
    */
   def throws[A](assertion: Assertion[Throwable]): Assertion[A] =
     Assertion.assertionRec("throws")(param(assertion))(assertion) { actual =>
@@ -748,7 +748,7 @@ object Assertion extends AssertionVariants {
     }
 
   /**
-   * Returns a new assertion that requires the expression to throw an instance
+   * Makes a new assertion that requires the expression to throw an instance
    * of given type (or its subtype).
    */
   def throwsA[E: ClassTag]: Assertion[Any] =

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -459,7 +459,7 @@ object Assertion extends AssertionVariants {
     Assertion.assertion("isEmptyString")()(_.isEmpty)
 
   /**
-   * Makes a new assertion that requires a value be true.
+   * Makes a new assertion that requires a value be false.
    */
   def isFalse: Assertion[Boolean] =
     Assertion.assertion("isFalse")()(!_)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -69,6 +69,7 @@
     "How to": [
       "howto/howto_index",
       "howto/howto_use_layers",
+      "howto/howto_test_assertions",
       "howto/howto_test_effects",
       "howto/howto_mock_services",
       "howto/howto_handle_errors",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -59,6 +59,7 @@
       "usecases/usecases_concurrency",
       "usecases/usecases_parallelism",
       "usecases/usecases_queuing",
+      "usecases/usecases_retrying",
       "usecases/usecases_scheduling",
       "usecases/usecases_streaming",
       "usecases/usecases_testing"


### PR DESCRIPTION
- `test_assertions.md` contains an attempt at documentation for the various `Assertion` functions, categorized by the value type they operate on. This is intended to make it easier to narrow in on the set of applicable functions in any given context, both for newcomers as well as a handy cheat sheet when fleshing out ideas.
- Linking missing [`usecases_retrying`](https://zio.dev/docs/usecases/usecases_retrying) section mentioned in the docs but missing on the sidebar (and hence having no structure on the generated page)
- Making the section headers links, as the blurb at the bottom of the page says "Explore the pages above[...]", but the pages above aren't currently links.
- Consolidating the different wording on `Assertion` members scaladocs to be of the form `Makes a new assertion that [...].`
- Replacing non-breaking spaces (0xA0) with standard spaces (0x20)