### PR TITLE
Fix #4457 race condition during FiberContext interruption

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/FiberInterruptSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberInterruptSpec.scala
@@ -1,12 +1,12 @@
 package zio.internal
 
 import zio.Promise.internal.Pending
-import zio.duration._
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.flaky
-import zio.test._
 import zio.test.environment.Live
+import zio.test.{ ZSpec, assertM, suite, testM }
 import zio.{ Promise, ZIOBaseSpec }
+import zio.duration._
+import zio.test.TestAspect._
 
 object FiberInterruptSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberInterruptSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberInterruptSpec.scala
@@ -1,12 +1,12 @@
 package zio.internal
 
 import zio.Promise.internal.Pending
+import zio.duration._
 import zio.test.Assertion.equalTo
+import zio.test.TestAspect._
 import zio.test.environment.Live
 import zio.test.{ ZSpec, assertM, suite, testM }
 import zio.{ Promise, ZIOBaseSpec }
-import zio.duration._
-import zio.test.TestAspect._
 
 object FiberInterruptSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
@@ -3,13 +3,13 @@ package zio.internal
 import zio.Promise.internal.Pending
 import zio.duration._
 import zio.test.Assertion.equalTo
+import zio.test.TestAspect.flaky
 import zio.test._
 import zio.test.environment.Live
 import zio.{ Promise, ZIOBaseSpec }
 
 object FiberInterruptSpec extends ZIOBaseSpec {
 
-  //Flaky
   override def spec: ZSpec[Environment, Failure] =
     suite("FiberInterruptSpec")(
       testM("must interrupt all Promise joiners") {
@@ -33,6 +33,6 @@ object FiberInterruptSpec extends ZIOBaseSpec {
         } yield joinerSize
 
         assertM(Live.live(io))(equalTo(0))
-      }
+      } @@ flaky
     )
 }

