### PR TITLE
primitive evaluation of delay

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -522,7 +522,7 @@ sealed abstract class Schedule[-Env, -In, +Out] private (
         self(now, in).flatMap {
           case Done(out) => ZIO.succeed(Done(out))
           case Continue(out, interval, next) =>
-            val delay = Duration(interval.toInstant.toEpochMilli - now.toInstant.toEpochMilli, TimeUnit.MILLISECONDS)
+            val delay = Duration.fromInterval(interval, now)
 
             f(out, delay).map { duration =>
               val newInterval = now.plusNanos(duration.toNanos)


### PR DESCRIPTION
Update Schedule.scala for a primitive evaluation of delay. The proposed change seems to be more direct. We just have to make sure tests pass and that I am not getting order wrong between interval and now.