### PR TITLE
Deprecate ZQueue#both Operators

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -759,7 +759,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       for {
         q1 <- Queue.bounded[Int](100)
         q2 <- Queue.bounded[Int](100)
-        q   = q1 both q2
+        q   = q1 both q2 @silent("deprecated")
         _  <- q.offer(10)
         v  <- q.take
       } yield assert(v)(equalTo((10, 10)))

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+import com.github.ghik.silencer.silent
 import zio.ZQueueSpecUtil.waitForSize
 import zio.duration._
 import zio.test.Assertion._
@@ -759,7 +760,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       for {
         q1 <- Queue.bounded[Int](100)
         q2 <- Queue.bounded[Int](100)
-        q   = q1 both q2 @silent("deprecated")
+        q   = (q1 both q2): @silent("deprecated")
         _  <- q.offer(10)
         v  <- q.take
       } yield assert(v)(equalTo((10, 10)))

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -144,6 +144,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
   /**
    * Alias for `both`.
    */
+  @deprecated("use ZStream", "2.0.0")
   final def &&[RA1 <: RA, RB1 <: RB, EA1 >: EA, EB1 >: EB, A1 <: A, C, D](
     that: ZQueue[RA1, RB1, EA1, EB1, A1, C]
   ): ZQueue[RA1, RB1, EA1, EB1, A1, (B, C)] =
@@ -152,6 +153,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
   /**
    * Like `bothWith`, but tuples the elements instead of applying a function.
    */
+  @deprecated("use ZStream", "2.0.0")
   final def both[RA1 <: RA, RB1 <: RB, EA1 >: EA, EB1 >: EB, A1 <: A, C, D](
     that: ZQueue[RA1, RB1, EA1, EB1, A1, C]
   ): ZQueue[RA1, RB1, EA1, EB1, A1, (B, C)] =
@@ -160,6 +162,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
   /**
    * Like `bothWithM`, but uses a pure function.
    */
+  @deprecated("use ZStream", "2.0.0")
   final def bothWith[RA1 <: RA, RB1 <: RB, EA1 >: EA, EB1 >: EB, A1 <: A, C, D](
     that: ZQueue[RA1, RB1, EA1, EB1, A1, C]
   )(f: (B, C) => D): ZQueue[RA1, RB1, EA1, EB1, A1, D] =
@@ -174,6 +177,7 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
    * For example, a dropping queue and a bounded queue composed together may apply `f`
    * to different elements.
    */
+  @deprecated("use ZStream", "2.0.0")
   final def bothWithM[RA1 <: RA, RB1 <: RB, R3 <: RB1, EA1 >: EA, EB1 >: EB, E3 >: EB1, A1 <: A, C, D](
     that: ZQueue[RA1, RB1, EA1, EB1, A1, C]
   )(f: (B, C) => ZIO[R3, E3, D]): ZQueue[RA1, R3, EA1, E3, A1, D] =


### PR DESCRIPTION
Resolves #4636.

I don't think the operators to combine two queues together are used very often and some of the semantics are also not very well defined. I think we are better off pushing people to use streams for use cases like this where there is a richer set of operators designed specifically for these types of problems.