### PR TITLE
ZIO-Test: Solve the `test` conflict with `zio.test`.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -25,7 +25,7 @@ object CauseSpec extends ZIOBaseSpec {
       testM("`Cause#untraced` removes all traces") {
         check(causes)(c => assert(c.untraced.traces.headOption)(isNone))
       },
-      zio.test.test("`Cause.failures is stack safe") {
+      test("`Cause.failures is stack safe") {
         val n     = 100000
         val cause = List.fill(n)(Cause.fail("fail")).reduce(_ && _)
         assert(cause.failures.length)(equalTo(n))
@@ -210,14 +210,14 @@ object CauseSpec extends ZIOBaseSpec {
       }
     ),
     suite("stripSomeDefects")(
-      zio.test.test("returns `Some` with remaining causes") {
+      test("returns `Some` with remaining causes") {
         val c1       = Cause.die(new NumberFormatException("can't parse to int"))
         val c2       = Cause.die(new ArithmeticException("division by zero"))
         val cause    = Cause.Both(c1, c2)
         val stripped = cause.stripSomeDefects { case _: NumberFormatException => }
         assert(stripped)(isSome(equalTo(c2)))
       },
-      zio.test.test("returns `None` if there are no remaining causes") {
+      test("returns `None` if there are no remaining causes") {
         val cause    = Cause.die(new NumberFormatException("can't parse to int"))
         val stripped = cause.stripSomeDefects { case _: NumberFormatException => }
         assert(stripped)(isNone)

--- a/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
@@ -21,7 +21,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Boolean
         assert(builder.toString)(equalTo("ChunkBuilder.Boolean"))
       }
@@ -41,7 +41,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Byte
         assert(builder.toString)(equalTo("ChunkBuilder.Byte"))
       }
@@ -61,7 +61,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Char
         assert(builder.toString)(equalTo("ChunkBuilder.Char"))
       }
@@ -81,7 +81,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Double
         assert(builder.toString)(equalTo("ChunkBuilder.Double"))
       }
@@ -101,7 +101,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Float
         assert(builder.toString)(equalTo("ChunkBuilder.Float"))
       }
@@ -121,7 +121,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Int
         assert(builder.toString)(equalTo("ChunkBuilder.Int"))
       }
@@ -141,7 +141,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Long
         assert(builder.toString)(equalTo("ChunkBuilder.Long"))
       }
@@ -161,7 +161,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
           assert(builder.result())(equalTo(as))
         }
       },
