### PR TITLE
Prevent Interruption During Queue Shutdown

### DIFF
--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -586,7 +586,7 @@ object ZQueue {
 
         UIO
           .whenM(shutdownHook.succeed(()))(
-            UIO.foreachPar(unsafePollAll(takers))(_.interruptAs(fiberId)) *> strategy.shutdown
+            UIO.foreachPar_(unsafePollAll(takers))(_.interruptAs(fiberId)) *> strategy.shutdown
           )
       }.uninterruptible
 

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -588,8 +588,7 @@ object ZQueue {
           .whenM(shutdownHook.succeed(()))(
             UIO.foreachPar(unsafePollAll(takers))(_.interruptAs(fiberId)) *> strategy.shutdown
           )
-          .uninterruptible
-      }
+      }.uninterruptible
 
     val isShutdown: UIO[Boolean] = UIO(shutdownFlag.get)
 


### PR DESCRIPTION
Currently the finalizers in `ZQueue` are uninterruptible but we could be interrupted between setting the shutdown flag and running the finalizers, which leaves us in a somewhat undefined state where the queue says it has been shutdown but actually hasn't been shutdown yet. We can move the `uninterruptible` around the outer scope to ensure that if the shutdown flag is set the finalization logic will run as well.