### PR TITLE
Flatten exit in supervisor unsafeOnEnd

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -201,7 +201,7 @@ trait Runtime[+R] {
     if (supervisor ne Supervisor.none) {
       supervisor.unsafeOnStart(environment, zio, None, context)
 
-      context.onDone(exit => supervisor.unsafeOnEnd(exit, context))
+      context.onDone(exit => supervisor.unsafeOnEnd(exit.flatten, context))
     }
 
     context.evaluateNow(ZIOFn.recordStackTrace(() => zio)(zio.asInstanceOf[IO[E, A]]))

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -719,7 +719,7 @@ private[zio] final class FiberContext[E, A](
     if (currentSup ne Supervisor.none) {
       currentSup.unsafeOnStart(currentEnv, zio, Some(self), childContext)
 
-      childContext.onDone(exit => currentSup.unsafeOnEnd(exit, childContext))
+      childContext.onDone(exit => currentSup.unsafeOnEnd(exit.flatten, childContext))
     }
 
     val childZio = if (parentScope ne ZScope.global) {


### PR DESCRIPTION
As per discussion in Discord `unsafeOnEnd` should get the actual exit `Exit[E,A]` and not `Exit[Nothing, Exit[E,A]]` that is provided by `FiberContext#onDone` this PR uses `flatten` to re-enstablish the correct exit value