### PR TITLE
Added comment about cats timer when using a custom environment.

### DIFF
--- a/docs/interop/catseffect.md
+++ b/docs/interop/catseffect.md
@@ -51,6 +51,7 @@ import zio.interop.catz.implicits._
 ```
 
 The reason why a `Timer[Task]` is not provided by the default "interop" import is that it makes testing programs that require timing capabilities very difficult. The extra import (wherever needed) makes reasoning about timing-related effects much easier.
+If you are using `RIO` for a custom environment then your environment must use the `Clock` service, e.g. `R <: Clock` to get a timer.
 
 ## Example
 


### PR DESCRIPTION
Just a small comment to help users get bring the zioTimer from zio-iterop-cats into play and get a cats.effect.timer. 