### PR TITLE
Support Collection Transformations For Effects Returning Nothing

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -896,7 +896,17 @@ object ZIOSpec extends ZIOBaseSpec {
             assert(result3.dieOption)(isSome(equalTo(boom))) && assert(result3.interrupted)(isTrue)
           }
         }
-      } @@ nonFlaky
+      } @@ nonFlaky,
+      testM("infers correctly") {
+        for {
+          ref <- Ref.make(0)
+          worker = ZIO.never
+          workers = List.fill(4)(worker)
+          fiber <- ZIO.forkAll(workers)
+          _     <- fiber.interrupt
+          value <- ref.get
+        } yield assert(value)(equalTo(0))
+      }
     ),
     suite("forkAs")(
       testM("child has specified name") {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -899,12 +899,12 @@ object ZIOSpec extends ZIOBaseSpec {
       } @@ nonFlaky,
       testM("infers correctly") {
         for {
-          ref <- Ref.make(0)
-          worker = ZIO.never
+          ref    <- Ref.make(0)
+          worker  = ZIO.never
           workers = List.fill(4)(worker)
-          fiber <- ZIO.forkAll(workers)
-          _     <- fiber.interrupt
-          value <- ref.get
+          fiber  <- ZIO.forkAll(workers)
+          _      <- fiber.interrupt
+          value  <- ref.get
         } yield assert(value)(equalTo(0))
       }
     ),

--- a/core/shared/src/main/scala-2.13+/zio/BuildFromCompat.scala
+++ b/core/shared/src/main/scala-2.13+/zio/BuildFromCompat.scala
@@ -1,5 +1,12 @@
 package zio
 
+import scala.collection.IterableOps
+
 private[zio] trait BuildFromCompat {
+
   type BuildFrom[-From, -A, +C] = scala.collection.BuildFrom[From, A, C]
+
+  implicit def buildFromAny[Element, Collection[+Element] <: Iterable[Element] with IterableOps[Any, Collection, Any]]
+    : BuildFrom[Collection[Any], Element, Collection[Element]] =
+    scala.collection.BuildFrom.buildFromIterableOps[Collection, Any, Element]
 }


### PR DESCRIPTION
We have had an issue with collection transformation where an implicit `BuildFrom` cannot be found on Scala 2.13 when the return type of the effect is `Nothing`. See scala/bug#12104. This PR resolves that by implementing a new `canBuildFromAny` instance which provides proof that given an original collection `Collection[Any]` and an element type `Element` we can build a `Collection[Element]`.