### PR TITLE
Implement ZIO#replicateM

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1550,16 +1550,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     repeatUntilM(e => f(e).map(!_))
 
   /**
-    * Performs this effect the specified number of times and collects the
-    * results.
-    */
+   * Performs this effect the specified number of times and collects the
+   * results.
+   */
   final def replicateM(n: Int): ZIO[R, E, Iterable[A]] =
     ZIO.collectAll(ZIO.replicate(n)(self))
 
   /**
-    * Performs this effect the specified number of times, discarding the
-    * results.
-    */
+   * Performs this effect the specified number of times, discarding the
+   * results.
+   */
   final def replicateM_(n: Int): ZIO[R, E, Unit] =
     ZIO.collectAll_(ZIO.replicate(n)(self))
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1550,6 +1550,20 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     repeatUntilM(e => f(e).map(!_))
 
   /**
+    * Performs this effect the specified number of times and collects the
+    * results.
+    */
+  final def replicateM(n: Int): ZIO[R, E, Iterable[A]] =
+    ZIO.collectAll(ZIO.replicate(n)(self))
+
+  /**
+    * Performs this effect the specified number of times, discarding the
+    * results.
+    */
+  final def replicateM_(n: Int): ZIO[R, E, Unit] =
+    ZIO.collectAll_(ZIO.replicate(n)(self))
+
+  /**
    * Retries with the specified retry policy.
    * Retries are done following the failure of the original `io` (up to a fixed maximum with
    * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means


### PR DESCRIPTION
I think we could use a slightly better way of describing "do this effect N times". Currently, our solution for this is `ZIO#repeatN`. However, this has a couple of issues.

First, the `N` there is how many times to repeat the effect, so if you want to perform an effect a hundred times you need to remember to do `zio.repeatN(99)` instead of `zio.repeatN(100)`.

Second, it gives you back the last result whereas you probably either want all the results or don't care about any of them. 

Third, it introduces a yield between each repetition, which makes sense if we are repeating because some condition wasn't true and need to allow that condition to actually change, but doesn't really make sense if weI just want to perform an effect a given number of times.

This PR adds a `replicateM` operator on `ZIO` that just runs an effect the specified number of times and collects all the results. There is also a `replicateM_` operator for where you don't need the result, like you just have a bunch of chunks and you want to offer all of them to a queue.