### PR TITLE
Use IntelliJ's default order for Organize Imports

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -20,11 +20,11 @@ Disable {
 OrganizeImports {
   expandRelative = true
   groupedImports = Merge
+  # IntelliJ IDEA's order so that they don't fight each other
   groups = [
-    "re:javax?\\.",
-    "scala.",
-    "*",
-    "zio."
+    "java."
+    "*"
+    "scala."
   ]
 }
 

--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.scalacheck
-
 import zio.IOBenchmarks.unsafeRun
 import zio.test.Gen
 

--- a/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
@@ -2,9 +2,9 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable.Range
-
 import org.openjdk.jmh.annotations._
+
+import scala.collection.immutable.Range
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable.Range
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks.unsafeRun
+
+import scala.collection.immutable.Range
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -15,7 +15,6 @@ import org.openjdk.jmh.annotations.{
   Threads,
   Warmup
 }
-
 import zio.IOBenchmarks.verify
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -1,12 +1,11 @@
 package zio
 
-import scala.concurrent.ExecutionContext
-
 import cats._
 import cats.effect.{ ContextShift, Fiber => CFiber, IO => CIO }
 import monix.eval.{ Task => MTask }
-
 import zio.internal._
+
+import scala.concurrent.ExecutionContext
 
 object IOBenchmarks extends BootstrapRuntime {
 

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -3,7 +3,6 @@ package zio
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -3,7 +3,6 @@ package zio
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Deferred
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.annotation.tailrec
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.annotation.tailrec
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -2,11 +2,10 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Await
-
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
+
+import scala.concurrent.Await
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -2,16 +2,15 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future }
-
 import cats.effect.implicits._
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks.{ monixScheduler, unsafeRun }
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -2,9 +2,6 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.collection.Iterable
-import scala.util.Random
-
 import org.openjdk.jmh.annotations.{
   Benchmark,
   BenchmarkMode,
@@ -19,6 +16,9 @@ import org.openjdk.jmh.annotations.{
   State,
   Warmup
 }
+
+import scala.collection.Iterable
+import scala.util.Random
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -2,14 +2,13 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.{ ContextShift, IO => CIO }
 import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio.stm._
+
+import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -2,14 +2,13 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.{ ContextShift, IO => CIO }
 import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio.stm._
+
+import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -2,17 +2,16 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.SPSC
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio.stm._
+
+import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -2,18 +2,17 @@ package zio
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContextExecutor }
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Keep, Sink => AkkaSink, Source => AkkaSource }
 import cats.effect.{ IO => CatsIO }
 import fs2.{ Chunk => FS2Chunk, Stream => FS2Stream }
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio.stream._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContextExecutor }
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import cats.data.Chain
 import org.openjdk.jmh.annotations._
-
 import zio.Chunk
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.Chunk
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.Chunk
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State }
-
 import zio.Chunk
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.Chunk
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.chunks
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/internal/ForeachPar_Benchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ForeachPar_Benchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio._
 

--- a/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio.ZIO.succeedNow
 import zio._

--- a/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.internal.BenchUtils._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
 import zio.internal.BenchUtils._
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
 

--- a/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.{ Blackhole, Control }
-
 import zio.internal.BenchUtils._
 
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.internal.BenchUtils._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
 import zio.internal.BenchUtils._
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
 

--- a/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio._
 

--- a/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
@@ -3,7 +3,6 @@ package zio.internal
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.internal.BenchUtils._
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
@@ -3,7 +3,6 @@ package zio.stacktracer
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.internal.stacktracer.impl.{ AkkaLineNumbers, AkkaLineNumbersTracer }
 import zio.stacktracer.TracersBenchmark.{ akkaTracer, asmTracer }
 import zio.stacktracer.impls.AsmTracer

--- a/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
@@ -18,13 +18,12 @@ package zio.stacktracer.impls
 
 import java.lang.invoke.SerializedLambda
 
-import scala.util.{ Failure, Success, Try }
-
 import org.objectweb.asm._
-
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.ZTraceElement.SourceLocation
 import zio.stacktracer.impls.AsmTracer.MethodSearchVisitor
+
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Java 8+ only

--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -4,7 +4,6 @@ import java.lang.{ Runtime => JRuntime }
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -2,13 +2,12 @@ package zio.stm
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.{ ContextShift, IO => CIO }
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio._
+
+import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio.IOBenchmarks._
 import zio._
 

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 import zio.clock.Clock
 

--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.locks.StampedLock
 
 import org.openjdk.jmh.annotations.{ Benchmark, Group, GroupThreads, _ }
 import org.openjdk.jmh.infra.Blackhole
-
 import zio.IOBenchmarks._
 import zio._
 

--- a/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
@@ -3,7 +3,6 @@ package zio.stm
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-
 import zio._
 
 @State(Scope.Thread)

