### PR TITLE
Update portable-scala-reflect to 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,6 +169,14 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings(dottySettings)
   .configure(_.enablePlugins(JCStressPlugin))
   .settings(replSettings)
+  .settings {
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Provided).withDottyCompat(scalaVersion.value))
+      else
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
+    }
+  }
 
 lazy val coreTestsJS = coreTests.js
   .settings(jsSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -169,14 +169,7 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings(dottySettings)
   .configure(_.enablePlugins(JCStressPlugin))
   .settings(replSettings)
-  .settings {
-    libraryDependencies ++= {
-      if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
-      else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
-    }
-  }
+  .settings(scalaReflectTestSettings)
 
 lazy val coreTestsJS = coreTests.js
   .settings(jsSettings)
@@ -282,14 +275,7 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
 
 lazy val testTestsJVM = testTests.jvm
   .settings(dottySettings)
-  .settings {
-    libraryDependencies ++= {
-      if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
-      else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
-    }
-  }
+  .settings(scalaReflectTestSettings)
 lazy val testTestsJS = testTests.js.settings(jsSettings)
 
 lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
@@ -393,6 +379,11 @@ lazy val testRunner = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(core)
   .dependsOn(test)
 
+lazy val testRunnerJVM = testRunner.jvm
+  .settings(dottySettings)
+  .settings(scalaReflectTestSettings)
+lazy val testRunnerJS = testRunner.js.settings(jsSettings)
+
 lazy val testJunitRunner = crossProject(JVMPlatform)
   .in(file("test-junit"))
   .settings(stdSettings("zio-test-junit"))
@@ -401,18 +392,6 @@ lazy val testJunitRunner = crossProject(JVMPlatform)
   .dependsOn(test)
 
 lazy val testJunitRunnerJVM = testJunitRunner.jvm.settings(dottySettings)
-
-lazy val testRunnerJVM = testRunner.jvm
-  .settings(dottySettings)
-  .settings {
-    libraryDependencies ++= {
-      if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
-      else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
-    }
-  }
-lazy val testRunnerJS = testRunner.js.settings(jsSettings)
 
 lazy val testJunitRunnerTests = crossProject(JVMPlatform)
   .in(file("test-junit-tests"))
@@ -456,6 +435,7 @@ lazy val testJunitRunnerTestsJVM = testJunitRunnerTests.jvm
         .dependsOn(Keys.publishM2 in stacktracerJVM)
         .value
   )
+  .settings(scalaReflectTestSettings)
 
 /**
  * Examples sub-project that is not included in the root project.

--- a/build.sbt
+++ b/build.sbt
@@ -239,7 +239,7 @@ lazy val test = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(macroExpansionSettings)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.portable-scala" %%% "portable-scala-reflect" % "1.0.0")
+      ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.0")
         .withDottyCompat(scalaVersion.value)
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -172,9 +172,9 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings {
     libraryDependencies ++= {
       if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213).withDottyCompat(scalaVersion.value))
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
       else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
     }
   }
 
@@ -280,8 +280,17 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .settings(macroExpansionSettings)
   .enablePlugins(BuildInfoPlugin)
 
-lazy val testTestsJVM = testTests.jvm.settings(dottySettings)
-lazy val testTestsJS  = testTests.js.settings(jsSettings)
+lazy val testTestsJVM = testTests.jvm
+  .settings(dottySettings)
+  .settings {
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
+      else
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
+    }
+  }
+lazy val testTestsJS = testTests.js.settings(jsSettings)
 
 lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-magnolia"))

--- a/build.sbt
+++ b/build.sbt
@@ -402,8 +402,17 @@ lazy val testJunitRunner = crossProject(JVMPlatform)
 
 lazy val testJunitRunnerJVM = testJunitRunner.jvm.settings(dottySettings)
 
-lazy val testRunnerJVM = testRunner.jvm.settings(dottySettings)
-lazy val testRunnerJS  = testRunner.js.settings(jsSettings)
+lazy val testRunnerJVM = testRunner.jvm
+  .settings(dottySettings)
+  .settings {
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
+      else
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
+    }
+  }
+lazy val testRunnerJS = testRunner.js.settings(jsSettings)
 
 lazy val testJunitRunnerTests = crossProject(JVMPlatform)
   .in(file("test-junit-tests"))

--- a/build.sbt
+++ b/build.sbt
@@ -172,9 +172,9 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings {
     libraryDependencies ++= {
       if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Provided).withDottyCompat(scalaVersion.value))
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213).withDottyCompat(scalaVersion.value))
       else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
     }
   }
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -296,6 +296,15 @@ object BuildHelper {
     Compile / doc / sources := Seq.empty
   )
 
+  val scalaReflectTestSettings: List[Setting[_]] = List(
+    libraryDependencies ++= {
+      if (isDotty.value)
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
+      else
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
+    }
+  )
+
   def welcomeMessage = onLoadMessage := {
     import scala.Console
 


### PR DESCRIPTION
closes https://github.com/zio/zio/pull/4604

---
EDIT: fixed

Unfortunately this fails with
```
[error] /home/ondra/Projects/zio/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala:8:22: object io is not a member of package reflect
[error] import scala.reflect.io.File
[error]                      ^
[error] /home/ondra/Projects/zio/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala:15:65: not found: value File
[error]         assertM(live(system.env("PATH")))(isSome(containsString(File.separator + "bin")))
[error]                                                                 ^
[error] /home/ondra/Projects/zio/core-tests/jvm/src/test/scala/zio/system/SystemSpec.scala:23:77: not found: value File
[error]         assertM(live(system.envs.map(_.get("PATH"))))(isSome(containsString(File.separator + "bin")))
[error]                                                                             ^
...
[error] (coreTestsJVM / Test / compileIncremental) Compilation failed
```

Any idea what could be going wrong?