### PR TITLE
Make go and loop recursive functions naming consistent

### DIFF
--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -21,22 +21,22 @@ class IOEmptyRaceBenchmark {
   def monixEmptyRace(): Int = {
     import monix.eval.Task
 
-    def loop(i: Int): monix.eval.Task[Int] =
-      if (i < size) Task.race(Task.never, Task.eval(i + 1)).flatMap(_ => loop(i + 1))
+    def go(i: Int): monix.eval.Task[Int] =
+      if (i < size) Task.race(Task.never, Task.eval(i + 1)).flatMap(_ => go(i + 1))
       else Task.pure(i)
 
-    loop(0).runSyncUnsafe()
+    go(0).runSyncUnsafe()
   }
 
   @Benchmark
   def catsEmptyRace(): Int = {
     import cats.effect.IO
 
-    def loop(i: Int): IO[Int] =
-      if (i < size) IO.race(IO.never, IO.delay(i + 1)).flatMap(_ => loop(i + 1))
+    def go(i: Int): IO[Int] =
+      if (i < size) IO.race(IO.never, IO.delay(i + 1)).flatMap(_ => go(i + 1))
       else IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    go(0).unsafeRunSync()
   }
 
   @Benchmark
@@ -46,10 +46,10 @@ class IOEmptyRaceBenchmark {
   def zioTracedEmptyRace(): Int = zioEmptyRace(TracedRuntime)
 
   private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
-    def loop(i: Int): UIO[Int] =
-      if (i < size) IO.never.raceFirst(IO.effectTotal(i + 1)).flatMap(loop)
+    def go(i: Int): UIO[Int] =
+      if (i < size) IO.never.raceFirst(IO.effectTotal(i + 1)).flatMap(go)
       else IO.succeedNow(i)
 
-    runtime.unsafeRun(loop(0))
+    runtime.unsafeRun(go(0))
   }
 }

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -22,26 +22,26 @@ class IOForkInterruptBenchmark {
   def monixForkInterrupt(): Unit = {
     import monix.eval.Task
 
-    def loop(i: Int): monix.eval.Task[Unit] =
+    def go(i: Int): monix.eval.Task[Unit] =
       if (i < size) Deferred[Task, Unit].flatMap { p1 =>
         Deferred[Task, Unit].flatMap { p2 =>
           p1.complete(())
             .flatMap(_ => Task.never)
             .guarantee(p2.complete(()))
             .start
-            .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => loop(i + 1)))))
+            .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => go(i + 1)))))
         }
       }
       else Task.unit
 
-    loop(0).runSyncUnsafe()
+    go(0).runSyncUnsafe()
   }
 
   @Benchmark
   def catsForkInterrupt(): Unit = {
     import cats.effect.IO
 
-    def loop(i: Int): IO[Unit] =
+    def go(i: Int): IO[Unit] =
       if (i < size)
         Deferred[IO, Unit].flatMap { p1 =>
           Deferred[IO, Unit].flatMap { p2 =>
@@ -49,12 +49,12 @@ class IOForkInterruptBenchmark {
               .flatMap(_ => IO.never)
               .guarantee(p2.complete(()))
               .start
-              .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => loop(i + 1)))))
+              .flatMap(f => p1.get.flatMap(_ => f.cancel.flatMap(_ => p2.get.flatMap(_ => go(i + 1)))))
           }
         }
       else IO.unit
 
-    loop(0).unsafeRunSync()
+    go(0).unsafeRunSync()
   }
 
   @Benchmark
