### PR TITLE
Fix Naming Conflict

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/MutableConcurrentQueueSpecJVM.scala
@@ -11,7 +11,7 @@ import zio.test._
  *
  * Concurrent tests are run via jcstress and are in [[RingBufferConcurrencyTests]].
  */
-object MutableConcurrentQueueJVM extends ZIOBaseSpec {
+object MutableConcurrentQueueSpecJVM extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("MutableConcurrentQueueSpec")(
     suite("Serialization works for")(


### PR DESCRIPTION
Naming conflict between file name and class name currently leads to an error when running concurrency stress tests.