### PR TITLE
Support Bulk Queue Operations Directly in the RingBuffer

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
@@ -16,8 +16,8 @@ import java.util.concurrent.TimeUnit
  */
 class QueueChunkBenchmark {
 
-  val totalSize   = 100000
-  val chunkSize   = 1000
+  val totalSize   = 1000
+  val chunkSize   = 10
   val parallelism = 5
 
   var zioQ: Queue[Int] = _

--- a/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
@@ -4,7 +4,6 @@ import org.openjdk.jmh.annotations._
 import zio.IOBenchmarks._
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueChunkBenchmark.scala
@@ -1,0 +1,64 @@
+package zio
+
+import org.openjdk.jmh.annotations._
+import zio.IOBenchmarks._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(1)
+/**
+ * This benchmark offers and takes a number of items in parallel, without back pressure.
+ */
+class QueueChunkBenchmark {
+
+  val totalSize   = 100000
+  val chunkSize   = 1000
+  val parallelism = 5
+
+  var zioQ: Queue[Int] = _
+  val chunk: List[Int] = List.fill(chunkSize)(0)
+
+  @Setup(Level.Trial)
+  def createQueues(): Unit =
+    zioQ = unsafeRun(Queue.bounded[Int](totalSize))
+
+  @Benchmark
+  def zioQueueSequential(): Int = {
+
+    def repeat(task: UIO[Unit], max: Int): UIO[Unit] =
+      if (max < 1) IO.unit
+      else task.flatMap(_ => repeat(task, max - 1))
+
+    val io = for {
+      _ <- repeat(zioQ.offerAll(chunk).unit, totalSize / chunkSize)
+      _ <- repeat(zioQ.takeUpTo(chunkSize).unit, totalSize / chunkSize)
+    } yield 0
+
+    unsafeRun(io)
+  }
+
+  @Benchmark
+  def zioQueueParallel(): Int = {
+
+    val io = for {
+      offers <- IO.forkAll(
+                  List.fill(parallelism)(repeat(totalSize * 1 / chunkSize * 1 / parallelism)(zioQ.offerAll(chunk).unit))
+                )
+      takes <- IO.forkAll(
+                 List.fill(parallelism)(
+                   repeat(totalSize * 1 / chunkSize * 1 / parallelism)(zioQ.takeBetween(chunkSize, chunkSize).unit)
+                 )
+               )
+      _ <- offers.join
+      _ <- takes.join
+    } yield 0
+
+    unsafeRun(io)
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/internal/RingBufferArbConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/RingBufferArbConcurrencyTests.scala
@@ -166,4 +166,149 @@ object RingBufferArbConcurrencyTests {
       r.r4 = p22
     }
   }
+
+  /*
+   * Tests that [[RingBufferArb.offerAll]] is atomic.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("1, 2, 3, 4"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 2, 4"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 4, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 4, 1, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 4, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 2, 4"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllTest {
+    val q: RingBufferArb[Int] = RingBufferArb(4)
+
+    @Actor
+    def actor1(): Unit = {
+      q.offerAll(List(1, 2))
+      ()
+    }
+
+    @Actor
+    def actor2(): Unit = {
+      q.offerAll(List(3, 4))
+      ()
+    }
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = q.poll(-1)
+      r.r2 = q.poll(-2)
+      r.r3 = q.poll(-3)
+      r.r4 = q.poll(-4)
+    }
+  }
+
+  /*
+   * Tests that [[RingBufferArb.offerAll]] honors capacity, i.e. operations are atomic and no values get lost or overwritten.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("1, 2, 0, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 1, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 1, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 4, 2, 0"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllTestMaxedCapacity {
+    val q: RingBufferArb[Int] = RingBufferArb(2)
+    var (offer1, offer2)      = (0, 0)
+
+    @Actor
+    def actor1(): Unit =
+      offer1 = q.offerAll(List(1, 2)).size
+
+    @Actor
+    def actor2(): Unit =
+      offer2 = q.offerAll(List(3, 4)).size
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = q.poll(-1)
+      r.r2 = q.poll(-2)
+
+      r.r3 = offer1
+      r.r4 = offer2
+    }
+  }
+
+  /*
+   * Tests that polls are atomic, i.e. no value gets polled twice or not polled at all.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(
+        id = Array("-10, -11, -20, -21"),
+        expect = Expect.ACCEPTABLE,
+        desc = "Both pollers finish before offer starts"
+      ),
+      /*
+       * Only the first offer finishes before pollers start polling.
+       * Expect.ACCEPTABLE outcomes are those when at most one poller gets the element during 1st or 2nd poll.
+       */
+      new Outcome(id = Array("1, -11, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, -20, 1"), expect = Expect.ACCEPTABLE),
+      /*
+       * Both offers finish before pollers start to poll.
+       * Expect.ACCEPTABLE outcomes are those where elements are dequeued exactly once,
+       * and if both dequeues happen within a single thread elements are dequeued
+       * in order (1 and then 2).
+       */
+      new Outcome(id = Array("1, 2, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, -11, 2, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, -11, -20, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, 2, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, -20, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, 1, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("2, -11, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("2, -11, -20, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 2, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 2, -20, 1"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllPollUpToTest {
+    val q: RingBufferArb[Int] = RingBufferArb(2)
+    var (p1, p2, p3, p4)      = (0, 0, 0, 0)
+
+    @Actor
+    def actor1(): Unit = {
+      q.offerAll(List(1, 2))
+      ()
+    }
+
+    @Actor
+    def actor2(): Unit = {
+      val chunk = q.pollUpTo(2).toIndexedSeq
+      p1 = chunk.lift(0).getOrElse(-10)
+      p2 = chunk.lift(1).getOrElse(-11)
+    }
+
+    @Actor
+    def actor3(): Unit = {
+      val chunk = q.pollUpTo(2).toIndexedSeq
+      p3 = chunk.lift(0).getOrElse(-20)
+      p4 = chunk.lift(1).getOrElse(-21)
+    }
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = p1
+      r.r2 = p2
+      r.r3 = p3
+      r.r4 = p4
+    }
+  }
 }

--- a/core-tests/jvm/src/test/scala/zio/internal/RingBufferPow2ConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/RingBufferPow2ConcurrencyTests.scala
@@ -166,4 +166,149 @@ object RingBufferPow2ConcurrencyTests {
       r.r4 = p22
     }
   }
+
+  /*
+   * Tests that [[RingBufferArb.offerAll]] is atomic.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("1, 2, 3, 4"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 2, 4"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 4, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 4, 1, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 4, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 2, 4"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllTest {
+    val q: RingBufferArb[Int] = RingBufferArb(4)
+
+    @Actor
+    def actor1(): Unit = {
+      q.offerAll(List(1, 2))
+      ()
+    }
+
+    @Actor
+    def actor2(): Unit = {
+      q.offerAll(List(3, 4))
+      ()
+    }
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = q.poll(-1)
+      r.r2 = q.poll(-2)
+      r.r3 = q.poll(-3)
+      r.r4 = q.poll(-4)
+    }
+  }
+
+  /*
+   * Tests that [[RingBufferArb.offerAll]] honors capacity, i.e. operations are atomic and no values get lost or overwritten.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("1, 2, 0, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, 3, 1, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 1, 1, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("3, 4, 2, 0"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllTestMaxedCapacity {
+    val q: RingBufferArb[Int] = RingBufferArb(2)
+    var (offer1, offer2)      = (0, 0)
+
+    @Actor
+    def actor1(): Unit =
+      offer1 = q.offerAll(List(1, 2)).size
+
+    @Actor
+    def actor2(): Unit =
+      offer2 = q.offerAll(List(3, 4)).size
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = q.poll(-1)
+      r.r2 = q.poll(-2)
+
+      r.r3 = offer1
+      r.r4 = offer2
+    }
+  }
+
+  /*
+   * Tests that polls are atomic, i.e. no value gets polled twice or not polled at all.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(
+        id = Array("-10, -11, -20, -21"),
+        expect = Expect.ACCEPTABLE,
+        desc = "Both pollers finish before offer starts"
+      ),
+      /*
+       * Only the first offer finishes before pollers start polling.
+       * Expect.ACCEPTABLE outcomes are those when at most one poller gets the element during 1st or 2nd poll.
+       */
+      new Outcome(id = Array("1, -11, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, -20, 1"), expect = Expect.ACCEPTABLE),
+      /*
+       * Both offers finish before pollers start to poll.
+       * Expect.ACCEPTABLE outcomes are those where elements are dequeued exactly once,
+       * and if both dequeues happen within a single thread elements are dequeued
+       * in order (1 and then 2).
+       */
+      new Outcome(id = Array("1, 2, -20, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, -11, 2, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("1, -11, -20, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, 2, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 1, -20, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, -11, 1, 2"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("2, -11, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("2, -11, -20, 1"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 2, 1, -21"), expect = Expect.ACCEPTABLE),
+      new Outcome(id = Array("-10, 2, -20, 1"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class OfferAllPollUpToTest {
+    val q: RingBufferArb[Int] = RingBufferArb(2)
+    var (p1, p2, p3, p4)      = (0, 0, 0, 0)
+
+    @Actor
+    def actor1(): Unit = {
+      q.offerAll(List(1, 2))
+      ()
+    }
+
+    @Actor
+    def actor2(): Unit = {
+      val chunk = q.pollUpTo(2).toIndexedSeq
+      p1 = chunk.lift(0).getOrElse(-10)
+      p2 = chunk.lift(1).getOrElse(-11)
+    }
+
+    @Actor
+    def actor3(): Unit = {
+      val chunk = q.pollUpTo(2).toIndexedSeq
+      p3 = chunk.lift(0).getOrElse(-20)
+      p4 = chunk.lift(1).getOrElse(-21)
+    }
+
+    @Arbiter
+    def arbiter(r: IIII_Result): Unit = {
+      r.r1 = p1
+      r.r2 = p2
+      r.r3 = p3
+      r.r4 = p4
+    }
+  }
 }

--- a/core/js/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/js/src/main/scala/zio/internal/RingBuffer.scala
@@ -111,60 +111,76 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     }
   }
 
-  override def offerAll(as: Iterable[A]): Iterable[A] = {
-    var curSeq   = 0L
-    var curHead  = 0L
-    var curTail  = tail
-    var curIdx   = 0
-    val offers   = as.size.toLong
-    var forQueue = math.min(offers, capacity - (curTail - curHead))
-    var enqTail  = 0L
-    var state    = STATE_LOOP
+  override final def offerAll(as: Iterable[A]): Iterable[A] = {
+    var curSeq  = 0L
+    var curHead = 0L
+    var curTail = tail
+    var curIdx  = 0
+    var state   = STATE_LOOP
+    val offers  = as.size.toLong
+    var enqHead = 0L
+    var enqTail = 0L
 
     while (state == STATE_LOOP) {
+      curHead = head
+      curTail = tail
+      val size      = curTail - curHead
+      val available = capacity - size
+      val forQueue  = math.min(offers, available)
       if (forQueue == 0) {
+        // There are no elements to offer or no space in the queue, terminate
+        // immediately.
         state = STATE_FULL
       } else {
-        curIdx = posToIdx(curTail, capacity)
-        curSeq = seq(curIdx)
-        if (curSeq < curTail) {
-          curHead = head
-          if (curTail >= curHead + capacity) {
-            state = STATE_LOOP
-          } else {
-            state = STATE_FULL
+        // We know that space for this many elements has been reserved in the
+        // queue. However, elements in some of these spaces may be in the
+        // process of being dequeued so we need to check for that.
+        enqHead = curTail
+        enqTail = curTail + forQueue
+        var continue = true
+        while (continue & enqHead < enqTail) {
+          curIdx = posToIdx(enqHead, capacity)
+          curSeq = seq(curIdx)
+          if (curSeq != enqHead) {
+            // The element at this spot has not been dequeued yet, or possibly
+            // has been dequeued and another thread has already enqueued a new
+            // element. We need to abort and retry.
+            continue = false
           }
-        } else if (curSeq == curTail) {
-          enqTail = curTail + forQueue
-          if (tail == curTail) {
-            tail = enqTail
-            state = STATE_RESERVED
-          } else {
-            curTail += 1
-            forQueue -= 1
-            state = STATE_LOOP
-          }
+          enqHead += 1
+        }
+        // If all elements have been dequeued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && tail == curTail) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // enqueue the elements and publish our changes.
+          tail = enqTail
+          enqHead = curTail
+          state = STATE_RESERVED
         } else {
-          curHead = head
-          curTail = tail
-          forQueue = math.min(offers, capacity - (curTail - curHead))
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
-
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Enqueue the
+      // elements sequentially and publish our changes as we go.
       val iterator = as.iterator
-      while (curTail < enqTail) {
+      while (enqHead < enqTail) {
         val a = iterator.next()
-        curIdx = posToIdx(curTail, capacity)
+        curIdx = posToIdx(enqHead, capacity)
         buf(curIdx) = a.asInstanceOf[AnyRef]
-        seq(curIdx) = curTail + 1
-        curTail += 1
+        seq(curIdx) = enqHead + 1
+        enqHead += 1
       }
       Chunk.fromIterator(iterator)
     } else {
+      // There was no space in the queue or the original collection was empty.
+      // Just return the original collection unchanged.
       as
     }
   }
@@ -244,61 +260,75 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     }
   }
 
-  override def pollUpTo(n: Int): Iterable[A] = {
+  override final def pollUpTo(n: Int): Iterable[A] = {
     var curSeq  = 0L
     var curHead = head
     var curIdx  = 0
-    var curTail = tail
-    val takers  = n.toLong
-    var toTake  = math.min(takers, curTail - curHead)
-    var deqHead = 0L
+    var curTail = 0L
     var state   = STATE_LOOP
+    val takers  = n.toLong
+    var deqHead = 0L
+    var deqTail = 0L
 
     while (state == STATE_LOOP) {
-      if (toTake == 0) {
+      curHead = head
+      curTail = tail
+      val size   = curTail - curHead
+      val toTake = math.min(takers, size)
+      if (toTake <= 0) {
+        // There are no elements to take, terminate immediately.
         state = STATE_EMPTY
       } else {
-        curIdx = posToIdx(curHead, capacity)
-        curSeq = seq(curIdx)
-        if (curSeq <= curHead) {
-          curTail = tail
-          if (curHead >= curTail) {
-            state = STATE_EMPTY
-          } else {
-            state = STATE_LOOP
+        // We know that space for this many elements has been reserved in the
+        // queue. However, some of these elements may still be in the process
+        // of being enqueued, so we need to check for that.
+        deqHead = curHead
+        deqTail = curHead + toTake
+        var continue = true
+        while (continue && deqHead < deqTail) {
+          curIdx = posToIdx(deqHead, capacity)
+          curSeq = seq(curIdx)
+          if (curSeq != deqHead + 1) {
+            // The element at this spot has not been enqueued yet, or possibly
+            // has been enqueued and already dequeued by another thread. We
+            // need to abort and retry.
+            continue = false
           }
-        } else if (curSeq == curHead + 1) {
-          deqHead = curHead + toTake
-          if (head == curHead) {
-            head = deqHead
-            state = STATE_RESERVED
-          } else {
-            curHead += 1
-            toTake -= 1
-            state = STATE_LOOP
-          }
+          deqHead += 1
+        }
+        // If all elements have been enqueued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && head == curHead) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // dequeue the elements and publish our changes.
+          head = deqTail
+          deqHead = curHead
+          state = STATE_RESERVED
         } else {
-          curHead = head
-          curTail = tail
-          toTake = math.min(takers, curTail - curHead)
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Dequeue the
+      // elements sequentially and publish our changes as we go.
       val builder = ChunkBuilder.make[A]()
       builder.sizeHint(n)
-      while (curHead < deqHead) {
-        curIdx = posToIdx(curHead, capacity)
+      while (deqHead < deqTail) {
+        curIdx = posToIdx(deqHead, capacity)
         val a = buf(curIdx).asInstanceOf[A]
         buf(curIdx) = null
-        seq(curIdx) = curHead + capacity
+        seq(curIdx) = deqHead + capacity
         builder += a
-        curHead += 1
+        deqHead += 1
       }
       builder.result()
     } else {
+      // There were no elements to take, just return an empty collection.
       Chunk.empty
     }
   }

--- a/core/js/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/js/src/main/scala/zio/internal/RingBuffer.scala
@@ -248,7 +248,7 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     var curSeq  = 0L
     var curHead = head
     var curIdx  = 0
-    var curTail = 0L
+    var curTail = tail
     val takers  = n.toLong
     var toTake  = math.min(takers, curTail - curHead)
     var deqHead = 0L

--- a/core/js/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/js/src/main/scala/zio/internal/RingBuffer.scala
@@ -112,14 +112,14 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
   }
 
   override def offerAll(as: Iterable[A]): Iterable[A] = {
-    var curSeq  = 0L
-    var curHead = 0L
-    var curTail = tail
-    var curIdx  = 0
+    var curSeq   = 0L
+    var curHead  = 0L
+    var curTail  = tail
+    var curIdx   = 0
     val offers   = as.size.toLong
     var forQueue = math.min(offers, capacity - (curTail - curHead))
     var enqTail  = 0L
-    var state   = STATE_LOOP
+    var state    = STATE_LOOP
 
     while (state == STATE_LOOP) {
       if (forQueue == 0) {

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -272,7 +272,7 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
       val size      = curTail - curHead
       val available = aCapacity - size
       val forQueue  = math.min(offers, available)
-      if (forQueue <= 0) {
+      if (forQueue == 0) {
         state = STATE_FULL
       } else {
         enqHead = curTail
@@ -280,13 +280,13 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
         var loop = true
         while (loop & enqHead < enqTail) {
           curIdx = posToIdx(enqHead, aCapacity)
-          curSeq = seq.get(curIdx)
+          curSeq = aSeq.get(curIdx)
           if (curSeq != enqHead) {
             loop = false
           }
           enqHead += 1
         }
-        if (enqHead == enqTail && aTail.compareAndSet(this, curTail, enqTail)) {
+        if (loop && aTail.compareAndSet(this, curTail, enqTail)) {
           state = STATE_RESERVED
         } else {
           state = STATE_LOOP
@@ -431,13 +431,13 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
         var loop = true
         while (loop && deqHead < deqTail) {
           curIdx = posToIdx(deqHead, aCapacity)
-          curSeq = seq.get(curIdx)
+          curSeq = aSeq.get(curIdx)
           if (curSeq != deqHead + 1) {
             loop = false
           }
           deqHead += 1
         }
-        if (deqHead == deqTail && aHead.compareAndSet(this, curHead, deqTail)) {
+        if (loop && aHead.compareAndSet(this, curHead, deqTail)) {
           state = STATE_RESERVED
         } else {
           state = STATE_LOOP

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -273,38 +273,58 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
       val available = aCapacity - size
       val forQueue  = math.min(offers, available)
       if (forQueue == 0) {
+        // There are no elements to offer or no space in the queue, terminate
+        // immediately.
         state = STATE_FULL
       } else {
+        // We know that space for this many elements has been reserved in the
+        // queue. However, elements in some of these spaces may be in the
+        // process of being dequeued so we need to check for that.
         enqHead = curTail
         enqTail = curTail + forQueue
-        var loop = true
-        while (loop & enqHead < enqTail) {
+        var continue = true
+        while (continue & enqHead < enqTail) {
           curIdx = posToIdx(enqHead, aCapacity)
           curSeq = aSeq.get(curIdx)
           if (curSeq != enqHead) {
-            loop = false
+            // The element at this spot has not been dequeued yet, or possibly
+            // has been dequeued and another thread has already enqueued a new
+            // element. We need to abort and retry.
+            continue = false
           }
           enqHead += 1
         }
-        if (loop && aTail.compareAndSet(this, curTail, enqTail)) {
+        // If all elements have been dequeued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && aTail.compareAndSet(this, curTail, enqTail)) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // enqueue the elements and publish our changes.
+          enqHead = curTail
           state = STATE_RESERVED
         } else {
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Enqueue the
+      // elements sequentially and publish our changes as we go.
       val iterator = as.iterator
-      while (curTail < enqTail) {
+      while (enqHead < enqTail) {
         val a = iterator.next()
-        curIdx = posToIdx(curTail, aCapacity)
+        curIdx = posToIdx(enqHead, aCapacity)
         buf(curIdx) = a.asInstanceOf[AnyRef]
-        aSeq.lazySet(curIdx, curTail + 1)
-        curTail += 1
+        aSeq.lazySet(curIdx, enqHead + 1)
+        enqHead += 1
       }
       Chunk.fromIterator(iterator)
     } else {
+      // There was no space in the queue or the original collection was empty.
+      // Just return the original collection unchanged.
       as
     }
   }
@@ -424,40 +444,58 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
       val size   = curTail - curHead
       val toTake = math.min(takers, size)
       if (toTake <= 0) {
+        // There are no elements to take, terminate immediately.
         state = STATE_EMPTY
       } else {
+        // We know that space for this many elements has been reserved in the
+        // queue. However, some of these elements may still be in the process
+        // of being enqueued, so we need to check for that.
         deqHead = curHead
         deqTail = curHead + toTake
-        var loop = true
-        while (loop && deqHead < deqTail) {
+        var continue = true
+        while (continue && deqHead < deqTail) {
           curIdx = posToIdx(deqHead, aCapacity)
           curSeq = aSeq.get(curIdx)
           if (curSeq != deqHead + 1) {
-            loop = false
+            // The element at this spot has not been enqueued yet, or possibly
+            // has been enqueued and already dequeued by another thread. We
+            // need to abort and retry.
+            continue = false
           }
           deqHead += 1
         }
-        if (loop && aHead.compareAndSet(this, curHead, deqTail)) {
+        // If all elements have been enqueued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && aHead.compareAndSet(this, curHead, deqTail)) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // dequeue the elements and publish our changes.
+          deqHead = curHead
           state = STATE_RESERVED
         } else {
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Dequeue the
+      // elements sequentially and publish our changes as we go.
       val builder = ChunkBuilder.make[A]()
       builder.sizeHint(n)
-      while (curHead < deqTail) {
-        curIdx = posToIdx(curHead, aCapacity)
+      while (deqHead < deqTail) {
+        curIdx = posToIdx(deqHead, aCapacity)
         val a = buf(curIdx).asInstanceOf[A]
         buf(curIdx) = null
-        aSeq.lazySet(curIdx, curHead + aCapacity)
+        aSeq.lazySet(curIdx, deqHead + aCapacity)
         builder += a
-        curHead += 1
+        deqHead += 1
       }
       builder.result()
     } else {
+      // There were no elements to take, just return an empty collection.
       Chunk.empty
     }
   }

--- a/core/native/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/RingBuffer.scala
@@ -111,60 +111,76 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     }
   }
 
-  override def offerAll(as: Iterable[A]): Iterable[A] = {
-    var curSeq   = 0L
-    var curHead  = 0L
-    var curTail  = tail
-    var curIdx   = 0
-    val offers   = as.size.toLong
-    var forQueue = math.min(offers, capacity - (curTail - curHead))
-    var enqTail  = 0L
-    var state    = STATE_LOOP
+  override final def offerAll(as: Iterable[A]): Iterable[A] = {
+    var curSeq  = 0L
+    var curHead = 0L
+    var curTail = tail
+    var curIdx  = 0
+    var state   = STATE_LOOP
+    val offers  = as.size.toLong
+    var enqHead = 0L
+    var enqTail = 0L
 
     while (state == STATE_LOOP) {
+      curHead = head
+      curTail = tail
+      val size      = curTail - curHead
+      val available = capacity - size
+      val forQueue  = math.min(offers, available)
       if (forQueue == 0) {
+        // There are no elements to offer or no space in the queue, terminate
+        // immediately.
         state = STATE_FULL
       } else {
-        curIdx = posToIdx(curTail, capacity)
-        curSeq = seq(curIdx)
-        if (curSeq < curTail) {
-          curHead = head
-          if (curTail >= curHead + capacity) {
-            state = STATE_LOOP
-          } else {
-            state = STATE_FULL
+        // We know that space for this many elements has been reserved in the
+        // queue. However, elements in some of these spaces may be in the
+        // process of being dequeued so we need to check for that.
+        enqHead = curTail
+        enqTail = curTail + forQueue
+        var continue = true
+        while (continue & enqHead < enqTail) {
+          curIdx = posToIdx(enqHead, capacity)
+          curSeq = seq(curIdx)
+          if (curSeq != enqHead) {
+            // The element at this spot has not been dequeued yet, or possibly
+            // has been dequeued and another thread has already enqueued a new
+            // element. We need to abort and retry.
+            continue = false
           }
-        } else if (curSeq == curTail) {
-          enqTail = curTail + forQueue
-          if (tail == curTail) {
-            tail = enqTail
-            state = STATE_RESERVED
-          } else {
-            curTail += 1
-            forQueue -= 1
-            state = STATE_LOOP
-          }
+          enqHead += 1
+        }
+        // If all elements have been dequeued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && tail == curTail) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // enqueue the elements and publish our changes.
+          tail = enqTail
+          enqHead = curTail
+          state = STATE_RESERVED
         } else {
-          curHead = head
-          curTail = tail
-          forQueue = math.min(offers, capacity - (curTail - curHead))
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
-
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Enqueue the
+      // elements sequentially and publish our changes as we go.
       val iterator = as.iterator
-      while (curTail < enqTail) {
+      while (enqHead < enqTail) {
         val a = iterator.next()
-        curIdx = posToIdx(curTail, capacity)
+        curIdx = posToIdx(enqHead, capacity)
         buf(curIdx) = a.asInstanceOf[AnyRef]
-        seq(curIdx) = curTail + 1
-        curTail += 1
+        seq(curIdx) = enqHead + 1
+        enqHead += 1
       }
       Chunk.fromIterator(iterator)
     } else {
+      // There was no space in the queue or the original collection was empty.
+      // Just return the original collection unchanged.
       as
     }
   }
@@ -244,61 +260,75 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     }
   }
 
-  override def pollUpTo(n: Int): Iterable[A] = {
+  override final def pollUpTo(n: Int): Iterable[A] = {
     var curSeq  = 0L
     var curHead = head
     var curIdx  = 0
-    var curTail = tail
-    val takers  = n.toLong
-    var toTake  = math.min(takers, curTail - curHead)
-    var deqHead = 0L
+    var curTail = 0L
     var state   = STATE_LOOP
+    val takers  = n.toLong
+    var deqHead = 0L
+    var deqTail = 0L
 
     while (state == STATE_LOOP) {
-      if (toTake == 0) {
+      curHead = head
+      curTail = tail
+      val size   = curTail - curHead
+      val toTake = math.min(takers, size)
+      if (toTake <= 0) {
+        // There are no elements to take, terminate immediately.
         state = STATE_EMPTY
       } else {
-        curIdx = posToIdx(curHead, capacity)
-        curSeq = seq(curIdx)
-        if (curSeq <= curHead) {
-          curTail = tail
-          if (curHead >= curTail) {
-            state = STATE_EMPTY
-          } else {
-            state = STATE_LOOP
+        // We know that space for this many elements has been reserved in the
+        // queue. However, some of these elements may still be in the process
+        // of being enqueued, so we need to check for that.
+        deqHead = curHead
+        deqTail = curHead + toTake
+        var continue = true
+        while (continue && deqHead < deqTail) {
+          curIdx = posToIdx(deqHead, capacity)
+          curSeq = seq(curIdx)
+          if (curSeq != deqHead + 1) {
+            // The element at this spot has not been enqueued yet, or possibly
+            // has been enqueued and already dequeued by another thread. We
+            // need to abort and retry.
+            continue = false
           }
-        } else if (curSeq == curHead + 1) {
-          deqHead = curHead + toTake
-          if (head == curHead) {
-            head = deqHead
-            state = STATE_RESERVED
-          } else {
-            curHead += 1
-            toTake -= 1
-            state = STATE_LOOP
-          }
+          deqHead += 1
+        }
+        // If all elements have been enqueued, we can do compare and swap to
+        // try to reserve the space in the queue.
+        if (continue && head == curHead) {
+          // We successfully reserved the space in the queue. We can prepare to
+          // dequeue the elements and publish our changes.
+          head = deqTail
+          deqHead = curHead
+          state = STATE_RESERVED
         } else {
-          curHead = head
-          curTail = tail
-          toTake = math.min(takers, curTail - curHead)
+          // Another thread beat us to reserving space in the queue. We need to
+          // abort and retry.
           state = STATE_LOOP
         }
       }
     }
 
     if (state == STATE_RESERVED) {
+      // We have successfully resserved space in the queue and have exclusive
+      // ownership of each space until we publish our changes. Dequeue the
+      // elements sequentially and publish our changes as we go.
       val builder = ChunkBuilder.make[A]()
       builder.sizeHint(n)
-      while (curHead < deqHead) {
-        curIdx = posToIdx(curHead, capacity)
+      while (deqHead < deqTail) {
+        curIdx = posToIdx(deqHead, capacity)
         val a = buf(curIdx).asInstanceOf[A]
         buf(curIdx) = null
-        seq(curIdx) = curHead + capacity
+        seq(curIdx) = deqHead + capacity
         builder += a
-        curHead += 1
+        deqHead += 1
       }
       builder.result()
     } else {
+      // There were no elements to take, just return an empty collection.
       Chunk.empty
     }
   }

--- a/core/native/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/RingBuffer.scala
@@ -248,7 +248,7 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
     var curSeq  = 0L
     var curHead = head
     var curIdx  = 0
-    var curTail = 0L
+    var curTail = tail
     val takers  = n.toLong
     var toTake  = math.min(takers, curTail - curHead)
     var deqHead = 0L

--- a/core/native/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/RingBuffer.scala
@@ -112,14 +112,14 @@ final class RingBuffer[A](override final val capacity: Int) extends MutableConcu
   }
 
   override def offerAll(as: Iterable[A]): Iterable[A] = {
-    var curSeq  = 0L
-    var curHead = 0L
-    var curTail = tail
-    var curIdx  = 0
+    var curSeq   = 0L
+    var curHead  = 0L
+    var curTail  = tail
+    var curIdx   = 0
     val offers   = as.size.toLong
     var forQueue = math.min(offers, capacity - (curTail - curHead))
     var enqTail  = 0L
-    var state   = STATE_LOOP
+    var state    = STATE_LOOP
 
     while (state == STATE_LOOP) {
       if (forQueue == 0) {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -311,34 +311,14 @@ object ZQueue {
     /**
      * Poll n items from the queue
      */
-    def unsafePollN[A](q: MutableConcurrentQueue[A], max: Int): List[A] = {
-      val empty = null.asInstanceOf[A]
-
-      @tailrec
-      def poll(as: List[A], n: Int): List[A] =
-        if (n < 1) as
-        else
-          q.poll(empty) match {
-            case null => as
-            case a    => poll(a :: as, n - 1)
-          }
-
-      poll(List.empty[A], max).reverse
-    }
+    def unsafePollN[A](q: MutableConcurrentQueue[A], max: Int): List[A] =
+      q.pollUpTo(max).toList
 
     /**
      * Offer items to the queue
      */
-    def unsafeOfferAll[A](q: MutableConcurrentQueue[A], as: List[A]): List[A] = {
-      @tailrec
-      def offerAll(as: List[A]): List[A] =
-        as match {
-          case Nil          => as
-          case head :: tail => if (q.offer(head)) offerAll(tail) else as
-        }
-
-      offerAll(as)
-    }
+    def unsafeOfferAll[A](q: MutableConcurrentQueue[A], as: List[A]): List[A] =
+      q.offerAll(as).toList
 
     /**
      * Remove an item from the queue

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -16,6 +16,8 @@
 
 package zio.internal
 
+import zio.ChunkBuilder
+
 object MutableConcurrentQueue {
 
   /**
@@ -58,6 +60,25 @@ protected[zio] abstract class MutableConcurrentQueue[A] {
   def offer(a: A): Boolean
 
   /**
+   * A non-blocking enqueue of multiple elements.
+   */
+  def offerAll(as: Iterable[A]): Iterable[A] = {
+    val builder = ChunkBuilder.make[A]()
+    builder.sizeHint(as.size)
+    val iterator = as.iterator
+    var loop     = true
+    while (loop && iterator.hasNext) {
+      val a = iterator.next()
+      if (!offer(a)) {
+        builder += a
+        loop = false
+      }
+    }
+    builder ++= iterator
+    builder.result()
+  }
+
+  /**
    * A non-blocking dequeue.
    *
    * @return either an element from the queue, or the `default`
@@ -68,6 +89,23 @@ protected[zio] abstract class MutableConcurrentQueue[A] {
    * to pay for lower heap churn from not using [[scala.Option]] here.
    */
   def poll(default: A): A
+
+  /**
+   * A non-blocking dequeue of multiple elements.
+   */
+  def pollUpTo(n: Int): Iterable[A] = {
+    val builder = ChunkBuilder.make[A]()
+    builder.sizeHint(n)
+    val default = null.asInstanceOf[A]
+    var i       = n
+    while (i > 0) {
+      val a = poll(default)
+      if (a == default) i = 0
+      else builder += a
+      i -= 1
+    }
+    builder.result()
+  }
 
   /**
    * @return the '''current''' number of elements inside the queue.

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -16,6 +16,8 @@
 
 package zio.internal
 
+import com.github.ghik.silencer.silent
+
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 
@@ -42,6 +44,13 @@ private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with S
     val success = jucConcurrentQueue.offer(a)
     if (success) enqueuedCounter.incrementAndGet()
     success
+  }
+
+  override def offerAll(as: Iterable[A]): Iterable[A] = {
+    import collection.JavaConverters._
+    jucConcurrentQueue.addAll(as.asJavaCollection): @silent("JavaConverters")
+    enqueuedCounter.addAndGet(as.size.toLong)
+    Iterable.empty
   }
 
   override def poll(default: A): A = {


### PR DESCRIPTION
Operations on the `RingBuffer` take place in three phases:

1. Determination of whether a space is available based on its `seq` value
2. Reservation of the space by compare and set on the `head` or `tail`
3. Publishing the changes by setting the `seq`

Unfortunately given the concurrent nature of the `RingBuffer` there is no way to determine whether a group of spaces are available other than checking each of their `seq` values. However, we can take advantage of bulk operations by doing compare and swap once to reserve a whole block of spaces after we determine whether they are available. This reduces the number of compare and swap operations from `n` to `1`. The disadvantage is that there is more time between getting the initial state and doing the compare and set since we have to check the `seq` values in between.

As a baseline, here is the performance of the existing `ZQueue` benchmarks on my local machine for 1,000 elements with no chunking on `master`. Note that this is with my latest optimizations to `takeBetween`.

```
[info] Benchmark                           Mode  Cnt     Score    Error  Units
[info] QueueParallelBenchmark.zioQueue    thrpt    5  5043.535 ± 173.277  ops/s
[info] QueueSequentialBenchmark.zioQueue  thrpt    5  9357.960 ± 61.826  ops/s
```

Here is the performance, also on `master` of a new benchmark that is exactly the same except it uses `offerAll` and `takeBetween` with a chunk size of 10.

```
[info] Benchmark                                Mode  Cnt      Score     Error  Units
[info] QueueChunkBenchmark.zioQueueParallel    thrpt    5   6288.556 ± 255.551  ops/s
[info] QueueChunkBenchmark.zioQueueSequential  thrpt    5  20674.860 ±  86.972  ops/s
```

Here is the performance of the same benchmark on this branch.

```
[info] Benchmark                                Mode  Cnt      Score     Error  Units
[info] QueueChunkBenchmark.zioQueueParallel    thrpt   45  13610.646 ± 116.241  ops/s
[info] QueueChunkBenchmark.zioQueueSequential  thrpt   45  28048.018 ± 186.584  ops/s
```

One risk with this strategy is that under very high contention we could be caught repeatedly retrying. It could be interesting to explore tracking how many times we have retried a bulk operation and either reverting to the single element case or doing exponential backoff on the chunk size we attempt to offer.