### PR TITLE
Address Flaky Tests

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -4,7 +4,7 @@ import zio.clock.Clock
 import zio.duration._
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.test.TestAspect.{failing, flaky, timeout}
+import zio.test.TestAspect.{failing, timeout}
 import zio.test._
 import zio.test.environment.{TestClock, TestRandom}
 
@@ -133,10 +133,10 @@ object ScheduleSpec extends ZIOBaseSpec {
         assertM(scheduled)(equalTo(expected))
       },
       testM("free from stack overflow") {
-        assertM(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(1000000)).runCount)(
-          equalTo(1000000L)
+        assertM(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(100000)).runCount)(
+          equalTo(100000L)
         )
-      } @@ flaky
+      }
     ),
     suite("Retry on failure according to a provided strategy")(
       testM("retry 0 time for `once` when first time succeeds") {


### PR DESCRIPTION
First part of effort to address flaky tests.

This test in `ScheduleSpec` is causing significant flakiness because evaluating a stream produces from a schedule that generates a million elements just takes too long. Reducing the size to a hundred thousand should eliminate the timeout issue while still preventing regressions.

There may be other sources of flakiness as well but in my observation this is by far the most common one right now so addressing it should lead to both an immediate increase in stability and make it easier to identify other issues.