### PR TITLE
Upstream Generators From ZIO Test Refined Module #4600

### DIFF
--- a/test-refined/shared/src/main/scala/zio/test/refined/CharInstances.scala
+++ b/test-refined/shared/src/main/scala/zio/test/refined/CharInstances.scala
@@ -9,34 +9,26 @@ import zio.test.magnolia.DeriveGen
 object char extends CharInstances
 
 trait CharInstances {
-  private val alphaCharGen: Gen[Random, Char] =
-    Gen.weighted(Gen.char(65, 90) -> 26, Gen.char(97, 122) -> 26)
-
-  private val numericCharGen: Gen[Random, Char] =
-    Gen.weighted(Gen.char(48, 57) -> 10)
-
-  private val whitespaceChars: Seq[Char] =
-    (Char.MinValue to Char.MaxValue).filter(_.isWhitespace)
 
   implicit def digitArbitrary: DeriveGen[Refined[Char, Digit]] =
-    DeriveGen.instance(numericCharGen.map(value => Refined.unsafeApply(value)))
+    DeriveGen.instance(Gen.numericChar.map(value => Refined.unsafeApply(value)))
 
   implicit def letterDeriveGen: DeriveGen[Refined[Char, Letter]] =
-    DeriveGen.instance(alphaCharGen.map(value => Refined.unsafeApply(value)))
+    DeriveGen.instance(Gen.alphaChar.map(value => Refined.unsafeApply(value)))
 
   implicit def lowerCaseDeriveGen: DeriveGen[Refined[Char, LowerCase]] =
     DeriveGen.instance(
-      alphaCharGen.map(value => Refined.unsafeApply(value.toLower))
+      Gen.alphaChar.map(value => Refined.unsafeApply(value.toLower))
     )
 
   implicit def upperCaseDeriveGen: DeriveGen[Refined[Char, UpperCase]] =
     DeriveGen.instance(
-      alphaCharGen.map(value => Refined.unsafeApply(value.toUpper))
+      Gen.alphaChar.map(value => Refined.unsafeApply(value.toUpper))
     )
 
   implicit def whitespaceDeriveGen: DeriveGen[Refined[Char, Whitespace]] = {
     val whiteSpaceGens: Seq[Gen[Random, Char]] =
-      whitespaceChars.map(Gen.const(_))
+      Gen.whitespaceChars.map(Gen.const(_))
 
     DeriveGen.instance(
       Gen

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -182,6 +182,24 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     weighted(char(48, 57) -> 10, char(65, 90) -> 26, char(97, 122) -> 26)
 
   /**
+   * A generator of alpha characters.
+   */
+  val alphaChar: Gen[Random, Char] =
+    weighted(char(65, 90) -> 26, char(97, 122) -> 26)
+
+  /**
+   * A generator of numeric characters. Shrinks toward '0'.
+   */
+  val numericChar: Gen[Random, Char] =
+    weighted(char(48, 57) -> 10)
+
+  /**
+   * A generator of whitespace characters.
+   */
+  val whitespaceChars: Seq[Char] =
+    (Char.MinValue to Char.MaxValue).filter(_.isWhitespace)
+
+  /**
    * A generator of alphanumeric strings. Shrinks towards the empty string.
    */
   val alphaNumericString: Gen[Random with Sized, String] =


### PR DESCRIPTION
Implementation for #4600.

Moved three generators from [CharInstances](https://github.com/zio/zio/blob/2769933b193e47a21a205a9fcecd626876333f02/test-refined/shared/src/main/scala/zio/test/refined/CharInstances.scala#L11) to [Gen](https://github.com/zio/zio/blob/2769933b193e47a21a205a9fcecd626876333f02/test/shared/src/main/scala/zio/test/Gen.scala#L167)

However, I'm not sure about javadoc description and shrinks. Please, check them out.