### PR TITLE
FiberRef.link - mirror FiberRef contents to ThreadLocals

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.FiberRefSpecUtil._
+import zio.ZRefSpec.current
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -345,6 +346,24 @@ object FiberRefSpec extends ZIOBaseSpec {
           value1   <- fiberRef.get
           value2   <- UIO(handle.get())
         } yield assert((value1, value2))(equalTo((initial, initial)))
+      },
+      testM("link to thread") {
+        val threadLocal = new ThreadLocal[Option[String]]() {
+          override def initialValue(): Option[String] = None
+        }
+        for {
+          _                 <- FiberRef.make(current, link = (s:String) => threadLocal.set(Some(s)))
+          loopThreadVals    <- ZIO.foreach(0 to 2000: Seq[Int])(_ =>  UIO(threadLocal.get))
+          blockingThreadVal <- zio.blocking.effectBlocking {
+            Thread.sleep(10)
+            threadLocal.get
+          }.orDie
+          asyncThreadVal        <- Live.live(zio.clock.sleep(10.millis)) *> UIO(threadLocal.get)
+        } yield {
+          assert(loopThreadVals)(forall(isSome(equalTo(current)))) &&
+          assert(blockingThreadVal)(isSome(equalTo(current))) &&
+          assert(asyncThreadVal)(isSome(equalTo(current)))
+        }
       }
     )
   )

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -650,7 +650,7 @@ object Fiber extends FiberPlatformSpecific {
   /**
    * A `FiberRef` that stores the name of the fiber, which defaults to `None`.
    */
-  val fiberName: FiberRef[Option[String]] = new FiberRef(None, identity, (old, _) => old)
+  val fiberName: FiberRef[Option[String]] = new FiberRef(None, identity, (old, _) => old, _ => ())
 
   /**
    * Lifts an [[zio.IO]] into a `Fiber`.

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -48,7 +48,8 @@ package zio
 final class FiberRef[A] private[zio] (
   private[zio] val initial: A,
   private[zio] val fork: A => A,
-  private[zio] val join: (A, A) => A
+  private[zio] val join: (A, A) => A,
+  private[zio] val link: A => Unit
 ) extends Serializable { self =>
 
   /**
@@ -202,6 +203,6 @@ object FiberRef extends Serializable {
   /**
    * Creates a new `FiberRef` with given initial value.
    */
-  def make[A](initial: A, fork: A => A = (a: A) => a, join: (A, A) => A = ((_: A, a: A) => a)): UIO[FiberRef[A]] =
-    new ZIO.FiberRefNew(initial, fork, join)
+  def make[A](initial: A, fork: A => A = (a: A) => a, join: (A, A) => A = ((_: A, a: A) => a), link: A => Unit  = (_: A) => ()): UIO[FiberRef[A]] =
+    new ZIO.FiberRefNew(initial, fork, join, link)
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4357,7 +4357,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     override def tag = Tags.EffectSuspendTotalWith
   }
 
-  private[zio] final class FiberRefNew[A](val initial: A, private[zio] val onFork: A => A, val onJoin: (A, A) => A)
+  private[zio] final class FiberRefNew[A](val initial: A, private[zio] val onFork: A => A, val onJoin: (A, A) => A, val link: A => Unit)
       extends UIO[FiberRef[A]] {
     override def tag = Tags.FiberRefNew
   }


### PR DESCRIPTION
This attempts to add an ability for a `FiberRef` contents to be mirrored to non-zio infra (outside of our control) backed by `ThreadLocals`.
For example, when using NewRelic and it's [Tokens](https://docs.newrelic.com/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#tokens) to connect async flows to what they call a transaction (think an incoming request).
In this case, we would store the new relic token in a `FiberRef` like this:
```scala
    FiberRef.make(nrToken, link = _.link())
```
The provided `link` function will be called by zio after every async boundary so any effect running in this fiber (or a fiber inheriting this ref) will run on a thread "linked" to the token

(`MDC` is a simpler example, but maybe easier to work around with libraries like `zio-logging` or `FiberRef.unsafeAsThreadLocal`)

**Note**: this is a very rough draft:
1. Not sure if running `link` in at the start of `FiberContext.evaluateNow()` covers all cases where fibers "jump" threads.
1. Need to make sure `FiberContext` additions are optimized and no overhead is incurred when `link` function is not provided  (need benchmarks) 
2. Maybe also need to support `unlink` for cleanup at the end of the boundary.

@adamgfraser this is what we discussed on discord.
@jdegoes WDYT?
