### PR TITLE
Replace buildFromAny with buildFromNothing

### DIFF
--- a/core/shared/src/main/scala-2.13+/zio/BuildFromCompat.scala
+++ b/core/shared/src/main/scala-2.13+/zio/BuildFromCompat.scala
@@ -6,7 +6,12 @@ private[zio] trait BuildFromCompat {
 
   type BuildFrom[-From, -A, +C] = scala.collection.BuildFrom[From, A, C]
 
-  implicit def buildFromAny[Element, Collection[+Element] <: Iterable[Element] with IterableOps[Any, Collection, Any]]
+  @deprecated("Use BuildFrom.buildFromIterableOps or buildFromNothing instead", "1.0.6")
+  def buildFromAny[Element, Collection[+Element] <: Iterable[Element] with IterableOps[Any, Collection, Any]]
     : BuildFrom[Collection[Any], Element, Collection[Element]] =
     scala.collection.BuildFrom.buildFromIterableOps[Collection, Any, Element]
+
+  implicit def buildFromNothing[A, Collection[+Element] <: Iterable[Element] with IterableOps[A, Collection, _]]
+    : BuildFrom[Collection[A], Nothing, Collection[Nothing]] =
+    scala.collection.BuildFrom.buildFromIterableOps[Collection, A, Nothing]
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -6,18 +6,13 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
 object MimaSettings {
-  lazy val bincompatVersionToCompare = "1.0.1"
+  lazy val bincompatVersionToCompare = "1.0.5"
 
   def mimaSettings(failOnProblem: Boolean) =
     Seq(
       mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
       mimaBinaryIssueFilters ++= Seq(
         exclude[Problem]("zio.internal.*"),
-        exclude[DirectMissingMethodProblem]("zio.ZManaged.reserve"),
-        exclude[DirectMissingMethodProblem]("zio.ZIO#Fork.this"),
-        exclude[IncompatibleResultTypeProblem]("zio.stm.TSemaphore.assertNonNegative$extension"),
-        exclude[MissingClassProblem]("zio.ZIO$Lock"),
-        exclude[DirectMissingMethodProblem]("zio.ZIO#Tags.Lock"),
         exclude[ReversedMissingMethodProblem](
           "zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="
         ),


### PR DESCRIPTION
Instead of generalizing to `Any` we need to specialize to `Nothing`.
All other cases are covered by the default `BuildFrom.buildFromIterableOps`.

Also fixes Intellij highlighting issue.

See scala/bug#12350
Workaround for scala/bug#12104
Followup to zio/zio#4582
