### PR TITLE
Support adding aspects to top level suite in MutableRunnableSpec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/MutableRunnableSpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/MutableRunnableSpecSpec.scala
@@ -1,0 +1,28 @@
+package zio.test
+
+import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.test.environment.TestEnvironment
+import zio.{Ref, ZIO}
+
+object MutableRunnableSpecSpec
+    extends MutableRunnableSpec(
+      TestEnvironment.any ++ Ref.make(0).toLayer,
+      sequential >>> samples(10) >>> before(ZIO.service[Ref[Int]].flatMap(_.update(_ + 1)))
+    ) {
+  testM("ref 1") {
+    assertM(ZIO.service[Ref[Int]].flatMap(_.get))(equalTo(1))
+  }
+
+  testM("ref 2") {
+    assertM(ZIO.service[Ref[Int]].flatMap(_.get))(equalTo(2))
+  }
+
+  testM("check samples") {
+    for {
+      ref   <- ZIO.service[Ref[Int]]
+      _     <- checkM(Gen.anyInt.noShrink)(_ => assertM(ref.update(_ + 1))(anything))
+      value <- ref.get
+    } yield assert(value)(equalTo(13))
+  }
+}

--- a/test/shared/src/main/scala/zio/test/DefaultMutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultMutableRunnableSpec.scala
@@ -19,4 +19,4 @@ import zio.test.environment.TestEnvironment
  * }
  * }}}
  */
-class DefaultMutableRunnableSpec extends MutableRunnableSpec(ZLayer.identity[TestEnvironment])
+class DefaultMutableRunnableSpec extends MutableRunnableSpec(ZLayer.identity[TestEnvironment], TestAspect.identity)

--- a/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
@@ -10,7 +10,7 @@ import scala.util.control.NoStackTrace
 /**
  * Syntax for writing test like
  * {{{
- * object MySpec extends MutableRunnableSpec(layer) {
+ * object MySpec extends MutableRunnableSpec(layer, aspect) {
  *   suite("foo") {
  *     testM("name") {
  *     } @@ ignore
@@ -23,8 +23,10 @@ import scala.util.control.NoStackTrace
  * }
  * }}}
  */
-class MutableRunnableSpec[R <: Has[_]](layer: ZLayer[TestEnvironment, Throwable, R])
-    extends RunnableSpec[TestEnvironment, Any] {
+class MutableRunnableSpec[R <: Has[_]](
+  layer: ZLayer[TestEnvironment, Throwable, R],
+  aspect: TestAspect[R, R, Any, Any]
+) extends RunnableSpec[TestEnvironment, Any] {
   self =>
 
   private class InAnotherTestException(`type`: String, label: String)
@@ -127,7 +129,7 @@ class MutableRunnableSpec[R <: Has[_]](layer: ZLayer[TestEnvironment, Throwable,
 
   final override def spec: ZSpec[Environment, Failure] = {
     specBuilt = true
-    stack.head.toSpec.provideLayerShared(layer.mapError(TestFailure.fail))
+    (stack.head @@ aspect).toSpec.provideLayerShared(layer.mapError(TestFailure.fail))
   }
 
   override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =


### PR DESCRIPTION
This PR adds support for adding aspects to top level suite in `MutableRunnableSpec`, which is always created automatically.
Alternate approach could be supplying aspects via additional constructor parameter, but this prevents us for using same object methods in aspects like `before`, `after` or others.  And  `topSuite @ aspect1 @ aspect2...`  reads better.