### PR TITLE
Retrieve Current Executor in ZIO#runtime and ZIO#executor

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -351,6 +351,17 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(IO.done(failed).run)(fails(equalTo(error)))
       }
     ),
+    suite("executor")(
+      testM("retrieves the current executor for this effect") {
+        val executor = internal.Executor.fromExecutionContext(100) {
+          scala.concurrent.ExecutionContext.Implicits.global
+        }
+        for {
+          default <- ZIO.executor
+          global  <- ZIO.executor.lock(executor)
+        } yield assert(default)(not(equalTo(global)))
+      }
+    ),
     suite("repeatUntil")(
       testM("repeatUntil repeats until condition is true") {
         for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2698,7 +2698,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Retrieves the executor for this effect.
    */
   def executor: UIO[Executor] =
-    effectSuspendTotalWith((platform, _) => ZIO.succeedNow(platform.executor))
+    ZIO.descriptorWith(descriptor => ZIO.succeedNow(descriptor.executor))
 
   /**
    * Returns an effect that models failure with the specified error.
@@ -3765,7 +3765,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     for {
       environment <- environment[R]
       platform    <- effectSuspendTotalWith((p, _) => ZIO.succeedNow(p))
-    } yield Runtime(environment, platform)
+      executor    <- executor
+    } yield Runtime(environment, platform.withExecutor(executor))
 
   /**
    * Passes the fiber's scope to the specified function, which creates an effect


### PR DESCRIPTION
Currently the `runtime` and `executor` operators on `ZIO` retrieve ZIO's overall runtime system and the executor associated with it. This is somewhat non-compositional because it means that if the user accesses the `Runtime` or the `Executor` in an inner scope they can end up running effects on the default thread pool instead of the thread pool that the region is locked on. This PR changes that behavior to access the current `Executor` for the fiber and use that.