### PR TITLE
GH-4593: Ensure all docs compiled, remove invisible tags

### DIFF
--- a/docs/datatypes/chunk.md
+++ b/docs/datatypes/chunk.md
@@ -4,7 +4,7 @@ title:  "Chunk"
 ---
 A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed are usually backed by arrays, but expose a purely functional, safe interface to the underlying elements, and they become lazy on operations that would be costly with arrays, such as repeated concatenation.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 

--- a/docs/datatypes/fiber.md
+++ b/docs/datatypes/fiber.md
@@ -11,7 +11,7 @@ You can `fork` any `IO[E, A]` to immediately yield an `UIO[Fiber[E, A]]`. The pr
 import zio._
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 sealed trait Analysis
 case object Analyzed extends Analysis
 
@@ -83,7 +83,7 @@ There are no circumstances in which any errors will be "lost", which makes the `
 
 To execute actions in parallel, the `zipPar` method can be used:
 
-```scala mdoc:invisible
+```scala mdoc
 case class Matrix()
 def computeInverse(m: Matrix): UIO[Matrix] = IO.succeed(m)
 def applyMatrices(m1: Matrix, m2: Matrix, m3: Matrix): UIO[Matrix] = IO.succeed(m1)

--- a/docs/datatypes/io.md
+++ b/docs/datatypes/io.md
@@ -37,14 +37,14 @@ because the `Nothing` type is _uninhabitable_, i.e. there can be no actual value
 
 You can use the `effectTotal` method of `IO` to import effectful synchronous code into your purely functional program:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.Task
 ```
 ```scala mdoc:silent
 val effectTotalTask: Task[Long] = IO.effectTotal(System.nanoTime())
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.File
 import org.apache.commons.io.FileUtils
 import java.io.IOException
@@ -61,7 +61,7 @@ def readFile(name: String): IO[IOException, Array[Byte]] =
 
 You can use the `effectAsync` method of `IO` to import effectful asynchronous code into your purely functional program:
 
-```scala mdoc:invisible
+```scala mdoc
 case class HttpException()
 case class Request()
 case class Response()
@@ -128,7 +128,7 @@ The release action is guaranteed to be executed by the runtime system, even if t
 import zio.{ UIO, IO }
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]

--- a/docs/datatypes/managed.md
+++ b/docs/datatypes/managed.md
@@ -57,7 +57,7 @@ It is possible to combine multiple `Managed` using `flatMap` to obtain a single 
 import zio._
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]

--- a/docs/datatypes/schedule.md
+++ b/docs/datatypes/schedule.md
@@ -24,7 +24,7 @@ A `Schedule[R, A, B]` consumes input values of type `A` (errors in the case of `
 
 ## Base Schedules
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.duration._
 ```
 

--- a/docs/howto/howto_macros.md
+++ b/docs/howto/howto_macros.md
@@ -37,7 +37,7 @@ libraryDependencies += "dev.zio" %% "zio-macros" % "<zio-version>"
 
 The `@accessible` macro generates _capability accessors_ into annotated module object.
 
-```scala
+```scala mdoc
 import zio.{ Has, ZIO }
 import zio.macros.accessible
 
@@ -68,7 +68,7 @@ libraryDependencies += "dev.zio" %% "zio-test" % "<zio-version>"
 
 The `@mockable[A]` generates _capability tags_ and _mock layer_ into annotated object.
 
-```scala
+```scala mdoc
 import zio.test.mock.mockable
 
 @mockable[AccountObserver.Service]
@@ -77,7 +77,7 @@ object AccountObserverMock
 
 Will result in:
 
-```scala
+```scala mdoc
 import zio.{ Has, UIO, URLayer, ZLayer }
 import zio.test.mock.{ Mock, Proxy }
 

--- a/docs/howto/mock_services.md
+++ b/docs/howto/mock_services.md
@@ -20,7 +20,7 @@ If the job of the _capability_ is to call on another _capability_, how should we
 A pure function is such a function which operates only on its inputs and produces only its output. Command-like methods, by definition are impure, as
 their job is to change state of the collaborating object (performing a _side effect_). For example:
 
-```scala mdoc:invisible
+```scala mdoc
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait Event
@@ -40,7 +40,7 @@ not the one you expected.
 
 Inside the future there may be happening any side effects. It may open a file, print to console, connect to databases. We simply don't know. Let's have a look how this problem would be solved using ZIO's effect system:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 trait Event
 ```
 
