### PR TITLE
Implement ZManaged.lock

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -481,8 +481,8 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("lock")(
       testM("locks acquire, use, and release actions to the specified executor") {
-        val executor = ZIO.descriptorWith(descriptor => ZIO.succeedNow(descriptor.executor))
-        val global   = Executor.fromExecutionContext(100)(ExecutionContext.global)
+        val executor: UIO[Executor] = ZIO.descriptorWith(descriptor => ZIO.succeedNow(descriptor.executor))
+        val global                  = Executor.fromExecutionContext(100)(ExecutionContext.global)
         for {
           default <- executor
           ref1    <- Ref.make[Executor](default)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -4,10 +4,13 @@ import zio.Cause.Interrupt
 import zio.Exit.Failure
 import zio.ZManaged.ReleaseMap
 import zio.duration._
+import zio.internal.Executor
 import zio.test.Assertion._
 import zio.test.TestAspect.{nonFlaky, scala2Only}
 import zio.test._
 import zio.test.environment._
+
+import scala.concurrent.ExecutionContext
 
 object ZManagedSpec extends ZIOBaseSpec {
 
@@ -474,6 +477,23 @@ object ZManagedSpec extends ZIOBaseSpec {
         val onFalse: ZManaged[R1, E1, A] = ZManaged.succeed(new A {})
         val _                            = ZManaged.ifM(b)(onTrue, onFalse)
         ZIO.succeed(assertCompletes)
+      }
+    ),
+    suite("lock")(
+      testM("locks acquire, use, and release actions to the specified executor") {
+        val executor = ZIO.descriptorWith(descriptor => ZIO.succeedNow(descriptor.executor))
+        val global   = Executor.fromExecutionContext(100)(ExecutionContext.global)
+        for {
+          default <- executor
+          ref1    <- Ref.make[Executor](default)
+          ref2    <- Ref.make[Executor](default)
+          managed  = ZManaged.make_(ZIO.executor.flatMap(ref1.set))(ZIO.executor.flatMap(ref2.set)).lock(global)
+          use     <- managed.use_(ZIO.executor)
+          acquire <- ref1.get
+          release <- ref2.get
+        } yield assert(acquire)(equalTo(global)) &&
+          assert(use)(equalTo(global)) &&
+          assert(release)(equalTo(global))
       }
     ),
     suite("mergeAll")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3383,7 +3383,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * [[ZIO!.lock]].
    */
   def lock[R, E, A](executor: => Executor)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
-    ZIO.effectSuspendTotal(new ZIO.Lock(executor, zio))
+    ZIO.descriptorWith(descriptor => ZIO.shift(executor).bracket_(ZIO.shift(descriptor.executor), zio))
 
   /**
    * Loops with the specified effectual function, collecting the results into a
@@ -3804,6 +3804,16 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   def services[A: Tag, B: Tag, C: Tag, D: Tag]: URIO[Has[A] with Has[B] with Has[C] with Has[D], (A, B, C, D)] =
     ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
+
+  /**
+   * Returns an effect that shifts execution to the specified executor. This
+   * is useful to specify a default executor that effects sequenced after this
+   * one will be run on if they are not shifted somewhere else. It can also be
+   * used to implement higher level operators to manage where an effect is run
+   * such as [[ZIO!.lock]] and [[ZIO!.on]].
+   */
+  def shift(executor: Executor): UIO[Unit] =
+    new ZIO.Shift(executor)
 
   /**
    * Returns an effect that suspends for the specified duration. This method is
@@ -4282,7 +4292,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     final val EffectAsync              = 8
     final val Fork                     = 9
     final val Descriptor               = 10
-    final val Lock                     = 11
+    final val Shift                    = 11
     final val Yield                    = 12
     final val Access                   = 13
     final val Provide                  = 14
@@ -4370,8 +4380,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     override def tag = Tags.Descriptor
   }
 
-  private[zio] final class Lock[R, E, A](val executor: Executor, val zio: ZIO[R, E, A]) extends ZIO[R, E, A] {
-    override def tag = Tags.Lock
+  private[zio] final class Shift(val executor: Executor) extends UIO[Unit] {
+    override def tag = Tags.Shift
   }
 
   private[zio] object Yield extends UIO[Unit] {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -64,10 +64,11 @@ private[zio] final class FiberContext[E, A](
 
   private[this] val stack             = Stack[Any => IO[Any, Any]]()
   private[this] val environments      = Stack[AnyRef](startEnv)
-  private[this] val executors         = Stack[Executor](startExec)
   private[this] val interruptStatus   = StackBool(startIStatus.toBoolean)
   private[this] val supervisors       = Stack[Supervisor[Any]](supervisor0)
   private[this] val forkScopeOverride = Stack[Option[ZScope[Exit[Any, Any]]]]()
+
+  private[this] var currentExecutor = startExec
 
   var scopeKey: ZScope.Key = null
 
@@ -209,7 +210,8 @@ private[zio] final class FiberContext[E, A](
     discardedFolds
   }
 
-  private[this] def executor: Executor = executors.peekOrElse(platform.executor)
+  private[this] def executor: Executor =
+    if (currentExecutor ne null) currentExecutor else platform.executor
 
   @inline private[this] def raceWithImpl[R, EL, ER, E, A, B, C](
     race: ZIO.RaceWith[R, EL, ER, E, A, B, C]
@@ -526,12 +528,12 @@ private[zio] final class FiberContext[E, A](
 
                     curZio = k(getDescriptor())
 
-                  case ZIO.Tags.Lock =>
-                    val zio = curZio.asInstanceOf[ZIO.Lock[Any, E, Any]]
+                  case ZIO.Tags.Shift =>
+                    val zio = curZio.asInstanceOf[ZIO.Shift]
 
                     curZio =
-                      if (zio.executor eq executors.peek()) zio.zio
-                      else lock(zio.executor).bracket_(unlock, zio.zio)
+                      if (zio.executor eq currentExecutor) ZIO.unit
+                      else shift(zio.executor)
 
                   case ZIO.Tags.Yield =>
                     evaluateLater(ZIO.unit)
@@ -659,11 +661,8 @@ private[zio] final class FiberContext[E, A](
       }
     } finally Fiber._currentFiber.remove()
 
-  private[this] def lock(executor: Executor): UIO[Unit] =
-    ZIO.effectTotal(executors.push(executor)) *> ZIO.yieldNow
-
-  private[this] def unlock: UIO[Unit] =
-    ZIO.effectTotal(executors.pop()) *> ZIO.yieldNow
+  private[this] def shift(executor: Executor): UIO[Unit] =
+    ZIO.effectTotal { currentExecutor = executor } *> ZIO.yieldNow
 
   private[this] def getDescriptor(): Fiber.Descriptor =
     Fiber.Descriptor(
@@ -707,7 +706,7 @@ private[zio] final class FiberContext[E, A](
       childId,
       platform,
       currentEnv,
-      executors.peek(),
+      currentExecutor,
       InterruptStatus.fromBoolean(interruptStatus.peekOrElse(true)),
       ancestry,
       tracingRegion,

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -15,7 +15,9 @@ object MimaSettings {
         exclude[Problem]("zio.internal.*"),
         exclude[DirectMissingMethodProblem]("zio.ZManaged.reserve"),
         exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this"),
-        exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension")
+        exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension"),
+        exclude[MissingClassProblem]("zio.ZIO$Lock"),
+        exclude[DirectMissingMethodProblem]("zio.ZIO#Tags.Lock")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
Resolves #4661.

To support this we need to change the algebra of `ZIO` slightly. `lock` describes a static scope of shifting onto and off of a thread pool around a given effect. However, that doesn't give us the power to describe shifting for dynamic scopes. To support this we remove `lock` as a primitive and replace it with `shift`, which shifts to a specified `Executor`. `lock` can then be implemented using a combination of `shift` and `bracket`. With this change, `lock` just becomes a `ZManaged` effect that describes shifting onto a thread pool as its `acquire` effect and shifting back as its `release` effect.