### PR TITLE
Add support for polymorphic service types to mockable macro (#4717)

### DIFF
--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -124,7 +124,12 @@ object modules {
   type PolyModulePureDefsModule[R, E, A] = Has[PolyModulePureDefsModule.Service[R, E, A]]
   object PolyModulePureDefsModule {
     trait Service[R, E, A] {
+      val static: ZIO[R, E, A]
+      def zeroParams: ZIO[R, E, A]
       def zeroParamsWithParens(): ZIO[R, E, A]
+      def singleParam(a: Int): ZIO[R, E, A]
+      def manyParams(a: Int, b: String, c: Long): ZIO[R, E, A]
+      def manyParamLists(a: Int)(b: String)(c: Long): ZIO[R, E, A]
     }
   }
 }

--- a/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
+++ b/test-tests/shared/src/main/scala/zio/test/mock/modules.scala
@@ -1,6 +1,6 @@
 package zio.test.mock
 
-import zio.{Has, IO, Tag, UIO}
+import zio.{Has, IO, Tag, UIO, ZIO}
 
 /**
  * https://github.com/scalamacros/paradise/issues/75
@@ -118,6 +118,13 @@ object modules {
     trait Service {
       def foo(i: Int): String = bar(i.toString)
       def bar(s: String): String
+    }
+  }
+
+  type PolyModulePureDefsModule[R, E, A] = Has[PolyModulePureDefsModule.Service[R, E, A]]
+  object PolyModulePureDefsModule {
+    trait Service[R, E, A] {
+      def zeroParamsWithParens(): ZIO[R, E, A]
     }
   }
 }

--- a/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
+++ b/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
@@ -246,11 +246,18 @@ object MockableSpec extends DefaultRunnableSpec {
       },
       test("generates mocks for polymorphic services") {
         assert({
-          @mockable[PolyModulePureDefsModule.Service[Int, String, Unit]]
+          @mockable[PolyModulePureDefsModule.Service[String, Exception, Double]]
           object ModuleMock
 
           object Check {
-            val mock: Mock[PolyModulePureDefsModule[Int, String, Unit]] = ModuleMock
+            val mock: Mock[PolyModulePureDefsModule[String, Exception, Double]] = ModuleMock
+
+            val Static: ModuleMock.Effect[Unit, Exception, Double]                        = ModuleMock.Static
+            val ZeroParams: ModuleMock.Effect[Unit, Exception, Double]                    = ModuleMock.ZeroParams
+            val ZeroParamsWithParens: ModuleMock.Effect[Unit, Exception, Double]          = ModuleMock.ZeroParamsWithParens
+            val SingleParam: ModuleMock.Effect[Int, Exception, Double]                    = ModuleMock.SingleParam
+            val ManyParams: ModuleMock.Effect[(Int, String, Long), Exception, Double]     = ModuleMock.ManyParams
+            val ManyParamLists: ModuleMock.Effect[(Int, String, Long), Exception, Double] = ModuleMock.ManyParamLists
           }
 
           Check

--- a/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
+++ b/test-tests/shared/src/test/scala-2.x/zio/test/mock/MockableSpec.scala
@@ -243,6 +243,18 @@ object MockableSpec extends DefaultRunnableSpec {
 
           Check
         })(anything)
+      },
+      test("generates mocks for polymorphic services") {
+        assert({
+          @mockable[PolyModulePureDefsModule.Service[Int, String, Unit]]
+          object ModuleMock
+
+          object Check {
+            val mock: Mock[PolyModulePureDefsModule[Int, String, Unit]] = ModuleMock
+          }
+
+          Check
+        })(anything)
       }
     )
   )


### PR DESCRIPTION
Implementation for #4718 
This implementation seems to work, but am keen for advice on how to improve it. Perhaps there are some corner cases missed? 