### PR TITLE
Add note for ifM to ZIO.cond

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2477,6 +2477,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Similar to Either.cond, evaluate the predicate,
    * return the given A as success if predicate returns true, and the given E as error otherwise
+   *
+   * For effectful conditionals, see [[ZIO.ifM]]
    */
   def cond[E, A](predicate: Boolean, result: => A, error: => E): IO[E, A] =
     if (predicate) ZIO.succeed(result) else ZIO.fail(error)


### PR DESCRIPTION
Useful in the case where you have a `Ref[Boolean]` and need to perform some effects, for example

```scala
ZIO.condM(isEnabled)(consumeNext, log.info("Disabled").as(StopProcessing))
```