### PR TITLE
add alias for CompletableFuture

### DIFF
--- a/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
@@ -25,7 +25,7 @@ private[zio] trait TaskPlatformSpecific {
   def effectAsyncWithCompletionHandler[T](op: CompletionHandler[T, Any] => Any): Task[T] =
     javaz.effectAsyncWithCompletionHandler(op)
 
-  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage*/
+  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage */
   def fromCompletableFuture[A](cs: => CompletableFuture[A]): Task[A] = fromCompletionStage(cs)
 
   def fromCompletionStage[A](cs: => CompletionStage[A]): Task[A] = javaz.fromCompletionStage(cs)

--- a/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
@@ -17,6 +17,7 @@
 package zio
 
 import zio.interop.javaz
+
 import java.nio.channels.CompletionHandler
 import java.util.concurrent.{CompletableFuture, CompletionStage}
 

--- a/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/TaskPlatformSpecific.scala
@@ -17,14 +17,16 @@
 package zio
 
 import zio.interop.javaz
-
 import java.nio.channels.CompletionHandler
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 private[zio] trait TaskPlatformSpecific {
 
   def effectAsyncWithCompletionHandler[T](op: CompletionHandler[T, Any] => Any): Task[T] =
     javaz.effectAsyncWithCompletionHandler(op)
+
+  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage*/
+  def fromCompletableFuture[A](cs: => CompletableFuture[A]): Task[A] = fromCompletionStage(cs)
 
   def fromCompletionStage[A](cs: => CompletionStage[A]): Task[A] = javaz.fromCompletionStage(cs)
 

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -37,6 +37,9 @@ private[zio] trait ZIOCompanionPlatformSpecific {
 
   def fromCompletionStage[A](cs: => CompletionStage[A]): Task[A] = javaz.fromCompletionStage(cs)
 
+  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage*/
+  def fromCompletableFuture[A](cs: => CompletableFuture[A]): Task[A] = fromCompletionStage(cs)
+
   /** WARNING: this uses the blocking Future#get, consider using `fromCompletionStage` */
   def fromFutureJava[A](future: => Future[A]): RIO[Blocking, A] = javaz.fromFutureJava(future)
 

--- a/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -37,7 +37,7 @@ private[zio] trait ZIOCompanionPlatformSpecific {
 
   def fromCompletionStage[A](cs: => CompletionStage[A]): Task[A] = javaz.fromCompletionStage(cs)
 
-  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage*/
+  /** Alias for `formCompletionStage` for a concrete implementation of CompletionStage */
   def fromCompletableFuture[A](cs: => CompletableFuture[A]): Task[A] = fromCompletionStage(cs)
 
   /** WARNING: this uses the blocking Future#get, consider using `fromCompletionStage` */


### PR DESCRIPTION
`CompletionStage` is a bit confusing for scala users with no java background. a lot of people that deal with java libraries dont have much experience in java. `CompletableFuture` matches the most comon implementation of `CompletitionStage` that is used in java libraries that scala users might use. so matching the type with the call is helpful for them
