### PR TITLE
Improve TSemaphore

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,7 +14,8 @@ object MimaSettings {
       mimaBinaryIssueFilters ++= Seq(
         exclude[Problem]("zio.internal.*"),
         exclude[DirectMissingMethodProblem]("zio.ZManaged.reserve"),
-        exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this")
+        exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this"),
+        exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
### Before

```
SemaphoreBenchmark.semaphoreCatsContention        10   1000  thrpt   15  81.221 ± 0.813  ops/s
SemaphoreBenchmark.semaphoreContention            10   1000  thrpt   15  90.358 ± 3.090  ops/s
SemaphoreBenchmark.tsemaphoreContention           10   1000  thrpt   15  71.509 ± 1.580  ops/s
```

### After

```
Benchmark                                   (fibers)  (ops)   Mode  Cnt    Score   Error  Units
SemaphoreBenchmark.semaphoreCatsContention        10   1000  thrpt   15   87.725 ± 1.801  ops/s
SemaphoreBenchmark.semaphoreContention            10   1000  thrpt   15   93.385 ± 4.835  ops/s
SemaphoreBenchmark.tsemaphoreContention           10   1000  thrpt   15  130.562 ± 0.780  ops/s
```
