### PR TITLE
Change Default Scala Version To 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,14 +287,14 @@ jobs:
     <<: *lint
     <<: *machine_ubuntu
     environment:
-      - <<: *scala_212
+      - <<: *scala_213
       - <<: *jdk_8
 
   mdoc:
     <<: *mdoc
     <<: *machine_ubuntu
     environment:
-      - <<: *scala_212
+      - <<: *scala_213
       - <<: *jdk_8
 
   test_211_jdk8_jvm:
@@ -345,7 +345,7 @@ jobs:
       - <<: *scala_dotty
       - <<: *jdk_8
 
-  test_212_jdk11_jvm:
+  test_213_jdk11_jvm:
     <<: *testJVM
     <<: *machine_ubuntu
     <<: *machine_resource

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,7 +440,7 @@ workflows:
             - lint
           filters:
             <<: *filter_tags
-      - test_212_jdk11_jvm:
+      - test_213_jdk11_jvm:
           requires:
             - lint
           filters:
@@ -472,10 +472,10 @@ workflows:
             - test_211_jdk8_js
             - test_211_jdk8_native
             - test_212_jdk8_jvm
-            - test_212_jdk11_jvm
             - test_212_jdk8_js
             - test_213_jdk8_jvm
             - test_213_jdk8_js
+            - test_213_jdk11_jvm
             - test_dotty_jdk8_jvm
             - mdoc
             - mima_212

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -16,6 +16,8 @@
 
 package zio
 
+import zio.Chunk.BitChunk
+
 import scala.collection.mutable.{ArrayBuilder, Builder}
 import scala.{
   Boolean => SBoolean,
@@ -27,8 +29,6 @@ import scala.{
   Long => SLong,
   Short => SShort
 }
-
-import zio.Chunk.BitChunk
 
 /**
  * A `ChunkBuilder[A]` can build a `Chunk[A]` given elements of type `A`.

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -16,9 +16,8 @@
 
 package zio
 
-import scala.collection.IterableFactoryDefaults
-import scala.collection.SeqFactory
 import scala.collection.immutable.{IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps}
+import scala.collection.{IterableFactoryDefaults, SeqFactory}
 import scala.reflect.ClassTag
 
 /**

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -224,7 +224,7 @@ object BuildHelper {
   def stdSettings(prjName: String) = Seq(
     name := s"$prjName",
     crossScalaVersions := Seq(Scala211, Scala212, Scala213),
-    scalaVersion in ThisBuild := Scala212,
+    scalaVersion in ThisBuild := Scala213,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, isDotty.value, optimize = !isSnapshot.value),
     libraryDependencies ++= {
       if (isDotty.value)

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -12,7 +12,7 @@ inThisBuild(
         url("http://degoes.net")
       )
     ),
-    scalaVersion := V.scala212,
+    scalaVersion := V.scala213,
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= List(
       "-Yrangepos",


### PR DESCRIPTION
There is a regression in the latest version of Scala 2.12 that causes compiler crashes when there is a compilation issue instead of providing a helpful warning. In addition, with Scala 3 around the corner I think it makes sense that we are on Scala 2.13 by default. We will still include earlier versions in the CI matrix to make sure we support them.