### PR TITLE
Fixed Clock.currentTime implementation

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
@@ -1,11 +1,11 @@
 package zio.clock
 
-import java.time.Instant
-
 import zio._
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.Live
+
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 object ClockSpecJVM extends ZIOBaseSpec {

--- a/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
@@ -1,10 +1,11 @@
 package zio.clock
 
+import java.time.Instant
+
 import zio._
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.Live
-
 import java.util.concurrent.TimeUnit
 
 object ClockSpecJVM extends ZIOBaseSpec {
@@ -23,6 +24,15 @@ object ClockSpecJVM extends ZIOBaseSpec {
         @@ TestAspect.flaky
         // This test should only run on JRE >= 9, which is when microsecond precision was introduced.
         // Versions of JREs < 9 started with s"1.${majorVersion}", then with JEP 223 they switched to semantic versioning.
-        @@ TestAspect.ifProp("java.version", not(startsWithString("1.")))
+        @@ TestAspect.ifProp("java.version", not(startsWithString("1."))),
+      testM("currentTime has correct time") {
+        val unit = TimeUnit.MICROSECONDS
+        for {
+          start  <- ZIO.effectTotal(Instant.now).map(_.toEpochMilli)
+          time   <- clock.currentTime(unit).map(TimeUnit.MILLISECONDS.convert(_, unit))
+          finish <- ZIO.effectTotal(Instant.now).map(_.toEpochMilli)
+        } yield assert(time)(isGreaterThanEqualTo(start) && isLessThanEqualTo(finish))
+      }.provideLayer(Clock.live)
+        @@ TestAspect.nonFlaky
     )
 }

--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -54,11 +54,9 @@ package object clock {
             // However, ChronoUnit is not available on all platforms
             unit match {
               case TimeUnit.NANOSECONDS =>
-                val micros = inst.toEpochMilli() * 1000000 + inst.getNano()
-                unit.convert(micros, TimeUnit.NANOSECONDS)
+                inst.getEpochSecond() * 1000000000 + inst.getNano()
               case TimeUnit.MICROSECONDS =>
-                val micros = inst.toEpochMilli() * 1000 + inst.getNano() / 1000
-                unit.convert(micros, TimeUnit.MICROSECONDS)
+                inst.getEpochSecond() * 1000000 + inst.getNano() / 1000
               case _ => unit.convert(inst.toEpochMilli(), TimeUnit.MILLISECONDS)
             }
           }


### PR DESCRIPTION
`Instant.getEpochMilli` and `Instant.getNano` both contains millisecond part.
so `inst.toEpochMilli() * 1000000 + inst.getNano()` resulted to milliseconds being counted twice.

First commit has test which fails with old implementation.