### PR TITLE
Add ZStream.effectAsyncManaged

### DIFF
--- a/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -109,6 +109,55 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         } yield assert(isDone)(isFalse)
       }
     ),
+    suite("effectAsyncManaged")(
+      testM("effectAsyncManaged")(checkM(Gen.chunkOf(Gen.anyInt).filter(_.nonEmpty)) { chunk =>
+        for {
+          latch <- Promise.make[Nothing, Unit]
+          fiber <- ZStream
+                     .effectAsyncManaged[Any, Throwable, Int] { k =>
+                       global.execute(() => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
+                       latch.succeed(()).toManaged_ *>
+                         Task.unit.toManaged_
+                     }
+                     .take(chunk.size.toLong)
+                     .run(ZSink.collectAll[Int])
+                     .fork
+          _ <- latch.await
+          s <- fiber.join
+        } yield assert(s)(equalTo(chunk))
+      }),
+      testM("effectAsyncManaged signal end stream") {
+        for {
+          result <- ZStream
+                      .effectAsyncManaged[Any, Nothing, Int] { k =>
+                        k(IO.fail(None))
+                        UIO.unit.toManaged_
+                      }
+                      .runCollect
+        } yield assert(result)(equalTo(Chunk.empty))
+      },
+      testM("effectAsyncManaged back pressure") {
+        for {
+          refCnt  <- Ref.make(0)
+          refDone <- Ref.make[Boolean](false)
+          stream = ZStream.effectAsyncManaged[Any, Throwable, Int](
+                     cb => {
+                       Future
+                         .sequence(
+                           (1 to 7).map(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
+                         )
+                         .flatMap(_ => cb(refDone.set(true) *> ZIO.fail(None)))
+                       UIO.unit.toManaged_
+                     },
+                     5
+                   )
+          run    <- stream.run(ZSink.fromEffect[Any, Nothing, Int, Nothing](ZIO.never)).fork
+          _      <- refCnt.get.repeatWhile(_ != 7)
+          isDone <- refDone.get
+          _      <- run.interrupt
+        } yield assert(isDone)(isFalse)
+      }
+    ),
     suite("effectAsyncInterrupt")(
       testM("effectAsyncInterrupt Left") {
         for {

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -128,6 +128,55 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
           } yield assert(isDone)(isFalse)
         }
       ),
+      suite("effectAsyncManaged")(
+        testM("effectAsyncManaged")(checkM(Gen.chunkOf(Gen.anyInt).filter(_.nonEmpty)) { chunk =>
+          for {
+            latch <- Promise.make[Nothing, Unit]
+            fiber <- ZStream
+                       .effectAsyncManaged[Any, Throwable, Int] { k =>
+                         global.execute(() => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
+                         latch.succeed(()).toManaged_ *>
+                           Task.unit.toManaged_
+                       }
+                       .take(chunk.size.toLong)
+                       .run(ZSink.collectAll[Int])
+                       .fork
+            _ <- latch.await
+            s <- fiber.join
+          } yield assert(s)(equalTo(chunk))
+        }),
+        testM("effectAsyncManaged signal end stream") {
+          for {
+            result <- ZStream
+                        .effectAsyncManaged[Any, Nothing, Int] { k =>
+                          global.execute(() => k(IO.fail(None)))
+                          UIO.unit.toManaged_
+                        }
+                        .runCollect
+          } yield assert(result)(equalTo(Chunk.empty))
+        },
+        testM("effectAsyncManaged back pressure") {
+          for {
+            refCnt  <- Ref.make(0)
+            refDone <- Ref.make[Boolean](false)
+            stream = ZStream.effectAsyncManaged[Any, Throwable, Int](
+                       cb => {
+                         global.execute { () =>
+                           // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
+                           (1 to 7).foreach(i => cb(refCnt.set(i) *> ZIO.succeedNow(Chunk.single(1))))
+                           cb(refDone.set(true) *> ZIO.fail(None))
+                         }
+                         UIO.unit.toManaged_
+                       },
+                       5
+                     )
+            run    <- stream.run(ZSink.fromEffect[Any, Nothing, Int, Nothing](ZIO.never)).fork
+            _      <- refCnt.get.repeatWhile(_ != 7)
+            isDone <- refDone.get
+            _      <- run.interrupt
+          } yield assert(isDone)(isFalse)
+        }
+      ),
       suite("effectAsyncInterrupt")(
         testM("effectAsyncInterrupt Left") {
           for {

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -81,6 +81,38 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
     }
 
   /**
+   * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The registration of the callback itself returns an a managed resource.
+   * The optionality of the error type `E` can be used to signal the end of the
+   * stream, by setting it to `None`.
+   */
+  def effectAsyncManaged[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => ZManaged[R, E, Any],
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    managed {
+      for {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        _ <- register { k =>
+               try {
+                 runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
+               } catch {
+                 case FiberFailure(c) if c.interrupted =>
+                   Future.successful(false)
+               }
+             }
+        done <- ZRef.makeManaged(false)
+        pull = done.get.flatMap {
+                 if (_)
+                   Pull.end
+                 else
+                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+               }
+      } yield pull
+    }.flatMap(repeatEffectChunkOption(_))
+
+  /**
    * Creates a stream from an asynchronous callback that can be called multiple times
    * The registration of the callback itself returns an effect. The optionality of the
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -81,6 +81,38 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
     }
 
   /**
+   * Creates a stream from an asynchronous callback that can be called multiple times.
+   * The registration of the callback itself returns an a managed resource.
+   * The optionality of the error type `E` can be used to signal the end of the
+   * stream, by setting it to `None`.
+   */
+  def effectAsyncManaged[R, E, A](
+    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => ZManaged[R, E, Any],
+    outputBuffer: Int = 16
+  ): ZStream[R, E, A] =
+    managed {
+      for {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged_
+        _ <- register { k =>
+               try {
+                 runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
+               } catch {
+                 case FiberFailure(c) if c.interrupted =>
+                   Future.successful(false)
+               }
+             }
+        done <- ZRef.makeManaged(false)
+        pull = done.get.flatMap {
+                 if (_)
+                   Pull.end
+                 else
+                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+               }
+      } yield pull
+    }.flatMap(repeatEffectChunkOption(_))
+
+  /**
    * Creates a stream from an asynchronous callback that can be called multiple times
    * The registration of the callback itself returns an effect. The optionality of the
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.


### PR DESCRIPTION
Adds `ZStream.effectAsyncManaged` which works like `effectAsyncM` but for resourceful return values.

I ran across the need for this when integrating with the Google PubSub client, which both requires a callback and is a managed resource in itself.

```scala
import zio._
import zio.streams._
import zio.blocking._
import com.google.cloud.pubsub.v1.Subscriber
import com.google.cloud.pubsub.v1.AckReplyConsumer
import com.google.pubsub.v1.PubsubMessage
import com.google.cloud.pubsub.v1.MessageReceiver
import com.google.pubsub.v1.ProjectSubscriptionName
import com.google.common.util.concurrent.MoreExecutors

module pubsub {
  type Delivery = (PubsubMessage, AckReplyConsumer)
  def subscribe(projectId: String,
      subscriptionId: String
  ): ZStream[Blocking, Throwable, Delivery] = {
    ZStream.effectAsyncManaged[Blocking, Throwable, Delivery](cb => {
            val name = ProjectSubscriptionName.of(projectId, subscriptionId)
            val recv: MessageReceiver =
              (m: PubsubMessage, ack: AckReplyConsumer) =>
                cb(ZIO.succeed(Chunk((m, ack))))

            effectBlocking({
              val subscriber = Subscriber
                .newBuilder(name, recv)
                .build

              subscriber.addListener(
                new Listener {
                  override def failed(
                      state: State,
                      t: Throwable
                  ): Unit = {
                    cb(ZIO.fail(Some(t)))
                  }
                },
                MoreExecutors.directExecutor()
              )
              subscriber.startAsync().awaitRunning()
              subscriber
            }).toManaged(s =>
              effectBlocking {
                s.stopAsync().awaitTerminated(20, TimeUnit.SECONDS)
              }.orDie
            )
          })
  }
}
```