@@ -148,7 +148,7 @@ For overloaded methods we nest a list of numbered objects, each representing sub
 Finally we need to define a _compose layer_ that can create our environment from a `Proxy`.
 A `Proxy` holds the mock state and serves predefined responses to calls.
 
-```scala mdoc:invisible
+```scala mdoc
 def withRuntime[R]: URIO[R, Runtime[R]] = ???
 ```
 
@@ -185,7 +185,7 @@ multiple services.
 
 ## Complete example
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 trait AccountEvent
 ```
 
@@ -259,7 +259,7 @@ For each built-in ZIO service you will find their mockable counterparts in `zio.
 
 To create expectations we use the previously defined _capability tags_:
 
-```scala mdoc:invisible
+```scala mdoc
 object Example {
   trait Service {
     def zeroArgs: UIO[Int]

--- a/docs/howto/test_assertions.md
+++ b/docs/howto/test_assertions.md
@@ -12,13 +12,13 @@ operate on `Seq[A]`, with the type `Assertion[Seq[A]]`.
 For this example, I would select `hasAt`, as it accepts both the position into
 a sequence, as well as an `Assertion[A]` to apply at that position:
 
-```scala
+```scala mdoc
 Assertion.hasAt[A](pos: Int)(assertion: Assertion[A]): Assertion[Seq[A]]
 ```
 
 I could start by writing:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 
@@ -37,7 +37,7 @@ of the return type `Assertion[A]`.
 I could select `equalTo`, as it accepts an `A` as a parameter, allowing me to
 supply `5`:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 
@@ -56,13 +56,13 @@ section. `approximatelyEquals` looks like what we want, as it permits the
 starting value `reference`, as well as a `tolerance`, for any `A` that is
 `Numeric`:
 
-```scala
+```scala mdoc
 Assertion.approximatelyEquals[A: Numeric](reference: A, tolerance: A): Assertion[A]
 ```
 
 Changing out `equalTo` with `approximatelyEquals` leaves us with:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 

--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -172,7 +172,7 @@ control and determinism. However there is another source of complexity that come
 
 It is easy to accidentally use different test instances at the same time.
 
-```scala
+```scala mdoc
 import zio.test._
 import zio.test.environment.TestClock
 import Assertion._

--- a/docs/howto/use_modules_and_layers.md
+++ b/docs/howto/use_modules_and_layers.md
@@ -15,7 +15,7 @@ To access the DB we need a `DBConnection`, and each step in our program represen
 
 The result is a program that, in turn, depends on the `DBConnection`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ Has, IO, Layer, UIO, URIO, ZEnv, ZIO, ZLayer }
 import zio.clock.Clock
 import zio.console.Console
@@ -45,7 +45,7 @@ val created: URIO[DBConnection, Boolean] = for {
 
 To run the program we must supply a `DBConnection` through `provide`, before feeding it to ZIO runtime.
 
-```scala
+```scala mdoc
 val dbConnection: DBConnection = ???
 val runnable: UIO[Boolean] = created.provide(dbConnection)
 
@@ -91,7 +91,7 @@ object UserRepo {
 }
 ```
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.{ Has, IO, Layer, UIO, URIO, ZEnv, ZIO, ZLayer }
 import zio.clock.Clock
 import zio.console.Console
@@ -112,7 +112,7 @@ We encountered two new data types: [`Has`][Has], and [`ZLayer`][ZLayer]. Let's g
 `Has[A]` represents a dependency on a service of type `A`. Some components in an application might depend upon more than
 one service. Two or more `Has[_]` elements can be combined _horizontally_ using their `++` operator:
 
-```scala mdoc:invisible
+```scala mdoc
 object Repo {
   trait Service {}
 }
@@ -362,13 +362,13 @@ No other code will need to be changed, because the previous implementation's dep
 
 However, if an upstream dependency is used by many other services, it can be convenient to "pass through" that dependency, and include it in the output of a layer. This can be done with the `>+>` operator, which provides the output of one layer to another layer, returning a new layer that outputs the services of _both_ layers.
 
