### PR TITLE
zio-test: improvements for assert capturing expression and location

### DIFF
--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import scala.collection.mutable.{ ArrayBuilder, Builder }
+import scala.collection.mutable.{ArrayBuilder, Builder}
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -18,7 +18,7 @@ package zio
 
 import scala.collection.IterableFactoryDefaults
 import scala.collection.SeqFactory
-import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps }
+import scala.collection.immutable.{IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps}
 import scala.reflect.ClassTag
 
 /**

--- a/core/shared/src/main/scala-dotty/zio/=!=.scala
+++ b/core/shared/src/main/scala-dotty/zio/=!=.scala
@@ -21,7 +21,6 @@ import scala.util.Not
 
 /**
  * Evidence type `A` is not equal to type `B`.
- *
  */
 @implicitNotFound("${A} must not be ${B}")
 abstract class =!=[A, B] extends Serializable

--- a/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ExampleSpec.scala
@@ -9,6 +9,14 @@ object ExampleSpec extends DefaultRunnableSpec {
       val stuff = 1
       assert(stuff)(Assertion.equalTo(2))
     },
+    test("failing test 2") {
+      val stuff = Some(1)
+      assert(stuff)(Assertion.isSome(Assertion.equalTo(2)))
+    },
+    test("failing test 3") {
+      val stuff = Some(1)
+      assert(stuff)(Assertion.isSome(Assertion.not(Assertion.equalTo(1))))
+    },
     test("passing test") {
       assert(1)(Assertion.equalTo(1))
     }

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -29,13 +29,14 @@ object MavenJunitSpec extends DefaultRunnableSpec {
             "should fail",
             s"""zio.test.junit.TestFailed:
                |11 did not satisfy equalTo(12)
-               |11 did not satisfy (equalTo(12) ?? "assert(`11`) (at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10)")""".stripMargin
+               |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10""".stripMargin
           ) &&
             containsFailure(
               "should fail - isSome",
               s"""zio.test.junit.TestFailed:
                  |11 did not satisfy equalTo(12)
-                 |Some(11) did not satisfy (isSome(equalTo(12)) ?? "assert(`Some[Int](11)`) (at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13)")""".stripMargin
+                 |`Some[Int](11)` = Some(11) did not satisfy isSome(equalTo(12))
+                 |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13""".stripMargin
             ) &&
             containsSuccess("should succeed")
         )

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -35,7 +35,7 @@ object MavenJunitSpec extends DefaultRunnableSpec {
               "should fail - isSome",
               s"""zio.test.junit.TestFailed:
                  |11 did not satisfy equalTo(12)
-                 |`Some[Int](11)` = Some(11) did not satisfy isSome(equalTo(12))
+                 |Some(11) did not satisfy isSome(equalTo(12))
                  |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13""".stripMargin
             ) &&
             containsSuccess("should succeed")

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -42,7 +42,9 @@ object MavenJunitSpec extends DefaultRunnableSpec {
         )
       }
     }
-  ) @@ TestAspect.sequential
+  ) @@ TestAspect.sequential @@
+    // flaky: sometimes maven fails to download dependencies in CI
+    TestAspect.flaky(3)
 
   def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
     projectDir <-

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -85,7 +85,7 @@ object ZTestFrameworkSpec {
           s"${reset("info:")} ${red("- some suite")} - ignored: 1",
           s"${reset("info:")}   ${red("- failing test")}",
           s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("equalTo(2)")}",
-          s"${reset("info:")}     ${blue("1")} did not satisfy ${cyan("(") + yellow("equalTo(2)") + cyan(s" ?? ${assertLabel("1")})")}",
+          s"${reset("info:")}       ${blue(assertLocation)}",
           s"${reset("info:")}   ${green("+")} passing test",
           s"${reset("info:")}   ${yellow("-")} ${yellow("ignored test")} - ignored: 1"
         ).mkString("\n")