@@ -64,10 +64,10 @@ class IOForkInterruptBenchmark {
   def zioTracedForkInterrupt(): Unit = zioForkInterrupt(TracedRuntime)
 
   private[this] def zioForkInterrupt(runtime: Runtime[Any]): Unit = {
-    def loop(i: Int): UIO[Unit] =
-      if (i < size) IO.never.fork.flatMap(_.interrupt *> loop(i + 1))
+    def go(i: Int): UIO[Unit] =
+      if (i < size) IO.never.fork.flatMap(_.interrupt *> go(i + 1))
       else IO.unit
 
-    runtime.unsafeRun(loop(0))
+    runtime.unsafeRun(go(0))
   }
 }

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -20,9 +20,9 @@ class IOLeftBindBenchmark {
 
   @Benchmark
   def thunkLeftBindBenchmark(): Int = {
-    def loop(i: Int): Thunk[Int] =
-      if (i % depth == 0) Thunk(i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => Thunk(i))
+    def go(i: Int): Thunk[Int] =
+      if (i % depth == 0) Thunk(i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => Thunk(i))
       else Thunk(i)
 
     Thunk(0).unsafeRun()
@@ -33,26 +33,26 @@ class IOLeftBindBenchmark {
     import scala.concurrent.Future
     import scala.concurrent.duration.Duration.Inf
 
-    def loop(i: Int): Future[Int] =
-      if (i % depth == 0) Future(i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => Future(i))
+    def go(i: Int): Future[Int] =
+      if (i % depth == 0) Future(i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => Future(i))
       else Future(i)
 
-    Await.result(Future(0).flatMap(loop), Inf)
+    Await.result(Future(0).flatMap(go), Inf)
   }
 
   @Benchmark
   def completableFutureLeftBindBenchmark(): Int = {
     import java.util.concurrent.CompletableFuture
 
-    def loop(i: Int): CompletableFuture[Int] =
-      if (i % depth == 0) CompletableFuture.completedFuture(i + 1).thenCompose(loop)
-      else if (i < size) loop(i + 1).thenCompose(i => CompletableFuture.completedFuture(i))
+    def go(i: Int): CompletableFuture[Int] =
+      if (i % depth == 0) CompletableFuture.completedFuture(i + 1).thenCompose(go)
+      else if (i < size) go(i + 1).thenCompose(i => CompletableFuture.completedFuture(i))
       else CompletableFuture.completedFuture(i)
 
     CompletableFuture
       .completedFuture(0)
-      .thenCompose(loop)
+      .thenCompose(go)
       .get()
   }
 
@@ -60,14 +60,14 @@ class IOLeftBindBenchmark {
   def monoLeftBindBenchmark(): Int = {
     import reactor.core.publisher.Mono
 
-    def loop(i: Int): Mono[Int] =
-      if (i % depth == 0) Mono.fromSupplier(() => i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => Mono.fromSupplier(() => i))
+    def go(i: Int): Mono[Int] =
+      if (i % depth == 0) Mono.fromSupplier(() => i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => Mono.fromSupplier(() => i))
       else Mono.fromSupplier(() => i)
 
     Mono
       .fromSupplier(() => 0)
-      .flatMap(loop)
+      .flatMap(go)
       .block()
   }
 
@@ -75,14 +75,14 @@ class IOLeftBindBenchmark {
   def rxSingleLeftBindBenchmark(): Int = {
     import io.reactivex.Single
 
-    def loop(i: Int): Single[Int] =
-      if (i % depth == 0) Single.fromCallable(() => i + 1).flatMap(loop(_))
-      else if (i < size) loop(i + 1).flatMap(i => Single.fromCallable(() => i))
+    def go(i: Int): Single[Int] =
+      if (i % depth == 0) Single.fromCallable(() => i + 1).flatMap(go(_))
+      else if (i < size) go(i + 1).flatMap(i => Single.fromCallable(() => i))
       else Single.fromCallable(() => i)
 
     Single
       .fromCallable(() => 0)
-      .flatMap(loop(_))
+      .flatMap(go(_))
       .blockingGet()
   }
 
@@ -90,14 +90,14 @@ class IOLeftBindBenchmark {
   def twitterLeftBindBenchmark(): Int = {
     import com.twitter.util.{ Await, Future }
 
-    def loop(i: Int): Future[Int] =
-      if (i % depth == 0) Future(i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => Future(i))
+    def go(i: Int): Future[Int] =
+      if (i % depth == 0) Future(i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => Future(i))
       else Future(i)
 
     Await.result(
       Future(0)
-        .flatMap(loop)
+        .flatMap(go)
     )
   }
 
@@ -105,12 +105,12 @@ class IOLeftBindBenchmark {
   def monixLeftBindBenchmark(): Int = {
     import monix.eval.Task
 
-    def loop(i: Int): Task[Int] =
-      if (i % depth == 0) Task.eval(i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => Task.eval(i))
+    def go(i: Int): Task[Int] =
+      if (i % depth == 0) Task.eval(i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => Task.eval(i))
       else Task.eval(i)
 
-    Task.eval(0).flatMap(loop).runSyncStep.fold(_ => sys.error("Either.right.get on Left"), identity)
+    Task.eval(0).flatMap(go).runSyncStep.fold(_ => sys.error("Either.right.get on Left"), identity)
   }
 
   @Benchmark
@@ -120,23 +120,23 @@ class IOLeftBindBenchmark {
   def zioTracedLeftBindBenchmark(): Int = zioLeftBindBenchmark(TracedRuntime)
 
   private[this] def zioLeftBindBenchmark(runtime: Runtime[Any]): Int = {
-    def loop(i: Int): UIO[Int] =
-      if (i % depth == 0) IO.effectTotal[Int](i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => IO.effectTotal(i))
+    def go(i: Int): UIO[Int] =
+      if (i % depth == 0) IO.effectTotal[Int](i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => IO.effectTotal(i))
       else IO.effectTotal(i)
 
-    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](go))
   }
 
   @Benchmark
   def catsLeftBindBenchmark(): Int = {
     import cats.effect._
 
-    def loop(i: Int): IO[Int] =
-      if (i % depth == 0) IO(i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => IO(i))
+    def go(i: Int): IO[Int] =
+      if (i % depth == 0) IO(i + 1).flatMap(go)
+      else if (i < size) go(i + 1).flatMap(i => IO(i))
       else IO(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(go).unsafeRunSync()
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -34,14 +34,14 @@ trait ZIOBaseSpec extends DefaultRunnableSpec {
 
   private def getSubTags(zioTag: ZIOTag): List[String] = {
     @tailrec
-    def loop(currentZioTag: ZIOTag, remainingZioTags: List[ZIOTag], result: List[String]): List[String] =
+    def go(currentZioTag: ZIOTag, remainingZioTags: List[ZIOTag], result: List[String]): List[String] =
       (currentZioTag.subTags, remainingZioTags) match {
         case (Nil, Nil)      => currentZioTag.value :: result
-        case (Nil, t :: ts)  => loop(t, ts, currentZioTag.value :: result)
-        case (st :: sts, ts) => loop(st, sts ++ ts, currentZioTag.value :: result)
+        case (Nil, t :: ts)  => go(t, ts, currentZioTag.value :: result)
+        case (st :: sts, ts) => go(st, sts ++ ts, currentZioTag.value :: result)
       }
     zioTag.subTags match {
-      case t :: ts => loop(t, ts, Nil)
+      case t :: ts => go(t, ts, Nil)
       case Nil     => Nil
     }
   }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3567,20 +3567,20 @@ object ZIOSpec extends ZIOBaseSpec {
 
   def deepMapNow(n: Int): UIO[Int] = {
     @tailrec
-    def loop(n: Int, acc: UIO[Int]): UIO[Int] =
+    def go(n: Int, acc: UIO[Int]): UIO[Int] =
       if (n <= 0) acc
-      else loop(n - 1, acc.map(_ + 1))
+      else go(n - 1, acc.map(_ + 1))
 
-    loop(n, IO.succeed(0))
+    go(n, IO.succeed(0))
   }
 
   def deepMapEffect(n: Int): UIO[Int] = {
     @tailrec
-    def loop(n: Int, acc: UIO[Int]): UIO[Int] =
+    def go(n: Int, acc: UIO[Int]): UIO[Int] =
       if (n <= 0) acc
-      else loop(n - 1, acc.map(_ + 1))
+      else go(n - 1, acc.map(_ + 1))
 
-    loop(n, IO.effectTotal(0))
+    go(n, IO.effectTotal(0))
   }
 
   def deepErrorEffect(n: Int): Task[Unit] =

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -1300,10 +1300,10 @@ object ZSTMSpec extends ZIOBaseSpec {
       testM("long mapError chains") {
         def chain(depth: Int): IO[Int, Nothing] = {
           @annotation.tailrec
-          def loop(n: Int, acc: STM[Int, Nothing]): IO[Int, Nothing] =
-            if (n <= 0) acc.commit else loop(n - 1, acc.mapError(_ + 1))
+          def go(n: Int, acc: STM[Int, Nothing]): IO[Int, Nothing] =
+            if (n <= 0) acc.commit else go(n - 1, acc.mapError(_ + 1))
 
-          loop(depth, STM.fail(0))
+          go(depth, STM.fail(0))
         }
 
         assertM(chain(10000).run)(fails(equalTo(10000)))
@@ -1475,9 +1475,9 @@ object ZSTMSpec extends ZIOBaseSpec {
 
   def chain(depth: Int)(next: STM[Nothing, Int] => STM[Nothing, Int]): UIO[Int] = {
     @annotation.tailrec
-    def loop(n: Int, acc: STM[Nothing, Int]): UIO[Int] =
-      if (n <= 0) acc.commit else loop(n - 1, next(acc))
+    def go(n: Int, acc: STM[Nothing, Int]): UIO[Int] =
+      if (n <= 0) acc.commit else go(n - 1, next(acc))
 
-    loop(depth, STM.succeed(0))
+    go(depth, STM.succeed(0))
   }
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -465,14 +465,14 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
   final def foldWhileM[R, E, S](z: S)(pred: S => Boolean)(f: (S, A) => ZIO[R, E, S]): ZIO[R, E, S] = {
     val iterator = arrayIterator
 
-    def loop(s: S, iterator: Iterator[Array[A]], array: Array[A], i: Int, length: Int): ZIO[R, E, S] =
+    def go(s: S, iterator: Iterator[Array[A]], array: Array[A], i: Int, length: Int): ZIO[R, E, S] =
       if (i < length) {
-        if (pred(s)) f(s, self(i)).flatMap(loop(_, iterator, array, i + 1, length))
+        if (pred(s)) f(s, self(i)).flatMap(go(_, iterator, array, i + 1, length))
         else IO.succeedNow(s)
       } else if (iterator.hasNext) {
         val array  = iterator.next()
         val length = array.length
-        loop(s, iterator, array, 0, length)
+        go(s, iterator, array, 0, length)
       } else {
         ZIO.succeedNow(s)
       }
@@ -480,7 +480,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     if (iterator.hasNext) {
       val array  = iterator.next()
       val length = array.length
-      loop(z, iterator, array, 0, length)
+      go(z, iterator, array, 0, length)
     } else {
       ZIO.succeedNow(z)
     }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -203,7 +203,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
 
     type S = StepFunction[RIn1, E, Any]
 
-    lazy val loop: ZLayer[(RIn1, S), E, ROut] =
+    lazy val go: ZLayer[(RIn1, S), E, ROut] =
       (ZLayer.first >>> self).catchAll {
         val update: ZLayer[((RIn1, S), E), E, (RIn1, S)] =
           ZLayer.fromFunctionManyM {
@@ -213,9 +213,9 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
                 case Continue(_, interval, next) => clock.sleep(Duration.fromInterval(now, interval)) as ((r, next))
               }).provide(r)
           }
-        update >>> ZLayer.suspend(loop.fresh)
+        update >>> ZLayer.suspend(go.fresh)
       }
-    ZLayer.identity <&> ZLayer.fromEffectMany(ZIO.succeed(schedule.step)) >>> loop
+    ZLayer.identity <&> ZLayer.fromEffectMany(ZIO.succeed(schedule.step)) >>> go
   }
 
   /**

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1077,15 +1077,15 @@ private[zio] object FiberContext {
     def status: Fiber.Status
     def interrupting: Boolean = {
       @tailrec
-      def loop(status0: Fiber.Status): Boolean =
+      def go(status0: Fiber.Status): Boolean =
         status0 match {
           case Status.Running(b)                      => b
           case Status.Finishing(b)                    => b
-          case Status.Suspended(previous, _, _, _, _) => loop(previous)
+          case Status.Suspended(previous, _, _, _, _) => go(previous)
           case _                                      => false
         }
 
-      loop(status)
+      go(status)
     }
   }
   object FiberState extends Serializable {

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -136,10 +136,10 @@ package object random {
           if ((n & m) == 0L)
             UIO.succeedNow(r & m)
           else {
-            def loop(u: Long): UIO[Long] =
-              if (u + m - u % m < 0L) nextLong.flatMap(r => loop(r >>> 1))
+            def go(u: Long): UIO[Long] =
+              if (u + m - u % m < 0L) nextLong.flatMap(r => go(r >>> 1))
               else UIO.succeedNow(u % n)
-            loop(r >>> 1)
+            go(r >>> 1)
           }
         }
       }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1161,10 +1161,10 @@ object ZSTM {
    */
   def foreach_[R, E, A](in: Iterable[A])(f: A => ZSTM[R, E, Any]): ZSTM[R, E, Unit] =
     ZSTM.succeedNow(in.iterator).flatMap[R, E, Unit] { it =>
-      def loop: ZSTM[R, E, Unit] =
-        if (it.hasNext) f(it.next()) *> loop
+      def go: ZSTM[R, E, Unit] =
+        if (it.hasNext) f(it.next()) *> go
         else ZSTM.unit
-      loop
+      go
     }
 
   /**

--- a/docs/datatypes/ref.md
+++ b/docs/datatypes/ref.md
@@ -22,13 +22,13 @@ The simplest way to use a `Ref` is by means of `update` or its more powerful sib
 ```scala mdoc:silent
 def repeat[E, A](n: Int)(io: IO[E, A]): IO[E, Unit] =
   Ref.make(0).flatMap { iRef =>
-    def loop: IO[E, Unit] = iRef.get.flatMap { i =>
+    def go: IO[E, Unit] = iRef.get.flatMap { i =>
       if (i < n)
         io *> iRef.update(_ + 1) *> loop
       else
         IO.unit
     }
-    loop
+    go
   }
 ```
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -119,16 +119,16 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Boot
           case Ignored      => notifier.fireTestIgnored(label, path)
         }
       )
-    def loop(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
+    def go(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
       specCase match {
         case TestCase(label, test, annotations) => TestCase(label, instrumentTest(label, path, test), annotations)
         case SuiteCase(label, specs, es) =>
           @silent("inferred to be `Any`")
           val instrumented =
-            specs.flatMap(ZManaged.foreach(_)(s => ZManaged.succeedNow(Spec(loop(s.caseValue, path :+ label)))))
+            specs.flatMap(ZManaged.foreach(_)(s => ZManaged.succeedNow(Spec(go(s.caseValue, path :+ label)))))
           SuiteCase(label, instrumented.map(_.toVector), es)
       }
-    Spec(loop(zspec.caseValue))
+    Spec(go(zspec.caseValue))
   }
 
   private def filteredSpec: ZSpec[spec.Environment, spec.Failure] =

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
@@ -26,7 +26,7 @@ package object sbt {
    */
   private[sbt] def colored(s: String): String = {
     @tailrec
-    def loop(s: String, i: Int, color: Option[String]): String =
+    def go(s: String, i: Int, color: Option[String]): String =
       if (i >= s.length) s
       else {
         val s1 = s.slice(i, i + 5)
@@ -36,14 +36,14 @@ package object sbt {
           s1 == Console.RED ||
           s1 == Console.YELLOW
         if (isColor)
-          loop(s, i + 5, Some(s1))
+          go(s, i + 5, Some(s1))
         else if (s.slice(i, i + 4) == Console.RESET)
-          loop(s, i + 4, None)
+          go(s, i + 4, None)
         else if (s.slice(i, i + 1) == "\n" && color.isDefined)
-          loop(s.patch(i + 1, color.get, 0), i + 6, color)
-        else loop(s, i + 1, color)
+          go(s.patch(i + 1, color.get, 0), i + 6, color)
+        else go(s, i + 1, color)
 
       }
-    loop(s, 0, None)
+    go(s, 0, None)
   }
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -436,14 +436,14 @@ object Assertion extends AssertionVariants {
    */
   val isDistinct: Assertion[Iterable[Any]] = {
     @scala.annotation.tailrec
-    def loop(iterator: Iterator[Any], seen: Set[Any]): Boolean = iterator.hasNext match {
+    def go(iterator: Iterator[Any], seen: Set[Any]): Boolean = iterator.hasNext match {
       case false => true
       case true =>
         val x = iterator.next()
-        if (seen.contains(x)) false else loop(iterator, seen + x)
+        if (seen.contains(x)) false else go(iterator, seen + x)
     }
 
-    Assertion.assertion("isDistinct")()(actual => loop(actual.iterator, Set.empty))
+    Assertion.assertion("isDistinct")()(actual => go(actual.iterator, Set.empty))
   }
 
   /**
@@ -609,7 +609,7 @@ object Assertion extends AssertionVariants {
    */
   def isSorted[A](implicit ord: Ordering[A]): Assertion[Iterable[A]] = {
     @scala.annotation.tailrec
-    def loop(iterator: Iterator[A]): Boolean = iterator.hasNext match {
+    def go(iterator: Iterator[A]): Boolean = iterator.hasNext match {
       case false => true
       case true =>
         val x = iterator.next()
@@ -617,11 +617,11 @@ object Assertion extends AssertionVariants {
           case false => true
           case true =>
             val y = iterator.next()
-            if (ord.lteq(x, y)) loop(Iterator(y) ++ iterator) else false
+            if (ord.lteq(x, y)) go(Iterator(y) ++ iterator) else false
         }
     }
 
-    Assertion.assertion("isSorted")()(actual => loop(actual.iterator))
+    Assertion.assertion("isSorted")()(actual => go(actual.iterator))
   }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -34,15 +34,15 @@ trait TimeoutVariants {
         predicate: String => Boolean,
         spec: ZSpec[R, E]
       ): ZSpec[R, E] = {
-        def loop(labels: List[String], spec: ZSpec[R, E]): ZSpec[R with Live, E] =
+        def go(labels: List[String], spec: ZSpec[R, E]): ZSpec[R with Live, E] =
           spec.caseValue match {
             case Spec.SuiteCase(label, specs, exec) =>
-              Spec.suite(label, specs.map(_.map(loop(label :: labels, _))), exec)
+              Spec.suite(label, specs.map(_.map(go(label :: labels, _))), exec)
             case Spec.TestCase(label, test, annotations) =>
               Spec.test(label, warn(labels, label, test, duration), annotations)
           }
 
-        loop(Nil, spec)
+        go(Nil, spec)
       }
     }
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -128,18 +128,18 @@ package object test extends CompileVariants {
 
   private def traverseResult[A](value: => A, assertResult: AssertResult, assertion: AssertionM[A]): TestResult =
     assertResult.flatMap { fragment =>
-      def loop(whole: AssertionValue, failureDetails: FailureDetails): TestResult =
+      def go(whole: AssertionValue, failureDetails: FailureDetails): TestResult =
         if (whole.sameAssertion(failureDetails.assertion.head))
           BoolAlgebra.success(failureDetails)
         else {
           val fragment = whole.result
           val result   = if (fragment.isSuccess) fragment else !fragment
           result.flatMap { fragment =>
-            loop(fragment, FailureDetails(::(whole, failureDetails.assertion), failureDetails.gen))
+            go(fragment, FailureDetails(::(whole, failureDetails.assertion), failureDetails.gen))
           }
         }
 
-      loop(fragment, FailureDetails(::(AssertionValue(assertion, value, assertResult), Nil)))
+      go(fragment, FailureDetails(::(AssertionValue(assertion, value, assertResult), Nil)))
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
@@ -158,17 +158,17 @@ object GenOrderingPoly {
   private implicit def ListOrdering[A: Ordering]: Ordering[List[A]] = {
 
     @tailrec
-    def loop[A: Ordering](left: List[A], right: List[A]): Int =
+    def go[A: Ordering](left: List[A], right: List[A]): Int =
       (left, right) match {
         case (Nil, Nil) => 0
         case (Nil, _)   => -1
         case (_, Nil)   => +1
         case ((h1 :: t1), (h2 :: t2)) =>
           val compare = Ordering[A].compare(h1, h2)
-          if (compare == 0) loop(t1, t2) else compare
+          if (compare == 0) go(t1, t2) else compare
       }
 
-    (l, r) => loop(l, r)
+    (l, r) => go(l, r)
   }
 
   /**
@@ -179,15 +179,15 @@ object GenOrderingPoly {
       val j = l.length
       val k = r.length
 
-      def loop(i: Int): Int =
+      def go(i: Int): Int =
         if (i == j && i == k) 0
         else if (i == j) -1
         else if (i == k) +1
         else {
           val compare = Ordering[A].compare(l(i), r(i))
-          if (compare == 0) loop(i + 1) else compare
+          if (compare == 0) go(i + 1) else compare
         }
 
-      loop(0)
+      go(0)
     }
 }


### PR DESCRIPTION
Sometimes zio codebase uses "go" name for recursive functions and sometimes "loop". This PR makes naming consistent.