### PR TITLE
Add Type Alias For Intersection Types On Scala 2

### DIFF
--- a/core/shared/src/main/scala-2.11/zio/IntersectionTypeCompat.scala
+++ b/core/shared/src/main/scala-2.11/zio/IntersectionTypeCompat.scala
@@ -16,6 +16,6 @@
 
  package zio
 
- private[zio] trait VersionSpecific {
+ private[zio] trait IntersectionTypeCompat {
   type &[+A, +B] = A with B
  }

--- a/core/shared/src/main/scala-2.11/zio/IntersectionTypeCompat.scala
+++ b/core/shared/src/main/scala-2.11/zio/IntersectionTypeCompat.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package zio
+
+ private[zio] trait VersionSpecific {
+  type &[+A, +B] = A with B
+ }

--- a/core/shared/src/main/scala-2.12-2.13/zio/IntersectionTypeCompat.scala
+++ b/core/shared/src/main/scala-2.12-2.13/zio/IntersectionTypeCompat.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+private[zio] trait IntersectionTypeCompat {
+  type &[+A, +B] = A with B
+}

--- a/core/shared/src/main/scala-dotty/zio/IntersectionTypeCompat.scala
+++ b/core/shared/src/main/scala-dotty/zio/IntersectionTypeCompat.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package zio
+
+ private[zio] trait IntersectionTypeCompat

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -17,9 +17,10 @@
 package object zio
     extends BuildFromCompat
     with EitherCompat
+    with FunctionToLayerOps
+    with IntersectionTypeCompat
     with PlatformSpecific
-    with VersionSpecific
-    with FunctionToLayerOps {
+    with VersionSpecific {
   private[zio] type Callback[E, A] = Exit[E, A] => Any
 
   type Canceler[-R] = URIO[R, Any]


### PR DESCRIPTION
Resolves #4844. Adds a type alias to allow `&` to be used on both Scala 2 and Scala 3.