### PR TITLE
Adopt the new IntelliJ import order

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -22,9 +22,8 @@ OrganizeImports {
   groupedImports = Merge
   # IntelliJ IDEA's order so that they don't fight each other
   groups = [
-    "java."
     "*"
-    "scala."
+    "re:(javax?|scala)\\."
   ]
 }
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,9 +8,6 @@ docstrings = JavaDoc
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
 danglingParentheses.preset = true
-spaces {
-  inImportCurlyBraces = true
-}
 optIn.annotationNewlines = true
 newlines.alwaysBeforeMultilineDef = false
 

--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -1,11 +1,11 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.scalacheck
 import zio.IOBenchmarks.unsafeRun
 import zio.test.Gen
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
@@ -1,9 +1,8 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 
+import java.util.concurrent.TimeUnit
 import scala.collection.immutable.Range
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks.unsafeRun
 
+import java.util.concurrent.TimeUnit
 import scala.collection.immutable.Range
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations.{
   Benchmark,
   BenchmarkMode,
@@ -16,6 +14,8 @@ import org.openjdk.jmh.annotations.{
   Warmup
 }
 import zio.IOBenchmarks.verify
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/IOBenchmarks.scala
@@ -1,8 +1,8 @@
 package zio
 
 import cats._
-import cats.effect.{ ContextShift, Fiber => CFiber, IO => CIO }
-import monix.eval.{ Task => MTask }
+import cats.effect.{ContextShift, Fiber => CFiber, IO => CIO}
+import monix.eval.{Task => MTask}
 import zio.internal._
 
 import scala.concurrent.ExecutionContext

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepAttemptBenchmark.scala
@@ -91,7 +91,7 @@ class IODeepAttemptBenchmark {
 
   @Benchmark
   def twitterDeepAttempt(): BigInt = {
-    import com.twitter.util.{ Await, Future }
+    import com.twitter.util.{Await, Future}
 
     def descent(n: Int): Future[BigInt] =
       if (n == depth)

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -77,7 +77,7 @@ class IODeepFlatMapBenchmark {
 
   @Benchmark
   def twitterDeepFlatMap(): BigInt = {
-    import com.twitter.util.{ Await, Future }
+    import com.twitter.util.{Await, Future}
 
     def fib(n: Int): Future[BigInt] =
       if (n <= 1) Future(n)

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -1,9 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -1,9 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOForkInterruptBenchmark.scala
@@ -1,10 +1,10 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.concurrent.Deferred
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -86,7 +86,7 @@ class IOLeftBindBenchmark {
 
   @Benchmark
   def twitterLeftBindBenchmark(): Int = {
-    import com.twitter.util.{ Await, Future }
+    import com.twitter.util.{Await, Future}
 
     def loop(i: Int): Future[Int] =
       if (i % depth == 0) Future(i + 1).flatMap(loop)

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -26,7 +26,7 @@ class IOMapBenchmark {
   @Benchmark
   def futureMap(): BigInt = {
     import scala.concurrent.duration.Duration.Inf
-    import scala.concurrent.{ Await, Future }
+    import scala.concurrent.{Await, Future}
 
     @tailrec
     def sumTo(t: Future[BigInt], n: Int): Future[BigInt] =
@@ -77,7 +77,7 @@ class IOMapBenchmark {
 
   @Benchmark
   def twitterFutureMap(): BigInt = {
-    import com.twitter.util.{ Await, Future }
+    import com.twitter.util.{Await, Future}
 
     @tailrec
     def sumTo(t: Future[BigInt], n: Int): Future[BigInt] =

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -80,7 +80,7 @@ class IONarrowFlatMapBenchmark {
 
   @Benchmark
   def twitterNarrowFlatMap(): Int = {
-    import com.twitter.util.{ Await, Future }
+    import com.twitter.util.{Await, Future}
 
     def loop(i: Int): Future[Int] =
       if (i < size) Future(i + 1).flatMap(loop)

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -1,10 +1,9 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -94,8 +94,8 @@ class IOShallowAttemptBenchmark {
 
   @Benchmark
   def twitterShallowAttempt(): BigInt = {
-    import com.twitter.util.{ Await, Future }
-    import com.twitter.util.{ Return, Throw }
+    import com.twitter.util.{Await, Future}
+    import com.twitter.util.{Return, Throw}
 
     def throwup(n: Int): Future[BigInt] =
       if (n == 0) throwup(n + 1).rescue { case _ =>

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.implicits._
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
@@ -9,6 +7,7 @@ import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks.{ monixScheduler, unsafeRun }
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future }
 

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -1,15 +1,15 @@
 package zio
 
 import cats.effect.implicits._
-import cats.effect.{ ContextShift, IO => CIO }
+import cats.effect.{ContextShift, IO => CIO}
 import cats.implicits._
-import monix.eval.{ Task => MTask }
+import monix.eval.{Task => MTask}
 import org.openjdk.jmh.annotations._
-import zio.IOBenchmarks.{ monixScheduler, unsafeRun }
+import zio.IOBenchmarks.{monixScheduler, unsafeRun}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations.{
   Benchmark,
   BenchmarkMode,
@@ -17,6 +15,7 @@ import org.openjdk.jmh.annotations.{
   Warmup
 }
 
+import java.util.concurrent.TimeUnit
 import scala.collection.Iterable
 import scala.util.Random
 

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -1,13 +1,12 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.{ ContextShift, IO => CIO }
 import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stm._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -1,7 +1,7 @@
 package zio
 
-import cats.effect.{ ContextShift, IO => CIO }
-import monix.eval.{ Task => MTask }
+import cats.effect.{ContextShift, IO => CIO}
+import monix.eval.{Task => MTask}
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stm._

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -1,13 +1,12 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.{ ContextShift, IO => CIO }
 import monix.eval.{ Task => MTask }
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stm._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueParallelBenchmark.scala
@@ -1,7 +1,7 @@
 package zio
 
-import cats.effect.{ ContextShift, IO => CIO }
-import monix.eval.{ Task => MTask }
+import cats.effect.{ContextShift, IO => CIO}
+import monix.eval.{Task => MTask}
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stm._

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.{ ContextShift, IO => CIO }
 import cats.implicits._
 import monix.eval.{ Task => MTask }
@@ -11,6 +9,7 @@ import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stm._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSequentialBenchmark.scala
@@ -1,8 +1,8 @@
 package zio
 
-import cats.effect.{ ContextShift, IO => CIO }
+import cats.effect.{ContextShift, IO => CIO}
 import cats.implicits._
-import monix.eval.{ Task => MTask }
+import monix.eval.{Task => MTask}
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.SPSC
 import org.openjdk.jmh.annotations._

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.util.concurrent.TimeUnit
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Keep, Sink => AkkaSink, Source => AkkaSource }
@@ -11,6 +9,7 @@ import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stream._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContextExecutor }
 

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -2,16 +2,16 @@ package zio
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{ Keep, Sink => AkkaSink, Source => AkkaSource }
-import cats.effect.{ IO => CatsIO }
-import fs2.{ Chunk => FS2Chunk, Stream => FS2Stream }
+import akka.stream.scaladsl.{Keep, Sink => AkkaSink, Source => AkkaSource}
+import cats.effect.{IO => CatsIO}
+import fs2.{Chunk => FS2Chunk, Stream => FS2Stream}
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.stream._
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContextExecutor }
+import scala.concurrent.{Await, ExecutionContextExecutor}
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/ZIOArray.scala
+++ b/benchmarks/src/main/scala/zio/ZIOArray.scala
@@ -1,6 +1,6 @@
 package zio
 
-import scala.{ Array, Boolean, Int, Unit }
+import scala.{Array, Boolean, Int, Unit}
 
 object ZIOArray {
 

--- a/benchmarks/src/main/scala/zio/chunks/ArrayBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ArrayBenchmarks.scala
@@ -1,8 +1,8 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChainBenchmarks.scala
@@ -1,10 +1,10 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import cats.data.Chain
 import org.openjdk.jmh.annotations._
 import zio.Chunk
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkAppendBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.Chunk
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkArrayBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.Chunk
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State }
 import zio.Chunk
+
+import java.util.concurrent.TimeUnit
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkCreationBenchmarks.scala
@@ -1,6 +1,6 @@
 package zio.chunks
 
-import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State }
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State}
 import zio.Chunk
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkPrependBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.Chunk
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.chunks
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/ForeachPar_Benchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ForeachPar_Benchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MergeAllParBenchmark.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio.ZIO.succeedNow
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OfferBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.internal.BenchUtils._
+
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
@@ -3,7 +3,7 @@ package zio.internal
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 import zio.internal.BenchUtils._
-import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
+import zio.internal.ProducerConsumerBenchmark.{OfferCounters, PollCounters}
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueConcBenchmark.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 import zio.internal.BenchUtils._
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
+
+import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/OneElementQueueSeqBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 import org.openjdk.jmh.annotations._
-import org.openjdk.jmh.infra.{ Blackhole, Control }
+import org.openjdk.jmh.infra.{Blackhole, Control}
 import zio.internal.BenchUtils._
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PingPongBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.{ Blackhole, Control }
 import zio.internal.BenchUtils._
+
+import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/PollBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.internal.BenchUtils._
+
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
@@ -3,7 +3,7 @@ package zio.internal
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 import zio.internal.BenchUtils._
-import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
+import zio.internal.ProducerConsumerBenchmark.{OfferCounters, PollCounters}
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ProducerConsumerBenchmark.scala
@@ -1,11 +1,11 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 import zio.internal.BenchUtils._
 import zio.internal.ProducerConsumerBenchmark.{ OfferCounters, PollCounters }
+
+import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/ReduceAllParBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RingBufferMethodDispatchBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
 
 /*
  * Main purposes of this set of benchmarks are:

--- a/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/RoundtripBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.internal
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.internal.BenchUtils._
+
+import java.util.concurrent.TimeUnit
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
@@ -1,11 +1,11 @@
 package zio.stacktracer
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.internal.stacktracer.impl.{ AkkaLineNumbers, AkkaLineNumbersTracer }
 import zio.stacktracer.TracersBenchmark.{ akkaTracer, asmTracer }
 import zio.stacktracer.impls.AsmTracer
+
+import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/TracersBenchmark.scala
@@ -1,8 +1,8 @@
 package zio.stacktracer
 
 import org.openjdk.jmh.annotations._
-import zio.internal.stacktracer.impl.{ AkkaLineNumbers, AkkaLineNumbersTracer }
-import zio.stacktracer.TracersBenchmark.{ akkaTracer, asmTracer }
+import zio.internal.stacktracer.impl.{AkkaLineNumbers, AkkaLineNumbersTracer}
+import zio.stacktracer.TracersBenchmark.{akkaTracer, asmTracer}
 import zio.stacktracer.impls.AsmTracer
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
@@ -22,7 +22,7 @@ import zio.internal.stacktracer.ZTraceElement.SourceLocation
 import zio.stacktracer.impls.AsmTracer.MethodSearchVisitor
 
 import java.lang.invoke.SerializedLambda
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
  * Java 8+ only

--- a/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
+++ b/benchmarks/src/main/scala/zio/stacktracer/impls/AsmTracer.scala
@@ -16,13 +16,12 @@
 
 package zio.stacktracer.impls
 
-import java.lang.invoke.SerializedLambda
-
 import org.objectweb.asm._
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.ZTraceElement.SourceLocation
 import zio.stacktracer.impls.AsmTracer.MethodSearchVisitor
 
+import java.lang.invoke.SerializedLambda
 import scala.util.{ Failure, Success, Try }
 
 /**

--- a/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMFlatMapBenchmark.scala
@@ -1,9 +1,9 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.stm
 
-import java.lang.{ Runtime => JRuntime }
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.lang.{ Runtime => JRuntime }
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -3,7 +3,7 @@ package zio.stm
 import org.openjdk.jmh.annotations._
 import zio._
 
-import java.lang.{ Runtime => JRuntime }
+import java.lang.{Runtime => JRuntime}
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -1,12 +1,11 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import cats.effect.{ ContextShift, IO => CIO }
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -1,6 +1,6 @@
 package zio.stm
 
-import cats.effect.{ ContextShift, IO => CIO }
+import cats.effect.{ContextShift, IO => CIO}
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio._

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -1,10 +1,10 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapContentionBenchmarks.scala
@@ -1,10 +1,10 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
 import zio.clock.Clock
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TMapOpsBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
@@ -1,6 +1,6 @@
 package zio.stm
 
-import org.openjdk.jmh.annotations.{ Benchmark, Group, GroupThreads, _ }
+import org.openjdk.jmh.annotations.{Benchmark, Group, GroupThreads, _}
 import org.openjdk.jmh.infra.Blackhole
 import zio.IOBenchmarks._
 import zio._

--- a/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
@@ -1,12 +1,12 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.StampedLock
-
 import org.openjdk.jmh.annotations.{ Benchmark, Group, GroupThreads, _ }
 import org.openjdk.jmh.infra.Blackhole
 import zio.IOBenchmarks._
 import zio._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.StampedLock
 
 @State(Scope.Group)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSetOpsBenchmarks.scala
@@ -1,9 +1,9 @@
 package zio.stm
 
-import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import zio._
+
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ inThisBuild(
 
 addCommandAlias("build", "; prepare; testJVM")
 addCommandAlias("prepare", "; fix; fmt")
-addCommandAlias("fix", "all compile:scalafix test:scalafix")
+addCommandAlias("fix", "all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll")
 addCommandAlias(
   "fixCheck",
   "; compile:scalafix --check ; test:scalafix --check"

--- a/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
+++ b/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
@@ -4,7 +4,7 @@ import zio._
 import zio.test.Assertion._
 import zio.test._
 
-import scala.scalajs.js.{ Promise => JSPromise }
+import scala.scalajs.js.{Promise => JSPromise}
 
 object JSSpec extends ZIOBaseSpec {
   def spec: Spec[Any, TestFailure[Throwable], TestSuccess] = suite("JSSpec")(

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -3,7 +3,7 @@ package zio
 import zio.blocking.Blocking
 import zio.duration._
 import zio.internal.stacktracer.ZTraceElement
-import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
+import zio.internal.stacktracer.ZTraceElement.{NoLocation, SourceLocation}
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock

--- a/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
@@ -1,12 +1,11 @@
 package zio
 
-import java.util.concurrent.Executors
-
 import zio.internal.Executor
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
+import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 
 object CancelableFutureSpecJVM extends ZIOBaseSpec {

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -1,10 +1,10 @@
 package zio
 
-import java.util.concurrent.atomic.AtomicReference
-
 import zio.FiberRefSpecUtil._
 import zio.test.Assertion._
 import zio.test._
+
+import java.util.concurrent.atomic.AtomicReference
 
 object FiberRefSpecJvm extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -3,7 +3,7 @@ package zio
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ nonFlaky, silent }
+import zio.test.TestAspect.{nonFlaky, silent}
 import zio.test._
 import zio.test.environment.Live
 

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -1,14 +1,14 @@
 package zio
 
-import java.util.concurrent.Callable
-import java.util.concurrent.atomic.AtomicInteger
-
 import zio.clock.Clock
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ nonFlaky, silent }
 import zio.test._
 import zio.test.environment.Live
+
+import java.util.concurrent.Callable
+import java.util.concurrent.atomic.AtomicInteger
 
 object RTSSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -1,7 +1,5 @@
 package zio
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
-
 import zio.SerializableSpecHelpers._
 import zio.internal.stacktracer.ZTraceElement
 import zio.system.System
@@ -9,6 +7,8 @@ import zio.test.Assertion._
 import zio.test.TestAspect.scala2Only
 import zio.test.environment.Live
 import zio.test.{ test => testSync, _ }
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
 
 object SerializableSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -6,9 +6,9 @@ import zio.system.System
 import zio.test.Assertion._
 import zio.test.TestAspect.scala2Only
 import zio.test.environment.Live
-import zio.test.{ test => testSync, _ }
+import zio.test.{test => testSync, _}
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 object SerializableSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
@@ -3,9 +3,9 @@ package zio
 import zio.test.Assertion._
 import zio.test._
 
-import java.io.{ File, IOException }
+import java.io.{File, IOException}
 import java.nio.file.Files
-import java.{ util => ju }
+import java.{util => ju}
 
 object ZManagedPlatformSpecificSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
@@ -1,11 +1,11 @@
 package zio
 
+import zio.test.Assertion._
+import zio.test._
+
 import java.io.{ File, IOException }
 import java.nio.file.Files
 import java.{ util => ju }
-
-import zio.test.Assertion._
-import zio.test._
 
 object ZManagedPlatformSpecificSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -4,7 +4,7 @@ import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test._
-import zio.{ UIO, ZIOBaseSpec }
+import zio.{UIO, ZIOBaseSpec}
 
 import java.util.concurrent.atomic.AtomicBoolean
 

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -1,12 +1,12 @@
 package zio.blocking
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test._
 import zio.{ UIO, ZIOBaseSpec }
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 object BlockingSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/internal/OneElementConcurrentQueueConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/OneElementConcurrentQueueConcurrencyTests.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 import org.openjdk.jcstress.annotations._
-import org.openjdk.jcstress.infra.results.{ IIII_Result, II_Result, I_Result }
+import org.openjdk.jcstress.infra.results.{IIII_Result, II_Result, I_Result}
 
 object OneElementConcurrentQueueConcurrencyTests {
   /*

--- a/core-tests/jvm/src/test/scala/zio/internal/RingBufferArbConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/RingBufferArbConcurrencyTests.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 import org.openjdk.jcstress.annotations._
-import org.openjdk.jcstress.infra.results.{ IIIIII_Result, IIII_Result, II_Result }
+import org.openjdk.jcstress.infra.results.{IIIIII_Result, IIII_Result, II_Result}
 
 object RingBufferArbConcurrencyTests {
   /*

--- a/core-tests/jvm/src/test/scala/zio/internal/RingBufferPow2ConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/RingBufferPow2ConcurrencyTests.scala
@@ -1,7 +1,7 @@
 package zio.internal
 
 import org.openjdk.jcstress.annotations._
-import org.openjdk.jcstress.infra.results.{ IIIIII_Result, IIII_Result, II_Result }
+import org.openjdk.jcstress.infra.results.{IIIIII_Result, IIII_Result, II_Result}
 
 object RingBufferPow2ConcurrencyTests {
   /*

--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -8,8 +8,8 @@ import zio.test._
 
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
-import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
+import java.nio.channels.{AsynchronousServerSocketChannel, AsynchronousSocketChannel}
+import java.util.concurrent.{CompletableFuture, CompletionStage, Future}
 
 object JavaSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -1,15 +1,15 @@
 package zio
 package interop
 
-import java.net.InetSocketAddress
-import java.nio.ByteBuffer
-import java.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
-import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
-
 import zio.blocking.Blocking
 import zio.interop.javaz._
 import zio.test.Assertion._
 import zio.test._
+
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
+import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
 
 object JavaSpec extends ZIOBaseSpec {
 

--- a/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala
@@ -3,7 +3,7 @@ package system
 
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.{ Live, live }
+import zio.test.environment.{Live, live}
 
 import scala.reflect.io.File
 

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.Cause.{ Both, Then }
+import zio.Cause.{Both, Then}
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._

--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -1,9 +1,9 @@
 package zio
 
-import java.nio._
-
 import zio.test.Assertion.equalTo
 import zio.test._
+
+import java.nio._
 
 object ChunkBufferSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -4,12 +4,12 @@ import zio.clock.Clock
 import zio.duration._
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.test.TestAspect.{ failing, timeout }
+import zio.test.TestAspect.{failing, timeout}
 import zio.test._
-import zio.test.environment.{ TestClock, TestRandom }
+import zio.test.environment.{TestClock, TestRandom}
 
-import java.time.temporal.{ ChronoField, ChronoUnit }
-import java.time.{ Instant, OffsetDateTime, ZoneId }
+import java.time.temporal.{ChronoField, ChronoUnit}
+import java.time.{Instant, OffsetDateTime, ZoneId}
 import scala.concurrent.Future
 
 object ScheduleSpec extends ZIOBaseSpec {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -1,8 +1,5 @@
 package zio
 
-import java.time.temporal.{ ChronoField, ChronoUnit }
-import java.time.{ Instant, OffsetDateTime, ZoneId }
-
 import zio.clock.Clock
 import zio.duration._
 import zio.stream.ZStream
@@ -11,6 +8,8 @@ import zio.test.TestAspect.{ failing, timeout }
 import zio.test._
 import zio.test.environment.{ TestClock, TestRandom }
 
+import java.time.temporal.{ ChronoField, ChronoUnit }
+import java.time.{ Instant, OffsetDateTime, ZoneId }
 import scala.concurrent.Future
 
 object ScheduleSpec extends ZIOBaseSpec {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -7,12 +7,12 @@ import zio.duration._
 import zio.internal.Platform
 import zio.random.Random
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, forked, ignore, jvm, jvmOnly, nonFlaky, scala2Only }
+import zio.test.TestAspect.{flaky, forked, ignore, jvm, jvmOnly, nonFlaky, scala2Only}
 import zio.test._
-import zio.test.environment.{ Live, TestClock }
+import zio.test.environment.{Live, TestClock}
 
 import scala.annotation.tailrec
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 object ZIOSpec extends ZIOBaseSpec {
 
@@ -944,7 +944,7 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("running Future can be interrupted") {
         import java.util.concurrent.atomic.AtomicInteger
 
-        import scala.concurrent.{ ExecutionContext, Future }
+        import scala.concurrent.{ExecutionContext, Future}
         def infiniteFuture(ref: AtomicInteger)(implicit ec: ExecutionContext): Future[Nothing] =
           Future(ref.getAndIncrement()).flatMap(_ => infiniteFuture(ref))
         for {

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -5,7 +5,7 @@ import zio.Exit.Failure
 import zio.ZManaged.ReleaseMap
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ nonFlaky, scala2Only }
+import zio.test.TestAspect.{nonFlaky, scala2Only}
 import zio.test._
 import zio.test.environment._
 

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -3,7 +3,7 @@ package zio
 import zio.ZQueueSpecUtil.waitForSize
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ jvm, nonFlaky }
+import zio.test.TestAspect.{jvm, nonFlaky}
 import zio.test._
 import zio.test.environment.Live
 

--- a/core-tests/shared/src/test/scala/zio/clock/ClockSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/clock/ClockSpec.scala
@@ -1,9 +1,9 @@
 package zio.clock
 
-import java.time.DateTimeException
-
 import zio._
 import zio.test._
+
+import java.time.DateTimeException
 
 object ClockSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -4,9 +4,9 @@ import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
 
-import java.time.{ Duration => JavaDuration }
+import java.time.{Duration => JavaDuration}
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.{ Duration => ScalaDuration }
+import scala.concurrent.duration.{Duration => ScalaDuration}
 
 object DurationSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/duration/DurationSpec.scala
@@ -1,12 +1,11 @@
 package zio.duration
 
-import java.time.{ Duration => JavaDuration }
-import java.util.concurrent.TimeUnit
-
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
 
+import java.time.{ Duration => JavaDuration }
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{ Duration => ScalaDuration }
 
 object DurationSpec extends ZIOBaseSpec {

--- a/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
@@ -1,10 +1,9 @@
 package zio.internal
-import java.util.concurrent.RejectedExecutionException
-
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
 import zio.test._
 
+import java.util.concurrent.RejectedExecutionException
 import scala.concurrent.ExecutionContext
 
 final class TestExecutor(val submitResult: Boolean) extends Executor {

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -3,7 +3,7 @@ package zio.internal
 import zio.ZIOBaseSpec
 import zio.random.Random
 import zio.test.Assertion.equalTo
-import zio.test.{ Gen, ZSpec, assert, checkAll, suite, test, testM }
+import zio.test.{Gen, ZSpec, assert, checkAll, suite, test, testM}
 
 import scala.util.Random.nextInt
 

--- a/core-tests/shared/src/test/scala/zio/stm/STMLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMLazinessSpec.scala
@@ -1,7 +1,7 @@
 package zio.stm
 
 import zio.test._
-import zio.{ UIO, ZIOBaseSpec }
+import zio.{UIO, ZIOBaseSpec}
 
 object STMLazinessSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -17,7 +17,7 @@ package zio.stm
 
 import zio.test.Assertion._
 import zio.test._
-import zio.{ Chunk, ZIOBaseSpec }
+import zio.{Chunk, ZIOBaseSpec}
 
 object TArraySpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import zio.test.Assertion._
 import zio.test._
-import zio.{ URIO, ZIOBaseSpec }
+import zio.{URIO, ZIOBaseSpec}
 
 object TMapSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TPriorityQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TPriorityQueueSpec.scala
@@ -3,7 +3,7 @@ package zio.stm
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._
-import zio.{ Chunk, ZIOBaseSpec }
+import zio.{Chunk, ZIOBaseSpec}
 
 object TPriorityQueueSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TReentrantLockSpec.scala
@@ -18,9 +18,9 @@ package zio.stm
 
 import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ flaky, timeout }
+import zio.test.TestAspect.{flaky, timeout}
 import zio.test._
-import zio.{ Exit, Promise, Ref, Schedule, ZIO }
+import zio.{Exit, Promise, Ref, Schedule, ZIO}
 
 object TReentrantLockSpec extends DefaultRunnableSpec {
   def pollSchedule[E, A]: Schedule[Any, Option[Exit[E, A]], Option[Exit[E, A]]] =

--- a/core/js/src/main/scala/zio/ChunkPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ChunkPlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
-import scala.reflect.{ ClassTag, classTag }
+import scala.reflect.{ClassTag, classTag}
 
 private[zio] trait ChunkPlatformSpecific {
 

--- a/core/js/src/main/scala/zio/TaskPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/TaskPlatformSpecific.scala
@@ -17,7 +17,7 @@
 package zio
 
 import scala.scalajs.js
-import scala.scalajs.js.{ Promise => JSPromise }
+import scala.scalajs.js.{Promise => JSPromise}
 
 private[zio] trait TaskPlatformSpecific { self: Task.type =>
 

--- a/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -17,7 +17,7 @@
 package zio
 
 import scala.scalajs.js
-import scala.scalajs.js.{ Promise => JSPromise }
+import scala.scalajs.js.{Promise => JSPromise}
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
 

--- a/core/js/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
+++ b/core/js/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
@@ -17,7 +17,7 @@
 package zio.internal
 
 import java.io.Serializable
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
 final class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   private[this] val ref = new AtomicReference[AnyRef]()

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,9 +19,9 @@ package zio.internal
 import com.github.ghik.silencer.silent
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
-import zio.{ Cause, Supervisor }
+import zio.{Cause, Supervisor}
 
-import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
+import java.util.{HashMap, HashSet, Map => JMap, Set => JSet}
 import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,13 +16,12 @@
 
 package zio.internal
 
-import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
-
 import com.github.ghik.silencer.silent
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 import zio.{ Cause, Supervisor }
 
+import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
 import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {

--- a/core/jvm/src/main/scala/zio/ChunkPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ChunkPlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
-import scala.reflect.{ ClassTag, classTag }
+import scala.reflect.{ClassTag, classTag}
 
 private[zio] trait ChunkPlatformSpecific {
 

--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import _root_.java.util.concurrent.{ CompletionStage, Future }
+import _root_.java.util.concurrent.{CompletionStage, Future}
 import zio.blocking.Blocking
 import zio.interop.javaz
 

--- a/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
@@ -16,10 +16,10 @@
 
 package zio
 
+import zio.interop.javaz
+
 import java.nio.channels.CompletionHandler
 import java.util.concurrent.CompletionStage
-
-import zio.interop.javaz
 
 private[zio] trait TaskPlatformSpecific {
 

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -16,11 +16,11 @@
 
 package zio
 
-import java.nio.channels.CompletionHandler
-import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
-
 import zio.blocking.Blocking
 import zio.interop.javaz
+
+import java.nio.channels.CompletionHandler
+import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   def toCompletableFuture[A1 >: A](implicit ev: E <:< Throwable): URIO[R, CompletableFuture[A1]] =

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -20,7 +20,7 @@ import zio.blocking.Blocking
 import zio.interop.javaz
 
 import java.nio.channels.CompletionHandler
-import java.util.concurrent.{ CompletableFuture, CompletionStage, Future }
+import java.util.concurrent.{CompletableFuture, CompletionStage, Future}
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   def toCompletableFuture[A1 >: A](implicit ev: E <:< Throwable): URIO[R, CompletableFuture[A1]] =

--- a/core/jvm/src/main/scala/zio/ZInputStream.scala
+++ b/core/jvm/src/main/scala/zio/ZInputStream.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import java.io.IOException
-
 import zio.blocking._
+
+import java.io.IOException
 
 abstract class ZInputStream {
   def readN(n: Int): ZIO[Blocking, Option[IOException], Chunk[Byte]]

--- a/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
@@ -16,12 +16,12 @@
 
 package zio
 
+import zio.blocking._
+
 import java.io
 import java.io.IOException
 import java.net.{ URI, URL }
 import java.nio.file.Path
-
-import zio.blocking._
 
 private[zio] trait ZManagedPlatformSpecific {
 

--- a/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
@@ -20,7 +20,7 @@ import zio.blocking._
 
 import java.io
 import java.io.IOException
-import java.net.{ URI, URL }
+import java.net.{URI, URL}
 import java.nio.file.Path
 
 private[zio] trait ZManagedPlatformSpecific {

--- a/core/jvm/src/main/scala/zio/ZOutputStream.scala
+++ b/core/jvm/src/main/scala/zio/ZOutputStream.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import java.io.IOException
-
 import zio.blocking._
+
+import java.io.IOException
 
 abstract class ZOutputStream {
   def write(chunk: Chunk[Byte]): ZIO[Blocking, IOException, Unit]

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -17,7 +17,7 @@
 package zio
 
 import zio.internal.tracing.ZIOFn
-import zio.internal.{ Executor, NamedThreadFactory }
+import zio.internal.{Executor, NamedThreadFactory}
 
 import java.io.IOException
 import java.util.concurrent._

--- a/core/jvm/src/main/scala/zio/blocking/package.scala
+++ b/core/jvm/src/main/scala/zio/blocking/package.scala
@@ -16,11 +16,11 @@
 
 package zio
 
-import java.io.IOException
-import java.util.concurrent._
-
 import zio.internal.tracing.ZIOFn
 import zio.internal.{ Executor, NamedThreadFactory }
+
+import java.io.IOException
+import java.util.concurrent._
 
 package object blocking {
   type Blocking = Has[Blocking.Service]

--- a/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
@@ -17,7 +17,7 @@
 package zio.clock
 
 import zio.duration.Duration
-import zio.internal.{ NamedThreadFactory, Scheduler }
+import zio.internal.{NamedThreadFactory, Scheduler}
 
 import java.util.concurrent._
 

--- a/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/clock/PlatformSpecific.scala
@@ -16,10 +16,10 @@
 
 package zio.clock
 
-import java.util.concurrent._
-
 import zio.duration.Duration
 import zio.internal.{ NamedThreadFactory, Scheduler }
+
+import java.util.concurrent._
 
 private[clock] trait PlatformSpecific {
   import Scheduler.CancelToken

--- a/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
+++ b/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
@@ -1,6 +1,6 @@
 package zio.internal
 
-import java.util.concurrent.{ LinkedBlockingQueue, RejectedExecutionException, ThreadPoolExecutor, TimeUnit }
+import java.util.concurrent.{LinkedBlockingQueue, RejectedExecutionException, ThreadPoolExecutor, TimeUnit}
 
 private[internal] abstract class DefaultExecutors {
   final def makeDefault(yieldOpCount: Int): Executor =

--- a/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
@@ -16,9 +16,9 @@
 
 package zio.internal
 
-import java.util.concurrent.{ AbstractExecutorService, TimeUnit }
-import java.{ util => ju }
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutorService }
+import java.util.concurrent.{AbstractExecutorService, TimeUnit}
+import java.{util => ju}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 trait ExecutorPlatformSpecific { this: Executor =>
 

--- a/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
@@ -18,7 +18,6 @@ package zio.internal
 
 import java.util.concurrent.{ AbstractExecutorService, TimeUnit }
 import java.{ util => ju }
-
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutorService }
 
 trait ExecutorPlatformSpecific { this: Executor =>

--- a/core/jvm/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
+++ b/core/jvm/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
@@ -17,7 +17,7 @@
 package zio.internal
 
 import java.io.Serializable
-import java.util.concurrent.atomic.{ AtomicReference, LongAdder }
+import java.util.concurrent.atomic.{AtomicReference, LongAdder}
 
 /**
  * This is a specialized implementation of MutableConcurrentQueue of

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,15 +16,14 @@
 
 package zio.internal
 
-import java.lang.ref.WeakReference
-import java.util.concurrent.ConcurrentHashMap
-import java.util.{ Collections, Map => JMap, Set => JSet, WeakHashMap }
-
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig
 import zio.{ Cause, Supervisor }
 
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{ Collections, Map => JMap, Set => JSet, WeakHashMap }
 import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,11 +19,11 @@ package zio.internal
 import zio.internal.stacktracer.Tracer
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer
 import zio.internal.tracing.TracingConfig
-import zio.{ Cause, Supervisor }
+import zio.{Cause, Supervisor}
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{ Collections, Map => JMap, Set => JSet, WeakHashMap }
+import java.util.{Collections, Map => JMap, Set => JSet, WeakHashMap}
 import scala.concurrent.ExecutionContext
 
 private[internal] trait PlatformSpecific {

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -16,9 +16,9 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.AtomicLongArray
-
 import zio.internal.MutableQueueFieldsPadding.{ headUpdater, tailUpdater }
+
+import java.util.concurrent.atomic.AtomicLongArray
 
 object RingBuffer {
 

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -16,7 +16,7 @@
 
 package zio.internal
 
-import zio.internal.MutableQueueFieldsPadding.{ headUpdater, tailUpdater }
+import zio.internal.MutableQueueFieldsPadding.{headUpdater, tailUpdater}
 
 import java.util.concurrent.atomic.AtomicLongArray
 
@@ -155,7 +155,7 @@ object RingBuffer {
  * better performance in some very specific situations.
  */
 abstract class RingBuffer[A](override final val capacity: Int) extends MutableQueueFieldsPadding[A] with Serializable {
-  import RingBuffer.{ STATE_EMPTY, STATE_FULL, STATE_LOOP, STATE_RESERVED }
+  import RingBuffer.{STATE_EMPTY, STATE_FULL, STATE_LOOP, STATE_RESERVED}
 
   private val buf: Array[AnyRef]   = new Array[AnyRef](capacity)
   private val seq: AtomicLongArray = new AtomicLongArray(capacity)

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -17,9 +17,9 @@
 package zio.interop
 
 import _root_.java.nio.channels.CompletionHandler
-import _root_.java.util.concurrent.{ CompletableFuture, CompletionException, CompletionStage, Future }
+import _root_.java.util.concurrent.{CompletableFuture, CompletionException, CompletionStage, Future}
 import zio._
-import zio.blocking.{ Blocking, blocking }
+import zio.blocking.{Blocking, blocking}
 
 import scala.concurrent.ExecutionException
 

--- a/core/native/src/main/scala/zio/ChunkPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ChunkPlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
-import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.{classTag, ClassTag}
 
 private[zio] trait ChunkPlatformSpecific {
 

--- a/core/native/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
@@ -16,10 +16,10 @@
 
 package zio.internal
 
-import java.util.concurrent.{ AbstractExecutorService, TimeUnit }
-import java.{ util => ju }
+import java.util.concurrent.{AbstractExecutorService, TimeUnit}
+import java.{util => ju}
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutorService }
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 trait ExecutorPlatformSpecific { this: Executor =>
 

--- a/core/native/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
+++ b/core/native/src/main/scala/zio/internal/OneElementConcurrentQueue.scala
@@ -18,7 +18,7 @@ package zio.internal
 
 import java.io.Serializable
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
 final class OneElementConcurrentQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   private[this] val ref = new AtomicReference[AnyRef]()

--- a/core/native/src/main/scala/zio/internal/PlatformLive.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformLive.scala
@@ -17,7 +17,7 @@
 package zio.internal
 
 import scala.concurrent.ExecutionContext
-import zio.{ Cause, Supervisor }
+import zio.{Cause, Supervisor}
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 import scala.scalanative.loop.EventLoop

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,12 +16,12 @@
 
 package zio.internal
 
-import java.util.{ HashMap, HashSet, Map => JMap, Set => JSet }
+import java.util.{HashMap, HashSet, Map => JMap, Set => JSet}
 
 import scala.concurrent.ExecutionContext
 
 import com.github.ghik.silencer.silent
-import zio.{ Cause, Supervisor }
+import zio.{Cause, Supervisor}
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 

--- a/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.Chunk.BitChunk
 
-import scala.collection.mutable.{ ArrayBuilder, Builder }
+import scala.collection.mutable.{ArrayBuilder, Builder}
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,

--- a/core/shared/src/main/scala-2.11-2.12/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/ChunkLike.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import scala.collection.generic.{ CanBuildFrom, GenericCompanion, GenericTraversableTemplate }
+import scala.collection.generic.{CanBuildFrom, GenericCompanion, GenericTraversableTemplate}
 import scala.collection.immutable.IndexedSeq
-import scala.collection.{ GenTraversableOnce, IndexedSeqLike }
+import scala.collection.{GenTraversableOnce, IndexedSeqLike}
 import scala.reflect.ClassTag
 
 /**

--- a/core/shared/src/main/scala-2.12+/zio/FutureTransformCompat.scala
+++ b/core/shared/src/main/scala-2.12+/zio/FutureTransformCompat.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 private[zio] trait FutureTransformCompat[+A] { this: CancelableFuture[A] =>

--- a/core/shared/src/main/scala/zio/CancelableFuture.scala
+++ b/core/shared/src/main/scala/zio/CancelableFuture.scala
@@ -17,7 +17,7 @@
 package zio
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ CanAwait, ExecutionContext, Future }
+import scala.concurrent.{CanAwait, ExecutionContext, Future}
 import scala.util.Try
 
 abstract class CancelableFuture[+A](val future: Future[A]) extends Future[A] with FutureTransformCompat[A] {

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -291,7 +291,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
       val stackless = maybeData.fold(false)(_.stackless)
       if (stackless) List(e.toString)
       else {
-        import java.io.{ PrintWriter, StringWriter }
+        import java.io.{PrintWriter, StringWriter}
         val sw = new StringWriter()
         val pw = new PrintWriter(sw)
         e.printStackTrace(pw)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -18,7 +18,6 @@ package zio
 
 import java.nio._
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.annotation.tailrec
 import scala.collection.mutable.Builder
 import scala.reflect.{ ClassTag, classTag }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -20,7 +20,7 @@ import java.nio._
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
 import scala.collection.mutable.Builder
-import scala.reflect.{ ClassTag, classTag }
+import scala.reflect.{ClassTag, classTag}
 
 /**
  * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.console.Console
 import zio.internal.stacktracer.ZTraceElement
-import zio.internal.{ Executor, FiberRenderer }
+import zio.internal.{Executor, FiberRenderer}
 
 import scala.concurrent.Future
 

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
+import zio.internal.{Executor, Platform}
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import java.util.concurrent.atomic.AtomicReference
-
 import zio.Promise.internal._
+
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A promise represents an asynchronous variable, of [[zio.IO]] type, that can

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -2,7 +2,7 @@ package zio
 
 import zio.clock.Clock
 import zio.duration.Duration
-import zio.internal.{ Executor, Platform }
+import zio.internal.{Executor, Platform}
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -16,8 +16,8 @@
 
 package zio
 
-import zio.internal.tracing.{ TracingConfig, ZIOFn }
-import zio.internal.{ Executor, FiberContext, Platform, PlatformConstants, Tracing }
+import zio.internal.tracing.{TracingConfig, ZIOFn}
+import zio.internal.{Executor, FiberContext, Platform, PlatformConstants, Tracing}
 
 import scala.concurrent.Future
 

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -16,15 +16,15 @@
 
 package zio
 
+import zio.clock.Clock
+import zio.duration._
+import zio.random._
+
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoField._
 import java.time.temporal.ChronoUnit._
 import java.time.temporal.{ ChronoField, TemporalAdjusters }
 import java.util.concurrent.TimeUnit
-
-import zio.clock.Clock
-import zio.duration._
-import zio.random._
 
 /**
  * A `Schedule[Env, In, Out]` defines a recurring schedule, which consumes values of type `In`, and

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -23,7 +23,7 @@ import zio.random._
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoField._
 import java.time.temporal.ChronoUnit._
-import java.time.temporal.{ ChronoField, TemporalAdjusters }
+import java.time.temporal.{ChronoField, TemporalAdjusters}
 import java.util.concurrent.TimeUnit
 
 /**

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -23,7 +23,7 @@ package zio
 import zio.internals._
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{ Queue => IQueue }
+import scala.collection.immutable.{Queue => IQueue}
 
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.{ Platform, Sync }
+import zio.internal.{Platform, Sync}
 
 import scala.collection.immutable.SortedSet
 

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
+import zio.internal.{Executor, Platform}
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.internal.{ Executor, Platform }
+import zio.internal.{Executor, Platform}
 
 import scala.reflect.ClassTag
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -2,7 +2,7 @@ package zio
 
 import zio.clock.Clock
 import zio.duration.Duration
-import zio.internal.{ Executor, Platform }
+import zio.internal.{Executor, Platform}
 
 import scala.reflect.ClassTag
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -18,15 +18,15 @@ package zio
 
 import zio.clock.Clock
 import zio.duration._
-import zio.internal.tracing.{ ZIOFn, ZIOFn1, ZIOFn2 }
-import zio.internal.{ Executor, Platform }
-import zio.{ TracingStatus => TracingS }
+import zio.internal.tracing.{ZIOFn, ZIOFn1, ZIOFn2}
+import zio.internal.{Executor, Platform}
+import zio.{TracingStatus => TracingS}
 
 import scala.annotation.implicitNotFound
 import scala.collection.mutable.Builder
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 /**
  * A `ZIO[R, E, A]` value is an immutable value that lazily describes a

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -16,11 +16,10 @@
 
 package zio
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import zio.ZQueue.internal._
 import zio.internal.MutableConcurrentQueue
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
 
 /**

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -19,7 +19,7 @@ package zio
 import zio.internal.Sync
 
 import java.util.Map
-import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 /**
  * A `ZScope[A]` is a value that allows adding finalizers identified by a key.

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -16,10 +16,10 @@
 
 package zio
 
+import zio.internal.Sync
+
 import java.util.Map
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
-
-import zio.internal.Sync
 
 /**
  * A `ZScope[A]` is a value that allows adding finalizers identified by a key.

--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -16,10 +16,10 @@
 
 package zio
 
+import zio.duration.Duration
+
 import java.time.{ DateTimeException, Instant, OffsetDateTime, ZoneId }
 import java.util.concurrent.TimeUnit
-
-import zio.duration.Duration
 
 package object clock {
 

--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.duration.Duration
 
-import java.time.{ DateTimeException, Instant, OffsetDateTime, ZoneId }
+import java.time.{DateTimeException, Instant, OffsetDateTime, ZoneId}
 import java.util.concurrent.TimeUnit
 
 package object clock {

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -17,7 +17,6 @@
 package zio
 
 import java.io.{ EOFException, IOException, PrintStream }
-
 import scala.io.StdIn
 import scala.{ Console => SConsole }
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -16,9 +16,9 @@
 
 package zio
 
-import java.io.{ EOFException, IOException, PrintStream }
+import java.io.{EOFException, IOException, PrintStream}
 import scala.io.StdIn
-import scala.{ Console => SConsole }
+import scala.{Console => SConsole}
 
 package object console {
   type Console = Has[Console.Service]

--- a/core/shared/src/main/scala/zio/duration/package.scala
+++ b/core/shared/src/main/scala/zio/duration/package.scala
@@ -16,12 +16,11 @@
 
 package zio
 
+import zio.duration.Duration
+
 import java.time.temporal.{ ChronoUnit, TemporalUnit }
 import java.time.{ Duration => JavaDuration, Instant, OffsetDateTime }
 import java.util.concurrent.TimeUnit
-
-import zio.duration.Duration
-
 import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
 import scala.language.implicitConversions
 import scala.math.Ordering

--- a/core/shared/src/main/scala/zio/duration/package.scala
+++ b/core/shared/src/main/scala/zio/duration/package.scala
@@ -18,10 +18,10 @@ package zio
 
 import zio.duration.Duration
 
-import java.time.temporal.{ ChronoUnit, TemporalUnit }
-import java.time.{ Duration => JavaDuration, Instant, OffsetDateTime }
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.{Duration => JavaDuration, Instant, OffsetDateTime}
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
+import scala.concurrent.duration.{Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration}
 import scala.language.implicitConversions
 import scala.math.Ordering
 

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -17,7 +17,6 @@
 package zio.internal
 
 import java.util.concurrent._
-
 import scala.concurrent.ExecutionContext
 
 /**

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -23,8 +23,8 @@ import zio.internal.FiberContext.FiberRefLocals
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.tracing.ZIOFn
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
-import scala.annotation.{ switch, tailrec }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import scala.annotation.{switch, tailrec}
 import scala.collection.JavaConverters._
 
 /**

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -16,8 +16,6 @@
 
 package zio.internal
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
-
 import com.github.ghik.silencer.silent
 import zio.Fiber.Status
 import zio._
@@ -25,6 +23,7 @@ import zio.internal.FiberContext.FiberRefLocals
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.tracing.ZIOFn
 
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._
 

--- a/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRenderer.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
 import zio.Fiber.Dump
-import zio.Fiber.Status.{ Done, Finishing, Running, Suspended }
-import zio.{ Fiber, UIO, ZIO }
+import zio.Fiber.Status.{Done, Finishing, Running, Suspended}
+import zio.{Fiber, UIO, ZIO}
 
 private[zio] object FiberRenderer {
 

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -17,7 +17,7 @@
 package zio.internal
 
 import zio.internal.tracing.TracingConfig
-import zio.{ Cause, Supervisor }
+import zio.{Cause, Supervisor}
 
 /**
  * A `Platform` provides the minimum capabilities necessary to bootstrap

--- a/core/shared/src/main/scala/zio/internal/Scheduler.scala
+++ b/core/shared/src/main/scala/zio/internal/Scheduler.scala
@@ -1,9 +1,9 @@
 package zio.internal
 
-import java.util.concurrent.{ ScheduledExecutorService, TimeUnit }
-
 import zio.duration.Duration
 import zio.internal.Scheduler.CancelToken
+
+import java.util.concurrent.{ ScheduledExecutorService, TimeUnit }
 
 private[zio] abstract class Scheduler {
   def schedule(task: Runnable, duration: Duration): CancelToken

--- a/core/shared/src/main/scala/zio/internal/Scheduler.scala
+++ b/core/shared/src/main/scala/zio/internal/Scheduler.scala
@@ -3,7 +3,7 @@ package zio.internal
 import zio.duration.Duration
 import zio.internal.Scheduler.CancelToken
 
-import java.util.concurrent.{ ScheduledExecutorService, TimeUnit }
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
 
 private[zio] abstract class Scheduler {
   def schedule(task: Runnable, duration: Duration): CancelToken

--- a/core/shared/src/main/scala/zio/random/package.scala
+++ b/core/shared/src/main/scala/zio/random/package.scala
@@ -28,7 +28,7 @@ package object random {
 
     object Service {
       val live: Service = new Service {
-        import scala.util.{ Random => SRandom }
+        import scala.util.{Random => SRandom}
 
         val nextBoolean: UIO[Boolean] =
           ZIO.effectTotal(SRandom.nextBoolean())

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -16,7 +16,7 @@
 
 package zio.stm
 
-import zio.{ BuildFrom, CanFail, Fiber, IO }
+import zio.{BuildFrom, CanFail, Fiber, IO}
 
 import scala.util.Try
 

--- a/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TPriorityQueue.scala
@@ -17,7 +17,7 @@
 package zio.stm
 
 import zio.stm.ZSTM.internal._
-import zio.{ Chunk, ChunkBuilder }
+import zio.{Chunk, ChunkBuilder}
 
 import scala.collection.immutable.SortedMap
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import zio.stm.ZSTM.internal._
 
-import scala.collection.immutable.{ Queue => ScalaQueue }
+import scala.collection.immutable.{Queue => ScalaQueue}
 
 final class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -18,7 +18,7 @@ package zio.stm
 
 import zio.stm.TReentrantLock._
 import zio.stm.ZSTM.internal.TExit
-import zio.{ Fiber, Managed, UManaged }
+import zio.{Fiber, Managed, UManaged}
 
 /**
  * A `TReentrantLock` is a reentrant read/write lock. Multiple readers may all

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -16,13 +16,12 @@
 
 package zio.stm
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
-import java.util.{ HashMap => MutableMap }
-
 import com.github.ghik.silencer.silent
 import zio._
 import zio.internal.{ Platform, Stack, Sync }
 
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
+import java.util.{ HashMap => MutableMap }
 import scala.annotation.tailrec
 import scala.collection.mutable.Builder
 import scala.util.{ Failure, Success, Try }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -18,13 +18,13 @@ package zio.stm
 
 import com.github.ghik.silencer.silent
 import zio._
-import zio.internal.{ Platform, Stack, Sync }
+import zio.internal.{Platform, Stack, Sync}
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
-import java.util.{ HashMap => MutableMap }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+import java.util.{HashMap => MutableMap}
 import scala.annotation.tailrec
 import scala.collection.mutable.Builder
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
  * `STM[E, A]` represents an effect that can be performed transactionally,
@@ -72,7 +72,7 @@ import scala.util.{ Failure, Success, Try }
 final class ZSTM[-R, +E, +A] private[stm] (
   private val exec: (ZSTM.internal.Journal, Fiber.Id, AtomicLong, R) => ZSTM.internal.TExit[E, A]
 ) extends AnyVal { self =>
-  import ZSTM.internal.{ prepareResetJournal, TExit }
+  import ZSTM.internal.{prepareResetJournal, TExit}
 
   /**
    * Alias for `<*>` and `zip`.

--- a/core/shared/src/main/scala/zio/stm/ZTRef.scala
+++ b/core/shared/src/main/scala/zio/stm/ZTRef.scala
@@ -16,10 +16,10 @@
 
 package zio.stm
 
-import java.util.concurrent.atomic.AtomicReference
-
 import zio.UIO
 import zio.stm.ZSTM.internal._
+
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A `ZTRef[EA, EB, A, B]` is a polymorphic, purely functional description of a

--- a/core/shared/src/main/scala/zio/stm/random/package.scala
+++ b/core/shared/src/main/scala/zio/stm/random/package.scala
@@ -184,7 +184,7 @@ package object random {
       } yield bf.fromSpecific(collection)(result)
 
     private[zio] object PureRandom {
-      import scala.util.{ Random => SRandom }
+      import scala.util.{Random => SRandom}
 
       type Seed = Long
 

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -18,7 +18,7 @@ package zio
 
 import com.github.ghik.silencer.silent
 
-import java.lang.{ System => JSystem }
+import java.lang.{System => JSystem}
 import scala.collection.JavaConverters._
 
 package object system {

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -16,10 +16,9 @@
 
 package zio
 
-import java.lang.{ System => JSystem }
-
 import com.github.ghik.silencer.silent
 
+import java.lang.{ System => JSystem }
 import scala.collection.JavaConverters._
 
 package object system {

--- a/macros/shared/src/main/scala-2.x/zio/macros/accessible.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/accessible.scala
@@ -16,7 +16,7 @@
 
 package zio.macros
 
-import scala.annotation.{ StaticAnnotation, compileTimeOnly }
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 
 @compileTimeOnly("enable macro paradise to expand macro annotations")
 class accessible[A] extends StaticAnnotation {

--- a/macros/shared/src/main/scala-2.x/zio/macros/accessibleM.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/accessibleM.scala
@@ -16,7 +16,7 @@
 
 package zio.macros
 
-import scala.annotation.{ StaticAnnotation, compileTimeOnly }
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 
 @compileTimeOnly("enable macro paradise to expand macro annotations")
 class accessibleM[F[_]] extends StaticAnnotation {

--- a/macros/shared/src/main/scala-2.x/zio/macros/accessibleMM.scala
+++ b/macros/shared/src/main/scala-2.x/zio/macros/accessibleMM.scala
@@ -16,7 +16,7 @@
 
 package zio.macros
 
-import scala.annotation.{ StaticAnnotation, compileTimeOnly }
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 
 @compileTimeOnly("enable macro paradise to expand macro annotations")
 class accessibleMM[F[_, _]] extends StaticAnnotation {

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -1,5 +1,5 @@
 import sbt._
-import sbt.Keys.{ name, organization }
+import sbt.Keys.{name, organization}
 
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.core._

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbers.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbers.scala
@@ -16,7 +16,7 @@
 
 package zio.internal.stacktracer.impl
 
-import java.io.{ DataInputStream, InputStream }
+import java.io.{DataInputStream, InputStream}
 import java.lang.invoke.SerializedLambda
 import scala.annotation.switch
 import scala.util.control.NonFatal

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbers.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbers.scala
@@ -18,7 +18,6 @@ package zio.internal.stacktracer.impl
 
 import java.io.{ DataInputStream, InputStream }
 import java.lang.invoke.SerializedLambda
-
 import scala.annotation.switch
 import scala.util.control.NonFatal
 

--- a/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
+++ b/stacktracer/jvm/src/main/scala/zio/internal/stacktracer/impl/AkkaLineNumbersTracer.scala
@@ -16,9 +16,9 @@
 
 package zio.internal.stacktracer.impl
 
-import zio.internal.stacktracer.ZTraceElement.{ NoLocation, SourceLocation }
+import zio.internal.stacktracer.ZTraceElement.{NoLocation, SourceLocation}
 import zio.internal.stacktracer.impl.AkkaLineNumbersTracer.lambdaNamePattern
-import zio.internal.stacktracer.{ Tracer, ZTraceElement }
+import zio.internal.stacktracer.{Tracer, ZTraceElement}
 
 import scala.util.matching.Regex
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
@@ -1,7 +1,7 @@
 package zio.stream
 
 import zio.test._
-import zio.{ UIO, ZIOBaseSpec }
+import zio.{UIO, ZIOBaseSpec}
 
 object StreamLazinessSpec extends ZIOBaseSpec {
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
@@ -1,11 +1,11 @@
 package zio.stream
 
-import java.nio.file.Files
-
 import zio._
 import zio.blocking.Blocking
 import zio.test.Assertion._
 import zio.test._
+
+import java.nio.file.Files
 
 object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
   override def spec: Spec[Blocking, TestFailure[Throwable], TestSuccess] = suite("ZSink JVM")(

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -1,17 +1,16 @@
 package zio.stream
 
+import zio._
+import zio.blocking.{ Blocking, effectBlockingIO }
+import zio.test.Assertion._
+import zio.test._
+
 import java.io.{ FileNotFoundException, FileReader, IOException, OutputStream, Reader }
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousSocketChannel
 import java.nio.file.{ Files, NoSuchFileException, Paths }
 import java.nio.{ Buffer, ByteBuffer }
 import java.util.concurrent.CountDownLatch
-
-import zio._
-import zio.blocking.{ Blocking, effectBlockingIO }
-import zio.test.Assertion._
-import zio.test._
-
 import scala.concurrent.ExecutionContext.global
 
 object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -1,15 +1,15 @@
 package zio.stream
 
 import zio._
-import zio.blocking.{ Blocking, effectBlockingIO }
+import zio.blocking.{Blocking, effectBlockingIO}
 import zio.test.Assertion._
 import zio.test._
 
-import java.io.{ FileNotFoundException, FileReader, IOException, OutputStream, Reader }
+import java.io.{FileNotFoundException, FileReader, IOException, OutputStream, Reader}
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousSocketChannel
-import java.nio.file.{ Files, NoSuchFileException, Paths }
-import java.nio.{ Buffer, ByteBuffer }
+import java.nio.file.{Files, NoSuchFileException, Paths}
+import java.nio.{Buffer, ByteBuffer}
 import java.util.concurrent.CountDownLatch
 import scala.concurrent.ExecutionContext.global
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZTransducerPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZTransducerPlatformSpecificSpec.scala
@@ -5,9 +5,9 @@ import zio.blocking.Blocking
 import zio.test.Assertion._
 import zio.test._
 
-import java.io.{ IOException, InputStream }
+import java.io.{IOException, InputStream}
 import java.nio.charset.Charset
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{Files, Path, Paths}
 
 object ZTransducerPlatformSpecificSpec extends ZIOBaseSpec {
   private val bomTestFilesPath: Path = Paths.get("zio/stream/bom")

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZTransducerPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZTransducerPlatformSpecificSpec.scala
@@ -1,13 +1,13 @@
 package zio.stream
 
-import java.io.{ IOException, InputStream }
-import java.nio.charset.Charset
-import java.nio.file.{ Files, Path, Paths }
-
 import zio._
 import zio.blocking.Blocking
 import zio.test.Assertion._
 import zio.test._
+
+import java.io.{ IOException, InputStream }
+import java.nio.charset.Charset
+import java.nio.file.{ Files, Path, Paths }
 
 object ZTransducerPlatformSpecificSpec extends ZIOBaseSpec {
   private val bomTestFilesPath: Path = Paths.get("zio/stream/bom")

--- a/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
@@ -1,13 +1,13 @@
 package zio.stream.compression
 
 import zio._
-import zio.stream.ZTransducer.{ deflate, gunzip, gzip, inflate }
+import zio.stream.ZTransducer.{deflate, gunzip, gzip, inflate}
 import zio.stream._
 import zio.stream.compression.TestData._
 import zio.test.Assertion._
 import zio.test._
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
 import java.util.zip.{

--- a/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
@@ -1,5 +1,12 @@
 package zio.stream.compression
 
+import zio._
+import zio.stream.ZTransducer.{ deflate, gunzip, gzip, inflate }
+import zio.stream._
+import zio.stream.compression.TestData._
+import zio.test.Assertion._
+import zio.test._
+
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
@@ -12,14 +19,6 @@ import java.util.zip.{
   Inflater,
   InflaterInputStream
 }
-
-import zio._
-import zio.stream.ZTransducer.{ deflate, gunzip, gzip, inflate }
-import zio.stream._
-import zio.stream.compression.TestData._
-import zio.test.Assertion._
-import zio.test._
-
 import scala.annotation.tailrec
 
 object CompressionSpec extends DefaultRunnableSpec {

--- a/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/SinkUtils.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
 import zio.test.Assertion.equalTo
-import zio.test.{ Assertion, TestResult, assert }
-import zio.{ IO, UIO }
+import zio.test.{Assertion, TestResult, assert}
+import zio.{IO, UIO}
 
 object SinkUtils {
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -1,12 +1,12 @@
 package zio.stream
 
 import zio.duration._
-import zio.stream.SinkUtils.{ findSink, sinkRaceLaw }
+import zio.stream.SinkUtils.{findSink, sinkRaceLaw}
 import zio.stream.ZStreamGen._
-import zio.test.Assertion.{ equalTo, isFalse, isGreaterThanEqualTo, isTrue, succeeds }
+import zio.test.Assertion.{equalTo, isFalse, isGreaterThanEqualTo, isTrue, succeeds}
 import zio.test.environment.TestClock
-import zio.test.{ assertM, _ }
-import zio.{ ZIOBaseSpec, _ }
+import zio.test.{assertM, _}
+import zio.{ZIOBaseSpec, _}
 
 import scala.util.Random
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamGen.scala
@@ -2,7 +2,7 @@ package zio.stream
 
 import zio._
 import zio.random.Random
-import zio.test.{ Gen, GenZIO, Sized }
+import zio.test.{Gen, GenZIO, Sized}
 
 object ZStreamGen extends GenZIO {
   def tinyListOf[R <: Random, A](g: Gen[R, A]): Gen[R, List[A]] =

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1,8 +1,5 @@
 package zio.stream
 
-import java.io.{ ByteArrayInputStream, IOException }
-import java.util.concurrent.TimeUnit
-
 import zio._
 import zio.clock.Clock
 import zio.duration._
@@ -10,10 +7,12 @@ import zio.stm.TQueue
 import zio.stream.ZSink.Push
 import zio.stream.ZStreamGen._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, scala2Only, timeout }
+import zio.test.TestAspect.{exceptJS, flaky, nonFlaky, scala2Only, timeout}
 import zio.test._
 import zio.test.environment.TestClock
 
+import java.io.{ByteArrayInputStream, IOException}
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 object ZStreamSpec extends ZIOBaseSpec {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -1,12 +1,11 @@
 package zio.stream
 
-import java.nio.charset.StandardCharsets
-
 import zio._
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._
 
+import java.nio.charset.StandardCharsets
 import scala.io.Source
 
 object ZTransducerSpec extends ZIOBaseSpec {

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -2,7 +2,7 @@ package zio.stream
 
 import zio._
 
-import java.io.{ IOException, InputStream }
+import java.io.{IOException, InputStream}
 import scala.concurrent.Future
 
 trait ZSinkPlatformSpecificConstructors

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -1,9 +1,8 @@
 package zio.stream
 
-import java.io.{ IOException, InputStream }
-
 import zio._
 
+import java.io.{ IOException, InputStream }
 import scala.concurrent.Future
 
 trait ZSinkPlatformSpecificConstructors

--- a/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
@@ -1,10 +1,9 @@
 package zio.stream.compression
 
-import java.util.zip.Deflater
-import java.{ util => ju }
-
 import zio.{ Chunk, ZIO, ZManaged }
 
+import java.util.zip.Deflater
+import java.{ util => ju }
 import scala.annotation.tailrec
 
 object Deflate {

--- a/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
@@ -1,9 +1,9 @@
 package zio.stream.compression
 
-import zio.{ Chunk, ZIO, ZManaged }
+import zio.{Chunk, ZIO, ZManaged}
 
 import java.util.zip.Deflater
-import java.{ util => ju }
+import java.{util => ju}
 import scala.annotation.tailrec
 
 object Deflate {

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
@@ -1,10 +1,9 @@
 package zio.stream.compression
 
-import java.util.zip.{ CRC32, Inflater }
-import java.{ util => ju }
-
 import zio._
 
+import java.util.zip.{ CRC32, Inflater }
+import java.{ util => ju }
 import scala.annotation.tailrec
 
 /**

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
@@ -2,8 +2,8 @@ package zio.stream.compression
 
 import zio._
 
-import java.util.zip.{ CRC32, Inflater }
-import java.{ util => ju }
+import java.util.zip.{CRC32, Inflater}
+import java.{util => ju}
 import scala.annotation.tailrec
 
 /**

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
@@ -1,9 +1,9 @@
 package zio.stream.compression
 
-import java.util.zip.{ CRC32, Deflater }
-
 import zio.stream.compression.Gzipper._
 import zio.{ Chunk, ZIO }
+
+import java.util.zip.{ CRC32, Deflater }
 
 private[compression] class Gzipper(
   bufferSize: Int,

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
@@ -1,9 +1,9 @@
 package zio.stream.compression
 
 import zio.stream.compression.Gzipper._
-import zio.{ Chunk, ZIO }
+import zio.{Chunk, ZIO}
 
-import java.util.zip.{ CRC32, Deflater }
+import java.util.zip.{CRC32, Deflater}
 
 private[compression] class Gzipper(
   bufferSize: Int,

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -1,17 +1,17 @@
 package zio.stream
 
 import zio._
-import zio.blocking.{ Blocking, effectBlockingIO }
+import zio.blocking.{Blocking, effectBlockingIO}
 import zio.stream.compression._
 
 import java.io._
 import java.net.InetSocketAddress
-import java.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler, FileChannel }
+import java.nio.channels.{AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler, FileChannel}
 import java.nio.file.StandardOpenOption._
-import java.nio.file.{ OpenOption, Path }
-import java.nio.{ Buffer, ByteBuffer }
-import java.util.zip.{ DataFormatException, Inflater }
-import java.{ util => ju }
+import java.nio.file.{OpenOption, Path}
+import java.nio.{Buffer, ByteBuffer}
+import java.util.zip.{DataFormatException, Inflater}
+import java.{util => ju}
 import scala.annotation.tailrec
 
 trait ZSinkPlatformSpecificConstructors {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -1,5 +1,9 @@
 package zio.stream
 
+import zio._
+import zio.blocking.{ Blocking, effectBlockingIO }
+import zio.stream.compression._
+
 import java.io._
 import java.net.InetSocketAddress
 import java.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler, FileChannel }
@@ -8,11 +12,6 @@ import java.nio.file.{ OpenOption, Path }
 import java.nio.{ Buffer, ByteBuffer }
 import java.util.zip.{ DataFormatException, Inflater }
 import java.{ util => ju }
-
-import zio._
-import zio.blocking.{ Blocking, effectBlockingIO }
-import zio.stream.compression._
-
 import scala.annotation.tailrec
 
 trait ZSinkPlatformSpecificConstructors {

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -1,6 +1,6 @@
 package zio.stream
 
-import java.io.{ IOException, InputStream }
+import java.io.{IOException, InputStream}
 
 import scala.concurrent.Future
 

--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -16,7 +16,7 @@
 
 package zio.stream
 
-import zio.{ RefM, UIO }
+import zio.{RefM, UIO}
 
 /**
  * A `SubscriptionRef[A]` contains a `RefM[A]` and a `Stream` that will emit

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1,7 +1,5 @@
 package zio.stream
 
-import java.{ util => ju }
-
 import zio._
 import zio.clock.Clock
 import zio.duration._
@@ -10,6 +8,7 @@ import zio.stm.TQueue
 import zio.stream.internal.Utils.zipChunks
 import zio.stream.internal.{ ZInputStream, ZReader }
 
+import java.{ util => ju }
 import scala.reflect.ClassTag
 
 /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -6,9 +6,9 @@ import zio.duration._
 import zio.internal.UniqueKey
 import zio.stm.TQueue
 import zio.stream.internal.Utils.zipChunks
-import zio.stream.internal.{ ZInputStream, ZReader }
+import zio.stream.internal.{ZInputStream, ZReader}
 
-import java.{ util => ju }
+import java.{util => ju}
 import scala.reflect.ClassTag
 
 /**
@@ -58,7 +58,7 @@ import scala.reflect.ClassTag
  */
 abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Option[E], Chunk[O]]]) { self =>
 
-  import ZStream.{ BufferedPull, Pull, TerminationStrategy }
+  import ZStream.{BufferedPull, Pull, TerminationStrategy}
 
   /**
    * Symbolic alias for [[ZStream#cross]].
@@ -2064,7 +2064,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     strategy: TerminationStrategy = TerminationStrategy.Both
   )(l: O => O3, r: O2 => O3): ZStream[R1, E1, O3] =
     ZStream {
-      import TerminationStrategy.{ Left => L, Right => R, Either => E }
+      import TerminationStrategy.{Left => L, Right => R, Either => E}
 
       for {
         handoff <- ZStream.Handoff.make[Take[E1, O3]].toManaged_

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -1,9 +1,8 @@
 package zio.stream
 
-import java.nio.charset.{ Charset, StandardCharsets }
-
 import zio._
 
+import java.nio.charset.{ Charset, StandardCharsets }
 import scala.collection.mutable
 
 // Contract notes for transducers:

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -2,7 +2,7 @@ package zio.stream
 
 import zio._
 
-import java.nio.charset.{ Charset, StandardCharsets }
+import java.nio.charset.{Charset, StandardCharsets}
 import scala.collection.mutable
 
 // Contract notes for transducers:

--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -1,6 +1,6 @@
 package zio.stream.internal
 
-import zio.{ Chunk, Exit, FiberFailure, Runtime, ZIO }
+import zio.{Chunk, Exit, FiberFailure, Runtime, ZIO}
 
 import scala.annotation.tailrec
 

--- a/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
@@ -1,6 +1,6 @@
 package zio.stream.internal
 
-import zio.{ Chunk, Exit, FiberFailure, Runtime, ZIO }
+import zio.{Chunk, Exit, FiberFailure, Runtime, ZIO}
 
 import scala.annotation.tailrec
 

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -1,13 +1,12 @@
 package zio.test.junit
 
-import java.io.File
-
 import org.apache.maven.cli.MavenCli
 import zio.blocking.{ Blocking, effectBlocking }
 import zio.test.Assertion._
 import zio.test.{ DefaultRunnableSpec, ZSpec, _ }
 import zio.{ RIO, ZIO }
 
+import java.io.File
 import scala.collection.immutable
 import scala.xml.XML
 

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -1,10 +1,10 @@
 package zio.test.junit
 
 import org.apache.maven.cli.MavenCli
-import zio.blocking.{ Blocking, effectBlocking }
+import zio.blocking.{Blocking, effectBlocking}
 import zio.test.Assertion._
-import zio.test.{ DefaultRunnableSpec, ZSpec, _ }
-import zio.{ RIO, ZIO }
+import zio.test.{DefaultRunnableSpec, ZSpec, _}
+import zio.{RIO, ZIO}
 
 import java.io.File
 import scala.collection.immutable

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -1,17 +1,17 @@
 package zio.test.junit
 
 import com.github.ghik.silencer.silent
-import org.junit.runner.manipulation.{ Filter, Filterable }
-import org.junit.runner.notification.{ Failure, RunNotifier }
-import org.junit.runner.{ Description, RunWith, Runner }
+import org.junit.runner.manipulation.{Filter, Filterable}
+import org.junit.runner.notification.{Failure, RunNotifier}
+import org.junit.runner.{Description, RunWith, Runner}
 import zio.ZIO.effectTotal
 import zio._
 import zio.test.FailureRenderer.FailureMessage.Message
 import zio.test.RenderedResult.CaseType.Test
 import zio.test.RenderedResult.Status.Failed
-import zio.test.Spec.{ SpecCase, SuiteCase, TestCase }
-import zio.test.TestFailure.{ Assertion, Runtime }
-import zio.test.TestSuccess.{ Ignored, Succeeded }
+import zio.test.Spec.{SpecCase, SuiteCase, TestCase}
+import zio.test.TestFailure.{Assertion, Runtime}
+import zio.test.TestSuccess.{Ignored, Succeeded}
 import zio.test._
 
 /**

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -16,12 +16,12 @@
 
 package zio.test.magnolia
 
-import java.time.{ Instant, LocalDate, LocalDateTime }
-import java.util.UUID
-
 import magnolia._
 import zio.random.Random
 import zio.test.{ Gen, Sized }
+
+import java.time.{ Instant, LocalDate, LocalDateTime }
+import java.util.UUID
 
 /**
  * A `DeriveGen[A]` can derive a generator of `A` values. Implicit instances of

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -18,9 +18,9 @@ package zio.test.magnolia
 
 import magnolia._
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
-import java.time.{ Instant, LocalDate, LocalDateTime }
+import java.time.{Instant, LocalDate, LocalDateTime}
 import java.util.UUID
 
 /**

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -17,8 +17,8 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.test.{ Summary, TestArgs }
-import zio.{ Exit, Runtime, ZIO }
+import zio.test.{Summary, TestArgs}
+import zio.{Exit, Runtime, ZIO}
 
 import scala.collection.mutable
 

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -16,11 +16,11 @@
 
 package zio.test.sbt
 
-import java.util.concurrent.atomic.AtomicReference
-
 import sbt.testing._
 import zio.ZIO
 import zio.test.{ Summary, TestArgs }
+
+import java.util.concurrent.atomic.AtomicReference
 
 final class ZTestRunner(val args: Array[String], val remoteArgs: Array[String], testClassLoader: ClassLoader)
     extends Runner {

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -18,7 +18,7 @@ package zio.test.sbt
 
 import sbt.testing._
 import zio.ZIO
-import zio.test.{ Summary, TestArgs }
+import zio.test.{Summary, TestArgs}
 
 import java.util.concurrent.atomic.AtomicReference
 

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/MockLogger.scala
@@ -1,9 +1,9 @@
 package zio.test.sbt
 
-import java.util.concurrent.atomic.AtomicReference
-
 import sbt.testing.Logger
 import zio.test.sbt.TestingSupport._
+
+import java.util.concurrent.atomic.AtomicReference
 
 class MockLogger extends Logger {
   private val logged = new AtomicReference(Vector.empty[String])

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/TestingSupport.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/TestingSupport.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Try }
+import scala.util.{Failure, Try}
 
 object TestingSupport {
   def test[T](l: String)(body: => Unit): Try[Unit] =

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -16,8 +16,6 @@
 
 package zio.test.sbt
 
-import java.util.regex.Pattern
-
 import sbt.testing._
 import zio.UIO
 import zio.test.sbt.TestingSupport._
@@ -34,6 +32,7 @@ import zio.test.{
   ZSpec
 }
 
+import java.util.regex.Pattern
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -1,9 +1,9 @@
 package zio.test.sbt
 
-import sbt.testing.{ EventHandler, Logger, Task, TaskDef }
+import sbt.testing.{EventHandler, Logger, Task, TaskDef}
 import zio.clock.Clock
-import zio.test.{ AbstractRunnableSpec, FilteredSpec, SummaryBuilder, TestArgs, TestLogger }
-import zio.{ Layer, Runtime, UIO, ZIO, ZLayer }
+import zio.test.{AbstractRunnableSpec, FilteredSpec, SummaryBuilder, TestArgs, TestLogger}
+import zio.{Layer, Runtime, UIO, ZIO, ZLayer}
 
 abstract class BaseTestTask(
   val taskDef: TaskDef,

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.test.{ ExecutedSpec, TestFailure, TestSuccess }
+import zio.test.{ExecutedSpec, TestFailure, TestSuccess}
 
 final case class ZTestEvent(
   fullyQualifiedName: String,

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
@@ -1,6 +1,6 @@
 package zio.test
 
-import zio.{ UIO, URIO }
+import zio.{UIO, URIO}
 
 import scala.annotation.tailrec
 

--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -1,6 +1,6 @@
 package zio.test.mock
 
-import zio.{ Has, IO, Tag, UIO }
+import zio.{Has, IO, Tag, UIO}
 
 /**
  * https://github.com/scalamacros/paradise/issues/75

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -2,10 +2,10 @@ package zio.test
 
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.{ Chunk, Exit }
+import zio.{Chunk, Exit}
 
 import scala.collection.immutable.SortedSet
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 object AssertionSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio.test.Assertion._
 import zio.test.TestAspect.failing
-import zio.{ Chunk, Ref, ZIO, random }
+import zio.{Chunk, Ref, ZIO, random}
 
 object CheckSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.Assertion._
-import zio.{ ZIO, random }
+import zio.{ZIO, random}
 
 import scala.math.abs
 

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -1,7 +1,5 @@
 package zio.test
 
-import java.time._
-
 import zio.duration.{ Duration, _ }
 import zio.random.Random
 import zio.test.Assertion._
@@ -10,6 +8,7 @@ import zio.test.TestAspect.{ nonFlaky, scala2Only, setSeed }
 import zio.test.{ check => Check, checkN => CheckN }
 import zio.{ Chunk, NonEmptyChunk, ZIO }
 
+import java.time._
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -1,12 +1,12 @@
 package zio.test
 
-import zio.duration.{ Duration, _ }
+import zio.duration.{Duration, _}
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test.GenUtils._
-import zio.test.TestAspect.{ nonFlaky, scala2Only, setSeed }
-import zio.test.{ check => Check, checkN => CheckN }
-import zio.{ Chunk, NonEmptyChunk, ZIO }
+import zio.test.TestAspect.{nonFlaky, scala2Only, setSeed}
+import zio.test.{check => Check, checkN => CheckN}
+import zio.{Chunk, NonEmptyChunk, ZIO}
 
 import java.time._
 import scala.math.Numeric.DoubleIsFractional

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -1,11 +1,11 @@
 package zio.test
 
-import zio.Exit.{ Failure, Success }
+import zio.Exit.{Failure, Success}
 import zio.random.Random
 import zio.stream.ZStream
-import zio.test.Assertion.{ equalTo, forall }
+import zio.test.Assertion.{equalTo, forall}
 import zio.test.environment.TestRandom
-import zio.{ Exit, UIO, URIO, ZIO }
+import zio.{Exit, UIO, URIO, ZIO}
 
 object GenUtils {
 

--- a/test-tests/shared/src/test/scala/zio/test/GenZIOSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenZIOSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio.test.Assertion._
 import zio.test.Gen._
-import zio.test.GenUtils.{ partitionExit, sampleEffect }
+import zio.test.GenUtils.{partitionExit, sampleEffect}
 
 object GenZIOSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -1,16 +1,16 @@
 package zio.test
 
 import zio.clock.Clock
-import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan, isRight, isSome, not }
-import zio.test.environment.{ TestClock, TestConsole, TestEnvironment, testEnvironment }
+import zio.test.Assertion.{equalTo, isGreaterThan, isLessThan, isRight, isSome, not}
+import zio.test.environment.{TestClock, TestConsole, TestEnvironment, testEnvironment}
 import zio.test.mock.Expectation._
 import zio.test.mock.internal.InvalidCall._
 import zio.test.mock.internal.MockException._
 import zio.test.mock.module.PureModuleMock
-import zio.{ Cause, Layer, ZIO }
+import zio.{Cause, Layer, ZIO}
 
 import java.util.regex.Pattern
-import scala.{ Console => SConsole }
+import scala.{Console => SConsole}
 
 object ReportingTestUtils {
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -1,7 +1,5 @@
 package zio.test
 
-import java.util.regex.Pattern
-
 import zio.clock.Clock
 import zio.test.Assertion.{ equalTo, isGreaterThan, isLessThan, isRight, isSome, not }
 import zio.test.environment.{ TestClock, TestConsole, TestEnvironment, testEnvironment }
@@ -11,6 +9,7 @@ import zio.test.mock.internal.MockException._
 import zio.test.mock.module.PureModuleMock
 import zio.{ Cause, Layer, ZIO }
 
+import java.util.regex.Pattern
 import scala.{ Console => SConsole }
 
 object ReportingTestUtils {

--- a/test-tests/shared/src/test/scala/zio/test/SampleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SampleSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.{ UIO, ZIO }
+import zio.{UIO, ZIO}
 
 object SampleSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -5,7 +5,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.TestRandom
-import zio.{ Ref, TracingStatus, ZIO }
+import zio.{Ref, TracingStatus, ZIO}
 
 import scala.reflect.ClassTag
 

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.environment.TestEnvironment
-import zio.{ ExecutionStrategy, UIO }
+import zio.{ExecutionStrategy, UIO}
 
 object TestUtils {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -10,7 +10,7 @@ import zio.test.TestAspect._
 import zio.test._
 import zio.test.environment.TestClock._
 
-import java.time.{ OffsetDateTime, ZoneId }
+import java.time.{OffsetDateTime, ZoneId}
 import java.util.concurrent.TimeUnit
 
 object ClockSpec extends ZIOBaseSpec {

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -1,8 +1,5 @@
 package zio.test.environment
 
-import java.time.{ OffsetDateTime, ZoneId }
-import java.util.concurrent.TimeUnit
-
 import zio._
 import zio.clock._
 import zio.duration.Duration._
@@ -12,6 +9,9 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 import zio.test.environment.TestClock._
+
+import java.time.{ OffsetDateTime, ZoneId }
+import java.util.concurrent.TimeUnit
 
 object ClockSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -3,7 +3,7 @@ package zio.test.environment
 import zio.ZIO
 import zio.console._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ nonFlaky, silent }
+import zio.test.TestAspect.{nonFlaky, silent}
 import zio.test._
 import zio.test.environment.TestConsole._
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/EnvironmentSpec.scala
@@ -1,13 +1,13 @@
 package zio.test.environment
 
-import java.util.concurrent.TimeUnit
-
 import zio._
 import zio.clock._
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
+
+import java.util.concurrent.TimeUnit
 
 object EnvironmentSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
@@ -3,7 +3,7 @@ package zio.test.environment
 import zio.duration._
 import zio.test.Assertion._
 import zio.test._
-import zio.{ clock, console }
+import zio.{clock, console}
 
 import java.util.concurrent.TimeUnit
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/LiveSpec.scala
@@ -1,11 +1,11 @@
 package zio.test.environment
 
-import java.util.concurrent.TimeUnit
-
 import zio.duration._
 import zio.test.Assertion._
 import zio.test._
 import zio.{ clock, console }
+
+import java.util.concurrent.TimeUnit
 
 object LiveSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -5,9 +5,9 @@ import zio.random.Random
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.test.environment.TestRandom.{ DefaultData, Test => ZRandom }
+import zio.test.environment.TestRandom.{DefaultData, Test => ZRandom}
 
-import scala.util.{ Random => SRandom }
+import scala.util.{Random => SRandom}
 
 object RandomSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -1,6 +1,6 @@
 package zio.test.environment
 
-import zio.{ system }
+import zio.{system}
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test._

--- a/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/SystemSpec.scala
@@ -1,6 +1,6 @@
 package zio.test.environment
 
-import zio.{system}
+import zio.system
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test._

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
@@ -1,9 +1,9 @@
 package zio.test.mock
 
 import zio.ZIO
-import zio.test.mock.internal.{ InvalidCall, MockException }
-import zio.test.mock.module.{ PureModule, PureModuleMock }
-import zio.test.{ Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite }
+import zio.test.mock.internal.{InvalidCall, MockException}
+import zio.test.mock.module.{PureModule, PureModuleMock}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
 
 object AdvancedEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
@@ -1,9 +1,9 @@
 package zio.test.mock
 
-import zio.test.mock.internal.{ InvalidCall, MockException }
-import zio.test.mock.module.{ ImpureModule, ImpureModuleMock }
-import zio.test.{ Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite }
-import zio.{ URIO, ZIO }
+import zio.test.mock.internal.{InvalidCall, MockException}
+import zio.test.mock.module.{ImpureModule, ImpureModuleMock}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.{URIO, ZIO}
 
 object AdvancedMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
@@ -2,10 +2,10 @@ package zio.test.mock
 
 import zio.duration._
 import zio.test.environment.Live
-import zio.test.mock.internal.{ ExpectationState, InvalidCall, MockException }
-import zio.test.mock.module.{ PureModule, PureModuleMock }
-import zio.test.{ Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite }
-import zio.{ IO, UIO }
+import zio.test.mock.internal.{ExpectationState, InvalidCall, MockException}
+import zio.test.mock.module.{PureModule, PureModuleMock}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.{IO, UIO}
 
 object BasicEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
@@ -1,9 +1,9 @@
 package zio.test.mock
 
-import zio.test.mock.internal.{ ExpectationState, InvalidCall, MockException }
-import zio.test.mock.module.{ ImpureModule, ImpureModuleMock }
-import zio.test.{ Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite }
-import zio.{ IO, UIO }
+import zio.test.mock.internal.{ExpectationState, InvalidCall, MockException}
+import zio.test.mock.module.{ImpureModule, ImpureModuleMock}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.{IO, UIO}
 
 object BasicMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
@@ -1,9 +1,9 @@
 package zio.test.mock
 
 import zio.Chunk
-import zio.stream.{ ZSink, ZStream }
-import zio.test.mock.module.{ StreamModule, StreamModuleMock }
-import zio.test.{ Annotations, Assertion, TestAspect, ZIOBaseSpec, ZSpec, suite }
+import zio.stream.{ZSink, ZStream}
+import zio.test.mock.module.{StreamModule, StreamModuleMock}
+import zio.test.{Annotations, Assertion, TestAspect, ZIOBaseSpec, ZSpec, suite}
 
 object BasicStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -5,8 +5,8 @@ import zio.console.Console
 import zio.duration._
 import zio.random.Random
 import zio.system.System
-import zio.test.{ Assertion, ZIOBaseSpec, ZSpec, assertM, suite, testM }
-import zio.{ Has, Tag, ULayer, ZIO, clock, console, random, system }
+import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assertM, suite, testM}
+import zio.{Has, Tag, ULayer, ZIO, clock, console, random, system}
 
 object ComposedMockSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -1,8 +1,8 @@
 package zio.test.mock
 
 import zio.Has
-import zio.test.mock.module.{ PureModule, PureModuleMock }
-import zio.test.{ Assertion, ZIOBaseSpec, ZSpec, assert, suite, test }
+import zio.test.mock.module.{PureModule, PureModuleMock}
+import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assert, suite, test}
 
 object ExpectationSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/MockSpecUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/MockSpecUtils.scala
@@ -18,8 +18,8 @@ package zio.test.mock
 import zio.duration._
 import zio.test.environment.Live
 import zio.test.mock.module.T22
-import zio.test.{ Assertion, ZSpec, assertM, testM }
-import zio.{ IO, ULayer, ZIO }
+import zio.test.{Assertion, ZSpec, assertM, testM}
+import zio.{IO, ULayer, ZIO}
 
 trait MockSpecUtils[R] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/PolyMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/PolyMockSpec.scala
@@ -1,8 +1,8 @@
 package zio.test.mock
 
-import zio.test.mock.internal.{ InvalidCall, MockException }
-import zio.test.mock.module.{ PureModule, PureModuleMock }
-import zio.test.{ Annotations, Assertion, Spec, TestAspect, TestFailure, TestSuccess, ZIOBaseSpec, suite }
+import zio.test.mock.internal.{InvalidCall, MockException}
+import zio.test.mock.module.{PureModule, PureModuleMock}
+import zio.test.{Annotations, Assertion, Spec, TestAspect, TestFailure, TestSuccess, ZIOBaseSpec, suite}
 
 object PolyMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModule.scala
@@ -17,7 +17,7 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-import zio.{ Tag, URIO, ZIO }
+import zio.{Tag, URIO, ZIO}
 
 /**
  * Example of impure module used for testing ZIO Mock framework.

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/ImpureModuleMock.scala
@@ -17,8 +17,8 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-import zio.test.mock.{ Mock, Proxy }
-import zio.{ Has, Tag, URLayer, ZLayer }
+import zio.test.mock.{Mock, Proxy}
+import zio.{Has, Tag, URLayer, ZLayer}
 
 /**
  * Example module used for testing ZIO Mock framework.

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModule.scala
@@ -16,7 +16,7 @@
 
 package zio.test.mock.module
 
-import zio.{ IO, Tag, URIO, ZIO }
+import zio.{IO, Tag, URIO, ZIO}
 
 import scala.reflect.ClassTag
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/PureModuleMock.scala
@@ -17,8 +17,8 @@
 package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
-import zio.test.mock.{ Mock, Proxy }
-import zio.{ Has, IO, Tag, UIO, URLayer, ZLayer }
+import zio.test.mock.{Mock, Proxy}
+import zio.{Has, IO, Tag, UIO, URLayer, ZLayer}
 
 /**
  * Example pure module used for testing ZIO Mock framework.

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModule.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModule.scala
@@ -16,8 +16,8 @@
 
 package zio.test.mock.module
 
-import zio.stream.{ Sink, Stream }
-import zio.{ URIO, ZIO }
+import zio.stream.{Sink, Stream}
+import zio.{URIO, ZIO}
 
 /**
  * Example of ZIO Data Types module used for testing ZIO Mock framework.

--- a/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/module/StreamModuleMock.scala
@@ -18,8 +18,8 @@ package zio.test.mock.module
 
 import com.github.ghik.silencer.silent
 import zio.stream.ZSink
-import zio.test.mock.{ Mock, Proxy }
-import zio.{ Has, UIO, URLayer, ZLayer }
+import zio.test.mock.{Mock, Proxy}
+import zio.{Has, UIO, URLayer, ZLayer}
 
 /**
  * Example module used for testing ZIO Mock framework.

--- a/test/jvm/src/main/scala/zio/test/ConcurrentHashMap.scala
+++ b/test/jvm/src/main/scala/zio/test/ConcurrentHashMap.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import java.util.concurrent.{ ConcurrentHashMap => JConcurrentHashMap }
+import java.util.concurrent.{ConcurrentHashMap => JConcurrentHashMap}
 
 private[test] final case class ConcurrentHashMap[K, V] private (private val map: JConcurrentHashMap[K, V]) {
   def foldLeft[B](z: B)(op: (B, (K, V)) => B): B = {

--- a/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/PlatformSpecific.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.blocking.Blocking
 import zio.test.environment._
-import zio.{ ZEnv, ZLayer }
+import zio.{ZEnv, ZLayer}
 
 private[test] abstract class PlatformSpecific {
   type TestEnvironment =

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.UIO
 
-import scala.reflect.macros.{ TypecheckException, blackbox }
+import scala.reflect.macros.{TypecheckException, blackbox}
 
 private[test] object Macros {
 

--- a/test/shared/src/main/scala-2.x/zio/test/mock/mockable.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/mock/mockable.scala
@@ -15,7 +15,7 @@
  */
 package zio.test.mock
 
-import scala.annotation.{ StaticAnnotation, compileTimeOnly }
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 
 @compileTimeOnly("enable macro paradise to expand macro annotations")
 class mockable[A] extends StaticAnnotation {

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.clock.Clock
 import zio.test.reflect.Reflect.EnableReflectiveInstantiation
-import zio.{ Has, URIO }
+import zio.{Has, URIO}
 
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -17,10 +17,10 @@
 package zio.test
 
 import zio.test.AssertionM.RenderParam
-import zio.{ Cause, Exit, ZIO }
+import zio.{Cause, Exit, ZIO}
 
 import scala.reflect.ClassTag
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
  * An `Assertion[A]` is capable of producing assertion results on an `A`. As a

--- a/test/shared/src/main/scala/zio/test/AssertionM.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionM.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ UIO, ZIO }
+import zio.{UIO, ZIO}
 
 import scala.reflect.ClassTag
 import scala.util.Try

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -17,14 +17,14 @@
 package zio.test
 
 import zio.duration._
-import zio.test.ConsoleUtils.{ cyan, red, _ }
-import zio.test.FailureRenderer.FailureMessage.{ Fragment, Message }
+import zio.test.ConsoleUtils.{cyan, red, _}
+import zio.test.FailureRenderer.FailureMessage.{Fragment, Message}
 import zio.test.RenderedResult.CaseType._
 import zio.test.RenderedResult.Status._
-import zio.test.RenderedResult.{ CaseType, Status }
+import zio.test.RenderedResult.{CaseType, Status}
 import zio.test.mock.Expectation
-import zio.test.mock.internal.{ InvalidCall, MockException }
-import zio.{ Cause, Has }
+import zio.test.mock.internal.{InvalidCall, MockException}
+import zio.{Cause, Has}
 
 import java.util.regex.Pattern
 import scala.io.AnsiColor

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -16,8 +16,6 @@
 
 package zio.test
 
-import java.util.regex.Pattern
-
 import zio.duration._
 import zio.test.ConsoleUtils.{ cyan, red, _ }
 import zio.test.FailureRenderer.FailureMessage.{ Fragment, Message }
@@ -28,6 +26,7 @@ import zio.test.mock.Expectation
 import zio.test.mock.internal.{ InvalidCall, MockException }
 import zio.{ Cause, Has }
 
+import java.util.regex.Pattern
 import scala.io.AnsiColor
 import scala.util.Try
 

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.internal.Executor
-import zio.{ Runtime, URIO, ZIO }
+import zio.{Runtime, URIO, ZIO}
 
 import scala.concurrent.ExecutionContext
 

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -17,8 +17,8 @@
 package zio.test
 
 import zio.random._
-import zio.stream.{ Stream, ZStream }
-import zio.{ Chunk, ExecutionStrategy, NonEmptyChunk, UIO, URIO, ZIO }
+import zio.stream.{Stream, ZStream}
+import zio.{Chunk, ExecutionStrategy, NonEmptyChunk, UIO, URIO, ZIO}
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -16,13 +16,12 @@
 
 package zio.test
 
-import java.nio.charset.StandardCharsets
-import java.util.UUID
-
 import zio.random._
 import zio.stream.{ Stream, ZStream }
 import zio.{ Chunk, ExecutionStrategy, NonEmptyChunk, UIO, URIO, ZIO }
 
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import scala.collection.immutable.SortedMap
 import scala.math.Numeric.DoubleIsFractional
 

--- a/test/shared/src/main/scala/zio/test/RenderUtils.scala
+++ b/test/shared/src/main/scala/zio/test/RenderUtils.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import scala.{ Console => SConsole }
+import scala.{Console => SConsole}
 
 private[test] object ConsoleUtils {
 

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.clock.Clock
-import zio.{ Has, URIO }
+import zio.{Has, URIO}
 
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.stream.ZStream
-import zio.{ Cause, Exit, ZIO }
+import zio.{Cause, Exit, ZIO}
 
 /**
  * A sample is a single observation from a random variable, together with a

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.duration._
-import zio.{ Chunk, Fiber, Tag }
+import zio.{Chunk, Fiber, Tag}
 
 /**
  * A type of annotation.

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -18,8 +18,8 @@ package zio.test
 
 import zio._
 import zio.duration._
-import zio.test.Assertion.{ equalTo, hasMessage, isCase, isSubtype }
-import zio.test.environment.{ Live, Restorable, TestClock, TestConsole, TestRandom, TestSystem }
+import zio.test.Assertion.{equalTo, hasMessage, isCase, isSubtype}
+import zio.test.environment.{Live, Restorable, TestClock, TestConsole, TestRandom, TestSystem}
 
 /**
  * A `TestAspect` is an aspect that can be weaved into specs. You can think of

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{ ExecutionStrategy, Has, Layer, UIO, ZIO }
+import zio.{ExecutionStrategy, Has, Layer, UIO, ZIO}
 
 /**
  * A `TestExecutor[R, E]` is capable of executing specs that require an

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -16,10 +16,10 @@
 
 package zio.test
 
-import java.time.{ Instant, LocalDateTime, OffsetDateTime, ZoneOffset }
-
 import zio.duration.Duration
 import zio.random.Random
+
+import java.time.{ Instant, LocalDateTime, OffsetDateTime, ZoneOffset }
 
 trait TimeVariants {
 

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.duration.Duration
 import zio.random.Random
 
-import java.time.{ Instant, LocalDateTime, OffsetDateTime, ZoneOffset }
+import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneOffset}
 
 trait TimeVariants {
 

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.duration._
 import zio.test.environment.Live
-import zio.{ URIO, ZIO, console }
+import zio.{URIO, ZIO, console}
 
 trait TimeoutVariants {
 

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -16,10 +16,6 @@
 
 package zio.test
 
-import java.io.{ EOFException, IOException }
-import java.time.{ Instant, OffsetDateTime, ZoneId }
-import java.util.concurrent.TimeUnit
-
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
@@ -27,6 +23,9 @@ import zio.random.Random
 import zio.system.System
 import zio.{ PlatformSpecific => _, _ }
 
+import java.io.{ EOFException, IOException }
+import java.time.{ Instant, OffsetDateTime, ZoneId }
+import java.util.concurrent.TimeUnit
 import scala.collection.immutable.{ Queue, SortedSet }
 import scala.math.{ log, sqrt }
 

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -21,13 +21,13 @@ import zio.console.Console
 import zio.duration._
 import zio.random.Random
 import zio.system.System
-import zio.{ PlatformSpecific => _, _ }
+import zio.{PlatformSpecific => _, _}
 
-import java.io.{ EOFException, IOException }
-import java.time.{ Instant, OffsetDateTime, ZoneId }
+import java.io.{EOFException, IOException}
+import java.time.{Instant, OffsetDateTime, ZoneId}
 import java.util.concurrent.TimeUnit
-import scala.collection.immutable.{ Queue, SortedSet }
-import scala.math.{ log, sqrt }
+import scala.collection.immutable.{Queue, SortedSet}
+import scala.math.{log, sqrt}
 
 /**
  * The `environment` package contains testable versions of all the standard ZIO

--- a/test/shared/src/main/scala/zio/test/laws/GenF.scala
+++ b/test/shared/src/main/scala/zio/test/laws/GenF.scala
@@ -18,7 +18,7 @@ package zio.test.laws
 
 import zio.Chunk
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 /**
  * A `GenF` knows how to construct a generator of `F[A]` values given a

--- a/test/shared/src/main/scala/zio/test/laws/GenF2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/GenF2.scala
@@ -1,7 +1,7 @@
 package zio.test.laws
 
 import zio.random.Random
-import zio.test.{ FunctionVariants, Gen }
+import zio.test.{FunctionVariants, Gen}
 
 /**
  * A `GenF` knows how to construct a generator of `F[A,B]` values given a

--- a/test/shared/src/main/scala/zio/test/laws/ZLaws.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLaws.scala
@@ -16,8 +16,8 @@
 
 package zio.test.laws
 
-import zio.test.{ Gen, TestConfig, TestResult, check, checkM }
-import zio.{ URIO, ZIO }
+import zio.test.{Gen, TestConfig, TestResult, check, checkM}
+import zio.{URIO, ZIO}
 
 /**
  * `ZLaws[Caps, R]` represents a set of laws that values with capabilities

--- a/test/shared/src/main/scala/zio/test/laws/ZLaws2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLaws2.scala
@@ -16,8 +16,8 @@
 
 package zio.test.laws
 
-import zio.test.{ Gen, TestConfig, TestResult, check }
-import zio.{ URIO, ZIO }
+import zio.test.{Gen, TestConfig, TestResult, check}
+import zio.{URIO, ZIO}
 
 abstract class ZLaws2[-CapsBoth[_, _], -CapsLeft[_], -CapsRight[_], -R] { self =>
 

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF.scala
@@ -16,8 +16,8 @@
 
 package zio.test.laws
 
-import zio.test.{ Gen, TestConfig, TestResult, check, checkM }
-import zio.{ URIO, ZIO }
+import zio.test.{Gen, TestConfig, TestResult, check, checkM}
+import zio.{URIO, ZIO}
 
 /**
  * `ZLaws[CapsF, Caps, R]` describes a set of laws that a parameterized type

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF2.scala
@@ -1,7 +1,7 @@
 package zio.test.laws
 
-import zio.test.{ Gen, TestConfig, TestResult, check }
-import zio.{ URIO, ZIO }
+import zio.test.{Gen, TestConfig, TestResult, check}
+import zio.{URIO, ZIO}
 
 object ZLawsF2 {
 

--- a/test/shared/src/main/scala/zio/test/mock/Capability.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Capability.scala
@@ -18,7 +18,7 @@ package zio.test.mock
 
 import com.github.ghik.silencer.silent
 import zio.test.Assertion
-import zio.{ =!=, Has, IO, LightTypeTag, Tag, taggedIsSubtype, taggedTagType }
+import zio.{=!=, Has, IO, LightTypeTag, Tag, taggedIsSubtype, taggedTagType}
 
 import java.util.UUID
 

--- a/test/shared/src/main/scala/zio/test/mock/Capability.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Capability.scala
@@ -16,11 +16,11 @@
 
 package zio.test.mock
 
-import java.util.UUID
-
 import com.github.ghik.silencer.silent
 import zio.test.Assertion
 import zio.{ =!=, Has, IO, LightTypeTag, Tag, taggedIsSubtype, taggedTagType }
+
+import java.util.UUID
 
 /**
  * A `Capability[R, I, E, A]` represents a capability of environment `R` that takes an input `I`

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -17,10 +17,10 @@
 package zio.test.mock
 
 import zio.test.Assertion
-import zio.test.mock.Expectation.{ And, Chain, Or, Repeated }
-import zio.test.mock.Result.{ Fail, Succeed }
-import zio.test.mock.internal.{ ExpectationState, MockException, MockState, ProxyFactory }
-import zio.{ Has, IO, Managed, Tag, ULayer, URLayer, ZLayer }
+import zio.test.mock.Expectation.{And, Chain, Or, Repeated}
+import zio.test.mock.Result.{Fail, Succeed}
+import zio.test.mock.internal.{ExpectationState, MockException, MockState, ProxyFactory}
+import zio.{Has, IO, Managed, Tag, ULayer, URLayer, ZLayer}
 
 import scala.language.implicitConversions
 

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -17,9 +17,9 @@
 package zio.test.mock
 
 import zio.internal.Executor
-import zio.stream.{ ZSink, ZStream }
+import zio.stream.{ZSink, ZStream}
 import zio.test.TestPlatform
-import zio.{ Has, Runtime, Tag, URIO, URLayer, ZIO }
+import zio.{Has, Runtime, Tag, URIO, URLayer, ZIO}
 
 /**
  * A `Mock[R]` represents a mockable environment `R`.

--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -16,12 +16,12 @@
 
 package zio.test.mock
 
-import java.time.{ DateTimeException, OffsetDateTime }
-import java.util.concurrent.TimeUnit
-
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.{ Has, IO, UIO, URLayer, ZLayer }
+
+import java.time.{ DateTimeException, OffsetDateTime }
+import java.util.concurrent.TimeUnit
 
 object MockClock extends Mock[Clock] {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockClock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockClock.scala
@@ -18,9 +18,9 @@ package zio.test.mock
 
 import zio.clock.Clock
 import zio.duration.Duration
-import zio.{ Has, IO, UIO, URLayer, ZLayer }
+import zio.{Has, IO, UIO, URLayer, ZLayer}
 
-import java.time.{ DateTimeException, OffsetDateTime }
+import java.time.{DateTimeException, OffsetDateTime}
 import java.util.concurrent.TimeUnit
 
 object MockClock extends Mock[Clock] {

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -17,7 +17,7 @@
 package zio.test.mock
 
 import zio.console.Console
-import zio.{ Has, IO, UIO, URLayer, ZLayer }
+import zio.{Has, IO, UIO, URLayer, ZLayer}
 
 import java.io.IOException
 

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -16,10 +16,10 @@
 
 package zio.test.mock
 
-import java.io.IOException
-
 import zio.console.Console
 import zio.{ Has, IO, UIO, URLayer, ZLayer }
+
+import java.io.IOException
 
 object MockConsole extends Mock[Console] {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockRandom.scala
@@ -17,7 +17,7 @@
 package zio.test.mock
 
 import zio.random.Random
-import zio.{ Chunk, Has, UIO, URLayer, ZLayer }
+import zio.{Chunk, Has, UIO, URLayer, ZLayer}
 
 object MockRandom extends Mock[Random] {
 

--- a/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockSystem.scala
@@ -17,7 +17,7 @@
 package zio.test.mock
 
 import zio.system.System
-import zio.{ Has, IO, UIO, URLayer, ZLayer }
+import zio.{Has, IO, UIO, URLayer, ZLayer}
 
 object MockSystem extends Mock[System] {
 

--- a/test/shared/src/main/scala/zio/test/mock/Proxy.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Proxy.scala
@@ -16,7 +16,7 @@
 
 package zio.test.mock
 
-import zio.{ Has, ZIO }
+import zio.{Has, ZIO}
 
 /**
  * A `Proxy` provides the machinery to map mocked invocations to predefined results

--- a/test/shared/src/main/scala/zio/test/mock/Result.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Result.scala
@@ -16,7 +16,7 @@
 
 package zio.test.mock
 
-import zio.{ IO, UIO }
+import zio.{IO, UIO}
 
 /**
  * A `Result[-I, +E, +A]` represents the value or failure that will be returned

--- a/test/shared/src/main/scala/zio/test/mock/internal/Matched.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/Matched.scala
@@ -17,7 +17,7 @@
 package zio.test.mock.internal
 
 import zio.test.mock.Expectation
-import zio.{ Has, IO }
+import zio.{Has, IO}
 
 /**
  * A `Matched[R, E, A]` represents a succesful result of depth first search

--- a/test/shared/src/main/scala/zio/test/mock/internal/MockException.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/MockException.scala
@@ -17,7 +17,7 @@
 package zio.test.mock.internal
 
 import zio.Has
-import zio.test.mock.{ Capability, Expectation }
+import zio.test.mock.{Capability, Expectation}
 
 /**
  * A `MockException` is used internally by the mock framework to signal

--- a/test/shared/src/main/scala/zio/test/mock/internal/MockState.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/MockState.scala
@@ -17,7 +17,7 @@
 package zio.test.mock.internal
 
 import zio.test.mock.Expectation
-import zio.{ Has, Ref, UIO, ZIO }
+import zio.{Has, Ref, UIO, ZIO}
 
 /**
  * A `MockState[R]` represents the state of a mock.

--- a/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/ProxyFactory.scala
@@ -17,8 +17,8 @@
 package zio.test.mock.internal
 
 import zio.test.Assertion
-import zio.test.mock.{ Capability, Expectation, Proxy }
-import zio.{ Has, IO, Tag, UIO, ULayer, ZIO, ZLayer }
+import zio.test.mock.{Capability, Expectation, Proxy}
+import zio.{Has, IO, Tag, UIO, ULayer, ZIO, ZLayer}
 
 import scala.util.Try
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -18,8 +18,8 @@ package zio
 
 import zio.console.Console
 import zio.duration.Duration
-import zio.stream.{ ZSink, ZStream }
-import zio.test.environment.{ TestClock, TestConsole, TestEnvironment, TestRandom, TestSystem, testEnvironment }
+import zio.stream.{ZSink, ZStream}
+import zio.test.environment.{TestClock, TestConsole, TestEnvironment, TestRandom, TestSystem, testEnvironment}
 
 import scala.collection.immutable.SortedSet
 import scala.util.Try

--- a/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
@@ -17,7 +17,7 @@
 package zio.test.poly
 
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 /**
  * `GenFractionalPoly` provides evidence that instances of `Gen[T]` and

--- a/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
@@ -17,7 +17,7 @@
 package zio.test.poly
 
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 /**
  * `GenIntegralPoly` provides evidence that instances of `Gen[T]` and

--- a/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
@@ -17,7 +17,7 @@
 package zio.test.poly
 
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 /**
  * `GenNumericPoly` provides evidence that instances of `Gen[T]` and

--- a/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
@@ -17,7 +17,7 @@
 package zio.test.poly
 
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 import scala.annotation.tailrec
 

--- a/test/shared/src/main/scala/zio/test/poly/GenPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenPoly.scala
@@ -17,7 +17,7 @@
 package zio.test.poly
 
 import zio.random.Random
-import zio.test.{ Gen, Sized }
+import zio.test.{Gen, Sized}
 
 /**
  * `GenPoly` provides evidence that an instance of `Gen[T]` exists for some


### PR DESCRIPTION
Intellij IDEA has recently changed the order of import blocks. For the good of our contributors, we should follow it.