### PR TITLE
Add includeCase parameter to DefaultTestReporter.render

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
@@ -9,6 +9,9 @@ object SummaryBuilderSpec extends ZIOBaseSpec {
   def summarize(log: Vector[String]): String =
     log.filter(!_.contains("+")).mkString.stripLineEnd
 
+  def labelOnly(log: Vector[String]): String =
+    log.take(1).mkString.stripLineEnd
+
   def spec: ZSpec[Environment, Failure] =
     suite("SummaryBuilderSpec")(
       testM("doesn't generate summary for a successful test") {
@@ -18,7 +21,7 @@ object SummaryBuilderSpec extends ZIOBaseSpec {
         assertM(runSummary(test3))(equalTo(summarize(test3Expected)))
       },
       testM("correctly reports an error in a test") {
-        assertM(runSummary(test4))(equalTo(summarize(test4Expected)))
+        assertM(runSummary(test4))(equalTo(labelOnly(test4Expected)))
       },
       testM("doesn't generate summary for a successful test suite") {
         assertM(runSummary(suite1))(equalTo(""))

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -35,7 +35,8 @@ object DefaultTestReporter {
 
   def render[E](
     executedSpec: ExecutedSpec[E],
-    testAnnotationRenderer: TestAnnotationRenderer
+    testAnnotationRenderer: TestAnnotationRenderer,
+    includeCause: Boolean
   ): Seq[RenderedResult[String]] = {
     def loop(
       executedSpec: ExecutedSpec[E],
@@ -79,7 +80,7 @@ object DefaultTestReporter {
                 label,
                 Failed,
                 depth,
-                (Seq(renderFailureLabel(label, depth)) ++ Seq(renderCause(cause, depth))): _*
+                (Seq(renderFailureLabel(label, depth)) ++ Seq(renderCause(cause, depth)).filter(_ => includeCause)): _*
               )
           }
           Seq(renderedResult.withAnnotations(renderedAnnotations))
@@ -89,7 +90,7 @@ object DefaultTestReporter {
 
   def apply[E](testAnnotationRenderer: TestAnnotationRenderer): TestReporter[E] = {
     (duration: Duration, executedSpec: ExecutedSpec[E]) =>
-      val rendered = render(executedSpec, testAnnotationRenderer).flatMap(_.rendered)
+      val rendered = render(executedSpec, testAnnotationRenderer, true).flatMap(_.rendered)
       val stats    = logStats(duration, executedSpec)
       TestLogger.logLine((rendered ++ Seq(stats)).mkString("\n"))
   }

--- a/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
+++ b/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
@@ -13,7 +13,7 @@ object SummaryBuilder {
     }
     val failures = extractFailures(executedSpec)
     val rendered = failures
-      .flatMap(DefaultTestReporter.render(_, TestAnnotationRenderer.silent))
+      .flatMap(DefaultTestReporter.render(_, TestAnnotationRenderer.silent, false))
       .flatMap(_.rendered)
       .mkString("\n")
     Summary(success, fail, ignore, rendered)


### PR DESCRIPTION
Suppress the second Cause during ZTestFramework output.

*NB:* This is not a binary compatible change, if that is desired I can attempt to ensure compatibility.

An alternate implementation of this feature could be to duplicate the `render` method.

Currently, the output is of the structure:

    - SuiteName
      - Test label
      Fiber failed.
      <snip>
    Ran 1 test in 2 s 167 ms: 0 succeeded, 0 ignored, 1 failed
    - SuiteName
      - Test label
      Fiber failed.
      <snip>
    Done

This obscures the individual test failures, the summary at the very end
should only have the SuiteName and Test label, with stacktrace
suppressed, to highlight which tests are having a problem to make it
easier to scroll up in the test log.

With this alteration, the output of the test structure now looks like:

    - SuiteName
      - Test label
      Fiber failed.
      <snip>
    Ran 1 test in 2 s 167 ms: 0 succeeded, 0 ignored, 1 failed
    - SuiteName
      - Test label
    Done

(notice, the second `Fiber failed.` and stacktrace have been omitted)