### PR TITLE
Improve Performance Of Chunk

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -367,18 +367,12 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * Returns the first element that satisfies the predicate.
    */
   override final def find(f: A => Boolean): Option[A] = {
-    val iterator          = arrayIterator
+    val iterator          = self.iterator
     var result: Option[A] = None
     while (result.isEmpty && iterator.hasNext) {
-      val array  = iterator.next()
-      val length = array.length
-      var i      = 0
-      while (result.isEmpty && i < length) {
-        val a = array(i)
-        if (f(a)) {
-          result = Some(a)
-        }
-        i += 1
+      val a = iterator.next()
+      if (f(a)) {
+        result = Some(a)
       }
     }
     result
@@ -1518,6 +1512,9 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def foreach[B](f: A => B): Unit =
       array.foreach(f)
 
+    override def iterator: Iterator[A] =
+      array.iterator
+
     override def materialize[A1 >: A]: Chunk[A1] =
       self
 
@@ -1601,6 +1598,9 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       right.foreach(f)
     }
 
+    override def iterator: Iterator[A] =
+      left.iterator ++ right.iterator
+
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = {
       left.toArray(n, dest)
       right.toArray(n + left.length, dest)
@@ -1657,6 +1657,9 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
         i += 1
       }
     }
+
+    override def iterator: Iterator[A] =
+      chunk.iterator.slice(offset, offset + l)
 
     override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = {
       var i = 0


### PR DESCRIPTION
Initial work to improve performance of `Chunk` on certain benchmarks.

I'm sure there are a variety of other improvements that we can make but my initial approach is based on the idea that the implementation of the `arrayIterator` was a mistake and we should instead implement an efficient `iterator` method.

By way of background, most operators on `Chunk` were originally implemented in terms of indexed access to each element of the chunk, similar to how collection operations would be implemented for arrays. This had efficiency issues because when the chunk is not fully materialized each indexed access can go through multiple pointers, resulting in iteration that is significantly slower than direct iteration. To address this, we implemented the `arrayIterator`, which allows iterating over all the arrays underlying the chunk. We could then iterate over the arrays and efficiently do indexed access to each of the underlying arrays.

However, that has created an issue where we are unnecessarily forced to construct new arrays in some situations. In particular, a `Slice` chunk has to construct a new array unless the boundaries of the slice happen to align exactly with the lengths of the existing underlying arrays.

I now think that the correct solution is for us to be implementing an efficient `iterator` operator for chunks and then implement almost all operators in terms of that. An initial implementation for `find` results in an order of magnitude improvement with this approach for chunks that have not been materialized.

```
[info] Benchmark                     (size)  Mode  Cnt      Score     Error  Units
[info] MixedChunkBenchmarks.filterM    1000  avgt    5  57214.227 ± 365.931  ns/op
[info] MixedChunkBenchmarks.find       1000  avgt    5    362.710 ±   1.359  ns/op
[info] MixedChunkBenchmarks.flatMap    1000  avgt    5  46148.292 ± 297.795  ns/op
[info] MixedChunkBenchmarks.fold       1000  avgt    5   9668.758 ±  68.002  ns/op
[info] MixedChunkBenchmarks.foldM      1000  avgt    5  33776.485 ± 500.937  ns/op
[info] MixedChunkBenchmarks.map        1000  avgt    5  11292.190 ±  35.927  ns/op
[info] MixedChunkBenchmarks.mapM       1000  avgt    5      6.923 ±   0.024  ns/op

[info] Benchmark                     (size)  Mode  Cnt      Score     Error  Units
[info] MixedChunkBenchmarks.filterM    1000  avgt    5  60767.230 ± 120.665  ns/op
[info] MixedChunkBenchmarks.find       1000  avgt    5     30.580 ±   1.613  ns/op
[info] MixedChunkBenchmarks.flatMap    1000  avgt    5  45992.119 ± 203.180  ns/op
[info] MixedChunkBenchmarks.fold       1000  avgt    5   7800.875 ±  56.276  ns/op
[info] MixedChunkBenchmarks.foldM      1000  avgt    5  35482.390 ± 146.847  ns/op
[info] MixedChunkBenchmarks.map        1000  avgt    5  12396.030 ± 252.868  ns/op
[info] MixedChunkBenchmarks.mapM       1000  avgt    5      6.906 ±   0.017  ns/op
```