### PR TITLE
Handle Interruption After Fatal Error In FiberContext

### DIFF
--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -16,6 +16,8 @@
 
 package zio
 
+import zio.internal.FiberContext
+
 /**
  * The entry point for a purely-functional application on the JVM.
  *
@@ -55,9 +57,18 @@ trait App extends BootstrapRuntime {
         for {
           fiber <- run(args0.toList).fork
           _ <- IO.effectTotal(java.lang.Runtime.getRuntime.addShutdownHook(new Thread {
-                 override def run() = {
-                   val _ = unsafeRunSync(fiber.interrupt)
-                 }
+                 override def run() =
+                   if (FiberContext.fatal.get) {
+                     println(
+                       "**** WARNING ***\n" +
+                         "Catastrophic JVM error encountered. " +
+                         "Application not safely interrupted. " +
+                         "Resources may be leaked. " +
+                         "Check the logs for more details and consider overriding `Platform.reportFatal` to capture context."
+                     )
+                   } else {
+                     val _ = unsafeRunSync(fiber.interrupt)
+                   }
                }))
           result <- fiber.join
           _      <- fiber.interrupt

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1072,8 +1072,8 @@ private[zio] final class FiberContext[E, A](
     val exit         = Exit.die(t)
     val currentState = state.getAndSet(Done(exit))
     currentState match {
-      case Executing(_, observers, _) => notifyObservers(exit, observers)
-      case _                          =>
+      case Executing(_, observers: List[Callback[Nothing, Exit[E, A]]], _) => notifyObservers(exit, observers)
+      case _                                                               =>
     }
   }
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1072,8 +1072,8 @@ private[zio] final class FiberContext[E, A](
     val exit         = Exit.die(t)
     val currentState = state.getAndSet(Done(exit))
     currentState match {
-      case Executing(status, observers, interrupted) => notifyObservers(exit, observers)
-      case Done(value)                               =>
+      case Executing(_, observers, _) => notifyObservers(exit, observers)
+      case _                          =>
     }
   }
 


### PR DESCRIPTION
Resolves #4810.

The cause of the issue is that when we attempt to interrupt the main fiber in the shutdown hook added by `App` we suspend indefinitely.

My analysis is that when we call `interrupt` it invokes `kill0` in `FiberContext`, which if the fiber is still in an `Executing` state adds an interrupted cause and then calls `await`, which if the fiber is in an `Executing` state registers itself as an observer of the fiber and waits for the fiber to be done. Normally this works fine because adding the interrupted cause leads to the fiber entering a `Done` state and notifying the observers, allowing the interruption to successfully return.

However, when a fatal exception is thrown we stop interpreting further continuations in the main run loop for that fiber, so we never get to a `Done` state and never notify the observers of that fiber, hence the interruption hanging forever.

To address that, this PR implements a new `fatal` method that sets the state to `Done` and notifies any pending observers at that point.