### PR TITLE
ZIO Test: Implement SuiteM

### DIFF
--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -48,6 +48,12 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
     zio.test.suite(label)(specs: _*)
 
   /**
+   * Builds an effectual suite containing a number of other specs.
+   */
+  def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Spec[R, E, T] =
+    zio.test.suiteM(label)(specs)
+
+  /**
    * Builds a spec with a single pure test.
    */
   def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -554,7 +554,7 @@ package object test extends CompileVariants {
   /**
    * Builds an effectual suite containing a number of other specs.
    */
-  def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Soec[R, E, T] =
+  def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Spec[R, E, T] =
     Spec.suite(label, specs.map(_.toVector).toManaged_, None)
 
   /**

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -552,6 +552,12 @@ package object test extends CompileVariants {
     Spec.suite(label, ZManaged.succeedNow(specs.toVector), None)
 
   /**
+   * Builds an effectual suite containing a number of other specs.
+   */
+  def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Soec[R, E, T] =
+    Spec.suite(label, specs.map(_.toVector).toManaged_, None)
+
+  /**
    * Builds a spec with a single pure test.
    */
   def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =


### PR DESCRIPTION
Analogous to `testM`, `suiteM` allows building effectual suites. For example, you could open a collection of files and create a test based on the contents of each file.