### PR TITLE
Fix Flaky Transplant Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3053,7 +3053,7 @@ object ZIOSpec extends ZIOBaseSpec {
           fiber <- ZIO.transplant { grafter =>
                      grafter {
                        val zio = for {
-                         _ <- (latch1.succeed(()) *> ZIO.infinity.onInterrupt(latch2.succeed(()))).fork
+                         _ <- (latch1.succeed(()) *> ZIO.infinity).onInterrupt(latch2.succeed(())).fork
                          _ <- ZIO.infinity
                        } yield ()
                        zio.fork


### PR DESCRIPTION
There is a race condition in the current version where after the first latch gets completed the fiber can be interrupted in the continuation before beginning to execute `ZIO.infinity`. In this case the `onInterrupt` effect would never be triggered and the second latch would not be completed, causing the test to time out. Tested locally with `nonFlaky(100000)`.