### PR TITLE
Rename await variable to prevent JS exceptions

### DIFF
--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -321,14 +321,14 @@ package object environment extends PlatformSpecific {
       def sleep(duration: Duration): UIO[Unit] =
         for {
           promise <- Promise.make[Nothing, Unit]
-          await <- clockState.modify { data =>
-                     val end = data.duration + duration
-                     if (end > data.duration)
-                       (true, data.copy(sleeps = (end, promise) :: data.sleeps))
-                     else
-                       (false, data)
-                   }
-          _ <- if (await) warningStart *> promise.await else promise.succeed(())
+          shouldAwait <- clockState.modify { data =>
+                           val end = data.duration + duration
+                           if (end > data.duration)
+                             (true, data.copy(sleeps = (end, promise) :: data.sleeps))
+                           else
+                             (false, data)
+                         }
+          _ <- if (shouldAwait) warningStart *> promise.await else promise.succeed(())
         } yield ()
 
       /**


### PR DESCRIPTION
Before this change, the code gets compiled to the following JS:
```javascript
      var await = $uZ(await$2);
        var $$x3;
        if (await) {
          var this$8 = this$2$1.Lzio_test_environment_package$TestClock$Test__f_warningStart;
          var that = new $c_sjsr_AnonFunction0(((this$7, promise$1$1) => (() => promise$1$1.await__Lzio_ZIO()))(this$2$1, promise$3));
          $$x3 = $f_Lzio_ZIO__$times$greater__F0__Lzio_ZIO(this$8, that)
        } else {
          $$x3 = promise$3.succeed__O__Lzio_ZIO((void 0))
        };
```
Unfortunately, this throws an error in Firefox (and potentially other browsers):
```
Uncaught SyntaxError: await is a reserved identifier
```
I've searched through the generated JS code, and this seems to be the only occurrence of `await` without any prefix or suffix, so hopefully this change should fix the problem.