### PR TITLE
Optimize ZQueue#takeBetween

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -269,6 +269,16 @@ object ZQueueSpec extends ZIOBaseSpec {
           getter  = queue.takeBetween(5, 10)
           res    <- getter.race(updater)
         } yield assert(res)(hasSize(isGreaterThanEqualTo(5)))
+      },
+      testM("returns elements in the correct order") {
+        checkM(Gen.listOf(Gen.int(-10, 10))) { as =>
+          for {
+            queue <- Queue.bounded[Int](100)
+            f     <- ZIO.foreach(as)(queue.offer).fork
+            bs    <- queue.takeBetween(as.length, as.length)
+            _     <- f.interrupt
+          } yield assert(as)(equalTo(bs))
+        }
       }
     ),
     testM("offerAll with takeAll") {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -103,9 +103,10 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
   def takeUpTo(max: Int): ZIO[RB, EB, List[B]]
 
   /**
-   * Takes between min and max number of values from the queue. If there
-   * is less than min items available, it'll block until the items are
-   * collected.
+   * Takes a number of elements from the queue between the specified minimum
+   * and maximum. If there are fewer than the minimum number of elements
+   * available, suspends until at least the minimum number of elements have
+   * been collected.
    */
   final def takeBetween(min: Int, max: Int): ZIO[RB, EB, List[B]] =
     ZIO.effectSuspendTotal {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -20,8 +20,8 @@ import zio.ZQueue.internal._
 import zio.internal.MutableConcurrentQueue
 
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.collection.mutable.ListBuffer
 import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
 
 /**
  * A `ZQueue[RA, RB, EA, EB, A, B]` is a lightweight, asynchronous queue into which values of

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -112,7 +112,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
     ZIO.effectSuspendTotal {
       val buffer = ListBuffer[B]()
 
-      def takeRemainder(min: Int, max: Int): ZIO[RB, EB, Unit] =
+      def takeRemainder(min: Int, max: Int): ZIO[RB, EB, Any] =
         if (max < min) ZIO.unit
         else
           takeUpTo(max).flatMap { bs =>


### PR DESCRIPTION
Currently, the `takeBetween` operator on `ZQueue` starts out by calling `takeUpTo`, which has an optimized implementation that attempts to immediately take the specified number of elements from the underlying queue. However, if the elements are not immediately available we fall back to repeatedly taking individual elements from the queue. This causes us to lose the benefits of taking multiple elements at once if they are not immediately available.

This PR change the implementation of `takeBetween`  to call `take`  once if additional elements are required to suspend until new elements are available but then to recursively call `takeBetween` to attempt to take multiple queue elements again in case more elements are available by the time we resume.