### PR TITLE
Have Scala Steward's PRs autoupdated

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,0 +1,14 @@
+name: autoupdate
+on:
+  push: {}
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PR_FILTER: "labelled"
+          PR_LABELS: "dependency-update,autoupdate"
+          EXCLUDED_LABELS: "do-not-autoupdate"


### PR DESCRIPTION
If we don't have this, PRs like https://github.com/zio/zio/pull/4548 won't automatically retried and won't get merged.
It's a shame, that GitHub's PR mechanism needs a workaround like this, but such is life :crying_cat_face: 
