### PR TITLE
Update scala-java-time versions in docs

### DIFF
--- a/docs/overview/platforms.md
+++ b/docs/overview/platforms.md
@@ -19,8 +19,8 @@ While ZIO is a zero dependency library, some basic capabilities of the platform 
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.github.cquiroz" %%% "scala-java-time" % "2.0.0"
-  "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0"
+  "io.github.cquiroz" %%% "scala-java-time" % "2.2.0"
+  "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.2.0"
 )
 ```
 


### PR DESCRIPTION
@adamgfraser Turns out `1.0.5` wasn't broken in Scala.js—I just needed to read the docs 😜 