### PR TITLE
Fix bug in CI where tests ran on Java 8 instead of 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,11 @@ install_jdk: &install_jdk
         fi
         sudo apt update
         if [ $JDK_VERSION == 11 ]; then
-          sudo apt install -y adoptopenjdk-11-hotspot
+          sudo apt install -y --no-install-recommends adoptopenjdk-11-hotspot-jre
+          sudo update-alternatives --set java /usr/lib/jvm/adoptopenjdk-11-hotspot-jre-amd64/bin/java
         elif [ $JDK_VERSION == 8 ]; then
-          sudo apt install -y openjdk-8-jdk
+          sudo apt install -y --no-install-recommends openjdk-8-jre-headless
+          sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
         fi
         java -version
 


### PR DESCRIPTION
Also ZIO suffered from it
https://app.circleci.com/pipelines/github/zio/zio/9434/workflows/996fb9f8-d37b-45c4-b06b-fd0ecdf91de9/jobs/96486
```
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
```