### PR TITLE
zio-test: make `assert` capture expression and source location using macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -341,6 +341,11 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-sbt"))
   .settings(stdSettings("zio-test-sbt"))
   .settings(crossProjectSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %%% "sourcecode" % "0.2.1" % Test
+    )
+  )
   .settings(mainClass in (Test, run) := Some("zio.test.sbt.TestMain"))
   .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion))
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))

--- a/build.sbt
+++ b/build.sbt
@@ -278,11 +278,6 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.test"))
   .settings(skip in publish := true)
   .settings(macroExpansionSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.lihaoyi" %%% "sourcecode" % "0.2.1" % Test
-    )
-  )
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testTestsJVM = testTests.jvm.settings(dottySettings)
@@ -341,11 +336,6 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-sbt"))
   .settings(stdSettings("zio-test-sbt"))
   .settings(crossProjectSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.lihaoyi" %%% "sourcecode" % "0.2.1" % Test
-    )
-  )
   .settings(mainClass in (Test, run) := Some("zio.test.sbt.TestMain"))
   .jsSettings(libraryDependencies ++= Seq("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion))
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))

--- a/build.sbt
+++ b/build.sbt
@@ -278,6 +278,11 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.test"))
   .settings(skip in publish := true)
   .settings(macroExpansionSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %%% "sourcecode" % "0.2.1" % Test
+    )
+  )
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testTestsJVM = testTests.jvm.settings(dottySettings)

