### PR TITLE
Implement Chunk#split

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -580,6 +580,15 @@ object ChunkSpec extends ZIOBaseSpec {
       assertM(
         Chunk.unfoldM(0)(n => if (n < 10) IO.some((n, n + 1)) else IO.none)
       )(equalTo(Chunk.fromIterable(0 to 9)))
+    },
+    testM("split") {
+      val smallInts = Gen.small(n => Gen.const(n), 1)
+      val chunks    = Gen.chunkOf(Gen.anyInt)
+      check(smallInts, chunks) { (n, chunk) =>
+        val groups = chunk.split(n)
+        assert(groups.flatten)(equalTo(chunk)) &&
+        assert(groups.size)(equalTo(n min chunk.length))
+      }
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -701,7 +701,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     val chunks    = ChunkBuilder.make[Chunk[A]]()
     var i         = 0
     while (i < remainder) {
-      val chunk = ChunkBuilder.make[A]
+      val chunk = ChunkBuilder.make[A]()
       var j     = 0
       while (j <= quotient) {
         chunk += iterator.next()

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -691,6 +691,41 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     ev(apply(index))
 
   /**
+   * Splits this chunk into `n` equally sized chunks.
+   */
+  final def split(n: Int): Chunk[Chunk[A]] = {
+    val length    = self.length
+    val quotient  = length / n
+    val remainder = length % n
+    val iterator  = self.iterator
+    val chunks    = ChunkBuilder.make[Chunk[A]]()
+    var i         = 0
+    while (i < remainder) {
+      val chunk = ChunkBuilder.make[A]
+      var j     = 0
+      while (j <= quotient) {
+        chunk += iterator.next()
+        j += 1
+      }
+      chunks += chunk.result()
+      i += 1
+    }
+    if (quotient > 0) {
+      while (i < n) {
+        val chunk = ChunkBuilder.make[A]()
+        var j     = 0
+        while (j < quotient) {
+          chunk += iterator.next()
+          j += 1
+        }
+        chunks += chunk.result()
+        i += 1
+      }
+    }
+    chunks.result()
+  }
+
+  /**
    * Returns two splits of this chunk at the specified index.
    */
   override final def splitAt(n: Int): (Chunk[A], Chunk[A]) =


### PR DESCRIPTION
Splits a `Chunk` into `n` equally sized chunks. I had to implement this for dividing a collection into groups that could be processed in parallel and thought it could be useful for others.

Note that there is an existing `grouped` operator on Scala collections that does something similar but I think is slightly less useful for these types of operations. `grouped` divides a collection into groups where each group has the specified size, which means the actual number of groups may be more or less than the desired level of parallelism. This guarantees that the resulting number of groups will be equal to `n` (unless the chunk size is smaller than `n`) and that the chunks will be as close to equally sized as possible.