### PR TITLE
Fixed minor typo in "AdGear"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ production to craft concurrent applications.
 
 Want to see your company here? [Submit a PR](https://github.com/zio/zio/edit/master/README.md)!
 
+* [AdGear / Samsung Ads](https://adgear.com/en/)
 * [Adidas](https://www.adidas.com/)
-* [Adgear / Samsung Ads](https://adgear.com/en/)
 * [adsquare](https://www.adsquare.com/)
 * [Asana](https://asana.com/)
 * [Aurinko](https://www.aurinko.io/)


### PR DESCRIPTION
- Fixed minor typo in "AdGear" (Uppercase G)
- Moved Adgear before Adidas to respect alphabetical order