--- a/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
@@ -15,8 +15,8 @@ object FiberInterruptSpec extends ZIOBaseSpec {
       testM("must interrupt all Promise joiners") {
 
         /**
-         * The idea here, that spawn and interrupt as much joiners as possible
-         * To make sure that, all of them got cleaned up
+         * The idea here to spawn and interrupt as much joiners as possible
+         * And to make sure that, all of them got cleaned up
          */
         (for {
           p <- Promise.make[Throwable, Unit]

--- a/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberInterruptSpec.scala
@@ -1,0 +1,39 @@
+package zio.internal
+
+import zio.Promise.internal.Pending
+import zio.clock.Clock
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, suite, testM }
+import zio.{ Promise, ZIOBaseSpec }
+import zio.duration._
+
+object FiberInterruptSpec extends ZIOBaseSpec {
+
+  //Flaky
+  override def spec =
+    suite("FiberInterruptSpec")(
+      testM("must interrupt all Promise joiners") {
+
+        /**
+         * The idea here, that spawn and interrupt as much joiners as possible
+         * To make sure that, all of them got cleaned up
+         */
+        (for {
+          p <- Promise.make[Throwable, Unit]
+          loopFiber <- (for {
+                         fb <- p.await.fork
+                         _  <- fb.interrupt.fork
+                       } yield ()).forever.fork
+          _ <- loopFiber.interrupt.delay(30.seconds)
+          joinerSize <- p.currentState.map {
+                          case Pending(joiners) => joiners.size
+                          case _                => 0
+                        }.delay(1.second) //Just to make sure all races already resolved
+          _ <- p.succeed(())
+
+        } yield {
+          assert(joinerSize)(equalTo(0))
+        }).provideCustomLayer(Clock.live)
+      }
+    )
+}

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -200,6 +200,8 @@ final class Promise[E, A] private (private val state: AtomicReference[State[E, A
     }
   }
 
+  private[zio] def currentState: UIO[State[E, A]] = IO.succeed(state.get())
+
   private[zio] def unsafeDone(io: IO[E, A]): Unit = {
     var retry: Boolean                 = true
     var joiners: List[IO[E, A] => Any] = null

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -20,7 +20,9 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference 
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
+
 import com.github.ghik.silencer.silent
+
 import zio.Fiber.Status
 import zio._
 import zio.internal.FiberContext.FiberRefLocals

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -284,7 +284,7 @@ private[zio] final class FiberContext[E, A](
     val newEvaluation     = EvaluationState.Pending(Thread.currentThread().getId)
     if (
       !currentEvaluation.isEqual(newEvaluation) ||
-        !evaluationsInProgress.compareAndSet(currentEvaluation, newEvaluation)
+      !evaluationsInProgress.compareAndSet(currentEvaluation, newEvaluation)
     ) {
       evaluateLater(io0)
     } else {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -275,11 +275,9 @@ private[zio] final class FiberContext[E, A](
    */
   def evaluateNow(io0: IO[E, Any]): Unit = {
 
-    /**
-     * We must respect the order of instructions if another evaluation is in progress of current FiberContext
-     * Since we are not allowed to interrupt in the middle of another evaluation due to various race conditions,
-     * we will delay new zio effect and wait until current instruction will be completed by `shouldInterrupt()`
-     */
+    // We must respect the order of instructions if another evaluation is in progress of current FiberContext
+    // Since we are not allowed to interrupt in the middle of another evaluation due to various race conditions,
+    // we will delay new zio effect and wait until current instruction will be completed by `shouldInterrupt()`
     val currentEvaluation = evaluationsInProgress.get()
     val newEvaluation     = EvaluationState.Pending(Thread.currentThread().getId)
     if (

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,7 +16,7 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
@@ -64,13 +64,13 @@ private[zio] final class FiberContext[E, A](
   private[this] val traceEffects: Boolean =
     traceExec && platform.tracing.tracingConfig.traceEffectOpsInExecution
 
-  private[this] val stack                 = Stack[Any => IO[Any, Any]]()
-  private[this] val environments          = Stack[AnyRef](startEnv)
-  private[this] val executors             = Stack[Executor](startExec)
-  private[this] val interruptStatus       = StackBool(startIStatus.toBoolean)
-  private[this] val supervisors           = Stack[Supervisor[Any]](supervisor0)
-  private[this] val forkScopeOverride     = Stack[Option[ZScope[Exit[Any, Any]]]]()
-  private[this] val evaluationsInProgress = new AtomicReference[EvaluationState](EvaluationState.Empty)
+  private[this] val stack              = Stack[Any => IO[Any, Any]]()
+  private[this] val environments       = Stack[AnyRef](startEnv)
+  private[this] val executors          = Stack[Executor](startExec)
+  private[this] val interruptStatus    = StackBool(startIStatus.toBoolean)
+  private[this] val supervisors        = Stack[Supervisor[Any]](supervisor0)
+  private[this] val forkScopeOverride  = Stack[Option[ZScope[Exit[Any, Any]]]]()
+  private[this] val evaluationThreadId = new AtomicLong(Long.MinValue)
 
   var scopeKey: ZScope.Key = null
 
@@ -276,13 +276,15 @@ private[zio] final class FiberContext[E, A](
   def evaluateNow(io0: IO[E, Any]): Unit = {
 
     // We must respect the order of instructions if another evaluation is in progress of current FiberContext
-    // Since we are not allowed to interrupt in the middle of another evaluation due to various race conditions,
-    // we will delay new zio effect and wait until current instruction will be completed by `shouldInterrupt()`
-    val currentEvaluation = evaluationsInProgress.get()
-    val newEvaluation     = EvaluationState.Pending(Thread.currentThread().getId)
+    // Since we are not allowed to interrupt it from another thread in the middle
+    // of another evaluation due to various race conditions,
+    // we will delay new zio effect and wait until current instruction will be completed
+    val contextThreadId = evaluationThreadId.get()
+    val currentThreadId = Thread.currentThread().getId
     if (
-      !currentEvaluation.isEqual(newEvaluation) ||
-      !evaluationsInProgress.compareAndSet(currentEvaluation, newEvaluation)
+      (contextThreadId != Long.MinValue &&
+        contextThreadId != currentThreadId) ||
+      !evaluationThreadId.compareAndSet(contextThreadId, currentThreadId)
     ) {
       evaluateLater(io0)
     } else {
@@ -673,7 +675,7 @@ private[zio] final class FiberContext[E, A](
           }
         }
       } finally {
-        evaluationsInProgress.set(EvaluationState.Empty)
+        evaluationThreadId.set(Long.MinValue)
         Fiber._currentFiber.remove()
       }
 
@@ -1091,25 +1093,6 @@ private[zio] final class FiberContext[E, A](
 
 }
 private[zio] object FiberContext {
-
-  sealed trait EvaluationState {
-    def isEqual(that: EvaluationState): Boolean
-  }
-
-  object EvaluationState {
-
-    case class Pending(threadId: Long) extends EvaluationState {
-      override def isEqual(that: EvaluationState): Boolean = that match {
-        case Pending(thatThreadId) if thatThreadId != threadId => false
-        case _                                                 => true
-      }
-    }
-
-    case object Empty extends EvaluationState {
-      override def isEqual(that: EvaluationState): Boolean = true
-    }
-
-  }
 
   sealed abstract class FiberState[+E, +A] extends Serializable with Product {
     def interrupted: Cause[Nothing]

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,7 +16,7 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._


### PR DESCRIPTION
Lock-free fix for 
https://github.com/zio/zio/issues/4457
https://github.com/zio/zio/issues/4395
https://github.com/zio/zio-kafka/issues/238
Just ensure that executions of `evaluateNow` in single FiberContext is ordered

Also run some benchmarks, no visible impact on performance obviously, would be surprised otherwise

**IOForkInterruptBenchmark**
```
New version with fix
[info] Benchmark                                        (size)   Mode  Cnt     Score    Error  Units
[info] IOForkInterruptBenchmark.catsForkInterrupt          100  thrpt   10  1886.918 ± 54.849  ops/s
[info] IOForkInterruptBenchmark.monixForkInterrupt         100  thrpt   10  1889.506 ± 54.990  ops/s
[info] IOForkInterruptBenchmark.zioForkInterrupt           100  thrpt   10   981.964 ± 18.538  ops/s
[info] IOForkInterruptBenchmark.zioTracedForkInterrupt     100  thrpt   10   839.156 ± 13.164  ops/s

Old version without fix
[info] Benchmark                                        (size)   Mode  Cnt     Score    Error  Units
[info] IOForkInterruptBenchmark.catsForkInterrupt          100  thrpt   10  1962.195 ± 51.303  ops/s
[info] IOForkInterruptBenchmark.monixForkInterrupt         100  thrpt   10  1803.737 ± 67.609  ops/s
[info] IOForkInterruptBenchmark.zioForkInterrupt           100  thrpt   10   943.982 ± 24.360  ops/s
[info] IOForkInterruptBenchmark.zioTracedForkInterrupt     100  thrpt   10   801.554 ± 10.535  ops/s
```

**ReduceAllParBenchmark**
```
New version with fix
[info] Benchmark                                 Mode  Cnt   Score   Error  Units
[info] ReduceAllParBenchmark.naiveReduceAllPar  thrpt    5  13.098 ± 1.667  ops/s
[info] ReduceAllParBenchmark.reduceAllPar       thrpt    5  28.519 ± 6.495  ops/s

Old version without fix
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                 Mode  Cnt   Score   Error  Units
[info] ReduceAllParBenchmark.naiveReduceAllPar  thrpt    5  12.868 ± 0.705  ops/s
[info] ReduceAllParBenchmark.reduceAllPar       thrpt    5  28.716 ± 6.213  ops/s
```
