### PR TITLE
Issue/4347 ignored tests not visible in report

### DIFF
--- a/docs/resources/resources.md
+++ b/docs/resources/resources.md
@@ -55,6 +55,7 @@ _These articles reflect the state of ZIO at the time of their publication. The c
 ## Talks
 
 - [Redis Streams with ZIO](https://youtu.be/jJnco6sMZQY) by [Leszek Gruchała](https://twitter.com/leszekgruchala) (October 2020)
+- [Declarative Concurrency with ZIO STM](https://www.youtube.com/watch?v=MEH7hQmGK5M) by Dejan Mijic (June 2020)
 - [FP to the Max](https://www.youtube.com/watch?v=sxudIMiOo68) by John De Goes (July 2018)
 - [Modern Data Driven Applications with ZIO Streams](https://youtu.be/bbss7elSfxs) by Itamar Ravid (December 2019)
 - Systematic error management in application - We ported Rudder to ZIO: [video in French](https://www.youtube.com/watch?v=q0PlcgR5M1Q), [slides in English](https://speakerdeck.com/fanf42/systematic-error-management-we-ported-rudder-to-zio) by François Armand (Scala.io, October 2019)

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/TestingSupport.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/TestingSupport.scala
@@ -32,6 +32,7 @@ object TestingSupport {
   lazy val green: String => String               = colored(Console.GREEN) _
   lazy val cyan: String => String                = colored(Console.CYAN) _
   lazy val blue: String => String                = colored(Console.BLUE) _
+  lazy val yellow: String => String              = colored(Console.YELLOW) _
 
   def reset(str: String): String =
     s"${Console.RESET}$str"

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -85,7 +85,8 @@ object ZTestFrameworkSpec {
           s"${reset("info:")} ${red("- some suite")} - ignored: 1",
           s"${reset("info:")}   ${red("- failing test")}",
           s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
-          s"${reset("info:")}   ${green("+")} passing test"
+          s"${reset("info:")}   ${green("+")} passing test",
+          s"${reset("info:")}   ${yellow("-")} ${yellow("ignored test")} - ignored: 1"
         ).mkString("\n")
       )
     )

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -19,6 +19,9 @@ object ReportingTestUtils {
   def expectedFailure(label: String): String =
     red("- " + label) + "\n"
 
+  def expectedIgnored(label: String): String =
+    yellow("- ") + yellow(label) + " - " + TestAnnotation.ignored.identifier + " suite" + "\n"
+
   def withOffset(n: Int)(s: String): String =
     " " * n + s
 
@@ -170,6 +173,7 @@ object ReportingTestUtils {
   val suite4: Spec[Any, TestFailure[Nothing], TestSuccess] = suite("Suite4")(suite1, suite("Empty")(), test3)
   val suite4Expected: Vector[String] = Vector(expectedFailure("Suite4")) ++
     suite1Expected.map(withOffset(2)) ++
+    Vector(withOffset(2)(expectedIgnored("Empty"))) ++
     test3Expected.map(withOffset(2))
 
   val mock1: ZSpec[Any, Nothing] = zio.test.test("Invalid call") {

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -117,7 +117,7 @@ object DefaultTestReporter {
     withOffset(offset)(green("+") + " " + label)
 
   private def renderIgnoreLabel(label: String, offset: Int) =
-    withOffset(offset)(yellow("-") + " " + yellow(label))
+    withOffset(offset)(yellow("-") + " " + yellow(label) + " - " + TestAnnotation.ignored.identifier + " suite")
 
   private def renderFailure(label: String, offset: Int, details: FailureDetails): Seq[String] =
     renderFailureLabel(label, offset) +: renderFailureDetails(details, offset)

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -117,7 +117,7 @@ object DefaultTestReporter {
     withOffset(offset)(green("+") + " " + label)
 
   private def renderIgnoreLabel(label: String, offset: Int) =
-    withOffset(offset)(yellow("-") + " " + yellow(label) + " - " + TestAnnotation.ignored.identifier + " suite")
+    withOffset(offset)(yellow("- ") + yellow(label) + " - " + TestAnnotation.ignored.identifier + " suite")
 
   private def renderFailure(label: String, offset: Int, details: FailureDetails): Seq[String] =
     renderFailureLabel(label, offset) +: renderFailureDetails(details, offset)

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -82,9 +82,7 @@ object DefaultTestReporter {
                 (Seq(renderFailureLabel(label, depth)) ++ Seq(renderCause(cause, depth))): _*
               )
           }
-          Seq(renderedResult.withAnnotations(
-            if (renderedAnnotations.exists(_.contains(TestAnnotation.ignored.identifier))) Seq.empty
-            else renderedAnnotations))
+          Seq(renderedResult.withAnnotations(renderedAnnotations))
       }
     loop(executedSpec, 0, List.empty)
   }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -54,7 +54,7 @@ object DefaultTestReporter {
           }
           val status = if (hasFailures) Failed else Passed
           val renderedLabel =
-            if (specs.isEmpty) Seq.empty
+            if (specs.isEmpty) Seq(renderIgnoreLabel(label, depth))
             else if (hasFailures) Seq(renderFailureLabel(label, depth))
             else Seq(renderSuccessLabel(label, depth))
           val renderedAnnotations = testAnnotationRenderer.run(ancestors, annotations)
@@ -66,7 +66,7 @@ object DefaultTestReporter {
             case Right(TestSuccess.Succeeded(_)) =>
               rendered(Test, label, Passed, depth, withOffset(depth)(green("+") + " " + label))
             case Right(TestSuccess.Ignored) =>
-              rendered(Test, label, Ignored, depth)
+              rendered(Test, label, Ignored, depth, withOffset(depth)(yellow("-") + " " + yellow(label)))
             case Left(TestFailure.Assertion(result)) =>
               result.fold(details => rendered(Test, label, Failed, depth, renderFailure(label, depth, details): _*))(
                 _ && _,
@@ -115,6 +115,9 @@ object DefaultTestReporter {
 
   private def renderSuccessLabel(label: String, offset: Int) =
     withOffset(offset)(green("+") + " " + label)
+
+  private def renderIgnoreLabel(label: String, offset: Int) =
+    withOffset(offset)(yellow("-") + " " + yellow(label))
 
   private def renderFailure(label: String, offset: Int, details: FailureDetails): Seq[String] =
     renderFailureLabel(label, offset) +: renderFailureDetails(details, offset)

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -82,7 +82,9 @@ object DefaultTestReporter {
                 (Seq(renderFailureLabel(label, depth)) ++ Seq(renderCause(cause, depth))): _*
               )
           }
-          Seq(renderedResult.withAnnotations(renderedAnnotations))
+          Seq(renderedResult.withAnnotations(
+            if (renderedAnnotations.exists(_.contains(TestAnnotation.ignored.identifier))) Seq.empty
+            else renderedAnnotations))
       }
     loop(executedSpec, 0, List.empty)
   }

--- a/test/shared/src/main/scala/zio/test/RenderUtils.scala
+++ b/test/shared/src/main/scala/zio/test/RenderUtils.scala
@@ -23,6 +23,9 @@ private[test] object ConsoleUtils {
   def green(s: String): String =
     SConsole.GREEN + s + SConsole.RESET
 
+  def yellow(s: String): String =
+    SConsole.YELLOW + s + SConsole.RESET
+
   def red(s: String): String =
     SConsole.RED + s + SConsole.RESET
 
@@ -31,4 +34,5 @@ private[test] object ConsoleUtils {
 
   def cyan(s: String): String =
     SConsole.CYAN + s + SConsole.RESET
+
 }


### PR DESCRIPTION
- Add ignored suites to the list of suite presented in the test reports, with `-` and in `yellow` color.
- Add ignored tests to the list of tests presented in the test reports, with `-` and in `yellow` color.
- Suites which executed only contain the ignored count for the suites which were not ignored (since ignored suites are not executed and they could eventually have nested suites with more tests).
- The ignored tests were left with the `- ignored: 1` line in order to facilitate non-color-based distinction, since errors are presented also with `-`, and a fully colorblind person would be unable to distinguish between both without the textual hint.
- The ignored suites now have `- ignored suite` to also explicitly mark them as completely ignored on top of the yellow color.
- Closes #4347

Example image attached below:

![2020-11-21_22-57-47](https://user-images.githubusercontent.com/1115819/99889467-84f9cf00-2c4d-11eb-9c3d-bea131f2d6b2.png)

The Spec used to produce this result was:

```
object MyZIOSpec extends DefaultRunnableSpec {
  def spec = suite("4 Suites")(
    suite1,
    suite2,
    suite3,
    suite4
  )

  def suite1 = suite("Suite 1 with 3 tests")(
    test("2 and 2 are the same number")(assert(2)(equalTo(2))),
    test("3 and 3 are the same number")(assert(3)(equalTo(3))),
    test("4 and 4 are the same number")(assert(4)(equalTo(4)))
  )

  def suite2 = suite("Suite 2 with 5 tests - 1 success, 1 failure and 3 ignore")(
    test("2 and 2 are the same number")(assert(2)(equalTo(2))),
    test("4 and 4 are the same number")(assert(4)(equalTo(4))) @@ TestAspect.ignore,
    test("3 and 4 are the same number")(assert(3)(equalTo(4))), // Fails
    test("5 and 5 are the same number")(assert(5)(equalTo(5))) @@ TestAspect.ignore,
    test("6 and 5 are the same number")(assert(6)(equalTo(5))) @@ TestAspect.ignore
  )

  def suite3 = suite("Suite 3 with 3 tests which will be ignored")(
    test("2 and 2 are the same number")(assert(2)(equalTo(2))),
    test("3 and 3 are the same number")(assert(3)(equalTo(3))),
    test("4 and 4 are the same number")(assert(4)(equalTo(4)))
  ) @@ TestAspect.ignore

  def suite4 = suite("Suite 4 not ignored but with 4 ignored tests")(
    test("4 and 4 are the same number")(assert(4)(equalTo(4))) @@ TestAspect.ignore,
    test("3 and 4 are the same number")(assert(3)(equalTo(4))) @@ TestAspect.ignore,
    test("5 and 5 are the same number")(assert(5)(equalTo(5))) @@ TestAspect.ignore,
    test("6 and 5 are the same number")(assert(6)(equalTo(5))) @@ TestAspect.ignore
  )
}
```