### PR TITLE
Add zio-test-akka-http to ecosystem.md

### DIFF
--- a/docs/ecosystem/ecosystem.md
+++ b/docs/ecosystem/ecosystem.md
@@ -51,6 +51,7 @@ If you know a useful library that has direct support for ZIO, please consider [s
 - [zio-saga](https://github.com/VladKopanev/zio-saga): Purely functional transaction management with Saga pattern
 - [zio-slf4j](https://github.com/NeQuissimus/zio-slf4j): Referentially transparent logging with slf4j
 - [zio-slick](https://github.com/rleibman/zio-slick): Bridge library between ZIO and Slick Functional Relational Mapping Library
+- [zio-test-akka-http](https://github.com/senia-psm/zio-test-akka-http): Akka-HTTP Route TestKit for zio-test
 
 
 ## Tools for ZIO


### PR DESCRIPTION
I'd like to add my library [zio-test-akka-http](https://github.com/senia-psm/zio-test-akka-http) to ecosystem list.

It's an akka-HTTP Route TestKit for zio-test