### PR TITLE
Don't Use Mutable Data Structures Inside Ref

### DIFF
--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -149,8 +149,10 @@ package object random {
       collection: Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]]): UIO[Collection[A]] =
       for {
-        buffer <- ZIO.effectTotal(new scala.collection.mutable.ArrayBuffer[A])
-        _      <- ZIO.effectTotal(buffer ++= collection)
+        buffer <- ZIO.effectTotal {
+                    val buffer = new scala.collection.mutable.ArrayBuffer[A]
+                    buffer += collection
+                  }
         swap = (i1: Int, i2: Int) =>
                  ZIO.effectTotal {
                    val tmp = buffer(i1)
@@ -159,7 +161,7 @@ package object random {
                    buffer
                  }
         _ <-
-          ZIO.foreach((collection.size to 2 by -1).toList)((n: Int) => nextIntBounded(n).flatMap(k => swap(n - 1, k)))
+          ZIO.foreach_((collection.size to 2 by -1).toList)((n: Int) => nextIntBounded(n).flatMap(k => swap(n - 1, k)))
       } yield bf.fromSpecific(collection)(buffer)
   }
 

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -151,7 +151,7 @@ package object random {
       for {
         buffer <- ZIO.effectTotal {
                     val buffer = new scala.collection.mutable.ArrayBuffer[A]
-                    buffer += collection
+                    buffer ++= collection
                   }
         swap = (i1: Int, i2: Int) =>
                  ZIO.effectTotal {

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -149,10 +149,10 @@ package object random {
       collection: Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]]): UIO[Collection[A]] =
       for {
-        bufferRef <- Ref.make(new scala.collection.mutable.ArrayBuffer[A])
-        _         <- bufferRef.update(_ ++= collection)
+        buffer <- ZIO.effectTotal(new scala.collection.mutable.ArrayBuffer[A])
+        _      <- ZIO.effectTotal(buffer ++= collection)
         swap = (i1: Int, i2: Int) =>
-                 bufferRef.update { case buffer =>
+                 ZIO.effectTotal {
                    val tmp = buffer(i1)
                    buffer(i1) = buffer(i2)
                    buffer(i2) = tmp
@@ -160,7 +160,6 @@ package object random {
                  }
         _ <-
           ZIO.foreach((collection.size to 2 by -1).toList)((n: Int) => nextIntBounded(n).flatMap(k => swap(n - 1, k)))
-        buffer <- bufferRef.get
       } yield bf.fromSpecific(collection)(buffer)
   }
 


### PR DESCRIPTION
We were using a mutable `ArrayBuffer` inside a `Ref`. It wasn't actually causing an issue because the `Ref` wasn't being concurrently updated but that also means we don't really need a `Ref` and I think better not to do unsafe things in our code base unless we have to.