### PR TITLE
Implement ZIO#debug and related methods

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -459,20 +459,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Taps the effect, printing the result of calling `.toString` on the value
    */
   final def debug: ZIO[R, E, A] =
-    self.tap(value => UIO(println(value)))
-
-  /**
-   * Taps the effect, printing the result of calling `.toString` on the value.
-   * Prefixes the output with the given message.
-   */
-  final def debug(prefix: => String): ZIO[R, E, A] =
-    self.tap(value => UIO(println(s"$prefix: $value")))
-
-  /**
-   * Taps the effect, printing the result of calling `.toString` on the value
-   * or the error.
-   */
-  final def debugBoth: ZIO[R, E, A] =
     self.tapBoth(
       error => UIO(println(s"<FAIL> $error")),
       value => UIO(println(value))
@@ -482,24 +468,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Taps the effect, printing the result of calling `.toString` on the value.
    * Prefixes the output with the given message.
    */
-  final def debugBoth(prefix: => String): ZIO[R, E, A] =
+  final def debug(prefix: => String): ZIO[R, E, A] =
     self.tapBoth(
       error => UIO(println(s"<FAIL> $prefix: $error")),
       value => UIO(println(s"$prefix: $value"))
     )
-
-  /**
-   * Taps the effect, printing the result of calling `.toString` on the failure.
-   */
-  final def debugError: ZIO[R, E, A] =
-    self.tapError(error => UIO(println(s"<FAIL> $error")))
-
-  /**
-   * Taps the effect, printing the result of calling `.toString` on the failure.
-   * Prefixes the output with the given message.
-   */
-  final def debugError(prefix: => String): ZIO[R, E, A] =
-    self.tapError(error => UIO(println(s"<FAIL> $prefix: $error")))
 
   /**
    * Returns an effect that is delayed from this effect by the specified

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -456,6 +456,52 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def compose[R1, E1 >: E](that: ZIO[R1, E1, R]): ZIO[R1, E1, A] = self <<< that
 
   /**
+   * Taps the effect, printing the result of calling `.toString` on the value
+   */
+  final def debug: ZIO[R, E, A] =
+    self.tap(value => UIO(println(value)))
+
+  /**
+   * Taps the effect, printing the result of calling `.toString` on the value.
+   * Prefixes the output with the given message.
+   */
+  final def debug(prefix: => String): ZIO[R, E, A] =
+    self.tap(value => UIO(println(s"$prefix: $value")))
+
+  /**
+   * Taps the effect, printing the result of calling `.toString` on the value
+   * or the error.
+   */
+  final def debugBoth: ZIO[R, E, A] =
+    self.tapBoth(
+      error => UIO(println(s"<FAIL> $error")),
+      value => UIO(println(value))
+    )
+
+  /**
+   * Taps the effect, printing the result of calling `.toString` on the value.
+   * Prefixes the output with the given message.
+   */
+  final def debugBoth(prefix: => String): ZIO[R, E, A] =
+    self.tapBoth(
+      error => UIO(println(s"<FAIL> $prefix: $error")),
+      value => UIO(println(s"$prefix: $value"))
+    )
+
+  /**
+   * Taps the effect, printing the result of calling `.toString` on the failure.
+   */
+  final def debugError: ZIO[R, E, A] =
+    self.tapError(error => UIO(println(s"<FAIL> $error")))
+
+  /**
+   * Taps the effect, printing the result of calling `.toString` on the failure.
+   * Prefixes the output with the given message.
+   */
+  final def debugError(prefix: => String): ZIO[R, E, A] =
+    self.tapError(error => UIO(println(s"<FAIL> $prefix: $error")))
+
+  /**
    * Returns an effect that is delayed from this effect by the specified
    * [[zio.duration.Duration]].
    */


### PR DESCRIPTION
A useful method for debugging/teaching/learning. `putStrLn` is a bit difficult to use in an ad hoc manner as it requires a string, so you have to write `.tap(arg => console.putStrLn(a.toString))`, which is a bit of a mouthful when you just want to peek at the current value.

I've implemented `debug` and `debug(prefix: String)` and related methods for easily printing out the value. All it does is `tap` and `putStrLn` after calling `toString`, also optionally prefixing the output with the specified message.

```scala
object Example extends App {
  val effect = random.nextInt.flatMap {
    case i if i % 3 == 0 => ZIO.fail(s"OH NO $i")
    case i => UIO(i)
  }

  def run(args: List[String]) =
    ZIO
      .replicateParM(10)(effect.debugBoth("Cool"))
      .exitCode
}
```
This will output:
```shell
Cool: -1522815466
Cool: 541453234
Cool: -482366690
Cool: 1597855825
Cool: -507234278
Cool: 364903378
Cool: 594767090
Cool <FAIL>: OH NO 811767111
Cool <FAIL>: OH NO -2115255561
Cool <FAIL>: OH NO 1561730550
```