### PR TITLE
New Sequence operator for collections of ZIO elements.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3531,21 +3531,22 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("sequence")(
       testM("transforms a List of ZIOs into a ZIO of List") {
         val expectedResult: List[Int] = List(1, 2, 3, 4)
-        val in: List[UIO[Int]] = List(ZIO.succeed(1), ZIO.succeed(2), ZIO.succeed(3), ZIO.succeed(4))
-        val outZIO: UIO[List[Int]] = ZIO.sequence[Any, Nothing, Int, List](in)
+        val in: List[UIO[Int]]        = List(ZIO.succeed(1), ZIO.succeed(2), ZIO.succeed(3), ZIO.succeed(4))
+        val outZIO: UIO[List[Int]]    = ZIO.sequence[Any, Nothing, Int, List](in)
         for {
           out <- outZIO
         } yield assert(out)(equalTo(expectedResult))
       },
       testM("returns the first throwable if present") {
-        val in: List[ZIO[Any, Throwable, Int]] = List(ZIO.succeed(1), ZIO.succeed(2),
-          ZIO.fail(new RuntimeException("An exception")), ZIO.succeed(4))
+        val in: List[ZIO[Any, Throwable, Int]] =
+          List(ZIO.succeed(1), ZIO.succeed(2), ZIO.fail(new RuntimeException("An exception")), ZIO.succeed(4))
         val outZIO: ZIO[Any, Throwable, List[Int]] = ZIO.sequence(in)
 
         assertM(outZIO.run)(fails(isSubtype[RuntimeException](anything)))
       },
       testM("transform an iterable of ZIOs with an internal Functor into a ZIO of Iterable") {
-        val expectedResult: Iterable[Seq[Int]] = Iterable.newBuilder.+=(Seq(1)).+=(Seq(2)).+=(Seq(3)).+=(Seq(4)).result()
+        val expectedResult: Iterable[Seq[Int]] =
+          Iterable.newBuilder.+=(Seq(1)).+=(Seq(2)).+=(Seq(3)).+=(Seq(4)).result()
         val in = Iterable.newBuilder
           .+=(ZIO.effect(List(1)))
           .+=(ZIO.succeed(List(2)))

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3527,6 +3527,36 @@ object ZIOSpec extends ZIOBaseSpec {
           assert(value)(equalTo("Controlling side-effect of function passed to promise"))
         }
       }
+    ),
+    suite("sequence")(
+      testM("transforms a List of ZIOs into a ZIO of List") {
+        val expectedResult: List[Int] = List(1, 2, 3, 4)
+        val in: List[UIO[Int]] = List(ZIO.succeed(1), ZIO.succeed(2), ZIO.succeed(3), ZIO.succeed(4))
+        val outZIO: UIO[List[Int]] = ZIO.sequence[Any, Nothing, Int, List](in)
+        for {
+          out <- outZIO
+        } yield assert(out)(equalTo(expectedResult))
+      },
+      testM("returns the first throwable if present") {
+        val in: List[ZIO[Any, Throwable, Int]] = List(ZIO.succeed(1), ZIO.succeed(2),
+          ZIO.fail(new RuntimeException("An exception")), ZIO.succeed(4))
+        val outZIO: ZIO[Any, Throwable, List[Int]] = ZIO.sequence(in)
+
+        assertM(outZIO.run)(fails(isSubtype[RuntimeException](anything)))
+      },
+      testM("transform an iterable of ZIOs with an internal Functor into a ZIO of Iterable") {
+        val expectedResult: Iterable[Seq[Int]] = Iterable.newBuilder.+=(Seq(1)).+=(Seq(2)).+=(Seq(3)).+=(Seq(4)).result()
+        val in = Iterable.newBuilder
+          .+=(ZIO.effect(List(1)))
+          .+=(ZIO.succeed(List(2)))
+          .+=(ZIO.succeed(List(3)))
+          .+=(ZIO.succeed(List(4)))
+          .result()
+        val outZIO = ZIO.sequence(in)
+        for {
+          out <- outZIO
+        } yield assert(out)(equalTo(expectedResult))
+      }
     )
   )
 


### PR DESCRIPTION
Working with ZIO in our project, we noticed that there is not a Sequence operator like in Scala's Future.
I've implemented it, based on the one from Future.

It is very useful for when you end up with a Collection of ZIO elements.