### PR TITLE
Fix Race Condition in ZIO#effectAsyncInterrupt

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2934,10 +2934,10 @@ object ZIOSpec extends ZIOBaseSpec {
                      ref.incrementAndGet()
                      Left(ZIO.effectTotal(ref.decrementAndGet()))
                    }
-          _     <- ZIO.unit.race(effect).repeatN(100000)
-          value <- ZIO.effectTotal(ref.get)
+          _     <- ZIO.unit.race(effect)
+          value <- ZIO.effectTotal(ref.get())
         } yield assert(value)(equalTo(0))
-      }
+      } @@ jvm(nonFlaky(100000))
     ) @@ zioTag(interruption),
     suite("RTS environment")(
       testM("provide is modular") {


### PR DESCRIPTION
Resolves #4457.

I think the issue in #4457 can be traced to a race condition in `effectAsyncInterrupt`, which is used in the implementation of `Promise`. Specifically, if `effectAsyncInterrupt` is interrupted before the asynchronous effect starts executing then no canceler will be run, but the state is not updated to ensure that the register function is not invoked. With this change the original test that joiners are properly removed passes.

Copying @jsfwa and @narma.