### PR TITLE
Add TSemaphore To Index

### DIFF
--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -23,6 +23,7 @@ ZIO contains a small number of data types that can help you solve complex proble
  - **[TQueue](tqueue.md)** - A `TQueue` is a mutable queue that can participate in transactions.
  - **[TReentrantLock](treentrantlock.md)** - A `TReentrantLock` is a reentrant read / write lock that can be composed.
  - **[TRef](tref.md)** - A `TRef` is a mutable reference to an immutable value that can participate in transactions.
+  - **[TSemaphore](tsemaphore.md)** - A `TSemaphore` is a semaphore that can participate in transactions.
  - **[TSet](tset.md)** - A `TSet` is a mutable set that can participate in transactions.
  - **[Has](has.md)** - A `Has` is used to express an effect's dependency on a service of type `A`.
  - **[ZLayer](zlayer.md)** - A `ZLayer` describes a layer of an application.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -17,8 +17,10 @@
   "datatypes-sidebar": {
     "Data Types": [
       "datatypes/datatypes_index",
+      "datatypes/datatypes_chunk",
       "datatypes/datatypes_fiber",
       "datatypes/datatypes_fiberref",
+      "datatypes/datatypes_has",
       "datatypes/datatypes_io",
       "datatypes/datatypes_managed",
       "datatypes/datatypes_promise",
@@ -28,15 +30,16 @@
       "datatypes/datatypes_semaphore",
       "datatypes/datatypes_sink",
       "datatypes/datatypes_stream",
-      "datatypes/datatypes_chunk",
       "datatypes/datatypes_tarray",
       "datatypes/datatypes_tmap",
       "datatypes/datatypes_tpriorityqueue",
-      "datatypes/datatypes_treentrantlock",
       "datatypes/datatypes_tpromise",
       "datatypes/datatypes_tqueue",
+      "datatypes/datatypes_treentrantlock",
       "datatypes/datatypes_tref",
-      "datatypes/datatypes_tset"
+      "datatypes/datatypes_tsemaphore",
+      "datatypes/datatypes_tset",
+      "datatypes/datatypes_zlayer"
     ]
   },
   "interop-sidebar": {


### PR DESCRIPTION
We have existing documentation on `TSemaphore` but it was not being included in the index [here](https://zio.dev/docs/datatypes/datatypes_index).