### PR TITLE
Add helpful implicit errors

### DIFF
--- a/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -24,7 +24,7 @@ private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   /**
    * Converts the current `ZIO` to a Scala.js promise.
    */
-  def toPromiseJS(implicit ev: E HasError Throwable): URIO[R, JSPromise[A]] =
+  def toPromiseJS(implicit ev: E IsSubtypeOfError Throwable): URIO[R, JSPromise[A]] =
     toPromiseJSWith(ev)
 
   /**

--- a/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -24,7 +24,7 @@ private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   /**
    * Converts the current `ZIO` to a Scala.js promise.
    */
-  def toPromiseJS(implicit ev: E <:< Throwable): URIO[R, JSPromise[A]] =
+  def toPromiseJS(implicit ev: E HasError Throwable): URIO[R, JSPromise[A]] =
     toPromiseJSWith(ev)
 
   /**

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -23,7 +23,7 @@ import java.nio.channels.CompletionHandler
 import java.util.concurrent.{CompletableFuture, CompletionStage, Future}
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
-  def toCompletableFuture[A1 >: A](implicit ev: E <:< Throwable): URIO[R, CompletableFuture[A1]] =
+  def toCompletableFuture[A1 >: A](implicit ev: E HasError Throwable): URIO[R, CompletableFuture[A1]] =
     toCompletableFutureWith(ev)
 
   def toCompletableFutureWith[A1 >: A](f: E => Throwable): URIO[R, CompletableFuture[A1]] =

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -23,7 +23,7 @@ import java.nio.channels.CompletionHandler
 import java.util.concurrent.{CompletableFuture, CompletionStage, Future}
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
-  def toCompletableFuture[A1 >: A](implicit ev: E HasError Throwable): URIO[R, CompletableFuture[A1]] =
+  def toCompletableFuture[A1 >: A](implicit ev: E IsSubtypeOfError Throwable): URIO[R, CompletableFuture[A1]] =
     toCompletableFutureWith(ev)
 
   def toCompletableFutureWith[A1 >: A](f: E => Throwable): URIO[R, CompletableFuture[A1]] =

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -389,7 +389,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
    */
-  final def squash(implicit ev: E HasError Throwable): Throwable =
+  final def squash(implicit ev: E IsSubtypeOfError Throwable): Throwable =
     squashWith(ev)
 
   /**
@@ -413,7 +413,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * In addition, appends a new element the to `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    */
-  final def squashTrace(implicit ev: E HasError Throwable): Throwable =
+  final def squashTrace(implicit ev: E IsSubtypeOfError Throwable): Throwable =
     squashTraceWith(ev)
 
   /**

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -389,7 +389,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the
    * "most important" `Throwable`.
    */
-  final def squash(implicit ev: E <:< Throwable): Throwable =
+  final def squash(implicit ev: E HasError Throwable): Throwable =
     squashWith(ev)
 
   /**
@@ -413,7 +413,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * In addition, appends a new element the to `Throwable`s "caused by" chain,
    * with this `Cause` "pretty printed" (in stackless mode) as the message.
    */
-  final def squashTrace(implicit ev: E <:< Throwable): Throwable =
+  final def squashTrace(implicit ev: E HasError Throwable): Throwable =
     squashTraceWith(ev)
 
   /**

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -274,7 +274,7 @@ sealed abstract class Fiber[+E, +A] { self =>
    * @param ev implicit witness that E is a subtype of Throwable
    * @return `UIO[Future[A]]`
    */
-  final def toFuture(implicit ev: E HasError Throwable): UIO[CancelableFuture[A]] =
+  final def toFuture(implicit ev: E IsSubtypeOfError Throwable): UIO[CancelableFuture[A]] =
     self toFutureWith ev
 
   /**

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -274,7 +274,7 @@ sealed abstract class Fiber[+E, +A] { self =>
    * @param ev implicit witness that E is a subtype of Throwable
    * @return `UIO[Future[A]]`
    */
