### PR TITLE
Add Links to Documentation For TReentrantLock

### DIFF
--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -21,6 +21,7 @@ ZIO contains a small number of data types that can help you solve complex proble
  - **[TPriorityQueue](tpriorityqueue.md)** - A `TPriorityQueue[A]` is a mutable priority queue that can participate in transactions.
  - **[TPromise](tpromise.md)** - A `TPromise` is a mutable reference that can be set exactly once and can participate in transactions.
  - **[TQueue](tqueue.md)** - A `TQueue` is a mutable queue that can participate in transactions.
+ - **[TReentrantLock](treentrantlock.md)** - A `TReentrantLock` is a reentrant read / write lock that can be composed.
  - **[TRef](tref.md)** - A `TRef` is a mutable reference to an immutable value that can participate in transactions.
  - **[TSet](tset.md)** - A `TSet` is a mutable set that can participate in transactions.
  - **[Has](has.md)** - A `Has` is used to express an effect's dependency on a service of type `A`.

--- a/docs/datatypes/treentrantlock.md
+++ b/docs/datatypes/treentrantlock.md
@@ -1,5 +1,5 @@
 ---
-id: datatypes_treentrant_lock
+id: datatypes_treentrantlock
 title:  "TReentrantLock"
 ---
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -32,6 +32,7 @@
       "datatypes/datatypes_tarray",
       "datatypes/datatypes_tmap",
       "datatypes/datatypes_tpriorityqueue",
+      "datatypes/datatypes_treentrantlock",
       "datatypes/datatypes_tpromise",
       "datatypes/datatypes_tqueue",
       "datatypes/datatypes_tref",


### PR DESCRIPTION
We have great documentation on `TReentrantLock` thanks to @calvinlfer and @FrancisToth but there wasn't a link to it on the index or sidebar so it was a "hidden gem". This PR fixes that.