### PR TITLE
Implement ZQueue#filterOutput

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -788,6 +788,32 @@ object ZQueueSpec extends ZIOBaseSpec {
       } yield assert(s1)(equalTo(0)) &&
         assert(s2)(equalTo(1))
     },
+    testM("queue filterOutput with take") {
+      for {
+        queue <- Queue.bounded[Int](2).map(_.filterOutput(_ % 2 == 0))
+        _     <- queue.offer(1)
+        _     <- queue.offer(2)
+        value <- queue.take
+      } yield assert(value)(equalTo(2))
+    },
+    testM("queue filterOutput with takeAll") {
+      for {
+        queue  <- Queue.unbounded[Int].map(_.filterOutput(_ % 2 == 0))
+        _      <- queue.offerAll(List(1, 2, 3, 4, 5))
+        values <- queue.takeAll
+        size   <- queue.size
+      } yield assert(values)(equalTo(List(2, 4))) &&
+        assert(size)(equalTo(0))
+    },
+    testM("queue filterOutput with takeUpTo") {
+      for {
+        queue  <- Queue.unbounded[Int].map(_.filterOutput(_ % 2 == 0))
+        _      <- queue.offerAll(List(1, 2, 3, 4, 5))
+        values <- queue.takeUpTo(2)
+        size   <- queue.size
+      } yield assert(values)(equalTo(List(2, 4))) &&
+        assert(size)(equalTo(1))
+    },
     testM("queue isShutdown") {
       for {
         queue <- Queue.bounded[Int](5)

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -288,6 +288,59 @@ sealed abstract class ZQueue[-RA, -RB, +EA, +EB, -A, +B] extends Serializable { 
     }
 
   /**
+   * Filters elements dequeued from the queue using the specified predicate.
+   */
+  final def filterOutput(f: B => Boolean): ZQueue[RA, RB, EA, EB, A, B] =
+    filterOutputM(b => ZIO.succeedNow(f(b)))
+
+  /**
+   * Filters elements dequeued from the queue using the specified effectual
+   * predicate.
+   */
+  def filterOutputM[RB1 <: RB, EB1 >: EB](f: B => ZIO[RB1, EB1, Boolean]): ZQueue[RA, RB1, EA, EB1, A, B] =
+    new ZQueue[RA, RB1, EA, EB1, A, B] {
+      def awaitShutdown: UIO[Unit] =
+        self.awaitShutdown
+      def capacity: Int =
+        self.capacity
+      def isShutdown: UIO[Boolean] =
+        self.isShutdown
+      def offer(a: A): ZIO[RA, EA, Boolean] =
+        self.offer(a)
+      def offerAll(as: Iterable[A]): ZIO[RA, EA, Boolean] =
+        self.offerAll(as)
+      def shutdown: UIO[Unit] =
+        self.shutdown
+      def size: UIO[Int] =
+        self.size
+      def take: ZIO[RB1, EB1, B] =
+        self.take.flatMap { b =>
+          f(b).flatMap { p =>
+            if (p) ZIO.succeedNow(b)
+            else take
+          }
+        }
+      def takeAll: ZIO[RB1, EB1, List[B]] =
+        self.takeAll.flatMap(bs => ZIO.filter(bs)(f))
+      def takeUpTo(max: Int): ZIO[RB1, EB1, List[B]] =
+        ZIO.effectSuspendTotal {
+          val buffer = ListBuffer[B]()
+          def loop(max: Int): ZIO[RB1, EB1, Unit] =
+            self.takeUpTo(max).flatMap { bs =>
+              if (bs.isEmpty) ZIO.unit
+              else
+                ZIO.filter(bs)(f).flatMap { filtered =>
+                  buffer ++= filtered
+                  val length = filtered.length
+                  if (length == max) ZIO.unit
+                  else loop(max - length)
+                }
+            }
+          loop(max).as(buffer.toList)
+        }
+    }
+
+  /**
    * Transforms elements dequeued from this queue with a function.
    */
   final def map[C](f: B => C): ZQueue[RA, RB, EA, EB, A, C] =


### PR DESCRIPTION
Implements `filterOutput` and `filterOutputM` operators on `ZQueue` analogous to the existing `filterInput` and `filterInputM` operators. Particularly useful if the queue represents values that are being broadcast from an upstream producer to allow a consumer to receive only a subset of the values.