@@ -97,7 +97,6 @@ object ZTestFrameworkSpec {
     val loggers = Seq.fill(3)(new MockLogger)
 
     loadAndExecute(multiLineSpecFQN, loggers = loggers)
-    val label = assertLabel(zio.test.showExpression("Hello,\nWorld!"))
     loggers.map(_.messages) foreach (messages =>
       assertEquals(
         "logged messages",
@@ -106,10 +105,7 @@ object ZTestFrameworkSpec {
           s"${red("- multi-line test")}",
           s"  ${Console.BLUE}Hello,",
           s"${blue("World!")} did not satisfy ${cyan("equalTo(Hello, World!)")}",
-          s"  ${Console.BLUE}Hello,",
-          s"${blue("World!")} did not satisfy ${cyan("(") + yellow("equalTo(Hello, World!)") + cyan(
-            s" ?? ${label.split('\n').mkString("\n" + Console.CYAN)})"
-          )}"
+          s"    ${blue(assertLocation)}"
         ).mkString("\n")
           .split('\n')
           .map(s"${reset("info:")} " + _)
@@ -221,8 +217,8 @@ object ZTestFrameworkSpec {
     }
   }
 
-  lazy val sourceFilePath: String       = zio.test.sourcePath
-  def assertLabel(expr: String): String = s""""assert(`$expr`) (at $sourceFilePath:XXX)""""
+  lazy val sourceFilePath: String = zio.test.sourcePath
+  lazy val assertLocation: String = s"at $sourceFilePath:XXX"
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =
       output.replaceAll(Pattern.quote(sourceFilePath + ":") + "\\d+", sourceFilePath + ":XXX")

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -86,16 +86,14 @@ object ReportingTestUtils {
     expectedFailure("Value falls within range"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("((") + yellow("equalTo(42)") + cyan(
-        s" || (isGreaterThan(5) && isLessThan(10))) ?? ${assertLabel("52")})"
-      )}\n"
+      s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
     ),
+    withOffset(4)(assertSourceLocation() + "\n"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
     withOffset(2)(
-      s"${blue("52")} did not satisfy ${cyan("((equalTo(42) || (isGreaterThan(5) && ") + yellow(
-        "isLessThan(10)"
-      ) + cyan(s")) ?? ${assertLabel("52")})")}\n"
-    )
+      s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
+    ),
+    withOffset(4)(assertSourceLocation() + "\n")
   )
 
   val test4: Spec[Any, TestFailure[String], Nothing] =
@@ -112,9 +110,7 @@ object ReportingTestUtils {
   val test5Expected: Vector[String] = Vector(
     expectedFailure("Addition works fine"),
     withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n"),
-    withOffset(2)(
-      s"${blue("2")} did not satisfy ${cyan("(") + yellow("equalTo(3)") + cyan(s" ?? ${assertLabel("2")})")}\n"
-    )
+    withOffset(4)(assertSourceLocation() + "\n")
   )
 
   val test6: ZSpec[Any, Nothing] =
@@ -126,10 +122,9 @@ object ReportingTestUtils {
       s"${blue("Some(3)")} did not satisfy ${cyan("isSome(") + yellow("isGreaterThan(4)") + cyan(")")}\n"
     ),
     withOffset(2)(
-      s"${blue("Right(Some(3))")} did not satisfy ${cyan("(isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(
-        s") ?? ${assertLabel("Right[Nothing, Some[Int]](Some[Int](3))")})"
-      )}\n"
-    )
+      s"${blue(s"`${showExpression(Right(Some(3)))}` = Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
+    ),
+    withOffset(4)(assertSourceLocation() + "\n")
   )
 
   val test7: ZSpec[Any, Nothing] = testM("labeled failures") {
@@ -147,8 +142,9 @@ object ReportingTestUtils {
     expectedFailure("labeled failures"),
     withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
     withOffset(2)(
-      s"${blue("Some(0)")} did not satisfy ${cyan("((isSome(") + yellow("equalTo(1)") + cyan(s""") ?? "third") ?? ${assertLabel("c")})""")}\n"
-    )
+      s"${blue("`c` = Some(0)")} did not satisfy ${cyan("(isSome(") + yellow("equalTo(1)") + cyan(") ?? \"third\")")}\n"
+    ),
+    withOffset(4)(assertSourceLocation() + "\n")
   )
 
   val test8: ZSpec[Any, Nothing] = zio.test.test("Not combinator") {
@@ -158,8 +154,9 @@ object ReportingTestUtils {
     expectedFailure("Not combinator"),
     withOffset(2)(s"${blue("100")} satisfied ${cyan("equalTo(100)")}\n"),
     withOffset(2)(
-      s"${blue("100")} did not satisfy ${cyan("(not(") + yellow("equalTo(100)") + cyan(s") ?? ${assertLabel("100")})")}\n"
-    )
+      s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}\n"
+    ),
+    withOffset(4)(assertSourceLocation() + "\n")
   )
 
   val suite1: Spec[Any, TestFailure[Nothing], TestSuccess] = suite("Suite1")(test1, test2)
@@ -244,7 +241,7 @@ object ReportingTestUtils {
     withOffset(2)(s"""${red("- invalid repetition range 4 to 2 by -1")}\n""")
   )
 
-  def assertLabel(expr: String): String = s""""assert(`$expr`) (at $sourceFilePath:XXX)""""
+  def assertSourceLocation(): String = blue(s"at $sourceFilePath:XXX")
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =
       output.replaceAll(Pattern.quote(sourceFilePath + ":") + "\\d+", sourceFilePath + ":XXX")

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -107,9 +107,14 @@ object ReportingTestUtils {
   )
 
   val test5: ZSpec[Any, Nothing] = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(3)))
+  // the captured expression for `1+1` is different between dotty and 2.x
+  def expressionIfNotRedundant(expr: String, value: Any): String =
+    Option(expr).filterNot(_ == value.toString).fold(value.toString)(e => s"`$e` = $value")
   val test5Expected: Vector[String] = Vector(
     expectedFailure("Addition works fine"),
-    withOffset(2)(s"${blue("2")} did not satisfy ${cyan("equalTo(3)")}\n"),
+    withOffset(2)(
+      s"${blue(expressionIfNotRedundant(showExpression(1 + 1), 2))} did not satisfy ${cyan("equalTo(3)")}\n"
+    ),
     withOffset(4)(assertSourceLocation() + "\n")
   )
 
@@ -122,7 +127,7 @@ object ReportingTestUtils {
       s"${blue("Some(3)")} did not satisfy ${cyan("isSome(") + yellow("isGreaterThan(4)") + cyan(")")}\n"
     ),
     withOffset(2)(
-      s"${blue(s"`${showExpression(Right(Some(3)))}` = Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
+      s"${blue(s"Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
     ),
     withOffset(4)(assertSourceLocation() + "\n")
   )

--- a/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
@@ -1,0 +1,28 @@
+package zio.test
+
+import zio.test.Assertion._
+
+object ShowExpressionSpec extends ZIOBaseSpec {
+  val fooVal = "foo"
+  case class SomeData(foo: String, more: Seq[Nested], nested: Nested)
+  case class Nested(bar: Int)
+
+  override def spec: ZSpec[Any, Any] = suite("ShowExprSpec")(
+    test("Some(1)", showExpression(Some(1)), "Some(1)"),
+    test("Some(Right(1))", showExpression(Some(Right(1))), "Some(Right(1))"),
+    test("class member val", showExpression(fooVal), "fooVal"),
+    test("tuple", showExpression(("foo", true, 1, 1.2, fooVal)), "(\"foo\", true, 1, 1.2, fooVal)"),
+    test(
+      "nested case classes",
+      showExpression(SomeData("foo barvaz", Seq(Nested(1), Nested(2)), Nested(3))),
+      "SomeData(\"foo barvaz\", Seq(Nested(1), Nested(2)), Nested(3))"
+    ),
+    test("multiline string literal", showExpression("foo\nbar\n\nbaz"), "\"foo\\nbar\\n\\nbaz\"")
+  )
+
+  def test(desc: String, actual: String, expected: String): ZSpec[Any, Nothing] =
+    zio.test.test(desc) {
+      val code = actual
+      assert(code)(equalTo(expected))
+    }
+}

--- a/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SummaryBuilderSpec.scala
@@ -7,7 +7,7 @@ import zio.test.TestAspect.silent
 object SummaryBuilderSpec extends ZIOBaseSpec {
 
   def summarize(log: Vector[String]): String =
-    log.filter(!_.contains("+")).mkString.stripLineEnd
+    log.filter(!_.contains(green("+"))).mkString.stripLineEnd
 
   def labelOnly(log: Vector[String]): String =
     log.take(1).mkString.stripLineEnd

--- a/test/shared/src/main/scala-2.x/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/Macros.scala
@@ -18,6 +18,7 @@ package zio.test
 
 import zio.UIO
 
+import scala.annotation.tailrec
 import scala.reflect.macros.{TypecheckException, blackbox}
 
 private[test] object Macros {
@@ -35,15 +36,28 @@ private[test] object Macros {
 
   private[test] val fieldInAnonymousClassPrefix = "$anon.this."
 
-  def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult = zio.test.assertImpl(value)(assertion)
+  private[test] def location(c: blackbox.Context): (String, Int) = {
+    val path = c.enclosingPosition.source.path
+    val line = c.enclosingPosition.line
+    (path, line)
+  }
+
+  def assertImpl[A](value: => A, label: String, location: String)(assertion: Assertion[A]): TestResult =
+    zio.test.assertImpl(value, Some(label), Some(location))(assertion)
+
+  def assertM_impl(c: blackbox.Context)(effect: c.Tree)(assertion: c.Tree): c.Tree = {
+    import c.universe._
+    val (fileName, line) = location(c)
+    val srcLocation      = s"$fileName:$line"
+    q"_root_.zio.test.CompileVariants.assertMInternal($effect, $srcLocation)($assertion)"
+  }
 
   def assert_impl(c: blackbox.Context)(expr: c.Tree)(assertion: c.Tree): c.Tree = {
     import c.universe._
-    val fileName = c.enclosingPosition.source.path
-    val line     = c.enclosingPosition.line
-    val code     = showExpr(c)(expr)
-    val label    = s"assert(`$code`) (at $fileName:$line)"
-    q"_root_.zio.test.CompileVariants.assertImpl($expr)($assertion.label($label))"
+    val (fileName, line) = location(c)
+    val srcLocation      = s"$fileName:$line"
+    val code             = showExpr(c)(expr)
+    q"_root_.zio.test.CompileVariants.assertImpl($expr, $code, $srcLocation)($assertion)"
   }
 
   def sourcePath_impl(c: blackbox.Context): c.Tree = {
@@ -53,14 +67,22 @@ private[test] object Macros {
 
   private def showExpr(c: blackbox.Context)(expr: c.Tree) = {
     import c.universe._
-    showCode(expr)
-      .stripPrefix(fieldInAnonymousClassPrefix)
-      // for scala 3 compatibility
-      .replace(".`package`.", ".")
-      // reduce clutter
-      .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
-      .replaceAll("""\.apply(\s*[\[(])""", "$1")
+    dropQuotes(
+      showCode(expr)
+        .stripPrefix(fieldInAnonymousClassPrefix)
+        // for scala 3 compatibility
+        .replace(".`package`.", ".")
+        // reduce clutter
+        .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
+        .replaceAll("""\.apply(\s*[\[(])""", "$1")
+    )
   }
+
+  @tailrec
+  private def dropQuotes(str: String): String =
+    if (str.startsWith("\"") && str.endsWith("\"")) {
+      dropQuotes(str.slice(1, str.length - 1))
+    } else str
 
   def showExpression_impl(c: blackbox.Context)(expr: c.Tree): c.Tree = {
     import c.universe._

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -16,8 +16,10 @@
 
 package zio.test
 
-import zio.UIO
+import zio.test.Macros.location
+import zio.{UIO, ZIO}
 
+import scala.annotation.tailrec
 import scala.compiletime.testing.typeChecks
 
 trait CompileVariants {
@@ -42,9 +44,18 @@ trait CompileVariants {
   /**
    * Checks the assertion holds for the given value.
    */
-  private[test] def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult
+  private[test] def assertImpl[A](value: => A, expression: Option[String] = None, sourceLocation: Option[String] = None)
+                                 (assertion: Assertion[A]): TestResult
+  /**
+   * Checks the assertion holds for the given effectfully-computed value.
+   */
+  private[test] def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: Option[String] = None)
+                                            (assertion: AssertionM[A]): ZIO[R, E, TestResult]
+
 
   inline def assert[A](inline value: => A)(inline assertion: Assertion[A]): TestResult = ${Macros.assert_impl('value)('assertion)}
+
+  inline def assertM[R, E, A](effect: ZIO[R, E, A])(assertion: AssertionM[A]): ZIO[R, E, TestResult] = ${Macros.assertM_impl('effect)('assertion)}
 
   private[zio] inline def sourcePath: String = ${Macros.sourcePath_impl}
 
@@ -55,25 +66,56 @@ object CompileVariants {
   /**
    * just a proxy to call package private assertRuntime from the macro
    */
-  def assertImpl[A](value: => A)(assertion: Assertion[A]): TestResult = zio.test.assertImpl(value)(assertion)
+  def assertImpl[A](value: => A, expression: String, sourceLocation: String)(assertion: Assertion[A]): TestResult =
+    zio.test.assertImpl(value, Some(expression), Some(sourceLocation))(assertion)
+
+  def assertMInternal[R, E, A](effect: ZIO[R, E, A], sourceLocation: String)
+                              (assertion: AssertionM[A]): ZIO[R, E, TestResult] =
+    zio.test.assertMInternal(effect, Some(sourceLocation))(assertion)
 }
 
 object Macros {
   import scala.quoted._
-  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: Quotes, tp: Type[A]): Expr[TestResult] = {
-    import quotes.reflect._
+
+  private def location(ctx: Quotes): (String, Int) = {
+    import ctx.reflect._
     val path = Position.ofMacroExpansion.sourceFile.jpath.toString
     val line = Position.ofMacroExpansion.startLine + 1
+    (path, line)
+  }
+
+  def assert_impl[A](value: Expr[A])(assertion: Expr[Assertion[A]])(using ctx: Quotes, tp: Type[A]): Expr[TestResult] = {
+    import quotes.reflect._
+    val (path, line) = location(ctx)
     val code = showExpr(value)
-    val label = s"assert(`$code`) (at $path:$line)"
-    '{_root_.zio.test.CompileVariants.assertImpl[A]($value)(${assertion}.label(${Expr(label)}))}
+    val srcLocation = s"$path:$line"
+    '{_root_.zio.test.CompileVariants.assertImpl[A]($value, ${Expr(code)}, ${Expr(srcLocation)})($assertion)}
+  }
+
+  def assertM_impl[R: Type, E: Type, A: Type](effect: Expr[ZIO[R, E, A]])(assertion: Expr[AssertionM[A]])
+                           (using ctx: Quotes): Expr[ZIO[R, E, TestResult]] = {
+    import quotes.reflect._
+    val (path, line) = location(ctx)
+    val srcLocation = s"$path:$line"
+    '{_root_.zio.test.CompileVariants.assertMInternal($effect, ${Expr(srcLocation)})($assertion)}
   }
 
   private def showExpr[A](expr: Expr[A])(using ctx: Quotes) = {
-    expr.show
-      // reduce clutter
-      .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
-      .replaceAll("""\.apply(\s*[\[(])""", "$1")
+    dropQuotes(
+      expr.show
+        // reduce clutter
+        .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
+        .replaceAll("""\.apply(\s*[\[(])""", "$1")
+        // scala 2.* compatibility for string literals
+        .replaceAll("""\\n""", "\n")
+    )
+  }
+
+  @tailrec
+  private def dropQuotes(str: String): String = {
+    if(str.startsWith("\"") && str.endsWith("\"")) {
+      dropQuotes(str.slice(1, str.length - 1))
+    } else str
   }
 
   def sourcePath_impl(using ctx: Quotes): Expr[String] = {

--- a/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/CompileVariants.scala
@@ -101,21 +101,8 @@ object Macros {
   }
 
   private def showExpr[A](expr: Expr[A])(using ctx: Quotes) = {
-    dropQuotes(
-      expr.show
-        // reduce clutter
-        .replaceAll("""scala\.([a-zA-Z0-9_]+)""", "$1")
-        .replaceAll("""\.apply(\s*[\[(])""", "$1")
-        // scala 2.* compatibility for string literals
-        .replaceAll("""\\n""", "\n")
-    )
-  }
-
-  @tailrec
-  private def dropQuotes(str: String): String = {
-    if(str.startsWith("\"") && str.endsWith("\"")) {
-      dropQuotes(str.slice(1, str.length - 1))
-    } else str
+    import quotes.reflect._
+    Term.of(expr).pos.sourceCode
   }
 
   def sourcePath_impl(using ctx: Quotes): Expr[String] = {

--- a/test/shared/src/main/scala/zio/test/AssertionValue.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionValue.scala
@@ -24,25 +24,44 @@ package zio.test
 sealed abstract class AssertionValue {
   type Value
   def value: Value
+  def expression: Option[String]
+  def sourceLocation: Option[String]
   protected def assertion: AssertionM[Value]
   def result: AssertResult
 
-  def printAssertion: String                       = assertion.toString
-  def label(string: String): AssertionValue        = AssertionValue(assertion.label(string), value, result)
+  def printAssertion: String = assertion.toString
+  def label(string: String): AssertionValue =
+    AssertionValue(assertion.label(string), value, result, expression, sourceLocation)
   def sameAssertion(that: AssertionValue): Boolean = assertion == that.assertion
 
-  def negate: AssertionValue = AssertionValue(assertion.negate, value, !result)
+  def negate: AssertionValue = AssertionValue(assertion.negate, value, !result, expression, sourceLocation)
+  def withContext(expr: Option[String], sourceLocation: Option[String]): AssertionValue =
+    AssertionValue(assertion, value, result, expr, sourceLocation)
 }
 
 object AssertionValue {
-  def apply[A](assertion: AssertionM[A], value: => A, result: => AssertResult): AssertionValue = {
-    def inner(assertion0: AssertionM[A], value0: => A, result0: => AssertResult) =
+  def apply[A](
+    assertion: AssertionM[A],
+    value: => A,
+    result: => AssertResult,
+    expression: Option[String] = None,
+    sourceLocation: Option[String] = None
+  ): AssertionValue = {
+    def inner(
+      assertion0: AssertionM[A],
+      value0: => A,
+      result0: => AssertResult,
+      expression0: Option[String],
+      sourceLocation0: Option[String]
+    ) =
       new AssertionValue {
         type Value = A
-        protected val assertion: AssertionM[Value] = assertion0
-        lazy val value: Value                      = value0
-        lazy val result: AssertResult              = result0
+        protected val assertion: AssertionM[Value]  = assertion0
+        lazy val value: Value                       = value0
+        lazy val result: AssertResult               = result0
+        override val expression: Option[String]     = expression0
+        override val sourceLocation: Option[String] = sourceLocation0
       }
-    inner(assertion, value, result)
+    inner(assertion, value, result, expression, sourceLocation)
   }
 }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -303,8 +303,18 @@ object FailureRenderer {
     }
 
   private def renderValue(av: AssertionValue) = (av.value, av.expression) match {
-    case (v, Some(expression)) if v.toString != expression => s"`$expression` = $v"
-    case (v, _)                                            => v.toString
+    case (v, Some(expression)) if !expressionRedundant(v.toString, expression) => s"`$expression` = $v"
+    case (v, _)                                                                => v.toString
+  }
+
+  private def expressionRedundant(valueStr: String, expression: String) = {
+    // toString drops double quotes, and for tuples and collections doesn't include spaces after the comma
+    def strip(s: String) = s
+      .replace("\"", "")
+      .replace(" ", "")
+      .replace("\n", "")
+      .replace("\\n", "")
+    strip(valueStr) == strip(expression)
   }
 
   private def renderAssertionLocation(av: AssertionValue, offset: Int) = av.sourceLocation.fold(Message()) { location =>

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -16,8 +16,6 @@
 
 package zio.test
 
-import java.util.regex.Pattern
-
 import zio.duration._
 import zio.test.ConsoleUtils.{cyan, red, _}
 import zio.test.FailureRenderer.FailureMessage.{Fragment, Message}
@@ -28,6 +26,7 @@ import zio.test.mock.Expectation
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.{Cause, Has}
 
+import java.util.regex.Pattern
 import scala.io.AnsiColor
 import scala.util.Try
 

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -26,6 +26,7 @@ import zio.test.mock.Expectation
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.{Cause, Has}
 
+import java.io.File
 import java.util.regex.Pattern
 import scala.io.AnsiColor
 import scala.util.Try
@@ -262,7 +263,11 @@ object FailureRenderer {
         case _ =>
           rendered
       }
-    renderFragment(failureDetails.head, offset).toMessage ++ loop(failureDetails, Message.empty)
+
+    renderFragment(failureDetails.head, offset).toMessage ++ loop(
+      failureDetails,
+      Message.empty
+    ) ++ renderAssertionLocation(failureDetails.last, offset)
   }
 
   private def renderGenFailureDetails[A](failureDetails: Option[GenFailureDetails], offset: Int): Message =
@@ -286,17 +291,28 @@ object FailureRenderer {
 
   private def renderWhole(fragment: AssertionValue, whole: AssertionValue, offset: Int): Line =
     withOffset(offset + tabSize) {
-      blue(whole.value.toString) +
+      blue(renderValue(whole)) +
         renderSatisfied(whole) ++
         highlight(cyan(whole.printAssertion), fragment.printAssertion)
     }
 
   private def renderFragment(fragment: AssertionValue, offset: Int): Line =
     withOffset(offset + tabSize) {
-      blue(fragment.value.toString) +
+      blue(renderValue(fragment)) +
         renderSatisfied(fragment) +
         cyan(fragment.printAssertion)
     }
+
+  private def renderValue(av: AssertionValue) = (av.value, av.expression) match {
+    case (v, Some(expression)) if v.toString != expression => s"`$expression` = $v"
+    case (v, _)                                            => v.toString
+  }
+
+  private def renderAssertionLocation(av: AssertionValue, offset: Int) = av.sourceLocation.fold(Message()) { location =>
+    blue(s"at ${File.separator}${location.stripPrefix(File.separator)}").toLine
+      .withOffset(offset + 2 * tabSize)
+      .toMessage
+  }
 
   private def highlight(fragment: Fragment, substring: String, colorCode: String = AnsiColor.YELLOW): Line = {
     val parts = fragment.text.split(Pattern.quote(substring))

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -309,7 +309,7 @@ object FailureRenderer {
   }
 
   private def renderAssertionLocation(av: AssertionValue, offset: Int) = av.sourceLocation.fold(Message()) { location =>
-    blue(s"at ${File.separator}${location.stripPrefix(File.separator)}").toLine
+    blue(s"at $location").toLine
       .withOffset(offset + 2 * tabSize)
       .toMessage
   }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -16,6 +16,8 @@
 
 package zio.test
 
+import java.util.regex.Pattern
+
 import zio.duration._
 import zio.test.ConsoleUtils.{cyan, red, _}
 import zio.test.FailureRenderer.FailureMessage.{Fragment, Message}
@@ -26,8 +28,6 @@ import zio.test.mock.Expectation
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.{Cause, Has}
 
-import java.io.File
-import java.util.regex.Pattern
 import scala.io.AnsiColor
 import scala.util.Try
 


### PR DESCRIPTION
This is a refinement of #4427
Moves the captured expression into the description of the value being asserted on.
Moves the source location to a separate line.
![image](https://user-images.githubusercontent.com/1577551/103547622-522e3200-4ead-11eb-8551-42bc03d2ee49.png)

Also made rendered expressions much cleaner - closer to how you would normally write the code.
Under dotty the actual source code is shown.
Example (for Scala 2.x)
``` scala
//before
Tuple4.apply[String, Int, String, Boolean]("foo", 123, Test.this.fooVal, false)
// now 
("foo", 123, fooVal, false)
```
