### PR TITLE
Fix refineOrDie implementation

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3337,7 +3337,17 @@ object ZStreamSpec extends ZIOBaseSpec {
               "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"
             assertM(result)(isLeft(equalTo(expected)))
           } @@ scala2Only
-        )
+        ),
+        testM("refineOrDie") {
+          val error = new Exception
+
+          ZStream
+            .fail(error)
+            .refineOrDie { case e: IllegalArgumentException => e }
+            .runDrain
+            .run
+            .map(assert(_)(dies(equalTo(error))))
+        }
       ),
       suite("Constructors")(
         testM("access") {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2276,10 +2276,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   final def refineOrDie[E1](
     pf: PartialFunction[E, E1]
   )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZStream[R, E1, O] =
-    ZStream(self.process.map(_.mapError {
-      case None                         => None
-      case Some(e) if pf.isDefinedAt(e) => Some(pf.apply(e))
-    }))
+    refineOrDieWith(pf)(ev1)
 
   /**
    * Keeps some of the errors, and terminates the fiber with the rest, using


### PR DESCRIPTION
As mentioned in Discord, the current `refineOrDie` implementation contains a non-exhaustive match.