### PR TITLE
Parameterized tests

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -41,14 +41,14 @@ lazy val tests = project
   .settings(
     skip in publish := true,
     libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
-    compile.in(Compile) := 
+    compile.in(Compile) :=
       compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
     scalafixTestkitOutputSourceDirectories :=
       sourceDirectories.in(output, Compile).value,
     scalafixTestkitInputSourceDirectories :=
       sourceDirectories.in(input, Compile).value,
     scalafixTestkitInputClasspath :=
-      fullClasspath.in(input, Compile).value,
+      fullClasspath.in(input, Compile).value
   )
   .dependsOn(rules)
   .enablePlugins(ScalafixTestkitPlugin)

--- a/test-tests/shared/src/test/scala/zio/test/TestAllSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAllSpec.scala
@@ -1,0 +1,35 @@
+package zio.test
+
+import zio.test.Assertion._
+import zio.{ZIO, ZManaged}
+
+object TestAllSpec extends ZIOBaseSpec {
+  val gen: Gen[Any, Int] = Gen.fromIterable(List(1, 2, 3))
+  val spec: ZSpec[Environment, Failure] = suite("Parameterized tests")(
+    testAllM("Runs a test for generated value")(gen) { value =>
+      val _ = value // do something with value
+      ZIO.succeedNow(assertCompletes)
+    },
+    suite("testAllM")(
+      testM("testAllM produces a given number of tests") {
+        val spec = testAllM("tests")(gen)(_ => ZIO.succeedNow(assertCompletes))
+        assertM(spec.countTests(_ => true).useNow)(equalTo(3))
+      },
+      testM("testAllM creates a label containing the parameter") {
+        val spec = testAllM("tests")(gen)(_ => ZIO.succeedNow(assertCompletes))
+        assertM(testLabels(spec).useNow)(
+          hasSameElements(
+            List("tests 1", "tests 2", "tests 3")
+          )
+        )
+      }
+    )
+  )
+
+  private def testLabels[R, E](spec: ZSpec[R, E]) =
+    spec.fold[ZManaged[R, Any, Vector[String]]] {
+      case Spec.SuiteCase(_, specs, _) => specs.flatMap(ZManaged.collectAll(_).map(_.flatten))
+      case Spec.TestCase(label, _, _)  => ZManaged.succeedNow(Vector(label))
+    }
+
+}

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -566,6 +566,20 @@ package object test extends CompileVariants {
       .annotate(TestAnnotation.location, loc :: Nil)
 
   /**
+   * Builds a parameterized spec with test values provided by a generator.
+   */
+  def testAllM[R0, R1, E, A](
+    label: String
+  )(gen: Gen[R0, A])(test: A => ZIO[R1, E, TestResult])(implicit
+    loc: SourceLocation
+  ): Spec[R0 with R1, TestFailure[E], TestSuccess] = {
+    val specs =
+      gen.sample.map(a => testM(s"$label ${a.value}")(test(a.value))).runCollect.map(_.toVector)
+
+    Spec.suite(label, ZManaged.fromEffect(specs), None)
+  }
+
+  /**
    * Passes version specific information to the specified function, which will
    * use that information to create a test. If the version is neither Dotty nor
    * Scala 2, an ignored test result will be returned.


### PR DESCRIPTION
This PR adds a method called `testAllM` which accepts a generator and produces multiple tests from that generator. It simulates a concept called Parameterized tests where the same test operates on a different input value.

We've been using this function at work and it's proven to be handy when need to test against a fixed input parameter list, but does not necessarily need to be a property test.

Usage:

```scala
val gen = Gen.fromIterable(List("file1.bin", "file2.bin", "file3.bin"))

testAllM("Can parse contents for file")(gen) { file =>
   ... // do something with file
  assertM(...)(...)
}
```
When ran, this produces three tests:

```
+ Can parse contents for file
  + Can parse contents for file file1.bin
  + Can parse contents for file file2.bin
  + Can parse contents for file file3.bin
```

Would be nice to have this in ZIO.
