### PR TITLE
Implement ZIO#cachedWith

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -164,17 +164,17 @@ object ZIOSpec extends ZIOBaseSpec {
         def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.updateAndGet(_ + 1)
         for {
           ref              <- Ref.make(0)
-          tuple            <- incrementAndGet(ref).cachedWith(60.minutes)
-          (get, invalidate) = tuple
-          a                <- get
+          tuple            <- incrementAndGet(ref).cachedInvalidate(60.minutes)
+          (cached, invalidate) = tuple
+          a                <- cached
           _                <- TestClock.adjust(59.minutes)
-          b                <- get
+          b                <- cached
           _                <- invalidate
-          c                <- get
+          c                <- cached
           _                <- TestClock.adjust(1.minute)
-          d                <- get
+          d                <- cached
           _                <- TestClock.adjust(59.minutes)
-          e                <- get
+          e                <- cached
         } yield assert(a)(equalTo(b)) &&
           assert(b)(not(equalTo(c))) &&
           assert(c)(equalTo(d)) &&

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -163,18 +163,18 @@ object ZIOSpec extends ZIOBaseSpec {
       testM("returns new instances after duration") {
         def incrementAndGet(ref: Ref[Int]): UIO[Int] = ref.updateAndGet(_ + 1)
         for {
-          ref              <- Ref.make(0)
-          tuple            <- incrementAndGet(ref).cachedInvalidate(60.minutes)
+          ref                 <- Ref.make(0)
+          tuple               <- incrementAndGet(ref).cachedInvalidate(60.minutes)
           (cached, invalidate) = tuple
-          a                <- cached
-          _                <- TestClock.adjust(59.minutes)
-          b                <- cached
-          _                <- invalidate
-          c                <- cached
-          _                <- TestClock.adjust(1.minute)
-          d                <- cached
-          _                <- TestClock.adjust(59.minutes)
-          e                <- cached
+          a                   <- cached
+          _                   <- TestClock.adjust(59.minutes)
+          b                   <- cached
+          _                   <- invalidate
+          c                   <- cached
+          _                   <- TestClock.adjust(1.minute)
+          d                   <- cached
+          _                   <- TestClock.adjust(59.minutes)
+          e                   <- cached
         } yield assert(a)(equalTo(b)) &&
           assert(b)(not(equalTo(c))) &&
           assert(c)(equalTo(d)) &&

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -286,7 +286,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * this effect. Cached results will expire after `timeToLive` duration.
    */
   final def cached(timeToLive: Duration): ZIO[R with Clock, Nothing, IO[E, A]] =
-    cachedWith(timeToLive).map(_._1)
+    cachedInvalidate(timeToLive).map(_._1)
 
   /**
    * Returns an effect that, if evaluated, will return the cached result of
@@ -294,7 +294,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * addition, returns an effect that can be used to invalidate the current
    * cached value before the `timeToLive` duration expires.
    */
-  final def cachedWith(timeToLive: Duration): ZIO[R with Clock, Nothing, (IO[E, A], UIO[Unit])] = {
+  final def cachedInvalidate(timeToLive: Duration): ZIO[R with Clock, Nothing, (IO[E, A], UIO[Unit])] = {
 
     def compute(start: Long): ZIO[R with Clock, Nothing, Option[(Long, Promise[E, A])]] =
       for {


### PR DESCRIPTION
We've gotten several requests recently for a variant of `cached` that allows the caller to invalidate the cache before the `timeToLive` has expired.  This is potentially getting a little specialized but given user demand I think it makes sense to add and we can implement the current `cached` operator in terms of this one so it is not adding much new code.