### PR TITLE
Add support for scala 3.0.0-M2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ scala_213: &scala_213
   SCALA_VERSION: 2.13.3
 
 scala_dotty: &scala_dotty
-  SCALA_VERSION: 3.0.0-M1
+  SCALA_VERSION: 3.0.0-M2
 
 jdk_8: &jdk_8
   JDK_VERSION: 8

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -13,7 +13,7 @@ object BuildHelper {
   val Scala211   = "2.11.12"
   val Scala212   = "2.12.12"
   val Scala213   = "2.13.3"
-  val ScalaDotty = "3.0.0-M1"
+  val ScalaDotty = "3.0.0-M2"
 
   val SilencerVersion = "1.7.1"
 
@@ -88,7 +88,7 @@ object BuildHelper {
   )
 
   val scalaReflectSettings = Seq(
-    libraryDependencies ++= Seq("dev.zio" %%% "izumi-reflect" % "1.0.0-M10")
+    libraryDependencies ++= Seq("dev.zio" %%% "izumi-reflect" % "1.0.0-M11")
   )
 
   // Keep this consistent with the version in .core-tests/shared/src/test/scala/REPLSpec.scala

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -60,28 +60,28 @@ object CompileVariants {
 
 object Macros {
   import scala.quoted._
-  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: QuoteContext, tp: Type[A]): Expr[TestResult] = {
-    import ctx.tasty._
-    val path = rootPosition.sourceFile.jpath.toString
-    val line = rootPosition.startLine + 1
+  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: Quotes, tp: Type[A]): Expr[TestResult] = {
+    import quotes.reflect._
+    val path = Position.ofMacroExpansion.sourceFile.jpath.toString
+    val line = Position.ofMacroExpansion.startLine + 1
     val code = showExpr(value)
     val label = s"assert(`$code`) (at $path:$line)"
     '{_root_.zio.test.CompileVariants.assertImpl[A]($value)(${assertion}.label(${Expr(label)}))}
   }
 
-  private def showExpr[A](expr: Expr[A])(using ctx: QuoteContext) = {
+  private def showExpr[A](expr: Expr[A])(using ctx: Quotes) = {
     expr.show
       // reduce clutter
       .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
       .replaceAll("""\.apply(\s*[\[(])""", "$1")
   }
 
-  def sourcePath_impl(using ctx: QuoteContext): Expr[String] = {
-    import ctx.tasty._
-    Expr(rootPosition.sourceFile.jpath.toString)
+  def sourcePath_impl(using ctx: Quotes): Expr[String] = {
+    import quotes.reflect._
+    Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
   }
-  def showExpression_impl[A](value: Expr[A])(using ctx: QuoteContext) = {
-    import ctx.tasty._
+  def showExpression_impl[A](value: Expr[A])(using ctx: Quotes) = {
+    import quotes.reflect._
     Expr(showExpr(value))
   }
 }


### PR DESCRIPTION
Adding support for `scala 3.0.0-M2` and izumi-reflect `1.0.0-M11`. I upgraded the CompilerVariants test according to what was defined as breaking changes in the scala 3.0.0-M2 release. As scalajs now is supported by Scala 3 it would be very nice to get a new release of the excellent ZIO library as well :-)

Scala 3.0.0-M2 breaking changes are defined here:

https://github.com/lampepfl/dotty/releases/tag/3.0.0-M2