--- a/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -6,7 +6,8 @@ object ExampleSpec extends DefaultRunnableSpec {
 
   def spec = suite("some suite")(
     test("failing test") {
-      assert(1)(Assertion.equalTo(2))
+      val stuff = 1
+      assert(stuff)(Assertion.equalTo(2))
     },
     test("passing test") {
       assert(1)(Assertion.equalTo(1))

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -67,8 +67,8 @@ object MavenJunitSpec extends DefaultRunnableSpec {
   } yield new MavenDriver(projectDir, projectVer)
 
   class MavenDriver(projectDir: String, projectVersion: String) {
-    val mvnRoot     = new File(s"$projectDir/../maven").getCanonicalPath
-    private val cli = new MavenCli
+    val mvnRoot: String = new File(s"$projectDir/../maven").getCanonicalPath
+    private val cli     = new MavenCli
     System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
 
     def clean(): RIO[Blocking, Int] = run("clean")

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -27,10 +27,17 @@ object MavenJunitSpec extends DefaultRunnableSpec {
       } yield {
         assert(mvnResult)(not(equalTo(0))) &&
         assert(report)(
-          containsFailure("should fail", "zio.test.junit.TestFailed: 11 did not satisfy equalTo(12)") &&
+          containsFailure(
+            "should fail",
+            s"""zio.test.junit.TestFailed:
+               |11 did not satisfy equalTo(12)
+               |11 did not satisfy (equalTo(12) ?? "assert(`11`) (at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10)")""".stripMargin
+          ) &&
             containsFailure(
               "should fail - isSome",
-              "zio.test.junit.TestFailed: \n11 did not satisfy equalTo(12)\nSome(11) did not satisfy isSome(equalTo(12))"
+              s"""zio.test.junit.TestFailed:
+                 |11 did not satisfy equalTo(12)
+                 |Some(11) did not satisfy (isSome(equalTo(12)) ?? "assert(`Some[Int](11)`) (at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13)")""".stripMargin
             ) &&
             containsSuccess("should succeed")
         )
@@ -54,14 +61,14 @@ object MavenJunitSpec extends DefaultRunnableSpec {
         .orElseFail(
           new AssertionError(
             "Missing project.version system property\n" +
-              "when running from IDE put this into `VM Parameters`: `-Dproject.dir=<current zio version>`"
+              "when running from IDE put this into `VM Parameters`: `-Dproject.version=<current zio version>`"
           )
         )
   } yield new MavenDriver(projectDir, projectVer)
 
   class MavenDriver(projectDir: String, projectVersion: String) {
-    private val mvnRoot = new File(s"$projectDir/../maven").getCanonicalPath
-    private val cli     = new MavenCli
+    val mvnRoot     = new File(s"$projectDir/../maven").getCanonicalPath
+    private val cli = new MavenCli
     System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
 
     def clean(): RIO[Blocking, Int] = run("clean")
@@ -77,7 +84,9 @@ object MavenJunitSpec extends DefaultRunnableSpec {
         (report \ "testcase").map { tcNode =>
           TestCase(
             tcNode \@ "name",
-            (tcNode \ "error").headOption.map(error => TestError(error.text.trim, error \@ "type"))
+            (tcNode \ "error").headOption.map(error =>
+              TestError(error.text.linesIterator.map(_.trim).mkString("\n"), error \@ "type")
+            )
           )
         }
       }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -99,19 +99,23 @@ object ZTestFrameworkSpec {
     val loggers = Seq.fill(3)(new MockLogger)
 
     loadAndExecute(multiLineSpecFQN, loggers = loggers)
-    val Seq(labelLine1, labelLine2) = assertLabel("\"\"\"Hello,\nWorld!\"\"\"").linesIterator.toSeq
+    val label = assertLabel(zio.test.showExpression("Hello,\nWorld!"))
     loggers.map(_.messages) foreach (messages =>
       assertEquals(
         "logged messages",
         messages.mkString.split("\n").dropRight(1).mkString("\n").withNoLineNumbers,
         List(
-          s"${reset("info:")} ${red("- multi-line test")}",
-          s"${reset("info:")}   ${Console.BLUE}Hello,",
-          s"${reset("info:")} ${blue("World!")} did not satisfy ${cyan("equalTo(Hello, World!)")}",
-          s"${reset("info:")}   ${Console.BLUE}Hello,",
-          s"${reset("info:")} ${blue("World!")} did not satisfy ${cyan("(") + yellow("equalTo(Hello, World!)") + s"${Console.CYAN} ?? $labelLine1"}",
-          s"${reset("info:")} ${cyan(s"$labelLine2)")}"
+          s"${red("- multi-line test")}",
+          s"  ${Console.BLUE}Hello,",
+          s"${blue("World!")} did not satisfy ${cyan("equalTo(Hello, World!)")}",
+          s"  ${Console.BLUE}Hello,",
+          s"${blue("World!")} did not satisfy ${cyan("(") + yellow("equalTo(Hello, World!)") + cyan(
+            s" ?? ${label.linesIterator.mkString("\n" + Console.CYAN)})"
+          )}"
         ).mkString("\n")
+          .linesIterator
+          .map(s"${reset("info:")} " + _)
+          .mkString("\n")
       )
     )
   }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -219,7 +219,7 @@ object ZTestFrameworkSpec {
     }
   }
 
-  lazy val sourceFilePath: String       = sourcecode.File()
+  lazy val sourceFilePath: String       = zio.test.sourcePath
   def assertLabel(expr: String): String = s""""assert(`$expr`) (at $sourceFilePath:XXX)""""
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -110,10 +110,10 @@ object ZTestFrameworkSpec {
           s"${blue("World!")} did not satisfy ${cyan("equalTo(Hello, World!)")}",
           s"  ${Console.BLUE}Hello,",
           s"${blue("World!")} did not satisfy ${cyan("(") + yellow("equalTo(Hello, World!)") + cyan(
-            s" ?? ${label.linesIterator.mkString("\n" + Console.CYAN)})"
+            s" ?? ${label.split('\n').mkString("\n" + Console.CYAN)})"
           )}"
         ).mkString("\n")
-          .linesIterator
+          .split('\n')
           .map(s"${reset("info:")} " + _)
           .mkString("\n")
       )

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -13,6 +13,8 @@ import zio.{ Cause, Layer, ZIO }
 
 object ReportingTestUtils {
 
+  val sourceFilePath: String = sourcecode.File()
+
   def expectedSuccess(label: String): String =
     green("+") + " " + label + "\n"
 
@@ -83,11 +85,15 @@ object ReportingTestUtils {
     expectedFailure("Value falls within range"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("((") + yellow("equalTo(42)") + cyan(
+        s" || (isGreaterThan(5) && isLessThan(10))) ?? ${assertLabel("52", 80)})"
+      )}\n"
     ),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
+      s"${blue("52")} did not satisfy ${cyan("((equalTo(42) || (isGreaterThan(5) && ") + yellow(
+        "isLessThan(10)"
+      ) + cyan(s")) ?? ${assertLabel("52", 80)})")}\n"
     )
   )
 
@@ -104,7 +110,10 @@ object ReportingTestUtils {
   val test5: ZSpec[Any, Nothing] = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(3)))
   val test5Expected: Vector[String] = Vector(
     expectedFailure("Addition works fine"),
-    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n")
+    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n"),
+    withOffset(2)(
+      s"${blue("2")} did not satisfy ${cyan("(") + yellow("equalTo(3)") + cyan(s" ?? ${assertLabel("2", 103)})")}\n"
+    )
   )
 
   val test6: ZSpec[Any, Nothing] =
@@ -116,7 +125,9 @@ object ReportingTestUtils {
       s"${blue("Some(3)")} did not satisfy ${cyan("isSome(") + yellow("isGreaterThan(4)") + cyan(")")}\n"
     ),
     withOffset(2)(
-      s"${blue("Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
+      s"${blue("Right(Some(3))")} did not satisfy ${cyan("(isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(
+        s") ?? ${assertLabel("Right[Nothing, Some[Int]](Some[Int](3))", 111)})"
+      )}\n"
     )
   )
 
