### PR TITLE
Implement Default Supervisor

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -116,6 +116,7 @@ private[internal] trait PlatformSpecific {
    */
   final def makeDefault(yieldOpCount: Int = defaultYieldOpCount): Platform =
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ExecutionContext.global))
+      .withSupervisor(Supervisor.unsafeTrack(true))
 
   final def newWeakSet[A](): JSet[A] = new HashSet[A]()
 

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -126,7 +126,7 @@ private[internal] trait PlatformSpecific {
    * Makes a new default platform. This is a side-effecting method.
    */
   def makeDefault(yieldOpCount: Int = defaultYieldOpCount): Platform =
-    fromExecutor(Executor.makeDefault(yieldOpCount))
+    fromExecutor(Executor.makeDefault(yieldOpCount)).withSupervisor(Supervisor.unsafeTrack(true))
 
   final def newWeakHashMap[A, B](): JMap[A, B] =
     Collections.synchronizedMap(new WeakHashMap[A, B]())

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -116,6 +116,7 @@ private[internal] trait PlatformSpecific {
    */
   final def makeDefault(yieldOpCount: Int = defaultYieldOpCount): Platform =
     fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ExecutionContext.global))
+      .withSupervisor(Supervisor.unsafeTrack(true))
 
   final def newWeakSet[A](): JSet[A] = new HashSet[A]()
 


### PR DESCRIPTION
Includes a supervisor in the default runtime that tracks all fibers forked in the application. The one thing that is not great here is the type of the `Supervisor` in `Runtime` is `Any` so the user has to call `Supervisor#value` to get the result of a supervision event and then pattern match on it to recover the information that it is a chunk of fibers. Possibly in 2.0 we could add a type parameter to `Runtime` for the result of a supervision event to improve this.