### PR TITLE
Replace the list of joiners in Promise to a LongMap

### DIFF
--- a/benchmarks/src/main/scala/zio/PromiseBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/PromiseBenchmark.scala
@@ -1,0 +1,68 @@
+package zio
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+class PromiseBenchmark {
+
+  @Param(Array("100000"))
+  var n: Int = _
+
+  @Benchmark
+  def tracedAwaitComplete(): Unit =
+    createAwaitComplete(IOBenchmarks.TracedRuntime)
+
+  @Benchmark
+  def unTracedAwaitComplete(): Unit =
+    createAwaitComplete(IOBenchmarks)
+
+  @Benchmark
+  def tracedAwaitUnsafeDone(): Unit =
+    createAwaitUnsafeDone(IOBenchmarks.TracedRuntime)
+
+  @Benchmark
+  def unTracedAwaitUnsafeDone(): Unit =
+    createAwaitUnsafeDone(IOBenchmarks)
+
+  @Benchmark
+  def tracedAwaitInterrupt(): Unit =
+    createAwaitInterrupt(IOBenchmarks.TracedRuntime)
+
+  @Benchmark
+  def unTracedAwaitInterrupt(): Unit =
+    createAwaitInterrupt(IOBenchmarks)
+
+  private def createAwaitComplete(runtime: Runtime[Any]): Unit = runtime.unsafeRun {
+    for {
+      promise <- Promise.make[Nothing, Unit]
+      joiners <- ZIO.loop(1)(_ <= n, _ + 1)(_ => promise.await.fork)
+      _       <- promise.succeed(())
+      _       <- ZIO.foreach_(joiners)(_.join)
+    } yield ()
+  }
+
+  private def createAwaitUnsafeDone(runtime: Runtime[Any]): Unit = runtime.unsafeRun {
+    for {
+      promise <- Promise.make[Nothing, Unit]
+      joiners <- ZIO.loop(1)(_ <= n, _ + 1)(_ => promise.await.fork)
+      _       <- UIO.effectTotal(promise.unsafeDone(IO.succeedNow(())))
+      _       <- ZIO.foreach_(joiners)(_.join)
+    } yield ()
+  }
+
+  private def createAwaitInterrupt(runtime: Runtime[Any]): Unit = runtime.unsafeRun {
+    for {
+      promise <- Promise.make[Nothing, Unit]
+      joiners <- ZIO.loop(1)(_ <= n, _ + 1)(_ => promise.await.fork)
+      _       <- ZIO.foreach_(joiners)(_.interrupt)
+    } yield ()
+  }
+}


### PR DESCRIPTION
Replaces the `List` holding the joiners awaiting a `Promise` to `LongMap` so interrupting one is more efficient as described in https://github.com/zio/zio/issues/4402.

Benchmarks with the `List` optimization on JDK 15 with Scala 2.12.12:

```
[info] PromiseBenchmark.tracedAwaitComplete         64  thrpt    5  2971,525 ±  213,709  ops/s
[info] PromiseBenchmark.tracedAwaitComplete       1024  thrpt    5   125,310 ±    9,464  ops/s
[info] PromiseBenchmark.tracedAwaitComplete      16384  thrpt    5     7,052 ±    0,600  ops/s
[info] PromiseBenchmark.tracedAwaitComplete     100000  thrpt    5     0,930 ±    0,405  ops/s

[info] PromiseBenchmark.tracedAwaitInterrupt        64  thrpt    5  1297,796 ±  113,169  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt      1024  thrpt    5    51,439 ±    3,058  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt     16384  thrpt    5     0,582 ±    0,104  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt    100000  thrpt    5     0,012 ±    0,004  ops/s

[info] PromiseBenchmark.tracedAwaitUnsafeDone       64  thrpt    5  3065,293 ±  210,131  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone     1024  thrpt    5   150,733 ±   10,081  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone    16384  thrpt    5     6,910 ±    0,829  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone   100000  thrpt    5     1,114 ±    0,345  ops/s

[info] PromiseBenchmark.unTracedAwaitComplete       64  thrpt    5  4983,479 ± 1439,190  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete     1024  thrpt    5   347,312 ±    7,473  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete    16384  thrpt    5    20,641 ±    1,125  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete   100000  thrpt    5     2,666 ±    2,982  ops/s

[info] PromiseBenchmark.unTracedAwaitInterrupt      64  thrpt    5  1688,665 ±  419,389  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt    1024  thrpt    5    70,609 ±    1,945  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt   16384  thrpt    5     0,687 ±    0,075  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt  100000  thrpt    5     0,016 ±    0,005  ops/s

[info] PromiseBenchmark.unTracedAwaitUnsafeDone     64  thrpt    5  5270,397 ±  944,127  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone   1024  thrpt    5   368,176 ±  122,218  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone  16384  thrpt    5    24,946 ±    1,481  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone 100000  thrpt    5     3,507 ±    3,426  ops/s
```
And with the new implementation:

```
[info] PromiseBenchmark.tracedAwaitComplete          64  thrpt    5  2657,282 ± 282,901  ops/s
[info] PromiseBenchmark.tracedAwaitComplete        1024  thrpt    5   133,221 ±  13,853  ops/s
[info] PromiseBenchmark.tracedAwaitComplete       16384  thrpt    5     6,601 ±   0,780  ops/s
[info] PromiseBenchmark.tracedAwaitComplete      100000  thrpt    5     1,015 ±   0,617  ops/s

[info] PromiseBenchmark.tracedAwaitInterrupt         64  thrpt    5  1252,523 ± 153,398  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt       1024  thrpt    5    70,021 ±   4,401  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt      16384  thrpt    5     3,671 ±   0,883  ops/s
[info] PromiseBenchmark.tracedAwaitInterrupt     100000  thrpt    5     0,580 ±   0,066  ops/s

[info] PromiseBenchmark.tracedAwaitUnsafeDone        64  thrpt    5  2827,377 ±  72,801  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone      1024  thrpt    5   125,962 ±   3,376  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone     16384  thrpt    5     7,527 ±   0,767  ops/s
[info] PromiseBenchmark.tracedAwaitUnsafeDone    100000  thrpt    5     0,945 ±   0,376  ops/s

[info] PromiseBenchmark.unTracedAwaitComplete        64  thrpt    5  4955,338 ± 840,694  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete      1024  thrpt    5   359,770 ±  28,458  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete     16384  thrpt    5    15,463 ±  14,079  ops/s
[info] PromiseBenchmark.unTracedAwaitComplete    100000  thrpt    5     2,294 ±   0,850  ops/s

[info] PromiseBenchmark.unTracedAwaitInterrupt       64  thrpt    5  1552,931 ± 349,530  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt     1024  thrpt    5    98,314 ±  29,283  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt    16384  thrpt    5     5,865 ±   0,569  ops/s
[info] PromiseBenchmark.unTracedAwaitInterrupt   100000  thrpt    5     0,837 ±   0,508  ops/s

[info] PromiseBenchmark.unTracedAwaitUnsafeDone      64  thrpt    5  4758,183 ± 179,123  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone    1024  thrpt    5   365,498 ±  25,011  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone   16384  thrpt    5    20,241 ±   3,963  ops/s
[info] PromiseBenchmark.unTracedAwaitUnsafeDone  100000  thrpt    5     2,817 ±   1,295  ops/s
```