### PR TITLE
Import-less test methods

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ImportlessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ImportlessSpec.scala
@@ -1,0 +1,10 @@
+package zio
+
+import zio.test.{DefaultRunnableSpec, ZSpec, assertCompletes}
+
+object ImportlessSpec extends DefaultRunnableSpec {
+  val spec: ZSpec[Environment, Failure] = suite("Suite")(
+    test("This is a test without imports")(assertCompletes),
+    testM("This is an effectful test without imports")(ZIO.succeed(assertCompletes))
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NonEmptyChunkSpec.scala
@@ -58,7 +58,7 @@ object NonEmptyChunkSpec extends ZIOBaseSpec {
       }
     },
     suite("unapplySeq")(
-      zio.test.test("matches a nonempty chunk") {
+      test("matches a nonempty chunk") {
         val chunk = Chunk(1, 2, 3)
         val actual = chunk match {
           case NonEmptyChunk(x, y, z) => Some((x, y, z))
@@ -67,7 +67,7 @@ object NonEmptyChunkSpec extends ZIOBaseSpec {
         val expected = Some((1, 2, 3))
         assert(actual)(equalTo(expected))
       },
-      zio.test.test("does not match an empty chunk") {
+      test("does not match an empty chunk") {
         val chunk = Chunk.empty
         val actual = chunk match {
           case NonEmptyChunk(x, y, z) => Some((x, y, z))
@@ -76,7 +76,7 @@ object NonEmptyChunkSpec extends ZIOBaseSpec {
         val expected = None
         assert(actual)(equalTo(expected))
       },
-      zio.test.test("does not match another collection type") {
+      test("does not match another collection type") {
         val vector = Vector(1, 2, 3)
         val actual = vector match {
           case NonEmptyChunk(x, y, z) => Some((x, y, z))

--- a/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackBoolSpec.scala
@@ -3,7 +3,7 @@ package zio.internal
 import zio.ZIOBaseSpec
 import zio.random.Random
 import zio.test.Assertion.equalTo
-import zio.test.{Gen, ZSpec, assert, checkAll, suite, testM}
+import zio.test.{Gen, ZSpec, assert, checkAll}
 
 import scala.util.Random.nextInt
 

--- a/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala
@@ -1,7 +1,7 @@
 package zio.examples.test
 
 import zio.test.junit.JUnitRunnableSpec
-import zio.test.{Assertion, assert, suite}
+import zio.test.{Assertion, assert}
 
 class ExampleSpecWithJUnit extends JUnitRunnableSpec {
   def spec = suite("some suite")(

--- a/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion._
 import zio.test.junit.JUnitRunnableSpec
 import zio.test.mock.Expectation.{value, valueF}
 import zio.test.mock.{MockClock, MockConsole, MockRandom}
-import zio.test.{assertM, suite, testM}
+import zio.test.assertM
 import zio.{clock, console, random}
 
 class MockExampleSpecWithJUnit extends JUnitRunnableSpec {

--- a/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
@@ -3,7 +3,7 @@ package zio.examples.test
 import zio.test.Assertion._
 import zio.test.mock.Expectation.{ value, valueF }
 import zio.test.mock.{ MockClock, MockConsole, MockRandom }
-import zio.test.{ assertM, suite, testM, DefaultRunnableSpec }
+import zio.test.{ assertM, DefaultRunnableSpec }
 import zio.{ clock, console, random }
 
 object MockExampleSpec extends DefaultRunnableSpec {

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -74,14 +74,14 @@ object ReportingTestUtils {
       reporter = DefaultTestReporter(TestAnnotationRenderer.default)
     )
 
-  val test1: ZSpec[Any, Nothing] = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(2)))
+  val test1: ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(2)))
   val test1Expected: String      = expectedSuccess("Addition works fine")
 
-  val test2: ZSpec[Any, Nothing] = zio.test.test("Subtraction works fine")(assert(1 - 1)(equalTo(0)))
+  val test2: ZSpec[Any, Nothing] = test("Subtraction works fine")(assert(1 - 1)(equalTo(0)))
   val test2Expected: String      = expectedSuccess("Subtraction works fine")
 
   val test3: ZSpec[Any, Nothing] =
-    zio.test.test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
+    test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
   val test3Expected: Vector[String] = Vector(
     expectedFailure("Value falls within range"),
     withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
@@ -106,7 +106,7 @@ object ReportingTestUtils {
       withOffset(2)("No ZIO Trace available.\n")
   )
 
-  val test5: ZSpec[Any, Nothing] = zio.test.test("Addition works fine")(assert(1 + 1)(equalTo(3)))
+  val test5: ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
   // the captured expression for `1+1` is different between dotty and 2.x
   def expressionIfNotRedundant(expr: String, value: Any): String =
     Option(expr).filterNot(_ == value.toString).fold(value.toString)(e => s"`$e` = $value")
@@ -119,7 +119,7 @@ object ReportingTestUtils {
   )
 
   val test6: ZSpec[Any, Nothing] =
-    zio.test.test("Multiple nested failures")(assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4)))))
+    test("Multiple nested failures")(assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4)))))
   val test6Expected: Vector[String] = Vector(
     expectedFailure("Multiple nested failures"),
     withOffset(2)(s"${blue("3")} did not satisfy ${cyan("isGreaterThan(4)")}\n"),
@@ -152,7 +152,7 @@ object ReportingTestUtils {
     withOffset(4)(assertSourceLocation() + "\n")
   )
 
-  val test8: ZSpec[Any, Nothing] = zio.test.test("Not combinator") {
+  val test8: ZSpec[Any, Nothing] = test("Not combinator") {
     assert(100)(not(equalTo(100)))
   }
   val test8Expected: Vector[String] = Vector(
@@ -190,7 +190,7 @@ object ReportingTestUtils {
     Vector(withOffset(2)(expectedIgnored("Empty"))) ++
     test3Expected.map(withOffset(2))
 
-  val mock1: ZSpec[Any, Nothing] = zio.test.test("Invalid call") {
+  val mock1: ZSpec[Any, Nothing] = test("Invalid call") {
     throw InvalidCallException(
       List(
         InvalidCapability(PureModuleMock.SingleParam, PureModuleMock.ParameterizedCommand, equalTo(1)),
@@ -212,7 +212,7 @@ object ReportingTestUtils {
     )
   )
 
-  val mock2: ZSpec[Any, Nothing] = zio.test.test("Unsatisfied expectations") {
+  val mock2: ZSpec[Any, Nothing] = test("Unsatisfied expectations") {
     throw UnsatisfiedExpectationsException(
       PureModuleMock.SingleParam(equalTo(2), value("foo")) ++
         PureModuleMock.SingleParam(equalTo(3), value("bar"))
@@ -227,7 +227,7 @@ object ReportingTestUtils {
     withOffset(6)(s"""zio.test.mock.module.PureModuleMock.SingleParam with arguments ${cyan("equalTo(3)")}\n""")
   )
 
-  val mock3: ZSpec[Any, Nothing] = zio.test.test("Extra calls") {
+  val mock3: ZSpec[Any, Nothing] = test("Extra calls") {
     throw UnexpectedCallException(PureModuleMock.ManyParams, (2, "3", 4L))
   }
 
@@ -237,7 +237,7 @@ object ReportingTestUtils {
     withOffset(4)(s"${cyan("(2,3,4)")}\n")
   )
 
-  val mock4: ZSpec[Any, Nothing] = zio.test.test("Invalid range") {
+  val mock4: ZSpec[Any, Nothing] = test("Invalid range") {
     throw InvalidRangeException(4 to 2 by -1)
   }
 

--- a/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
@@ -21,7 +21,7 @@ object ShowExpressionSpec extends ZIOBaseSpec {
   )
 
   def test(desc: String, actual: String, expected: String): ZSpec[Any, Nothing] =
-    zio.test.test(desc) {
+    test(desc) {
       val code = actual
       assert(code)(equalTo(expected))
     }

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
@@ -3,7 +3,7 @@ package zio.test.mock
 import zio.ZIO
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.test.mock.module.{PureModule, PureModuleMock}
-import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec}
 
 object AdvancedEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.test.mock.module.{ImpureModule, ImpureModuleMock}
-import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec}
 import zio.{URIO, ZIO}
 
 object AdvancedMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] {

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicEffectMockSpec.scala
@@ -4,7 +4,7 @@ import zio.duration._
 import zio.test.environment.Live
 import zio.test.mock.internal.{ExpectationState, InvalidCall, MockException}
 import zio.test.mock.module.{PureModule, PureModuleMock}
-import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec}
 import zio.{IO, UIO}
 
 object BasicEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicMethodMockSpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.test.mock.internal.{ExpectationState, InvalidCall, MockException}
 import zio.test.mock.module.{ImpureModule, ImpureModuleMock}
-import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.test.{Assertion, Spec, TestFailure, TestSuccess, ZIOBaseSpec}
 import zio.{IO, UIO}
 
 object BasicMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModule] {

--- a/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/BasicStreamMockSpec.scala
@@ -3,7 +3,7 @@ package zio.test.mock
 import zio.Chunk
 import zio.stream.{ZSink, ZStream}
 import zio.test.mock.module.{StreamModule, StreamModuleMock}
-import zio.test.{Annotations, Assertion, TestAspect, ZIOBaseSpec, ZSpec, suite}
+import zio.test.{Annotations, Assertion, TestAspect, ZIOBaseSpec, ZSpec}
 
 object BasicStreamMockSpec extends ZIOBaseSpec with MockSpecUtils[StreamModule] {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -5,7 +5,7 @@ import zio.console.Console
 import zio.duration._
 import zio.random.Random
 import zio.system.System
-import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assertM, suite, testM}
+import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assertM}
 import zio.{Has, Tag, ULayer, ZIO, clock, console, random, system}
 
 object ComposedMockSpec extends ZIOBaseSpec {

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.Has
 import zio.test.mock.module.{PureModule, PureModuleMock}
-import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assert, suite}
+import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assert}
 
 object ExpectationSpec extends ZIOBaseSpec {
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/PolyMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/PolyMockSpec.scala
@@ -2,7 +2,7 @@ package zio.test.mock
 
 import zio.test.mock.internal.{InvalidCall, MockException}
 import zio.test.mock.module.{PureModule, PureModuleMock}
-import zio.test.{Annotations, Assertion, Spec, TestAspect, TestFailure, TestSuccess, ZIOBaseSpec, suite}
+import zio.test.{Annotations, Assertion, Spec, TestAspect, TestFailure, TestSuccess, ZIOBaseSpec}
 
 object PolyMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule] {
 

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -16,10 +16,10 @@
 
 package zio.test
 
-import zio.URIO
 import zio.clock.Clock
 import zio.duration._
 import zio.test.environment.TestEnvironment
+import zio.{URIO, ZIO}
 
 /**
  * A default runnable spec that provides testable versions of all of the
@@ -42,8 +42,20 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
     runner.run(aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers)
 
   /**
+   * Builds a suite containing a number of other specs.
+   */
+  def suite[R, E, T](label: String)(specs: Spec[R, E, T]*): Spec[R, E, T] =
+    zio.test.suite(label)(specs: _*)
+
+  /**
    * Builds a spec with a single pure test.
    */
   def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =
     zio.test.test(label)(assertion)
+
+  /**
+   * Builds a spec with a single effectful test.
+   */
+  def testM[R, E](label: String)(assertion: => ZIO[R, E, TestResult])(implicit loc: SourceLocation): ZSpec[R, E] =
+    zio.test.testM(label)(assertion)
 }


### PR DESCRIPTION
This is a follow-up of sorts to #4520/#4532. Introduces `suite` and `testM` in addition to `test` on the `DefaultRunnableSpec`. This allows creating an entire suite just with importing `zio.test.DefaultRunnableSpec` and nothing else:

```
import zio.ZIO
import zio.test.{DefaultRunnableSpec, assertCompletes}

object ImportlessSpec extends DefaultRunnableSpec {
  val spec = suite("Importless suite")(
    test("Importless test")(assertCompletes),
    testM("Importless effectful test")(ZIO.succeed(assertCompletes))
  )
}
```

Additional imports (`zio.ZIO`, assertions) may be added as needed. But this suite compiles and runs without explicitly adding `import zio.test._`.