-  final def toFuture(implicit ev: E <:< Throwable): UIO[CancelableFuture[A]] =
+  final def toFuture(implicit ev: E HasError Throwable): UIO[CancelableFuture[A]] =
     self toFutureWith ev
 
   /**

--- a/core/shared/src/main/scala/zio/IsSubtype.scala
+++ b/core/shared/src/main/scala/zio/IsSubtype.scala
@@ -1,0 +1,27 @@
+package zio
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("\nOutput Type Mismatch\n  expected: ${B}\n    actual: ${A}\n\n")
+sealed abstract class HasOutput[-A, +B] extends (A => B)
+object HasOutput {
+  implicit def impl[A, B](implicit subtype: A <:< B): HasOutput[A, B] = new HasOutput[A, B] {
+    override def apply(a: A): B = subtype(a)
+  }
+
+  implicit def implNothing[B]: HasOutput[Nothing, B] = new HasOutput[Nothing, B] {
+    override def apply(a: Nothing): B = a
+  }
+}
+
+@implicitNotFound("\nError Type Mismatch\n  expected: ${B}\n    actual: ${A}\n\n")
+sealed abstract class HasError[-A, +B] extends (A => B)
+object HasError {
+  implicit def impl[A, B](implicit subtype: A <:< B): HasError[A, B] = new HasError[A, B] {
+    override def apply(a: A): B = subtype(a)
+  }
+
+  implicit def implNothing[B]: HasError[Nothing, B] = new HasError[Nothing, B] {
+    override def apply(a: Nothing): B = a
+  }
+}

--- a/core/shared/src/main/scala/zio/IsSubtype.scala
+++ b/core/shared/src/main/scala/zio/IsSubtype.scala
@@ -2,26 +2,26 @@ package zio
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("\nOutput Type Mismatch\n  expected: ${B}\n    actual: ${A}\n\n")
-sealed abstract class HasOutput[-A, +B] extends (A => B)
-object HasOutput {
-  implicit def impl[A, B](implicit subtype: A <:< B): HasOutput[A, B] = new HasOutput[A, B] {
+@implicitNotFound("This operator requires that the output type be a subtype of ${B} but the actual type was ${A}.")
+sealed abstract class IsSubtypeOfOutput[-A, +B] extends (A => B) with Serializable
+object IsSubtypeOfOutput {
+  implicit def impl[A, B](implicit subtype: A <:< B): IsSubtypeOfOutput[A, B] = new IsSubtypeOfOutput[A, B] {
     override def apply(a: A): B = subtype(a)
   }
 
-  implicit def implNothing[B]: HasOutput[Nothing, B] = new HasOutput[Nothing, B] {
+  implicit def implNothing[B]: IsSubtypeOfOutput[Nothing, B] = new IsSubtypeOfOutput[Nothing, B] {
     override def apply(a: Nothing): B = a
   }
 }
 
-@implicitNotFound("\nError Type Mismatch\n  expected: ${B}\n    actual: ${A}\n\n")
-sealed abstract class HasError[-A, +B] extends (A => B)
-object HasError {
-  implicit def impl[A, B](implicit subtype: A <:< B): HasError[A, B] = new HasError[A, B] {
+@implicitNotFound("This operator requires that the error type be a subtype of ${B} but the actual type was ${A}.")
+sealed abstract class IsSubtypeOfError[-A, +B] extends (A => B) with Serializable
+object IsSubtypeOfError {
+  implicit def impl[A, B](implicit subtype: A <:< B): IsSubtypeOfError[A, B] = new IsSubtypeOfError[A, B] {
     override def apply(a: A): B = subtype(a)
   }
 
-  implicit def implNothing[B]: HasError[Nothing, B] = new HasError[Nothing, B] {
+  implicit def implNothing[B]: IsSubtypeOfError[Nothing, B] = new IsSubtypeOfError[Nothing, B] {
     override def apply(a: Nothing): B = a
   }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -950,7 +950,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns a new effect where boolean value of this effect is negated.
    */
   final def negate(implicit ev: A IsSubtypeOfOutput Boolean): ZIO[R, E, Boolean] =
