### PR TITLE
Up our CI game

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,19 +1,36 @@
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feature'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    labels:
-      - 'build'
-  - title: '🌱 Dependency Updates'
-    labels:
-      - 'dependency-update'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 template: |
-  ## Changes
+  # What's Changed
   $CHANGES
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: feature'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Maintenance'
+    label: 'type: maintenance'
+  - title: 'Documentation'
+    label: 'type: docs'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "automerge": true,
+  "labels": ["type: dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "sbt"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,7 @@
 name: CI
 
 env:
-  JAVA8: adopt@1.8
-  JAVA11: adopt@1.11
-  SCALA_211: 2.11.12
-  SCALA_212: 2.12.13
-  SCALA_213: 2.13.5
-  SCALA_3: 3.0.0-RC1
-  JAVA_OPTS: -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-  JVM_OPTS:  -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
   pull_request:
@@ -30,7 +23,7 @@ jobs:
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
     - name: Lint code
-      run: sbt fmtCheck fixCheck
+      run: sbt check
 
   mdoc:
     runs-on: ubuntu-20.04
@@ -64,25 +57,32 @@ jobs:
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
     - name: Mima Checks
-      if: ${{ matrix.scala != env.SCALA_211 && matrix.scala != env.SCALA_3 && matrix.platform == 'JVM' }}
+      if: ${{ !startsWith(matrix.scala, '2.11.') && !startsWith(matrix.scala, '3.0.') && matrix.platform == 'JVM' }}
       run: sbt ++${{ matrix.scala }}! mimaChecks
     - name: Test 2.11.x
-      if: ${{ matrix.scala == env.SCALA_211 && matrix.java == env.JAVA8 && matrix.platform != 'Native' }}
+      if: ${{ startsWith(matrix.scala, '2.11.') && contains(matrix.java, '1.8') && matrix.platform != 'Native' }}
       run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}211
     - name: Test 2.12.x and 2.13.x
-      if: ${{ matrix.scala != env.SCALA_211 && matrix.scala != env.SCALA_3 && matrix.platform != 'Native' }}
+      if: ${{ !startsWith(matrix.scala, '2.11.') && !startsWith(matrix.scala, '3.0.') && matrix.platform != 'Native' }}
       run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
     - name: Test 3.x (JVM only)
-      if: ${{ matrix.scala == env.SCALA_3 && matrix.java == env.JAVA8 && matrix.platform == 'JVM' }}
+      if: ${{ startsWith(matrix.scala, '3.0.') && contains(matrix.java, '1.8') && matrix.platform == 'JVM' }}
       run: sbt ++${{ matrix.scala }}! testJVMDotty
     - name: Test native
-      if: ${{ matrix.scala != env.SCALA_3 && matrix.platform == 'Native' }}
+      if: ${{ !startsWith(matrix.scala, '3.0.') && matrix.platform == 'Native' }}
       run: sbt ++${{ matrix.scala }}! testNative
+
+  ci:
+    runs-on: ubuntu-20.04
+    needs: [lint, mdoc, test]
+    steps:
+      - name: Aggregate of lint, mdoc and all tests
+        run: echo "ci passed"
 
   publish:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
-    needs: [lint, mdoc, test]
+    needs: [ci]
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  JAVA_OPTS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # sadly, Java 8 is not modern enough
+  JVM_OPTS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  JVM_OPTS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xmx3G # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  JVM_OPTS: -XX:+PrintCommandLineFlags -Xmx3G # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -Xms2G -Xmx4G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
       uses: olafurpg/setup-scala@v10
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
-    - name: Print used Java options
-      run: 'echo "$JDK_JAVA_OPTIONS"'
     - name: Lint code
       run: sbt check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -Xms2G -Xmx4G -Xss6M -XX:+UseG1GC -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  JAVA_OPTS: -XX:+PrintCommandLineFlags -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8 # sadly, Java 8 is not modern enough
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -Xms2G -Xmx4G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -Xms2G -Xmx6G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
   pull_request:
@@ -22,6 +22,8 @@ jobs:
       uses: olafurpg/setup-scala@v10
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
+    - name: Print used Java options
+      run: 'echo "$JDK_JAVA_OPTIONS"'
     - name: Lint code
       run: sbt check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -Xms2G -Xmx8G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -Xms2G -Xmx4G -Xss6M -XX:+UseG1GC -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -Xms2G -Xmx6G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+  JDK_JAVA_OPTIONS: -Xms2G -Xmx8G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
   pull_request:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,39 +6,21 @@ pull_request_rules:
       assign:
         users: [adamgfraser]
       label:
-        add: [dependency-update]
+        add: ["type: dependencies"]
+  - name: label scala-steward's breaking PRs
+    conditions:
+      - author=scala-steward
+      - "body~=(labels: library-update, semver-major)|(labels: sbt-plugin-update, semver-major)"
+    actions:
+      label:
+        add: ["type: breaking"]
   - name: merge Scala Steward's PRs
     conditions:
       - base=master
       - author=scala-steward