--- a/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
+++ b/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
@@ -1,10 +1,10 @@
 package zio.interop
 
-import scala.scalajs.js.{ Promise => JSPromise }
-
 import zio._
 import zio.test.Assertion._
 import zio.test._
+
+import scala.scalajs.js.{ Promise => JSPromise }
 
 object JSSpec extends ZIOBaseSpec {
   def spec: Spec[Any, TestFailure[Throwable], TestSuccess] = suite("JSSpec")(

--- a/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
@@ -2,12 +2,12 @@ package zio
 
 import java.util.concurrent.Executors
 
-import scala.concurrent.ExecutionContext
-
 import zio.internal.Executor
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
+
+import scala.concurrent.ExecutionContext
 
 object CancelableFutureSpecJVM extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
@@ -1,11 +1,11 @@
 package zio
 package system
 
-import scala.reflect.io.File
-
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.{ Live, live }
+
+import scala.reflect.io.File
 
 object SystemSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/REPLSpec.scala
+++ b/core-tests/shared/src/test/scala/REPLSpec.scala
@@ -1,5 +1,4 @@
 import com.github.ghik.silencer.silent
-
 import zio.test._
 
 object REPLSpec extends DefaultRunnableSpec {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -3,8 +3,6 @@ package zio
 import java.time.temporal.{ ChronoField, ChronoUnit }
 import java.time.{ Instant, OffsetDateTime, ZoneId }
 
-import scala.concurrent.Future
-
 import zio.clock.Clock
 import zio.duration._
 import zio.stream.ZStream
@@ -12,6 +10,8 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{ failing, timeout }
 import zio.test._
 import zio.test.environment.{ TestClock, TestRandom }
+
+import scala.concurrent.Future
 
 object ScheduleSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -1,10 +1,10 @@
 package zio
 
-import scala.annotation.tailrec
-
 import zio.duration._
 import zio.test._
 import zio.test.environment.Live
+
+import scala.annotation.tailrec
 
 trait ZIOBaseSpec extends DefaultRunnableSpec {
   override def aspects: List[TestAspectAtLeastR[Live]] =

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1,8 +1,5 @@
 package zio
 
-import scala.annotation.tailrec
-import scala.util.{ Failure, Success, Try }
-
 import zio.Cause._
 import zio.LatchOps._
 import zio.clock.Clock
@@ -13,6 +10,9 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{ flaky, forked, ignore, jvm, jvmOnly, nonFlaky, scala2Only }
 import zio.test._
 import zio.test.environment.{ Live, TestClock }
+
+import scala.annotation.tailrec
+import scala.util.{ Failure, Success, Try }
 
 object ZIOSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -1,13 +1,13 @@
 package zio
 
-import scala.collection.immutable.Range
-
 import zio.ZQueueSpecUtil.waitForSize
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ jvm, nonFlaky }
 import zio.test._
 import zio.test.environment.Live
+
+import scala.collection.immutable.Range
 
 object ZQueueSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -3,11 +3,11 @@ package zio.duration
 import java.time.{ Duration => JavaDuration }
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.{ Duration => ScalaDuration }
-
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
+
+import scala.concurrent.duration.{ Duration => ScalaDuration }
 
 object DurationSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
@@ -1,11 +1,11 @@
 package zio.internal
 import java.util.concurrent.RejectedExecutionException
 
-import scala.concurrent.ExecutionContext
-
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
+
+import scala.concurrent.ExecutionContext
 
 final class TestExecutor(val submitResult: Boolean) extends Executor {
   val here: Boolean                       = true

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
-import scala.util.Random.nextInt
-
 import zio.ZIOBaseSpec
 import zio.random.Random
 import zio.test.Assertion.equalTo
 import zio.test.{ Gen, ZSpec, assert, checkAll, suite, test, testM }
+
+import scala.util.Random.nextInt
 
 object StackBoolSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -2,7 +2,6 @@ package zio
 package stm
 
 import com.github.ghik.silencer.silent
-
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky

--- a/core/js/src/main/scala/zio/clock/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/clock/PlatformSpecific.scala
@@ -16,10 +16,10 @@
 
 package zio.clock
 
-import scala.scalajs.js
-
 import zio.duration.Duration
 import zio.internal.Scheduler
+
+import scala.scalajs.js
 
 private[clock] trait PlatformSpecific {
   private[clock] val globalScheduler = new Scheduler {

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -18,13 +18,12 @@ package zio.internal
 
 import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 
-import scala.concurrent.ExecutionContext
-
 import com.github.ghik.silencer.silent
-
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 import zio.{ Cause, Supervisor }
+
+import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {
 

--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -17,7 +17,6 @@
 package zio
 
 import _root_.java.util.concurrent.{ CompletionStage, Future }
-
 import zio.blocking.Blocking
 import zio.interop.javaz
 

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -20,12 +20,12 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{ Collections, Map => JMap, Set => JSet, WeakHashMap }
 
-import scala.concurrent.ExecutionContext
-
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig
 import zio.{ Cause, Supervisor }
+
+import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {
 

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -16,13 +16,12 @@
 
 package zio.interop
 
-import scala.concurrent.ExecutionException
-
 import _root_.java.nio.channels.CompletionHandler
 import _root_.java.util.concurrent.{ CompletableFuture, CompletionException, CompletionStage, Future }
-
 import zio._
 import zio.blocking.{ Blocking, blocking }
+
+import scala.concurrent.ExecutionException
 
 private[zio] object javaz {
   def effectAsyncWithCompletionHandler[T](op: CompletionHandler[T, Any] => Any): Task[T] =

--- a/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
@@ -16,6 +16,8 @@
 
 package zio
 
+import zio.Chunk.BitChunk
+
 import scala.collection.mutable.{ ArrayBuilder, Builder }
 import scala.{
   Boolean => SBoolean,
@@ -27,8 +29,6 @@ import scala.{
   Long => SLong,
   Short => SShort
 }
-
-import zio.Chunk.BitChunk
 
 /**
  * A `ChunkBuilder[A]` can build a `Chunk[A]` given elements of type `A`.

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -16,10 +16,10 @@
 
 package zio
 
+import zio.internal.Platform
+
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
-import zio.internal.Platform
 
 sealed abstract class Cause[+E] extends Product with Serializable { self =>
   import Cause.Internal._

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,11 +16,11 @@
 
 package zio
 
-import scala.concurrent.Future
-
 import zio.console.Console
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.{ Executor, FiberRenderer }
+
+import scala.concurrent.Future
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1,9 +1,9 @@
 package zio
 
+import zio.internal.{ Executor, Platform }
+
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
-
-import zio.internal.{ Executor, Platform }
 
 object IO {
 

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import scala.language.implicitConversions
-
 import zio.NonEmptyChunk._
+
+import scala.language.implicitConversions
 
 /**
  * A `NonEmptyChunk` is a `Chunk` that is guaranteed to contain at least one

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -1,11 +1,11 @@
 package zio
 
-import scala.concurrent.ExecutionContext
-import scala.reflect.ClassTag
-
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
+
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
 
 object RIO {
 

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -16,10 +16,10 @@
 
 package zio
 
-import scala.concurrent.Future
-
 import zio.internal.tracing.{ TracingConfig, ZIOFn }
 import zio.internal.{ Executor, FiberContext, Platform, PlatformConstants, Tracing }
+
+import scala.concurrent.Future
 
 /**
  * A `Runtime[R]` is capable of executing tasks within an environment `R`.

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -20,10 +20,10 @@
 
 package zio
 
+import zio.internals._
+
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Queue => IQueue }
-
-import zio.internals._
 
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import scala.collection.immutable.SortedSet
-
 import zio.internal.{ Platform, Sync }
+
+import scala.collection.immutable.SortedSet
 
 /**
  * A `Supervisor[A]` is allowed to supervise the launching and termination of

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1,9 +1,9 @@
 package zio
 
+import zio.internal.{ Executor, Platform }
+
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
-
-import zio.internal.{ Executor, Platform }
 
 object Task extends TaskPlatformSpecific {
 

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1,8 +1,8 @@
 package zio
 
-import scala.reflect.ClassTag
-
 import zio.internal.{ Executor, Platform }
+
+import scala.reflect.ClassTag
 
 object UIO {
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -1,10 +1,10 @@
 package zio
 
-import scala.reflect.ClassTag
-
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.{ Executor, Platform }
+
+import scala.reflect.ClassTag
 
 object URIO {
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -16,17 +16,17 @@
 
 package zio
 
-import scala.annotation.implicitNotFound
-import scala.collection.mutable.Builder
-import scala.concurrent.ExecutionContext
-import scala.reflect.ClassTag
-import scala.util.{ Failure, Success }
-
 import zio.clock.Clock
 import zio.duration._
 import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
 import zio.internal.{ Executor, Platform }
 import zio.{ TracingStatus => TracingS }
+
+import scala.annotation.implicitNotFound
+import scala.collection.mutable.Builder
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+import scala.util.{ Failure, Success }
 
 /**
  * A `ZIO[R, E, A]` value is an immutable value that lazily describes a

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -16,12 +16,12 @@
 
 package zio
 
-import scala.collection.immutable.LongMap
-import scala.reflect.ClassTag
-
 import zio.ZManaged.ReleaseMap
 import zio.clock.Clock
 import zio.duration.Duration
+
+import scala.collection.immutable.LongMap
+import scala.reflect.ClassTag
 
 /**
  * A `Reservation[-R, +E, +A]` encapsulates resource acquisition and disposal

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -18,10 +18,10 @@ package zio
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.annotation.tailrec
-
 import zio.ZQueue.internal._
 import zio.internal.MutableConcurrentQueue
+
+import scala.annotation.tailrec
 
 /**
  * A `ZQueue[RA, RB, EA, EB, A, B]` is a lightweight, asynchronous queue into which values of

--- a/core/shared/src/main/scala/zio/ZTrace.scala
+++ b/core/shared/src/main/scala/zio/ZTrace.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import scala.annotation.tailrec
-
 import zio.internal.stacktracer.ZTraceElement
+
+import scala.annotation.tailrec
 
 final case class ZTrace(
   fiberId: Fiber.Id,

--- a/core/shared/src/main/scala/zio/duration/package.scala
+++ b/core/shared/src/main/scala/zio/duration/package.scala
@@ -20,11 +20,11 @@ import java.time.temporal.{ ChronoUnit, TemporalUnit }
 import java.time.{ Duration => JavaDuration, Instant, OffsetDateTime }
 import java.util.concurrent.TimeUnit
 
+import zio.duration.Duration
+
 import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
 import scala.language.implicitConversions
 import scala.math.Ordering
-
-import zio.duration.Duration
 
 package object duration {
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -18,16 +18,15 @@ package zio.internal
 
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
-import scala.annotation.{ switch, tailrec }
-import scala.collection.JavaConverters._
-
 import com.github.ghik.silencer.silent
-
 import zio.Fiber.Status
 import zio._
 import zio.internal.FiberContext.FiberRefLocals
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.tracing.ZIOFn
+
+import scala.annotation.{ switch, tailrec }
+import scala.collection.JavaConverters._
 
 /**
  * An implementation of Fiber that maintains context necessary for evaluation.

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
-import scala.util.Try
-
 import zio.{ BuildFrom, CanFail, Fiber, IO }
+
+import scala.util.Try
 
 object STM {
 

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -16,10 +16,10 @@
 
 package zio.stm
 
-import scala.collection.immutable.SortedMap
-
 import zio.stm.ZSTM.internal._
 import zio.{ Chunk, ChunkBuilder }
+
+import scala.collection.immutable.SortedMap
 
 /**
  * A `TPriorityQueue` contains values of type `A` that an `Ordering` is defined

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -16,9 +16,9 @@
 
 package zio.stm
 
-import scala.collection.immutable.{ Queue => ScalaQueue }
-
 import zio.stm.ZSTM.internal._
+
+import scala.collection.immutable.{ Queue => ScalaQueue }
 
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -19,14 +19,13 @@ package zio.stm
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 import java.util.{ HashMap => MutableMap }
 
+import com.github.ghik.silencer.silent
+import zio._
+import zio.internal.{ Platform, Stack, Sync }
+
 import scala.annotation.tailrec
 import scala.collection.mutable.Builder
 import scala.util.{ Failure, Success, Try }
-
-import com.github.ghik.silencer.silent
-
-import zio._
-import zio.internal.{ Platform, Stack, Sync }
 
 /**
  * `STM[E, A]` represents an effect that can be performed transactionally,

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -18,9 +18,9 @@ package zio
 
 import java.lang.{ System => JSystem }
 
-import scala.collection.JavaConverters._
-
 import com.github.ghik.silencer.silent
+
+import scala.collection.JavaConverters._
 
 package object system {
 

--- a/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMMacroBase.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMMacroBase.scala
@@ -16,9 +16,9 @@
 
 package zio.macros
 
-import scala.reflect.macros.whitebox
-
 import com.github.ghik.silencer.silent
+
+import scala.reflect.macros.whitebox
 
 private[macros] abstract class AccessibleMMacroBase(override val c: whitebox.Context) extends AccessibleMacroBase(c) {
 

--- a/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacro.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacro.scala
@@ -16,9 +16,9 @@
 
 package zio.macros
 
-import scala.reflect.macros.whitebox
-
 import com.github.ghik.silencer.silent
+
+import scala.reflect.macros.whitebox
 
 /**
  * Generates method accessors for a service into annotated object.

--- a/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacroBase.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacroBase.scala
@@ -16,9 +16,9 @@
 
 package zio.macros
 
-import scala.reflect.macros.whitebox
-
 import com.github.ghik.silencer.silent
+
+import scala.reflect.macros.whitebox
 
 private[macros] abstract class AccessibleMacroBase(val c: whitebox.Context) {
 

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
@@ -16,11 +16,11 @@
 
 package zio.internal.stacktracer.impl
 
-import scala.util.matching.Regex
-
 import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer.lambdaNamePattern
 import zio.internal.stacktracer.{ Tracer, ZTraceElement }
+
+import scala.util.matching.Regex
 
 /**
  * A [[Tracer]] implementation powered by Akka's `LineNumbers` bytecode parser (shipped with ZIO, no dependency on Akka)

--- a/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -1,11 +1,11 @@
 package zio.stream
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
 import zio._
 import zio.test.Assertion._
 import zio.test._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZStream JS")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -7,12 +7,12 @@ import java.nio.file.{ Files, NoSuchFileException, Paths }
 import java.nio.{ Buffer, ByteBuffer }
 import java.util.concurrent.CountDownLatch
 
-import scala.concurrent.ExecutionContext.global
-
 import zio._
 import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.test.Assertion._
 import zio.test._
+
+import scala.concurrent.ExecutionContext.global
 
 object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
@@ -13,14 +13,14 @@ import java.util.zip.{
   InflaterInputStream
 }
 
-import scala.annotation.tailrec
-
 import zio._
 import zio.stream.ZTransducer.{ deflate, gunzip, gzip, inflate }
 import zio.stream._
 import zio.stream.compression.TestData._
 import zio.test.Assertion._
 import zio.test._
+
+import scala.annotation.tailrec
 
 object CompressionSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[Environment, Failure] =

--- a/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
+++ b/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
@@ -1,5 +1,4 @@
 import com.github.ghik.silencer.silent
-
 import zio.test._
 
 object StreamREPLSpec extends DefaultRunnableSpec {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -1,7 +1,5 @@
 package zio.stream
 
-import scala.util.Random
-
 import zio.duration._
 import zio.stream.SinkUtils.{ findSink, sinkRaceLaw }
 import zio.stream.ZStreamGen._
@@ -9,6 +7,8 @@ import zio.test.Assertion.{ equalTo, isFalse, isGreaterThanEqualTo, isTrue, succ
 import zio.test.environment.TestClock
 import zio.test.{ assertM, _ }
 import zio.{ ZIOBaseSpec, _ }
+
+import scala.util.Random
 
 object ZSinkSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZSinkSpec")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3,8 +3,6 @@ package zio.stream
 import java.io.{ ByteArrayInputStream, IOException }
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
-
 import zio._
 import zio.clock.Clock
 import zio.duration._
@@ -15,6 +13,8 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, scala2Only, timeout }
 import zio.test._
 import zio.test.environment.TestClock
+
+import scala.concurrent.ExecutionContext
 
 object ZStreamSpec extends ZIOBaseSpec {
   import ZIOTag._

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -2,12 +2,12 @@ package zio.stream
 
 import java.nio.charset.StandardCharsets
 
-import scala.io.Source
-
 import zio._
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._
+
+import scala.io.Source
 
 object ZTransducerSpec extends ZIOBaseSpec {
   import ZIOTag._

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -2,9 +2,9 @@ package zio.stream
 
 import java.io.{ IOException, InputStream }
 
-import scala.concurrent.Future
-
 import zio._
+
+import scala.concurrent.Future
 
 trait ZSinkPlatformSpecificConstructors
 

--- a/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
@@ -3,9 +3,9 @@ package zio.stream.compression
 import java.util.zip.Deflater
 import java.{ util => ju }
 
-import scala.annotation.tailrec
-
 import zio.{ Chunk, ZIO, ZManaged }
+
+import scala.annotation.tailrec
 
 object Deflate {
 

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
@@ -3,9 +3,9 @@ package zio.stream.compression
 import java.util.zip.{ CRC32, Inflater }
 import java.{ util => ju }
 
-import scala.annotation.tailrec
-
 import zio._
+
+import scala.annotation.tailrec
 
 /**
  * Performs few steps of parsing header, then decompresses body and checks trailer.

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -9,11 +9,11 @@ import java.nio.{ Buffer, ByteBuffer }
 import java.util.zip.{ DataFormatException, Inflater }
 import java.{ util => ju }
 
-import scala.annotation.tailrec
-
 import zio._
 import zio.blocking.{ Blocking, effectBlockingIO }
 import zio.stream.compression._
+
+import scala.annotation.tailrec
 
 trait ZSinkPlatformSpecificConstructors {
   self: ZSink.type =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2,8 +2,6 @@ package zio.stream
 
 import java.{ util => ju }
 
-import scala.reflect.ClassTag
-
 import zio._
 import zio.clock.Clock
 import zio.duration._
@@ -11,6 +9,8 @@ import zio.internal.UniqueKey
 import zio.stm.TQueue
 import zio.stream.internal.Utils.zipChunks
 import zio.stream.internal.{ ZInputStream, ZReader }
+
+import scala.reflect.ClassTag
 
 /**
  * A `ZStream[R, E, O]` is a description of a program that, when evaluated,

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -2,9 +2,9 @@ package zio.stream
 
 import java.nio.charset.{ Charset, StandardCharsets }
 
-import scala.collection.mutable
-
 import zio._
+
+import scala.collection.mutable
 
 // Contract notes for transducers:
 // - When a None is received, the transducer must flush all of its internal state

--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -1,8 +1,8 @@
 package zio.stream.internal
 
-import scala.annotation.tailrec
-
 import zio.{ Chunk, Exit, FiberFailure, Runtime, ZIO }
+
+import scala.annotation.tailrec
 
 private[zio] class ZInputStream(private var chunks: Iterator[Chunk[Byte]]) extends java.io.InputStream {
   private var current: Chunk[Byte] = Chunk.empty

--- a/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
@@ -1,8 +1,8 @@
 package zio.stream.internal
 
-import scala.annotation.tailrec
-
 import zio.{ Chunk, Exit, FiberFailure, Runtime, ZIO }
+
+import scala.annotation.tailrec
 
 private[zio] class ZReader(private var chunks: Iterator[Chunk[Char]]) extends java.io.Reader {
   private var current: Chunk[Char] = Chunk.empty

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -2,15 +2,14 @@ package zio.test.junit
 
 import java.io.File
 
-import scala.collection.immutable
-import scala.xml.XML
-
 import org.apache.maven.cli.MavenCli
-
 import zio.blocking.{ Blocking, effectBlocking }
 import zio.test.Assertion._
 import zio.test.{ DefaultRunnableSpec, ZSpec, _ }
 import zio.{ RIO, ZIO }
+
+import scala.collection.immutable
+import scala.xml.XML
 
 /**
  * when running from IDE run `sbt publishM2`, copy the snapshot version the artifacts were published under (something like: `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`)

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -4,7 +4,6 @@ import com.github.ghik.silencer.silent
 import org.junit.runner.manipulation.{ Filter, Filterable }
 import org.junit.runner.notification.{ Failure, RunNotifier }
 import org.junit.runner.{ Description, RunWith, Runner }
-
 import zio.ZIO.effectTotal
 import zio._
 import zio.test.FailureRenderer.FailureMessage.Message

--- a/test-magnolia/shared/src/main/scala/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala/zio/test/magnolia/DeriveGen.scala
@@ -20,7 +20,6 @@ import java.time.{ Instant, LocalDate, LocalDateTime }
 import java.util.UUID
 
 import magnolia._
-
 import zio.random.Random
 import zio.test.{ Gen, Sized }
 

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -16,12 +16,11 @@
 
 package zio.test.sbt
 
-import scala.collection.mutable
-
 import sbt.testing._
-
 import zio.test.{ Summary, TestArgs }
 import zio.{ Exit, Runtime, ZIO }
+
+import scala.collection.mutable
 
 sealed abstract class ZTestRunner(
   val args: Array[String],

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -19,7 +19,6 @@ package zio.test.sbt
 import java.util.concurrent.atomic.AtomicReference
 
 import sbt.testing._
-
 import zio.ZIO
 import zio.test.{ Summary, TestArgs }
 

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
@@ -3,7 +3,6 @@ package zio.test.sbt
 import java.util.concurrent.atomic.AtomicReference
 
 import sbt.testing.Logger
-
 import zio.test.sbt.TestingSupport._
 
 class MockLogger extends Logger {

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -18,11 +18,7 @@ package zio.test.sbt
 
 import java.util.regex.Pattern
 
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Try
-
 import sbt.testing._
-
 import zio.UIO
 import zio.test.sbt.TestingSupport._
 import zio.test.{
@@ -37,6 +33,9 @@ import zio.test.{
   TestSuccess,
   ZSpec
 }
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
 
 object ZTestFrameworkSpec {
 

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -1,7 +1,6 @@
 package zio.test.sbt
 
 import sbt.testing.{ EventHandler, Logger, Task, TaskDef }
-
 import zio.clock.Clock
 import zio.test.{ AbstractRunnableSpec, FilteredSpec, SummaryBuilder, TestArgs, TestLogger }
 import zio.{ Layer, Runtime, UIO, ZIO, ZLayer }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/RunnableSpecFingerprint.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/RunnableSpecFingerprint.scala
@@ -1,7 +1,6 @@
 package zio.test.sbt
 
 import sbt.testing.SubclassFingerprint
-
 import zio.test.AbstractRunnableSpec
 
 object RunnableSpecFingerprint extends SubclassFingerprint {

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -1,7 +1,6 @@
 package zio.test.sbt
 
 import sbt.testing._
-
 import zio.test.{ ExecutedSpec, TestFailure, TestSuccess }
 
 final case class ZTestEvent(

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
@@ -1,8 +1,8 @@
 package zio.test
 
-import scala.annotation.tailrec
-
 import zio.{ UIO, URIO }
+
+import scala.annotation.tailrec
 
 package object sbt {
 

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -1,11 +1,11 @@
 package zio.test
 
-import scala.collection.immutable.SortedSet
-import scala.util.{ Failure, Success }
-
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.{ Chunk, Exit }
+
+import scala.collection.immutable.SortedSet
+import scala.util.{ Failure, Success }
 
 object AssertionSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -1,9 +1,9 @@
 package zio.test
 
-import scala.math.abs
-
 import zio.test.Assertion._
 import zio.{ ZIO, random }
+
+import scala.math.abs
 
 object FunSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -2,8 +2,6 @@ package zio.test
 
 import java.time._
 
-import scala.math.Numeric.DoubleIsFractional
-
 import zio.duration.{ Duration, _ }
 import zio.random.Random
 import zio.test.Assertion._
@@ -11,6 +9,8 @@ import zio.test.GenUtils._
 import zio.test.TestAspect.{ nonFlaky, scala2Only, setSeed }
 import zio.test.{ check => Check, checkN => CheckN }
 import zio.{ Chunk, NonEmptyChunk, ZIO }
+
+import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
   implicit val localDateTimeOrdering: Ordering[LocalDateTime] = _ compareTo _

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -2,8 +2,6 @@ package zio.test
 
 import java.util.regex.Pattern
 
-import scala.{ Console => SConsole }
-
 import zio.clock.Clock
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan, isRight, isSome, not }
 import zio.test.environment.{ TestClock, TestConsole, TestEnvironment, testEnvironment }
@@ -12,6 +10,8 @@ import zio.test.mock.internal.InvalidCall._
 import zio.test.mock.internal.MockException._
 import zio.test.mock.module.PureModuleMock
 import zio.{ Cause, Layer, ZIO }
+
+import scala.{ Console => SConsole }
 
 object ReportingTestUtils {
 

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -1,13 +1,13 @@
 package zio.test
 
-import scala.reflect.ClassTag
-
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.TestRandom
 import zio.{ Ref, TracingStatus, ZIO }
+
+import scala.reflect.ClassTag
 
 object TestAspectSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -1,13 +1,13 @@
 package zio.test.environment
 
-import scala.util.{ Random => SRandom }
-
 import zio._
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 import zio.test.environment.TestRandom.{ DefaultData, Test => ZRandom }
+
+import scala.util.{ Random => SRandom }
 
 object RandomSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
@@ -17,7 +17,6 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-
 import zio.{ Tag, URIO, ZIO }
 
 /**

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
@@ -17,7 +17,6 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-
 import zio.test.mock.{ Mock, Proxy }
 import zio.{ Has, Tag, URLayer, ZLayer }
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
@@ -16,9 +16,9 @@
 
 package zio.test.mock.module
 
-import scala.reflect.ClassTag
-
 import zio.{ IO, Tag, URIO, ZIO }
+
+import scala.reflect.ClassTag
 
 /**
  * Example module used for testing ZIO Mock framework.

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
@@ -17,7 +17,6 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-
 import zio.test.mock.{ Mock, Proxy }
 import zio.{ Has, IO, Tag, UIO, URLayer, ZLayer }
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
@@ -17,7 +17,6 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-
 import zio.stream.ZSink
 import zio.test.mock.{ Mock, Proxy }
 import zio.{ Has, UIO, URLayer, ZLayer }

--- a/test-tests/shared/src/test/scala/zio/test/poly/PolySpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/poly/PolySpec.scala
@@ -1,10 +1,10 @@
 package zio.test.poly
 
-import scala.annotation.tailrec
-
 import zio.random._
 import zio.test.Assertion._
 import zio.test._
+
+import scala.annotation.tailrec
 
 object PolySpec extends DefaultRunnableSpec {
 

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -16,9 +16,9 @@
 
 package zio.test
 
-import scala.reflect.macros.{ TypecheckException, blackbox }
-
 import zio.UIO
+
+import scala.reflect.macros.{ TypecheckException, blackbox }
 
 private[test] object Macros {
 

--- a/test/shared/src/main/scala-2.x/zio/test/mock/MockableMacro.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/mock/MockableMacro.scala
@@ -16,11 +16,10 @@
 
 package zio.test.mock
 
-import scala.reflect.macros.whitebox.Context
-
 import com.github.ghik.silencer.silent
-
 import zio.test.TestVersion
+
+import scala.reflect.macros.whitebox.Context
 
 /**
  * Generates method tags for a service into annotated object.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -16,11 +16,11 @@
 
 package zio.test
 
-import scala.reflect.ClassTag
-import scala.util.{ Failure, Success, Try }
-
 import zio.test.AssertionM.RenderParam
 import zio.{ Cause, Exit, ZIO }
+
+import scala.reflect.ClassTag
+import scala.util.{ Failure, Success, Try }
 
 /**
  * An `Assertion[A]` is capable of producing assertion results on an `A`. As a

--- a/test/shared/src/main/scala/zio/test/AssertionM.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionM.scala
@@ -16,10 +16,10 @@
 
 package zio.test
 
+import zio.{ UIO, ZIO }
+
 import scala.reflect.ClassTag
 import scala.util.Try
-
-import zio.{ UIO, ZIO }
 
 /**
  * An `AssertionM[A]` is capable of producing assertion results on an `A`. As a

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -18,9 +18,6 @@ package zio.test
 
 import java.util.regex.Pattern
 
-import scala.io.AnsiColor
-import scala.util.Try
-
 import zio.duration._
 import zio.test.ConsoleUtils.{ cyan, red, _ }
 import zio.test.FailureRenderer.FailureMessage.{ Fragment, Message }
@@ -30,6 +27,9 @@ import zio.test.RenderedResult.{ CaseType, Status }
 import zio.test.mock.Expectation
 import zio.test.mock.internal.{ InvalidCall, MockException }
 import zio.{ Cause, Has }
+
+import scala.io.AnsiColor
+import scala.util.Try
 
 object DefaultTestReporter {
 

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -16,10 +16,10 @@
 
 package zio.test
 
-import scala.concurrent.ExecutionContext
-
 import zio.internal.Executor
 import zio.{ Runtime, URIO, ZIO }
+
+import scala.concurrent.ExecutionContext
 
 /**
  * A `Fun[A, B]` is a referentially transparent version of a potentially

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,12 +19,12 @@ package zio.test
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
-import scala.collection.immutable.SortedMap
-import scala.math.Numeric.DoubleIsFractional
-
 import zio.random._
 import zio.stream.{ Stream, ZStream }
 import zio.{ Chunk, ExecutionStrategy, NonEmptyChunk, UIO, URIO, ZIO }
+
+import scala.collection.immutable.SortedMap
+import scala.math.Numeric.DoubleIsFractional
 
 /**
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -20,15 +20,15 @@ import java.io.{ EOFException, IOException }
 import java.time.{ Instant, OffsetDateTime, ZoneId }
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable.{ Queue, SortedSet }
-import scala.math.{ log, sqrt }
-
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
 import zio.random.Random
 import zio.system.System
 import zio.{ PlatformSpecific => _, _ }
+
+import scala.collection.immutable.{ Queue, SortedSet }
+import scala.math.{ log, sqrt }
 
 /**
  * The `environment` package contains testable versions of all the standard ZIO

--- a/test/shared/src/main/scala/zio/test/mock/Capability.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Capability.scala
@@ -19,7 +19,6 @@ package zio.test.mock
 import java.util.UUID
 
 import com.github.ghik.silencer.silent
-
 import zio.test.Assertion
 import zio.{ =!=, Has, IO, LightTypeTag, Tag, taggedIsSubtype, taggedTagType }
 

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -16,13 +16,13 @@
 
 package zio.test.mock
 
-import scala.language.implicitConversions
-
 import zio.test.Assertion
 import zio.test.mock.Expectation.{ And, Chain, Or, Repeated }
 import zio.test.mock.Result.{ Fail, Succeed }
 import zio.test.mock.internal.{ ExpectationState, MockException, MockState, ProxyFactory }
 import zio.{ Has, IO, Managed, Tag, ULayer, URLayer, ZLayer }
+
+import scala.language.implicitConversions
 
 /**
  * An `Expectation[R]` is an immutable tree structure that represents

--- a/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
@@ -16,11 +16,11 @@
 
 package zio.test.mock.internal
 
-import scala.util.Try
-
 import zio.test.Assertion
 import zio.test.mock.{ Capability, Expectation, Proxy }
 import zio.{ Has, IO, Tag, UIO, ULayer, ZIO, ZLayer }
+
+import scala.util.Try
 
 object ProxyFactory {
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -16,13 +16,13 @@
 
 package zio
 
-import scala.collection.immutable.SortedSet
-import scala.util.Try
-
 import zio.console.Console
 import zio.duration.Duration
 import zio.stream.{ ZSink, ZStream }
 import zio.test.environment.{ TestClock, TestConsole, TestEnvironment, TestRandom, TestSystem, testEnvironment }
+
+import scala.collection.immutable.SortedSet
+import scala.util.Try
 
 /**
  * _ZIO Test_ is a featherweight testing library for effectful programs.

--- a/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
@@ -16,10 +16,10 @@
 
 package zio.test.poly
 
-import scala.annotation.tailrec
-
 import zio.random.Random
 import zio.test.{ Gen, Sized }
+
+import scala.annotation.tailrec
 
 /**
  * `GenOrderingPoly` provides evidence that instances of `Gen[T]` and


### PR DESCRIPTION
Many of our contributors use IntelliJ and it's then causing friction, when they bum up against unhappy linter step in CI (even though they believe they've made everything orderly).
