### PR TITLE
Implement `Chunk#head` to Avoid Version Specific Issues With Scala Collections Library

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -517,7 +517,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * or iterating over the elements of the chunk in lower level, performance
    * sensitive code unless you really only need the first element of the chunk.
    */
-  override final def head: A =
+  override def head: A =
     self(0)
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -511,6 +511,16 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
   }
 
   /**
+   * Returns the first element of this chunk. Note that this method is partial
+   * in that it will throw an exception if the chunk is empty. Consider using
+   * `headOption` to explicitly handle the possibility that the chunk is empty
+   * or iterating over the elements of the chunk in lower level, performance
+   * sensitive code unless you really only need the first element of the chunk.
+   */
+  override final def head: A =
+    self(0)
+
+  /**
    * Returns the first element of this chunk if it exists.
    */
   override final def headOption: Option[A] =


### PR DESCRIPTION
Resolves #4438.

On Scala version 2.13.0 and 2.13.1 `Chunk#head` throws a `NoSuchMethodError` from `scala.collection.IndexedSeqOps`. This issue does not occur on later Scala versions and also seems to be quite specific (e.g. `last` works fine). We may have users who are stuck on various Scala versions because of other dependencies so I think it makes sense to address this if possible. We can do so by just reimplementing `head` ourselves in terms of `apply`.