@@ -135,7 +146,7 @@ object ReportingTestUtils {
     expectedFailure("labeled failures"),
     withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
     withOffset(2)(
-      s"${blue("Some(0)")} did not satisfy ${cyan("(isSome(") + yellow("equalTo(1)") + cyan(") ?? \"third\")")}\n"
+      s"${blue("Some(0)")} did not satisfy ${cyan("((isSome(") + yellow("equalTo(1)") + cyan(s""") ?? "third") ?? ${assertLabel("c", 131)})""")}\n"
     )
   )
 
@@ -146,7 +157,7 @@ object ReportingTestUtils {
     expectedFailure("Not combinator"),
     withOffset(2)(s"${blue("100")} satisfied ${cyan("equalTo(100)")}\n"),
     withOffset(2)(
-      s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}\n"
+      s"${blue("100")} did not satisfy ${cyan("(not(") + yellow("equalTo(100)") + cyan(s") ?? ${assertLabel("100", 143)})")}\n"
     )
   )
 
@@ -231,4 +242,6 @@ object ReportingTestUtils {
     expectedFailure("Invalid range"),
     withOffset(2)(s"""${red("- invalid repetition range 4 to 2 by -1")}\n""")
   )
+
+  def assertLabel(expr: String, line: Int): String = s""""assert(`$expr`) (at $sourceFilePath:$line)""""
 }

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -15,7 +15,7 @@ import zio.{ Cause, Layer, ZIO }
 
 object ReportingTestUtils {
 
-  val sourceFilePath: String = sourcecode.File()
+  val sourceFilePath: String = zio.test.sourcePath
 
   def expectedSuccess(label: String): String =
     green("+") + " " + label + "\n"

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -67,7 +67,7 @@ object ReportingTestUtils {
                      TestLogger.fromConsole ++ TestClock.default
                    )
       actualSummary = SummaryBuilder.buildSummary(results)
-    } yield actualSummary.summary
+    } yield actualSummary.summary.withNoLineNumbers
 
   private[this] def TestTestRunner(testEnvironment: Layer[Nothing, TestEnvironment]) =
     TestRunner[TestEnvironment, String](

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -112,7 +112,7 @@ object ReportingTestUtils {
     expectedFailure("Addition works fine"),
     withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n"),
     withOffset(2)(
-      s"${blue("2")} did not satisfy ${cyan("(") + yellow("equalTo(3)") + cyan(s" ?? ${assertLabel("2", 103)})")}\n"
+      s"${blue("2")} did not satisfy ${cyan("(") + yellow("equalTo(3)") + cyan(s" ?? ${assertLabel("2", 107)})")}\n"
     )
   )
 
@@ -126,7 +126,7 @@ object ReportingTestUtils {
     ),
     withOffset(2)(
       s"${blue("Right(Some(3))")} did not satisfy ${cyan("(isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(
-        s") ?? ${assertLabel("Right[Nothing, Some[Int]](Some[Int](3))", 111)})"
+        s") ?? ${assertLabel("Right[Nothing, Some[Int]](Some[Int](3))", 117)})"
       )}\n"
     )
   )
@@ -146,7 +146,7 @@ object ReportingTestUtils {
     expectedFailure("labeled failures"),
     withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
     withOffset(2)(
-      s"${blue("Some(0)")} did not satisfy ${cyan("((isSome(") + yellow("equalTo(1)") + cyan(s""") ?? "third") ?? ${assertLabel("c", 131)})""")}\n"
+      s"${blue("Some(0)")} did not satisfy ${cyan("((isSome(") + yellow("equalTo(1)") + cyan(s""") ?? "third") ?? ${assertLabel("c", 139)})""")}\n"
     )
   )
 
@@ -157,7 +157,7 @@ object ReportingTestUtils {
     expectedFailure("Not combinator"),
     withOffset(2)(s"${blue("100")} satisfied ${cyan("equalTo(100)")}\n"),
     withOffset(2)(
-      s"${blue("100")} did not satisfy ${cyan("(not(") + yellow("equalTo(100)") + cyan(s") ?? ${assertLabel("100", 143)})")}\n"
+      s"${blue("100")} did not satisfy ${cyan("(not(") + yellow("equalTo(100)") + cyan(s") ?? ${assertLabel("100", 151)})")}\n"
     )
   )
 

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -16,8 +16,6 @@
 
 package zio.test
 
-import scala.language.experimental.macros
-
 import zio.UIO
 
 trait CompileVariants {

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -31,10 +31,18 @@ trait CompileVariants {
   final def typeCheck(code: String): UIO[Either[String, Unit]] =
     macro Macros.typeCheck_impl
 
-  def assertRuntime[A](value: => A)(assertion: Assertion[A]): TestResult
+  private[test] def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult
 
   /**
    * Checks the assertion holds for the given value.
    */
   def assert[A](expr: => A)(assertion: Assertion[A]): TestResult = macro Macros.assert_impl
+}
+
+object CompileVariants {
+
+  /**
+   * just a proxy to call package private assertRuntime from the macro
+   */
+  def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult = zio.test.assertImpl(value)(assertion)
 }

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -37,6 +37,8 @@ trait CompileVariants {
   def assert[A](expr: => A)(assertion: Assertion[A]): TestResult = macro Macros.assert_impl
 
   private[zio] def sourcePath: String = macro Macros.sourcePath_impl
+
+  private[zio] def showExpression[A](expr: => A): String = macro Macros.showExpression_impl
 }
 
 object CompileVariants {

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -35,6 +35,8 @@ trait CompileVariants {
    * Checks the assertion holds for the given value.
    */
   def assert[A](expr: => A)(assertion: Assertion[A]): TestResult = macro Macros.assert_impl
+
+  private[zio] def sourcePath: String = macro Macros.sourcePath_impl
 }
 
 object CompileVariants {

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -16,9 +16,9 @@
 
 package zio.test
 
-import zio.UIO
-
 import scala.language.experimental.macros
+
+import zio.UIO
 
 trait CompileVariants {
 
@@ -37,11 +37,4 @@ trait CompileVariants {
    * Checks the assertion holds for the given value.
    */
   def assert[A](expr: => A)(assertion: Assertion[A]): TestResult = macro Macros.assert_impl
-}
-
-object CompileVariants {
-  class PartialAssert[+A](value: => A, label: String, f: (=> A) => Assertion[A] => TestResult)
-      extends (Assertion[A] => TestResult) {
-    def apply(assertion: Assertion[A]) = f(value)(assertion.label(label))
-  }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -35,12 +35,14 @@ private[test] object Macros {
 
   private val fieldInAnonymousClassPrefix = "$anon.this."
 
+  def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult = zio.test.assertImpl(value)(assertion)
+
   def assert_impl(c: blackbox.Context)(expr: c.Tree)(assertion: c.Tree): c.Tree = {
     import c.universe._
     val fileName = c.enclosingPosition.source.path
     val line     = c.enclosingPosition.line
     val code     = s"${showCode(expr).stripPrefix(fieldInAnonymousClassPrefix)}"
-    val label    = s"expression: `$code` (at $fileName:$line))"
-    q"_root_.zio.test.assertRuntime($expr)($assertion.label($label))"
+    val label    = s"assert(`$code`) (at $fileName:$line)"
+    q"_root_.zio.test.CompileVariants.assertImpl($expr)($assertion.label($label))"
   }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -41,6 +41,6 @@ private[test] object Macros {
     val line     = c.enclosingPosition.line
     val code     = s"${showCode(expr).stripPrefix(fieldInAnonymousClassPrefix)}"
     val label    = s"expression: `$code` (at $fileName:$line))"
-    q"zio.test.assertRuntime($expr)($assertion.label($label))"
+    q"_root_.zio.test.assertRuntime($expr)($assertion.label($label))"
   }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -41,19 +41,29 @@ private[test] object Macros {
     import c.universe._
     val fileName = c.enclosingPosition.source.path
     val line     = c.enclosingPosition.line
-    val code = showCode(expr)
-      .stripPrefix(fieldInAnonymousClassPrefix)
-      // for scala 3 compatibility
-      .replace(".`package`.", ".")
-      // reduce clutter
-      .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
-      .replaceAll("""\.apply(\s*[\[(])""", "$1")
-    val label = s"assert(`$code`) (at $fileName:$line)"
+    val code     = showExpr(c)(expr)
+    val label    = s"assert(`$code`) (at $fileName:$line)"
     q"_root_.zio.test.CompileVariants.assertImpl($expr)($assertion.label($label))"
   }
 
   def sourcePath_impl(c: blackbox.Context): c.Tree = {
     import c.universe._
     q"${c.enclosingPosition.source.path}"
+  }
+
+  private def showExpr(c: blackbox.Context)(expr: c.Tree) = {
+    import c.universe._
+    showCode(expr)
+      .stripPrefix(fieldInAnonymousClassPrefix)
+      // for scala 3 compatibility
+      .replace(".`package`.", ".")
+      // reduce clutter
+      .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
+      .replaceAll("""\.apply(\s*[\[(])""", "$1")
+  }
+
+  def showExpression_impl(c: blackbox.Context)(expr: c.Tree): c.Tree = {
+    import c.universe._
+    q"${showExpr(c)(expr)}"
   }
 }

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -51,4 +51,9 @@ private[test] object Macros {
     val label = s"assert(`$code`) (at $fileName:$line)"
     q"_root_.zio.test.CompileVariants.assertImpl($expr)($assertion.label($label))"
   }
+
+  def sourcePath_impl(c: blackbox.Context): c.Tree = {
+    import c.universe._
+    q"${c.enclosingPosition.source.path}"
+  }
 }

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -61,6 +61,9 @@ object Macros {
     val path = rootPosition.sourceFile.jpath.toString
     val line = rootPosition.startLine + 1
     val code = value.show
+      // reduce clutter
+      .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
+      .replaceAll("""\.apply(\s*[\[(])""", "$1")
     val label = s"assert(`$code`) (at $path:$line)"
     '{_root_.zio.test.CompileVariants.assertImpl[A]($value)(${assertion}.label(${Expr(label)}))}
   }

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -45,6 +45,8 @@ trait CompileVariants {
   private[test] def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult
 
   inline def assert[A](inline value: => A)(inline assertion: Assertion[A]): TestResult = ${Macros.assert_impl('value)('assertion)}
+
+  private[zio] inline def sourcePath: String = ${Macros.sourcePath_impl}
 }
 
 object CompileVariants {
@@ -66,5 +68,9 @@ object Macros {
       .replaceAll("""\.apply(\s*[\[(])""", "$1")
     val label = s"assert(`$code`) (at $path:$line)"
     '{_root_.zio.test.CompileVariants.assertImpl[A]($value)(${assertion}.label(${Expr(label)}))}
+  }
+  def sourcePath_impl(using ctx: QuoteContext): Expr[String] = {
+    import ctx.tasty._
+    Expr(rootPosition.sourceFile.jpath.toString)
   }
 }

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -56,6 +56,6 @@ object Macros {
     val line = rootPosition.startLine + 1
     val code = value.show
     val label = s"expression: `$code` (at $path:$line))"
-    '{zio.test.assertRuntime[A]($value)(${assertion}.label(${Expr(label)}))}
+    '{_root_.zio.test.assertRuntime[A]($value)(${assertion}.label(${Expr(label)}))}
   }
 }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -357,7 +357,7 @@ object FailureRenderer {
     failedMatches.map {
       case InvalidCall.InvalidArguments(invoked, args, assertion) =>
         val header = red(s"- $invoked called with invalid arguments").toLine
-        (header +: renderTestFailure("", assert(args)(assertion)).drop(1)).withOffset(tabSize)
+        (header +: renderTestFailure("", assertRuntime(args)(assertion)).drop(1)).withOffset(tabSize)
 
       case InvalidCall.InvalidCapability(invoked, expected, assertion) =>
         Message(

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -357,7 +357,7 @@ object FailureRenderer {
     failedMatches.map {
       case InvalidCall.InvalidArguments(invoked, args, assertion) =>
         val header = red(s"- $invoked called with invalid arguments").toLine
-        (header +: renderTestFailure("", assertRuntime(args)(assertion)).drop(1)).withOffset(tabSize)
+        (header +: renderTestFailure("", assertImpl(args)(assertion)).drop(1)).withOffset(tabSize)
 
       case InvalidCall.InvalidCapability(invoked, expected, assertion) =>
         Message(

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -348,7 +348,7 @@ object TestAspect extends TimeoutVariants {
         test.foldM(
           failure =>
             if (assertion.test(failure)) ZIO.succeedNow(TestSuccess.Succeeded(BoolAlgebra.unit))
-            else ZIO.fail(TestFailure.assertion(assertRuntime(failure)(assertion))),
+            else ZIO.fail(TestFailure.assertion(assertImpl(failure)(assertion))),
           _ => ZIO.fail(TestFailure.die(new RuntimeException("did not fail as expected")))
         )
     }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -348,7 +348,7 @@ object TestAspect extends TimeoutVariants {
         test.foldM(
           failure =>
             if (assertion.test(failure)) ZIO.succeedNow(TestSuccess.Succeeded(BoolAlgebra.unit))
-            else ZIO.fail(TestFailure.assertion(assert(failure)(assertion))),
+            else ZIO.fail(TestFailure.assertion(assertRuntime(failure)(assertion))),
           _ => ZIO.fail(TestFailure.die(new RuntimeException("did not fail as expected")))
         )
     }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -145,7 +145,7 @@ package object test extends CompileVariants {
   /**
    * Checks the assertion holds for the given value.
    */
-  def assertRuntime[A](value: => A)(assertion: Assertion[A]): TestResult = {
+  private[test] def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult = {
     lazy val tryValue = Try(value)
     traverseResult(tryValue.get, assertion.run(tryValue.get), assertion)
   }
@@ -154,7 +154,7 @@ package object test extends CompileVariants {
    * Asserts that the given test was completed.
    */
   val assertCompletes: TestResult =
-    assertRuntime(true)(Assertion.isTrue)
+    assertImpl(true)(Assertion.isTrue)
 
   /**
    * Checks the assertion holds for the given effectfully-computed value.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -145,7 +145,7 @@ package object test extends CompileVariants {
   /**
    * Checks the assertion holds for the given value.
    */
-  def assert[A](value: => A)(assertion: Assertion[A]): TestResult = {
+  def assertRuntime[A](value: => A)(assertion: Assertion[A]): TestResult = {
     lazy val tryValue = Try(value)
     traverseResult(tryValue.get, assertion.run(tryValue.get), assertion)
   }
@@ -154,7 +154,7 @@ package object test extends CompileVariants {
    * Asserts that the given test was completed.
    */
   val assertCompletes: TestResult =
-    assert(true)(Assertion.isTrue)
+    assertRuntime(true)(Assertion.isTrue)
 
   /**
    * Checks the assertion holds for the given effectfully-computed value.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1577551/99886942-1450b380-2c49-11eb-9343-9762d6ac56d5.png)

Most tests verifying assert output are failing and need to be fixed.