### PR TITLE
Removed second argument group on `Chunk.nonEmptyOrElse`

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -664,7 +664,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
   /**
    * Runs `fn` if a `chunk` is not empty or returns default value
    */
-  def nonEmptyOrElse[B](ifEmpty: => B)(fn: NonEmptyChunk[A] => B): B =
+  def nonEmptyOrElse[B](ifEmpty: => B, fn: NonEmptyChunk[A] => B): B =
     if (isEmpty) ifEmpty else fn(NonEmptyChunk.nonEmpty(self))
 
   /**

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -204,7 +204,7 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
    * Zips this `NonEmptyCHunk` with the specified `NonEmptyChunk`, only
    * keeping as many elements as are in the smaller chunk.
    */
-  final def zipWith[B, C](that: NonEmptyChunk[B])(f: (A, B) => C): NonEmptyChunk[C] =
+  def zipWith[B, C](that: NonEmptyChunk[B])(f: (A, B) => C): NonEmptyChunk[C] =
     nonEmpty(chunk.zipWith(that.chunk)(f))
 
   /**
@@ -217,7 +217,7 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
    * Annotates each element of this `NonEmptyChunk` with its index, with the
    * specified offset.
    */
-  final def zipWithIndexFrom(indexOffset: Int): NonEmptyChunk[(A, Int)] =
+  def zipWithIndexFrom(indexOffset: Int): NonEmptyChunk[(A, Int)] =
     nonEmpty(chunk.zipWithIndexFrom(indexOffset))
 }
 
@@ -233,7 +233,7 @@ object NonEmptyChunk {
    * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
    */
   def fromChunk[A](chunk: Chunk[A]): Option[NonEmptyChunk[A]] =
-    chunk.nonEmptyOrElse[Option[NonEmptyChunk[A]]](None)(Some(_))
+    chunk.nonEmptyOrElse(None, Some(_))
 
   /**
    * Constructs a `NonEmptyChunk` from the `::` case of a `List`.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3184,13 +3184,12 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
       (leftUpd.isDefined, rightUpd.isDefined) match {
         case (true, true)   => Exit.succeed((emit, Running(newExcess)))
         case (false, false) => Exit.fail(None)
-        case _ => {
+        case _ =>
           val newState = newExcess match {
-            case Left(l)  => l.nonEmptyOrElse[State[O, O2]](End)(LeftDone(_))
-            case Right(r) => r.nonEmptyOrElse[State[O, O2]](End)(RightDone(_))
+            case Left(l)  => l.nonEmptyOrElse(End, LeftDone(_))
+            case Right(r) => r.nonEmptyOrElse(End, RightDone(_))
           }
           Exit.succeed((emit, newState))
-        }
       }
     }
 
@@ -3206,14 +3205,12 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
           {
             p2.optional.map(handleSuccess(None, _, Left(excessL)))
           }.catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
-        case RightDone(excessR) => {
+        case RightDone(excessR) =>
           p1.optional
             .map(handleSuccess(_, None, Right(excessR)))
             .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
-        }
-        case End => {
+        case End =>
           UIO.succeedNow(Exit.fail(None))
-        }
       }
     }
   }


### PR DESCRIPTION
When using `Chunk.nonEmptyOrElse`, the inference cannot select the expected type.

