### PR TITLE
Allow chaining multiple aspects to MutuableRunnableSpec suite

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultMutableRunnableSpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultMutableRunnableSpecSpec.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio.ZIO
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.ignore
+import zio.test.TestAspect._
 
 object DefaultMutableRunnableSpecSpec extends DefaultMutableRunnableSpec {
 
@@ -54,4 +54,9 @@ object DefaultMutableRunnableSpecSpec extends DefaultMutableRunnableSpec {
     assert(0)(equalTo(0))
   }
 
+  suite("suite supports chained aspects") {
+    test("test supports chained aspects") {
+      assertCompletes
+    } @@ ignore @@ timed
+  } @@ ignore @@ timed
 }

--- a/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
@@ -49,7 +49,7 @@ class MutableRunnableSpec[R <: Has[_]](layer: ZLayer[TestEnvironment, Throwable,
      */
     final def @@(
       aspect: TestAspect[R, R, Failure, Failure]
-    ): SpecBuilder = {
+    ): SuiteBuilder = {
       aspects = aspects :+ aspect
       this
     }


### PR DESCRIPTION
A small fix, allowing chained aspects on the `suite` of MutableRunnableSpec, otherwise it's a compilation error.

Thanks to @somdoron for the fix!