### PR TITLE
Support use of @accessible macro with implicits (#4466)

### DIFF
--- a/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacroBase.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/AccessibleMacroBase.scala
@@ -196,6 +196,8 @@ private[macros] abstract class AccessibleMacroBase(val c: whitebox.Context) {
             q"def $name[..$allTypeParams](implicit ev: _root_.izumi.reflect.Tag[Service[..$serviceTypeArgs]]): $returnType = $returnValue"
           case List(Nil) =>
             q"def $name[..$allTypeParams]()(implicit ev: _root_.izumi.reflect.Tag[Service[..$serviceTypeArgs]]): $returnType = $returnValue"
+          case first :+ last if last.forall(_.mods.hasFlag(Flag.IMPLICIT)) =>
+            q"def $name[..$allTypeParams](...$first)(implicit ..$last, ev: _root_.izumi.reflect.Tag[Service[..$serviceTypeArgs]]): $returnType = $returnValue"
           case _ =>
             q"def $name[..$allTypeParams](...$paramLists)(implicit ev: _root_.izumi.reflect.Tag[Service[..$serviceTypeArgs]]): $returnType = $returnValue"
         }


### PR DESCRIPTION
Existing automated tests pass but not sure how useful they are given that never picked up the bug described in #4466.

However manual testing with various combinations of implicits and normal parameters appear to work fine.