-      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update, semver-minor)|(labels: scalafix-rule-update, semver-patch)|(labels: test-library-update, semver-minor)|(labels: test-library-update, semver-patch)"
+      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)"
       - "status-success=license/cla"
-      - "status-success=lint"
-      - "status-success=mdoc"
-      - "status-success=test (adopt@1.8, 2.11.12, JVM)"
-      - "status-success=test (adopt@1.8, 2.11.12, JS)"
-      - "status-success=test (adopt@1.8, 2.11.12, Native)"
-      - "status-success=test (adopt@1.8, 2.12.13, JVM)"
-      - "status-success=test (adopt@1.8, 2.12.13, JS)"
-      - "status-success=test (adopt@1.8, 2.12.13, Native)"
-      - "status-success=test (adopt@1.8, 2.13.5, JVM)"
-      - "status-success=test (adopt@1.8, 2.13.5, JS)"
-      - "status-success=test (adopt@1.8, 2.13.5, Native)"
-      - "status-success=test (adopt@1.8, 3.0.0-RC1, JVM)"
-      - "status-success=test (adopt@1.8, 3.0.0-RC1, JS)"
-      - "status-success=test (adopt@1.8, 3.0.0-RC1, Native)"
-      - "status-success=test (adopt@1.11, 2.11.12, JVM)"
-      - "status-success=test (adopt@1.11, 2.11.12, JS)"
-      - "status-success=test (adopt@1.11, 2.11.12, Native)"
-      - "status-success=test (adopt@1.11, 2.12.13, JVM)"
-      - "status-success=test (adopt@1.11, 2.12.13, JS)"
-      - "status-success=test (adopt@1.11, 2.12.13, Native)"
-      - "status-success=test (adopt@1.11, 2.13.5, JVM)"
-      - "status-success=test (adopt@1.11, 2.13.5, JS)"
-      - "status-success=test (adopt@1.11, 2.13.5, Native)"
-      - "status-success=test (adopt@1.11, 3.0.0-RC1, JVM)"
-      - "status-success=test (adopt@1.11, 3.0.0-RC1, JS)"
-      - "status-success=test (adopt@1.11, 3.0.0-RC1, Native)"
+      - "status-success=ci"
     actions:
       merge:
         method: squash

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ addCommandAlias(
 )
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
+addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testMagnoliaTestsJVM/test:compile;testRefinedJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile;macrosTestsJVM/test:compile"

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -1,18 +1,28 @@
-import sbt._
-import Keys._
-import explicitdeps.ExplicitDepsPlugin.autoImport._
-import sbtcrossproject.CrossPlugin.autoImport._
-import sbtbuildinfo._
 import dotty.tools.sbtplugin.DottyPlugin.autoImport._
-import BuildInfoKeys._
+import explicitdeps.ExplicitDepsPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbtbuildinfo.BuildInfoKeys._
+import sbtbuildinfo._
+import sbtcrossproject.CrossPlugin.autoImport._
 import scalafix.sbt.ScalafixPlugin.autoImport._
 
 object BuildHelper {
-  // Keep this consistent with the version in .circleci/config.yml
-  val Scala211   = "2.11.12"
-  val Scala212   = "2.12.13"
-  val Scala213   = "2.13.5"
-  val ScalaDotty = "3.0.0-RC1"
+  private val versions: Map[String, String] = {
+    import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
+
+    import java.util.{List => JList, Map => JMap}
+    import scala.jdk.CollectionConverters._
+    val doc = new Load(LoadSettings.builder().build())
+      .loadFromReader(scala.io.Source.fromFile(".github/workflows/ci.yml").bufferedReader())
+    val yaml = doc.asInstanceOf[JMap[String, JMap[String, JMap[String, JMap[String, JMap[String, JList[String]]]]]]]
+    val list = yaml.get("jobs").get("test").get("strategy").get("matrix").get("scala").asScala
+    list.map(v => (v.split('.').take(2).mkString("."), v)).toMap
+  }
+  val Scala211: String   = versions("2.11")
+  val Scala212: String   = versions("2.12")
+  val Scala213: String   = versions("2.13")
+  val ScalaDotty: String = versions("3.0")
 
   val SilencerVersion = "1.7.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                   
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.2")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.0")
+
+libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.2.1"


### PR DESCRIPTION
Analogous PR in ZIO Prelude https://github.com/zio/zio-prelude/pull/592

 * use Renovate to maintain versions in GitHub Actions
 * manually managing each CI sub-step is unsustainable, now we have a step `ci` which aggregates all the necessary steps and which other tools can reference (e.g. GitHub or Mergify)
 * single source of truths for versions
   * Scala versions are read from `.github/workflows/ci.yml`
   * in `.github/workflows/ci.yml`, versions are not duplicated
 * better policy for Release Drafter, with better labeling support (taken from Release Drafter itself)
