### PR TITLE
Changed the actual api key with "API_KEY"

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -108,7 +108,7 @@ const siteConfig = {
 
   customDocsPath: 'zio-docs/target/mdoc',
   algolia: {
-    apiKey: '0c94b59071da7001757d08ab43d9e033',
+    apiKey: 'API_KEY',
     indexName: 'zio',
     algoliaOptions: {} // Optional, if provided by Algolia
   },


### PR DESCRIPTION
Seems like someone have exposed their api key. I replaced it with "API_KEY". Such sensitive data as api keys shouldn't be inside of the stuff hardcoded, instead one file in root directory of repository or such that contains all of them then take them from there.