### PR TITLE
Use scala-reflect as a dependency of JVM test-sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,6 @@ lazy val coreTestsJVM = coreTests.jvm
   .settings(dottySettings)
   .configure(_.enablePlugins(JCStressPlugin))
   .settings(replSettings)
-  .settings(scalaReflectTestSettings)
 
 lazy val coreTestsJS = coreTests.js
   .settings(jsSettings)
@@ -259,10 +258,8 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform)
   .settings(macroExpansionSettings)
   .enablePlugins(BuildInfoPlugin)
 
-lazy val testTestsJVM = testTests.jvm
-  .settings(dottySettings)
-  .settings(scalaReflectTestSettings)
-lazy val testTestsJS = testTests.js.settings(jsSettings)
+lazy val testTestsJVM = testTests.jvm.settings(dottySettings)
+lazy val testTestsJS  = testTests.js.settings(jsSettings)
 
 lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-magnolia"))
@@ -418,7 +415,6 @@ lazy val testJunitRunnerTestsJVM = testJunitRunnerTests.jvm
         .dependsOn(Keys.publishM2 in stacktracerJVM)
         .value
   )
-  .settings(scalaReflectTestSettings)
 
 /**
  * Examples sub-project that is not included in the root project.

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -298,9 +298,9 @@ object BuildHelper {
   val scalaReflectTestSettings: List[Setting[_]] = List(
     libraryDependencies ++= {
       if (isDotty.value)
-        Seq(("org.scala-lang" % "scala-reflect" % Scala213 % Test).withDottyCompat(scalaVersion.value))
+        Seq(("org.scala-lang" % "scala-reflect" % Scala213).withDottyCompat(scalaVersion.value))
       else
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Test)
+        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
     }
   )
 


### PR DESCRIPTION
Only JVM test-sbt needs scala-reflect, but it needs to be a normal dependency -- `Test` nor `Provided` work
(tested by `publishLocal` and using such artifacts on a project)

fixes https://github.com/zio/zio/issues/4643