-```scala
+```scala mdoc
 val layer: ZLayer[Any, Nothing, Connection with UserRepo] = connection >+> userRepo
 ```
 
 Here, the `Connection` dependency has been passed through, and is available to all downstream services. This allows a style of composition where the `>+>` operator is used to build a progressively larger set of services, with each new service able to depend on all the services before it.
 
-```scala mdoc:invisible
+```scala mdoc
 type Baker = Has[Baker.Service]
 type Ingredients = Has[Ingredients.Service]
 type Oven = Has[Oven.Service]

--- a/docs/interop/catseffect.md
+++ b/docs/interop/catseffect.md
@@ -7,13 +7,13 @@ The `interop-cats` module provides interoperability for the Cats Effect ecosyste
 
 To use this module, add the following to your `build.sbt`:
 
-```scala
+```scala mdoc
 libraryDependencies += "dev.zio" %% "zio-interop-cats" % "<version>"
 ```
 
 Most of the interop functionality resides in the following package:
 
-```scala
+```scala mdoc
 import zio.interop.catz._
 ```
 
@@ -25,14 +25,14 @@ Due to limitations of Cats Effect, ZIO cannot provide instances for arbitrary er
 
 For convenience, ZIO includes the `Task` and `RIO` type aliases, which fix the error type to `Throwable`, and may be useful for interop with Cats Effect:
 
-```scala
+```scala mdoc
 type Task[   +A] = ZIO[Any, Throwable, A]
 type RIO[-R, +A] = ZIO[  R, Throwable, A]
 ```
 
 In order to use Cats Effect instances for these types, you should have an implicit `Runtime[R]` in scope for the environment type of your effects. The following code snippet creates an implicit `Runtime` for all the modules built into ZIO:
 
-```scala
+```scala mdoc
 implicit val runtime: Runtime[ZEnv] = Runtime.default
 ```
 
@@ -46,7 +46,7 @@ As a convenience, your application can extend `CatsApp`, which automatically bri
 
 In order to get a `cats.effect.Timer[Task]` instance, we need an extra import:
 
-```scala
+```scala mdoc
 import zio.interop.catz.implicits._
 ```
 
@@ -57,7 +57,7 @@ If you are using `RIO` for a custom environment then your environment must use t
 
 The following example shows how to use ZIO with Doobie (a library for JDBC access) and FS2 (a streaming library), which both rely on Cats Effect instances:
 
-```scala
+```scala mdoc
 import doobie.imports._
 import fs2.Stream
 import zio.Task

--- a/docs/interop/future.md
+++ b/docs/interop/future.md
@@ -11,7 +11,7 @@ Basic interoperability with Scala's `Future` is now provided by ZIO, and does no
 
 Scala's `Future` can be converted into a ZIO effect with `ZIO.fromFuture`:
 
