### PR TITLE
Avoid Unnecessarily Constructing Complex Causes in ZLayer

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -75,7 +75,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
   final def >+>[E1 >: E, RIn2 >: ROut, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
   )(implicit ev: Has.Union[ROut1, ROut2], tagged: Tag[ROut2]): ZLayer[RIn, E1, ROut1 with ROut2] =
-    self.++[E1, RIn, ROut1, ROut2](self >>> that)
+    ZLayer.ZipWith(self, self >>> that, ev.union)
 
   /**
    * Feeds the output services of this layer into the input of the specified
@@ -293,6 +293,8 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
         Managed.succeed(_ => self)
       case ZLayer.Suspend(self) =>
          ZManaged.succeed(memoMap => memoMap.getOrElseMemoize(self()))
+      case ZLayer.ZipWith(self, that, f) =>
+        ZManaged.succeed(memoMap => memoMap.getOrElseMemoize(self).zipWith(memoMap.getOrElseMemoize(that))(f))   
       case ZLayer.ZipWithPar(self, that, f) =>
         ZManaged.succeed(memoMap => memoMap.getOrElseMemoize(self).zipWithPar(memoMap.getOrElseMemoize(that))(f))
     }
@@ -310,6 +312,11 @@ object ZLayer {
   private final case class Fresh[RIn, E, ROut](self: ZLayer[RIn, E, ROut])        extends ZLayer[RIn, E, ROut]
   private final case class Managed[-RIn, +E, +ROut](self: ZManaged[RIn, E, ROut]) extends ZLayer[RIn, E, ROut]
   private final case class Suspend[-RIn, +E, +ROut](self: () => ZLayer[RIn, E, ROut]) extends ZLayer[RIn, E, ROut]
+  private final case class ZipWith[-RIn, +E, ROut, ROut2, ROut3](
+    self: ZLayer[RIn, E, ROut],
+    that: ZLayer[RIn, E, ROut2],
+    f: (ROut, ROut2) => ROut3
+  ) extends ZLayer[RIn, E, ROut3]
   private final case class ZipWithPar[-RIn, +E, ROut, ROut2, ROut3](
     self: ZLayer[RIn, E, ROut],
     that: ZLayer[RIn, E, ROut2],


### PR DESCRIPTION
Resolves #4503.

Interestingly, the cause of the issue here is that when we construct large layers with `>+>` and an initial layer fails we safely and efficiently stop creating further layers but the nested parallel and sequential structure leads us to construct a very complex `Cause` that grows exponentially with the number of layers.

We don't actually need parallelism for the `>+>` operator so this PR implements a new `ZipWith` case of the `ZLayer` algebra that is used exclusively for this purpose. That way we increase the efficiency of this operation without compromising the simplicity that layers that don't depend on each other are acquired in parallel.

Eventually I would like to simplify the algebra to make this a "first" case that just expresses our ability to take a layer and return a new layer that does the work of the original layer and passes through an additional input unchanged, but unfortunately that doesn't quite work with the existing signature of `+>+` so that will have to wait for 2.0.