### PR TITLE
Fix Bug in ZQueue#takeBetween

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -264,13 +264,11 @@ object ZQueueSpec extends ZIOBaseSpec {
       },
       testM("blocks until a required minimum of elements is collected") {
         for {
-          queue   <- Queue.bounded[Int](100)
-          counter <- Ref.make(0)
-          updater  = (queue.offer(10) *> counter.update(_ + 1)).forever
-          getter   = queue.takeBetween(5, 10)
-          _       <- getter.race(updater)
-          count   <- counter.get
-        } yield assert(count >= 5)(isTrue)
+          queue  <- Queue.bounded[Int](100)
+          updater = queue.offer(10).forever
+          getter  = queue.takeBetween(5, 10)
+          res    <- getter.race(updater)
+        } yield assert(res)(hasSize(isGreaterThanEqualTo(5)))
       }
     ),
     testM("offerAll with takeAll") {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -120,7 +120,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
             if (n <= 0) ZIO.succeed(Nil)
             else take.flatMap(a => takeRemainder(n - 1).map(a :: _))
 
-          takeRemainder(remaining - 1).map(list => bs ++ list.reverse)
+          takeRemainder(remaining).map(list => bs ++ list.reverse)
         } else
           UIO.succeedNow(bs)
       }


### PR DESCRIPTION
Resolves #4436.

It looks like there were two issues here.

First, there is a race condition in the test where we update the `Ref` after offering a value to the queue, so it is possible that the `getter` fiber takes a value, completes, and interrupts the `updater` fiber before it has a chance to update the `Ref`. I addressed that by simplifying the test to just assert that the list of taken values has the requisite size.

Second, it looks like there was an off by one error in `takeBetween` itself. At the point we call `takeRemainder` we need to pass it the total number of remaining values and not the number of remaining values minus one.