-    map(result => !result)
+    map(result => !ev(result))
 
   /**
    * Requires the option produced by this value to be `None`.
@@ -958,7 +958,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def none[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, Option[E], Unit] =
     self.foldM(
       e => ZIO.fail(Some(e)),
-      a => a.fold[ZIO[R, Option[E], Unit]](ZIO.succeedNow(()))(_ => ZIO.fail(None))
+      a => ev(a).fold[ZIO[R, Option[E], Unit]](ZIO.succeedNow(()))(_ => ZIO.fail(None))
     )
 
   /**
@@ -1065,7 +1065,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def optional[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZIO[R, E1, Option[A]] =
     self.foldM(
-      e => e.fold[ZIO[R, E1, Option[A]]](ZIO.succeedNow(Option.empty[A]))(ZIO.fail(_)),
+      e => ev(e).fold[ZIO[R, E1, Option[A]]](ZIO.succeedNow(Option.empty[A]))(ZIO.fail(_)),
       a => ZIO.succeedNow(Some(a))
     )
 
@@ -1751,14 +1751,14 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def some[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, Option[E], B] =
     self.foldM(
       e => ZIO.fail(Some(e)),
-      a => a.fold[ZIO[R, Option[E], B]](ZIO.fail(Option.empty[E]))(ZIO.succeedNow)
+      a => ev(a).fold[ZIO[R, Option[E], B]](ZIO.fail(Option.empty[E]))(ZIO.succeedNow)
     )
 
   /**
    * Extracts the optional value, or returns the given 'default'.
    */
   final def someOrElse[B](default: => B)(implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, E, B] =
-    map(_.getOrElse(default))
+    map(a => ev(a).getOrElse(default))
 
   /**
    * Extracts the optional value, or executes the effect 'default'.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -164,14 +164,14 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect that submerges the error case of an `Either` into the
    * `ZIO`. The inverse operation of `ZIO.either`.
    */
-  final def absolve[E1 >: E, B](implicit ev: A HasOutput Either[E1, B]): ZIO[R, E1, B] =
+  final def absolve[E1 >: E, B](implicit ev: A IsSubtypeOfOutput Either[E1, B]): ZIO[R, E1, B] =
     ZIO.absolve(self.map(ev))
 
   /**
    * Attempts to convert defects into a failure, throwing away all information
    * about the cause of the failure.
    */
-  final def absorb(implicit ev: E HasError Throwable): RIO[R, A] =
+  final def absorb(implicit ev: E IsSubtypeOfError Throwable): RIO[R, A] =
     absorbWith(ev)
 
   /**
@@ -644,7 +644,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    *
    * This method can be used to "flatten" nested effects.
    */