-```scala
+```scala mdoc
 def loggedFuture[A](future: ExecutionContext => Future[A]): UIO[Task[A]] = {
   ZIO.fromFuture { implicit ec =>
     future(ec).flatMap { result =>
@@ -23,7 +23,7 @@ def loggedFuture[A](future: ExecutionContext => Future[A]): UIO[Task[A]] = {
 
 Scala's `Future` can also be converted into a `Fiber` with `Fiber.fromFuture`:
 
-```scala
+```scala mdoc
 def futureToFiber[A](future: => Future[A]): Fiber[Throwable, A] = 
   Fiber.fromFuture(future)
 ```
@@ -34,7 +34,7 @@ This is a pure operation, given any sensible notion of fiber equality.
 
 A ZIO `Task` effect can be converted into a `Future` with `ZIO#toFuture`:
 
-```scala
+```scala mdoc
 def taskToFuture[A](task: Task[A]): UIO[Future[A]] = 
   task.toFuture
 ```
@@ -43,7 +43,7 @@ Because converting a `Task` into an (eager) `Future` is effectful, the return va
 
 A ZIO `Fiber` can be converted into a `Future` with `Fiber#toFuture`:
 
-```scala
+```scala mdoc
 def fiberToFuture[A](fiber: Fiber[Throwable, A]): UIO[Future[A]] = 
   fiber.toFuture
 ```

--- a/docs/interop/java.md
+++ b/docs/interop/java.md
@@ -9,7 +9,7 @@ ZIO has full interoperability with foreign Java code. Let me show you how it wor
 
 `CompletionStage` is the interface that comes closest to emulate a functional asynchronous effects API like ZIO's, so we start with it. It's a breeze:
 
-```scala
+```scala mdoc
 def loggedStage[A](stage: => CompletionStage[A]): Task[A] =
     ZIO.fromCompletionStage(UIO {
         stage.thenApplyAsync { a =>
@@ -21,7 +21,7 @@ def loggedStage[A](stage: => CompletionStage[A]): Task[A] =
 
 By Jove, you can even turn it into fiber!
 
-```scala
+```scala mdoc
 def stageToFiber[A](stage: => CompletionStage[A]): Fiber[Throwable, A] = 
   Fiber.fromCompletionStage(future)
 ````
@@ -30,14 +30,14 @@ This API creates a synthetic fiber which doesn't have any notion of identity.
 
 Additionally, you may want to go the other way and convert a ZIO value into a `CompletionStage`. Easy as pie:
 
-```scala
+```scala mdoc
 def taskToStage[A](task: Task[A]): UIO[CompletableFuture[A]] =
     task.toCompletableFuture
 ```
 
 As you can see, it commits to a concrete class implementing the `CompletionStage` interface, i.e. `CompletableFuture`. It is worth to point out that any `IO[E, A]` can be turned into a completable future provided you can turn a value of type `E` into a `Throwable`:
 
-```scala
+```scala mdoc
 def ioToStage[E, A](io: IO[E, A])(toThrowable: E => Throwable): UIO[CompletableFuture[A]] =
     io.toCompletableFutureWith(toThrowable)
 ```
@@ -46,7 +46,7 @@ def ioToStage[E, A](io: IO[E, A])(toThrowable: E => Throwable): UIO[CompletableF
 
 You can embed any `java.util.concurrent.Future` in a ZIO computation via `ZIO.fromFutureJava`. A toy wrapper around Apache Async HTTP client could look like:
 
-```scala
+```scala mdoc
 def execute(client: HttpAsyncClient, request: HttpUriRequest): RIO[Blocking, HttpResponse] =
     ZIO.fromFutureJava(UIO {
         client.execute(request, null)
@@ -57,7 +57,7 @@ That's it. Just a bit of a warning here, mate. As you can see from the requireme
 
 Should you need it, it is also possible to convert a future into a fiber using `Fiber.fromFutureJava`. Same same, but different:
 
-```scala
+```scala mdoc
 def execute(client: HttpAsyncClient, request: HttpUriRequest): Fiber[Throwable, HttpResponse] =
     Fiber.fromFutureJava {
         client.execute(request, null)
@@ -68,7 +68,7 @@ def execute(client: HttpAsyncClient, request: HttpUriRequest): Fiber[Throwable, 
 
 Java libraries using channels from the NIO API for asynchronous, interruptible I/O can be hooked into by providing completion handlers. As in, reading the contents of a file:
 
-```scala
+```scala mdoc
 def readFile(file: AsynchronousFileChannel): Task[Chunk[Byte]] = for {
     pos <- Ref.make(0)
     buf <- ZIO.effectTotal(ByteBuffer.allocate(1024))

--- a/docs/interop/javascript.md
+++ b/docs/interop/javascript.md
@@ -19,7 +19,7 @@ Your main function can extend `App` as follows.
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
-```scala
+```scala mdoc
 import org.scalajs.dom.{document, raw}
 import zio._
 import zio.duration._

--- a/docs/interop/monix.md
+++ b/docs/interop/monix.md
@@ -14,14 +14,14 @@ Interop layer provides the following conversions:
 
 To convert an `IO` value to `Task`, use the following method:
 
-```scala
+```scala mdoc
 def toTask: UIO[eval.Task[A]]
 ```
 
 To perform conversion in other direction, use the following extension method
 available on `IO` companion object:
 
-```scala
+```scala mdoc
 def fromTask[A](task: eval.Task[A])(implicit scheduler: Scheduler): Task[A]
 ```
 
@@ -30,7 +30,7 @@ needs to be available.
 
 ### Example
 
-```scala
+```scala mdoc
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import zio.{ IO, Runtime }
@@ -58,20 +58,20 @@ object UnsafeExample extends App {
 
 To convert an `IO` value to `Coeval`, use the following method:
 
-```scala
+```scala mdoc
 def toCoeval: UIO[eval.Coeval[A]]
 ```
 
 To perform conversion in other direction, use the following extension method
 available on `IO` companion object:
 
-```scala
+```scala mdoc
 def fromCoeval[A](coeval: eval.Coeval[A]): Task[A]
 ```
 
 ### Example
 
-```scala
+```scala mdoc
 import monix.eval.Coeval
 import zio.{ IO, Runtime }
 import zio.interop.monix._

--- a/docs/interop/reactivestreams.md
+++ b/docs/interop/reactivestreams.md
@@ -15,7 +15,7 @@ conversions available.
 
 First, let's get a few imports out of the way.
 
-```scala
+```scala mdoc
 import org.reactivestreams.example.unicast._
 import zio._
 import zio.interop.reactivestreams._
@@ -26,7 +26,7 @@ val runtime = Runtime.default
 
 We use the following `Publisher` and `Subscriber` for the examples: 
 
-```scala
+```scala mdoc
 val publisher = new RangePublisher(3, 10)
 val subscriber = new SyncSubscriber[Int] {
   override protected def whenNext(v: Int): Boolean = {
@@ -41,7 +41,7 @@ val subscriber = new SyncSubscriber[Int] {
 A `Publisher` used as a `Stream` buffers up to `qSize` elements. If possible, `qSize` should be
 a power of two for best performance. The default is 16.
 
-```scala
+```scala mdoc
 val streamFromPublisher = publisher.toStream(qSize = 16)
 runtime.unsafeRun(
   streamFromPublisher.run(Sink.collectAll[Integer])
@@ -54,7 +54,7 @@ When running a `Stream` to a `Subscriber`, a side channel is needed for signalli
 For this reason `toSink` returns a tuple of `Promise` and `Sink`. The `Promise` must be failed
 on `Stream` failure. The type parameter on `toSink` is the error type of *the Stream*. 
 
-```scala
+```scala mdoc
 val asSink = subscriber.toSink[Throwable]
 val failingStream = Stream.range(3, 13) ++ Stream.fail(new RuntimeException("boom!"))
 runtime.unsafeRun(
@@ -66,7 +66,7 @@ runtime.unsafeRun(
 
 ### Stream to Publisher
 
-```scala
+```scala mdoc
 val stream = Stream.range(3, 13)
 runtime.unsafeRun(
   stream.toPublisher.flatMap { publisher =>
@@ -82,7 +82,7 @@ runtime.unsafeRun(
 A `Sink` used as a `Subscriber` buffers up to `qSize` elements. If possible, `qSize` should be
 a power of two for best performance. The default is 16.
 
-```scala
+```scala mdoc
 val sink = Sink.collectAll[Integer]
 runtime.unsafeRun(
   sink.toSubscriber(qSize = 16).flatMap { case (subscriber, result) => 

--- a/docs/interop/scalaz7x.md
+++ b/docs/interop/scalaz7x.md
@@ -9,7 +9,7 @@ If you are a happy Scalaz 7.2 user `interop-scala7x` module offers `ZIO` instanc
 
 ### Example
 
-```scala
+```scala mdoc
 import scalaz._, Scalaz._
 import zio.interop.scalaz72._
 
@@ -25,7 +25,7 @@ Due to `Applicative` and `Monad` coherence law `ZIO`'s `Applicative` instance ha
 
 ### Example
 
-```scala
+```scala mdoc
 import scalaz._, Scalaz._
 import zio.interop.scalaz72._
 

--- a/docs/interop/twitter.md
+++ b/docs/interop/twitter.md
@@ -7,7 +7,7 @@ title: "Twitter"
 
 ### Example
 
-```scala
+```scala mdoc
 import com.twitter.util.Future
 import zio.{ App, Task }
 import zio.console._

--- a/docs/overview/basic_concurrency.md
+++ b/docs/overview/basic_concurrency.md
@@ -30,7 +30,7 @@ The `Fiber[E, A]` data type in ZIO has two type parameters:
 
 Fibers do not have an `R` type parameter, because they model effects that are already running, and which already had their required environment provided to them.
 
-```scala mdoc:invisible
+```scala mdoc
 
 import zio._
 ```

--- a/docs/overview/basic_operations.md
+++ b/docs/overview/basic_operations.md
@@ -3,7 +3,7 @@ id: overview_basic_operations
 title:  "Basic Operations"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 ```

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -5,7 +5,7 @@ title:  "Creating Effects"
 
 This section explores some of the common ways to create ZIO effects from values, from common Scala types, and from both synchronous and asynchronous side-effects.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ ZIO, Task, UIO, URIO, IO }
 ```
 
@@ -69,7 +69,7 @@ val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
 
 You can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
 
-```scala mdoc:invisible
+```scala mdoc
 trait Team
 ```
 
@@ -179,7 +179,7 @@ val getStrLn2: IO[IOException, String] =
 
 An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.effectAsync`:
 
-```scala mdoc:invisible
+```scala mdoc
 trait User { 
   def teamId: String
 }

--- a/docs/overview/handling_errors.md
+++ b/docs/overview/handling_errors.md
@@ -5,7 +5,7 @@ title:  "Handling Errors"
 
 This section looks at some of the common ways to detect and respond to failure.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 
@@ -34,7 +34,7 @@ def sqrt(io: UIO[Double]): IO[String, Double] =
 
 If you want to catch and recover from all types of errors and effectfully attempt recovery, you can use the `catchAll` method:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ FileNotFoundException, IOException }
 
 def openFile(s: String): IO[IOException, Array[Byte]] = 
@@ -100,7 +100,7 @@ Nearly all error handling methods are defined in terms of `foldM`, because it is
 
 In the following example, `foldM` is used to handle both failure and success of the `readUrls` method:
 
-```scala mdoc:invisible
+```scala mdoc
 sealed trait Content
 case class NoContent(t: Throwable) extends Content
 case class OkContent(s: String) extends Content
@@ -130,7 +130,7 @@ val retriedOpenFile: ZIO[Clock, IOException, Array[Byte]] =
 
 The next most powerful function is `ZIO#retryOrElse`, which allows specification of a fallback to use, if the effect does not succeed with the specified policy:
 
-```scala
+```scala mdoc
   openFile("primary.data").retryOrElse(
     Schedule.recurs(5), 
     (_, _) => ZIO.succeed(DefaultData))

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -7,7 +7,7 @@ This section looks at some of the common ways to safely handle resources using Z
 
 ZIO's resource management features work across synchronous, asynchronous, concurrent, and other effect types, and provide strong guarantees even in the presence of failure, interruption, or defects in the application.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 
@@ -35,7 +35,7 @@ Unlike `try` / `finally`, `ensuring` works across all types of effects, includin
 
 A common use for `try` / `finally` is safely acquiring and releasing resources, such as new socket connections or opened files:
 
-```scala 
+```scala mdoc
 val handle = openFile(name)
 
 try {
@@ -47,7 +47,7 @@ ZIO encapsulates this common pattern with `ZIO#bracket`, which allows you to spe
 
 The release effect is guaranteed to be executed by the runtime system, even in the presence of errors or interruption.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import java.io.{ File, IOException }
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -21,7 +21,7 @@ For example, an effect of type `ZIO[Any, IOException, Byte]` has no requirements
 
 A value of type `ZIO[R, E, A]` is like an effectful version of the following function type:
 
-```scala
+```scala mdoc
 R => Either[E, A]
 ```
 

--- a/docs/overview/testing_effects.md
+++ b/docs/overview/testing_effects.md
@@ -7,7 +7,7 @@ There are many approaches to testing functional effects, including using free mo
 
 This section introduces environmental effects and shows you how to write testable functional code using them.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 ```
@@ -89,7 +89,7 @@ In this section, we'll explore how to use environmental effects by developing a 
 
 We will define the database service with the help of a module, which is an interface that contains only a single field, which provides access to the service.
 
-```scala mdoc:invisible
+```scala mdoc
 trait UserID
 trait UserProfile
 val userId = new UserID { }


### PR DESCRIPTION
Original issue:
```
We should ensure that all code snippets in the documentation are checked with mdoc to ensure that they compile as written.

Can I also ask that for all examples we NOT use hidden or invisible code? I know sometimes people do this because they want to omit things they see as boilerplate like imports or type definitions. However, a lot of people are going to copy and paste and compile these examples as written so if there are things missing it makes it harder for them to get started.
```