-      zio.test.test("toString") {
+      test("toString") {
         val builder = new ChunkBuilder.Short
         assert(builder.toString)(equalTo("ChunkBuilder.Short"))
       }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -36,23 +36,23 @@ object ChunkSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("ChunkSpec")(
     suite("size/length")(
-      zio.test.test("concatenated size must match length") {
+      test("concatenated size must match length") {
         val chunk = Chunk.empty ++ Chunk.fromArray(Array(1, 2)) ++ Chunk(3, 4, 5) ++ Chunk.single(6)
         assert(chunk.size)(equalTo(chunk.length))
       },
-      zio.test.test("empty size must match length") {
+      test("empty size must match length") {
         val chunk = Chunk.empty
         assert(chunk.size)(equalTo(chunk.length))
       },
-      zio.test.test("fromArray size must match length") {
+      test("fromArray size must match length") {
         val chunk = Chunk.fromArray(Array(1, 2, 3))
         assert(chunk.size)(equalTo(chunk.length))
       },
-      zio.test.test("fromIterable size must match length") {
+      test("fromIterable size must match length") {
         val chunk = Chunk.fromIterable(List("1", "2", "3"))
         assert(chunk.size)(equalTo(chunk.length))
       },
-      zio.test.test("single size must match length") {
+      test("single size must match length") {
         val chunk = Chunk.single(true)
         assert(chunk.size)(equalTo(chunk.length))
       }
@@ -102,7 +102,7 @@ object ChunkSpec extends ZIOBaseSpec {
           assert(actual)(equalTo(expected))
         }
       },
-      zio.test.test("returns most specific type") {
+      test("returns most specific type") {
         val seq = (zio.Chunk("foo"): Seq[String]) :+ "post1"
         assert(seq)(isSubtype[Chunk[String]](equalTo(Chunk("foo", "post1"))))
       }
@@ -152,7 +152,7 @@ object ChunkSpec extends ZIOBaseSpec {
           assert(actual)(equalTo(expected))
         }
       },
-      zio.test.test("returns most specific type") {
+      test("returns most specific type") {
         val seq = "pre1" +: (zio.Chunk("foo"): Seq[String])
         assert(seq)(isSubtype[Chunk[String]](equalTo(Chunk("pre1", "foo"))))
       }
@@ -205,7 +205,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
-    zio.test.test("splitWhere") {
+    test("splitWhere") {
       assert(Chunk(1, 2, 3, 4).splitWhere(_ == 2))(equalTo((Chunk(1), Chunk(2, 3, 4))))
     },
     testM("length") {
@@ -216,7 +216,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(c1.equals(c2))(equalTo(c1.toList.equals(c2.toList)))
       }
     },
-    zio.test.test("inequality") {
+    test("inequality") {
       assert(Chunk(1, 2, 3, 4, 5))(Assertion.not(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
     },
     testM("materialize") {
@@ -227,13 +227,13 @@ object ChunkSpec extends ZIOBaseSpec {
         (s0, f, c) => assert(c.fold(s0)(f))(equalTo(c.toArray.foldLeft(s0)(f)))
       }
     },
-    zio.test.test("foldRight") {
+    test("foldRight") {
       val chunk    = Chunk("a") ++ Chunk("b") ++ Chunk("c")
       val actual   = chunk.foldRight("d")(_ + _)
       val expected = "abcd"
       assert(actual)(equalTo(expected))
     },
-    zio.test.test("mapAccum") {
+    test("mapAccum") {
       assert(Chunk(1, 1, 1).mapAccum(0)((s, el) => (s + el, s + el)))(equalTo((3, Chunk(1, 2, 3))))
     },
     suite("mapAccumM")(
@@ -345,7 +345,7 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("toArray") {
       check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toList)(equalTo(c.toList)))
     },
-    zio.test.test("non-homogeneous element type") {
+    test("non-homogeneous element type") {
       trait Animal
       trait Cat extends Animal
       trait Dog extends Animal
@@ -356,21 +356,21 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assert(actual)(equalTo(expected))
     },
-    zio.test.test("toArray for an empty Chunk of type String") {
+    test("toArray for an empty Chunk of type String") {
       assert(Chunk.empty.toArray[String])(equalTo(Array.empty[String]))
     },
-    zio.test.test("to Array for an empty Chunk using filter") {
+    test("to Array for an empty Chunk using filter") {
       assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
     },
     testM("toArray with elements of type String") {
       check(mediumChunks(Gen.alphaNumericString))(c => assert(c.toArray.toList)(equalTo(c.toList)))
     },
-    zio.test.test("toArray for a Chunk of any type") {
+    test("toArray for a Chunk of any type") {
       val v: Vector[Any] = Vector("String", 1, Value(2))
       assert(Chunk.fromIterable(v).toArray.toVector)(equalTo(v))
     },
     suite("collect")(
-      zio.test.test("collect empty Chunk") {
+      test("collect empty Chunk") {
         assert(Chunk.empty.collect { case _ => 1 })(isEmpty)
       },
       testM("collect chunk") {
@@ -396,7 +396,7 @@ object ChunkSpec extends ZIOBaseSpec {
       } @@ zioTag(errors)
     ),
     suite("collectWhile")(
-      zio.test.test("collectWhile empty Chunk") {
+      test("collectWhile empty Chunk") {
         assert(Chunk.empty.collectWhile { case _ => 1 })(isEmpty)
       },
       testM("collectWhile chunk") {
@@ -436,37 +436,37 @@ object ChunkSpec extends ZIOBaseSpec {
         assert((c1 ++ c2).toList)(equalTo(c1.toList ++ c2.toList))
       }
     },
-    zio.test.test("chunk transitivity") {
+    test("chunk transitivity") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       val c3 = Chunk(1, 2, 3)
       assert(c1 == c2 && c2 == c3 && c1 == c3)(Assertion.isTrue)
     },
-    zio.test.test("chunk symmetry") {
+    test("chunk symmetry") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       assert(c1 == c2 && c2 == c1)(Assertion.isTrue)
     },
-    zio.test.test("chunk reflexivity") {
+    test("chunk reflexivity") {
       val c1 = Chunk(1, 2, 3)
       assert(c1 == c1)(Assertion.isTrue)
     },
-    zio.test.test("chunk negation") {
+    test("chunk negation") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       assert(c1 != c2 == !(c1 == c2))(Assertion.isTrue)
     },
-    zio.test.test("chunk substitutivity") {
+    test("chunk substitutivity") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       assert(c1 == c2 && c1.toString == c2.toString)(Assertion.isTrue)
     },
-    zio.test.test("chunk consistency") {
+    test("chunk consistency") {
       val c1 = Chunk(1, 2, 3)
       val c2 = Chunk(1, 2, 3)
       assert(c1 == c2 && c1.hashCode == c2.hashCode)(Assertion.isTrue)
     },
-    zio.test.test("nullArrayBug") {
+    test("nullArrayBug") {
       val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
 
       // foreach should not throw
@@ -474,7 +474,7 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assert(c.filter(_ => false).map(_ * 2).length)(equalTo(0))
     },
-    zio.test.test("toArrayOnConcatOfSlice") {
+    test("toArrayOnConcatOfSlice") {
       val onlyOdd: Int => Boolean = _ % 2 != 0
       val concat = Chunk(1, 1, 1).filter(onlyOdd) ++
         Chunk(2, 2, 2).filter(onlyOdd) ++
@@ -484,10 +484,10 @@ object ChunkSpec extends ZIOBaseSpec {
 
       assert(array)(equalTo(Array(1, 1, 1, 3, 3, 3)))
     },
-    zio.test.test("toArrayOnConcatOfEmptyAndInts") {
+    test("toArrayOnConcatOfEmptyAndInts") {
       assert(Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3)))(equalTo(Chunk(1, 2, 3)))
     },
-    zio.test.test("filterConstFalseResultsInEmptyChunk") {
+    test("filterConstFalseResultsInEmptyChunk") {
       assert(Chunk.fromArray(Array(1, 2, 3)).filter(_ => false))(equalTo(Chunk.empty))
     },
     testM("zip") {
@@ -497,7 +497,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
-    zio.test.test("zipAll") {
+    test("zipAll") {
       val a = Chunk(1, 2, 3)
       val b = Chunk(1, 2)
       val c = Chunk((Some(1), Some(1)), (Some(2), Some(2)), (Some(3), Some(3)))
@@ -507,47 +507,47 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(a.zipAll(b))(equalTo(d)) &&
       assert(b.zipAll(a))(equalTo(e))
     },
-    zio.test.test("zipAllWith") {
+    test("zipAllWith") {
       assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 4))) &&
       assert(Chunk(1, 2, 3).zipAllWith(Chunk(3, 2))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0))) &&
       assert(Chunk(1, 2).zipAllWith(Chunk(3, 2, 1))(_ => 0, _ => 0)(_ + _))(equalTo(Chunk(4, 4, 0)))
     },
-    zio.test.test("partitionMap") {
+    test("partitionMap") {
       val as       = Chunk(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
       val (bs, cs) = as.partitionMap(n => if (n % 2 == 0) Left(n) else Right(n))
       assert(bs)(equalTo(Chunk(0, 2, 4, 6, 8))) &&
       assert(cs)(equalTo(Chunk(1, 3, 5, 7, 9)))
     },
-    zio.test.test("stack safety concat") {
+    test("stack safety concat") {
       val n  = 1000000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => Chunk(a) ++ as)
       assert(as.toArray)(equalTo(Array.range(0, n)))
     },
-    zio.test.test("stack safety append") {
+    test("stack safety append") {
       val n  = 1000000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => as :+ a)
       assert(as.toArray)(equalTo(Array.range(0, n).reverse))
     },
-    zio.test.test("stack safety prepend") {
+    test("stack safety prepend") {
       val n  = 1000000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty)((a, as) => a +: as)
       assert(as.toArray)(equalTo(Array.range(0, n)))
     },
-    zio.test.test("stack safety concat and append") {
+    test("stack safety concat and append") {
       val n = 100000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty) { (a, as) =>
         if (a % 2 == 0) as :+ a else as ++ Chunk(a)
       }
       assert(as.toArray)(equalTo(Array.range(0, n).reverse))
     },
-    zio.test.test("stack safety concat and prepend") {
+    test("stack safety concat and prepend") {
       val n = 100000
       val as = List.range(0, n).foldRight[Chunk[Int]](Chunk.empty) { (a, as) =>
         if (a % 2 == 0) a +: as else Chunk(a) ++ as
       }
       assert(as.toArray)(equalTo(Array.range(0, n)))
     },
-    zio.test.test("toArray does not throw ClassCastException") {
+    test("toArray does not throw ClassCastException") {
       val chunk = Chunk("a")
       val array = chunk.toArray
       assert(array)(anything)
@@ -562,7 +562,7 @@ object ChunkSpec extends ZIOBaseSpec {
           }
       )(equalTo(2))
     },
-    zio.test.test("Tags.fromValue is safe on Scala.is") {
+    test("Tags.fromValue is safe on Scala.is") {
       val _ = Chunk(1, 128)
       assertCompletes
     },
@@ -571,7 +571,7 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(Chunk.fromIterable(as).toList)(equalTo(as))
       }
     },
-    zio.test.test("unfold") {
+    test("unfold") {
       assert(
         Chunk.unfold(0)(n => if (n < 10) Some((n, n + 1)) else None)
       )(equalTo(Chunk.fromIterable(0 to 9)))

--- a/core-tests/shared/src/test/scala/zio/HasSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/HasSpec.scala
@@ -34,7 +34,7 @@ object HasSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("HasSpec")(
     suite("monomorphic types")(
-      zio.test.test("Modules sharing common parent are independent") {
+      test("Modules sharing common parent are independent") {
         val hasBoth = Has(dog1).add[Cat](cat1)
 
         val dog = hasBoth.get[Dog]
@@ -42,7 +42,7 @@ object HasSpec extends ZIOBaseSpec {
 
         assert(dog)(anything) && assert(cat)(anything)
       },
-      zio.test.test("Siblings can be updated independently") {
+      test("Siblings can be updated independently") {
         val whole: Has[Dog] with Has[Cat] = Has(dog1).add(cat1)
 
         val updated: Has[Dog] with Has[Cat] = whole.update[Dog](_ => dog2).update[Cat](_ => cat2)
@@ -51,14 +51,14 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.get[Dog])(equalTo(dog2)) &&
         assert(updated.get[Cat])(equalTo(cat2))
       },
-      zio.test.test("Prune will delete what is not known about") {
+      test("Prune will delete what is not known about") {
         val whole: Has[Dog] with Has[Cat] = Has(dog1).add(cat1)
 
         assert(whole.size)(equalTo(2)) &&
         assert((whole: Has[Dog]).prune.size)(equalTo(1)) &&
         assert((whole: Has[Cat]).prune.size)(equalTo(1))
       },
-      zio.test.test("Union will prune what is not known about on RHS") {
+      test("Union will prune what is not known about on RHS") {
         val unioned = Has(dog1) union ((Has(dog2).add(bunny1)): Has[Bunny])
 
         assert(unioned.get[Dog])(equalTo(dog1)) &&
@@ -66,7 +66,7 @@ object HasSpec extends ZIOBaseSpec {
       }
     ),
     suite("covariant types")(
-      zio.test.test("Modules sharing common parent are independent") {
+      test("Modules sharing common parent are independent") {
         val hasBoth = Has(dogs1).add[IList[Cat]](cats1)
 
         val dogs = hasBoth.get[IList[Dog]]
@@ -74,7 +74,7 @@ object HasSpec extends ZIOBaseSpec {
 
         assert(dogs)(anything) && assert(cats)(anything)
       },
-      zio.test.test("Siblings can be updated independently") {
+      test("Siblings can be updated independently") {
         val whole: Has[IList[Dog]] with Has[IList[Cat]] = Has(dogs1).add(cats1)
 
         val updated: Has[IList[Dog]] with Has[IList[Cat]] =
@@ -84,14 +84,14 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.get[IList[Dog]])(equalTo(dogs2)) &&
         assert(updated.get[IList[Cat]])(equalTo(cats2))
       },
-      zio.test.test("Prune will delete what is not known about") {
+      test("Prune will delete what is not known about") {
         val whole: Has[IList[Dog]] with Has[IList[Cat]] = Has(dogs1).add(cats1)
 
         assert(whole.size)(equalTo(2)) &&
         assert((whole: Has[IList[Dog]]).prune.size)(equalTo(1)) &&
         assert((whole: Has[IList[Cat]]).prune.size)(equalTo(1))
       },
-      zio.test.test("Union will prune what is not known about on RHS") {
+      test("Union will prune what is not known about on RHS") {
         val unioned = Has(dogs1) union ((Has(dogs2).add(bunnies1)): Has[IList[Bunny]])
 
         assert(unioned.get[IList[Dog]])(equalTo(dogs1)) &&
@@ -99,7 +99,7 @@ object HasSpec extends ZIOBaseSpec {
       }
     ),
     suite("contravariant types")(
-      zio.test.test("Modules sharing common parent are independent") {
+      test("Modules sharing common parent are independent") {
         val hasBoth = Has(dogHotel1).add[PetHotel[Cat]](catHotel1)
 
         val dogHotel = hasBoth.get[PetHotel[Dog]]
@@ -107,7 +107,7 @@ object HasSpec extends ZIOBaseSpec {
 
         assert(dogHotel)(anything) && assert(catHotel)(anything)
       },
-      zio.test.test("Siblings can be updated independently") {
+      test("Siblings can be updated independently") {
         val whole: Has[PetHotel[Dog]] with Has[PetHotel[Cat]] = Has(dogHotel1).add(catHotel1)
 
         val updated: Has[PetHotel[Dog]] with Has[PetHotel[Cat]] =
@@ -117,14 +117,14 @@ object HasSpec extends ZIOBaseSpec {
         assert(updated.get[PetHotel[Dog]])(equalTo(dogHotel2)) &&
         assert(updated.get[PetHotel[Cat]])(equalTo(catHotel2))
       },
-      zio.test.test("Prune will delete what is not known about") {
+      test("Prune will delete what is not known about") {
         val whole: Has[PetHotel[Dog]] with Has[PetHotel[Cat]] = Has(dogHotel1).add(catHotel1)
 
         assert(whole.size)(equalTo(2)) &&
         assert((whole: Has[PetHotel[Dog]]).prune.size)(equalTo(1)) &&
         assert((whole: Has[PetHotel[Cat]]).prune.size)(equalTo(1))
       },
-      zio.test.test("Union will prune what is not known about on RHS") {
+      test("Union will prune what is not known about on RHS") {
         val unioned = Has(dogHotel1) union ((Has(dogHotel2).add(bunnyHotel1)): Has[PetHotel[Bunny]])
 
         assert(unioned.get[PetHotel[Dog]])(equalTo(dogHotel1)) &&

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -4,7 +4,7 @@ import zio.clock.Clock
 import zio.duration._
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.test.TestAspect.{failing, timeout}
+import zio.test.TestAspect.{failing, flaky, timeout}
 import zio.test._
 import zio.test.environment.{TestClock, TestRandom}
 
@@ -136,7 +136,7 @@ object ScheduleSpec extends ZIOBaseSpec {
         assertM(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(1000000)).runCount)(
           equalTo(1000000L)
         )
-      }
+      } @@ flaky
     ),
     suite("Retry on failure according to a provided strategy")(
       testM("retry 0 time for `once` when first time succeeds") {

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -3,7 +3,7 @@ package zio.internal
 import zio.ZIOBaseSpec
 import zio.random.Random
 import zio.test.Assertion.equalTo
-import zio.test.{Gen, ZSpec, assert, checkAll, suite, test, testM}
+import zio.test.{Gen, ZSpec, assert, checkAll, suite, testM}
 
 import scala.util.Random.nextInt
 

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
@@ -1,7 +1,7 @@
 package zio.examples.test
 
 import zio.test.junit.JUnitRunnableSpec
-import zio.test.{ assert, suite, test, Assertion }
+import zio.test.{Assertion, assert, suite}
 
 class ExampleSpecWithJUnit extends JUnitRunnableSpec {
   def spec = suite("some suite")(

--- a/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,6 +1,5 @@
 package zio.examples.test
 
-import zio._
 import zio.test._
 
 object ExampleSpec extends DefaultRunnableSpec {

--- a/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,7 +1,7 @@
 package zio.examples.test
 
 import zio._
-import test._
+import zio.test._
 
 object ExampleSpec extends DefaultRunnableSpec {
 

--- a/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -1,6 +1,7 @@
 package zio.examples.test
 
-import zio.test.{ assert, suite, test, Assertion, DefaultRunnableSpec }
+import zio._
+import test._
 
 object ExampleSpec extends DefaultRunnableSpec {
 

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -41,7 +41,9 @@ object MavenJunitSpec extends DefaultRunnableSpec {
         )
       }
     }
-  ) @@ TestAspect.sequential
+  ) @@ TestAspect.sequential @@
+    // flaky: sometimes maven fails to download dependencies in CI
+    TestAspect.flaky(3)
 
   def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
     projectDir <-

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -202,13 +202,13 @@ object ZTestFrameworkSpec {
   lazy val failingSpecFQN = SimpleFailingSpec.getClass.getName
   object SimpleFailingSpec extends DefaultRunnableSpec {
     def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = zio.test.suite("some suite")(
-      zio.test.test("failing test") {
+      test("failing test") {
         zio.test.assert(1)(Assertion.equalTo(2))
       },
-      zio.test.test("passing test") {
+      test("passing test") {
         zio.test.assert(1)(Assertion.equalTo(1))
       },
-      zio.test.test("ignored test") {
+      test("ignored test") {
         zio.test.assert(1)(Assertion.equalTo(2))
       } @@ TestAspect.ignore
     )
@@ -216,7 +216,7 @@ object ZTestFrameworkSpec {
 
   lazy val multiLineSpecFQN = MultiLineSpec.getClass.getName
   object MultiLineSpec extends DefaultRunnableSpec {
-    def spec: ZSpec[Environment, Failure] = zio.test.test("multi-line test") {
+    def spec: ZSpec[Environment, Failure] = test("multi-line test") {
       zio.test.assert("Hello,\nWorld!")(Assertion.equalTo("Hello, World!"))
     }
   }

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -31,7 +31,7 @@ object SpecSpec extends ZIOBaseSpec {
       testM("gracefully handles fiber death") {
         implicit val needsEnv = NeedsEnv
         val spec = suite("suite")(
-          zio.test.test("test") {
+          test("test") {
             assert(true)(isTrue)
           }
         ).provideLayerShared(ZLayer.fromEffectMany(ZIO.dieMessage("everybody dies")))
@@ -57,10 +57,10 @@ object SpecSpec extends ZIOBaseSpec {
       },
       testM("is not interfered with by test level failures") {
         val spec = suite("suite")(
-          zio.test.test("test1") {
+          test("test1") {
             assert(1)(Assertion.equalTo(2))
           },
-          zio.test.test("test2") {
+          test("test2") {
             assert(1)(Assertion.equalTo(1))
           },
           testM("test3") {

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.Has
 import zio.test.mock.module.{PureModule, PureModuleMock}
-import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assert, suite, test}
+import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assert, suite}
 
 object ExpectationSpec extends ZIOBaseSpec {
 

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -48,4 +48,9 @@ abstract class AbstractRunnableSpec {
    * the platform used by the runner
    */
   final def platform = runner.platform
+
+  /**
+   * Builds a spec with a single pure test.
+   */
+  def test(label: String)(assertion: => TestResult): ZSpec[Any, Nothing] = zio.test.test(label)(assertion)
 }


### PR DESCRIPTION
Adding `test` method to `AbstractRunnableSpec` seems to do the trick.
#4520 