-  final def flatten[R1 <: R, E1 >: E, B](implicit ev1: A HasOutput ZIO[R1, E1, B]): ZIO[R1, E1, B] =
+  final def flatten[R1 <: R, E1 >: E, B](implicit ev1: A IsSubtypeOfOutput ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     self.flatMap(a => ev1(a))
 
   /**
@@ -795,20 +795,25 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Unwraps the optional error, defaulting to the provided value.
    */
-  final def flattenErrorOption[E1, E2 <: E1](default: => E2)(implicit ev: E HasError Option[E1]): ZIO[R, E1, A] =
+  final def flattenErrorOption[E1, E2 <: E1](default: => E2)(implicit
+    ev: E IsSubtypeOfError Option[E1]
+  ): ZIO[R, E1, A] =
     self.mapError(e => ev(e).getOrElse(default))
 
   /**
    * Unwraps the optional success of this effect, but can fail with an None value.
    */
-  final def get[B](implicit ev1: E HasError Nothing, ev2: A HasOutput Option[B]): ZIO[R, Option[Nothing], B] =
+  final def get[B](implicit
+    ev1: E IsSubtypeOfError Nothing,
+    ev2: A IsSubtypeOfOutput Option[B]
+  ): ZIO[R, Option[Nothing], B] =
     ZIO.absolve(self.mapError(ev1)(CanFail).map(ev2(_).toRight(None)))
 
   /**
    * Returns a successful effect with the head of the list if the list is
    * non-empty or fails with the error `None` if the list is empty.
    */
-  final def head[B](implicit ev: A HasOutput List[B]): ZIO[R, Option[E], B] =
+  final def head[B](implicit ev: A IsSubtypeOfOutput List[B]): ZIO[R, Option[E], B] =
     self.foldM(
       e => ZIO.fail(Some(e)),
       a => ev(a).headOption.fold[ZIO[R, Option[E], B]](ZIO.fail(None))(ZIO.succeedNow)
@@ -903,7 +908,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect whose success is mapped by the specified side effecting
    * `f` function, translating any thrown exceptions into typed failed effects.
    */
-  final def mapEffect[B](f: A => B)(implicit ev: E HasError Throwable): RIO[R, B] =
+  final def mapEffect[B](f: A => B)(implicit ev: E IsSubtypeOfError Throwable): RIO[R, B] =
     foldM(e => ZIO.fail(ev(e)), a => ZIO.effect(f(a)))
 
   /**
@@ -938,19 +943,19 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns a new effect where the error channel has been merged into the
    * success channel to their common combined type.
    */
-  final def merge[A1 >: A](implicit ev1: E HasError A1, ev2: CanFail[E]): URIO[R, A1] =
+  final def merge[A1 >: A](implicit ev1: E IsSubtypeOfError A1, ev2: CanFail[E]): URIO[R, A1] =
     self.foldM(e => ZIO.succeedNow(ev1(e)), ZIO.succeedNow)
 
   /**
    * Returns a new effect where boolean value of this effect is negated.
    */
-  final def negate(implicit ev: A HasOutput Boolean): ZIO[R, E, Boolean] =
+  final def negate(implicit ev: A IsSubtypeOfOutput Boolean): ZIO[R, E, Boolean] =
     map(result => !result)
 
   /**
    * Requires the option produced by this value to be `None`.
    */
-  final def none[B](implicit ev: A HasOutput Option[B]): ZIO[R, Option[E], Unit] =
+  final def none[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, Option[E], Unit] =
     self.foldM(
       e => ZIO.fail(Some(e)),
       a => a.fold[ZIO[R, Option[E], Unit]](ZIO.succeedNow(()))(_ => ZIO.fail(None))
@@ -1058,7 +1063,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Converts an option on errors into an option on values.
    */
-  final def optional[E1](implicit ev: E HasError Option[E1]): ZIO[R, E1, Option[A]] =
+  final def optional[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZIO[R, E1, Option[A]] =
     self.foldM(
       e => e.fold[ZIO[R, E1, Option[A]]](ZIO.succeedNow(Option.empty[A]))(ZIO.fail(_)),
       a => ZIO.succeedNow(Some(a))
@@ -1068,7 +1073,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Translates effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  final def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): URIO[R, A] =
+  final def orDie(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): URIO[R, A] =
     orDieWith(ev1)
 
   /**
@@ -1086,7 +1091,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    *  val f2: Task[Unit] = f1.resurrect
    * }}}
    */
-  final def resurrect(implicit ev1: E HasError Throwable): RIO[R, A] =
+  final def resurrect(implicit ev1: E IsSubtypeOfError Throwable): RIO[R, A] =
     self.unrefineWith({ case e => e })(ev1)
 
   /**
@@ -1117,7 +1122,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def orElseOptional[R1 <: R, E1, A1 >: A](
     that: => ZIO[R1, Option[E1], A1]
-  )(implicit ev: E HasError Option[E1]): ZIO[R1, Option[E1], A1] =
+  )(implicit ev: E IsSubtypeOfError Option[E1]): ZIO[R1, Option[E1], A1] =
     catchAll(ev(_).fold(that)(e => ZIO.fail(Some(e))))
 
   /**
@@ -1219,7 +1224,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Left`, or fails with the error `None`.
    */
-  final def left[B, C](implicit ev: A HasOutput Either[B, C]): ZIO[R, Option[E], B] =
+  final def left[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Option[E], B] =
     self.foldM(
       e => ZIO.fail(Some(e)),
       a => ev(a).fold(ZIO.succeedNow, _ => ZIO.fail(None))
@@ -1228,7 +1233,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Left`, or fails with the error e.
    */
-  final def leftOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A HasOutput Either[B, C]): ZIO[R, E1, B] =
+  final def leftOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, B] =
     self.flatMap(ev(_) match {
       case Right(_)    => ZIO.fail(e)
       case Left(value) => ZIO.succeedNow(value)
@@ -1237,7 +1242,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Left`, or fails with the given error function 'e'.
    */
-  final def leftOrFailWith[B, C, E1 >: E](e: C => E1)(implicit ev: A HasOutput Either[B, C]): ZIO[R, E1, B] =
+  final def leftOrFailWith[B, C, E1 >: E](e: C => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, B] =
     self.flatMap(ev(_) match {
       case Left(value) => ZIO.succeedNow(value)
       case Right(err)  => ZIO.fail(e(err))
@@ -1247,8 +1252,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns a successful effect if the value is `Left`, or fails with a [[java.util.NoSuchElementException]].
    */
   final def leftOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A HasOutput Either[B, C],
-    ev2: E HasError E1
+    ev: A IsSubtypeOfOutput Either[B, C],
+    ev2: E IsSubtypeOfError E1
   ): ZIO[R, E1, B] =
     self.foldM(
       e => ZIO.fail(ev2(e)),
@@ -1265,7 +1270,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Right`, or fails with the error `None`.
    */
-  final def right[B, C](implicit ev: A HasOutput Either[B, C]): ZIO[R, Option[E], C] =
+  final def right[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Option[E], C] =
     self.foldM(
       e => ZIO.fail(Some(e)),
       a => ev(a).fold(_ => ZIO.fail(None), ZIO.succeedNow)
@@ -1274,7 +1279,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Right`, or fails with the given error 'e'.
    */
-  final def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A HasOutput Either[B, C]): ZIO[R, E1, C] =
+  final def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, C] =
     self.flatMap(ev(_) match {
       case Right(value) => ZIO.succeedNow(value)
       case Left(_)      => ZIO.fail(e)
@@ -1283,7 +1288,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns a successful effect if the value is `Right`, or fails with the given error function 'e'.
    */
-  final def rightOrFailWith[B, C, E1 >: E](e: B => E1)(implicit ev: A HasOutput Either[B, C]): ZIO[R, E1, C] =
+  final def rightOrFailWith[B, C, E1 >: E](e: B => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, C] =
     self.flatMap(ev(_) match {
       case Right(value) => ZIO.succeedNow(value)
       case Left(err)    => ZIO.fail(e(err))
@@ -1293,8 +1298,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns a successful effect if the value is `Right`, or fails with a [[java.util.NoSuchElementException]].
    */
   final def rightOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A HasOutput Either[B, C],
-    ev2: E HasError E1
+    ev: A IsSubtypeOfOutput Either[B, C],
+    ev2: E IsSubtypeOfError E1
   ): ZIO[R, E1, C] =
     self.foldM(
       e => ZIO.fail(ev2(e)),
@@ -1449,7 +1454,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def refineOrDie[E1](
     pf: PartialFunction[E, E1]
-  )(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZIO[R, E1, A] =
+  )(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZIO[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**
@@ -1743,7 +1748,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Converts an option on values into an option on errors.
    */
   // <:
-  final def some[B](implicit ev: A HasOutput Option[B]): ZIO[R, Option[E], B] =
+  final def some[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, Option[E], B] =
     self.foldM(
       e => ZIO.fail(Some(e)),
       a => a.fold[ZIO[R, Option[E], B]](ZIO.fail(Option.empty[E]))(ZIO.succeedNow)
@@ -1752,7 +1757,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Extracts the optional value, or returns the given 'default'.
    */
-  final def someOrElse[B](default: => B)(implicit ev: A HasOutput Option[B]): ZIO[R, E, B] =
+  final def someOrElse[B](default: => B)(implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, E, B] =
     map(_.getOrElse(default))
 
   /**
@@ -1760,7 +1765,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def someOrElseM[B, R1 <: R, E1 >: E](
     default: ZIO[R1, E1, B]
-  )(implicit ev: A HasOutput Option[B]): ZIO[R1, E1, B] =
+  )(implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R1, E1, B] =
     self.flatMap(ev(_) match {
       case Some(value) => ZIO.succeedNow(value)
       case None        => default
@@ -1769,7 +1774,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Extracts the optional value, or fails with the given error 'e'.
    */
-  final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A HasOutput Option[B]): ZIO[R, E1, B] =
+  final def someOrFail[B, E1 >: E](e: => E1)(implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, E1, B] =
     self.flatMap(ev(_) match {
       case Some(value) => ZIO.succeedNow(value)
       case None        => ZIO.fail(e)
@@ -1779,7 +1784,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Extracts the optional value, or fails with a [[java.util.NoSuchElementException]]
    */
   final def someOrFailException[B, E1 >: E](implicit
-    ev: A HasOutput Option[B],
+    ev: A IsSubtypeOfOutput Option[B],
     ev2: NoSuchElementException <:< E1
   ): ZIO[R, E1, B] =
     self.foldM(
@@ -1972,7 +1977,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Converts the effect into a [[scala.concurrent.Future]].
    */
-  final def toFuture(implicit ev2: E HasError Throwable): URIO[R, CancelableFuture[A]] =
+  final def toFuture(implicit ev2: E IsSubtypeOfError Throwable): URIO[R, CancelableFuture[A]] =
     self toFutureWith ev2
 
   /**
@@ -1991,7 +1996,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Constructs a layer from this effect, which must return one or more
    * services.
    */
-  final def toLayerMany[A1 <: Has[_]](implicit ev: A HasOutput A1): ZLayer[R, E, A1] =
+  final def toLayerMany[A1 <: Has[_]](implicit ev: A IsSubtypeOfOutput A1): ZLayer[R, E, A1] =
     ZLayer(ZManaged.fromEffect(self.map(ev)))
 
   /**
@@ -2046,7 +2051,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    *
    * This operation is the opposite of [[cause]].
    */
-  final def uncause[E1 >: E](implicit ev: A HasOutput Cause[E1]): ZIO[R, E1, Unit] =
+  final def uncause[E1 >: E](implicit ev: A IsSubtypeOfOutput Cause[E1]): ZIO[R, E1, Unit] =
     self.flatMap { a =>
       val cause = ev(a)
 
@@ -2113,7 +2118,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * The inverse operation to `sandbox`. Submerges the full cause of failure.
    */
-  final def unsandbox[E1](implicit ev: E HasError Cause[E1]): ZIO[R, E1, A] =
+  final def unsandbox[E1](implicit ev: E IsSubtypeOfError Cause[E1]): ZIO[R, E1, A] =
     ZIO.unsandbox(self.mapError(ev))
 
   /**

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -182,7 +182,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    * Translates effect failure into death of the fiber, making all failures
    * unchecked and not a part of the type of the layer.
    */
-  final def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZLayer[RIn, Nothing, ROut] =
+  final def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZLayer[RIn, Nothing, ROut] =
     catchAll(ZLayer.second >>> ZLayer.fromFunctionManyM(ZIO.die(_)))
 
   /**

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -183,7 +183,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    * unchecked and not a part of the type of the layer.
    */
   final def orDie(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZLayer[RIn, Nothing, ROut] =
-    catchAll(ZLayer.second >>> ZLayer.fromFunctionManyM(ZIO.die(_)))
+    catchAll(ZLayer.second >>> ZLayer.fromFunctionManyM(e => ZIO.die(ev1(e))))
 
   /**
    * Executes this layer and returns its output, if it succeeds, but otherwise

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -182,7 +182,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    * Translates effect failure into death of the fiber, making all failures
    * unchecked and not a part of the type of the layer.
    */
-  final def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZLayer[RIn, Nothing, ROut] =
+  final def orDie(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZLayer[RIn, Nothing, ROut] =
     catchAll(ZLayer.second >>> ZLayer.fromFunctionManyM(ZIO.die(_)))
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -159,7 +159,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    * Attempts to convert defects into a failure, throwing away all information
    * about the cause of the failure.
    */
-  def absorb(implicit ev: E <:< Throwable): ZManaged[R, Throwable, A] =
+  def absorb(implicit ev: E HasError Throwable): ZManaged[R, Throwable, A] =
     absorbWith(ev)
 
   /**
@@ -462,7 +462,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    * Returns an effect whose success is mapped by the specified side effecting
    * `f` function, translating any thrown exceptions into typed failed effects.
    */
-  final def mapEffect[B](f: A => B)(implicit ev: E <:< Throwable): ZManaged[R, Throwable, B] =
+  final def mapEffect[B](f: A => B)(implicit ev: E HasError Throwable): ZManaged[R, Throwable, B] =
     foldM(e => ZManaged.fail(ev(e)), a => ZManaged.effect(f(a)))
 
   /**
@@ -590,7 +590,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    * Translates effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, Nothing, A] =
+  def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZManaged[R, Nothing, A] =
     orDieWith(ev1)
 
   /**
@@ -759,7 +759,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    */
   def refineOrDie[E1](
     pf: PartialFunction[E, E1]
-  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
+  )(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZManaged[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -514,7 +514,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
   final def none[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZManaged[R, Option[E], Unit] =
     self.foldM(
       e => ZManaged.fail(Some(e)),
-      a => a.fold[ZManaged[R, Option[E], Unit]](ZManaged.succeedNow(()))(_ => ZManaged.fail(None))
+      a => ev(a).fold[ZManaged[R, Option[E], Unit]](ZManaged.succeedNow(()))(_ => ZManaged.fail(None))
     )
 
   /**
@@ -585,7 +585,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    */
   final def optional[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
     self.foldM(
-      e => e.fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
+      e => ev(e).fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
       a => ZManaged.succeedNow(Some(a))
     )
 
@@ -862,14 +862,14 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
   final def some[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZManaged[R, Option[E], B] =
     self.foldM(
       e => ZManaged.fail(Some(e)),
-      a => a.fold[ZManaged[R, Option[E], B]](ZManaged.fail(Option.empty[E]))(ZManaged.succeedNow)
+      a => ev(a).fold[ZManaged[R, Option[E], B]](ZManaged.fail(Option.empty[E]))(ZManaged.succeedNow)
     )
 
   /**
    * Extracts the optional value, or returns the given 'default'.
    */
   final def someOrElse[B](default: => B)(implicit ev: A IsSubtypeOfOutput Option[B]): ZManaged[R, E, B] =
-    map(_.getOrElse(default))
+    map(a => ev(a).getOrElse(default))
 
   /**
    * Extracts the optional value, or executes the effect 'default'.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -459,7 +459,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * throw exceptions but is otherwise pure, translating any thrown exceptions
    * into typed failed effects.
    */
-  def mapPartial[B](f: A => B)(implicit ev: E HasError Throwable): ZSTM[R, Throwable, B] =
+  def mapPartial[B](f: A => B)(implicit ev: E IsSubtypeOfError Throwable): ZSTM[R, Throwable, B] =
     foldM(e => ZSTM.fail(ev(e)), a => ZSTM.partial(f(a)))
 
   /**
@@ -529,7 +529,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Translates `STM` effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): URSTM[R, A] =
+  def orDie(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): URSTM[R, A] =
     orDieWith(ev1)
 
   /**
@@ -601,7 +601,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
+  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -459,7 +459,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * throw exceptions but is otherwise pure, translating any thrown exceptions
    * into typed failed effects.
    */
-  def mapPartial[B](f: A => B)(implicit ev: E <:< Throwable): ZSTM[R, Throwable, B] =
+  def mapPartial[B](f: A => B)(implicit ev: E HasError Throwable): ZSTM[R, Throwable, B] =
     foldM(e => ZSTM.fail(ev(e)), a => ZSTM.partial(f(a)))
 
   /**
@@ -529,7 +529,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * Translates `STM` effect failure into death of the fiber, making all failures unchecked and
    * not a part of the type of the effect.
    */
-  def orDie(implicit ev1: E <:< Throwable, ev2: CanFail[E]): URSTM[R, A] =
+  def orDie(implicit ev1: E HasError Throwable, ev2: CanFail[E]): URSTM[R, A] =
     orDieWith(ev1)
 
   /**
@@ -601,7 +601,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
+  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -601,7 +601,9 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Keeps some of the errors, and terminates the fiber with the rest.
    */
-  def refineOrDie[E1](pf: PartialFunction[E, E1])(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
+  def refineOrDie[E1](
+    pf: PartialFunction[E, E1]
+  )(implicit ev1: E IsSubtypeOfError Throwable, ev2: CanFail[E]): ZSTM[R, E1, A] =
     refineOrDieWith(pf)(ev1)
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2306,7 +2306,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   final def refineOrDie[E1](
     pf: PartialFunction[E, E1]
-  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZStream[R, E1, O] =
+  )(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZStream[R, E1, O] =
     refineOrDieWith(pf)(ev1)
 
   /**
@@ -2990,7 +2990,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Converts this stream of bytes into a `java.io.InputStream` wrapped in a [[ZManaged]].
    * The returned input stream will only be valid within the scope of the ZManaged.
    */
-  def toInputStream(implicit ev0: E <:< Throwable, ev1: O <:< Byte): ZManaged[R, E, java.io.InputStream] =
+  def toInputStream(implicit ev0: E HasError Throwable, ev1: O <:< Byte): ZManaged[R, E, java.io.InputStream] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process.asInstanceOf[ZManaged[R, Nothing, ZIO[R, Option[Throwable], Chunk[Byte]]]]
@@ -3023,7 +3023,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Converts this stream of chars into a `java.io.Reader` wrapped in a [[ZManaged]].
    * The returned reader will only be valid within the scope of the ZManaged.
    */
-  def toReader(implicit ev0: E <:< Throwable, ev1: O <:< Char): ZManaged[R, E, java.io.Reader] =
+  def toReader(implicit ev0: E HasError Throwable, ev1: O <:< Char): ZManaged[R, E, java.io.Reader] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process.asInstanceOf[ZManaged[R, Nothing, ZIO[R, Option[Throwable], Chunk[Char]]]]

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2306,7 +2306,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   final def refineOrDie[E1](
     pf: PartialFunction[E, E1]
-  )(implicit ev1: E HasError Throwable, ev2: CanFail[E]): ZStream[R, E1, O] =
+  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZStream[R, E1, O] =
     refineOrDieWith(pf)(ev1)
 
   /**
@@ -2990,7 +2990,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Converts this stream of bytes into a `java.io.InputStream` wrapped in a [[ZManaged]].
    * The returned input stream will only be valid within the scope of the ZManaged.
    */
-  def toInputStream(implicit ev0: E HasError Throwable, ev1: O <:< Byte): ZManaged[R, E, java.io.InputStream] =
+  def toInputStream(implicit ev0: E <:< Throwable, ev1: O <:< Byte): ZManaged[R, E, java.io.InputStream] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process.asInstanceOf[ZManaged[R, Nothing, ZIO[R, Option[Throwable], Chunk[Byte]]]]
@@ -3023,7 +3023,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Converts this stream of chars into a `java.io.Reader` wrapped in a [[ZManaged]].
    * The returned reader will only be valid within the scope of the ZManaged.
    */
-  def toReader(implicit ev0: E HasError Throwable, ev1: O <:< Char): ZManaged[R, E, java.io.Reader] =
+  def toReader(implicit ev0: E <:< Throwable, ev1: O <:< Char): ZManaged[R, E, java.io.Reader] =
     for {
       runtime <- ZIO.runtime[R].toManaged_
       pull    <- process.asInstanceOf[ZManaged[R, Nothing, ZIO[R, Option[Throwable], Chunk[Char]]]]


### PR DESCRIPTION
ZIO uses many implicit evidence constraints to implement methods on the ZIO trait that only work with particular subtypes. For instance, `ZIO#some`, which requires that the `A` type is optional, is defined as:

```scala
final def some[B](implicit ev: A <:< Option[B]): ZIO[R, Option[E], B] = ???
```

This is a very cool technique. The only problem is that the error message requires the user to understand how this technique works, particularly the meaning of the `<:<` symbol:

```scala
[error] /Users/kit/code/example.scala:17:25: Cannot prove that Int <:< Option[B].
[error]   val example = UIO(10).some
```

This could be clearer. Basically, by making our own versions, we can give more ZIO specific compile errors:

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/7587245/111893199-3b807d00-89be-11eb-8f82-930211525b3d.png">

We could make this more specific for particularly difficult to use messages, potentially linking to documentation. Overall, this is basically an extension of the pattern used by the `CanFail` constraint.