### PR TITLE
Implement ZManaged.blocking

### DIFF
--- a/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
@@ -25,6 +25,14 @@ import java.nio.file.Path
 
 private[zio] trait ZManagedPlatformSpecific {
 
+  /**
+   * Returns a managed effect that describes shifting to the blocking executor
+   * as the `acquire` action and shifting back to the original executor as the
+   * `release` action.
+   */
+  val blocking: ZManaged[Blocking, Nothing, Unit] =
+    blockingExecutor.toManaged_.flatMap(executor => ZManaged.lock(executor))
+
   def readFile(path: Path): ZManaged[Blocking, IOException, ZInputStream] =
     readFile(path.toString())
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -17,6 +17,7 @@
 package zio
 
 import zio.ZManaged.ReleaseMap
+import zio.blocking._
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.Executor
@@ -1437,6 +1438,14 @@ object ZManaged extends ZManagedPlatformSpecific {
     new ZManaged[R, E, A] {
       def zio = run0
     }
+
+  /**
+   * Returns a managed effect that describes shifting to the blocking executor
+   * as the `acquire` action and shifting back to the original executor as the
+   * `release` action.
+   */
+  val blocking: ZManaged[Blocking, Nothing, Unit] =
+    blockingExecutor.toManaged_.flatMap(executor => ZManaged.lock(executor))
 
   /**
    * Evaluate each effect in the structure from left to right, collecting the

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -17,7 +17,6 @@
 package zio
 
 import zio.ZManaged.ReleaseMap
-import zio.blocking._
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.internal.Executor
@@ -1438,14 +1437,6 @@ object ZManaged extends ZManagedPlatformSpecific {
     new ZManaged[R, E, A] {
       def zio = run0
     }
-
-  /**
-   * Returns a managed effect that describes shifting to the blocking executor
-   * as the `acquire` action and shifting back to the original executor as the
-   * `release` action.
-   */
-  val blocking: ZManaged[Blocking, Nothing, Unit] =
-    blockingExecutor.toManaged_.flatMap(executor => ZManaged.lock(executor))
 
   /**
    * Evaluate each effect in the structure from left to right, collecting the

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -18,7 +18,9 @@ object MimaSettings {
         exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension"),
         exclude[MissingClassProblem]("zio.ZIO$Lock"),
         exclude[DirectMissingMethodProblem]("zio.ZIO#Tags.Lock"),
-        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="),
+        exclude[ReversedMissingMethodProblem](
+          "zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="
+        ),
         exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking")
       ),
       mimaFailOnProblem := failOnProblem

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -17,7 +17,9 @@ object MimaSettings {
         exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this"),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension"),
         exclude[MissingClassProblem]("zio.ZIO$Lock"),
-        exclude[DirectMissingMethodProblem]("zio.ZIO#Tags.Lock")
+        exclude[DirectMissingMethodProblem]("zio.ZIO#Tags.Lock"),
+        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="),
+        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
Currently it can be somewhat awkward to handle managed blocking effects because the `blocking` operator expects a `ZIO` rather than a `Managed`. This PR implements a `blocking` constructor on `ZManaged` that returns a managed effect that shifts to the blocking executor as its acquire action and shifts back to the previous locked executor as its release action. This can be used to ensure that a managed effect or other dynamic scope is run on the blocking executor.