### PR TITLE
adding .indexOf for Chunk.scala

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -288,6 +288,10 @@ object ChunkSpec extends ZIOBaseSpec {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
       check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.exists(p))(equalTo(chunk.toList.exists(p))))
     },
+    testM("indexOf") {
+      val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
+      check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.indexOf(p))(equalTo(chunk.toList.indexOf(p))))
+    },
     testM("forall") {
       val fn = Gen.function[Random with Sized, Int, Boolean](Gen.boolean)
       check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.forall(p))(equalTo(chunk.toList.forall(p))))

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -318,6 +318,28 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
   }
 
   /**
+   * Given an element, return its index in this chunk if it is found within it.
+   * Otherwise, return -1.
+   */
+  override final def indexOf[B >: A](elem: B): Int = {
+    val iterator = arrayIterator
+    var targetIndex = -1
+    while (targetIndex == -1 && iterator.hasNext) {
+      val array  = iterator.next()
+      val length = array.length
+      var i      = 0
+      while (i < length) {
+        val a = array(i)
+        if (a == elem) {
+          targetIndex = i
+        }
+        i += 1
+      }
+    }
+    targetIndex
+  }
+
+  /**
    * Returns a filtered subset of this chunk.
    */
   override def filter(f: A => Boolean): Chunk[A] = {


### PR DESCRIPTION
Following conversation in #2271, adds `.indexOf` on `Chunk`