### PR TITLE
Implement streams and sinks on top of channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ project/metals.sbt
 .idea
 coursier
 .DS_Store
+.bsp/
+project/project/
+*.iml
 
 # if you are here to add your IDE's files please read this instead:
 # https://stackoverflow.com/questions/7335420/global-git-ignore#22885996

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2053,6 +2053,15 @@ object ZIOSpec extends ZIOBaseSpec {
         val io = (clock.sleep(5.seconds) *> IO.succeed(true)).timeout(10.millis)
         assertM(Live.live(io))(isNone)
       },
+      testM("timeout a long computation with an error") {
+        val io = (clock.sleep(5.seconds) *> IO.succeed(true)).timeoutFail(false)(10.millis)
+        assertM(Live.live(io.run))(fails(equalTo(false)))
+      },
+      testM("timeout a long computation with a cause") {
+        val cause = Cause.die(new Error("BOOM"))
+        val io    = (clock.sleep(5.seconds) *> IO.succeed(true)).timeoutHalt(cause)(10.millis)
+        assertM(Live.live(io.sandbox.flip))(equalTo(cause))
+      },
       testM("timeout repetition of uninterruptible effect") {
         val effect = ZIO.unit.uninterruptible.forever
 

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -124,7 +124,9 @@ object Semaphore extends Serializable {
   /**
    * Creates a new `Sempahore` with the specified number of permits.
    */
-  def make(permits: Long): UIO[Semaphore] = Ref.make[State](Right(permits)).map(new Semaphore(_))
+  def make(permits: Long): UIO[Semaphore] = UIO(unsafeMake(permits))
+
+  private[zio] def unsafeMake(permits: Long): Semaphore = new Semaphore(ZRef.unsafeMake[State](Right(permits)))
 }
 
 private object internals {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1915,6 +1915,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     ZIO.flatten(timeoutTo(ZIO.fail(e))(ZIO.succeedNow)(d))
 
   /**
+   * The same as [[timeout]], but instead of producing a `None` in the event
+   * of timeout, it will produce the specified failure.
+   */
+  final def timeoutHalt[E1 >: E](cause: Cause[E1])(d: Duration): ZIO[R with Clock, E1, A] =
+    ZIO.flatten(timeoutTo(ZIO.halt(cause))(ZIO.succeedNow)(d))
+
+  /**
    * Returns an effect that will timeout this effect, returning either the
    * default value if the timeout elapses before the effect has produced a
    * value; and or returning the result of applying the function `f` to the
@@ -3147,6 +3154,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   def fromEither[E, A](v: => Either[E, A]): IO[E, A] =
     effectTotal(v).flatMap(_.fold(fail(_), succeedNow))
+
+  /**
+   * Lifts an `Either` into a `ZIO` value.
+   */
+  def fromEitherCause[E, A](v: => Either[Cause[E], A]): IO[E, A] =
+    effectTotal(v).flatMap(_.fold(halt(_), succeedNow))
 
   /**
    * Creates a `ZIO` value that represents the exit value of the specified

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -187,7 +187,10 @@ object ZRef extends Serializable {
    * Creates a new `ZRef` with the specified value.
    */
   def make[A](a: A): UIO[Ref[A]] =
-    UIO.effectTotal(Atomic(new AtomicReference(a)))
+    UIO.effectTotal(unsafeMake(a))
+
+  private[zio] def unsafeMake[A](a: A): Ref[A] =
+    Atomic(new AtomicReference(a))
 
   /**
    * Creates a new managed `ZRef` with the specified value

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
@@ -1,0 +1,238 @@
+package zio.stream.experimental
+
+import zio.random.Random
+import zio.stream.experimental.ZChannelSimulatedChecks.Simulation.{ opsToDoneChannel, opsToEffect, opsToOutChannel }
+import zio.stream.experimental.ZChannel
+import zio.test.Assertion._
+import zio.test._
+import zio.{ Chunk, IO, ZIO, ZIOBaseSpec }
+
+object ZChannelSimulatedChecks extends ZIOBaseSpec {
+  override def spec =
+    suite("ZChannel simulated checks")(
+      testM("done channel")(
+        checkM(gen) { sim =>
+          for {
+            channelResult <- sim.asDoneChannel.run.run
+            effectResult  <- sim.asEffect.run
+          } yield assert(channelResult)(equalTo(effectResult))
+        }
+      ),
+      testM("out channel")(
+        checkM(gen) { sim =>
+          for {
+            channelResult <- sim.asOutChannel.runCollect.map(_._1).run
+            effectResult  <- sim.asEffect.run.map(_.map(Chunk.single))
+          } yield assert(channelResult)(equalTo(effectResult))
+        }
+      )
+    )
+
+  type Err = String
+  type Res = Int
+
+  private val genErr: Gen[Sized with Random, Err] = Gen.oneOf(Gen.const("err1"), Gen.const("err2"), Gen.const("err3"))
+  private val genRes: Gen[Sized with Random, Res] = Gen.int(0, 100)
+
+  private def cutAtFailure(ops: List[Op]): List[Op] =
+    ops.reverse.dropWhile {
+      case Fail(_) => false
+      case _       => true
+    }.reverse
+
+  private def genOps(currentDepth: Int = 1): Gen[Sized with Random, Op] =
+    Gen.double(0.0, 1.0).flatMap { n =>
+      val r = (1.0 / currentDepth)
+
+      val nonRecursive = Seq(
+        Gen.const(Succeed),
+        genErr.map(Fail),
+        genRes.map(value => Map(value))
+      )
+
+      val recursive = Seq(
+        Gen.listOf1(genOps(currentDepth + 1)).map(ops => FlatMap(cutAtFailure(ops))),
+        Gen.listOf1(genOps(currentDepth + 1)).map(ops => Bracket(cutAtFailure(ops))),
+        Gen.listOf1(genOps(currentDepth + 1)).map(ops => CatchAll(cutAtFailure(ops)))
+      )
+
+      if (n < r) {
+        Gen.oneOf(nonRecursive ++ recursive: _*)
+      } else {
+        Gen.oneOf(nonRecursive: _*)
+      }
+    }
+
+  val gen: Gen[Sized with Random, Simulation] =
+    for {
+      first <- genRes
+      rest  <- Gen.listOf1(genOps()).map(cutAtFailure)
+    } yield Simulation(first, rest)
+
+  case class Simulation(start: Res, ops: List[Op]) {
+    val asDoneChannel: ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      opsToDoneChannel(ZChannel.succeed(start), ops)
+    val asOutChannel: ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      opsToOutChannel(ZChannel.write(start), ops)
+    val asEffect: IO[Err, Res] =
+      opsToEffect(ZIO.succeed(start), ops)
+
+    override def toString: String = {
+      val sb = new StringBuilder()
+      sb.append("{ ")
+      Simulation.writeOutChannelString(sb, s"ZChannel.write($start)", ops)
+      sb.append("\n}")
+      sb.toString()
+    }
+  }
+
+  object Simulation {
+    def opsToDoneChannel(
+      start: ZChannel[Any, Err, Any, Res, Err, Nothing, Res],
+      ops: List[Op]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      ops.foldLeft[ZChannel[Any, Err, Any, Res, Err, Nothing, Res]](start) { case (ch, op) =>
+        op.asChannel(ch)
+      }
+
+    def opsToOutChannel(
+      start: ZChannel[Any, Err, Any, Res, Err, Res, Any],
+      ops: List[Op]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ops.foldLeft[ZChannel[Any, Err, Any, Res, Err, Res, Any]](start) { case (ch, op) =>
+        op.asOutChannel(ch)
+      }
+
+    def opsToEffect(start: IO[Err, Res], ops: List[Op]): IO[Err, Res] =
+      ops.foldLeft[IO[Err, Res]](start) { case (effect, op) =>
+        op.asEffect(effect)
+      }
+
+    def writeOutChannelString(sb: StringBuilder, start: String, ops: List[Op]): Unit = {
+      sb.append(start)
+      ops.foreach(op => op.writeOutChannelString(sb))
+    }
+
+  }
+
+  sealed trait Op {
+    def asChannel(ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]): ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    def asOutChannel(ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]): ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    def asEffect(f: IO[Err, Res]): IO[Err, Res]
+    def writeOutChannelString(sb: StringBuilder): Unit
+  }
+  final case object Succeed extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] = ch
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any]       = ch
+    override def asEffect(f: IO[Err, Res]): IO[Err, Res] = f
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = {}
+  }
+  final case class Fail(error: Err) extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] = ch.flatMap(_ => ZChannel.fail(error))
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ch.concatMap(_ => ZChannel.fail(error))
+    override def asEffect(f: IO[Err, Res]): IO[Err, Nothing] = f.flatMap(_ => IO.fail(error))
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = {
+      sb.append(s""".concatMap(_ => ZChannel.fail("${error}"))"""); ()
+    }
+  }
+  final case class Map(addN: Int) extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      ch.map(_ + addN)
+
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ch.mapOut(_ + addN)
+
+    override def asEffect(f: IO[Err, Res]): IO[Err, Res] =
+      f.map(_ + addN)
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = { sb.append(s".mapOut(_ + $addN)"); () }
+  }
+  final case class FlatMap(ops: List[Op]) extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      ch.flatMap(value => Simulation.opsToDoneChannel(ZChannel.succeed(value), ops))
+
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ch.concatMap(value => Simulation.opsToOutChannel(ZChannel.write(value), ops))
+
+    override def asEffect(f: IO[Err, Res]): IO[Err, Res] =
+      f.flatMap(value => Simulation.opsToEffect(ZIO.succeed(value), ops))
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = {
+      sb.append(".concatMap { value => \n")
+      Simulation.writeOutChannelString(sb, "ZChannel.write(value)", ops)
+      sb.append("\n}")
+      ()
+    }
+  }
+  final case class Bracket(ops: List[Op]) extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      ch.flatMap { value =>
+        ZChannel.bracket(ZIO.succeed(value))(_ => ZIO.unit)(value =>
+          Simulation.opsToDoneChannel(ZChannel.succeed(value), ops)
+        )
+      }
+
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ch.concatMap { value =>
+        ZChannel.bracketOut(ZIO.succeed(value))(_ => ZIO.unit).concatMap { value =>
+          Simulation.opsToOutChannel(ZChannel.write(value), ops)
+        }
+      }
+
+    override def asEffect(f: IO[Err, Res]): IO[Err, Res] =
+      f.flatMap { value =>
+        ZIO.bracket(ZIO.succeed(value))(_ => ZIO.unit)(value => Simulation.opsToEffect(ZIO.succeed(value), ops))
+      }
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = {
+      sb.append(".concatMap { value => \nZChannel.bracketOut(ZIO.succeed(value))(_ => ZIO.unit).concatMap { value =>\n")
+      Simulation.writeOutChannelString(sb, "ZChannel.write(value)", ops)
+      sb.append("\n}\n}")
+      ()
+    }
+  }
+  final case class CatchAll(ops: List[Op]) extends Op {
+    override def asChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Nothing, Res]
+    ): ZChannel[Any, Err, Any, Res, Err, Nothing, Res] =
+      ch.catchAll(_ => Simulation.opsToDoneChannel(ZChannel.succeed(0), ops))
+
+    override def asOutChannel(
+      ch: ZChannel[Any, Err, Any, Res, Err, Res, Any]
+    ): ZChannel[Any, Err, Any, Res, Err, Res, Any] =
+      ch.catchAll(_ => Simulation.opsToOutChannel(ZChannel.write(0), ops))
+
+    override def asEffect(f: IO[Err, Res]): IO[Err, Res] =
+      f.catchAll(_ => Simulation.opsToEffect(ZIO.succeed(0), ops))
+
+    override def writeOutChannelString(sb: StringBuilder): Unit = {
+      sb.append(".catchAll { _ =>\n")
+      Simulation.writeOutChannelString(sb, "ZChannel.write(0)", ops)
+      sb.append("\n}")
+      ()
+    }
+  }
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSpec.scala
@@ -1,0 +1,624 @@
+package zio.stream.experimental
+
+import zio.test.Assertion._
+import zio.test._
+import zio._
+
+object ZChannelSpec extends ZIOBaseSpec {
+  import ZIOTag._
+
+  def spec = suite("ZChannelSpec")(
+    suite("interpreter")(
+      testM("ZChannel.succeed") {
+        for {
+          tuple     <- ZChannel.succeed(1).runCollect
+          (chunk, z) = tuple
+        } yield assert(chunk)(equalTo(Chunk.empty)) && assert(z)(equalTo(1))
+      },
+      testM("ZChannel.fail") {
+        for {
+          exit <- ZChannel.fail("Uh oh!").runCollect.run
+        } yield assert(exit)(fails(equalTo("Uh oh!")))
+      },
+      testM("ZChannel.map") {
+        for {
+          tuple     <- ZChannel.succeed(1).map(_ + 1).runCollect
+          (chunk, z) = tuple
+        } yield assert(chunk)(equalTo(Chunk.empty)) && assert(z)(equalTo(2))
+      },
+      suite("ZChannel#flatMap")(
+        testM("simple") {
+          val conduit = for {
+            x <- ZChannel.succeed(1)
+            y <- ZChannel.succeed(x * 2)
+            z <- ZChannel.succeed(x + y)
+          } yield x + y + z
+          for {
+            tuple     <- conduit.runCollect
+            (chunk, z) = tuple
+          } yield assert(chunk)(equalTo(Chunk.empty)) && assert(z)(equalTo(6))
+        },
+        testM("flatMap structure confusion") {
+          assertM(
+            (ZChannel
+              .write(Chunk(1, 2))
+              .concatMap(chunk => ZChannel.writeAll(chunk: _*))
+              *> ZChannel.fail("hello")).runDrain.run
+          )(fails(equalTo("hello")))
+        }
+      ),
+      suite("ZChannel#catchAll") {
+        testM("catchAll structure confusion") {
+          assertM(
+            ZChannel
+              .write(8)
+              .catchAll { _ =>
+                ZChannel.write(0).concatMap(_ => ZChannel.fail("err0"))
+              }
+              .concatMap { _ =>
+                ZChannel.fail("err1")
+              }
+              .runCollect
+              .run
+          )(fails(equalTo("err1")))
+        }
+      },
+      suite("ZChannel#ensuring")(
+        testM("prompt closure between continuations") {
+          Ref.make(Chunk[String]()).flatMap { events =>
+            (ZChannel
+              .fromEffect(events.update(_ :+ "Acquire1"))
+              .ensuring(events.update(_ :+ "Release11"))
+              .ensuring(events.update(_ :+ "Release12")) *>
+              ZChannel.fromEffect(events.update(_ :+ "Acquire2")).ensuring(events.update(_ :+ "Release2"))).runDrain *>
+              events.get.map(assert(_)(equalTo(Chunk("Acquire1", "Release11", "Release12", "Acquire2", "Release2"))))
+          }
+        },
+        testM("last finalizers are deferred to the ZManaged") {
+          Ref.make(Chunk[String]()).flatMap { events =>
+            def event(label: String) = events.update(_ :+ label)
+            val channel =
+              (ZChannel.fromEffect(event("Acquire1")).ensuring(event("Release11")).ensuring(event("Release12")) *>
+                ZChannel.fromEffect(event("Acquire2")).ensuring(event("Release2"))).ensuring(event("ReleaseOuter"))
+
+            channel.toPull.use { pull =>
+              pull.run *> events.get
+            }.flatMap { eventsInZManaged =>
+              events.get.map { eventsAfterZManaged =>
+                assert(eventsInZManaged)(equalTo(Chunk("Acquire1", "Release11", "Release12", "Acquire2"))) &&
+                assert(eventsAfterZManaged)(
+                  equalTo(Chunk("Acquire1", "Release11", "Release12", "Acquire2", "Release2", "ReleaseOuter"))
+                )
+              }
+            }
+          }
+        },
+        testM("mixture of concatMap and ensuring") {
+          Ref.make(Chunk[String]()).flatMap { events =>
+            case class First(i: Int)
+            case class Second(i: First)
+
+            val conduit = ZChannel
+              .writeAll(1, 2, 3)
+              .ensuring(events.update(_ :+ "Inner"))
+              .concatMap(i => ZChannel.write(First(i)).ensuring(events.update(_ :+ "First write")))
+              .ensuring(events.update(_ :+ "First concatMap"))
+              .concatMap(j => ZChannel.write(Second(j)).ensuring(events.update(_ :+ "Second write")))
+              .ensuring(events.update(_ :+ "Second concatMap"))
+
+            conduit.runCollect.zip(events.get).map { case ((elements, _), events) =>
+              assert(events)(
+                equalTo(
+                  Chunk(
+                    "Second write",
+                    "First write",
+                    "Second write",
+                    "First write",
+                    "Second write",
+                    "First write",
+                    "Inner",
+                    "First concatMap",
+                    "Second concatMap"
+                  )
+                )
+              ) &&
+                assert(elements)(
+                  equalTo(
+                    Chunk(
+                      Second(First(1)),
+                      Second(First(2)),
+                      Second(First(3))
+                    )
+                  )
+                )
+            }
+
+          }
+        }
+      ),
+      suite("ZChannel#mapOut")(
+        testM("simple") {
+          for {
+            tuple     <- ZChannel.writeAll(1, 2, 3).mapOut(_ + 1).runCollect
+            (chunk, z) = tuple
+          } yield assert(chunk)(equalTo(Chunk(2, 3, 4))) && assert(z)(isUnit)
+        },
+        testM("mixed with flatMap") {
+          ZChannel
+            .write(1)
+            .mapOut(_.toString)
+            .flatMap(_ => ZChannel.write("x"))
+            .runCollect
+            .map(_._1)
+            .map { result =>
+              assert(result)(equalTo(Chunk("1", "x")))
+            }
+        }
+      ),
+      suite("ZChannel.concatMap")(
+        testM("plain") {
+          ZChannel.writeAll(1, 2, 3).concatMap(i => ZChannel.writeAll(i, i)).runCollect.map { case (chunk, _) =>
+            assert(chunk)(equalTo(Chunk(1, 1, 2, 2, 3, 3)))
+          }
+        },
+        testM("complex") {
+          case class First[A](a: A)
+          case class Second[A](a: A)
+          val conduit = ZChannel
+            .writeAll(1, 2)
+            .concatMap(i => ZChannel.writeAll(i, i))
+            .mapOut(First(_))
+            .concatMap(i => ZChannel.writeAll(i, i))
+            .mapOut(Second(_))
+
+          val expected =
+            Chunk(
+              Second(First(1)),
+              Second(First(1)),
+              Second(First(1)),
+              Second(First(1)),
+              Second(First(2)),
+              Second(First(2)),
+              Second(First(2)),
+              Second(First(2))
+            )
+
+          conduit.runCollect.map { case (chunk, _) =>
+            assert(chunk)(equalTo(expected))
+          }
+        },
+        testM("read from inner conduit") {
+          val source = ZChannel.writeAll(1, 2, 3, 4)
+          val reader = ZChannel.read[Int].flatMap(ZChannel.write(_))
+          val readers =
+            ZChannel.writeAll((), ()).concatMap(_ => reader *> reader)
+
+          (source >>> readers).runCollect.map { case (chunk, _) =>
+            assert(chunk)(equalTo(Chunk(1, 2, 3, 4)))
+          }
+        },
+        testM("downstream failure") {
+          for {
+            exit <- ZChannel
+                      .write(0)
+                      .concatMap(_ => ZChannel.fail("error"))
+                      .runCollect
+                      .run
+          } yield assert(exit)(fails(equalTo("error")))
+        },
+        testM("upstream bracketOut + downstream failure") {
+          assertM(Ref.make(Chunk[String]()).flatMap { events =>
+            ZChannel
+              .bracketOut(events.update(_ :+ "Acquired"))(_ => events.update(_ :+ "Released"))
+              .concatMap(_ => ZChannel.fail("error"))
+              .runDrain
+              .run <*> events.get
+          })(equalTo((Exit.fail("error"), Chunk("Acquired", "Released"))))
+        },
+        testM("multiple concatMaps with failure in first") {
+          for {
+            exit <- ZChannel
+                      .write(())
+                      .concatMap(_ => ZChannel.write(ZChannel.fail("error")))
+                      .concatMap(e => e)
+                      .runCollect
+                      .run
+          } yield assert(exit)(fails(equalTo("error")))
+        },
+        testM("concatMap with failure then flatMap") {
+          for {
+            exit <- ZChannel
+                      .write(())
+                      .concatMap(_ => ZChannel.fail("error"))
+                      .flatMap(_ => ZChannel.write(()))
+                      .runCollect
+                      .run
+          } yield assert(exit)(fails(equalTo("error")))
+        },
+        testM("multiple concatMaps with failure in first and catchAll in second") {
+          for {
+            exit <- ZChannel
+                      .write(())
+                      .concatMap(_ => ZChannel.write(ZChannel.fail("error")))
+                      .concatMap(e => e.catchAllCause(_ => ZChannel.fail("error2")))
+                      .runCollect
+                      .run
+          } yield assert(exit)(fails(equalTo("error2")))
+        },
+        testM("done value combination") {
+          assertM(
+            ZChannel
+              .writeAll(1, 2, 3)
+              .as(List("Outer-0"))
+              .concatMapWith(i => ZChannel.write(i).as(List(s"Inner-$i")))(_ ++ _, (_, _))
+              .runCollect
+          )(equalTo((Chunk(1, 2, 3), (List("Inner-1", "Inner-2", "Inner-3"), List("Outer-0")))))
+        }
+      ),
+      suite("ZChannel#managedOut")(
+        testM("failure") {
+          for {
+            exit <- ZChannel.managedOut(ZManaged.fail("error")).runCollect.run
+          } yield assert(exit)(fails(equalTo("error")))
+        }
+      ),
+      suite("ZChannel#mergeWith")(
+        testM("simple merge") {
+          val conduit = ZChannel
+            .writeAll(1, 2, 3)
+            .mergeWith(ZChannel.writeAll(4, 5, 6))(
+              ex => ZChannel.MergeDecision.awaitConst(ZIO.done(ex)),
+              ex => ZChannel.MergeDecision.awaitConst(ZIO.done(ex))
+            )
+
+          conduit.runCollect.map { case (chunk, _) =>
+            assert(chunk.toSet)(equalTo(Set(1, 2, 3, 4, 5, 6)))
+          }
+        },
+        testM("merge with different types") {
+          val left  = ZChannel.write(1) *> ZChannel.fromEffect(Task("Whatever").refineToOrDie[RuntimeException])
+          val right = ZChannel.write(2) *> ZChannel.fromEffect(Task(true).refineToOrDie[IllegalStateException])
+
+          val merged = left.mergeWith(right)(
+            ex => ZChannel.MergeDecision.await(ex2 => ZIO.done(ex <*> ex2)),
+            ex2 => ZChannel.MergeDecision.await(ex => ZIO.done(ex <*> ex2))
+          )
+
+          merged.runCollect.map { case (chunk, result) =>
+            assert(chunk.toSet)(equalTo(Set(1, 2))) &&
+              assert(result)(equalTo(("Whatever", true)))
+          }
+        },
+        testM("handles polymorphic failures") {
+          val left  = ZChannel.write(1) *> ZChannel.fail("Boom").as(true)
+          val right = ZChannel.write(2) *> ZChannel.fail(true).as(true)
+
+          val merged = left.mergeWith(right)(
+            ex => ZChannel.MergeDecision.await(ex2 => ZIO.done(ex).flip.zip(ZIO.done(ex2).flip).flip),
+            ex2 => ZChannel.MergeDecision.await(ex => ZIO.done(ex).flip.zip(ZIO.done(ex2).flip).flip)
+          )
+
+          merged.runDrain.run.map(ex => assert(ex)(fails(equalTo(("Boom", true)))))
+        },
+        testM("interrupts losing side") {
+          Promise.make[Nothing, Unit].flatMap { latch =>
+            Ref.make(false).flatMap { interrupted =>
+              val left = ZChannel.write(1) *>
+                ZChannel.fromEffect((latch.succeed(()) *> ZIO.never).onInterrupt(interrupted.set(true)))
+              val right = ZChannel.write(2) *> ZChannel.fromEffect(latch.await)
+
+              val merged = left.mergeWith(right)(
+                ex => ZChannel.MergeDecision.done(ZIO.done(ex)),
+                _ => ZChannel.MergeDecision.done(interrupted.get.map(assert(_)(isTrue)))
+              )
+
+              merged.runDrain
+            }
+          }
+        }
+      ),
+      suite("ZChannel#interruptWhen")(
+        suite("interruptWhen(Promise)")(
+          testM("interrupts the current element") {
+            for {
+              interrupted <- Ref.make(false)
+              latch       <- Promise.make[Nothing, Unit]
+              halt        <- Promise.make[Nothing, Unit]
+              started     <- Promise.make[Nothing, Unit]
+              fiber <- ZChannel
+                         .fromEffect(
+                           (started.succeed(()) *> latch.await).onInterrupt(interrupted.set(true))
+                         )
+                         .interruptWhen(halt)
+                         .runDrain
+                         .fork
+              _      <- started.await *> halt.succeed(())
+              _      <- fiber.await
+              result <- interrupted.get
+            } yield assert(result)(isTrue)
+          },
+          testM("propagates errors") {
+            for {
+              halt <- Promise.make[String, Nothing]
+              _    <- halt.fail("Fail")
+              result <- (ZChannel.write(1) *> ZChannel.fromEffect(ZIO.never))
+                          .interruptWhen(halt.await)
+                          .runDrain
+                          .either
+            } yield assert(result)(isLeft(equalTo("Fail")))
+          } @@ zioTag(errors)
+        ) @@ zioTag(interruption),
+        suite("interruptWhen(IO)")(
+          testM("interrupts the current element") {
+            for {
+              interrupted <- Ref.make(false)
+              latch       <- Promise.make[Nothing, Unit]
+              halt        <- Promise.make[Nothing, Unit]
+              started     <- Promise.make[Nothing, Unit]
+              fiber <- ZChannel
+                         .fromEffect(
+                           (started.succeed(()) *> latch.await).onInterrupt(interrupted.set(true))
+                         )
+                         .interruptWhen(halt.await)
+                         .runDrain
+                         .fork
+              _      <- started.await *> halt.succeed(())
+              _      <- fiber.await
+              result <- interrupted.get
+            } yield assert(result)(isTrue)
+          },
+          testM("propagates errors") {
+            for {
+              halt <- Promise.make[String, Nothing]
+              _    <- halt.fail("Fail")
+              result <- ZChannel
+                          .fromEffect(ZIO.never)
+                          .interruptWhen(halt.await)
+                          .runDrain
+                          .either
+            } yield assert(result)(isLeft(equalTo("Fail")))
+          } @@ zioTag(errors)
+        ) @@ zioTag(interruption)
+      ),
+      suite("reads")(
+        testM("simple reads") {
+          case class Whatever(i: Int)
+
+          val left = ZChannel.writeAll(1, 2, 3)
+          val right = ZChannel
+            .read[Int]
+            .catchAll(_ => ZChannel.end(4))
+            .flatMap(i => ZChannel.write(Whatever(i)))
+
+          val conduit = left >>> (right *> right *> right *> right)
+
+          conduit.runCollect.map { case (outputs, _) =>
+            assert(outputs)(equalTo(Chunk(1, 2, 3, 4).map(Whatever(_))))
+          }
+        },
+        testM("pipeline") {
+          lazy val identity: ZChannel[Any, Any, Int, Any, Nothing, Int, Unit] =
+            ZChannel.readWith(
+              (i: Int) => ZChannel.write(i) *> identity,
+              (_: Any) => ZChannel.end(()),
+              (_: Any) => ZChannel.end(())
+            )
+
+          lazy val doubler: ZChannel[Any, Any, Int, Any, Nothing, Int, Unit] =
+            ZChannel.readWith(
+              (i: Int) => ZChannel.writeAll(i, i) *> doubler,
+              (_: Any) => ZChannel.end(()),
+              (_: Any) => ZChannel.end(())
+            )
+
+          val effect = ZChannel.fromEffect(Ref.make[List[Int]](Nil)).flatMap { ref =>
+            lazy val inner: ZChannel[Any, Any, Int, Any, Nothing, Int, Unit] =
+              ZChannel.readWith(
+                (i: Int) => ZChannel.fromEffect(ref.update(i :: _)) *> ZChannel.write(i) *> inner,
+                (_: Any) => ZChannel.end(()),
+                (_: Any) => ZChannel.end(())
+              )
+
+            inner *> ZChannel.fromEffect(ref.get)
+          }
+
+          val conduit = ZChannel.writeAll(1, 2) >>>
+            mapper(i => i) >>>
+            mapper((i: Int) => List(i, i)).concatMap(is => ZChannel.writeAll(is: _*)).as(()) >>>
+            effect
+
+          conduit.runCollect.map { case (outputs, result) =>
+            assert(outputs)(equalTo(Chunk(1, 1, 2, 2))) &&
+              assert(result)(equalTo(List(2, 2, 1, 1)))
+          }
+        },
+        testM("another pipeline") {
+          Ref.make(Chunk[Int]()).flatMap { sums =>
+            val intProducer: ZChannel[Any, Any, Any, Any, Nothing, Int, Unit] = ZChannel.writeAll(1, 2, 3, 4, 5)
+
+            def readNInts(n: Int): ZChannel[Any, Any, Int, Any, Nothing, Int, String] =
+              if (n > 0)
+                ZChannel.readWith(
+                  (i: Int) => ZChannel.write(i) *> readNInts(n - 1),
+                  (_: Any) => ZChannel.end("EOF"),
+                  (_: Any) => ZChannel.end("EOF")
+                )
+              else ZChannel.end("end")
+
+            def sum(label: String, acc: Int): ZChannel[Any, Any, Int, Any, Any, Nothing, Unit] =
+              ZChannel.readWith(
+                (i: Int) => sum(label, acc + i),
+                (_: Any) => ZChannel.fromEffect(sums.update(_ :+ acc)),
+                (_: Any) => ZChannel.fromEffect(sums.update(_ :+ acc))
+              )
+
+            val channel =
+              intProducer >>> ((readNInts(2) >>> sum("left", 0)) *> (readNInts(2) >>> sum("right", 0)))
+
+            channel.run *>
+              assertM(sums.get)(equalTo(Chunk(3, 7)))
+          }
+        },
+        testM("resources") {
+          Ref.make(Chunk[String]()).flatMap { events =>
+            val left = ZChannel
+              .bracketOut(events.update(_ :+ "Acquire outer"))(_ => events.update(_ :+ "Release outer"))
+              .concatMap { _ =>
+                ZChannel
+                  .writeAll(1, 2, 3)
+                  .concatMap { i =>
+                    ZChannel.bracketOut(events.update(_ :+ s"Acquire $i").as(i))(_ => events.update(_ :+ s"Release $i"))
+                  }
+              }
+
+            val read =
+              ZChannel.read[Int].mapM { i =>
+                events.update(_ :+ s"Read $i").unit
+              }
+
+            val right = (read *> read).catchAll(_ => ZChannel.end(()))
+
+            (left >>> right).runDrain *> events.get.map { events =>
+              assert(events)(
+                hasSameElements(
+                  Chunk(
+                    "Acquire outer",
+                    "Acquire 1",
+                    "Read 1",
+                    "Release 1",
+                    "Acquire 2",
+                    "Read 2",
+                    "Release 2",
+                    "Release outer"
+                  )
+                )
+              )
+            }
+          }
+        },
+        suite("concurrent reads")(
+          testM("simple concurrent reads") {
+            val capacity = 128
+
+            ZIO.collectAll(List.fill(capacity)(random.nextInt)).flatMap { data =>
+              Ref.make(data).zip(Ref.make(List[Int]())).flatMap { case (source, dest) =>
+                val twoWriters = refWriter(dest).mergeWith(refWriter(dest))(
+                  _ => ZChannel.MergeDecision.awaitConst(ZIO.unit),
+                  _ => ZChannel.MergeDecision.awaitConst(ZIO.unit)
+                )
+
+                (refReader(source) >>> twoWriters).mapM(_ => dest.get).run.map { result =>
+                  val missing = data.toSet -- result.toSet
+                  val surplus = result.toSet -- data.toSet
+
+                  assert(missing)(isEmpty ?? "No missing elements") &&
+                  assert(surplus)(isEmpty ?? "No surplus elements")
+                }
+
+              }
+            }
+          } @@ TestAspect.nonFlaky(1000),
+          testM("nested concurrent reads") {
+            val capacity      = 128
+            val f: Int => Int = _ + 1
+
+            ZIO.collectAll(List.fill(capacity)(random.nextInt)).flatMap { data =>
+              Ref.make(data).zip(Ref.make(List[Int]())).flatMap { case (source, dest) =>
+                val twoWriters = (mapper(f) >>> refWriter(dest)).mergeWith((mapper(f) >>> refWriter(dest)))(
+                  _ => ZChannel.MergeDecision.awaitConst(ZIO.unit),
+                  _ => ZChannel.MergeDecision.awaitConst(ZIO.unit)
+                )
+
+                (refReader(source) >>> twoWriters).mapM(_ => dest.get.map(_.toSet)).run.map { result =>
+                  val expected = data.map(f).toSet
+                  val missing  = expected -- result
+                  val surplus  = result -- expected
+
+                  assert(missing)(isEmpty ?? "No missing elements") &&
+                  assert(surplus)(isEmpty ?? "No surplus elements")
+                }
+              }
+            }
+          } @@ TestAspect.nonFlaky(1000)
+        ),
+        suite("ZChannel#mapError") {
+          testM("mapError structure confusion") {
+            assertM(
+              ZChannel
+                .fail("err")
+                .mapError(_ => 1)
+                .runCollect
+                .run
+            )(fails(equalTo(1)))
+          }
+        }
+      ),
+      suite("provide")(
+        testM("simple provide") {
+          assertM(
+            ZChannel
+              .fromEffect(ZIO.environment[Int])
+              .provide(100)
+              .run
+          )(equalTo(100))
+        },
+        testM("provide <*> provide") {
+          assertM(
+            (ZChannel.fromEffect(ZIO.environment[Int]).provide(100) <*>
+              ZChannel.fromEffect(ZIO.environment[Int]).provide(200)).run
+          )(equalTo((100, 200)))
+        },
+        testM("concatMap(provide).provide") {
+          assertM(
+            (ZChannel
+              .fromEffect(ZIO.environment[Int])
+              .emitCollect
+              .mapOut(_._2)
+              .concatMap(n =>
+                ZChannel
+                  .fromEffect(ZIO.environment[Int].map(m => (n, m)))
+                  .provide(200)
+                  .flatMap(ZChannel.write)
+              )
+              .provide(100))
+              .runCollect
+          )(equalTo((Chunk((100, 200)), ())))
+        },
+        testM("provide is modular") {
+          assertM(
+            (for {
+              v1 <- ZChannel.fromEffect(ZIO.environment[Int])
+              v2 <- ZChannel.fromEffect(ZIO.environment[Int]).provide(2)
+              v3 <- ZChannel.fromEffect(ZIO.environment[Int])
+            } yield (v1, v2, v3)).runDrain.provide(4)
+          )(equalTo((4, 2, 4)))
+        }
+      )
+    )
+  )
+
+  def refReader[T](ref: Ref[List[T]]): ZChannel[Any, Any, Any, Any, Nothing, T, Unit] =
+    ZChannel
+      .fromEffect(ref.modify {
+        case head :: tail => (Some(head), tail)
+        case Nil          => (None, Nil)
+      })
+      .flatMap {
+        case Some(i) => ZChannel.write(i) *> refReader(ref)
+        case None    => ZChannel.end(())
+      }
+
+  def refWriter[T](ref: Ref[List[T]]): ZChannel[Any, Any, T, Any, Nothing, Nothing, Unit] =
+    ZChannel.readWith(
+      (in: T) => ZChannel.fromEffect(ref.update(in :: _).unit) *> refWriter(ref),
+      (_: Any) => ZChannel.end(()),
+      (_: Any) => ZChannel.end(())
+    )
+
+  def mapper[T, U](f: T => U): ZChannel[Any, Any, T, Any, Nothing, U, Unit] =
+    ZChannel.readWith(
+      (in: T) => ZChannel.write(f(in)) *> mapper(f),
+      (_: Any) => ZChannel.end(()),
+      (_: Any) => ZChannel.end(())
+    )
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -1,0 +1,521 @@
+package zio.stream.experimental
+
+//import zio.duration._
+//import zio.stream.SinkUtils.{findSink, sinkRaceLaw}
+//import zio.stream.ZStreamGen._
+import zio.test.Assertion._
+//import zio.test.environment.TestClock
+//import zio.test.{assertM, _}
+//import zio.{ZIOBaseSpec, _}
+import zio.test._
+import zio._
+
+//import scala.util.Random
+
+object ZSinkSpec extends ZIOBaseSpec {
+
+  import ZIOTag._
+
+  def spec: ZSpec[Environment, Failure] = {
+    suite("ZSinkSpec")(
+      suite("Constructors")(
+        testM("collectAllToSet")(
+          assertM(
+            ZStream(1, 2, 3, 3, 4)
+              .run(ZSink.collectAllToSet[Nothing, Int])
+          )(equalTo(Set(1, 2, 3, 4)))
+        ),
+        testM("collectAllToMap")(
+          assertM(
+            ZStream
+              .range(0, 10)
+              .run(ZSink.collectAllToMap((_: Int) % 3)(_ + _))
+          )(equalTo(Map[Int, Int](0 -> 18, 1 -> 12, 2 -> 15)))
+        ),
+        suite("accessSink")(
+          testM("accessSink") {
+            assertM(
+              ZStream("ignore this")
+                .run(ZSink.accessSink[String](ZSink.succeed(_)).provide("use this"))
+            )(equalTo("use this"))
+          }
+        ),
+        //      suite("collectAllWhileWith")(
+        //        testM("example 1") {
+        //          ZIO
+        //            .foreach(List(1, 3, 20)) { chunkSize =>
+        //              assertM(
+        //                Stream
+        //                  .fromIterable(1 to 10)
+        //                  .chunkN(chunkSize)
+        //                  .run(ZSink.sum[Int].collectAllWhileWith(-1)((s: Int) => s == s)(_ + _))
+        //              )(equalTo(54))
+        //            }
+        //            .map(_.reduce(_ && _))
+        //        },
+        //        testM("example 2") {
+        //          val sink: ZSink[Any, Nothing, Int, Int, List[Int]] = ZSink
+        //            .head[Int]
+        //            .collectAllWhileWith[List[Int]](Nil)((a: Option[Int]) => a.fold(true)(_ < 5))(
+        //              (a: List[Int], b: Option[Int]) => a ++ b.toList
+        //            )
+        //          val stream = Stream.fromIterable(1 to 100)
+        //          assertM((stream ++ stream).chunkN(3).run(sink))(equalTo(List(1, 2, 3, 4)))
+        //        }
+        //      ),
+        //      testM("head")(
+        //        checkM(Gen.listOf(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))) { chunks =>
+        //          val headOpt = ZStream.fromChunks(chunks: _*).run(ZSink.head[Int])
+        //          assertM(headOpt)(equalTo(chunks.flatMap(_.toSeq).headOption))
+        //        }
+        //      ),
+        testM("last")(
+          checkM(Gen.listOf(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))) { chunks =>
+            val lastOpt = ZStream.fromChunks(chunks: _*).run(ZSink.last)
+            assertM(lastOpt)(equalTo(chunks.flatMap(_.toSeq).lastOption))
+          }
+        )
+        //      suite("managed")(
+        //        testM("happy path") {
+        //          for {
+        //            closed <- Ref.make[Boolean](false)
+        //            res     = ZManaged.make(ZIO.succeed(100))(_ => closed.set(true))
+        //            sink: ZSink[Any, Nothing, Int, Int, (Long, Boolean)] =
+        //              ZSink.managed(res)(m => ZSink.count.mapM(cnt => closed.get.map(cl => (cnt + m, cl))))
+        //            resAndState <- ZStream(1, 2, 3).run(sink)
+        //            finalState  <- closed.get
+        //          } yield {
+        //            assert(resAndState._1)(equalTo(103L)) && assert(resAndState._2)(isFalse) && assert(finalState)(isTrue)
+        //          }
+        //        },
+        //        testM("sad path") {
+        //          for {
+        //            closed     <- Ref.make[Boolean](false)
+        //            res         = ZManaged.make(ZIO.succeed(100))(_ => closed.set(true))
+        //            sink        = ZSink.managed(res)(_ => ZSink.succeed[Int, String]("ok"))
+        //            r          <- ZStream.fail("fail").run(sink).either
+        //            finalState <- closed.get
+        //          } yield assert(r)(equalTo(Left("fail"))) && assert(finalState)(isTrue)
+        //        }
+        //      ),
+      ),
+      testM("map")(
+        assertM(ZStream.range(1, 10).run(ZSink.succeed(1).map(_.toString)))(
+          equalTo("1")
+        )
+      ),
+      suite("mapM")(
+        testM("happy path")(
+          assertM(ZStream.range(1, 10).run(ZSink.succeed(1).mapM(e => ZIO.succeed(e + 1))))(
+            equalTo(2)
+          )
+        ),
+        testM("failure")(
+          assertM(ZStream.range(1, 10).run(ZSink.succeed(1).mapM(_ => ZIO.fail("fail"))).flip)(
+            equalTo("fail")
+          )
+        )
+      ),
+      testM("mapError")(
+        assertM(ZStream.range(1, 10).run(ZSink.fail("fail").mapError(s => s + "!")).either)(
+          equalTo(Left("fail!"))
+        )
+      ),
+      testM("as")(
+        assertM(ZStream.range(1, 10).run(ZSink.succeed(1).as("as")))(
+          equalTo("as")
+        )
+      ),
+      suite("contramap")(
+        testM("happy path") {
+          val parser = ZSink.collectAll[Nothing, Int].contramap[String](_.toInt)
+          assertM(ZStream("1", "2", "3").run(parser))(equalTo(Chunk(1, 2, 3)))
+        },
+        testM("error") {
+          val parser = ZSink.fail("Ouch").contramap[String](_.toInt)
+          assertM(ZStream("1", "2", "3").run(parser).either)(isLeft(equalTo("Ouch")))
+        } @@ zioTag(errors)
+      ),
+      suite("contramapChunks")(
+        testM("happy path") {
+          val parser = ZSink.collectAll[Nothing, Int].contramapChunks[String](_.map(_.toInt))
+          assertM(ZStream("1", "2", "3").run(parser))(equalTo(Chunk(1, 2, 3)))
+        },
+        testM("error") {
+          val parser = ZSink.fail("Ouch").contramapChunks[String](_.map(_.toInt))
+          assertM(ZStream("1", "2", "3").run(parser).either)(isLeft(equalTo("Ouch")))
+        } @@ zioTag(errors)
+      ),
+      suite("contramapM")(
+        testM("happy path") {
+          val parser = ZSink.collectAll[Throwable, Int].contramapM[Any, Throwable, String](a => ZIO.effect(a.toInt))
+          assertM(ZStream("1", "2", "3").run(parser))(equalTo(Chunk(1, 2, 3)))
+        },
+        testM("error") {
+          val parser = ZSink.fail("Ouch").contramapM[Any, Throwable, String](a => ZIO.effect(a.toInt))
+          assertM(ZStream("1", "2", "3").run(parser).either)(isLeft(equalTo("Ouch")))
+        } @@ zioTag(errors),
+        testM("error in transformation") {
+          val parser = ZSink.collectAll[Throwable, Int].contramapM[Any, Throwable, String](a => ZIO.effect(a.toInt))
+          assertM(ZStream("1", "a").run(parser).either)(isLeft(hasMessage(equalTo("For input string: \"a\""))))
+        } @@ zioTag(errors)
+      ),
+      suite("contramapChunksM")(
+        testM("happy path") {
+          val parser =
+            ZSink.collectAll[Throwable, Int].contramapChunksM[Any, Throwable, String](_.mapM(a => ZIO.effect(a.toInt)))
+          assertM(ZStream("1", "2", "3").run(parser))(equalTo(Chunk(1, 2, 3)))
+        },
+        testM("error") {
+          val parser = ZSink.fail("Ouch").contramapChunksM[Any, Throwable, String](_.mapM(a => ZIO.effect(a.toInt)))
+          assertM(ZStream("1", "2", "3").run(parser).either)(isLeft(equalTo("Ouch")))
+        } @@ zioTag(errors),
+        testM("error in transformation") {
+          val parser =
+            ZSink.collectAll[Throwable, Int].contramapChunksM[Any, Throwable, String](_.mapM(a => ZIO.effect(a.toInt)))
+          assertM(ZStream("1", "a").run(parser).either)(isLeft(hasMessage(equalTo("For input string: \"a\""))))
+        } @@ zioTag(errors)
+      ),
+      testM("collectAllWhile") {
+        val sink   = ZSink.collectAllWhile[Nothing, Int](_ < 5)
+        val input  = List(Chunk(3, 4, 5, 6, 7, 2), Chunk.empty, Chunk(3, 4, 5, 6, 5, 4, 3, 2), Chunk.empty)
+        val result = ZStream.fromChunks(input: _*).transduce(sink).runCollect
+        assertM(result)(equalTo(Chunk(Chunk(3, 4), Chunk(), Chunk(), Chunk(2, 3, 4), Chunk(), Chunk(), Chunk(4, 3, 2))))
+      },
+      testM("collectAllWhileM") {
+        val sink   = ZSink.collectAllWhileM[Any, Nothing, Int]((i: Int) => ZIO.succeed(i < 5))
+        val input  = List(Chunk(3, 4, 5, 6, 7, 2), Chunk.empty, Chunk(3, 4, 5, 6, 5, 4, 3, 2), Chunk.empty)
+        val result = ZStream.fromChunks(input: _*).transduce(sink).runCollect
+        assertM(result)(equalTo(Chunk(Chunk(3, 4), Chunk(), Chunk(), Chunk(2, 3, 4), Chunk(), Chunk(), Chunk(4, 3, 2))))
+      },
+      testM("foldLeft equivalence with Chunk#foldLeft")(
+        checkM(
+          Gen.small(ZStreamGen.pureStreamGen(Gen.anyInt, _)),
+          Gen.function2(Gen.anyString),
+          Gen.anyString
+        ) { (s, f, z) =>
+          for {
+            xs <- s.run(ZSink.foldLeft(z)(f))
+            ys <- s.runCollect.map(_.foldLeft(z)(f))
+          } yield assert(xs)(equalTo(ys))
+        }
+      ),
+      suite("foldM")(
+        testM("empty")(
+          assertM(
+            ZStream.empty
+              .transduce(
+                ZSink.foldM(0)(_ => true)((x, y: Int) => ZIO.succeed(x + y))
+              )
+              .runCollect
+          )(equalTo(Chunk(0)))
+        ),
+        testM("short circuits") {
+          val empty: ZStream[Any, Nothing, Int]     = ZStream.empty
+          val single: ZStream[Any, Nothing, Int]    = ZStream.succeed(1)
+          val double: ZStream[Any, Nothing, Int]    = ZStream(1, 2)
+          val failed: ZStream[Any, String, Nothing] = ZStream.fail("Ouch")
+
+          def run[E](stream: ZStream[Any, E, Int]) =
+            (for {
+              effects <- Ref.make[List[Int]](Nil)
+              exit <- stream
+                        .transduce(ZSink.foldM(0)(_ => true) { (_, a: Int) =>
+                          effects.update(a :: _) *> UIO.succeed(30)
+                        })
+                        .runCollect
+              result <- effects.get
+            } yield exit -> result).run
+
+          (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
+            assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
+            assertM(run(double))(succeeds(equalTo((Chunk(30), List(2, 1))))) <*>
+            assertM(run(failed))(fails(equalTo("Ouch")))).map { case (((r1, r2), r3), r4) =>
+            r1 && r2 && r3 && r4
+          }
+        },
+        testM("equivalence with List#foldLeft") {
+          val ioGen = ZStreamGen.successes(Gen.anyString)
+          checkM(Gen.small(ZStreamGen.pureStreamGen(Gen.anyInt, _)), Gen.function2(ioGen), ioGen) { (s, f, z) =>
+            for {
+              sinkResult <- z.flatMap(z => s.run(ZSink.foldLeftM(z)(f)))
+              foldResult <- s.runFold(List[Int]())((acc, el) => el :: acc)
+                              .map(_.reverse)
+                              .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
+                              .run
+            } yield assert(foldResult.succeeded)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
+          }
+        }
+      ),
+      suite("fold")(
+        testM("empty")(
+          assertM(
+            ZStream.empty
+              .transduce(ZSink.fold[Nothing, Int, Int](0)(_ => true)(_ + _))
+              .runCollect
+          )(equalTo(Chunk(0)))
+        ),
+        testM("short circuits") {
+          val empty: ZStream[Any, Nothing, Int]     = ZStream.empty
+          val single: ZStream[Any, Nothing, Int]    = ZStream.succeed(1)
+          val double: ZStream[Any, Nothing, Int]    = ZStream(1, 2)
+          val failed: ZStream[Any, String, Nothing] = ZStream.fail("Ouch")
+
+          def run[E](stream: ZStream[Any, E, Int]) =
+            (for {
+              effects <- Ref.make[List[Int]](Nil)
+              exit <- stream
+                        .transduce(ZSink.foldM(0)(_ => true) { (_, a: Int) =>
+                          effects.update(a :: _) *> UIO.succeed(30)
+                        })
+                        .runCollect
+              result <- effects.get
+            } yield (exit, result)).run
+
+          (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
+            assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
+            assertM(run(double))(succeeds(equalTo((Chunk(30), List(2, 1))))) <*>
+            assertM(run(failed))(fails(equalTo("Ouch")))).map { case (((r1, r2), r3), r4) =>
+            r1 && r2 && r3 && r4
+          }
+        },
+        testM("termination in the middle")(
+          assertM(ZStream.range(1, 10).run(ZSink.fold[Nothing, Int, Int](0)(_ <= 5)((a, b) => a + b)))(equalTo(6))
+        ),
+        testM("immediate termination")(
+          assertM(ZStream.range(1, 10).run(ZSink.fold[Nothing, Int, Int](0)(_ <= -1)((a, b) => a + b)))(equalTo(0))
+        ),
+        testM("termination in the middle")(
+          assertM(ZStream.range(1, 10).run(ZSink.fold[Nothing, Int, Int](0)(_ <= 500)((a, b) => a + b)))(equalTo(45))
+        )
+      ),
+      testM("foldUntil")(
+        assertM(
+          ZStream[Long](1, 1, 1, 1, 1, 1)
+            .transduce(ZSink.foldUntil(0L, 3)(_ + (_: Long)))
+            .runCollect
+        )(equalTo(Chunk(3L, 3L, 0L)))
+      ),
+      testM("foldUntilM")(
+        assertM(
+          ZStream[Long](1, 1, 1, 1, 1, 1)
+            .transduce(ZSink.foldUntilM(0L, 3)((s, (a: Long)) => UIO.succeedNow(s + a)))
+            .runCollect
+        )(equalTo(Chunk(3L, 3L, 0L)))
+      ),
+      testM("foldWeighted")(
+        assertM(
+          ZStream[Long](1, 5, 2, 3)
+            .transduce(
+              ZSink.foldWeighted(List[Long]())((_, x: Long) => x * 2, 12)((acc, el) => el :: acc).map(_.reverse)
+            )
+            .runCollect
+        )(equalTo(Chunk(List(1L, 5L), List(2L, 3L))))
+      ),
+      suite("foldWeightedDecompose")(
+        testM("simple example")(
+          assertM(
+            ZStream(1, 5, 1)
+              .transduce(
+                ZSink
+                  .foldWeightedDecompose(List[Int]())(
+                    (_, i: Int) => i.toLong,
+                    4,
+                    (i: Int) =>
+                      if (i > 1) Chunk(i - 1, 1)
+                      else Chunk(i)
+                  )((acc, el) => el :: acc)
+                  .map(_.reverse)
+              )
+              .runCollect
+          )(equalTo(Chunk(List(1, 3), List(1, 1, 1))))
+        ),
+        testM("empty stream")(
+          assertM(
+            ZStream.empty
+              .transduce(
+                ZSink.foldWeightedDecompose(0)((_, (x: Int)) => x.toLong, 1000, Chunk.single(_: Int))(_ + _)
+              )
+              .runCollect
+          )(equalTo(Chunk(0)))
+        )
+      ),
+      testM("foldWeightedM")(
+        assertM(
+          ZStream[Long](1, 5, 2, 3)
+            .transduce(
+              ZSink
+                .foldWeightedM(List.empty[Long])((_, a: Long) => UIO.succeedNow(a * 2), 12)((acc, el) =>
+                  UIO.succeedNow(el :: acc)
+                )
+                .map(_.reverse)
+            )
+            .runCollect
+        )(equalTo(Chunk(List(1L, 5L), List(2L, 3L))))
+      ),
+      suite("foldWeightedDecomposeM")(
+        testM("simple example")(
+          assertM(
+            ZStream(1, 5, 1)
+              .transduce(
+                ZSink
+                  .foldWeightedDecomposeM(List.empty[Int])(
+                    (_, i: Int) => UIO.succeedNow(i.toLong),
+                    4,
+                    (i: Int) =>
+                      UIO.succeedNow(
+                        if (i > 1) Chunk(i - 1, 1)
+                        else Chunk(i)
+                      )
+                  )((acc, el) => UIO.succeedNow(el :: acc))
+                  .map(_.reverse)
+              )
+              .runCollect
+          )(equalTo(Chunk(List(1, 3), List(1, 1, 1))))
+        ),
+        testM("empty stream")(
+          assertM(
+            ZStream.empty
+              .transduce(
+                ZSink.foldWeightedDecomposeM[Any, Nothing, Int, Int](0)(
+                  (_, x) => ZIO.succeed(x.toLong),
+                  1000,
+                  x => ZIO.succeed(Chunk.single(x))
+                )((x, y) => ZIO.succeed(x + y))
+              )
+              .runCollect
+          )(equalTo(Chunk(0)))
+        )
+      ),
+      suite("fail")(
+        testM("handles leftovers") {
+          val s =
+            ZSink
+              .fail("boom")
+              .foldM(err => ZSink.collectAll[String, Int].map(c => (c, err)), _ => sys.error("impossible"))
+          assertM(ZStream(1, 2, 3).run(s))(equalTo((Chunk(1, 2, 3), "boom")))
+        }
+      ),
+      // suite("foreach")(
+      //   testM("preserves leftovers in case of failure") {
+      //     for {
+      //       acc <- Ref.make[Int](0)
+      //       s    = ZSink.foreach[Any, String, Int]((i: Int) => if (i == 4) ZIO.fail("boom") else acc.update(_ + i))
+      //       sink = s.foldM(_ => ZSink.collectAll[String, Int], _ => sys.error("impossible"))
+      //       leftover <- ZStream.fromChunks(Chunk(1, 2), Chunk(3, 4, 5)).run(sink)
+      //       sum      <- acc.get
+      //     } yield {
+      //       assert(sum)(equalTo(6)) && assert(leftover)(equalTo(Chunk(5)))
+      //     }
+      //   }
+      // ),
+      suite("foreachWhile")(
+        testM("handles leftovers") {
+          val leftover = ZStream
+            .fromIterable(1 to 5)
+            .run(ZSink.foreachWhile((n: Int) => ZIO.succeed(n <= 3)).exposeLeftover)
+            .map(_._2)
+          assertM(leftover)(equalTo(Chunk(4, 5)))
+        }
+      ),
+      suite("fromEffect")(
+        testM("result is ok") {
+          val s = ZSink.fromEffect(ZIO.succeed("ok"))
+          assertM(ZStream(1, 2, 3).run(s))(
+            equalTo("ok")
+          )
+        }
+      ),
+      suite("succeed")(
+        testM("result is ok") {
+          assertM(ZStream(1, 2, 3).run(ZSink.succeed("ok")))(
+            equalTo("ok")
+          )
+        }
+      ),
+      suite("Combinators")(
+        //      testM("raceBoth") {
+        //        checkM(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
+        //          val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+        //          sinkRaceLaw(ZStream.fromIterable(Random.shuffle(stream)), findSink(20), findSink(40))
+        //        }
+        //      },
+        //      suite("zipWithPar")(
+        //        testM("coherence") {
+        //          checkM(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
+        //            val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+        //            SinkUtils
+        //              .zipParLaw(ZStream.fromIterable(Random.shuffle(stream)), findSink(20), findSink(40))
+        //          }
+        //        },
+        //        suite("zipRight (*>)")(
+        //          testM("happy path") {
+        //            assertM(ZStream(1, 2, 3).run(ZSink.head.zipParRight(ZSink.succeed[Int, String]("Hello"))))(
+        //              equalTo(("Hello"))
+        //            )
+        //          }
+        //        ),
+        //        suite("zipWith")(testM("happy path") {
+        //          assertM(ZStream(1, 2, 3).run(ZSink.head.zipParLeft(ZSink.succeed[Int, String]("Hello"))))(
+        //            equalTo(Some(1))
+        //          )
+        //        })
+        //      ),
+        //      testM("untilOutputM") {
+        //        val sink: ZSink[Any, Nothing, Int, Int, Option[Option[Int]]] =
+        //          ZSink.head[Int].untilOutputM(h => ZIO.succeed(h.fold(false)(_ >= 10)))
+        //        val assertions = ZIO.foreach(Chunk(1, 3, 7, 20)) { n =>
+        //          assertM(Stream.fromIterable(1 to 100).chunkN(n).run(sink))(equalTo(Some(Some(10))))
+        //        }
+        //        assertions.map(tst => tst.reduce(_ && _))
+        //      },
+        suite("flatMap")(
+          testM("non-empty input") {
+            assertM(
+              ZStream(1, 2, 3)
+                .run(ZSink.head[Nothing, Int].flatMap((x: Option[Int]) => ZSink.succeed(x)))
+            )(equalTo(Some(1)))
+          },
+          testM("empty input") {
+            assertM(ZStream.empty.run(ZSink.head[Nothing, Int].flatMap(h => ZSink.succeed(h))))(
+              equalTo(None)
+            )
+          },
+          testM("with leftovers") {
+            val headAndCount =
+              ZSink.head[Nothing, Int].flatMap((h: Option[Int]) => ZSink.count.map(cnt => (h, cnt)))
+            checkM(Gen.listOf(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))) { chunks =>
+              ZStream.fromChunks(chunks: _*).run(headAndCount).map {
+                case (head, count) => {
+                  assert(head)(equalTo(chunks.flatten.headOption)) &&
+                  assert(count + head.toList.size)(equalTo(chunks.map(_.size.toLong).sum))
+                }
+              }
+            }
+          }
+        ),
+        testM("take")(
+          checkM(Gen.chunkOf(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))), Gen.anyInt) { (chunks, n) =>
+            ZStream
+              .fromChunks(chunks: _*)
+              .peel(ZSink.take[Nothing, Int](n))
+              .flatMap { case (chunk, stream) =>
+                stream.runCollect.toManaged_.map { leftover =>
+                  assert(chunk)(equalTo(chunks.flatten.take(n))) &&
+                  assert(leftover)(equalTo(chunks.flatten.drop(n)))
+                }
+              }
+              .useNow
+          }
+        ) //,
+        //      testM("timed") {
+        //        for {
+        //          f <- ZStream.fromIterable(1 to 10).mapM(i => clock.sleep(10.millis).as(i)).run(ZSink.timed).fork
+        //          _ <- TestClock.adjust(100.millis)
+        //          r <- f.join
+        //        } yield assert(r)(isGreaterThanEqualTo(100.millis))
+        //      }
+      )
+    )
+  }
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamGen.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamGen.scala
@@ -1,0 +1,61 @@
+package zio.stream.experimental
+
+import zio._
+import zio.random.Random
+import zio.test.{ Gen, GenZIO, Sized }
+
+object ZStreamGen extends GenZIO {
+  def tinyListOf[R <: Random, A](g: Gen[R, A]): Gen[R, List[A]] =
+    Gen.listOfBounded(0, 5)(g)
+
+  def tinyChunkOf[R <: Random, A](g: Gen[R, A]): Gen[R, Chunk[A]] =
+    Gen.chunkOfBounded(0, 5)(g)
+
+  def streamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, ZStream[Any, String, A]] =
+    Gen.oneOf(failingStreamGen(a, max), pureStreamGen(a, max))
+
+  def pureStreamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, ZStream[Any, Nothing, A]] =
+    max match {
+      case 0 => Gen.const(ZStream.empty)
+      case n =>
+        Gen.oneOf(
+          Gen.const(ZStream.empty),
+          Gen
+            .int(1, n)
+            .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(a))))
+            .map(chunks => ZStream.fromChunks(chunks: _*))
+        )
+    }
+
+  def failingStreamGen[R <: Random, A](a: Gen[R, A], max: Int): Gen[R with Sized, ZStream[Any, String, A]] =
+    max match {
+      case 0 => Gen.const(ZStream.fromEffect(IO.fail("fail-case")))
+      case _ =>
+        Gen
+          .int(1, max)
+          .flatMap(n =>
+            for {
+              i  <- Gen.int(0, n - 1)
+              it <- Gen.listOfN(n)(a)
+            } yield ZStream.unfoldM((i, it)) {
+              case (_, Nil) | (0, _) => IO.fail("fail-case")
+              case (n, head :: rest) => IO.succeedNow(Some((head, (n - 1, rest))))
+            }
+          )
+    }
+
+  def nPulls[R, E, A](pull: ZIO[R, Option[E], A], n: Int): ZIO[R, Nothing, Iterable[Either[Option[E], A]]] =
+    ZIO.foreach(1 to n)(_ => pull.either)
+
+  val streamOfInts: Gen[Random with Sized, ZStream[Any, String, Int]] =
+    Gen.bounded(0, 5)(streamGen(Gen.anyInt, _)).zipWith(Gen.function(Gen.boolean))(injectEmptyChunks)
+
+  val pureStreamOfInts: Gen[Random with Sized, ZStream[Any, Nothing, Int]] =
+    Gen.bounded(0, 5)(pureStreamGen(Gen.anyInt, _)).zipWith(Gen.function(Gen.boolean))(injectEmptyChunks)
+
+  def injectEmptyChunks[R, E, A](stream: ZStream[R, E, A], predicate: Chunk[A] => Boolean): ZStream[R, E, A] =
+    stream.mapChunks { chunk =>
+      if (predicate(chunk)) chunk
+      else Chunk.empty
+    }
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -1,0 +1,3765 @@
+package zio.stream.experimental
+
+// import java.io.{ ByteArrayInputStream, IOException }
+// import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+import zio._
+import zio.clock.Clock
+import zio.duration._
+// import zio.stm.TQueue
+// import zio.stream.ZSink.Push
+import zio.stream.experimental.ZStreamGen._
+import zio.test.Assertion._
+// import zio.test.TestAspect.{ exceptJS, flaky, nonFlaky, scala2Only, timeout }
+import zio.test._
+import zio.test.environment.TestClock
+
+object ZStreamSpec extends ZIOBaseSpec {
+  import ZIOTag._
+
+  def inParallel(action: => Unit)(implicit ec: ExecutionContext): Unit =
+    ec.execute(() => action)
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("ZStreamSpec")(
+      suite("Combinators")(
+        suite("absolve")(
+          testM("happy path")(checkM(tinyChunkOf(Gen.anyInt)) { xs =>
+            val stream = ZStream.fromIterable(xs.map(Right(_)))
+            assertM(stream.absolve.runCollect)(equalTo(xs))
+          }),
+          testM("failure")(checkM(tinyChunkOf(Gen.anyInt)) { xs =>
+            val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
+            assertM(stream.absolve.runCollect.run)(fails(equalTo("Ouch")))
+          }),
+          testM("round-trip #1")(checkM(tinyChunkOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
+            val xss    = ZStream.fromIterable(xs.map(Right(_)))
+            val stream = xss ++ ZStream(Left(s)) ++ xss
+            for {
+              res1 <- stream.runCollect
+              res2 <- stream.absolve.either.runCollect
+            } yield assert(res1)(startsWith(res2))
+          }),
+          testM("round-trip #2")(checkM(tinyChunkOf(Gen.anyInt), Gen.anyString) { (xs, s) =>
+            val xss    = ZStream.fromIterable(xs)
+            val stream = xss ++ ZStream.fail(s)
+            for {
+              res1 <- stream.runCollect.run
+              res2 <- stream.either.absolve.runCollect.run
+            } yield assert(res1)(fails(equalTo(s))) && assert(res2)(fails(equalTo(s)))
+          })
+        ) @@ TestAspect.jvmOnly, // This is horrendously slow on Scala.js for some reason
+        testM("access") {
+          for {
+            result <- ZStream.access[String](identity).provide("test").runHead.get
+          } yield assert(result)(equalTo("test"))
+        },
+        suite("accessM")(
+          testM("accessM") {
+            for {
+              result <- ZStream.accessM[String](ZIO.succeed(_)).provide("test").runHead.get
+            } yield assert(result)(equalTo("test"))
+          },
+          testM("accessM fails") {
+            for {
+              result <- ZStream.accessM[Int](_ => ZIO.fail("fail")).provide(0).runHead.run
+            } yield assert(result)(fails(equalTo("fail")))
+          } @@ zioTag(errors)
+        ),
+        suite("accessStream")(
+          testM("accessStream") {
+            for {
+              result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.get
+            } yield assert(result)(equalTo("test"))
+          },
+          testM("accessStream fails") {
+            for {
+              result <- ZStream.accessStream[Int](_ => ZStream.fail("fail")).provide(0).runHead.run
+            } yield assert(result)(fails(equalTo("fail")))
+          } @@ zioTag(errors)
+        ),
+        suite("aggregateAsync")(
+          testM("simple example") {
+            ZStream(1, 1, 1, 1)
+              .aggregateAsync(ZSink.foldUntil(List[Int](), 3)((acc, (el: Int)) => el :: acc))
+              .runCollect
+              .map { result =>
+                assert(result.toList.flatten)(equalTo(List(1, 1, 1, 1))) &&
+                assert(result.forall(_.length <= 3))(isTrue)
+              }
+          },
+          testM("error propagation 1") {
+            val e = new RuntimeException("Boom")
+            assertM(
+              ZStream(1, 1, 1, 1)
+                .aggregateAsync(ZSink.die(e))
+                .runCollect
+                .run
+            )(dies(equalTo(e)))
+          },
+          testM("error propagation 2") {
+            val e = new RuntimeException("Boom")
+            assertM(
+              ZStream(1, 1)
+                .aggregateAsync(ZSink.foldLeftM(Nil)((_, (_: Any)) => ZIO.die(e)))
+                .runCollect
+                .run
+            )(dies(equalTo(e)))
+          },
+          testM("interruption propagation 1") {
+            for {
+              latch     <- Promise.make[Nothing, Unit]
+              cancelled <- Ref.make(false)
+              sink = ZSink.foldM(List[Int]())(_ => true) { (acc, el: Int) =>
+                       if (el == 1) UIO.succeedNow(el :: acc)
+                       else
+                         (latch.succeed(()) *> ZIO.infinity)
+                           .onInterrupt(cancelled.set(true))
+                     }
+              fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.untraced.fork
+              _      <- latch.await
+              _      <- fiber.interrupt
+              result <- cancelled.get
+            } yield assert(result)(isTrue)
+          },
+          testM("interruption propagation 2") {
+            for {
+              latch     <- Promise.make[Nothing, Unit]
+              cancelled <- Ref.make(false)
+              sink = ZSink.fromEffect {
+                       (latch.succeed(()) *> ZIO.infinity)
+                         .onInterrupt(cancelled.set(true))
+                     }
+              fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.untraced.fork
+              _      <- latch.await
+              _      <- fiber.interrupt
+              result <- cancelled.get
+            } yield assert(result)(isTrue)
+          },
+          testM("leftover handling") {
+            val data = List(1, 2, 2, 3, 2, 3)
+            assertM(
+              ZStream(data: _*)
+                .aggregateAsync(
+                  ZSink.foldWeighted(List[Int]())((_, x: Int) => x.toLong, 4)((acc, el) => el :: acc)
+                )
+                .map(_.reverse)
+                .runCollect
+                .map(_.toList.flatten)
+            )(equalTo(data))
+          }
+        ),
+        suite("transduce")(
+          testM("simple example") {
+            assertM(
+              ZStream('1', '2', ',', '3', '4')
+                .transduce(ZSink.collectAllWhile((_: Char).isDigit))
+                .map(_.mkString.toInt)
+                .runCollect
+            )(equalTo(Chunk(12, 34)))
+          },
+          testM("no remainder") {
+            assertM(
+              ZStream(1, 2, 3, 4)
+                .transduce(ZSink.fold(100)(_ % 2 == 0)(_ + (_: Int)))
+                .runCollect
+            )(equalTo(Chunk(101, 105, 104)))
+          },
+          testM("with a sink that always signals more") {
+            assertM(
+              ZStream(1, 2, 3)
+                .transduce(ZSink.fold(0)(_ => true)(_ + (_: Int)))
+                .runCollect
+            )(equalTo(Chunk(1 + 2 + 3)))
+          },
+          testM("propagate managed error") {
+            val fail = "I'm such a failure!"
+            val t    = ZSink.fail(fail)
+            assertM(ZStream(1, 2, 3).transduce(t).runCollect.either)(isLeft(equalTo(fail)))
+          }
+        ),
+        suite("aggregateAsyncWithinEither")(
+          testM("simple example") {
+            assertM(
+              ZStream(1, 1, 1, 1, 2, 2)
+                .aggregateAsyncWithinEither(
+                  ZSink
+                    .fold((List[Int](), true))(_._2) { (acc, el: Int) =>
+                      if (el == 1) (el :: acc._1, true)
+                      else if (el == 2 && acc._1.isEmpty) (el :: acc._1, false)
+                      else (el :: acc._1, false)
+                    }
+                    .map(_._1),
+                  Schedule.spaced(30.minutes)
+                )
+                .runCollect
+            )(
+              equalTo(Chunk(Right(List(2, 1, 1, 1, 1)), Right(List(2)), Right(List())))
+            )
+          },
+          testM("fails fast") {
+            for {
+              queue <- Queue.unbounded[Int]
+              _ <- ZStream
+                     .range(1, 10)
+                     .tap(i => ZIO.fail("BOOM!").when(i == 6) *> queue.offer(i))
+                     .aggregateAsyncWithin(
+                       ZSink.foldUntil[String, Int, Unit]((), 5)((_, (_: Int)) => ()),
+                       Schedule.forever
+                     )
+                     .runDrain
+                     .catchAll(_ => ZIO.succeedNow(()))
+              value <- queue.takeAll
+              _     <- queue.shutdown
+            } yield assert(value)(equalTo(Chunk(1, 2, 3, 4, 5)))
+          } @@ zioTag(errors),
+          testM("error propagation 1") {
+            val e = new RuntimeException("Boom")
+            assertM(
+              ZStream(1, 1, 1, 1)
+                .aggregateAsyncWithinEither(ZSink.die(e), Schedule.spaced(30.minutes))
+                .runCollect
+                .run
+            )(dies(equalTo(e)))
+          } @@ zioTag(errors),
+          testM("error propagation 2") {
+            val e = new RuntimeException("Boom")
+
+            assertM(
+              ZStream(1, 1)
+                .aggregateAsyncWithinEither(
+                  ZSink.foldM[Any, Nothing, Int, List[Int]](List[Int]())(_ => true)((_, _) => ZIO.die(e)),
+                  Schedule.spaced(30.minutes)
+                )
+                .runCollect
+                .run
+            )(dies(equalTo(e)))
+          } @@ zioTag(errors),
+          testM("interruption propagation") {
+            for {
+              latch     <- Promise.make[Nothing, Unit]
+              cancelled <- Ref.make(false)
+              sink = ZSink.foldM(List[Int]())(_ => true) { (acc, el: Int) =>
+                       if (el == 1) UIO.succeed(el :: acc)
+                       else
+                         (latch.succeed(()) *> ZIO.infinity)
+                           .onInterrupt(cancelled.set(true))
+                     }
+              fiber <- ZStream(1, 1, 2)
+                         .aggregateAsyncWithinEither(sink, Schedule.spaced(30.minutes))
+                         .runCollect
+                         .untraced
+                         .fork
+              _      <- latch.await
+              _      <- fiber.interrupt
+              result <- cancelled.get
+            } yield assert(result)(isTrue)
+          } @@ zioTag(interruption),
+          testM("interruption propagation") {
+            for {
+              latch     <- Promise.make[Nothing, Unit]
+              cancelled <- Ref.make(false)
+              sink = ZSink.fromEffect {
+                       (latch.succeed(()) *> ZIO.infinity)
+                         .onInterrupt(cancelled.set(true))
+                     }
+              fiber <- ZStream(1, 1, 2)
+                         .aggregateAsyncWithinEither(sink, Schedule.spaced(30.minutes))
+                         .runCollect
+                         .untraced
+                         .fork
+              _      <- latch.await
+              _      <- fiber.interrupt
+              result <- cancelled.get
+            } yield assert(result)(isTrue)
+          } @@ zioTag(interruption),
+          testM("child fiber handling") {
+            assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
+              for {
+                fib <- ZStream
+                         .fromQueue(c.queue.map(Take(_)))
+                         .tap(_ => c.proceed)
+                         .flattenTake
+                         .aggregateAsyncWithin(ZSink.last[Nothing, Int], Schedule.fixed(200.millis))
+                         .interruptWhen(ZIO.never)
+                         .take(2)
+                         .runCollect
+                         .fork
+                _       <- (c.offer *> TestClock.adjust(100.millis) *> c.awaitNext).repeatN(3)
+                results <- fib.join.map(_.collect { case Some(ex) => ex })
+              } yield assert(results)(equalTo(Chunk(2, 3)))
+            }
+          } @@ zioTag(interruption) @@ TestAspect.jvmOnly,
+          testM("leftover handling") {
+            val data = List(1, 2, 2, 3, 2, 3)
+            assertM(
+              for {
+                f <- (ZStream(data: _*)
+                       .aggregateAsyncWithinEither(
+                         ZSink
+                           .foldWeighted(List[Int]())((_, i: Int) => i.toLong, 4)((acc, el) => el :: acc)
+                           .map(_.reverse),
+                         Schedule.spaced(100.millis)
+                       )
+                       .collect { case Right(v) =>
+                         v
+                       }
+                       .runCollect
+                       .map(_.toList.flatten))
+                       .fork
+                _      <- TestClock.adjust(31.minutes)
+                result <- f.join
+              } yield result
+            )(equalTo(data))
+          }
+        ),
+        //     suite("bracket")(
+        //       testM("bracket")(
+        //         for {
+        //           done <- Ref.make(false)
+        //           iteratorStream = ZStream
+        //                              .bracket(UIO(0 to 2))(_ => done.set(true))
+        //                              .flatMap(ZStream.fromIterable(_))
+        //           result   <- iteratorStream.runCollect
+        //           released <- done.get
+        //         } yield assert(result)(equalTo(Chunk(0, 1, 2))) && assert(released)(isTrue)
+        //       ),
+        //       testM("bracket short circuits")(
+        //         for {
+        //           done <- Ref.make(false)
+        //           iteratorStream = ZStream
+        //                              .bracket(UIO(0 to 3))(_ => done.set(true))
+        //                              .flatMap(ZStream.fromIterable(_))
+        //                              .take(2)
+        //           result   <- iteratorStream.runCollect
+        //           released <- done.get
+        //         } yield assert(result)(equalTo(Chunk(0, 1))) && assert(released)(isTrue)
+        //       ),
+        //       testM("no acquisition when short circuiting")(
+        //         for {
+        //           acquired <- Ref.make(false)
+        //           iteratorStream = (ZStream(1) ++ ZStream.bracket(acquired.set(true))(_ => UIO.unit))
+        //                              .take(0)
+        //           _      <- iteratorStream.runDrain
+        //           result <- acquired.get
+        //         } yield assert(result)(isFalse)
+        //       ),
+        //       testM("releases when there are defects") {
+        //         for {
+        //           ref <- Ref.make(false)
+        //           _ <- ZStream
+        //                  .bracket(ZIO.unit)(_ => ref.set(true))
+        //                  .flatMap(_ => ZStream.fromEffect(ZIO.dieMessage("boom")))
+        //                  .runDrain
+        //                  .run
+        //           released <- ref.get
+        //         } yield assert(released)(isTrue)
+        //       },
+        //       testM("flatMap associativity doesn't affect bracket lifetime")(
+        //         for {
+        //           leftAssoc <- ZStream
+        //                          .bracket(Ref.make(true))(_.set(false))
+        //                          .flatMap(ZStream.succeed(_))
+        //                          .flatMap(r => ZStream.fromEffect(r.get))
+        //                          .runCollect
+        //                          .map(_.head)
+        //           rightAssoc <- ZStream
+        //                           .bracket(Ref.make(true))(_.set(false))
+        //                           .flatMap(ZStream.succeed(_).flatMap(r => ZStream.fromEffect(r.get)))
+        //                           .runCollect
+        //                           .map(_.head)
+        //         } yield assert(leftAssoc -> rightAssoc)(equalTo(true -> true))
+        //       )
+        //     ),
+        //     suite("broadcast")(
+        //       testM("Values") {
+        //         ZStream
+        //           .range(0, 5)
+        //           .broadcast(2, 12)
+        //           .use {
+        //             case s1 :: s2 :: Nil =>
+        //               for {
+        //                 out1    <- s1.runCollect
+        //                 out2    <- s2.runCollect
+        //                 expected = Chunk.fromIterable(Range(0, 5))
+        //               } yield assert(out1)(equalTo(expected)) && assert(out2)(equalTo(expected))
+        //             case _ =>
+        //               UIO(assert(())(Assertion.nothing))
+        //           }
+        //       },
+        //       testM("Errors") {
+        //         (ZStream.range(0, 1) ++ ZStream.fail("Boom")).broadcast(2, 12).use {
+        //           case s1 :: s2 :: Nil =>
+        //             for {
+        //               out1    <- s1.runCollect.either
+        //               out2    <- s2.runCollect.either
+        //               expected = Left("Boom")
+        //             } yield assert(out1)(equalTo(expected)) && assert(out2)(equalTo(expected))
+        //           case _ =>
+        //             UIO(assert(())(Assertion.nothing))
+        //         }
+        //       },
+        //       testM("BackPressure") {
+        //         ZStream
+        //           .range(0, 5)
+        //           .broadcast(2, 2)
+        //           .use {
+        //             case s1 :: s2 :: Nil =>
+        //               for {
+        //                 ref    <- Ref.make[List[Int]](Nil)
+        //                 latch1 <- Promise.make[Nothing, Unit]
+        //                 fib <- s1
+        //                          .tap(i => ref.update(i :: _) *> latch1.succeed(()).when(i == 2))
+        //                          .runDrain
+        //                          .fork
+        //                 _         <- latch1.await
+        //                 snapshot1 <- ref.get
+        //                 _         <- s2.runDrain
+        //                 _         <- fib.await
+        //                 snapshot2 <- ref.get
+        //               } yield assert(snapshot1)(equalTo(List(2, 1, 0))) && assert(snapshot2)(
+        //                 equalTo(Range(0, 5).toList.reverse)
+        //               )
+        //             case _ =>
+        //               UIO(assert(())(Assertion.nothing))
+        //           }
+        //       },
+        //       testM("Unsubscribe") {
+        //         ZStream.range(0, 5).broadcast(2, 2).use {
+        //           case s1 :: s2 :: Nil =>
+        //             for {
+        //               _    <- s1.process.use_(ZIO.unit).ignore
+        //               out2 <- s2.runCollect
+        //             } yield assert(out2)(equalTo(Chunk.fromIterable(Range(0, 5))))
+        //           case _ =>
+        //             UIO(assert(())(Assertion.nothing))
+        //         }
+        //       }
+        //     ),
+        suite("buffer")(
+          testM("maintains elements and ordering")(checkM(tinyChunkOf(tinyChunkOf(Gen.anyInt))) { chunk =>
+            assertM(
+              ZStream
+                .fromChunks(chunk: _*)
+                .buffer(2)
+                .runCollect
+            )(equalTo(chunk.flatten))
+          }),
+          testM("buffer the Stream with Error") {
+            val e = new RuntimeException("boom")
+            assertM(
+              (ZStream.range(0, 10) ++ ZStream.fail(e))
+                .buffer(2)
+                .runCollect
+                .run
+            )(fails(equalTo(e)))
+          },
+          testM("fast producer progress independently") {
+            for {
+              ref   <- Ref.make(List[Int]())
+              latch <- Promise.make[Nothing, Unit]
+              s = ZStream
+                    .range(1, 5)
+                    .tap(i => ref.update(i :: _) *> latch.succeed(()).when(i == 4))
+                    .buffer(2)
+              l1 <- s.take(2).runCollect
+              _  <- latch.await
+              l2 <- ref.get
+            } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          }
+        ),
+//            suite("bufferDropping")(
+//              testM("buffer the Stream with Error") {
+//                val e = new RuntimeException("boom")
+//                assertM(
+//                  (ZStream.range(1, 1000) ++ ZStream.fail(e) ++ ZStream.range(1001, 2000))
+//                    .bufferDropping(2)
+//                    .runCollect
+//                    .run
+//                )(fails(equalTo(e)))
+//              },
+        // testM("fast producer progress independently") {
+        //   for {
+        //     ref    <- Ref.make(List.empty[Int])
+        //     latch1 <- Promise.make[Nothing, Unit]
+        //     latch2 <- Promise.make[Nothing, Unit]
+        //     latch3 <- Promise.make[Nothing, Unit]
+        //     latch4 <- Promise.make[Nothing, Unit]
+        //     s1 = ZStream(0) ++ ZStream
+        //            .fromEffect(latch1.await)
+        //            .flatMap(_ => ZStream.range(1, 17).chunkN(1).ensuring(latch2.succeed(())))
+        //     s2 = ZStream
+        //            .fromEffect(latch3.await)
+        //            .flatMap(_ => ZStream.range(17, 25).chunkN(1).ensuring(latch4.succeed(())))
+        //     s = (s1 ++ s2).bufferDropping(8)
+        //     snapshots <- s.process.use { as =>
+        //                    for {
+        //                      zero      <- as
+        //                      _         <- latch1.succeed(())
+        //                      _         <- latch2.await
+        //                      _         <- as.flatMap(a => ref.update(a.toList ::: _)).repeatN(7)
+        //                      snapshot1 <- ref.get
+        //                      _         <- latch3.succeed(())
+        //                      _         <- latch4.await
+        //                      _         <- as.flatMap(a => ref.update(a.toList ::: _)).repeatN(7)
+        //                      snapshot2 <- ref.get
+        //                    } yield (zero, snapshot1, snapshot2)
+        //                  }
+        //   } yield assert(snapshots._1)(equalTo(Chunk.single(0))) && assert(snapshots._2)(
+        //     equalTo(List(8, 7, 6, 5, 4, 3, 2, 1))
+        //   ) &&
+        //     assert(snapshots._3)(
+        //       equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 8, 7, 6, 5, 4, 3, 2, 1))
+        //     )
+        // }
+        //),
+        suite("range")(
+          testM("range includes min value and excludes max value") {
+            assertM(
+              (ZStream.range(1, 2)).runCollect
+            )(equalTo(Chunk(1)))
+          },
+          testM("two large ranges can be concatenated") {
+            assertM(
+              (ZStream.range(1, 1000) ++ ZStream.range(1000, 2000)).runCollect
+            )(equalTo(Chunk.fromIterable(Range(1, 2000))))
+          },
+          testM("two small ranges can be concatenated") {
+            assertM(
+              (ZStream.range(1, 10) ++ ZStream.range(10, 20)).runCollect
+            )(equalTo(Chunk.fromIterable(Range(1, 20))))
+          },
+          testM("range emits no values when start >= end") {
+            assertM(
+              (ZStream.range(1, 1) ++ ZStream.range(2, 1)).runCollect
+            )(equalTo(Chunk.empty))
+          },
+          testM("range emits values in chunks of chunkSize") {
+            assertM(
+              (ZStream
+                .range(1, 10, 2))
+                .mapChunks(c => Chunk[Int](c.sum))
+                .runCollect
+            )(equalTo(Chunk(1 + 2, 3 + 4, 5 + 6, 7 + 8, 9)))
+          }
+        ),
+        //     suite("bufferSliding")(
+        //       testM("buffer the Stream with Error") {
+        //         val e = new RuntimeException("boom")
+        //         assertM(
+        //           (ZStream.range(1, 1000) ++ ZStream.fail(e) ++ ZStream.range(1001, 2000))
+        //             .bufferSliding(2)
+        //             .runCollect
+        //             .run
+        //         )(fails(equalTo(e)))
+        //       },
+        //       testM("fast producer progress independently") {
+        //         for {
+        //           ref    <- Ref.make(List.empty[Int])
+        //           latch1 <- Promise.make[Nothing, Unit]
+        //           latch2 <- Promise.make[Nothing, Unit]
+        //           latch3 <- Promise.make[Nothing, Unit]
+        //           latch4 <- Promise.make[Nothing, Unit]
+        //           s1 = ZStream(0) ++ ZStream
+        //                  .fromEffect(latch1.await)
+        //                  .flatMap(_ => ZStream.range(1, 17).chunkN(1).ensuring(latch2.succeed(())))
+        //           s2 = ZStream
+        //                  .fromEffect(latch3.await)
+        //                  .flatMap(_ => ZStream.range(17, 25).chunkN(1).ensuring(latch4.succeed(())))
+        //           s = (s1 ++ s2).bufferSliding(8)
+        //           snapshots <- s.process.use { as =>
+        //                          for {
+        //                            zero      <- as
+        //                            _         <- latch1.succeed(())
+        //                            _         <- latch2.await
+        //                            _         <- as.flatMap(a => ref.update(a.toList ::: _)).repeatN(7)
+        //                            snapshot1 <- ref.get
+        //                            _         <- latch3.succeed(())
+        //                            _         <- latch4.await
+        //                            _         <- as.flatMap(a => ref.update(a.toList ::: _)).repeatN(7)
+        //                            snapshot2 <- ref.get
+        //                          } yield (zero, snapshot1, snapshot2)
+        //                        }
+        //         } yield assert(snapshots._1)(equalTo(Chunk.single(0))) && assert(snapshots._2)(
+        //           equalTo(List(16, 15, 14, 13, 12, 11, 10, 9))
+        //         ) &&
+        //           assert(snapshots._3)(
+        //             equalTo(List(24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9))
+        //           )
+        //       }
+        //     ),
+        suite("bufferUnbounded")(
+          testM("buffer the Stream")(checkM(Gen.chunkOf(Gen.anyInt)) { chunk =>
+            assertM(
+              ZStream
+                .fromIterable(chunk)
+                .bufferUnbounded
+                .runCollect
+            )(equalTo(chunk))
+          }),
+          testM("buffer the Stream with Error") {
+            val e = new RuntimeException("boom")
+            assertM((ZStream.range(0, 10) ++ ZStream.fail(e)).bufferUnbounded.runCollect.run)(
+              fails(equalTo(e))
+            )
+          },
+          testM("fast producer progress independently") {
+            for {
+              ref   <- Ref.make(List[Int]())
+              latch <- Promise.make[Nothing, Unit]
+              s = ZStream
+                    .range(1, 1000)
+                    .tap(i => ref.update(i :: _) *> latch.succeed(()).when(i == 999))
+                    .bufferUnbounded
+              l1 <- s.take(2).runCollect
+              _  <- latch.await
+              l2 <- ref.get
+            } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 until 1000).toList))
+          }
+        ),
+        suite("catchAllCause")(
+          testM("recovery from errors") {
+            val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
+            val s2 = ZStream(3, 4)
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
+          },
+          testM("recovery from defects") {
+            val s1 = ZStream(1, 2) ++ ZStream.dieMessage("Boom")
+            val s2 = ZStream(3, 4)
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
+          },
+          testM("happy path") {
+            val s1 = ZStream(1, 2)
+            val s2 = ZStream(3, 4)
+            s1.catchAllCause(_ => s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
+          },
+          testM("executes finalizers") {
+            for {
+              fins   <- Ref.make(List[String]())
+              s1      = (ZStream(1, 2) ++ ZStream.fail("Boom")).ensuring(fins.update("s1" :: _))
+              s2      = (ZStream(3, 4) ++ ZStream.fail("Boom")).ensuring(fins.update("s2" :: _))
+              _      <- s1.catchAllCause(_ => s2).runCollect.run
+              result <- fins.get
+            } yield assert(result)(equalTo(List("s2", "s1")))
+          }
+//          testM("releases all resources by the time the failover stream has started") {
+//            for {
+//              fins <- Ref.make(Chunk[Int]())
+//              s = ZStream.finalizer(fins.update(1 +: _)) *>
+//                    ZStream.finalizer(fins.update(2 +: _)) *>
+//                    ZStream.finalizer(fins.update(3 +: _)) *>
+//                    ZStream.fail("boom")
+//              result <- s.drain.catchAllCause(_ => ZStream.fromEffect(fins.get)).runCollect
+//            } yield assert(result.flatten)(equalTo(Chunk(1, 2, 3)))
+//          },
+//          testM("propagates the right Exit value to the failing stream (#3609)") {
+//            for {
+//              ref <- Ref.make[Exit[Any, Any]](Exit.unit)
+//              _ <- ZStream
+//                     .bracketExit(UIO.unit)((_, exit) => ref.set(exit))
+//                     .flatMap(_ => ZStream.fail("boom"))
+//                     .either
+//                     .runDrain
+//                     .run
+//              result <- ref.get
+//            } yield assert(result)(fails(equalTo("boom")))
+//          }
+        ),
+        //     suite("catchSome")(
+        //       testM("recovery from some errors") {
+        //         val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
+        //         val s2 = ZStream(3, 4)
+        //         s1.catchSome { case "Boom" => s2 }.runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
+        //       },
+        //       testM("fails stream when partial function does not match") {
+        //         val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
+        //         val s2 = ZStream(3, 4)
+        //         s1.catchSome { case "Boomer" => s2 }.runCollect.either
+        //           .map(assert(_)(isLeft(equalTo("Boom"))))
+        //       }
+        //     ),
+        //     suite("catchSomeCause")(
+        //       testM("recovery from some errors") {
+        //         val s1 = ZStream(1, 2) ++ ZStream.halt(Cause.Fail("Boom"))
+        //         val s2 = ZStream(3, 4)
+        //         s1.catchSomeCause { case Cause.Fail("Boom") => s2 }.runCollect
+        //           .map(assert(_)(equalTo(Chunk(1, 2, 3, 4))))
+        //       },
+        //       testM("halts stream when partial function does not match") {
+        //         val s1 = ZStream(1, 2) ++ ZStream.fail("Boom")
+        //         val s2 = ZStream(3, 4)
+        //         s1.catchSomeCause { case Cause.empty => s2 }.runCollect.either
+        //           .map(assert(_)(isLeft(equalTo("Boom"))))
+        //       }
+        //     ),
+        //     testM("collect") {
+        //       assertM(ZStream(Left(1), Right(2), Left(3)).collect { case Right(n) =>
+        //         n
+        //       }.runCollect)(equalTo(Chunk(2)))
+        //     },
+        suite("collectM")(
+          testM("collectM") {
+            assertM(
+              ZStream(Left(1), Right(2), Left(3)).collectM { case Right(n) =>
+                ZIO(n * 2)
+              }.runCollect
+            )(equalTo(Chunk(4)))
+          },
+          testM("collectM on multiple Chunks") {
+            assertM(
+              ZStream
+                .fromChunks(Chunk(Left(1), Right(2)), Chunk(Right(3), Left(4)))
+                .collectM { case Right(n) =>
+                  ZIO(n * 10)
+                }
+                .runCollect
+            )(equalTo(Chunk(20, 30)))
+          },
+          testM("collectM fails") {
+            assertM(
+              ZStream(Left(1), Right(2), Left(3)).collectM { case Right(_) =>
+                ZIO.fail("Ouch")
+              }.runDrain.either
+            )(isLeft(isNonEmptyString))
+          },
+          testM("laziness on chunks") {
+            assertM(
+              ZStream(1, 2, 3).collectM {
+                case 3 => ZIO.fail("boom")
+                case x => UIO.succeed(x)
+              }.either.runCollect
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+          }
+        ),
+        //     testM("collectSome")(checkM(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.anyInt), _))) { s =>
+        //       for {
+        //         res1 <- (s.collectSome.runCollect)
+        //         res2 <- (s.runCollect.map(_.collect { case Some(x) => x }))
+        //       } yield assert(res1)(equalTo(res2))
+        //     }),
+        suite("collectWhile")(
+          testM("collectWhile") {
+            assertM(ZStream(Some(1), Some(2), Some(3), None, Some(4)).collectWhile { case Some(v) =>
+              v
+            }.runCollect)(equalTo(Chunk(1, 2, 3)))
+          },
+          testM("collectWhile short circuits") {
+            assertM(
+              (ZStream(Option(1)) ++ ZStream.fail("Ouch")).collectWhile { case None =>
+                1
+              }.runDrain.either
+            )(isRight(isUnit))
+          }
+        ),
+        suite("collectWhileM")(
+          testM("collectWhileM") {
+            assertM(
+              ZStream(Some(1), Some(2), Some(3), None, Some(4)).collectWhileM { case Some(v) =>
+                ZIO(v * 2)
+              }.runCollect
+            )(equalTo(Chunk(2, 4, 6)))
+          },
+          testM("collectWhileM short circuits") {
+            assertM(
+              (ZStream(Option(1)) ++ ZStream.fail("Ouch"))
+                .collectWhileM[Any, String, Int] { case None =>
+                  ZIO.succeedNow(1)
+                }
+                .runDrain
+                .either
+            )(isRight(isUnit))
+          },
+          testM("collectWhileM fails") {
+            assertM(
+              ZStream(Some(1), Some(2), Some(3), None, Some(4)).collectWhileM { case Some(_) =>
+                ZIO.fail("Ouch")
+              }.runDrain.either
+            )(isLeft(isNonEmptyString))
+          },
+          testM("laziness on chunks") {
+            assertM(
+              ZStream(1, 2, 3, 4).collectWhileM {
+                case 3 => ZIO.fail("boom")
+                case x => UIO.succeed(x)
+              }.either.runCollect
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+          }
+        ),
+        //     suite("concat")(
+        //       testM("concat")(checkM(streamOfInts, streamOfInts) { (s1, s2) =>
+        //         for {
+        //           chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
+        //           streamConcat <- (s1 ++ s2).runCollect.run
+        //         } yield assert(streamConcat.succeeded && chunkConcat.succeeded)(isTrue) implies assert(
+        //           streamConcat
+        //         )(
+        //           equalTo(chunkConcat)
+        //         )
+        //       }),
+        //       testM("finalizer order") {
+        //         for {
+        //           log <- Ref.make[List[String]](Nil)
+        //           _ <- (ZStream.finalizer(log.update("Second" :: _)) ++ ZStream
+        //                  .finalizer(log.update("First" :: _))).runDrain
+        //           execution <- log.get
+        //         } yield assert(execution)(equalTo(List("First", "Second")))
+        //       }
+        //     ),
+        //     suite("distributedWithDynamic")(
+        //       testM("ensures no race between subscription and stream end") {
+        //         ZStream.empty.distributedWithDynamic(1, _ => UIO.succeedNow(_ => true)).use { add =>
+        //           val subscribe = ZStream.unwrap(add.map { case (_, queue) =>
+        //             ZStream.fromQueue(queue).collectWhileSuccess
+        //           })
+        //           Promise.make[Nothing, Unit].flatMap { onEnd =>
+        //             subscribe.ensuring(onEnd.succeed(())).runDrain.fork *>
+        //               onEnd.await *>
+        //               subscribe.runDrain *>
+        //               ZIO.succeedNow(assertCompletes)
+        //           }
+        //         }
+        //       }
+        //     ),
+        suite("drain")(
+          testM("drain")(
+            for {
+              ref <- Ref.make(List[Int]())
+              _   <- ZStream.range(0, 10).mapM(i => ref.update(i :: _)).drain.runDrain
+              l   <- ref.get
+            } yield assert(l.reverse)(equalTo(Range(0, 10).toList))
+          ),
+          testM("isn't too eager") {
+            for {
+              ref    <- Ref.make[Int](0)
+              res    <- (ZStream(1).tap(ref.set) ++ ZStream.fail("fail")).runDrain.either
+              refRes <- ref.get
+            } yield assert(refRes)(equalTo(1)) && assert(res)(isLeft(equalTo("fail")))
+          }
+        ),
+//             suite("drainFork")(
+//               testM("runs the other stream in the background") {
+//                 for {
+//                   latch <- Promise.make[Nothing, Unit]
+//                   _ <- ZStream
+//                          .fromEffect(latch.await)
+//                          .drainFork(ZStream.fromEffect(latch.succeed(())))
+//                          .runDrain
+//                 } yield assertCompletes
+//               },
+//               testM("interrupts the background stream when the foreground exits") {
+//                 for {
+//                   bgInterrupted <- Ref.make(false)
+//                   latch         <- Promise.make[Nothing, Unit]
+//                   _ <- (ZStream(1, 2, 3) ++ ZStream.fromEffect(latch.await).drain)
+//                          .drainFork(
+//                            ZStream.fromEffect(
+//                              (latch.succeed(()) *> ZIO.never).onInterrupt(bgInterrupted.set(true))
+//                            )
+//                          )
+//                          .runDrain
+//                   result <- bgInterrupted.get
+//                 } yield assert(result)(isTrue)
+//               } @@ zioTag(interruption),
+//               testM("fails the foreground stream if the background fails with a typed error") {
+//                 assertM(ZStream.never.drainFork(ZStream.fail("Boom")).runDrain.run)(
+//                   fails(equalTo("Boom"))
+//                 )
+//               } @@ zioTag(errors),
+//               testM("fails the foreground stream if the background fails with a defect") {
+//                 val ex = new RuntimeException("Boom")
+//                 assertM(ZStream.never.drainFork(ZStream.die(ex)).runDrain.run)(dies(equalTo(ex)))
+//               } @@ zioTag(errors)
+//             ),
+        //     testM("drop")(checkM(streamOfInts, Gen.anyInt) { (s, n) =>
+        //       for {
+        //         dropStreamResult <- s.drop(n.toLong).runCollect.run
+        //         dropListResult   <- s.runCollect.map(_.drop(n)).run
+        //       } yield assert(dropListResult.succeeded)(isTrue) implies assert(dropStreamResult)(
+        //         equalTo(dropListResult)
+        //       )
+        //     }),
+        //     testM("dropUntil") {
+        //       checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+        //         for {
+        //           res1 <- s.dropUntil(p).runCollect
+        //           res2 <- s.runCollect.map(_.dropWhile(!p(_)).drop(1))
+        //         } yield assert(res1)(equalTo(res2))
+        //       }
+        //     },
+        //     suite("dropWhile")(
+        //       testM("dropWhile")(
+        //         checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+        //           for {
+        //             res1 <- s.dropWhile(p).runCollect
+        //             res2 <- s.runCollect.map(_.dropWhile(p))
+        //           } yield assert(res1)(equalTo(res2))
+        //         }
+        //       ),
+        //       testM("short circuits") {
+        //         assertM(
+        //           (ZStream(1) ++ ZStream.fail("Ouch"))
+        //             .take(1)
+        //             .dropWhile(_ => true)
+        //             .runDrain
+        //             .either
+        //         )(isRight(isUnit))
+        //       }
+        //     ),
+        testM("either") {
+          val s = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
+          s.either.runCollect
+            .map(assert(_)(equalTo(Chunk(Right(1), Right(2), Right(3), Left("Boom")))))
+        },
+        testM("ensuring") {
+          for {
+            log <- Ref.make[List[String]](Nil)
+            _ <- (for {
+                   _ <- ZStream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
+                   _ <- ZStream.fromEffect(log.update("Use" :: _))
+                 } yield ()).ensuring(log.update("Ensuring" :: _)).runDrain
+            execution <- log.get
+          } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+        },
+        //     testM("ensuringFirst") {
+        //       for {
+        //         log <- Ref.make[List[String]](Nil)
+        //         _ <- (for {
+        //                _ <- ZStream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
+        //                _ <- ZStream.fromEffect(log.update("Use" :: _))
+        //              } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
+        //         execution <- log.get
+        //       } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+        //     },
+        testM("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          for {
+            res1 <- s.filter(p).runCollect
+            res2 <- s.runCollect.map(_.filter(p))
+          } yield assert(res1)(equalTo(res2))
+        }),
+        suite("filterM")(
+          testM("filterM")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+            for {
+              res1 <- s.filterM(s => IO.succeed(p(s))).runCollect
+              res2 <- s.runCollect.map(_.filter(p))
+            } yield assert(res1)(equalTo(res2))
+          }),
+          testM("laziness on chunks") {
+            assertM(
+              ZStream(1, 2, 3).filterM {
+                case 3 => ZIO.fail("boom")
+                case _ => UIO.succeed(true)
+              }.either.runCollect
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+          }
+        ),
+        suite("flatMap")(
+          testM("deep flatMap stack safety") {
+            def fib(n: Int): ZStream[Any, Nothing, Int] =
+              if (n <= 1) ZStream.succeed(n)
+              else
+                fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZStream.succeed(a + b)))
+
+            val stream   = fib(20)
+            val expected = 6765
+
+            assertM(stream.runCollect)(equalTo(Chunk(expected)))
+          } @@ TestAspect.jvmOnly, // Too slow on Scala.js
+          testM("left identity")(checkM(Gen.anyInt, Gen.function(pureStreamOfInts)) { (x, f) =>
+            for {
+              res1 <- ZStream(x).flatMap(f).runCollect
+              res2 <- f(x).runCollect
+            } yield assert(res1)(equalTo(res2))
+          }),
+          testM("right identity")(
+            checkM(pureStreamOfInts)(m =>
+              for {
+                res1 <- m.flatMap(i => ZStream(i)).runCollect
+                res2 <- m.runCollect
+              } yield assert(res1)(equalTo(res2))
+            )
+          ),
+          testM("associativity") {
+            val tinyStream = Gen.int(0, 2).flatMap(pureStreamGen(Gen.anyInt, _))
+            val fnGen      = Gen.function(tinyStream)
+            checkM(tinyStream, fnGen, fnGen) { (m, f, g) =>
+              for {
+                leftStream  <- m.flatMap(f).flatMap(g).runCollect
+                rightStream <- m.flatMap(x => f(x).flatMap(g)).runCollect
+              } yield assert(leftStream)(equalTo(rightStream))
+            }
+          } @@ TestAspect.jvmOnly // Too slow on Scala.js
+          //       testM("inner finalizers") {
+          //         for {
+          //           effects <- Ref.make(List[Int]())
+          //           push     = (i: Int) => effects.update(i :: _)
+          //           latch   <- Promise.make[Nothing, Unit]
+          //           fiber <- ZStream(
+          //                      ZStream.bracket(push(1))(_ => push(1)),
+          //                      ZStream.fromEffect(push(2)),
+          //                      ZStream.bracket(push(3))(_ => push(3)) *> ZStream.fromEffect(
+          //                        latch.succeed(()) *> ZIO.never
+          //                      )
+          //                    ).flatMap(identity).runDrain.fork
+          //           _      <- latch.await
+          //           _      <- fiber.interrupt
+          //           result <- effects.get
+          //         } yield assert(result)(equalTo(List(3, 3, 2, 1, 1)))
+
+          //       },
+          //       testM("finalizer ordering") {
+          //         for {
+          //           effects <- Ref.make(List[String]())
+          //           push     = (i: String) => effects.update(i :: _)
+          //           stream = for {
+          //                      _ <- ZStream.bracket(push("open1"))(_ => push("close1"))
+          //                      _ <- ZStream
+          //                             .fromChunks(Chunk(()), Chunk(()))
+          //                             .tap(_ => push("use2"))
+          //                             .ensuring(push("close2"))
+          //                      _ <- ZStream.bracket(push("open3"))(_ => push("close3"))
+          //                      _ <- ZStream
+          //                             .fromChunks(Chunk(()), Chunk(()))
+          //                             .tap(_ => push("use4"))
+          //                             .ensuring(push("close4"))
+          //                    } yield ()
+          //           _      <- stream.runDrain
+          //           result <- effects.get
+          //         } yield assert(result.reverse)(
+          //           equalTo(
+          //             List(
+          //               "open1",
+          //               "use2",
+          //               "open3",
+          //               "use4",
+          //               "use4",
+          //               "close4",
+          //               "close3",
+          //               "use2",
+          //               "open3",
+          //               "use4",
+          //               "use4",
+          //               "close4",
+          //               "close3",
+          //               "close2",
+          //               "close1"
+          //             )
+          //           )
+          //         )
+          //       },
+          //       testM("exit signal") {
+          //         for {
+          //           ref <- Ref.make(false)
+          //           inner = ZStream
+          //                     .bracketExit(UIO.unit)((_, e) =>
+          //                       e match {
+          //                         case Exit.Failure(_) => ref.set(true)
+          //                         case Exit.Success(_) => UIO.unit
+          //                       }
+          //                     )
+          //                     .flatMap(_ => ZStream.fail("Ouch"))
+          //           _   <- ZStream.succeed(()).flatMap(_ => inner).runDrain.either.unit
+          //           fin <- ref.get
+          //         } yield assert(fin)(isTrue)
+          //       },
+          //       testM("finalizers are registered in the proper order") {
+          //         for {
+          //           fins <- Ref.make(List[Int]())
+          //           s = ZStream.finalizer(fins.update(1 :: _)) *>
+          //                 ZStream.finalizer(fins.update(2 :: _))
+          //           _      <- s.process.withEarlyRelease.use(_._2)
+          //           result <- fins.get
+          //         } yield assert(result)(equalTo(List(1, 2)))
+          //       },
+          //       testM("early release finalizer concatenation is preserved") {
+          //         for {
+          //           fins <- Ref.make(List[Int]())
+          //           s = ZStream.finalizer(fins.update(1 :: _)) *>
+          //                 ZStream.finalizer(fins.update(2 :: _))
+          //           result <- s.process.withEarlyRelease.use { case (release, pull) =>
+          //                       pull *> release *> fins.get
+          //                     }
+          //         } yield assert(result)(equalTo(List(1, 2)))
+          //       }
+        ),
+        //     suite("flatMapPar")(
+        //       testM("guarantee ordering")(checkM(tinyListOf(Gen.anyInt)) { (m: List[Int]) =>
+        //         for {
+        //           flatMap    <- ZStream.fromIterable(m).flatMap(i => ZStream(i, i)).runCollect
+        //           flatMapPar <- ZStream.fromIterable(m).flatMapPar(1)(i => ZStream(i, i)).runCollect
+        //         } yield assert(flatMap)(equalTo(flatMapPar))
+        //       }),
+        //       testM("consistent with flatMap")(
+        //         checkM(Gen.int(1, Int.MaxValue), tinyListOf(Gen.anyInt)) { (n, m) =>
+        //           for {
+        //             flatMap <- ZStream
+        //                          .fromIterable(m)
+        //                          .flatMap(i => ZStream(i, i))
+        //                          .runCollect
+        //                          .map(_.toSet)
+        //             flatMapPar <- ZStream
+        //                             .fromIterable(m)
+        //                             .flatMapPar(n)(i => ZStream(i, i))
+        //                             .runCollect
+        //                             .map(_.toSet)
+        //           } yield assert(n)(isGreaterThan(0)) implies assert(flatMap)(equalTo(flatMapPar))
+        //         }
+        //       ),
+        //       testM("short circuiting") {
+        //         assertM(
+        //           ZStream
+        //             .mergeAll(2)(
+        //               ZStream.never,
+        //               ZStream(1)
+        //             )
+        //             .take(1)
+        //             .runCollect
+        //         )(equalTo(Chunk(1)))
+        //       },
+        //       testM("interruption propagation") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           fiber <- ZStream(())
+        //                      .flatMapPar(1)(_ =>
+        //                        ZStream.fromEffect(
+        //                          (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                        )
+        //                      )
+        //                      .runDrain
+        //                      .fork
+        //           _         <- latch.await
+        //           _         <- fiber.interrupt
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue)
+        //       },
+        //       testM("inner errors interrupt all fibers") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- ZStream(
+        //                       ZStream.fromEffect(
+        //                         (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                       ),
+        //                       ZStream.fromEffect(latch.await *> ZIO.fail("Ouch"))
+        //                     ).flatMapPar(2)(identity).runDrain.either
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
+        //       },
+        //       testM("outer errors interrupt all fibers") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- (ZStream(()) ++ ZStream.fromEffect(latch.await *> ZIO.fail("Ouch")))
+        //                       .flatMapPar(2) { _ =>
+        //                         ZStream.fromEffect(
+        //                           (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                         )
+        //                       }
+        //                       .runDrain
+        //                       .either
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
+        //       } @@ nonFlaky,
+        //       testM("inner defects interrupt all fibers") {
+        //         val ex = new RuntimeException("Ouch")
+
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- ZStream(
+        //                       ZStream.fromEffect(
+        //                         (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                       ),
+        //                       ZStream.fromEffect(latch.await *> ZIO.die(ex))
+        //                     ).flatMapPar(2)(identity).runDrain.run
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
+        //       },
+        //       testM("outer defects interrupt all fibers") {
+        //         val ex = new RuntimeException()
+
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- (ZStream(()) ++ ZStream.fromEffect(latch.await *> ZIO.die(ex)))
+        //                       .flatMapPar(2) { _ =>
+        //                         ZStream.fromEffect(
+        //                           (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                         )
+        //                       }
+        //                       .runDrain
+        //                       .run
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
+        //       } @@ nonFlaky,
+        //       testM("finalizer ordering") {
+        //         for {
+        //           execution <- Ref.make[List[String]](Nil)
+        //           inner = ZStream
+        //                     .bracket(execution.update("InnerAcquire" :: _))(_ => execution.update("InnerRelease" :: _))
+        //           _ <-
+        //             ZStream
+        //               .bracket(execution.update("OuterAcquire" :: _).as(inner))(_ => execution.update("OuterRelease" :: _))
+        //               .flatMapPar(2)(identity)
+        //               .runDrain
+        //           results <- execution.get
+        //         } yield assert(results)(
+        //           equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire"))
+        //         )
+        //       }
+        //     ),
+        //     suite("flatMapParSwitch")(
+        //       testM("guarantee ordering no parallelism") {
+        //         for {
+        //           lastExecuted <- Ref.make(false)
+        //           semaphore    <- Semaphore.make(1)
+        //           _ <- ZStream(1, 2, 3, 4)
+        //                  .flatMapParSwitch(1) { i =>
+        //                    if (i > 3)
+        //                      ZStream
+        //                        .bracket(UIO.unit)(_ => lastExecuted.set(true))
+        //                        .flatMap(_ => ZStream.empty)
+        //                    else ZStream.managed(semaphore.withPermitManaged).flatMap(_ => ZStream.never)
+        //                  }
+        //                  .runDrain
+        //           result <- semaphore.withPermit(lastExecuted.get)
+        //         } yield assert(result)(isTrue)
+        //       },
+        //       testM("guarantee ordering with parallelism") {
+        //         for {
+        //           lastExecuted <- Ref.make(0)
+        //           semaphore    <- Semaphore.make(4)
+        //           _ <- ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        //                  .flatMapParSwitch(4) { i =>
+        //                    if (i > 8)
+        //                      ZStream
+        //                        .bracket(UIO.unit)(_ => lastExecuted.update(_ + 1))
+        //                        .flatMap(_ => ZStream.empty)
+        //                    else ZStream.managed(semaphore.withPermitManaged).flatMap(_ => ZStream.never)
+        //                  }
+        //                  .runDrain
+        //           result <- semaphore.withPermits(4)(lastExecuted.get)
+        //         } yield assert(result)(equalTo(4))
+        //       },
+        //       testM("short circuiting") {
+        //         assertM(
+        //           ZStream(ZStream.never, ZStream(1))
+        //             .flatMapParSwitch(2)(identity)
+        //             .take(1)
+        //             .runCollect
+        //         )(equalTo(Chunk(1)))
+        //       },
+        //       testM("interruption propagation") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           fiber <- ZStream(())
+        //                      .flatMapParSwitch(1)(_ =>
+        //                        ZStream.fromEffect(
+        //                          (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                        )
+        //                      )
+        //                      .runCollect
+        //                      .fork
+        //           _         <- latch.await
+        //           _         <- fiber.interrupt
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue)
+        //       } @@ flaky,
+        //       testM("inner errors interrupt all fibers") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- ZStream(
+        //                       ZStream.fromEffect(
+        //                         (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                       ),
+        //                       ZStream.fromEffect(latch.await *> IO.fail("Ouch"))
+        //                     ).flatMapParSwitch(2)(identity).runDrain.either
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
+        //       } @@ flaky,
+        //       testM("outer errors interrupt all fibers") {
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- (ZStream(()) ++ ZStream.fromEffect(latch.await *> IO.fail("Ouch")))
+        //                       .flatMapParSwitch(2) { _ =>
+        //                         ZStream.fromEffect(
+        //                           (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                         )
+        //                       }
+        //                       .runDrain
+        //                       .either
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
+        //       } @@ nonFlaky,
+        //       testM("inner defects interrupt all fibers") {
+        //         val ex = new RuntimeException("Ouch")
+
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- ZStream(
+        //                       ZStream.fromEffect(
+        //                         (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                       ),
+        //                       ZStream.fromEffect(latch.await *> ZIO.die(ex))
+        //                     ).flatMapParSwitch(2)(identity).runDrain.run
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
+        //       },
+        //       testM("outer defects interrupt all fibers") {
+        //         val ex = new RuntimeException()
+
+        //         for {
+        //           substreamCancelled <- Ref.make[Boolean](false)
+        //           latch              <- Promise.make[Nothing, Unit]
+        //           result <- (ZStream(()) ++ ZStream.fromEffect(latch.await *> ZIO.die(ex)))
+        //                       .flatMapParSwitch(2) { _ =>
+        //                         ZStream.fromEffect(
+        //                           (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+        //                         )
+        //                       }
+        //                       .runDrain
+        //                       .run
+        //           cancelled <- substreamCancelled.get
+        //         } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
+        //       } @@ nonFlaky,
+        //       testM("finalizer ordering") {
+        //         for {
+        //           execution <- Ref.make(List.empty[String])
+        //           inner      = ZStream.bracket(execution.update("InnerAcquire" :: _))(_ => execution.update("InnerRelease" :: _))
+        //           _ <-
+        //             ZStream
+        //               .bracket(execution.update("OuterAcquire" :: _).as(inner))(_ => execution.update("OuterRelease" :: _))
+        //               .flatMapParSwitch(2)(identity)
+        //               .runDrain
+        //           results <- execution.get
+        //         } yield assert(results)(
+        //           equalTo(List("OuterRelease", "InnerRelease", "InnerAcquire", "OuterAcquire"))
+        //         )
+        //       }
+        //     ),
+        suite("flattenExitOption")(
+          testM("happy path") {
+            assertM(
+              ZStream
+                .range(0, 10)
+                .toQueue(1)
+                .use(q => ZStream.fromQueue(q).map(_.exit).flattenExitOption.runCollect)
+                .map(_.flatMap(_.toList))
+            )(equalTo(Chunk.fromIterable(Range(0, 10))))
+          },
+          testM("errors") {
+            val e = new RuntimeException("boom")
+            assertM(
+              (ZStream.range(0, 10) ++ ZStream.fail(e))
+                .toQueue(1)
+                .use(q => ZStream.fromQueue(q).map(_.exit).flattenExitOption.runCollect)
+                .run
+            )(fails(equalTo(e)))
+          } @@ zioTag(errors)
+        ),
+        //     testM("flattenIterables")(checkM(tinyListOf(tinyListOf(Gen.anyInt))) { lists =>
+        //       assertM(ZStream.fromIterable(lists).flattenIterables.runCollect)(equalTo(Chunk.fromIterable(lists.flatten)))
+        //     }),
+        //     suite("flattenTake")(
+        //       testM("happy path")(checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
+        //         assertM(
+        //           ZStream
+        //             .fromChunks(chunks: _*)
+        //             .mapChunks(chunk => Chunk.single(Take.chunk(chunk)))
+        //             .flattenTake
+        //             .runCollect
+        //         )(equalTo(chunks.fold(Chunk.empty)(_ ++ _)))
+        //       }),
+        //       testM("stop collecting on Exit.Failure") {
+        //         assertM(
+        //           ZStream(
+        //             Take.chunk(Chunk(1, 2)),
+        //             Take.single(3),
+        //             Take.end
+        //           ).flattenTake.runCollect
+        //         )(equalTo(Chunk(1, 2, 3)))
+        //       },
+        //       testM("work with empty chunks") {
+        //         assertM(
+        //           ZStream(Take.chunk(Chunk.empty), Take.chunk(Chunk.empty)).flattenTake.runCollect
+        //         )(isEmpty)
+        //       },
+        //       testM("work with empty streams") {
+        //         assertM(ZStream.fromIterable[Take[Nothing, Nothing]](Nil).flattenTake.runCollect)(
+        //           isEmpty
+        //         )
+        //       }
+        //     ),
+        suite("foreach")(
+          testM("foreach") {
+            for {
+              ref <- Ref.make(0)
+              _   <- ZStream(1, 1, 1, 1, 1).foreach[Any, Nothing](a => ref.update(_ + a))
+              sum <- ref.get
+            } yield assert(sum)(equalTo(5))
+          },
+          testM("foreachWhile") {
+            for {
+              ref <- Ref.make(0)
+              _ <- ZStream(1, 1, 1, 1, 1, 1).runForeachWhile[Any, Nothing](a =>
+                     ref.modify(sum =>
+                       if (sum >= 3) (false, sum)
+                       else (true, sum + a)
+                     )
+                   )
+              sum <- ref.get
+            } yield assert(sum)(equalTo(3))
+          },
+          testM("foreachWhile short circuits") {
+            for {
+              flag <- Ref.make(true)
+              _ <- (ZStream(true, true, false) ++ ZStream.fromEffect(flag.set(false)).drain)
+                     .runForeachWhile(ZIO.succeedNow)
+              skipped <- flag.get
+            } yield assert(skipped)(isTrue)
+          }
+        ),
+        testM("forever") {
+          for {
+            ref <- Ref.make(0)
+            _ <- ZStream(1).forever.runForeachWhile[Any, Nothing](_ =>
+                   ref.modify(sum => (if (sum >= 9) false else true, sum + 1))
+                 )
+            sum <- ref.get
+          } yield assert(sum)(equalTo(10))
+        },
+        //     suite("groupBy")(
+        //       testM("values") {
+        //         val words = List.fill(1000)(0 to 100).flatten.map(_.toString())
+        //         assertM(
+        //           ZStream
+        //             .fromIterable(words)
+        //             .groupByKey(identity, 8192) { case (k, s) =>
+        //               ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
+        //             }
+        //             .runCollect
+        //             .map(_.toMap)
+        //         )(equalTo((0 to 100).map((_.toString -> 1000)).toMap))
+        //       },
+        //       testM("first") {
+        //         val words = List.fill(1000)(0 to 100).flatten.map(_.toString())
+        //         assertM(
+        //           ZStream
+        //             .fromIterable(words)
+        //             .groupByKey(identity, 1050)
+        //             .first(2) { case (k, s) =>
+        //               ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
+        //             }
+        //             .runCollect
+        //             .map(_.toMap)
+        //         )(equalTo((0 to 1).map((_.toString -> 1000)).toMap))
+        //       },
+        //       testM("filter") {
+        //         val words = List.fill(1000)(0 to 100).flatten
+        //         assertM(
+        //           ZStream
+        //             .fromIterable(words)
+        //             .groupByKey(identity, 1050)
+        //             .filter(_ <= 5) { case (k, s) =>
+        //               ZStream.fromEffect(s.runCollect.map(l => k -> l.size))
+        //             }
+        //             .runCollect
+        //             .map(_.toMap)
+        //         )(equalTo((0 to 5).map((_ -> 1000)).toMap))
+        //       },
+        //       testM("outer errors") {
+        //         val words = List("abc", "test", "test", "foo")
+        //         assertM(
+        //           (ZStream.fromIterable(words) ++ ZStream.fail("Boom"))
+        //             .groupByKey(identity) { case (_, s) => s.drain }
+        //             .runCollect
+        //             .either
+        //         )(isLeft(equalTo("Boom")))
+        //       }
+        //     ) @@ TestAspect.jvmOnly,
+        //     suite("haltWhen")(
+        //       suite("haltWhen(Promise)")(
+        //         testM("halts after the current element") {
+        //           for {
+        //             interrupted <- Ref.make(false)
+        //             latch       <- Promise.make[Nothing, Unit]
+        //             halt        <- Promise.make[Nothing, Unit]
+        //             _ <- ZStream
+        //                    .fromEffect(latch.await.onInterrupt(interrupted.set(true)))
+        //                    .haltWhen(halt)
+        //                    .runDrain
+        //                    .fork
+        //             _      <- halt.succeed(())
+        //             _      <- latch.succeed(())
+        //             result <- interrupted.get
+        //           } yield assert(result)(isFalse)
+        //         },
+        //         testM("propagates errors") {
+        //           for {
+        //             halt <- Promise.make[String, Nothing]
+        //             _    <- halt.fail("Fail")
+        //             result <- ZStream(1)
+        //                         .haltWhen(halt)
+        //                         .runDrain
+        //                         .either
+        //           } yield assert(result)(isLeft(equalTo("Fail")))
+        //         } @@ zioTag(errors)
+        //       ),
+        //       suite("haltWhen(IO)")(
+        //         testM("halts after the current element") {
+        //           for {
+        //             interrupted <- Ref.make(false)
+        //             latch       <- Promise.make[Nothing, Unit]
+        //             halt        <- Promise.make[Nothing, Unit]
+        //             _ <- ZStream
+        //                    .fromEffect(latch.await.onInterrupt(interrupted.set(true)))
+        //                    .haltWhen(halt.await)
+        //                    .runDrain
+        //                    .fork
+        //             _      <- halt.succeed(())
+        //             _      <- latch.succeed(())
+        //             result <- interrupted.get
+        //           } yield assert(result)(isFalse)
+        //         },
+        //         testM("propagates errors") {
+        //           for {
+        //             halt <- Promise.make[String, Nothing]
+        //             _    <- halt.fail("Fail")
+        //             result <- ZStream(0).forever
+        //                         .haltWhen(halt.await)
+        //                         .runDrain
+        //                         .either
+        //           } yield assert(result)(isLeft(equalTo("Fail")))
+        //         } @@ zioTag(errors)
+        //       )
+        //     ),
+        //     suite("haltAfter")(
+        //       testM("halts after given duration") {
+        //         assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3), Chunk(4))) { c =>
+        //           assertM(
+        //             for {
+        //               fiber <- ZStream
+        //                          .fromQueue(c.queue)
+        //                          .collectWhileSuccess
+        //                          .haltAfter(5.seconds)
+        //                          .tap(_ => c.proceed)
+        //                          .runCollect
+        //                          .fork
+        //               _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+        //               _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+        //               _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+        //               _      <- c.offer
+        //               result <- fiber.join
+        //             } yield result
+        //           )(equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3))))
+        //         }
+        //       },
+        //       testM("will process first chunk") {
+        //         for {
+        //           queue  <- Queue.unbounded[Int]
+        //           fiber  <- ZStream.fromQueue(queue).haltAfter(5.seconds).runCollect.fork
+        //           _      <- TestClock.adjust(6.seconds)
+        //           _      <- queue.offer(1)
+        //           result <- fiber.join
+        //         } yield assert(result)(equalTo(Chunk(1)))
+        //       }
+        //     ),
+        //     suite("grouped")(
+        //       testM("sanity") {
+        //         assertM(ZStream(1, 2, 3, 4, 5).grouped(2).runCollect)(equalTo(Chunk(Chunk(1, 2), Chunk(3, 4), Chunk(5))))
+        //       },
+        //       testM("group size is correct") {
+        //         assertM(ZStream.range(0, 100).grouped(10).map(_.size).runCollect)(equalTo(Chunk.fill(10)(10)))
+        //       },
+        //       testM("doesn't emit empty chunks") {
+        //         assertM(ZStream.fromIterable(List.empty[Int]).grouped(5).runCollect)(equalTo(Chunk.empty))
+        //       }
+        //     ),
+        //     suite("groupedWithin")(
+        //       testM("group based on time passed") {
+        //         assertWithChunkCoordination(List(Chunk(1, 2), Chunk(3, 4), Chunk.single(5))) { c =>
+        //           val stream = ZStream
+        //             .fromQueue(c.queue)
+        //             .collectWhileSuccess
+        //             .flattenChunks
+        //             .groupedWithin(10, 2.seconds)
+        //             .tap(_ => c.proceed)
+
+        //           assertM(for {
+        //             f      <- stream.runCollect.fork
+        //             _      <- c.offer *> TestClock.adjust(2.seconds) *> c.awaitNext
+        //             _      <- c.offer *> TestClock.adjust(2.seconds) *> c.awaitNext
+        //             _      <- c.offer
+        //             result <- f.join
+        //           } yield result)(equalTo(Chunk(Chunk(1, 2), Chunk(3, 4), Chunk(5))))
+        //         }
+        //       } @@ timeout(10.seconds) @@ flaky,
+        //       testM("group immediately when chunk size is reached") {
+        //         assertM(ZStream(1, 2, 3, 4).groupedWithin(2, 10.seconds).runCollect)(
+        //           equalTo(Chunk(Chunk(1, 2), Chunk(3, 4)))
+        //         )
+        //       }
+        //     ),
+        //     testM("interleave") {
+        //       val s1 = ZStream(2, 3)
+        //       val s2 = ZStream(5, 6, 7)
+
+        //       assertM(s1.interleave(s2).runCollect)(equalTo(Chunk(2, 5, 3, 6, 7)))
+        //     },
+        //     testM("interleaveWith") {
+        //       def interleave(b: Chunk[Boolean], s1: => Chunk[Int], s2: => Chunk[Int]): Chunk[Int] =
+        //         b.headOption.map { hd =>
+        //           if (hd) s1 match {
+        //             case h +: t =>
+        //               h +: interleave(b.tail, t, s2)
+        //             case _ =>
+        //               if (s2.isEmpty) Chunk.empty
+        //               else interleave(b.tail, Chunk.empty, s2)
+        //           }
+        //           else
+        //             s2 match {
+        //               case h +: t =>
+        //                 h +: interleave(b.tail, s1, t)
+        //               case _ =>
+        //                 if (s1.isEmpty) Chunk.empty
+        //                 else interleave(b.tail, s1, Chunk.empty)
+        //             }
+        //         }.getOrElse(Chunk.empty)
+
+        //       val int = Gen.int(0, 5)
+
+        //       checkM(
+        //         int.flatMap(pureStreamGen(Gen.boolean, _)),
+        //         int.flatMap(pureStreamGen(Gen.anyInt, _)),
+        //         int.flatMap(pureStreamGen(Gen.anyInt, _))
+        //       ) { (b, s1, s2) =>
+        //         for {
+        //           interleavedStream <- s1.interleaveWith(s2)(b).runCollect
+        //           b                 <- b.runCollect
+        //           s1                <- s1.runCollect
+        //           s2                <- s2.runCollect
+        //           interleavedLists   = interleave(b, s1, s2)
+        //         } yield assert(interleavedStream)(equalTo(interleavedLists))
+        //       }
+        //     },
+        //     suite("Stream.intersperse")(
+        //       testM("intersperse several") {
+        //         Stream(1, 2, 3, 4)
+        //           .map(_.toString)
+        //           .intersperse("@")
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("1", "@", "2", "@", "3", "@", "4"))))
+        //       },
+        //       testM("intersperse several with begin and end") {
+        //         Stream(1, 2, 3, 4)
+        //           .map(_.toString)
+        //           .intersperse("[", "@", "]")
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("[", "1", "@", "2", "@", "3", "@", "4", "]"))))
+        //       },
+        //       testM("intersperse single") {
+        //         Stream(1)
+        //           .map(_.toString)
+        //           .intersperse("@")
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("1"))))
+        //       },
+        //       testM("intersperse single with begin and end") {
+        //         Stream(1)
+        //           .map(_.toString)
+        //           .intersperse("[", "@", "]")
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("[", "1", "]"))))
+        //       },
+        //       testM("mkString(Sep) equivalence") {
+        //         checkM(
+        //           Gen
+        //             .int(0, 10)
+        //             .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))))
+        //         ) { chunks =>
+        //           val stream = ZStream.fromChunks(chunks: _*)
+
+        //           for {
+        //             interspersed <- stream.map(_.toString).intersperse("@").runCollect.map(_.mkString)
+        //             regular      <- stream.map(_.toString).runCollect.map(_.mkString("@"))
+        //           } yield assert(interspersed)(equalTo(regular))
+        //         }
+        //       },
+        //       testM("mkString(Before, Sep, After) equivalence") {
+        //         checkM(
+        //           Gen
+        //             .int(0, 10)
+        //             .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))))
+        //         ) { chunks =>
+        //           val stream = ZStream.fromChunks(chunks: _*)
+
+        //           for {
+        //             interspersed <- stream.map(_.toString).intersperse("[", "@", "]").runCollect.map(_.mkString)
+        //             regular      <- stream.map(_.toString).runCollect.map(_.mkString("[", "@", "]"))
+        //           } yield assert(interspersed)(equalTo(regular))
+        //         }
+        //       },
+        //       testM("intersperse several from repeat effect (#3729)") {
+        //         Stream
+        //           .repeatEffect(ZIO.succeed(42))
+        //           .map(_.toString)
+        //           .take(4)
+        //           .intersperse("@")
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("42", "@", "42", "@", "42", "@", "42"))))
+        //       },
+        //       testM("intersperse several from repeat effect chunk single element (#3729)") {
+        //         Stream
+        //           .repeatEffectChunk(ZIO.succeed(Chunk(42)))
+        //           .map(_.toString)
+        //           .intersperse("@")
+        //           .take(4)
+        //           .runCollect
+        //           .map(result => assert(result)(equalTo(Chunk("42", "@", "42", "@"))))
+        //       }
+        //     ),
+        //     suite("interruptWhen")(
+        //       suite("interruptWhen(Promise)")(
+        //         testM("interrupts the current element") {
+        //           for {
+        //             interrupted <- Ref.make(false)
+        //             latch       <- Promise.make[Nothing, Unit]
+        //             halt        <- Promise.make[Nothing, Unit]
+        //             started     <- Promise.make[Nothing, Unit]
+        //             fiber <- ZStream
+        //                        .fromEffect(
+        //                          (started.succeed(()) *> latch.await).onInterrupt(interrupted.set(true))
+        //                        )
+        //                        .interruptWhen(halt)
+        //                        .runDrain
+        //                        .fork
+        //             _      <- started.await *> halt.succeed(())
+        //             _      <- fiber.await
+        //             result <- interrupted.get
+        //           } yield assert(result)(isTrue)
+        //         },
+        //         testM("propagates errors") {
+        //           for {
+        //             halt <- Promise.make[String, Nothing]
+        //             _    <- halt.fail("Fail")
+        //             result <- ZStream(1)
+        //                         .interruptWhen(halt)
+        //                         .runDrain
+        //                         .either
+        //           } yield assert(result)(isLeft(equalTo("Fail")))
+        //         } @@ zioTag(errors)
+        //       ) @@ zioTag(interruption),
+        //       suite("interruptWhen(IO)")(
+        //         testM("interrupts the current element") {
+        //           for {
+        //             interrupted <- Ref.make(false)
+        //             latch       <- Promise.make[Nothing, Unit]
+        //             halt        <- Promise.make[Nothing, Unit]
+        //             started     <- Promise.make[Nothing, Unit]
+        //             fiber <- ZStream
+        //                        .fromEffect(
+        //                          (started.succeed(()) *> latch.await).onInterrupt(interrupted.set(true))
+        //                        )
+        //                        .interruptWhen(halt.await)
+        //                        .runDrain
+        //                        .fork
+        //             _      <- started.await *> halt.succeed(())
+        //             _      <- fiber.await
+        //             result <- interrupted.get
+        //           } yield assert(result)(isTrue)
+        //         },
+        //         testM("propagates errors") {
+        //           for {
+        //             halt <- Promise.make[String, Nothing]
+        //             _    <- halt.fail("Fail")
+        //             result <- ZStream
+        //                         .fromEffect(ZIO.never)
+        //                         .interruptWhen(halt.await)
+        //                         .runDrain
+        //                         .either
+        //           } yield assert(result)(isLeft(equalTo("Fail")))
+        //         } @@ zioTag(errors)
+        //       ) @@ zioTag(interruption)
+        //     ),
+        //     suite("interruptAfter")(
+        //       testM("interrupts after given duration") {
+        //         assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
+        //           assertM(
+        //             for {
+        //               fiber <- ZStream
+        //                          .fromQueue(c.queue)
+        //                          .collectWhileSuccess
+        //                          .interruptAfter(5.seconds)
+        //                          .tap(_ => c.proceed)
+        //                          .runCollect
+        //                          .fork
+        //               _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+        //               _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+        //               _      <- c.offer
+        //               result <- fiber.join
+        //             } yield result
+        //           )(equalTo(Chunk(Chunk(1), Chunk(2))))
+        //         }
+        //       },
+        //       testM("interrupts before first chunk") {
+        //         for {
+        //           queue  <- Queue.unbounded[Int]
+        //           fiber  <- ZStream.fromQueue(queue).interruptAfter(5.seconds).runCollect.fork
+        //           _      <- TestClock.adjust(6.seconds)
+        //           _      <- queue.offer(1)
+        //           result <- fiber.join
+        //         } yield assert(result)(isEmpty)
+        //       } @@ timeout(10.seconds) @@ flaky
+        //     ) @@ zioTag(interruption),
+        suite("managed")(
+          testM("preserves failure of effect") {
+            assertM(
+              ZStream.managed(ZManaged.fail("error")).runCollect.either
+            )(isLeft(equalTo("error")))
+          },
+          testM("preserves interruptibility of effect") {
+            for {
+              interruptible <- ZStream
+                                 .managed(ZManaged.fromEffect(ZIO.checkInterruptible(UIO.succeed(_))))
+                                 .runHead
+              uninterruptible <- ZStream
+                                   .managed(ZManaged.fromEffectUninterruptible(ZIO.checkInterruptible(UIO.succeed(_))))
+                                   .runHead
+            } yield assert(interruptible)(isSome(equalTo(InterruptStatus.Interruptible))) &&
+              assert(uninterruptible)(isSome(equalTo(InterruptStatus.Uninterruptible)))
+          }
+        ),
+        testM("map")(checkM(pureStreamOfInts, Gen.function(Gen.anyInt)) { (s, f) =>
+          for {
+            res1 <- s.map(f).runCollect
+            res2 <- s.runCollect.map(_.map(f))
+          } yield assert(res1)(equalTo(res2))
+        }),
+        testM("mapAccum") {
+          assertM(ZStream(1, 1, 1).mapAccum(0)((acc, el) => (acc + el, acc + el)).runCollect)(
+            equalTo(Chunk(1, 2, 3))
+          )
+        },
+        //     suite("mapAccumM")(
+        //       testM("mapAccumM happy path") {
+        //         assertM(
+        //           ZStream(1, 1, 1)
+        //             .mapAccumM[Any, Nothing, Int, Int](0)((acc, el) => IO.succeed((acc + el, acc + el)))
+        //             .runCollect
+        //         )(equalTo(Chunk(1, 2, 3)))
+        //       },
+        //       testM("mapAccumM error") {
+        //         ZStream(1, 1, 1)
+        //           .mapAccumM(0)((_, _) => IO.fail("Ouch"))
+        //           .runCollect
+        //           .either
+        //           .map(assert(_)(isLeft(equalTo("Ouch"))))
+        //       } @@ zioTag(errors),
+        //       testM("laziness on chunks") {
+        //         assertM(
+        //           ZStream(1, 2, 3)
+        //             .mapAccumM(()) {
+        //               case (_, 3) => ZIO.fail("boom")
+        //               case (_, x) => UIO.succeed(((), x))
+        //             }
+        //             .either
+        //             .runCollect
+        //         )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+        //       }
+        //     ),
+        //     testM("mapConcat")(checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+        //       for {
+        //         res1 <- s.mapConcat(f).runCollect
+        //         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        //       } yield assert(res1)(equalTo(res2))
+        //     }),
+        //     testM("mapConcatChunk")(checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
+        //       for {
+        //         res1 <- s.mapConcatChunk(f).runCollect
+        //         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        //       } yield assert(res1)(equalTo(res2))
+        //     }),
+        //     suite("mapConcatChunkM")(
+        //       testM("mapConcatChunkM happy path") {
+        //         checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.anyInt))) { (s, f) =>
+        //           for {
+        //             res1 <- s.mapConcatChunkM(b => UIO.succeedNow(f(b))).runCollect
+        //             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        //           } yield assert(res1)(equalTo(res2))
+        //         }
+        //       },
+        //       testM("mapConcatChunkM error") {
+        //         ZStream(1, 2, 3)
+        //           .mapConcatChunkM(_ => IO.fail("Ouch"))
+        //           .runCollect
+        //           .either
+        //           .map(assert(_)(equalTo(Left("Ouch"))))
+        //       }
+        //     ),
+        //     suite("mapConcatM")(
+        //       testM("mapConcatM happy path") {
+        //         checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.anyInt))) { (s, f) =>
+        //           for {
+        //             res1 <- s.mapConcatM(b => UIO.succeedNow(f(b))).runCollect
+        //             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
+        //           } yield assert(res1)(equalTo(res2))
+        //         }
+        //       },
+        //       testM("mapConcatM error") {
+        //         ZStream(1, 2, 3)
+        //           .mapConcatM(_ => IO.fail("Ouch"))
+        //           .runCollect
+        //           .either
+        //           .map(assert(_)(equalTo(Left("Ouch"))))
+        //       }
+        //     ),
+        //     testM("mapError") {
+        //       ZStream
+        //         .fail("123")
+        //         .mapError(_.toInt)
+        //         .runCollect
+        //         .either
+        //         .map(assert(_)(isLeft(equalTo(123))))
+        //     },
+        //     testM("mapErrorCause") {
+        //       ZStream
+        //         .halt(Cause.fail("123"))
+        //         .mapErrorCause(_.map(_.toInt))
+        //         .runCollect
+        //         .either
+        //         .map(assert(_)(isLeft(equalTo(123))))
+        //     },
+        suite("mapM")(
+          testM("ZIO#foreach equivalence") {
+            checkM(Gen.small(Gen.listOfN(_)(Gen.anyByte)), Gen.function(Gen.successes(Gen.anyByte))) { (data, f) =>
+              val s = ZStream.fromIterable(data)
+
+              for {
+                l <- s.mapM(f).runCollect
+                r <- IO.foreach(data)(f)
+              } yield assert(l.toList)(equalTo(r))
+            }
+          },
+          testM("laziness on chunks") {
+            assertM(
+              ZStream(1, 2, 3).mapM {
+                case 3 => ZIO.fail("boom")
+                case x => UIO.succeed(x)
+              }.either.runCollect
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+          }
+        ),
+        //     suite("mapMPar")(
+        //       testM("foreachParN equivalence") {
+        //         checkNM(10)(Gen.small(Gen.listOfN(_)(Gen.anyByte)), Gen.function(Gen.successes(Gen.anyByte))) { (data, f) =>
+        //           val s = ZStream.fromIterable(data)
+
+        //           for {
+        //             l <- s.mapMPar(8)(f).runCollect
+        //             r <- IO.foreachParN(8)(data)(f)
+        //           } yield assert(l.toList)(equalTo(r))
+        //         }
+        //       },
+        //       testM("order when n = 1") {
+        //         for {
+        //           queue  <- Queue.unbounded[Int]
+        //           _      <- ZStream.range(0, 9).mapMPar(1)(queue.offer).runDrain
+        //           result <- queue.takeAll
+        //         } yield assert(result)(equalTo(result.sorted))
+        //       },
+        //       testM("interruption propagation") {
+        //         for {
+        //           interrupted <- Ref.make(false)
+        //           latch       <- Promise.make[Nothing, Unit]
+        //           fib <- ZStream(())
+        //                    .mapMPar(1)(_ => (latch.succeed(()) *> ZIO.infinity).onInterrupt(interrupted.set(true)))
+        //                    .runDrain
+        //                    .fork
+        //           _      <- latch.await
+        //           _      <- fib.interrupt
+        //           result <- interrupted.get
+        //         } yield assert(result)(isTrue)
+        //       },
+        //       testM("guarantee ordering")(checkM(Gen.int(1, 4096), Gen.listOf(Gen.anyInt)) { (n: Int, m: List[Int]) =>
+        //         for {
+        //           mapM    <- ZStream.fromIterable(m).mapM(UIO.succeedNow).runCollect
+        //           mapMPar <- ZStream.fromIterable(m).mapMPar(n)(UIO.succeedNow).runCollect
+        //         } yield assert(n)(isGreaterThan(0)) implies assert(mapM)(equalTo(mapMPar))
+        //       }),
+        //       testM("awaits children fibers properly") {
+        //         assertM(
+        //           ZStream
+        //             .fromIterable((0 to 100))
+        //             .interruptWhen(ZIO.never)
+        //             .mapMPar(8)(_ => ZIO(1).repeatN(2000))
+        //             .runDrain
+        //             .run
+        //             .map(_.interrupted)
+        //         )(equalTo(false))
+        //       } @@ nonFlaky(10) @@ TestAspect.jvmOnly,
+        //       testM("interrupts pending tasks when one of the tasks fails") {
+        //         for {
+        //           interrupted <- Ref.make(0)
+        //           latch1      <- Promise.make[Nothing, Unit]
+        //           latch2      <- Promise.make[Nothing, Unit]
+        //           result <- ZStream(1, 2, 3)
+        //                       .mapMPar(3) {
+        //                         case 1 => (latch1.succeed(()) *> ZIO.never).onInterrupt(interrupted.update(_ + 1))
+        //                         case 2 => (latch2.succeed(()) *> ZIO.never).onInterrupt(interrupted.update(_ + 1))
+        //                         case 3 => latch1.await *> latch2.await *> ZIO.fail("Boom")
+        //                       }
+        //                       .runDrain
+        //                       .run
+        //           count <- interrupted.get
+        //         } yield assert(count)(equalTo(2)) && assert(result)(fails(equalTo("Boom")))
+        //       } @@ nonFlaky
+        //     ),
+        //     suite("mergeTerminateLeft")(
+        //       testM("terminates as soon as the first stream terminates") {
+        //         for {
+        //           queue1 <- Queue.unbounded[Int]
+        //           queue2 <- Queue.unbounded[Int]
+        //           stream1 = ZStream.fromQueue(queue1)
+        //           stream2 = ZStream.fromQueue(queue2)
+        //           fiber  <- stream1.mergeTerminateLeft(stream2).runCollect.fork
+        //           _      <- queue1.offer(1) *> TestClock.adjust(1.second)
+        //           _      <- queue1.offer(2) *> TestClock.adjust(1.second)
+        //           _      <- queue1.shutdown *> TestClock.adjust(1.second)
+        //           _      <- queue2.offer(3)
+        //           result <- fiber.join
+        //         } yield assert(result)(equalTo(Chunk(1, 2)))
+        //       },
+        //       testM("interrupts pulling on finish") {
+        //         val s1 = ZStream(1, 2, 3)
+        //         val s2 = ZStream.fromEffect(clock.sleep(5.seconds).as(4))
+        //         assertM(s1.mergeTerminateLeft(s2).runCollect)(equalTo(Chunk(1, 2, 3)))
+        //       }
+        //     ),
+        //     suite("mergeTerminateRight")(
+        //       testM("terminates as soon as the second stream terminates") {
+        //         for {
+        //           queue1 <- Queue.unbounded[Int]
+        //           queue2 <- Queue.unbounded[Int]
+        //           stream1 = ZStream.fromQueue(queue1)
+        //           stream2 = ZStream.fromQueue(queue2)
+        //           fiber  <- stream1.mergeTerminateRight(stream2).runCollect.fork
+        //           _      <- queue2.offer(2) *> TestClock.adjust(1.second)
+        //           _      <- queue2.offer(3) *> TestClock.adjust(1.second)
+        //           _      <- queue2.shutdown *> TestClock.adjust(1.second)
+        //           _      <- queue1.offer(1)
+        //           result <- fiber.join
+        //         } yield assert(result)(equalTo(Chunk(2, 3)))
+        //       } @@ exceptJS
+        //     ),
+        //     suite("mergeTerminateEither")(
+        //       testM("terminates as soon as either stream terminates") {
+        //         for {
+        //           queue1 <- Queue.unbounded[Int]
+        //           queue2 <- Queue.unbounded[Int]
+        //           stream1 = ZStream.fromQueue(queue1)
+        //           stream2 = ZStream.fromQueue(queue2)
+        //           fiber  <- stream1.mergeTerminateEither(stream2).runCollect.fork
+        //           _      <- queue1.shutdown
+        //           _      <- TestClock.adjust(1.second)
+        //           _      <- queue2.offer(1)
+        //           result <- fiber.join
+        //         } yield assert(result)(isEmpty)
+        //       }
+        //     ),
+        //     suite("mergeWith")(
+        //       testM("equivalence with set union")(checkM(streamOfInts, streamOfInts) {
+        //         (s1: ZStream[Any, String, Int], s2: ZStream[Any, String, Int]) =>
+        //           for {
+        //             mergedStream <- (s1 merge s2).runCollect.map(_.toSet).run
+        //             mergedLists <- s1.runCollect
+        //                              .zipWith(s2.runCollect)((left, right) => left ++ right)
+        //                              .map(_.toSet)
+        //                              .run
+        //           } yield assert(!mergedStream.succeeded && !mergedLists.succeeded)(isTrue) || assert(
+        //             mergedStream
+        //           )(
+        //             equalTo(mergedLists)
+        //           )
+        //       }),
+        //       testM("fail as soon as one stream fails") {
+        //         assertM(ZStream(1, 2, 3).merge(ZStream.fail(())).runCollect.run.map(_.succeeded))(
+        //           equalTo(false)
+        //         )
+        //       } @@ nonFlaky(20),
+        //       testM("prioritizes failure") {
+        //         val s1 = ZStream.never
+        //         val s2 = ZStream.fail("Ouch")
+
+        //         assertM(s1.mergeWith(s2)(_ => (), _ => ()).runCollect.either)(isLeft(equalTo("Ouch")))
+        //       }
+        //     ),
+        //     suite("partitionEither")(
+        //       testM("allows repeated runs without hanging") {
+        //         val stream = ZStream
+        //           .fromIterable[Int](Seq.empty)
+        //           .partitionEither(i => ZIO.succeedNow(if (i % 2 == 0) Left(i) else Right(i)))
+        //           .map { case (evens, odds) => evens.mergeEither(odds) }
+        //           .use(_.runCollect)
+        //         assertM(ZIO.collectAll(Range(0, 100).toList.map(_ => stream)).map(_ => 0))(equalTo(0))
+        //       },
+        //       testM("values") {
+        //         ZStream
+        //           .range(0, 6)
+        //           .partitionEither { i =>
+        //             if (i % 2 == 0) ZIO.succeedNow(Left(i))
+        //             else ZIO.succeedNow(Right(i))
+        //           }
+        //           .use { case (s1, s2) =>
+        //             for {
+        //               out1 <- s1.runCollect
+        //               out2 <- s2.runCollect
+        //             } yield assert(out1)(equalTo(Chunk(0, 2, 4))) && assert(out2)(
+        //               equalTo(Chunk(1, 3, 5))
+        //             )
+        //           }
+        //       },
+        //       testM("errors") {
+        //         (ZStream.range(0, 1) ++ ZStream.fail("Boom")).partitionEither { i =>
+        //           if (i % 2 == 0) ZIO.succeedNow(Left(i))
+        //           else ZIO.succeedNow(Right(i))
+        //         }.use { case (s1, s2) =>
+        //           for {
+        //             out1 <- s1.runCollect.either
+        //             out2 <- s2.runCollect.either
+        //           } yield assert(out1)(isLeft(equalTo("Boom"))) && assert(out2)(
+        //             isLeft(equalTo("Boom"))
+        //           )
+        //         }
+        //       },
+        //       testM("backpressure") {
+        //         ZStream
+        //           .range(0, 6)
+        //           .partitionEither(
+        //             i =>
+        //               if (i % 2 == 0) ZIO.succeedNow(Left(i))
+        //               else ZIO.succeedNow(Right(i)),
+        //             1
+        //           )
+        //           .use { case (s1, s2) =>
+        //             for {
+        //               ref    <- Ref.make[List[Int]](Nil)
+        //               latch1 <- Promise.make[Nothing, Unit]
+        //               fib <- s1
+        //                        .tap(i => ref.update(i :: _) *> latch1.succeed(()).when(i == 2))
+        //                        .runDrain
+        //                        .fork
+        //               _         <- latch1.await
+        //               snapshot1 <- ref.get
+        //               other     <- s2.runCollect
+        //               _         <- fib.await
+        //               snapshot2 <- ref.get
+        //             } yield assert(snapshot1)(equalTo(List(2, 0))) && assert(snapshot2)(
+        //               equalTo(List(4, 2, 0))
+        //             ) && assert(
+        //               other
+        //             )(
+        //               equalTo(
+        //                 Chunk(
+        //                   1,
+        //                   3,
+        //                   5
+        //                 )
+        //               )
+        //             )
+        //           }
+        //       }
+        //     ),
+        //     testM("peel") {
+        //       val sink: ZSink[Any, Nothing, Int, Nothing, Chunk[Int]] = ZSink {
+        //         ZManaged.succeed {
+        //           case Some(inputs) => Push.emit(inputs, Chunk.empty)
+        //           case None         => Push.emit(Chunk.empty, Chunk.empty)
+        //         }
+        //       }
+
+        //       ZStream.fromChunks(Chunk(1, 2, 3), Chunk(4, 5, 6)).peel(sink).use { case (chunk, rest) =>
+        //         rest.runCollect.map { rest =>
+        //           assert(chunk)(equalTo(Chunk(1, 2, 3))) &&
+        //           assert(rest)(equalTo(Chunk(4, 5, 6)))
+        //         }
+        //       }
+        //     },
+        //     testM("onError") {
+        //       for {
+        //         flag   <- Ref.make(false)
+        //         exit   <- ZStream.fail("Boom").onError(_ => flag.set(true)).runDrain.run
+        //         called <- flag.get
+        //       } yield assert(called)(isTrue) && assert(exit)(fails(equalTo("Boom")))
+        //     } @@ zioTag(errors),
+        //     testM("orElse") {
+        //       val s1 = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
+        //       val s2 = ZStream(4, 5, 6)
+        //       s1.orElse(s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2, 3, 4, 5, 6))))
+        //     },
+        //     testM("orElseEither") {
+        //       val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
+        //       val s2 = ZStream.succeed(2)
+        //       s1.orElseEither(s2).runCollect.map(assert(_)(equalTo(Chunk(Left(1), Right(2)))))
+        //     },
+        //     testM("orElseFail") {
+        //       val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
+        //       s1.orElseFail("Boomer").runCollect.either.map(assert(_)(isLeft(equalTo("Boomer"))))
+        //     },
+        //     testM("orElseOptional") {
+        //       val s1 = ZStream.succeed(1) ++ ZStream.fail(None)
+        //       val s2 = ZStream.succeed(2)
+        //       s1.orElseOptional(s2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
+        //     },
+        //     testM("orElseSucceed") {
+        //       val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
+        //       s1.orElseSucceed(2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
+        //     },
+        //     suite("repeat")(
+        //       testM("repeat")(
+        //         assertM(
+        //           ZStream(1)
+        //             .repeat(Schedule.recurs(4))
+        //             .runCollect
+        //         )(equalTo(Chunk(1, 1, 1, 1, 1)))
+        //       ),
+        //       testM("short circuits")(
+        //         for {
+        //           ref <- Ref.make[List[Int]](Nil)
+        //           fiber <- ZStream
+        //                      .fromEffect(ref.update(1 :: _))
+        //                      .repeat(Schedule.spaced(10.millis))
+        //                      .take(2)
+        //                      .runDrain
+        //                      .fork
+        //           _      <- TestClock.adjust(50.millis)
+        //           _      <- fiber.join
+        //           result <- ref.get
+        //         } yield assert(result)(equalTo(List(1, 1)))
+        //       )
+        //     ),
+        //     suite("repeatEither")(
+        //       testM("emits schedule output")(
+        //         assertM(
+        //           ZStream(1L)
+        //             .repeatEither(Schedule.recurs(4))
+        //             .runCollect
+        //         )(
+        //           equalTo(
+        //             Chunk(
+        //               Right(1L),
+        //               Right(1L),
+        //               Left(0L),
+        //               Right(1L),
+        //               Left(1L),
+        //               Right(1L),
+        //               Left(2L),
+        //               Right(1L),
+        //               Left(3L)
+        //             )
+        //           )
+        //         )
+        //       ),
+        //       testM("short circuits") {
+        //         for {
+        //           ref <- Ref.make[List[Int]](Nil)
+        //           fiber <- ZStream
+        //                      .fromEffect(ref.update(1 :: _))
+        //                      .repeatEither(Schedule.spaced(10.millis))
+        //                      .take(3) // take one schedule output
+        //                      .runDrain
+        //                      .fork
+        //           _      <- TestClock.adjust(50.millis)
+        //           _      <- fiber.join
+        //           result <- ref.get
+        //         } yield assert(result)(equalTo(List(1, 1)))
+        //       }
+        //     ),
+        //     testM("right") {
+        //       val s1 = ZStream.succeed(Right(1)) ++ ZStream.succeed(Left(0))
+        //       s1.right.runCollect.either.map(assert(_)(isLeft(equalTo(None))))
+        //     },
+        //     testM("rightOrFail") {
+        //       val s1 = ZStream.succeed(Right(1)) ++ ZStream.succeed(Left(0))
+        //       s1.rightOrFail(-1).runCollect.either.map(assert(_)(isLeft(equalTo(-1))))
+        //     },
+        //     suite("runHead")(
+        //       testM("nonempty stream")(
+        //         assertM(ZStream(1, 2, 3, 4).runHead)(equalTo(Some(1)))
+        //       ),
+        //       testM("empty stream")(
+        //         assertM(ZStream.empty.runHead)(equalTo(None))
+        //       ),
+        //       testM("Pulls up to the first non-empty chunk") {
+        //         for {
+        //           ref <- Ref.make[List[Int]](Nil)
+        //           head <- ZStream(
+        //                     ZStream.fromEffect(ref.update(1 :: _)).drain,
+        //                     ZStream.fromEffect(ref.update(2 :: _)).drain,
+        //                     ZStream(1),
+        //                     ZStream.fromEffect(ref.update(3 :: _))
+        //                   ).flatten.runHead
+        //           result <- ref.get
+        //         } yield assert(head)(isSome(equalTo(1))) && assert(result)(equalTo(List(2, 1)))
+        //       }
+        //     ),
+        //     suite("runLast")(
+        //       testM("nonempty stream")(
+        //         assertM(ZStream(1, 2, 3, 4).runLast)(equalTo(Some(4)))
+        //       ),
+        //       testM("empty stream")(
+        //         assertM(ZStream.empty.runLast)(equalTo(None))
+        //       )
+        //     ),
+        //     suite("runManaged")(
+        //       testM("properly closes the resources")(
+        //         for {
+        //           closed <- Ref.make[Boolean](false)
+        //           res     = ZManaged.make(ZIO.succeed(1))(_ => closed.set(true))
+        //           stream  = ZStream.managed(res).flatMap(a => ZStream(a, a, a))
+        //           collectAndCheck <- stream
+        //                                .runManaged(ZSink.collectAll)
+        //                                .flatMap(r => closed.get.toManaged_.map((r, _)))
+        //                                .useNow
+        //           (result, state) = collectAndCheck
+        //           finalState     <- closed.get
+        //         } yield {
+        //           assert(result)(equalTo(Chunk(1, 1, 1))) && assert(state)(isFalse) && assert(finalState)(isTrue)
+        //         }
+        //       )
+        //     ),
+        //     suite("scan")(
+        //       testM("scan")(checkM(pureStreamOfInts) { s =>
+        //         for {
+        //           streamResult <- s.scan(0)(_ + _).runCollect
+        //           chunkResult  <- s.runCollect.map(_.scan(0)(_ + _))
+        //         } yield assert(streamResult)(equalTo(chunkResult))
+        //       })
+        //     ),
+        //     suite("scanReduce")(
+        //       testM("scanReduce")(checkM(pureStreamOfInts) { s =>
+        //         for {
+        //           streamResult <- s.scanReduce(_ + _).runCollect
+        //           chunkResult  <- s.runCollect.map(_.scan(0)(_ + _).tail)
+        //         } yield assert(streamResult)(equalTo(chunkResult))
+        //       })
+        //     ),
+        //     suite("schedule")(
+        //       testM("scheduleWith")(
+        //         assertM(
+        //           ZStream("A", "B", "C", "A", "B", "C")
+        //             .scheduleWith(Schedule.recurs(2) *> Schedule.fromFunction((_) => "Done"))(
+        //               _.toLowerCase,
+        //               identity
+        //             )
+        //             .runCollect
+        //         )(equalTo(Chunk("a", "b", "c", "Done", "a", "b", "c", "Done")))
+        //       ),
+        //       testM("scheduleEither")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .scheduleEither(Schedule.recurs(2) *> Schedule.fromFunction((_) => "!"))
+        //             .runCollect
+        //         )(equalTo(Chunk(Right("A"), Right("B"), Right("C"), Left("!"))))
+        //       )
+        //     ),
+        //     suite("repeatElements")(
+        //       testM("repeatElementsWith")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .repeatElementsWith(Schedule.recurs(0) *> Schedule.fromFunction((_) => 123))(
+        //               identity,
+        //               _.toString
+        //             )
+        //             .runCollect
+        //         )(equalTo(Chunk("A", "123", "B", "123", "C", "123")))
+        //       ),
+        //       testM("repeatElementsEither")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .repeatElementsEither(Schedule.recurs(0) *> Schedule.fromFunction((_) => 123))
+        //             .runCollect
+        //         )(equalTo(Chunk(Right("A"), Left(123), Right("B"), Left(123), Right("C"), Left(123))))
+        //       ),
+        //       testM("repeated && assertspaced")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .repeatElements(Schedule.once)
+        //             .runCollect
+        //         )(equalTo(Chunk("A", "A", "B", "B", "C", "C")))
+        //       ),
+        //       testM("short circuits in schedule")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .repeatElements(Schedule.once)
+        //             .take(4)
+        //             .runCollect
+        //         )(equalTo(Chunk("A", "A", "B", "B")))
+        //       ),
+        //       testM("short circuits after schedule")(
+        //         assertM(
+        //           ZStream("A", "B", "C")
+        //             .repeatElements(Schedule.once)
+        //             .take(3)
+        //             .runCollect
+        //         )(equalTo(Chunk("A", "A", "B")))
+        //       )
+        //     ),
+        //     testM("some") {
+        //       val s1 = ZStream.succeed(Some(1)) ++ ZStream.succeed(None)
+        //       s1.some.runCollect.either.map(assert(_)(isLeft(equalTo(None))))
+        //     },
+        //     testM("someOrElse") {
+        //       val s1 = ZStream.succeed(Some(1)) ++ ZStream.succeed(None)
+        //       s1.someOrElse(-1).runCollect.map(assert(_)(equalTo(Chunk(1, -1))))
+        //     },
+        //     testM("someOrFail") {
+        //       val s1 = ZStream.succeed(Some(1)) ++ ZStream.succeed(None)
+        //       s1.someOrFail(-1).runCollect.either.map(assert(_)(isLeft(equalTo(-1))))
+        //     },
+        suite("take")(
+          testM("take")(checkM(streamOfInts, Gen.anyInt) { (s, n) =>
+            for {
+              takeStreamResult <- s.take(n.toLong).runCollect.run
+              takeListResult   <- s.runCollect.map(_.take(n)).run
+            } yield assert(takeListResult.succeeded)(isTrue) implies assert(takeStreamResult)(
+              equalTo(takeListResult)
+            )
+          }),
+          // testM("take short circuits")(
+          //   for {
+          //     ran    <- Ref.make(false)
+          //     stream  = (ZStream(1) ++ ZStream.fromEffect(ran.set(true)).drain).take(0)
+          //     _      <- stream.runDrain
+          //     result <- ran.get
+          //   } yield assert(result)(isFalse)
+          // ),
+          testM("take(0) short circuits")(
+            for {
+              units <- ZStream.never.take(0).runCollect
+            } yield assert(units)(equalTo(Chunk.empty))
+          ),
+          testM("take(1) short circuits")(
+            for {
+              ints <- (ZStream(1) ++ ZStream.never).take(1).runCollect
+            } yield assert(ints)(equalTo(Chunk(1)))
+          )
+        ),
+        //     testM("takeRight") {
+        //       checkM(pureStreamOfInts, Gen.int(1, 4)) { (s, n) =>
+        //         for {
+        //           streamTake <- s.takeRight(n).runCollect
+        //           chunkTake  <- s.runCollect.map(_.takeRight(n))
+        //         } yield assert(streamTake)(equalTo(chunkTake))
+        //       }
+        //     },
+        testM("takeUntil") {
+          checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+            for {
+              streamTakeUntil <- s.takeUntil(p).runCollect.run
+              chunkTakeUntil <- s.runCollect
+                                  .map(as => as.takeWhile(!p(_)) ++ as.dropWhile(!p(_)).take(1))
+                                  .run
+            } yield assert(chunkTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(
+              equalTo(chunkTakeUntil)
+            )
+          }
+        },
+        testM("takeUntilM") {
+          checkM(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
+            for {
+              streamTakeUntilM <- s.takeUntilM(p).runCollect.run
+              chunkTakeUntilM <- s.runCollect
+                                   .flatMap(as =>
+                                     as.takeWhileM(p(_).map(!_))
+                                       .zipWith(as.dropWhileM(p(_).map(!_)).map(_.take(1)))(_ ++ _)
+                                   )
+                                   .run
+            } yield assert(chunkTakeUntilM.succeeded)(isTrue) implies assert(streamTakeUntilM)(
+              equalTo(chunkTakeUntilM)
+            )
+          }
+        },
+        testM("takeUntilM - laziness on chunks") {
+          assertM(
+            ZStream(1, 2, 3).takeUntilM {
+              case 2 => ZIO.fail("boom")
+              case _ => UIO.succeed(false)
+            }.either.runCollect
+          )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+        },
+        suite("takeWhile")(
+          testM("takeWhile")(checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+            for {
+              streamTakeWhile <- s.takeWhile(p).runCollect.run
+              chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).run
+            } yield assert(chunkTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
+          }),
+          testM("takeWhile doesn't stop when hitting an empty chunk (#4272)") {
+            ZStream
+              .fromChunks(Chunk(1), Chunk(2), Chunk(3))
+              .mapChunks(_.flatMap {
+                case 2 => Chunk()
+                case x => Chunk(x)
+              })
+              .takeWhile(_ != 4)
+              .runCollect
+              .map(assert(_)(hasSameElements(List(1, 3))))
+          }
+        ),
+        testM("takeWhile short circuits")(
+          assertM(
+            (ZStream(1) ++ ZStream.fail("Ouch"))
+              .takeWhile(_ => false)
+              .runDrain
+              .either
+          )(isRight(isUnit))
+        ),
+        //     suite("tap")(
+        //       testM("tap") {
+        //         for {
+        //           ref <- Ref.make(0)
+        //           res <- ZStream(1, 1).tap[Any, Nothing](a => ref.update(_ + a)).runCollect
+        //           sum <- ref.get
+        //         } yield assert(res)(equalTo(Chunk(1, 1))) && assert(sum)(equalTo(2))
+        //       },
+        //       testM("laziness on chunks") {
+        //         assertM(Stream(1, 2, 3).tap(x => IO.when(x == 3)(IO.fail("error"))).either.runCollect)(
+        //           equalTo(Chunk(Right(1), Right(2), Left("error")))
+        //         )
+        //       }
+        //     ),
+        //     suite("throttleEnforce")(
+        //       testM("free elements") {
+        //         assertM(
+        //           ZStream(1, 2, 3, 4)
+        //             .throttleEnforce(0, Duration.Infinity)(_ => 0)
+        //             .runCollect
+        //         )(equalTo(Chunk(1, 2, 3, 4)))
+        //       },
+        //       testM("no bandwidth") {
+        //         assertM(
+        //           ZStream(1, 2, 3, 4)
+        //             .throttleEnforce(0, Duration.Infinity)(_ => 1)
+        //             .runCollect
+        //         )(equalTo(Chunk.empty))
+        //       }
+        //     ),
+        //     suite("throttleShape")(
+        //       testM("throttleShape") {
+        //         for {
+        //           fiber <- Queue
+        //                      .bounded[Int](10)
+        //                      .flatMap { queue =>
+        //                        ZStream
+        //                          .fromQueue(queue)
+        //                          .throttleShape(1, 1.second)(_.fold(0)(_ + _).toLong)
+        //                          .process
+        //                          .use { pull =>
+        //                            for {
+        //                              _    <- queue.offer(1)
+        //                              res1 <- pull
+        //                              _    <- queue.offer(2)
+        //                              res2 <- pull
+        //                              _    <- clock.sleep(4.seconds)
+        //                              _    <- queue.offer(3)
+        //                              res3 <- pull
+        //                            } yield assert(Chunk(res1, res2, res3))(
+        //                              equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3)))
+        //                            )
+        //                          }
+        //                      }
+        //                      .fork
+        //           _    <- TestClock.adjust(8.seconds)
+        //           test <- fiber.join
+        //         } yield test
+        //       },
+        //       testM("infinite bandwidth") {
+        //         Queue.bounded[Int](10).flatMap { queue =>
+        //           ZStream.fromQueue(queue).throttleShape(1, 0.seconds)(_ => 100000L).process.use { pull =>
+        //             for {
+        //               _       <- queue.offer(1)
+        //               res1    <- pull
+        //               _       <- queue.offer(2)
+        //               res2    <- pull
+        //               elapsed <- clock.currentTime(TimeUnit.SECONDS)
+        //             } yield assert(elapsed)(equalTo(0L)) && assert(Chunk(res1, res2))(
+        //               equalTo(Chunk(Chunk(1), Chunk(2)))
+        //             )
+        //           }
+        //         }
+        //       },
+        //       testM("with burst") {
+        //         for {
+        //           fiber <- Queue
+        //                      .bounded[Int](10)
+        //                      .flatMap { queue =>
+        //                        ZStream
+        //                          .fromQueue(queue)
+        //                          .throttleShape(1, 1.second, 2)(_.fold(0)(_ + _).toLong)
+        //                          .process
+        //                          .use { pull =>
+        //                            for {
+        //                              _    <- queue.offer(1)
+        //                              res1 <- pull
+        //                              _    <- TestClock.adjust(2.seconds)
+        //                              _    <- queue.offer(2)
+        //                              res2 <- pull
+        //                              _    <- TestClock.adjust(4.seconds)
+        //                              _    <- queue.offer(3)
+        //                              res3 <- pull
+        //                            } yield assert(Chunk(res1, res2, res3))(
+        //                              equalTo(Chunk(Chunk(1), Chunk(2), Chunk(3)))
+        //                            )
+        //                          }
+        //                      }
+        //                      .fork
+        //           test <- fiber.join
+        //         } yield test
+        //       },
+        //       testM("free elements") {
+        //         assertM(
+        //           ZStream(1, 2, 3, 4)
+        //             .throttleShape(1, Duration.Infinity)(_ => 0)
+        //             .runCollect
+        //         )(equalTo(Chunk(1, 2, 3, 4)))
+        //       }
+        //     ),
+        //     suite("debounce")(
+        //       testM("should drop earlier chunks within waitTime") {
+        //         assertWithChunkCoordination(List(Chunk(1), Chunk(3, 4), Chunk(5), Chunk(6, 7))) { c =>
+        //           val stream = ZStream
+        //             .fromQueue(c.queue)
+        //             .collectWhileSuccess
+        //             .debounce(1.second)
+        //             .tap(_ => c.proceed)
+
+        //           assertM(for {
+        //             fiber  <- stream.runCollect.fork
+        //             _      <- c.offer.fork
+        //             _      <- (clock.sleep(500.millis) *> c.offer).fork
+        //             _      <- (clock.sleep(2.seconds) *> c.offer).fork
+        //             _      <- (clock.sleep(2500.millis) *> c.offer).fork
+        //             _      <- TestClock.adjust(3500.millis)
+        //             result <- fiber.join
+        //           } yield result)(equalTo(Chunk(Chunk(3, 4), Chunk(6, 7))))
+        //         }
+        //       },
+        //       testM("should take latest chunk within waitTime") {
+        //         assertWithChunkCoordination(List(Chunk(1, 2), Chunk(3, 4), Chunk(5, 6))) { c =>
+        //           val stream = ZStream
+        //             .fromQueue(c.queue)
+        //             .collectWhileSuccess
+        //             .debounce(1.second)
+        //             .tap(_ => c.proceed)
+
+        //           assertM(for {
+        //             fiber  <- stream.runCollect.fork
+        //             _      <- c.offer *> c.offer *> c.offer
+        //             _      <- TestClock.adjust(1.second)
+        //             result <- fiber.join
+        //           } yield result)(equalTo(Chunk(Chunk(5, 6))))
+        //         }
+        //       },
+        //       testM("should work properly with parallelization") {
+        //         assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
+        //           val stream = ZStream
+        //             .fromQueue(c.queue)
+        //             .collectWhileSuccess
+        //             .debounce(1.second)
+        //             .tap(_ => c.proceed)
+
+        //           assertM(for {
+        //             fiber  <- stream.runCollect.fork
+        //             _      <- ZIO.collectAllPar_(List(c.offer, c.offer, c.offer))
+        //             _      <- TestClock.adjust(1.second)
+        //             result <- fiber.join
+        //           } yield result)(hasSize(equalTo(1)))
+        //         }
+        //       },
+        //       testM("should handle empty chunks properly") {
+        //         for {
+        //           fiber  <- ZStream(1, 2, 3).fixed(500.millis).debounce(1.second).runCollect.fork
+        //           _      <- TestClock.adjust(3.seconds)
+        //           result <- fiber.join
+        //         } yield assert(result)(equalTo(Chunk(3)))
+        //       },
+        //       testM("should fail immediately") {
+        //         val stream = ZStream.fromEffect(IO.fail(None)).debounce(Duration.Infinity)
+        //         assertM(stream.runCollect.either)(isLeft(equalTo(None)))
+        //       },
+        //       testM("should work with empty streams") {
+        //         val stream = ZStream.empty.debounce(5.seconds)
+        //         assertM(stream.runCollect)(isEmpty)
+        //       },
+        //       testM("should pick last element from every chunk") {
+        //         assertM(for {
+        //           fiber  <- ZStream(1, 2, 3).debounce(1.second).runCollect.fork
+        //           _      <- TestClock.adjust(1.second)
+        //           result <- fiber.join
+        //         } yield result)(equalTo(Chunk(3)))
+        //       },
+        //       testM("should interrupt fibers properly") {
+        //         assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
+        //           for {
+        //             fib <- ZStream
+        //                      .fromQueue(c.queue)
+        //                      .tap(_ => c.proceed)
+        //                      .flatMap(ex => ZStream.fromEffectOption(ZIO.done(ex)))
+        //                      .flattenChunks
+        //                      .debounce(200.millis)
+        //                      .interruptWhen(ZIO.never)
+        //                      .take(1)
+        //                      .runCollect
+        //                      .fork
+        //             _       <- (c.offer *> TestClock.adjust(100.millis) *> c.awaitNext).repeatN(3)
+        //             _       <- TestClock.adjust(100.millis)
+        //             results <- fib.join
+        //           } yield assert(results)(equalTo(Chunk(3)))
+        //         }
+        //       },
+        //       testM("should interrupt children fiber on stream interruption") {
+        //         for {
+        //           ref <- Ref.make(false)
+        //           fiber <- (ZStream.fromEffect(ZIO.unit) ++ ZStream.fromEffect(ZIO.never.onInterrupt(ref.set(true))))
+        //                      .debounce(800.millis)
+        //                      .runDrain
+        //                      .fork
+        //           _     <- TestClock.adjust(1.minute)
+        //           _     <- fiber.interrupt
+        //           value <- ref.get
+        //         } yield assert(value)(equalTo(true))
+        //       }
+        //     ),
+        suite("timeout")(
+          testM("succeed") {
+            assertM(
+              ZStream
+                .succeed(1)
+                .timeout(Duration.Infinity)
+                .runCollect
+            )(equalTo(Chunk(1)))
+          },
+          testM("should end stream") {
+            assertM(
+              ZStream
+                .range(0, 5)
+                .tap(_ => ZIO.sleep(Duration.Infinity))
+                .timeout(Duration.Zero)
+                .runCollect
+            )(isEmpty)
+          }
+        ),
+        testM("timeoutFail") {
+          assertM(
+            ZStream
+              .range(0, 5)
+              .tap(_ => ZIO.sleep(Duration.Infinity))
+              .timeoutFail(false)(Duration.Zero)
+              .runDrain
+              .map(_ => true)
+              .either
+              .map(_.merge)
+          )(isFalse)
+        },
+        testM("timeoutHalt") {
+          val throwable = new Exception("BOOM")
+          assertM(
+            ZStream
+              .range(0, 5)
+              .tap(_ => ZIO.sleep(Duration.Infinity))
+              .timeoutHalt(Cause.die(throwable))(Duration.Zero)
+              .runDrain
+              .sandbox
+              .either
+          )(equalTo(Left(Cause.Die(throwable))))
+        },
+        suite("timeoutTo")(
+          testM("succeed") {
+            assertM(
+              ZStream
+                .range(0, 5)
+                .timeoutTo(Duration.Infinity)(ZStream.succeed(-1))
+                .runCollect
+            )(equalTo(Chunk(0, 1, 2, 3, 4)))
+          },
+          testM("should switch stream") {
+            assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
+              assertM(
+                for {
+                  fiber <- ZStream
+                             .fromQueue(c.queue)
+                             .collectWhileSuccess
+                             .flattenChunks
+                             .timeoutTo(2.seconds)(ZStream.succeed(4))
+                             .tap(_ => c.proceed)
+                             .runCollect
+                             .fork
+                  _      <- c.offer *> TestClock.adjust(1.seconds) *> c.awaitNext
+                  _      <- c.offer *> TestClock.adjust(3.seconds) *> c.awaitNext
+                  _      <- c.offer
+                  result <- fiber.join
+                } yield result
+              )(equalTo(Chunk(1, 2, 4)))
+            }
+          },
+          testM("should not apply timeout after switch") {
+            for {
+              queue1 <- Queue.unbounded[Int]
+              queue2 <- Queue.unbounded[Int]
+              stream1 = ZStream.fromQueue(queue1)
+              stream2 = ZStream.fromQueue(queue2)
+              fiber  <- stream1.timeoutTo(2.seconds)(stream2).runCollect.fork
+              _      <- queue1.offer(1) *> TestClock.adjust(1.second)
+              _      <- queue1.offer(2) *> TestClock.adjust(3.second)
+              _      <- queue1.offer(3)
+              _      <- queue2.offer(4) *> TestClock.adjust(3.second)
+              _      <- queue2.offer(5) *> queue2.shutdown
+              result <- fiber.join
+            } yield assert(result)(equalTo(Chunk(1, 2, 4, 5)))
+          }
+        ),
+        //     suite("toInputStream")(
+        //       testM("read one-by-one") {
+        //         checkM(tinyListOf(Gen.chunkOf(Gen.anyByte))) { chunks =>
+        //           val content = chunks.flatMap(_.toList)
+        //           ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
+        //             ZIO.succeedNow(
+        //               assert(Iterator.continually(is.read()).takeWhile(_ != -1).map(_.toByte).toList)(
+        //                 equalTo(content)
+        //               )
+        //             )
+        //           }
+        //         }
+        //       },
+        //       testM("read in batches") {
+        //         checkM(tinyListOf(Gen.chunkOf(Gen.anyByte))) { chunks =>
+        //           val content = chunks.flatMap(_.toList)
+        //           ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
+        //             val batches: List[(Array[Byte], Int)] = Iterator.continually {
+        //               val buf = new Array[Byte](10)
+        //               val res = is.read(buf, 0, 4)
+        //               (buf, res)
+        //             }.takeWhile(_._2 != -1).toList
+        //             val combined = batches.flatMap { case (buf, size) => buf.take(size) }
+        //             ZIO.succeedNow(assert(combined)(equalTo(content)))
+        //           }
+        //         }
+        //       },
+        //       testM("`available` returns the size of chunk's leftover") {
+        //         ZStream
+        //           .fromIterable((1 to 10).map(_.toByte))
+        //           .chunkN(3)
+        //           .toInputStream
+        //           .use[Any, Throwable, TestResult](is =>
+        //             ZIO.effect {
+        //               val cold = is.available()
+        //               is.read()
+        //               val at1 = is.available()
+        //               is.read(new Array[Byte](2))
+        //               val at3 = is.available()
+        //               is.read()
+        //               val at4 = is.available()
+        //               List(
+        //                 assert(cold)(equalTo(0)),
+        //                 assert(at1)(equalTo(2)),
+        //                 assert(at3)(equalTo(0)),
+        //                 assert(at4)(equalTo(2))
+        //               ).reduce(_ && _)
+        //             }
+        //           )
+        //       },
+        //       testM("Preserves errors") {
+        //         assertM(
+        //           ZStream
+        //             .fail(new Exception("boom"))
+        //             .toInputStream
+        //             .use(is =>
+        //               Task {
+        //                 is.read
+        //               }
+        //             )
+        //             .run
+        //         )(
+        //           fails(hasMessage(equalTo("boom")))
+        //         )
+        //       },
+        //       testM("Be completely lazy") {
+        //         assertM(
+        //           ZStream
+        //             .fail(new Exception("boom"))
+        //             .toInputStream
+        //             .use(_ => ZIO.succeed("ok"))
+        //         )(equalTo("ok"))
+        //       },
+        //       testM("Preserves errors in the middle") {
+        //         val bytes: Seq[Byte] = (1 to 5).map(_.toByte)
+        //         val str: ZStream[Any, Throwable, Byte] =
+        //           ZStream.fromIterable(bytes) ++ ZStream.fail(new Exception("boom"))
+        //         assertM(
+        //           str.toInputStream
+        //             .use(is =>
+        //               Task {
+        //                 val buf = new Array[Byte](50)
+        //                 is.read(buf)
+        //                 "ok"
+        //               }
+        //             )
+        //             .run
+        //         )(fails(hasMessage(equalTo("boom"))))
+        //       },
+        //       testM("Allows reading something even in case of error") {
+        //         val bytes: Seq[Byte] = (1 to 5).map(_.toByte)
+        //         val str: ZStream[Any, Throwable, Byte] =
+        //           ZStream.fromIterable(bytes) ++ ZStream.fail(new Exception("boom"))
+        //         assertM(
+        //           str.toInputStream.use(is =>
+        //             Task {
+        //               val buf = new Array[Byte](5)
+        //               is.read(buf)
+        //               buf.toList
+        //             }
+        //           )
+        //         )(equalTo(bytes))
+        //       }
+        //     ),
+        //     testM("toIterator") {
+        //       (for {
+        //         counter  <- Ref.make(0).toManaged_ //Increment and get the value
+        //         effect    = counter.updateAndGet(_ + 1)
+        //         iterator <- ZStream.repeatEffect(effect).toIterator
+        //         n         = 2000
+        //         out <- ZStream
+        //                  .fromIterator(iterator.map(_.merge))
+        //                  .mapConcatM(element => effect.map(newElement => List(element, newElement)))
+        //                  .take(n.toLong)
+        //                  .runCollect
+        //                  .toManaged_
+        //       } yield assert(out)(equalTo(Chunk.fromIterable(1 to n)))).use(ZIO.succeed(_))
+        //     } @@ TestAspect.jvmOnly, // Until #3360 is solved
+        //     suite("toQueue")(
+        //       testM("toQueue")(checkM(Gen.chunkOfBounded(0, 3)(Gen.anyInt)) { (c: Chunk[Int]) =>
+        //         val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
+        //         assertM(
+        //           s.toQueue(1000)
+        //             .use(queue => queue.size.repeatWhile(_ != c.size + 1) *> queue.takeAll)
+        //         )(
+        //           equalTo(c.toSeq.toList.map(Take.single) :+ Take.end)
+        //         )
+        //       }),
+        //       testM("toQueueUnbounded")(checkM(Gen.chunkOfBounded(0, 3)(Gen.anyInt)) { (c: Chunk[Int]) =>
+        //         val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
+        //         assertM(
+        //           s.toQueueUnbounded.use(queue => queue.size.repeatWhile(_ != c.size + 1) *> queue.takeAll)
+        //         )(
+        //           equalTo(c.toSeq.toList.map(Take.single) :+ Take.end)
+        //         )
+        //       })
+        //     ),
+        //     suite("toReader")(
+        //       testM("read one-by-one") {
+        //         checkM(tinyListOf(Gen.chunkOf(Gen.anyChar))) { chunks =>
+        //           val content = chunks.flatMap(_.toList)
+        //           ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
+        //             ZIO.succeedNow(
+        //               assert(Iterator.continually(reader.read()).takeWhile(_ != -1).map(_.toChar).toList)(
+        //                 equalTo(content)
+        //               )
+        //             )
+        //           }
+        //         }
+        //       },
+        //       testM("read in batches") {
+        //         checkM(tinyListOf(Gen.chunkOf(Gen.anyChar))) { chunks =>
+        //           val content = chunks.flatMap(_.toList)
+        //           ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
+        //             val batches: List[(Array[Char], Int)] = Iterator.continually {
+        //               val buf = new Array[Char](10)
+        //               val res = reader.read(buf, 0, 4)
+        //               (buf, res)
+        //             }.takeWhile(_._2 != -1).toList
+        //             val combined = batches.flatMap { case (buf, size) => buf.take(size) }
+        //             ZIO.succeedNow(assert(combined)(equalTo(content)))
+        //           }
+        //         }
+        //       },
+        //       testM("Throws mark not supported") {
+        //         assertM(
+        //           ZStream
+        //             .fromChunk(Chunk.fromArray("Lorem ipsum".toArray))
+        //             .toReader
+        //             .use(reader =>
+        //               Task {
+        //                 reader.mark(0)
+        //               }
+        //             )
+        //             .run
+        //         )(fails(isSubtype[IOException](anything)))
+        //       },
+        //       testM("Throws reset not supported") {
+        //         assertM(
+        //           ZStream
+        //             .fromChunk(Chunk.fromArray("Lorem ipsum".toArray))
+        //             .toReader
+        //             .use(reader =>
+        //               Task {
+        //                 reader.reset()
+        //               }
+        //             )
+        //             .run
+        //         )(fails(isSubtype[IOException](anything)))
+        //       },
+        //       testM("Does not support mark") {
+        //         assertM(
+        //           ZStream
+        //             .fromChunk(Chunk.fromArray("Lorem ipsum".toArray))
+        //             .toReader
+        //             .use(reader => ZIO.succeed(reader.markSupported()))
+        //         )(equalTo(false))
+        //       },
+        //       testM("Ready is false") {
+        //         assertM(
+        //           ZStream
+        //             .fromChunk(Chunk.fromArray("Lorem ipsum".toArray))
+        //             .toReader
+        //             .use(reader => ZIO.succeed(reader.ready()))
+        //         )(equalTo(false))
+        //       },
+        //       testM("Preserves errors") {
+        //         assertM(
+        //           ZStream
+        //             .fail(new Exception("boom"))
+        //             .toReader
+        //             .use(reader =>
+        //               Task {
+        //                 reader.read
+        //               }
+        //             )
+        //             .run
+        //         )(
+        //           fails(hasMessage(equalTo("boom")))
+        //         )
+        //       },
+        //       testM("Be completely lazy") {
+        //         assertM(
+        //           ZStream
+        //             .fail(new Exception("boom"))
+        //             .toReader
+        //             .use(_ => ZIO.succeed("ok"))
+        //         )(equalTo("ok"))
+        //       },
+        //       testM("Preserves errors in the middle") {
+        //         val chars: Seq[Char] = (1 to 5).map(_.toChar)
+        //         val str: ZStream[Any, Throwable, Char] =
+        //           ZStream.fromIterable(chars) ++ ZStream.fail(new Exception("boom"))
+        //         assertM(
+        //           str.toReader
+        //             .use(reader =>
+        //               Task {
+        //                 val buf = new Array[Char](50)
+        //                 reader.read(buf)
+        //                 "ok"
+        //               }
+        //             )
+        //             .run
+        //         )(fails(hasMessage(equalTo("boom"))))
+        //       },
+        //       testM("Allows reading something even in case of error") {
+        //         val chars: Seq[Char] = (1 to 5).map(_.toChar)
+        //         val str: ZStream[Any, Throwable, Char] =
+        //           ZStream.fromIterable(chars) ++ ZStream.fail(new Exception("boom"))
+        //         assertM(
+        //           str.toReader.use(reader =>
+        //             Task {
+        //               val buf = new Array[Char](5)
+        //               reader.read(buf)
+        //               buf.toList
+        //             }
+        //           )
+        //         )(equalTo(chars))
+        //       }
+        //     ),
+        suite("zipWith")(
+          testM("zip doesn't pull too much when one of the streams is done") {
+            val l = ZStream.fromChunks(Chunk(1, 2), Chunk(3, 4), Chunk(5)) ++ ZStream.fail(
+              "Nothing to see here"
+            )
+            val r = ZStream.fromChunks(Chunk("a", "b"), Chunk("c"))
+            assertM(l.zip(r).runCollect)(equalTo(Chunk((1, "a"), (2, "b"), (3, "c"))))
+          },
+          testM("zip equivalence with Chunk#zipWith") {
+            checkM(
+              tinyListOf(Gen.chunkOf(Gen.anyInt)),
+              tinyListOf(Gen.chunkOf(Gen.anyInt))
+            ) { (l, r) =>
+              val expected = Chunk.fromIterable(l).flatten.zip(Chunk.fromIterable(r).flatten)
+              assertM(ZStream.fromChunks(l: _*).zip(ZStream.fromChunks(r: _*)).runCollect)(
+                equalTo(expected)
+              )
+            }
+          },
+          testM("zipWith prioritizes failure") {
+            assertM(
+              ZStream.never
+                .zipWith(ZStream.fail("Ouch"))((_, _) => None)
+                .runCollect
+                .either
+            )(isLeft(equalTo("Ouch")))
+          }
+        ),
+        suite("zipAllWith")(
+          testM("zipAllWith") {
+            checkM(
+              // We're using ZStream.fromChunks in the test, and that discards empty
+              // chunks; so we're only testing for non-empty chunks here.
+              tinyListOf(Gen.chunkOf(Gen.anyInt).filter(_.size > 0)),
+              tinyListOf(Gen.chunkOf(Gen.anyInt).filter(_.size > 0))
+            ) { (l, r) =>
+              val expected =
+                Chunk
+                  .fromIterable(l)
+                  .flatten
+                  .zipAllWith(Chunk.fromIterable(r).flatten)(Some(_) -> None, None -> Some(_))(
+                    Some(_) -> Some(_)
+                  )
+
+              assertM(
+                ZStream
+                  .fromChunks(l: _*)
+                  .map(Option(_))
+                  .zipAll(ZStream.fromChunks(r: _*).map(Option(_)))(None, None)
+                  .runCollect
+              )(equalTo(expected))
+            }
+          },
+          testM("zipAllWith prioritizes failure") {
+            assertM(
+              ZStream.never
+                .zipAll(ZStream.fail("Ouch"))(None, None)
+                .runCollect
+                .either
+            )(isLeft(equalTo("Ouch")))
+          }
+        )
+//             testM("zipWithIndex")(checkM(pureStreamOfInts) { s =>
+//               for {
+//                 res1 <- (s.zipWithIndex.runCollect)
+//                 res2 <- (s.runCollect.map(_.zipWithIndex.map(t => (t._1, t._2.toLong))))
+//               } yield assert(res1)(equalTo(res2))
+//             }),
+//             suite("zipWithLatest")(
+//               testM("succeed") {
+//                 for {
+//                   left   <- Queue.unbounded[Chunk[Int]]
+//                   right  <- Queue.unbounded[Chunk[Int]]
+//                   out    <- Queue.bounded[Take[Nothing, (Int, Int)]](1)
+//                   _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).runInto(out).fork
+//                   _      <- left.offer(Chunk(0))
+//                   _      <- right.offerAll(List(Chunk(0), Chunk(1)))
+//                   chunk1 <- ZIO.collectAll(ZIO.replicate(2)(out.take.flatMap(_.done))).map(_.flatten)
+//                   _      <- left.offerAll(List(Chunk(1), Chunk(2)))
+//                   chunk2 <- ZIO.collectAll(ZIO.replicate(2)(out.take.flatMap(_.done))).map(_.flatten)
+//                 } yield assert(chunk1)(equalTo(List((0, 0), (0, 1)))) && assert(chunk2)(equalTo(List((1, 1), (2, 1))))
+//               },
+//               testM("handle empty pulls properly") {
+//                 assertM(
+//                   ZStream
+//                     .unfold(0)(n => Some((if (n < 3) Chunk.empty else Chunk.single(2), n + 1)))
+//                     .flattenChunks
+//                     .forever
+//                     .zipWithLatest(ZStream(1).forever)((_, x) => x)
+//                     .take(3)
+//                     .runCollect
+//                 )(equalTo(Chunk(1, 1, 1)))
+//               }
+//             ),
+//             suite("zipWithNext")(
+//               testM("should zip with next element for a single chunk") {
+//                 for {
+//                   result <- ZStream(1, 2, 3).zipWithNext.runCollect
+//                 } yield assert(result)(equalTo(Chunk(1 -> Some(2), 2 -> Some(3), 3 -> None)))
+//               },
+//               testM("should work with multiple chunks") {
+//                 for {
+//                   result <- ZStream.fromChunks(Chunk(1), Chunk(2), Chunk(3)).zipWithNext.runCollect
+//                 } yield assert(result)(equalTo(Chunk(1 -> Some(2), 2 -> Some(3), 3 -> None)))
+//               },
+//               testM("should play well with empty streams") {
+//                 assertM(ZStream.empty.zipWithNext.runCollect)(isEmpty)
+//               },
+//               testM("should output same values as zipping with tail plus last element") {
+//                 checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
+//                   val stream = ZStream.fromChunks(chunks: _*)
+//                   for {
+//                     result0 <- stream.zipWithNext.runCollect
+//                     result1 <- stream.zipAll(stream.drop(1).map(Option(_)))(0, None).runCollect
+//                   } yield assert(result0)(equalTo(result1))
+//                 }
+//               }
+//             ) @@ TestAspect.jvmOnly,
+//             suite("zipWithPrevious")(
+//               testM("should zip with previous element for a single chunk") {
+//                 for {
+//                   result <- ZStream(1, 2, 3).zipWithPrevious.runCollect
+//                 } yield assert(result)(equalTo(Chunk(None -> 1, Some(1) -> 2, Some(2) -> 3)))
+//               },
+//               testM("should work with multiple chunks") {
+//                 for {
+//                   result <- ZStream.fromChunks(Chunk(1), Chunk(2), Chunk(3)).zipWithPrevious.runCollect
+//                 } yield assert(result)(equalTo(Chunk(None -> 1, Some(1) -> 2, Some(2) -> 3)))
+//               },
+//               testM("should play well with empty streams") {
+//                 assertM(ZStream.empty.zipWithPrevious.runCollect)(isEmpty)
+//               },
+//               testM("should output same values as first element plus zipping with init") {
+//                 checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
+//                   val stream = ZStream.fromChunks(chunks: _*)
+//                   for {
+//                     result0 <- stream.zipWithPrevious.runCollect
+//                     result1 <- (ZStream(None) ++ stream.map(Some(_))).zip(stream).runCollect
+//                   } yield assert(result0)(equalTo(result1))
+//                 }
+//               }
+//             ) @@ TestAspect.jvmOnly,
+//             suite("zipWithPreviousAndNext")(
+//               testM("succeed") {
+//                 for {
+//                   result <- ZStream(1, 2, 3).zipWithPreviousAndNext.runCollect
+//                 } yield assert(result)(
+//                   equalTo(Chunk((None, 1, Some(2)), (Some(1), 2, Some(3)), (Some(2), 3, None)))
+//                 )
+//               },
+//               testM("should output same values as zipping with both previous and next element") {
+//                 checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
+//                   val stream = ZStream.fromChunks(chunks: _*)
+//                   for {
+//                     result0 <- stream.zipWithPreviousAndNext.runCollect
+//                     previous = ZStream(None) ++ stream.map(Some(_))
+//                     next     = stream.drop(1).map(Some(_)) ++ ZStream(None)
+//                     result1 <- previous
+//                                  .zip(stream)
+//                                  .zip(next)
+//                                  .map { case ((p, c), n) => (p, c, n) }
+//                                  .runCollect
+//                   } yield assert(result0)(equalTo(result1))
+//                 }
+//               }
+//             ) @@ TestAspect.jvmOnly,
+//             suite("refineToOrDie")(
+//               testM("does not compile when refine type is not a subtype of error type") {
+//                 val result = typeCheck {
+//                   """
+//                   ZIO
+//                     .fail(new RuntimeException("BOO!"))
+//                     .refineToOrDie[Error]
+//                     """
+//                 }
+//                 val expected =
+//                   "type arguments [Error] do not conform to method refineToOrDie's type parameter bounds [E1 <: RuntimeException]"
+//                 assertM(result)(isLeft(equalTo(expected)))
+//               } @@ scala2Only
+//             )
+      ),
+      suite("Constructors")(
+        testM("access") {
+          for {
+            result <- ZStream.access[String](identity).provide("test").runCollect.map(_.head)
+          } yield assert(result)(equalTo("test"))
+        },
+        suite("accessM")(
+          testM("accessM") {
+            for {
+              result <- ZStream
+                          .accessM[String](ZIO.succeedNow)
+                          .provide("test")
+                          .runCollect
+                          .map(_.head)
+            } yield assert(result)(equalTo("test"))
+          },
+          testM("accessM fails") {
+            for {
+              result <- ZStream.accessM[Int](_ => ZIO.fail("fail")).provide(0).runCollect.run
+            } yield assert(result)(fails(equalTo("fail")))
+          }
+        ),
+        suite("accessStream")(
+          testM("accessStream") {
+            for {
+              result <- ZStream
+                          .accessStream[String](ZStream.succeed(_))
+                          .provide("test")
+                          .runCollect
+                          .map(_.head)
+            } yield assert(result)(equalTo("test"))
+          },
+          testM("accessStream fails") {
+            for {
+              result <- ZStream
+                          .accessStream[Int](_ => ZStream.fail("fail"))
+                          .provide(0)
+                          .runCollect
+                          .run
+            } yield assert(result)(fails(equalTo("fail")))
+          }
+        ),
+        testM("chunkN") {
+          checkM(tinyChunkOf(Gen.chunkOf(Gen.anyInt)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
+            val expected = Chunk.fromIterable(chunk.flatten.grouped(n).toList)
+            assertM(
+              ZStream
+                .fromChunks(chunk: _*)
+                .chunkN(n)
+                .mapChunks(ch => Chunk(ch))
+                .runCollect
+            )(equalTo(expected))
+          }
+        },
+        testM("concatAll") {
+          checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { chunks =>
+            assertM(
+              ZStream.concatAll(Chunk.fromIterable(chunks.map(ZStream.fromChunk(_)))).runCollect
+            )(
+              equalTo(Chunk.fromIterable(chunks).flatten)
+            )
+          }
+        },
+        testM("environment") {
+          for {
+            result <- ZStream.environment[String].provide("test").runCollect.map(_.head)
+          } yield assert(result)(equalTo("test"))
+        },
+        // suite("finalizer")(
+        //   testM("happy path") {
+        //     for {
+        //       log <- Ref.make[List[String]](Nil)
+        //       _ <- (for {
+        //              _ <- ZStream.bracket(log.update("Acquire" :: _))(_ => log.update("Release" :: _))
+        //              _ <- ZStream.finalizer(log.update("Use" :: _))
+        //            } yield ()).ensuring(log.update("Ensuring" :: _)).runDrain
+        //       execution <- log.get
+        //     } yield assert(execution)(equalTo(List("Ensuring", "Release", "Use", "Acquire")))
+        //   },
+        //   testM("finalizer is not run if stream is not pulled") {
+        //     for {
+        //       ref <- Ref.make(false)
+        //       _   <- ZStream.finalizer(ref.set(true)).process.use(_ => UIO.unit)
+        //       fin <- ref.get
+        //     } yield assert(fin)(isFalse)
+        //   }
+        // ),
+        testM("fromChunk") {
+          checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
+        },
+        // suite("fromChunks")(
+        //   testM("fromChunks") {
+        //     checkM(tinyListOf(Gen.chunkOf(Gen.anyInt))) { cs =>
+        //       assertM(ZStream.fromChunks(cs: _*).runCollect)(
+        //         equalTo(Chunk.fromIterable(cs).flatten)
+        //       )
+        //     }
+        //   },
+        //   testM("discards empty chunks") {
+        //     ZStream.fromChunks(Chunk(1), Chunk.empty, Chunk(1)).process.use { pull =>
+        //       assertM(nPulls(pull, 3))(equalTo(List(Right(Chunk(1)), Right(Chunk(1)), Left(None))))
+        //     }
+        //   }
+        // ),
+        suite("fromEffect")(
+          testM("failure") {
+            assertM(ZStream.fromEffect(ZIO.fail("error")).runCollect.either)(isLeft(equalTo("error")))
+          }
+        ),
+        suite("fromEffectOption")(
+          testM("emit one element with success") {
+            val fa: ZIO[Any, Option[Int], Int] = ZIO.succeed(5)
+            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(Chunk(5)))
+          },
+          testM("emit one element with failure") {
+            val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(Some(5))
+            assertM(ZStream.fromEffectOption(fa).runCollect.either)(isLeft(equalTo(5)))
+          } @@ zioTag(errors),
+          testM("do not emit any element") {
+            val fa: ZIO[Any, Option[Int], Int] = ZIO.fail(None)
+            assertM(ZStream.fromEffectOption(fa).runCollect)(equalTo(Chunk()))
+          }
+        ),
+        // suite("fromInputStream")(
+        //   testM("example 1") {
+        //     val chunkSize = ZStream.DefaultChunkSize
+        //     val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
+        //     def is        = new ByteArrayInputStream(data)
+        //     ZStream.fromInputStream(is, chunkSize).runCollect map { bytes => assert(bytes.toArray)(equalTo(data)) }
+        //   },
+        //   testM("example 2") {
+        //     checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyByte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
+        //       val is = new ByteArrayInputStream(bytes.toArray)
+        //       ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
+        //     }
+        //   }
+        // ),
+        // testM("fromIterable")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
+        //   def lazyL = l
+        //   assertM(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))
+        // }),
+        // testM("fromIterableM")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
+        //   assertM(ZStream.fromIterableM(UIO.effectTotal(l)).runCollect)(equalTo(l))
+        // }),
+        // testM("fromIterator")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
+        //   def lazyIt = l.iterator
+        //   assertM(ZStream.fromIterator(lazyIt).runCollect)(equalTo(l))
+        // }),
+        testM("fromIteratorTotal")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.anyInt))) { l =>
+          def lazyIt = l.iterator
+          assertM(ZStream.fromIteratorTotal(lazyIt).runCollect)(equalTo(l))
+        }),
+        // suite("fromIteratorManaged")(
+        //   testM("is safe to pull again after success") {
+        //     for {
+        //       ref <- Ref.make(false)
+        //       pulls <- ZStream
+        //                  .fromIteratorManaged(
+        //                    Managed.make(UIO.succeedNow(List(1, 2).iterator))(_ => ref.set(true))
+        //                  )
+        //                  .process
+        //                  .use(nPulls(_, 4))
+        //       fin <- ref.get
+        //     } yield assert(fin)(isTrue) && assert(pulls)(
+        //       equalTo(List(Right(Chunk(1)), Right(Chunk(2)), Left(None), Left(None)))
+        //     )
+        //   },
+        //   testM("is safe to pull again after failed acquisition") {
+        //     val ex = new Exception("Ouch")
+
+        //     for {
+        //       ref <- Ref.make(false)
+        //       pulls <- ZStream
+        //                  .fromIteratorManaged(Managed.make(IO.fail(ex))(_ => ref.set(true)))
+        //                  .process
+        //                  .use(nPulls(_, 3))
+        //       fin <- ref.get
+        //     } yield assert(fin)(isFalse) && assert(pulls)(
+        //       equalTo(List(Left(Some(ex)), Left(None), Left(None)))
+        //     )
+        //   },
+        //   testM("is safe to pull again after inner failure") {
+        //     val ex = new Exception("Ouch")
+        //     for {
+        //       ref <- Ref.make(false)
+        //       pulls <- ZStream
+        //                  .fromIteratorManaged(
+        //                    Managed.make(UIO.succeedNow(List(1, 2).iterator))(_ => ref.set(true))
+        //                  )
+        //                  .flatMap(n =>
+        //                    ZStream.succeed((n * 2).toString) ++ ZStream.fail(ex) ++ ZStream.succeed(
+        //                      (n * 3).toString
+        //                    )
+        //                  )
+        //                  .process
+        //                  .use(nPulls(_, 8))
+        //       fin <- ref.get
+        //     } yield assert(fin)(isTrue) && assert(pulls)(
+        //       equalTo(
+        //         List(
+        //           Right(Chunk("2")),
+        //           Left(Some(ex)),
+        //           Right(Chunk("3")),
+        //           Right(Chunk("4")),
+        //           Left(Some(ex)),
+        //           Right(Chunk("6")),
+        //           Left(None),
+        //           Left(None)
+        //         )
+        //       )
+        //     )
+        //   },
+        //   testM("is safe to pull again from a failed Managed") {
+        //     val ex = new Exception("Ouch")
+        //     ZStream
+        //       .fromIteratorManaged(Managed.fail(ex))
+        //       .process
+        //       .use(nPulls(_, 3))
+        //       .map(assert(_)(equalTo(List(Left(Some(ex)), Left(None), Left(None)))))
+        //   }
+        // ),
+        // testM("fromSchedule") {
+        //   val schedule = Schedule.exponential(1.second) <* Schedule.recurs(5)
+        //   val stream   = ZStream.fromSchedule(schedule)
+        //   val zio = for {
+        //     fiber <- stream.runCollect.fork
+        //     _     <- TestClock.adjust(62.seconds)
+        //     value <- fiber.join
+        //   } yield value
+        //   val expected = Chunk(1.seconds, 2.seconds, 4.seconds, 8.seconds, 16.seconds)
+        //   assertM(zio)(equalTo(expected))
+        // },
+        suite("fromQueue")(
+          testM("emits queued elements") {
+            assertWithChunkCoordination(List(Chunk(1, 2))) { c =>
+              assertM(for {
+                fiber <- ZStream
+                           .fromQueue(c.queue)
+                           .collectWhileSuccess
+                           .flattenChunks
+                           .tap(_ => c.proceed)
+                           .runCollect
+                           .fork
+                _      <- c.offer
+                result <- fiber.join
+              } yield result)(equalTo(Chunk(1, 2)))
+            }
+          },
+          testM("chunks up to the max chunk size") {
+            assertM(for {
+              queue <- Queue.unbounded[Int]
+              _     <- queue.offerAll(List(1, 2, 3, 4, 5, 6, 7))
+
+              result <- ZStream
+                          .fromQueue(queue, maxChunkSize = 2)
+                          .mapChunks(Chunk.single)
+                          .take(3)
+                          .runCollect
+            } yield result)(forall(hasSize(isLessThanEqualTo(2))))
+          }
+        ),
+        // testM("fromTQueue") {
+        //   TQueue.bounded[Int](5).commit.flatMap { tqueue =>
+        //     ZStream.fromTQueue(tqueue).toQueueUnbounded.use { queue =>
+        //       for {
+        //         _      <- tqueue.offerAll(List(1, 2, 3)).commit
+        //         first  <- ZStream.fromQueue(queue).take(3).runCollect
+        //         _      <- tqueue.offerAll(List(4, 5)).commit
+        //         second <- ZStream.fromQueue(queue).take(2).runCollect
+        //       } yield assert(first)(equalTo(Chunk(1, 2, 3).map(Take.single))) &&
+        //         assert(second)(equalTo(Chunk(4, 5).map(Take.single)))
+        //     }
+        //   }
+        // } @@ flaky,
+        testM("iterate")(
+          assertM(ZStream.iterate(1)(_ + 1).take(10).runCollect)(
+            equalTo(Chunk.fromIterable(1 to 10))
+          )
+        ),
+        testM("paginate") {
+          val s = (0, List(1, 2, 3))
+
+          ZStream
+            .paginate(s) {
+              case (x, Nil)      => x -> None
+              case (x, x0 :: xs) => x -> Some(x0 -> xs)
+            }
+            .runCollect
+            .map(assert(_)(equalTo(Chunk(0, 1, 2, 3))))
+        },
+        testM("paginateM") {
+          val s = (0, List(1, 2, 3))
+
+          assertM(
+            ZStream
+              .paginateM(s) {
+                case (x, Nil)      => ZIO.succeed(x -> None)
+                case (x, x0 :: xs) => ZIO.succeed(x -> Some(x0 -> xs))
+              }
+              .runCollect
+          )(equalTo(Chunk(0, 1, 2, 3)))
+        },
+        testM("paginateChunk") {
+          val s        = (Chunk.single(0), List(1, 2, 3, 4, 5))
+          val pageSize = 2
+
+          assertM(
+            ZStream
+              .paginateChunk(s) {
+                case (x, Nil) => x -> None
+                case (x, xs)  => x -> Some(Chunk.fromIterable(xs.take(pageSize)) -> xs.drop(pageSize))
+              }
+              .runCollect
+          )(equalTo(Chunk(0, 1, 2, 3, 4, 5)))
+        },
+        testM("paginateChunkM") {
+          val s        = (Chunk.single(0), List(1, 2, 3, 4, 5))
+          val pageSize = 2
+
+          assertM(
+            ZStream
+              .paginateChunkM(s) {
+                case (x, Nil) => ZIO.succeed(x -> None)
+                case (x, xs)  => ZIO.succeed(x -> Some(Chunk.fromIterable(xs.take(pageSize)) -> xs.drop(pageSize)))
+              }
+              .runCollect
+          )(equalTo(Chunk(0, 1, 2, 3, 4, 5)))
+        },
+        testM("range") {
+          assertM(ZStream.range(0, 10).runCollect)(equalTo(Chunk.fromIterable(Range(0, 10))))
+        },
+        testM("repeatEffect")(
+          assertM(
+            ZStream
+              .repeatEffect(IO.succeed(1))
+              .take(2)
+              .runCollect
+          )(equalTo(Chunk(1, 1)))
+        ),
+        suite("repeatEffectOption")(
+          testM("emit elements")(
+            assertM(
+              ZStream
+                .repeatEffectOption(IO.succeed(1))
+                .take(2)
+                .runCollect
+            )(equalTo(Chunk(1, 1)))
+          ),
+          testM("emit elements until pull fails with None")(
+            for {
+              ref <- Ref.make(0)
+              fa = for {
+                     newCount <- ref.updateAndGet(_ + 1)
+                     res      <- if (newCount >= 5) ZIO.fail(None) else ZIO.succeed(newCount)
+                   } yield res
+              res <- ZStream
+                       .repeatEffectOption(fa)
+                       .take(10)
+                       .runCollect
+            } yield assert(res)(equalTo(Chunk(1, 2, 3, 4)))
+          )
+//           testM("stops evaluating the effect once it fails with None") {
+//             for {
+//               ref <- Ref.make(0)
+//               _ <- ZStream.repeatEffectOption(ref.updateAndGet(_ + 1) *> ZIO.fail(None)).process.use { pull =>
+//                      pull.ignore *> pull.ignore
+//                    }
+//               result <- ref.get
+//             } yield assert(result)(equalTo(1))
+//           }
+        ),
+        suite("repeatEffectWith")(
+          testM("succeed")(
+            for {
+              ref <- Ref.make[List[Int]](Nil)
+              fiber <- ZStream
+                         .repeatEffectWith(ref.update(1 :: _), Schedule.spaced(10.millis))
+                         .take(2)
+                         .runDrain
+                         .fork
+              _      <- TestClock.adjust(50.millis)
+              _      <- fiber.join
+              result <- ref.get
+            } yield assert(result)(equalTo(List(1, 1)))
+          ),
+          testM("allow schedule rely on effect value")(checkNM(10)(Gen.int(1, 100)) { (length: Int) =>
+            for {
+              ref     <- Ref.make(0)
+              effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())
+              schedule = Schedule.identity[Int].whileOutput(_ < length)
+              result  <- ZStream.repeatEffectWith(effect, schedule).runCollect
+            } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
+          }),
+          testM("should perform repetitions in addition to the first execution (one repetition)") {
+            assertM(ZStream.repeatEffectWith(UIO(1), Schedule.once).runCollect)(
+              equalTo(Chunk(1, 1))
+            )
+          },
+          testM("should perform repetitions in addition to the first execution (zero repetitions)") {
+            assertM(ZStream.repeatEffectWith(UIO(1), Schedule.stop).runCollect)(
+              equalTo(Chunk(1))
+            )
+          },
+          testM("emits before delaying according to the schedule") {
+            val interval = 1.second
+
+            for {
+              collected <- Ref.make(0)
+              effect     = ZIO.unit
+              schedule   = Schedule.spaced(interval)
+              streamFiber <- ZStream
+                               .repeatEffectWith(effect, schedule)
+                               .tap(_ => collected.update(_ + 1))
+                               .runDrain
+                               .fork
+              _                      <- TestClock.adjust(0.seconds)
+              nrCollectedImmediately <- collected.get
+              _                      <- TestClock.adjust(1.seconds)
+              nrCollectedAfterDelay  <- collected.get
+              _                      <- streamFiber.interrupt
+
+            } yield assert(nrCollectedImmediately)(equalTo(1)) && assert(nrCollectedAfterDelay)(equalTo(2))
+          }
+        ),
+        testM("unfold") {
+          assertM(
+            ZStream
+              .unfold(0) { i =>
+                if (i < 10) Some((i, i + 1))
+                else None
+              }
+              .runCollect
+          )(equalTo(Chunk.fromIterable(0 to 9)))
+        },
+        testM("unfoldChunk") {
+          assertM(
+            ZStream
+              .unfoldChunk(0) { i =>
+                if (i < 10) Some((Chunk(i, i + 1), i + 2))
+                else None
+              }
+              .runCollect
+          )(equalTo(Chunk.fromIterable(0 to 9)))
+        },
+        testM("unfoldM") {
+          assertM(
+            ZStream
+              .unfoldM(0) { i =>
+                if (i < 10) IO.succeed(Some((i, i + 1)))
+                else IO.succeed(None)
+              }
+              .runCollect
+          )(equalTo(Chunk.fromIterable(0 to 9)))
+        },
+        testM("unwrapManaged") {
+          assertM(
+            ZStream.unwrapManaged {
+              ZManaged.succeed {
+                ZStream.fail("error")
+              }
+            }.runCollect.either
+          )(isLeft(equalTo("error")))
+        }
+      )
+    ) @@ TestAspect.timed
+
+  trait ChunkCoordination[A] {
+    def queue: Queue[Exit[Option[Nothing], Chunk[A]]]
+    def offer: UIO[Boolean]
+    def proceed: UIO[Unit]
+    def awaitNext: UIO[Unit]
+  }
+
+  def assertWithChunkCoordination[A](
+    chunks: List[Chunk[A]]
+  )(
+    assertion: ChunkCoordination[A] => ZIO[Clock with TestClock, Nothing, TestResult]
+  ): ZIO[Clock with TestClock, Nothing, TestResult] =
+    for {
+      q  <- Queue.unbounded[Exit[Option[Nothing], Chunk[A]]]
+      ps <- Queue.unbounded[Unit]
+      ref <- Ref
+               .make[List[List[Exit[Option[Nothing], Chunk[A]]]]](
+                 chunks.init.map { chunk =>
+                   List(Exit.succeed(chunk))
+                 } ++ chunks.lastOption.map(chunk => List(Exit.succeed(chunk), Exit.fail(None))).toList
+               )
+      chunkCoordination = new ChunkCoordination[A] {
+                            val queue = q
+                            val offer = ref.modify {
+                              case x :: xs => (x, xs)
+                              case Nil     => (Nil, Nil)
+                            }.flatMap(queue.offerAll)
+                            val proceed   = ps.offer(()).unit
+                            val awaitNext = ps.take
+                          }
+      testResult <- assertion(chunkCoordination)
+    } yield testResult
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/Take.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.stream.experimental
+
+import zio._
+
+/**
+ * A `Take[E, A]` represents a single `take` from a queue modeling a stream of
+ * values. A `Take` may be a failure cause `Cause[E]`, an chunk value `A`
+ * or an end-of-stream marker.
+ */
+case class Take[+E, +A](exit: Exit[Option[E], Chunk[A]]) extends AnyVal {
+
+  /**
+   * Transforms `Take[E, A]` to `ZIO[R, E, B]`.
+   */
+  def done[R]: ZIO[R, Option[E], Chunk[A]] =
+    IO.done(exit)
+
+  /**
+   * Folds over the failure cause, success value and end-of-stream marker to
+   * yield a value.
+   */
+  def fold[Z](end: => Z, error: Cause[E] => Z, value: Chunk[A] => Z): Z =
+    exit.fold(Cause.flipCauseOption(_).fold(end)(error), value)
+
+  /**
+   * Effectful version of [[Take#fold]].
+   *
+   * Folds over the failure cause, success value and end-of-stream marker to
+   * yield an effect.
+   */
+  def foldM[R, E1, Z](
+    end: => ZIO[R, E1, Z],
+    error: Cause[E] => ZIO[R, E1, Z],
+    value: Chunk[A] => ZIO[R, E1, Z]
+  ): ZIO[R, E1, Z] =
+    exit.foldM(Cause.flipCauseOption(_).fold(end)(error), value)
+
+  /**
+   * Checks if this `take` is done (`Take.end`).
+   */
+  def isDone: Boolean =
+    exit.fold(Cause.flipCauseOption(_).isEmpty, _ => false)
+
+  /**
+   * Checks if this `take` is a failure.
+   */
+  def isFailure: Boolean =
+    exit.fold(Cause.flipCauseOption(_).nonEmpty, _ => false)
+
+  /**
+   * Checks if this `take` is a success.
+   */
+  def isSuccess: Boolean =
+    exit.fold(_ => false, _ => true)
+
+  /**
+   * Transforms `Take[E, A]` to `Take[E, B]` by applying function `f`.
+   */
+  def map[B](f: A => B): Take[E, B] =
+    Take(exit.map(_.map(f)))
+
+  /**
+   * Returns an effect that effectfully "peeks" at the success of this take.
+   */
+  def tap[R, E1](f: Chunk[A] => ZIO[R, E1, Any]): ZIO[R, E1, Unit] =
+    exit.foreach(f).unit
+}
+
+object Take {
+
+  /**
+   * Creates a `Take[Nothing, A]` with a singleton chunk.
+   */
+  def single[A](a: A): Take[Nothing, A] =
+    Take(Exit.succeed(Chunk.single(a)))
+
+  /**
+   * Creates a `Take[Nothing, A]` with the specified chunk.
+   */
+  def chunk[A](as: Chunk[A]): Take[Nothing, A] =
+    Take(Exit.succeed(as))
+
+  /**
+   * Creates a failing `Take[E, Nothing]` with the specified failure.
+   */
+  def fail[E](e: E): Take[E, Nothing] =
+    Take(Exit.fail(Some(e)))
+
+  /**
+   * Creates an effect from `ZIO[R, E,A]` that does not fail, but succeeds with the `Take[E, A]`.
+   * Error from stream when pulling is converted to `Take.halt`. Creates a singleton chunk.
+   */
+  def fromEffect[R, E, A](zio: ZIO[R, E, A]): URIO[R, Take[E, A]] =
+    zio.foldCause(halt, single)
+
+  /**
+   * Creates effect from `Pull[R, E, A]` that does not fail, but succeeds with the `Take[E, A]`.
+   * Error from stream when pulling is converted to `Take.halt`, end of stream to `Take.end`.
+   */
+  def fromPull[R, E, A](pull: ZStream.Pull[R, E, A]): URIO[R, Take[E, A]] =
+    pull.foldCause(Cause.flipCauseOption(_).fold[Take[E, Nothing]](end)(halt), chunk)
+
+  /**
+   * Creates a failing `Take[E, Nothing]` with the specified cause.
+   */
+  def halt[E](c: Cause[E]): Take[E, Nothing] =
+    Take(Exit.halt(c.map(Some(_))))
+
+  /**
+   * Creates a failing `Take[Nothing, Nothing]` with the specified throwable.
+   */
+  def die(t: Throwable): Take[Nothing, Nothing] =
+    Take(Exit.die(t))
+
+  /**
+   * Creates a failing `Take[Nothing, Nothing]` with the specified error message.
+   */
+  def dieMessage(msg: String): Take[Nothing, Nothing] =
+    Take(Exit.die(new RuntimeException(msg)))
+
+  /**
+   * Creates a `Take[E, A]` from `Exit[E, A]`.
+   */
+  def done[E, A](exit: Exit[E, A]): Take[E, A] =
+    Take(exit.mapError[Option[E]](Some(_)).map(Chunk.single))
+
+  /**
+   * End-of-stream marker
+   */
+  val end: Take[Nothing, Nothing] =
+    Take(Exit.fail(None))
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -1,0 +1,1221 @@
+package zio.stream.experimental
+
+import zio.ZManaged.ReleaseMap
+import zio._
+import zio.stream.experimental.internal.{ AsyncInputConsumer, AsyncInputProducer, SingleProducerAsyncInput, ChannelExecutor }
+import ChannelExecutor.ChannelState
+
+/**
+ * A `ZChannel[In, Env, Err, Out, Z]` is a nexus of I/O operations, which supports both reading and
+ * writing. A channel may read values of type `In` and write values of type `Out`. When the channel
+ * finishes, it yields a value of type `Z`. A channel may fail with a value of type `Err`.
+ *
+ * Channels are the foundation of ZIO Streams: both streams and sinks are built on channels.
+ * Most users shouldn't have to use channels directly, as streams and sinks are much more convenient
+ * and cover all common use cases. However, when adding new stream and sink operators, or doing
+ * something highly specialized, it may be useful to use channels directly.
+ *
+ * Channels compose in a variety of ways:
+ *
+ *  - Piping. One channel can be piped to another channel, assuming the input type of the second
+ *    is the same as the output type of the first.
+ *  - Sequencing. The terminal value of one channel can be used to create another channel, and
+ *    both the first channel and the function that makes the second channel can be composed into a
+ *    channel.
+ *  - Concating. The output of one channel can be used to create other channels, which are all
+ *    concatenated together. The first channel and the function that makes the other channels can
+ *    be composed into a channel.
+ */
+sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone] { self =>
+
+  /**
+   * Returns a new channel that is the sequential composition of this channel and the specified
+   * channel. The returned channel terminates with a tuple of the terminal values of both channels.
+   *
+   * This is a symbol operator for [[ZChannel#zip]].
+   */
+  final def <*>[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, (OutDone, OutDone2)] =
+    self.flatMap(z => that.map(z2 => (z, z2)))
+
+  /**
+   * Returns a new channel that is the sequential composition of this channel and the specified
+   * channel. The returned channel terminates with the terminal value of the other channel.
+   *
+   * This is a symbol operator for [[ZChannel#zipRight]].
+   */
+  final def *>[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
+    self.flatMap(_ => that)
+
+  /**
+   * Returns a new channel that is the sequential composition of this channel and the specified
+   * channel. The returned channel terminates with the terminal value of this channel.
+   *
+   * This is a symbol operator for [[ZChannel#zipLeft]].
+   */
+  final def <*[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone] =
+    self.flatMap(z => that.as(z))
+
+  /**
+   * Returns a new channel that pipes the output of this channel into the specified channel.
+   * The returned channel has the input type of this channel, and the output type of the specified
+   * channel, terminating with the value of the specified channel.
+   *
+   * This is a symbolic operator for [[ZChannel##pipeTo]].
+   */
+  final def >>>[Env1 <: Env, OutErr2, OutElem2, OutDone2](
+    that: => ZChannel[Env1, OutErr, OutElem, OutDone, OutErr2, OutElem2, OutDone2]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr2, OutElem2, OutDone2] =
+    self pipeTo that
+
+  /**
+   * Returns a new channel that is the same as this one, except the terminal value of the channel
+   * is the specified constant value.
+   *
+   * This method produces the same result as mapping this channel to the specified constant value.
+   */
+  final def as[OutDone2](z2: => OutDone2): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone2] =
+    self.map(_ => z2)
+
+  /**
+   * Returns a new channel that is the same as this one, except if this channel errors for any
+   * typed error, then the returned channel will switch over to using the fallback channel returned
+   * by the specified error handler.
+   */
+  final def catchAll[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr2,
+    OutElem1 >: OutElem,
+    OutDone1 >: OutDone
+  ](
+    f: OutErr => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1] =
+    catchAllCause((cause: Cause[OutErr]) => cause.failureOrCause.fold(f(_), ZChannel.halt(_)))
+
+  /**
+   * Returns a new channel that is the same as this one, except if this channel errors for any
+   * cause at all, then the returned channel will switch over to using the fallback channel
+   * returned by the specified error handler.
+   */
+  final def catchAllCause[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr2,
+    OutElem1 >: OutElem,
+    OutDone1 >: OutDone
+  ](
+    f: Cause[OutErr] => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1] =
+    ZChannel.Fold(self, new ZChannel.Fold.K(ZChannel.Fold.successIdentity[OutDone1], f))
+
+  /**
+   * Returns a new channel whose outputs are fed to the specified factory function, which creates
+   * new channels in response. These new channels are sequentially concatenated together, and all
+   * their outputs appear as outputs of the newly returned channel.
+   */
+  final def concatMap[Env1 <: Env, InErr1 <: InErr, InElem1 <: InElem, InDone1 <: InDone, OutErr1 >: OutErr, OutElem2](
+    f: OutElem => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any] =
+    concatMapWith(f)((_, _) => (), (_, _) => ())
+
+  /**
+   * Returns a new channel whose outputs are fed to the specified factory function, which creates
+   * new channels in response. These new channels are sequentially concatenated together, and all
+   * their outputs appear as outputs of the newly returned channel. The provided merging function
+   * is used to merge the terminal values of all channels into the single terminal value of the
+   * returned channel.
+   */
+  final def concatMapWith[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem2,
+    OutDone2,
+    OutDone3
+  ](
+    f: OutElem => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone2]
+  )(
+    g: (OutDone2, OutDone2) => OutDone2,
+    h: (OutDone2, OutDone) => OutDone3
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone3] =
+    ZChannel.ConcatAll(g, h, self, f)
+
+  /**
+   * Returns a new channel, which is the same as this one, except its outputs are filtered and
+   * transformed by the specified partial function.
+   */
+  final def collect[OutElem2](
+    f: PartialFunction[OutElem, OutElem2]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone] = {
+    val pf = f.lift
+    lazy val collector: ZChannel[Env, OutErr, OutElem, OutDone, OutErr, OutElem2, OutDone] =
+      ZChannel.readWith(
+        pf(_: OutElem) match {
+          case None       => collector
+          case Some(out2) => ZChannel.write(out2) *> collector
+        },
+        (e: OutErr) => ZChannel.fail(e),
+        (z: OutDone) => ZChannel.end(z)
+      )
+
+    self pipeTo collector
+  }
+
+  /**
+   * Returns a new channel, which is the concatenation of all the channels that are written out by
+   * this channel. This method may only be called on channels that output other channels.
+   */
+  final def concatOut[Env1 <: Env, InErr1 <: InErr, InElem1 <: InElem, InDone1 <: InDone, OutErr1 >: OutErr, OutElem2](
+    implicit ev: OutElem <:< ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any] =
+    ZChannel.concatAll(self.mapOut(ev))
+
+  def contramap[InDone0](f: InDone0 => InDone): ZChannel[Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone] = {
+    lazy val reader: ZChannel[Any, InErr, InElem, InDone0, InErr, InElem, InDone] =
+      ZChannel.readWith(
+        (in: InElem) => ZChannel.write(in) *> reader,
+        (err: InErr) => ZChannel.fail(err),
+        (done0: InDone0) => ZChannel.end(f(done0))
+      )
+
+    reader >>> self
+  }
+
+  def contramapIn[InElem0](f: InElem0 => InElem): ZChannel[Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone] = {
+    lazy val reader: ZChannel[Any, InErr, InElem0, InDone, InErr, InElem, InDone] =
+      ZChannel.readWith(
+        (in: InElem0) => ZChannel.write(f(in)) *> reader,
+        (err: InErr) => ZChannel.fail(err),
+        (done: InDone) => ZChannel.end(done)
+      )
+
+    reader >>> self
+  }
+
+  def contramapM[InDone0, Env1 <: Env](
+    f: InDone0 => ZIO[Env1, InErr, InDone]
+  ): ZChannel[Env1, InErr, InElem, InDone0, OutErr, OutElem, OutDone] = {
+    lazy val reader: ZChannel[Env1, InErr, InElem, InDone0, InErr, InElem, InDone] =
+      ZChannel.readWith(
+        (in: InElem) => ZChannel.write(in) *> reader,
+        (err: InErr) => ZChannel.fail(err),
+        (done0: InDone0) => ZChannel.fromEffect(f(done0))
+      )
+
+    reader >>> self
+  }
+
+  def contramapInM[InElem0, Env1 <: Env](
+    f: InElem0 => ZIO[Env1, InErr, InElem]
+  ): ZChannel[Env1, InErr, InElem0, InDone, OutErr, OutElem, OutDone] = {
+    lazy val reader: ZChannel[Env1, InErr, InElem0, InDone, InErr, InElem, InDone] =
+      ZChannel.readWith(
+        (in: InElem0) => ZChannel.fromEffect(f(in)).flatMap(ZChannel.write(_)) *> reader,
+        (err: InErr) => ZChannel.fail(err),
+        (done: InDone) => ZChannel.end(done)
+      )
+
+    reader >>> self
+  }
+
+  /**
+   * Returns a new channel, which is the same as this one, except that all the outputs are
+   * collected and bundled into a tuple together with the terminal value of this channel.
+   *
+   * As the channel returned from this channel collect's all of this channel's output into an in-
+   * memory chunk, it is not safe to call this method on channels that output a large or unbounded
+   * number of values.
+   */
+  def doneCollect: ZChannel[Env, InErr, InElem, InDone, OutErr, Nothing, (Chunk[OutElem], OutDone)] =
+    ZChannel.unwrap {
+      UIO {
+        val builder = ChunkBuilder.make[OutElem]()
+
+        lazy val reader: ZChannel[Env, OutErr, OutElem, OutDone, OutErr, Nothing, OutDone] =
+          ZChannel.readWith(
+            (out: OutElem) => ZChannel.fromEffect(UIO(builder += out)) *> reader,
+            (e: OutErr) => ZChannel.fail(e),
+            (z: OutDone) => ZChannel.end(z)
+          )
+
+        (self pipeTo reader).mapM(z => UIO((builder.result(), z)))
+      }
+    }
+
+  /**
+   * Returns a new channel which reads all the elements from upstream's output channel
+   * and ignores them, then terminates with the upstream result value.
+   */
+  def drain: ZChannel[Env, InErr, InElem, InDone, OutErr, Nothing, OutDone] = {
+    lazy val drainer: ZChannel[Env, OutErr, OutElem, OutDone, OutErr, Nothing, OutDone] =
+      ZChannel.readWith(
+        (_: OutElem) => drainer,
+        (e: OutErr) => ZChannel.fail(e),
+        (z: OutDone) => ZChannel.end(z)
+      )
+
+    self.pipeTo(drainer)
+  }
+
+  def embedInput[InErr2, InElem2, InDone2](input: AsyncInputProducer[InErr2, InElem2, InDone2])(implicit
+    noInputErrors: Any <:< InErr,
+    noInputElements: Any <:< InElem,
+    noInputDone: Any <:< InDone
+  ): ZChannel[Env, InErr2, InElem2, InDone2, OutErr, OutElem, OutDone] =
+    ZChannel.Bridge(input, self.asInstanceOf[ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone]])
+
+  /**
+   * Returns a new channel, which is the same as this one, except it will be interrupted when the
+   * specified effect completes. If the effect completes successfully before the underlying channel
+   * is done, then the returned channel will yield the success value of the effect as its terminal
+   * value. On the other hand, if the underlying channel finishes first, then the returned channel
+   * will yield the success value of the underlying channel as its terminal value.
+   */
+  final def interruptWhen[Env1 <: Env, OutErr1 >: OutErr, OutDone1 >: OutDone](
+    io: ZIO[Env1, OutErr1, OutDone1]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem, OutDone1] =
+    self.mergeWith(ZChannel.fromEffect(io))(
+      selfDone => ZChannel.MergeDecision.done(ZIO.done(selfDone)),
+      ioDone => ZChannel.MergeDecision.done(ZIO.done(ioDone))
+    )
+
+  /**
+   * Returns a new channel, which is the same as this one, except it will be interrupted when the
+   * specified promise is completed. If the promise is completed before the underlying channel is
+   * done, then the returned channel will yield the value of the promise. Otherwise, if the
+   * underlying channel finishes first, then the returned channel will yield the value of the
+   * underlying channel.
+   */
+  final def interruptWhen[OutErr1 >: OutErr, OutDone1 >: OutDone](
+    promise: Promise[OutErr1, OutDone1]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr1, OutElem, OutDone1] =
+    interruptWhen(promise.await)
+
+  /**
+   * Returns a new channel that collects the output and terminal value of this channel, which it
+   * then writes as output of the returned channel.
+   */
+  final def emitCollect: ZChannel[Env, InErr, InElem, InDone, OutErr, (Chunk[OutElem], OutDone), Unit] =
+    doneCollect.flatMap(t => ZChannel.write(t))
+
+  /**
+   * Returns a new channel with an attached finalizer. The finalizer is guaranteed to be executed
+   * so long as the channel begins execution (and regardless of whether or not it completes).
+   */
+  final def ensuringWith[Env1 <: Env](
+    finalizer: Exit[OutErr, OutDone] => URIO[Env1, Any]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.Ensuring(self, finalizer)
+
+  final def ensuring[Env1 <: Env](
+    finalizer: URIO[Env1, Any]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ensuringWith(_ => finalizer)
+
+  /**
+   * Returns a new channel, which sequentially combines this channel, together with the provided
+   * factory function, which creates a second channel based on the terminal value of this channel.
+   * The result is a channel that will first perform the functions of this channel, before
+   * performing the functions of the created channel (including yielding its terminal value).
+   */
+  final def flatMap[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    f: OutDone => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
+    ZChannel.Fold(self, new ZChannel.Fold.K(f, ZChannel.Fold.haltIdentity[OutErr1]))
+
+  /**
+   * Returns a new channel, which flattens the terminal value of this channel. This function may
+   * only be called if the terminal value of this channel is another channel of compatible types.
+   */
+  final def flatten[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](implicit
+    ev: OutDone <:< ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
+    self.flatMap(ev)
+
+  /**
+   *
+   */
+  final def foldM[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1,
+    OutElem1 >: OutElem,
+    OutDone1
+  ](
+    onErr: OutErr => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1],
+    onSucc: OutDone => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1] =
+    foldCauseM(
+      _.failureOrCause match {
+        case Left(err)    => onErr(err)
+        case Right(cause) => ZChannel.halt(cause)
+      },
+      onSucc
+    )
+
+  /**
+   *
+   */
+  final def foldCauseM[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1,
+    OutElem1 >: OutElem,
+    OutDone1
+  ](
+    onErr: Cause[OutErr] => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1],
+    onSucc: OutDone => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone1] =
+    ZChannel.Fold(self, new ZChannel.Fold.K(onSucc, onErr))
+
+  /**
+   * Returns a new channel that will perform the operations of this one, until failure, and then
+   * it will switch over to the operations of the specified fallback channel.
+   */
+  final def orElse[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr2,
+    OutElem1 >: OutElem,
+    OutDone1 >: OutDone
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1] =
+    self.catchAll(_ => that)
+
+  /**
+   * Returns a new channel, which is the same as this one, except the terminal value of the
+   * returned channel is created by applying the specified function to the terminal value of this
+   * channel.
+   */
+  final def map[OutDone2](f: OutDone => OutDone2): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone2] =
+    self.flatMap(z => ZChannel.succeed(f(z)))
+
+  /**
+   * Returns a new channel, which is the same as this one, except the failure value of the returned
+   * channel is created by applying the specified function to the failure value of this channel.
+   */
+  final def mapError[OutErr2](f: OutErr => OutErr2): ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem, OutDone] =
+    catchAllCause((cause: Cause[OutErr]) => cause.failureOrCause.fold(err => ZChannel.fail(f(err)), ZChannel.halt(_)))
+
+  /**
+   * Returns a new channel, which is the same as this one, except the terminal value of the
+   * returned channel is created by applying the specified effectful function to the terminal value
+   * of this channel.
+   */
+  final def mapM[Env1 <: Env, OutErr1 >: OutErr, OutDone2](
+    f: OutDone => ZIO[Env1, OutErr1, OutDone2]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem, OutDone2] =
+    self.flatMap(z => ZChannel.fromEffect(f(z)))
+
+  /**
+   * Returns a new channel, which is the merge of this channel and the specified channel, where
+   * the behavior of the returned channel on left or right early termination is decided by the
+   * specified `leftDone` and `rightDone` merge decisions.
+   */
+  final def mergeWith[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr2,
+    OutErr3,
+    OutElem1 >: OutElem,
+    OutDone2,
+    OutDone3
+  ](that: ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone2])(
+    leftDone: Exit[OutErr, OutDone] => ZChannel.MergeDecision[Env1, OutErr2, OutDone2, OutErr3, OutDone3],
+    rightDone: Exit[OutErr2, OutDone2] => ZChannel.MergeDecision[Env1, OutErr, OutDone, OutErr3, OutDone3]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr3, OutElem1, OutDone3] = {
+    sealed trait MergeState
+    case class BothRunning(
+      left: Fiber[Either[OutErr, OutDone], OutElem1],
+      right: Fiber[Either[OutErr2, OutDone2], OutElem1]
+    ) extends MergeState
+    case class LeftDone(
+      f: Exit[OutErr2, OutDone2] => ZIO[Env1, OutErr3, OutDone3]
+    ) extends MergeState
+    case class RightDone(
+      f: Exit[OutErr, OutDone] => ZIO[Env1, OutErr3, OutDone3]
+    ) extends MergeState
+
+    val m =
+      for {
+        input      <- SingleProducerAsyncInput.make[InErr1, InElem1, InDone1].toManaged_
+        queueReader = ZChannel.fromInput(input)
+        pullL      <- (queueReader >>> self).toPull
+        pullR      <- (queueReader >>> that).toPull
+      } yield {
+        def handleSide[Err, Done, Err2, Done2](
+          exit: Exit[Either[Err, Done], OutElem1],
+          fiber: Fiber[Either[Err2, Done2], OutElem1],
+          pull: ZIO[Env1, Either[Err, Done], OutElem1]
+        )(
+          done: Exit[Err, Done] => ZChannel.MergeDecision[Env1, Err2, Done2, OutErr3, OutDone3],
+          both: (Fiber[Either[Err, Done], OutElem1], Fiber[Either[Err2, Done2], OutElem1]) => BothRunning,
+          single: (Exit[Err2, Done2] => ZIO[Env1, OutErr3, OutDone3]) => MergeState
+        ) =
+          exit match {
+            case Exit.Success(elem) =>
+              pull.fork.map { leftFiber =>
+                ZChannel.write(elem) *> go(both(leftFiber, fiber))
+              }
+
+            case Exit.Failure(cause) =>
+              done(Cause.flipCauseEither(cause).fold(Exit.halt(_), Exit.succeed(_))) match {
+                case ZChannel.MergeDecision.Done(zio) =>
+                  UIO.succeed(ZChannel.fromEffect(fiber.interrupt *> zio))
+                case ZChannel.MergeDecision.Await(f) =>
+                  fiber.await.map {
+                    case Exit.Success(elem) => ZChannel.write(elem) *> go(single(f))
+                    case Exit.Failure(cause) =>
+                      ZChannel
+                        .fromEffect(f(Cause.flipCauseEither(cause).fold(Exit.halt(_), Exit.succeed(_))))
+                  }
+              }
+          }
+
+        def go(state: MergeState): ZChannel[Env1, Any, Any, Any, OutErr3, OutElem1, OutDone3] =
+          state match {
+            case BothRunning(leftFiber, rightFiber) =>
+              val lj: ZIO[Env1, Either[OutErr, OutDone], OutElem1]   = leftFiber.join
+              val rj: ZIO[Env1, Either[OutErr2, OutDone2], OutElem1] = rightFiber.join
+
+              ZChannel.unwrap {
+                lj.raceWith(rj)(
+                  (leftEx, _) => handleSide(leftEx, rightFiber, pullL)(leftDone, BothRunning(_, _), LeftDone(_)),
+                  (rightEx, _) =>
+                    handleSide(rightEx, leftFiber, pullR)(rightDone, (l, r) => BothRunning(r, l), RightDone(_))
+                )
+              }
+
+            case LeftDone(f) =>
+              ZChannel.unwrap {
+                pullR.run.map {
+                  case Exit.Success(elem) => ZChannel.write(elem) *> go(LeftDone(f))
+                  case Exit.Failure(cause) =>
+                    ZChannel
+                      .fromEffect(f(Cause.flipCauseEither(cause).fold(Exit.halt(_), Exit.succeed(_))))
+                }
+              }
+
+            case RightDone(f) =>
+              ZChannel.unwrap {
+                pullL.run.map {
+                  case Exit.Success(elem) => ZChannel.write(elem) *> go(RightDone(f))
+                  case Exit.Failure(cause) =>
+                    ZChannel
+                      .fromEffect(f(Cause.flipCauseEither(cause).fold(Exit.halt(_), Exit.succeed(_))))
+                }
+              }
+          }
+
+        ZChannel.fromEffect(pullL.fork.zipWith(pullR.fork)(BothRunning(_, _))).flatMap(go).embedInput(input)
+      }
+
+    ZChannel.unwrapManaged(m)
+  }
+
+  def mergeMap[Env1 <: Env, InErr1 <: InErr, InElem1 <: InElem, InDone1 <: InDone, OutErr1 >: OutErr, OutElem2](
+    n: Long
+  )(
+    f: OutElem => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any] =
+    ZChannel.mergeAll(self.mapOut(f), n)
+
+  def mergeMapWith[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem2,
+    OutDone1 >: OutDone
+  ](n: Long)(
+    f: OutElem => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone1]
+  )(g: (OutDone1, OutDone1) => OutDone1): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone1] =
+    ???
+
+  def mapOut[OutElem2](f: OutElem => OutElem2): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone] = {
+    lazy val reader: ZChannel[Env, OutErr, OutElem, OutDone, OutErr, OutElem2, OutDone] =
+      ZChannel.readWith(
+        out => ZChannel.write(f(out)) *> reader,
+        (e: OutErr) => ZChannel.fail(e),
+        (z: OutDone) => ZChannel.end(z)
+      )
+
+    self >>> reader
+  }
+
+  def mapOutM[Env1 <: Env, OutErr1 >: OutErr, OutElem2](
+    f: OutElem => ZIO[Env1, OutErr1, OutElem2]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem2, OutDone] = {
+    lazy val reader: ZChannel[Env1, OutErr, OutElem, OutDone, OutErr1, OutElem2, OutDone] =
+      ZChannel.readWith(
+        (out: OutElem) => ZChannel.fromEffect(f(out)).flatMap(ZChannel.write(_)) *> reader,
+        (e: OutErr1) => ZChannel.fail(e),
+        (z: OutDone) => ZChannel.end(z)
+      )
+
+    self >>> reader
+  }
+
+  def mergeOut[Env1 <: Env, InErr1 <: InErr, InElem1 <: InElem, InDone1 <: InDone, OutErr1 >: OutErr, OutElem2](
+    n: Long
+  )(implicit
+    ev: OutElem <:< ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, Any] =
+    ZChannel.mergeAll(self.mapOut(ev), n)
+
+  def mergeOutWith[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem2,
+    OutDone1 >: OutDone
+  ](n: Long)(f: (OutDone1, OutDone1) => OutDone1)(implicit
+    ev: OutElem <:< ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone1]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone1] =
+    ZChannel.mergeAllWith(self.mapOut(ev), n)(f)
+
+  lazy val never: ZChannel[Any, Any, Any, Any, Nothing, Nothing, Nothing] =
+    ZChannel.fromEffect(ZIO.never)
+
+  def orDie(implicit ev: OutErr <:< Throwable): ZChannel[Env, InErr, InElem, InDone, Nothing, OutElem, OutDone] =
+    orDieWith(ev)
+
+  def orDieWith(f: OutErr => Throwable): ZChannel[Env, InErr, InElem, InDone, Nothing, OutElem, OutDone] =
+    self.catchAll(e => throw f(e))
+
+  def pipeTo[Env1 <: Env, OutErr2, OutElem2, OutDone2](
+    that: => ZChannel[Env1, OutErr, OutElem, OutDone, OutErr2, OutElem2, OutDone2]
+  ): ZChannel[Env1, InErr, InElem, InDone, OutErr2, OutElem2, OutDone2] =
+    ZChannel.PipeTo(() => self, () => that)
+
+  /**
+   * Provides the channel with its required environment, which eliminates
+   * its dependency on `Env`.
+   */
+  final def provide(env: Env)(implicit
+    ev: NeedsEnv[Env]
+  ): ZChannel[Any, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.Provide(env, self)
+
+  def repeated: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Nothing] =
+    self *> self.repeated
+
+  def runManaged(implicit
+    ev1: Any <:< InElem,
+    ev2: OutElem <:< Nothing
+  ): ZManaged[Env, OutErr, OutDone] =
+    ZManaged
+      .makeExit(
+        UIO(new ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](() => self, null))
+      ) { (exec, exit) =>
+        val finalize = exec.close(exit)
+        if (finalize ne null) finalize
+        else ZIO.unit
+      }
+      .mapM { exec =>
+        ZIO.effectSuspendTotal {
+          def interpret(channelState: ChannelExecutor.ChannelState[Env, OutErr]): ZIO[Env, OutErr, OutDone] =
+            channelState match {
+              case ChannelState.Effect(zio) =>
+                zio *> interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+              case ChannelState.Emit =>
+                // Can't really happen because Out <:< Nothing. So just skip ahead.
+                interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+              case ChannelState.Done =>
+                ZIO.done(exec.getDone)
+            }
+
+          interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+        }
+      }
+
+  def run(implicit ev1: Any <:< InElem, ev2: OutElem <:< Nothing): ZIO[Env, OutErr, OutDone] =
+    runManaged.useNow
+
+  def runCollect(implicit ev1: Any <:< InElem): ZIO[Env, OutErr, (Chunk[OutElem], OutDone)] =
+    doneCollect.run
+
+  def runDrain(implicit ev1: Any <:< InElem): ZIO[Env, OutErr, OutDone] =
+    self.drain.run
+
+  def unit: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Unit] =
+    self.as(())
+
+  def toPull: ZManaged[Env, Nothing, ZIO[Env, Either[OutErr, OutDone], OutElem]] =
+    ZManaged
+      .makeExit(
+        UIO(new ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](() => self, null))
+      ) { (exec, exit) =>
+        val finalize = exec.close(exit)
+        if (finalize ne null) finalize
+        else ZIO.unit
+      }
+      .map { exec =>
+        def interpret(
+          channelState: ChannelExecutor.ChannelState[Env, OutErr]
+        ): ZIO[Env, Either[OutErr, OutDone], OutElem] =
+          channelState match {
+            case ChannelState.Done =>
+              exec.getDone match {
+                case Exit.Success(done)  => ZIO.fail(Right(done))
+                case Exit.Failure(cause) => ZIO.halt(cause.map(Left(_)))
+              }
+            case ChannelState.Emit =>
+              ZIO.succeed(exec.getEmit)
+            case ChannelState.Effect(zio) =>
+              zio.mapError(Left(_)) *>
+                interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+          }
+
+        ZIO.effectSuspendTotal(interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]]))
+      }
+
+  def zip[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, (OutDone, OutDone2)] =
+    self.flatMap(l => that.map(r => (l, r)))
+
+  def zipOutWith[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem2,
+    OutElem3,
+    OutDone2
+  ](that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem2, OutDone2])(
+    f: (OutElem, OutElem2) => OutElem3
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem3, (OutDone, OutDone2)] =
+    ???
+
+  def zipLeft[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone] =
+    (self zip that).map(_._1)
+
+  def zipPar[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, (OutDone, OutDone2)] =
+    self.mergeWith(that)(
+      exit1 =>
+        ZChannel.MergeDecision.Await[Env1, OutErr1, OutDone2, OutErr1, (OutDone, OutDone2)](exit2 =>
+          ZIO.done(exit1.zip(exit2))
+        ),
+      exit2 =>
+        ZChannel.MergeDecision.Await[Env1, OutErr1, OutDone, OutErr1, (OutDone, OutDone2)](exit1 =>
+          ZIO.done(exit1.zip(exit2))
+        )
+    )
+
+  def zipParLeft[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone] =
+    (self zipPar that).map(_._1)
+
+  def zipParRight[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
+    (self zipPar that).map(_._2)
+
+  def zipRight[
+    Env1 <: Env,
+    InErr1 <: InErr,
+    InElem1 <: InElem,
+    InDone1 <: InDone,
+    OutErr1 >: OutErr,
+    OutElem1 >: OutElem,
+    OutDone2
+  ](
+    that: => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2]
+  ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
+    (self zip that).map(_._2)
+}
+
+object ZChannel {
+  private[zio] final case class PipeTo[
+    Env,
+    InErr,
+    InElem,
+    InDone,
+    OutErr,
+    OutErr2,
+    OutElem,
+    OutElem2,
+    OutDone,
+    OutDone2
+  ](
+    left: () => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    right: () => ZChannel[Env, OutErr, OutElem, OutDone, OutErr2, OutElem2, OutDone2]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem2, OutDone2]
+
+  private[zio] final case class Read[Env, InErr, InElem, InDone, OutErr, OutErr2, OutElem, OutElem2, OutDone, OutDone2](
+    more: InElem => ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem2, OutDone2],
+    done: Fold.K[Env, InErr, InElem, InDone, OutErr, OutErr2, OutElem2, OutDone, OutDone2]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem2, OutDone2]
+  private[zio] final case class Done[OutDone](terminal: OutDone)
+      extends ZChannel[Any, Any, Any, Any, Nothing, Nothing, OutDone]
+  private[zio] final case class Halt[OutErr](error: () => Cause[OutErr])
+      extends ZChannel[Any, Any, Any, Any, OutErr, Nothing, Nothing]
+  private[zio] final case class Effect[Env, OutErr, OutDone](zio: ZIO[Env, OutErr, OutDone])
+      extends ZChannel[Env, Any, Any, Any, OutErr, Nothing, OutDone]
+  private[zio] final case class Emit[OutElem](out: OutElem) extends ZChannel[Any, Any, Any, Any, Nothing, OutElem, Unit]
+  private[zio] final case class Ensuring[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channel: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    finalizer: Exit[OutErr, OutDone] => ZIO[Env, Nothing, Any]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  private[zio] final case class ConcatAll[
+    Env,
+    InErr,
+    InElem,
+    InDone,
+    OutErr,
+    OutElem,
+    OutElem2,
+    OutDone,
+    OutDone2,
+    OutDone3
+  ](
+    combineInners: (OutDone, OutDone) => OutDone,
+    combineAll: (OutDone, OutDone2) => OutDone3,
+    value: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone2],
+    k: OutElem => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone3]
+  private[zio] final case class Fold[Env, InErr, InElem, InDone, OutErr, OutErr2, OutElem, OutDone, OutDone2](
+    value: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    k: Fold.K[Env, InErr, InElem, InDone, OutErr, OutErr2, OutElem, OutDone, OutDone2]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem, OutDone2]
+  object Fold {
+    sealed abstract class Continuation[-Env, -InErr, -InElem, -InDone, OutErr, +OutErr2, +OutElem, OutDone, +OutDone2]
+    private[zio] final case class K[-Env, -InErr, -InElem, -InDone, OutErr, +OutErr2, +OutElem, OutDone, +OutDone2](
+      onSuccess: OutDone => ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem, OutDone2],
+      onHalt: Cause[OutErr] => ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem, OutDone2]
+    ) extends Continuation[Env, InErr, InElem, InDone, OutErr, OutErr2, OutElem, OutDone, OutDone2] {
+      def onExit(exit: Exit[OutErr, OutDone]): ZChannel[Env, InErr, InElem, InDone, OutErr2, OutElem, OutDone2] =
+        exit match {
+          case Exit.Success(value) => onSuccess(value)
+          case Exit.Failure(cause) => onHalt(cause)
+        }
+    }
+    private[zio] final case class Finalizer[Env, OutErr, OutDone](finalizer: Exit[OutErr, OutDone] => URIO[Env, Any])
+        extends Continuation[Env, Any, Any, Any, OutErr, Nothing, Nothing, OutDone, Nothing]
+
+    private[this] val SuccessIdentity: Any => ZChannel[Any, Any, Any, Any, Nothing, Nothing, Any] =
+      ZChannel.end(_)
+    def successIdentity[Z]: Z => ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
+      SuccessIdentity.asInstanceOf[Z => ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z]]
+
+    private[this] val HaltIdentity: Cause[Any] => ZChannel[Any, Any, Any, Any, Any, Nothing, Nothing] =
+      ZChannel.halt(_)
+    def haltIdentity[E]: Cause[E] => ZChannel[Any, Any, Any, Any, E, Nothing, Nothing] =
+      HaltIdentity.asInstanceOf[Cause[E] => ZChannel[Any, Any, Any, Any, E, Nothing, Nothing]]
+  }
+
+  private[zio] final case class Bridge[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone](
+    input: AsyncInputProducer[InErr, InElem, InDone],
+    channel: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+
+  private[zio] final case class BracketOut[R, E, Z](
+    acquire: ZIO[R, E, Z],
+    finalizer: (Z, Exit[Any, Any]) => URIO[R, Any]
+  ) extends ZChannel[R, Any, Any, Any, E, Z, Unit]
+
+  private[zio] final case class Provide[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    environment: Env,
+    inner: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ) extends ZChannel[Any, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+
+  sealed abstract class MergeDecision[-R, -E0, -Z0, +E, +Z]
+  object MergeDecision {
+    case class Done[R, E, Z](zio: ZIO[R, E, Z])                        extends MergeDecision[R, Any, Any, E, Z]
+    case class Await[R, E0, Z0, E, Z](f: Exit[E0, Z0] => ZIO[R, E, Z]) extends MergeDecision[R, E0, Z0, E, Z]
+
+    def done[R, E, Z](zio: ZIO[R, E, Z]): MergeDecision[R, Any, Any, E, Z]                      = Done(zio)
+    def await[R, E0, Z0, E, Z](f: Exit[E0, Z0] => ZIO[R, E, Z]): MergeDecision[R, E0, Z0, E, Z] = Await(f)
+    def awaitConst[R, E, Z](zio: ZIO[R, E, Z]): MergeDecision[R, Any, Any, E, Z]                = Await(_ => zio)
+  }
+
+  def bracketOut[Env, OutErr, Acquired](acquire: ZIO[Env, OutErr, Acquired])(
+    release: Acquired => URIO[Env, Any]
+  ): ZChannel[Env, Any, Any, Any, OutErr, Acquired, Unit] =
+    bracketOutExit(acquire)((z, _) => release(z))
+
+  def bracketOutExit[Env, OutErr, Acquired](acquire: ZIO[Env, OutErr, Acquired])(
+    release: (Acquired, Exit[Any, Any]) => URIO[Env, Any]
+  ): ZChannel[Env, Any, Any, Any, OutErr, Acquired, Unit] =
+    BracketOut(acquire, release)
+
+  def bracket[Env, InErr, InElem, InDone, OutErr, Acquired, OutElem2, OutDone](
+    acquire: ZIO[Env, OutErr, Acquired]
+  )(release: Acquired => URIO[Env, Any])(
+    use: Acquired => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone] =
+    bracketExit(acquire)((a, (_: Exit[OutErr, OutDone])) => release(a))(use)
+
+  def bracketExit[Env, InErr, InElem, InDone, OutErr, Acquired, OutElem2, OutDone](
+    acquire: ZIO[Env, OutErr, Acquired]
+  )(release: (Acquired, Exit[OutErr, OutDone]) => URIO[Env, Any])(
+    use: Acquired => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone] =
+    fromEffect(Ref.make[Exit[OutErr, OutDone] => URIO[Env, Any]](_ => UIO.unit)).flatMap { ref =>
+      fromEffect(acquire.tap(a => ref.set(release(a, _))).uninterruptible)
+        .flatMap(use)
+        .ensuringWith(ex => ref.get.flatMap(_.apply(ex)))
+    }
+
+  /**
+   * Creates a channel backed by a buffer. When the buffer is empty, the channel will simply
+   * passthrough its input as output. However, when the buffer is non-empty, the value inside
+   * the buffer will be passed along as output.
+   */
+  def buffer[InErr, InElem, InDone](
+    empty: InElem,
+    isEmpty: InElem => Boolean,
+    ref: Ref[InElem]
+  ): ZChannel[Any, InErr, InElem, InDone, InErr, InElem, InDone] =
+    unwrap(
+      ref.modify { v =>
+        if (isEmpty(v))
+          (
+            ZChannel.readWith(
+              (in: InElem) => ZChannel.write(in) *> buffer(empty, isEmpty, ref),
+              (err: InErr) => ZChannel.fail(err),
+              (done: InDone) => ZChannel.end(done)
+            ),
+            v
+          )
+        else
+          (ZChannel.write(v) *> buffer(empty, isEmpty, ref), empty)
+      }
+    )
+
+  def bufferChunk[InErr, InElem, InDone](
+    ref: Ref[Chunk[InElem]]
+  ): ZChannel[Any, InErr, Chunk[InElem], InDone, InErr, Chunk[InElem], InDone] =
+    buffer[InErr, Chunk[InElem], InDone](Chunk.empty, _.isEmpty, ref)
+
+  def concatAll[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any],
+      Any
+    ]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any] =
+    concatAllWith(channels)((_, _) => (), (_, _) => ())
+
+  def concatAllWith[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, OutDone2, OutDone3](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+      OutDone2
+    ]
+  )(
+    f: (OutDone, OutDone) => OutDone,
+    g: (OutDone, OutDone2) => OutDone3
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone3] =
+    ConcatAll(f, g, channels, (channel: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]) => channel)
+
+  def end[Z](result: => Z): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
+    Done(result)
+
+  def endWith[R, Z](f: R => Z): ZChannel[R, Any, Any, Any, Nothing, Nothing, Z] =
+    ZChannel.fromEffect(ZIO.access[R](f))
+
+  def write[Out](out: Out): ZChannel[Any, Any, Any, Any, Nothing, Out, Unit] =
+    Emit(out)
+
+  def writeAll[Out](outs: Out*): ZChannel[Any, Any, Any, Any, Nothing, Out, Unit] =
+    outs.foldRight(ZChannel.end(()): ZChannel[Any, Any, Any, Any, Nothing, Out, Unit])((out, conduit) =>
+      write(out) *> conduit
+    )
+
+  def fail[E](e: => E): ZChannel[Any, Any, Any, Any, E, Nothing, Nothing] =
+    halt(Cause.fail(e))
+
+  def fromEffect[R, E, A](zio: ZIO[R, E, A]): ZChannel[R, Any, Any, Any, E, Nothing, A] =
+    Effect(zio)
+
+  def fromEither[E, A](either: Either[E, A]): ZChannel[Any, Any, Any, Any, E, Nothing, A] =
+    either.fold(ZChannel.fail(_), ZChannel.succeed(_))
+
+  def fromOption[A](option: Option[A]): ZChannel[Any, Any, Any, Any, None.type, Nothing, A] =
+    option.fold[ZChannel[Any, Any, Any, Any, None.type, Nothing, A]](ZChannel.fail(None))(ZChannel.succeed(_))
+
+  def halt[E](cause: => Cause[E]): ZChannel[Any, Any, Any, Any, E, Nothing, Nothing] =
+    Halt(() => cause)
+
+  def identity[Err, Elem, Done]: ZChannel[Any, Err, Elem, Done, Err, Elem, Done] =
+    readWith(
+      (in: Elem) => write(in) *> identity[Err, Elem, Done],
+      (err: Err) => fail(err),
+      (done: Done) => end(done)
+    )
+
+  def interrupt(fiberId: Fiber.Id): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Nothing] =
+    halt(Cause.interrupt(fiberId))
+
+  def managed[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, A](m: ZManaged[Env, OutErr, A])(
+    use: A => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    bracket[Env, InErr, InElem, InDone, OutErr, ReleaseMap, OutElem, OutDone](ReleaseMap.make)(
+      _.releaseAll(
+        Exit.unit, // FIXME: BracketOut should be BracketOutExit
+        ExecutionStrategy.Sequential
+      )
+    ) { releaseMap =>
+      fromEffect[Env, OutErr, A](
+        m.zio
+          .provideSome[Env]((_, releaseMap))
+          .map(_._2)
+      )
+        .flatMap(use)
+    }
+
+  def managedOut[R, E, A](m: ZManaged[R, E, A]): ZChannel[R, Any, Any, Any, E, A, Any] =
+    bracketOut(ReleaseMap.make)(
+      _.releaseAll(
+        Exit.unit, // FIXME: BracketOut should be BracketOutExit
+        ExecutionStrategy.Sequential
+      )
+    ).concatMap { releaseMap =>
+      fromEffect(m.zio.provideSome[R]((_, releaseMap)).map(_._2)).flatMap(write(_))
+    }
+
+  def mergeAll[Env, InErr, InElem, InDone, OutErr, OutElem](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any],
+      Any
+    ],
+    n: Long
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any] =
+    mergeAllWith(channels, n)((_, _) => ())
+
+  def mergeAllUnbounded[Env, InErr, InElem, InDone, OutErr, OutElem](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any],
+      Any
+    ]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Any] =
+    mergeAll(channels, Long.MaxValue)
+
+  def mergeAllUnboundedWith[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+      OutDone
+    ]
+  )(f: (OutDone, OutDone) => OutDone): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    mergeAllWith(channels, Long.MaxValue)(f)
+
+  def mergeAllWith[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channels: ZChannel[
+      Env,
+      InErr,
+      InElem,
+      InDone,
+      OutErr,
+      ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+      OutDone
+    ],
+    n: Long
+  )(f: (OutDone, OutDone) => OutDone): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ???
+
+  def readWithCause[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    in: InElem => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    halt: Cause[InErr] => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    done: InDone => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    Read[Env, InErr, InElem, InDone, InErr, OutErr, OutElem, OutElem, InDone, OutDone](in, new Fold.K(done, halt))
+
+  def readWith[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    in: InElem => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    error: InErr => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+    done: InDone => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    readWithCause(in, (c: Cause[InErr]) => c.failureOrCause.fold(error, ZChannel.halt(_)), done)
+
+  def readOrFail[E, In](e: E): ZChannel[Any, Any, In, Any, E, Nothing, In] =
+    Read[Any, Any, In, Any, Any, E, Nothing, Nothing, In, In](
+      in => Done(in),
+      new Fold.K((_: Any) => ZChannel.fail(e), (_: Any) => ZChannel.fail(e))
+    )
+
+  def read[In]: ZChannel[Any, Any, In, Any, None.type, Nothing, In] =
+    readOrFail(None)
+
+  def succeed[Z](z: => Z): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
+    end(z)
+
+  val unit: ZChannel[Any, Any, Any, Any, Nothing, Nothing, Unit] =
+    succeed(())
+
+  def unwrap[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channel: ZIO[Env, OutErr, ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.fromEffect(channel).flatten
+
+  def unwrapManaged[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+    channel: ZManaged[Env, OutErr, ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]]
+  ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.concatAllWith(managedOut(channel))((d, _) => d, (d, _) => d)
+
+  def fromInput[Err, Elem, Done](
+    input: AsyncInputConsumer[Err, Elem, Done]
+  ): ZChannel[Any, Any, Any, Any, Err, Elem, Done] =
+    ZChannel.unwrap(
+      input.takeWith(
+        ZChannel.halt(_),
+        ZChannel.write(_) *> fromInput(input),
+        ZChannel.end(_)
+      )
+    )
+
+  def fromQueue[Err, Done, Elem](
+    queue: Dequeue[Exit[Either[Err, Done], Elem]]
+  ): ZChannel[Any, Any, Any, Any, Err, Elem, Done] =
+    ZChannel.fromEffect(queue.take).flatMap {
+      case Exit.Success(elem) => write(elem) *> fromQueue(queue)
+      case Exit.Failure(cause) =>
+        Cause.flipCauseEither(cause) match {
+          case Left(cause) => halt(cause)
+          case Right(done) => end(done)
+        }
+    }
+
+  def toQueue[Err, Done, Elem](
+    queue: Queue[Exit[Either[Err, Done], Elem]]
+  ): ZChannel[Any, Err, Elem, Done, Nothing, Nothing, Any] =
+    ZChannel.readWithCause(
+      (in: Elem) => ZChannel.fromEffect(queue.offer(Exit.succeed(in))) *> toQueue(queue),
+      (cause: Cause[Err]) => ZChannel.fromEffect(queue.offer(Exit.halt(cause.map(Left(_))))),
+      (done: Done) => ZChannel.fromEffect(queue.offer(Exit.fail(Right(done))))
+    )
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZPipeline.scala
@@ -1,0 +1,306 @@
+package zio.stream.experimental
+
+import zio._
+
+/**
+ * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer. Pipelines accept a stream
+ * as input, and return the transformed stream as output.
+ *
+ * Pipelines can be thought of as a recipe for calling a bunch of methods on a source stream, to
+ * yield a new (transformed) stream. A nice mental model is the following type alias:
+ *
+ * {{{
+ * type ZPipeline[Env, Err, In, Out] = ZStream[Env, Err, In] => ZStream[Env, Err, Out]
+ * }}}
+ *
+ * This encoding of a pipeline with a type alias is not used because it does not infer well.
+ * In its place, this trait captures the polymorphism inherent to many pipelines, which can
+ * therefore be more flexible about the environment and error types of the streams they transform.
+ *
+ * There is no fundamental requirement for pipelines to exist, because everything pipelines do
+ * can be done directly on a stream. However, because pipelines separate the stream transformation
+ * from the source stream itself, it becomes possible to abstract over stream transformations at the
+ * level of values, creating, storing, and passing around reusable transformation pipelines that can
+ * be applied to many different streams.
+ *
+ * The most common way to create a pipeline is to convert a sink into a pipeline (in general,
+ * transforming elements of a stream requires the power of a sink). However, the companion object
+ * has lots of other pipeline constructors based on the methods of stream.
+ */
+trait ZPipeline[-Env, +Err, -In, +Out] { self =>
+
+  /**
+   * Composes two pipelines into one pipeline, by first applying the transformation of this
+   * pipeline, and then applying the transformation of the specified pipeline.
+   */
+  final def >>>[Env1 <: Env, Err1 >: Err, Out2](
+    that: ZPipeline[Env1, Err1, Out, Out2]
+  ): ZPipeline[Env1, Err1, In, Out2] =
+    new ZPipeline[Env1, Err1, In, Out2] {
+      def apply[Env0 <: Env1, Err0 >: Err1](stream: ZStream[Env0, Err0, In]): ZStream[Env0, Err0, Out2] =
+        that(self(stream))
+    }
+
+  /**
+   * Composes two pipelines into one pipeline, by first applying the transformation of the
+   * specified pipeline, and then applying the transformation of this pipeline.
+   */
+  final def <<<[Env1 <: Env, Err1 >: Err, In2](
+    that: ZPipeline[Env1, Err1, In2, In]
+  ): ZPipeline[Env1, Err1, In2, Out] = self.compose(that)
+
+  /**
+   * A named version of the `>>>` operator.
+   */
+  final def andThen[Env1 <: Env, Err1 >: Err, Out2](
+    that: ZPipeline[Env1, Err1, Out, Out2]
+  ): ZPipeline[Env1, Err1, In, Out2] =
+    (self andThen that)
+
+  def apply[Env1 <: Env, Err1 >: Err](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, Out]
+
+  /**
+   * A named version of the `<<<` operator.
+   */
+  final def compose[Env1 <: Env, Err1 >: Err, In2](
+    that: ZPipeline[Env1, Err1, In2, In]
+  ): ZPipeline[Env1, Err1, In2, Out] =
+    new ZPipeline[Env1, Err1, In2, Out] {
+      def apply[Env0 <: Env1, Err0 >: Err1](stream: ZStream[Env0, Err0, In2]): ZStream[Env0, Err0, Out] =
+        self(that(stream))
+    }
+}
+object ZPipeline {
+
+  /**
+   * A shorter version of [[ZPipeline.identity]], which can facilitate more compact definition
+   * of pipelines.
+   *
+   * {{{
+   * ZPipeline[Int].filter(_ % 2 != 0)
+   * }}}
+   */
+  def apply[I]: ZPipeline[Any, Nothing, I, I] = identity[I]
+
+  /**
+   * Creates a pipeline that collects elements with the specified partial function.
+   *
+   * {{{
+   * ZPipeline.collect[Option[Int], Int] { case Some(v) => v }
+   * }}}
+   */
+  def collect[In, Out](f: PartialFunction[In, Out]): ZPipeline[Any, Nothing, In, Out] =
+    new ZPipeline[Any, Nothing, In, Out] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, Out] =
+        stream.collect(f)
+    }
+
+  /**
+   * Creates a transducer that always dies with the specified exception.
+   *
+   * {{{
+   * ZPipeline.die(new IllegalStateException)
+   * }}}
+   */
+  def die(e: => Throwable): ZPipeline[Any, Nothing, Any, Nothing] =
+    ZPipeline.halt(Cause.die(e))
+
+  /**
+   * Creates a pipeline that drops elements until the specified predicate evaluates to true.
+   *
+   * {{{
+   * ZPipeline.dropUntil[Int](_ > 100)
+   * }}}
+   */
+  def dropUntil[In](f: In => Boolean): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline[Any, Nothing, In, In] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, In] =
+        stream.dropUntil(f)
+    }
+
+  /**
+   * Creates a pipeline that drops elements while the specified predicate evaluates to true.
+   *
+   * {{{
+   * ZPipeline.dropWhile[Int](_ <= 100)
+   * }}}
+   */
+  def dropWhile[In](f: In => Boolean): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline[Any, Nothing, In, In] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, In] =
+        stream.dropWhile(f)
+    }
+
+  /**
+   * Creates a pipeline that always fails with the specified value.
+   */
+  def fail[E](e: => E): ZPipeline[Any, E, Any, Nothing] =
+    ZPipeline.halt(Cause.fail(e))
+
+  /**
+   * Creates a pipeline that filters elements according to the specified predicate.
+   */
+  def filter[In](f: In => Boolean): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline[Any, Nothing, In, In] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, In] =
+        stream.filter(f)
+    }
+
+  /**
+   * Creates a pipeline from the provided fold function, which operates on the state and the
+   * elements of the source stream.
+   *
+   * {{{
+   * val counter = ZPipeline.foldLeft(0)((count, _) => count + 1)
+   * }}}
+   */
+  def foldLeft[In, Out](z: Out)(f: (Out, In) => Out): ZPipeline[Any, Nothing, In, Out] =
+    fold(z)(_ => true)(f)
+
+  /**
+   * Creates a transducer by effectfully folding over a structure of type `O`. The transducer will
+   * fold the inputs until the stream ends, resulting in a stream with one element.
+   */
+  def foldLeftM[R, E, I, O](z: O)(f: (O, I) => ZIO[R, E, O]): ZPipeline[R, E, I, O] =
+    foldM(z)(_ => true)(f)
+
+  /**
+   * A stateful fold that will emit the state and reset to the starting state every time the
+   * specified predicate returns false.
+   */
+  def fold[I, O](out0: O)(contFn: O => Boolean)(f: (O, I) => O): ZPipeline[Any, Nothing, I, O] =
+    new ZPipeline[Any, Nothing, I, O] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, I]): ZStream[Env1, Err1, O] =
+        stream
+          .mapAccum(out0) { case (o0, i) =>
+            val o = f(o0, i)
+
+            if (contFn(o)) (o, Some(o))
+            else (out0, None)
+          }
+          .collect { case Some(v) => v }
+    }
+
+  /**
+   * A stateful fold that will emit the state and reset to the starting state every time the
+   * specified predicate returns false.
+   */
+  def foldM[R, E, I, O](out0: O)(contFn: O => Boolean)(f: (O, I) => ZIO[R, E, O]): ZPipeline[R, E, I, O] =
+    new ZPipeline[R, E, I, O] {
+      def apply[Env1 <: R, Err1 >: E](stream: ZStream[Env1, Err1, I]): ZStream[Env1, Err1, O] =
+        stream
+          .mapAccumM(out0) { case (o, i) =>
+            f(o, i).map { o =>
+              if (contFn(o)) (o, Some(o))
+              else (out0, None)
+            }
+          }
+          .collect { case Some(v) => v }
+    }
+
+  /**
+   * Creates a transducer that folds elements of type `I` into a structure
+   * of type `O` until `max` elements have been folded.
+   *
+   * Like [[foldWeighted]], but with a constant cost function of 1.
+   */
+  def foldUntil[I, O](z: O, max: Long)(f: (O, I) => O): ZPipeline[Any, Nothing, I, O] =
+    fold[I, (O, Long)]((z, 0))(_._2 < max) { case ((o, count), i) =>
+      (f(o, i), count + 1)
+    } >>> ZPipeline.map(_._1)
+
+  /**
+   * Creates a transducer that effectfully folds elements of type `I` into a structure
+   * of type `O` until `max` elements have been folded.
+   *
+   * Like [[foldWeightedM]], but with a constant cost function of 1.
+   */
+  def foldUntilM[R, E, I, O](z: O, max: Long)(f: (O, I) => ZIO[R, E, O]): ZPipeline[R, E, I, O] =
+    foldM[R, E, I, (O, Long)]((z, 0))(_._2 < max) { case ((o, count), i) =>
+      f(o, i).map((_, count + 1))
+    } >>> ZPipeline.map(_._1)
+
+  /**
+   * Creates a pipeline that effectfully maps elements to the specified effectfully-computed
+   * value.
+   */
+  def fromEffect[R, E, A](zio: ZIO[R, E, A]): ZPipeline[R, E, Any, A] =
+    new ZPipeline[R, E, Any, A] {
+      def apply[Env1 <: R, Err1 >: E](stream: ZStream[Env1, Err1, Any]): ZStream[Env1, Err1, A] =
+        stream.mapM(_ => zio)
+    }
+
+  /**
+   * Creates a pipeline from a sink, by transforming input streams with [[ZStream#transduce]].
+   */
+  // TODO
+//  def fromSink[Env, Err, In, Out](sink: ZSink[Env, Err, In, In, Out]): ZPipeline[Env, Err, In, Out] =
+//    new ZPipeline[Env, Err, In, Out] {
+//      def apply[Env1 <: Env, Err1 >: Err](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, Out] =
+//        stream.transduce(sink)
+//    }
+
+  /**
+   * Creates a transducer that always dies with the specified exception.
+   */
+  def halt[E](cause: => Cause[E]): ZPipeline[Any, E, Any, Nothing] =
+    new ZPipeline[Any, E, Any, Nothing] {
+      def apply[Env1 <: Any, Err1 >: E](stream: ZStream[Env1, Err1, Any]): ZStream[Env1, Err1, Nothing] =
+        ZStream.halt(cause)
+    }
+
+  /**
+   * The identity pipeline, which does not modify streams in any way.
+   */
+  def identity[A]: ZPipeline[Any, Nothing, A, A] =
+    new ZPipeline[Any, Nothing, A, A] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, A]): ZStream[Env1, Err1, A] =
+        stream
+    }
+
+  /**
+   * Creates a pipeline that maps elements with the specified function.
+   */
+  def map[In, Out](f: In => Out): ZPipeline[Any, Nothing, In, Out] =
+    new ZPipeline[Any, Nothing, In, Out] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, Out] =
+        stream.map(f)
+    }
+
+  /**
+   * Creates a pipeline that maps elements with the specified effectful function.
+   */
+  def mapM[Env0, Err0, In, Out](f: In => ZIO[Env0, Err0, Out]): ZPipeline[Env0, Err0, In, Out] =
+    new ZPipeline[Env0, Err0, In, Out] {
+      def apply[Env1 <: Env0, Err1 >: Err0](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, Out] =
+        stream.mapM(f)
+    }
+
+  /**
+   * Creates a pipeline that always succeeds with the specified value.
+   */
+  def succeed[A](a: => A): ZPipeline[Any, Nothing, Any, A] =
+    new ZPipeline[Any, Nothing, Any, A] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, Any]): ZStream[Env1, Err1, A] =
+        ZStream.succeed(a)
+    }
+
+  /**
+   * Creates a pipeline that takes elements until the specified predicate evaluates to true.
+   */
+  def takeUntil[In](f: In => Boolean): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline[Any, Nothing, In, In] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, In] =
+        stream.takeUntil(f)
+    }
+
+  /**
+   * Creates a pipeline that takes elements while the specified predicate evaluates to true.
+   */
+  def takeWhile[In](f: In => Boolean): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline[Any, Nothing, In, In] {
+      def apply[Env1 <: Any, Err1 >: Nothing](stream: ZStream[Env1, Err1, In]): ZStream[Env1, Err1, In] =
+        stream.takeWhile(f)
+    }
+
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -1,0 +1,909 @@
+package zio.stream.experimental
+
+import zio._
+import zio.clock.Clock
+import zio.duration.Duration
+
+class ZSink[-R, -InErr, -In, +OutErr, +L, +Z](val channel: ZChannel[R, InErr, Chunk[In], Any, OutErr, Chunk[L], Z])
+    extends AnyVal { self =>
+
+  /**
+   * Operator alias for [[race]].
+   */
+  final def |[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    race(that)
+
+  /**
+   * Operator alias for [[zip]].
+   */
+  final def <*>[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, (Z, Z1)] =
+    zip(that)
+
+  /**
+   * Operator alias for [[zipPar]].
+   */
+  final def <&>[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, (Z, Z1)] =
+    zipPar(that)
+
+  /**
+   * Operator alias for [[zipRight]].
+   */
+  final def *>[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    zipRight(that)
+
+  /**
+   * Operator alias for [[zipParRight]].
+   */
+  final def &>[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    zipParRight(that)
+
+  /**
+   * Operator alias for [[zipLeft]].
+   */
+  final def <*[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z] =
+    zipLeft(that)
+
+  /**
+   * Operator alias for [[zipParLeft]].
+   */
+  final def <&[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z] =
+    zipParLeft(that)
+
+  /**
+   * Replaces this sink's result with the provided value.
+   */
+  def as[Z2](z: => Z2): ZSink[R, InErr, In, OutErr, L, Z2] =
+    map(_ => z)
+
+  /**
+   * Repeatedly runs the sink for as long as its results satisfy
+   * the predicate `p`. The sink's results will be accumulated
+   * using the stepping function `f`.
+   */
+  def collectAllWhileWith[S](z: S)(p: Z => Boolean)(f: (S, Z) => S)(implicit
+    ev: L <:< In
+  ): ZSink[R, InErr, In, OutErr, L, S] =
+    ???
+
+  /**
+   * Transforms this sink's input elements.
+   */
+  def contramap[In1](f: In1 => In): ZSink[R, InErr, In1, OutErr, L, Z] =
+    contramapChunks(_.map(f))
+
+  /**
+   * Effectfully transforms this sink's input elements.
+   */
+  def contramapM[R1 <: R, InErr1 <: InErr, In1](
+    f: In1 => ZIO[R1, InErr1, In]
+  ): ZSink[R1, InErr1, In1, OutErr, L, Z] =
+    contramapChunksM(_.mapM(f))
+
+  /**
+   * Transforms this sink's input chunks.
+   * `f` must preserve chunking-invariance
+   */
+  def contramapChunks[In1](f: Chunk[In1] => Chunk[In]): ZSink[R, InErr, In1, OutErr, L, Z] = {
+    lazy val loop: ZChannel[R, InErr, Chunk[In1], Any, InErr, Chunk[In], Any] =
+      ZChannel.readWith[R, InErr, Chunk[In1], Any, InErr, Chunk[In], Any](
+        chunk => ZChannel.write(f(chunk)) *> loop,
+        ZChannel.fail(_),
+        ZChannel.succeed(_)
+      )
+    new ZSink(loop >>> self.channel)
+  }
+
+  /**
+   * Effectfully transforms this sink's input chunks.
+   * `f` must preserve chunking-invariance
+   */
+  def contramapChunksM[R1 <: R, InErr1 <: InErr, In1](
+    f: Chunk[In1] => ZIO[R1, InErr1, Chunk[In]]
+  ): ZSink[R1, InErr1, In1, OutErr, L, Z] = {
+    lazy val loop: ZChannel[R1, InErr1, Chunk[In1], Any, InErr1, Chunk[In], Any] =
+      ZChannel.readWith[R1, InErr1, Chunk[In1], Any, InErr1, Chunk[In], Any](
+        chunk => ZChannel.fromEffect(f(chunk)).flatMap(ZChannel.write) *> loop,
+        ZChannel.fail(_),
+        ZChannel.succeed(_)
+      )
+    new ZSink(loop >>> self.channel)
+  }
+
+  /**
+   * Transforms both inputs and result of this sink using the provided functions.
+   */
+  def dimap[In1, Z1](f: In1 => In, g: Z => Z1): ZSink[R, InErr, In1, OutErr, L, Z1] =
+    contramap(f).map(g)
+
+  /**
+   * Effectfully transforms both inputs and result of this sink using the provided functions.
+   */
+  def dimapM[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, In1, Z1](
+    f: In1 => ZIO[R1, InErr1, In],
+    g: Z => ZIO[R1, OutErr1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L, Z1] =
+    contramapM(f).mapM(g)
+
+  /**
+   * Transforms both input chunks and result of this sink using the provided functions.
+   */
+  def dimapChunks[In1, Z1](f: Chunk[In1] => Chunk[In], g: Z => Z1): ZSink[R, InErr, In1, OutErr, L, Z1] =
+    contramapChunks(f).map(g)
+
+  /**
+   * Effectfully transforms both input chunks and result of this sink using the provided functions.
+   * `f` and `g` must preserve chunking-invariance
+   */
+  def dimapChunksM[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, In1, Z1](
+    f: Chunk[In1] => ZIO[R1, InErr1, Chunk[In]],
+    g: Z => ZIO[R1, OutErr1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L, Z1] =
+    contramapChunksM(f).mapM(g)
+
+  /**
+   * Runs this sink until it yields a result, then uses that result to create another
+   * sink from the provided function which will continue to run until it yields a result.
+   *
+   * This function essentially runs sinks in sequence.
+   */
+  def flatMap[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, In1 <: In, L1 >: L, Z1](
+    f: Z => ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    foldM(ZSink.fail(_), f)
+
+  def foldM[R1 <: R, InErr1 <: InErr, OutErr2, In1 <: In, L1 >: L, Z1](
+    failure: OutErr => ZSink[R1, InErr1, In1, OutErr2, L1, Z1],
+    success: Z => ZSink[R1, InErr1, In1, OutErr2, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr2, L1, Z1] =
+    new ZSink(
+      channel.doneCollect.foldM(
+        failure(_).channel,
+        { case (leftovers, z) =>
+          (ZChannel.write(leftovers.flatMap(_.map(ev))) *> ZChannel.identity[InErr1, Chunk[In1], Any]) >>> success(
+            z
+          ).channel
+        }
+      )
+    )
+
+  /**
+   * Transforms this sink's result.
+   */
+  def map[Z2](f: Z => Z2): ZSink[R, InErr, In, OutErr, L, Z2] = new ZSink(channel.map(f))
+
+  /**
+   * Transforms the errors emitted by this sink using `f`.
+   */
+  def mapError[OutErr2](f: OutErr => OutErr2): ZSink[R, InErr, In, OutErr2, L, Z] =
+    new ZSink(channel.mapError(f))
+
+  /**
+   * Effectfully transforms this sink's result.
+   */
+  def mapM[R1 <: R, OutErr1 >: OutErr, Z1](f: Z => ZIO[R1, OutErr1, Z1]): ZSink[R1, InErr, In, OutErr1, L, Z1] =
+    new ZSink(channel.mapM(f))
+
+  /**
+   * Runs both sinks in parallel on the input, , returning the result or the error from the
+   * one that finishes first.
+   */
+  final def race[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    self.raceBoth(that).map(_.merge)
+
+  /**
+   * Runs both sinks in parallel on the input, returning the result or the error from the
+   * one that finishes first.
+   */
+  final def raceBoth[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]] =
+    ???
+
+  /**
+   * Returns the sink that executes this one and times its execution.
+   */
+  final def timed: ZSink[R with Clock, InErr, In, OutErr, L, (Z, Duration)] =
+    ???
+
+  def repeat: ZSink[R, InErr, In, OutErr, L, Chunk[Z]] = ???
+
+  def orElse[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr2 >: OutErr, L1 >: L, Z1 >: Z](
+    that: => ZSink[R1, InErr1, In1, OutErr2, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr2, L1, Z1] =
+    new ZSink[R1, InErr1, In1, OutErr2, L1, Z1](self.channel.orElse(that.channel))
+
+  def zip[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, (Z, Z1)] =
+    zipWith(that)((_, _))
+
+  /**
+   * Like [[zip]], but keeps only the result from the `that` sink.
+   */
+  final def zipLeft[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z] =
+    zipWith(that)((z, _) => z)
+
+  /**
+   * Runs both sinks in parallel on the input and combines the results in a tuple.
+   */
+  final def zipPar[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, (Z, Z1)] =
+    zipWithPar(that)((_, _))
+
+  /**
+   * Like [[zipPar]], but keeps only the result from this sink.
+   */
+  final def zipParLeft[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, Z] =
+    zipWithPar(that)((b, _) => b)
+
+  /**
+   * Like [[zipPar]], but keeps only the result from the `that` sink.
+   */
+  final def zipParRight[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  ): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    zipWithPar(that)((_, c) => c)
+
+  /**
+   * Like [[zip]], but keeps only the result from this sink.
+   */
+  final def zipRight[R1 <: R, InErr1 <: InErr, In1 <: In, OutErr1 >: OutErr, L1 >: L, Z1](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z1] =
+    zipWith(that)((_, z1) => z1)
+
+  /**
+   * Feeds inputs to this sink until it yields a result, then switches over to the
+   * provided sink until it yields a result, finally combining the two results with `f`.
+   */
+  final def zipWith[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, In1 <: In, L1 >: L, Z1, Z2](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(f: (Z, Z1) => Z2)(implicit ev: L <:< In1): ZSink[R1, InErr1, In1, OutErr1, L1, Z2] =
+    flatMap(z => that.map(f(z, _)))
+
+  /**
+   * Runs both sinks in parallel on the input and combines the results
+   * using the provided function.
+   */
+  final def zipWithPar[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, In1 <: In, L1 >: L, Z1, Z2](
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+  )(f: (Z, Z1) => Z2): ZSink[R1, InErr1, In1, OutErr1, L1, Z2] =
+    ???
+
+  def exposeLeftover: ZSink[R, InErr, In, OutErr, Nothing, (Z, Chunk[L])] =
+    new ZSink(channel.doneCollect.map { case (chunks, z) => (z, chunks.flatten) })
+
+  def dropLeftover: ZSink[R, InErr, In, OutErr, Nothing, Z] =
+    new ZSink(channel.drain)
+
+  /**
+   * Creates a sink that produces values until one verifies
+   * the predicate `f`.
+   */
+  def untilOutputM[R1 <: R, OutErr1 >: OutErr](
+    f: Z => ZIO[R1, OutErr1, Boolean]
+  )(implicit ev: L <:< In): ZSink[R1, InErr, In, OutErr1, L, Option[Z]] =
+    ???
+
+  /**
+   * Provides the sink with its required environment, which eliminates
+   * its dependency on `R`.
+   */
+  def provide(r: R)(implicit ev: NeedsEnv[R]): ZSink[Any, InErr, In, OutErr, L, Z] =
+    new ZSink(channel.provide(r))
+}
+
+object ZSink {
+
+  /**
+   * Accesses the environment of the sink in the context of a sink.
+   */
+  def accessSink[R]: AccessSinkPartiallyApplied[R] =
+    new AccessSinkPartiallyApplied[R]
+
+  def collectAll[Err, In]: ZSink[Any, Err, In, Err, Nothing, Chunk[In]] = {
+    def loop(acc: Chunk[In]): ZChannel[Any, Err, Chunk[In], Any, Err, Nothing, Chunk[In]] =
+      ZChannel.readWithCause(
+        chunk => loop(acc ++ chunk),
+        ZChannel.halt(_),
+        _ => ZChannel.succeed(acc)
+      )
+    new ZSink(loop(Chunk.empty))
+  }
+
+  /**
+   * A sink that collects all of its inputs into a map. The keys are extracted from inputs
+   * using the keying function `key`; if multiple inputs use the same key, they are merged
+   * using the `f` function.
+   */
+  def collectAllToMap[Err, In, K](key: In => K)(f: (In, In) => In): ZSink[Any, Err, In, Err, Nothing, Map[K, In]] =
+    foldLeftChunks(Map[K, In]()) { (acc, as) =>
+      as.foldLeft(acc) { (acc, a) =>
+        val k = key(a)
+
+        acc.updated(
+          k,
+          // Avoiding `get/getOrElse` here to avoid an Option allocation
+          if (acc.contains(k)) f(acc(k), a)
+          else a
+        )
+      }
+    }
+
+  /**
+   * A sink that collects all of its inputs into a set.
+   */
+  def collectAllToSet[Err, In]: ZSink[Any, Err, In, Err, Nothing, Set[In]] =
+    foldLeftChunks(Set[In]())((acc, as) => as.foldLeft(acc)(_ + _))
+
+  /**
+   * Accumulates incoming elements into a chunk as long as they verify predicate `p`.
+   */
+  def collectAllWhile[Err, In](p: In => Boolean): ZSink[Any, Err, In, Err, In, Chunk[In]] =
+    fold[Err, In, (List[In], Boolean)]((Nil, true))(_._2) { case ((as, _), a) =>
+      if (p(a)) (a :: as, true) else (as, false)
+    }.map { case (is, _) =>
+      Chunk.fromIterable(is.reverse)
+    }
+
+  /**
+   * Accumulates incoming elements into a chunk as long as they verify effectful predicate `p`.
+   */
+  def collectAllWhileM[Env, Err, In](p: In => ZIO[Env, Err, Boolean]): ZSink[Env, Err, In, Err, In, Chunk[In]] =
+    foldM[Env, Err, In, (List[In], Boolean)]((Nil, true))(_._2) { case ((as, _), a) =>
+      p(a).map(if (_) (a :: as, true) else (as, false))
+    }.map { case (is, _) =>
+      Chunk.fromIterable(is.reverse)
+    }
+
+  /**
+   * A sink that counts the number of elements fed to it.
+   */
+  def count[Err]: ZSink[Any, Err, Any, Err, Nothing, Long] =
+    foldLeft(0L)((s, _) => s + 1)
+
+  /**
+   * Creates a sink halting with the specified `Throwable`.
+   */
+  def die(e: => Throwable): ZSink[Any, Any, Any, Nothing, Nothing, Nothing] =
+    ZSink.halt(Cause.die(e))
+
+  /**
+   * Creates a sink halting with the specified message, wrapped in a
+   * `RuntimeException`.
+   */
+  def dieMessage(m: => String): ZSink[Any, Any, Any, Nothing, Nothing, Nothing] =
+    ZSink.halt(Cause.die(new RuntimeException(m)))
+
+  /**
+   * A sink that ignores its inputs.
+   */
+  def drain[Err]: ZSink[Any, Err, Any, Err, Nothing, Unit] =
+    new ZSink(ZChannel.read[Any].unit.repeated.catchAll(_ => ZChannel.unit))
+
+  /**
+   * A sink that always fails with the specified error.
+   */
+  def fail[E](e: => E): ZSink[Any, Any, Any, E, Nothing, Nothing] = new ZSink(ZChannel.fail(e))
+
+  /**
+   * A sink that folds its inputs with the provided function, termination predicate and initial state.
+   */
+  def fold[Err, In, S](z: S)(contFn: S => Boolean)(f: (S, In) => S): ZSink[Any, Err, In, Err, In, S] = {
+
+    /** Folds a chunk with a stopping condition and returns the leftover. */
+    def foldChunkSplit(z: S, chunk: Chunk[In])(
+      contFn: S => Boolean
+    )(f: (S, In) => S): (S, Option[Chunk[In]]) = {
+      def fold(s: S, chunk: Chunk[In], idx: Int, len: Int): (S, Option[Chunk[In]]) =
+        if (idx == len) {
+          (s, None)
+        } else {
+          val s1 = f(s, chunk(idx))
+          if (contFn(s1)) {
+            fold(s1, chunk, idx + 1, len)
+          } else {
+            (s1, Some(chunk.drop(idx + 1)))
+          }
+        }
+
+      fold(z, chunk, 0, chunk.length)
+    }
+
+    def reader(s: S): ZChannel[Any, Err, Chunk[In], Any, Err, Chunk[In], S] =
+      ZChannel.readWith(
+        (in: Chunk[In]) => {
+          val (nextS, leftovers) = foldChunkSplit(s, in)(contFn)(f)
+
+          leftovers match {
+            case Some(l) => ZChannel.write(l).as(nextS)
+            case None    => reader(nextS)
+          }
+        },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.end(s)
+      )
+
+    new ZSink(
+      if (contFn(z)) reader(z)
+      else ZChannel.end(z)
+    )
+  }
+
+  /**
+   * A sink that folds its input chunks with the provided function, termination predicate and initial state.
+   * `contFn` condition is checked only for the initial value and at the end of processing of each chunk.
+   * `f` and `contFn` must preserve chunking-invariance.
+   */
+  def foldChunks[Err, In, S](
+    z: S
+  )(contFn: S => Boolean)(f: (S, Chunk[In]) => S): ZSink[Any, Err, In, Err, Nothing, S] = {
+    def reader(s: S): ZChannel[Any, Err, Chunk[In], Any, Err, Nothing, S] = ZChannel.readWith(
+      (in: Chunk[In]) => {
+        val nextS = f(s, in)
+
+        if (contFn(nextS)) reader(nextS)
+        else ZChannel.end(nextS)
+      },
+      (err: Err) => ZChannel.fail(err),
+      (_: Any) => ZChannel.end(s)
+    )
+
+    new ZSink(
+      if (contFn(z)) reader(z)
+      else ZChannel.end(z)
+    )
+  }
+
+  /**
+   * A sink that effectfully folds its input chunks with the provided function, termination predicate and initial state.
+   * `contFn` condition is checked only for the initial value and at the end of processing of each chunk.
+   * `f` and `contFn` must preserve chunking-invariance.
+   */
+  def foldChunksM[Env, Err, In, S](
+    z: S
+  )(contFn: S => Boolean)(f: (S, Chunk[In]) => ZIO[Env, Err, S]): ZSink[Env, Err, In, Err, In, S] = {
+    def reader(s: S): ZChannel[Env, Err, Chunk[In], Any, Err, Nothing, S] =
+      ZChannel.readWith(
+        (in: Chunk[In]) =>
+          ZChannel.fromEffect(f(s, in)).flatMap { nextS =>
+            if (contFn(nextS)) reader(nextS)
+            else ZChannel.end(nextS)
+          },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.end(s)
+      )
+
+    new ZSink(
+      if (contFn(z)) reader(z)
+      else ZChannel.end(z)
+    )
+  }
+
+  /**
+   * A sink that effectfully folds its inputs with the provided function, termination predicate and initial state.
+   */
+  def foldM[Env, Err, In, S](z: S)(contFn: S => Boolean)(
+    f: (S, In) => ZIO[Env, Err, S]
+  ): ZSink[Env, Err, In, Err, In, S] = {
+    def foldChunkSplitM(z: S, chunk: Chunk[In])(
+      contFn: S => Boolean
+    )(f: (S, In) => ZIO[Env, Err, S]): ZIO[Env, Err, (S, Option[Chunk[In]])] = {
+      def fold(s: S, chunk: Chunk[In], idx: Int, len: Int): ZIO[Env, Err, (S, Option[Chunk[In]])] =
+        if (idx == len) UIO.succeed((s, None))
+        else
+          f(s, chunk(idx)).flatMap { s1 =>
+            if (contFn(s1)) {
+              fold(s1, chunk, idx + 1, len)
+            } else {
+              UIO.succeed((s1, Some(chunk.drop(idx + 1))))
+            }
+          }
+
+      fold(z, chunk, 0, chunk.length)
+    }
+
+    def reader(s: S): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[In], S] =
+      ZChannel.readWith(
+        (in: Chunk[In]) =>
+          ZChannel.fromEffect(foldChunkSplitM(s, in)(contFn)(f)).flatMap { case (nextS, leftovers) =>
+            leftovers match {
+              case Some(l) => ZChannel.write(l).as(nextS)
+              case None    => reader(nextS)
+            }
+          },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.end(s)
+      )
+
+    new ZSink(
+      if (contFn(z)) reader(z)
+      else ZChannel.end(z)
+    )
+  }
+
+  /**
+   * A sink that folds its inputs with the provided function and initial state.
+   */
+  def foldLeft[Err, In, S](z: S)(f: (S, In) => S): ZSink[Any, Err, In, Err, Nothing, S] =
+    fold(z)(_ => true)(f).dropLeftover
+
+  /**
+   * A sink that folds its input chunks with the provided function and initial state.
+   * `f` must preserve chunking-invariance.
+   */
+  def foldLeftChunks[Err, In, S](z: S)(f: (S, Chunk[In]) => S): ZSink[Any, Err, In, Err, Nothing, S] =
+    foldChunks[Err, In, S](z)(_ => true)(f)
+
+  /**
+   * A sink that effectfully folds its input chunks with the provided function and initial state.
+   * `f` must preserve chunking-invariance.
+   */
+  def foldLeftChunksM[R, Err, In, S](z: S)(
+    f: (S, Chunk[In]) => ZIO[R, Err, S]
+  ): ZSink[R, Err, In, Err, Nothing, S] =
+    foldChunksM[R, Err, In, S](z)(_ => true)(f).dropLeftover
+
+  /**
+   * A sink that effectfully folds its inputs with the provided function and initial state.
+   */
+  def foldLeftM[R, Err, In, S](z: S)(
+    f: (S, In) => ZIO[R, Err, S]
+  ): ZSink[R, Err, In, Err, In, S] =
+    foldM[R, Err, In, S](z)(_ => true)(f)
+
+  /**
+   * Creates a sink that folds elements of type `In` into a structure
+   * of type `S` until `max` elements have been folded.
+   *
+   * Like [[foldWeighted]], but with a constant cost function of 1.
+   */
+  def foldUntil[Err, In, S](z: S, max: Long)(f: (S, In) => S): ZSink[Any, Err, In, Err, In, S] =
+    fold[Err, In, (S, Long)]((z, 0))(_._2 < max) { case ((o, count), i) =>
+      (f(o, i), count + 1)
+    }.map(_._1)
+
+  /**
+   * Creates a sink that effectfully folds elements of type `In` into a structure
+   * of type `S` until `max` elements have been folded.
+   *
+   * Like [[foldWeightedM]], but with a constant cost function of 1.
+   */
+  def foldUntilM[Env, In, Err, S](z: S, max: Long)(
+    f: (S, In) => ZIO[Env, Err, S]
+  ): ZSink[Env, Err, In, Err, In, S] =
+    foldM[Env, Err, In, (S, Long)]((z, 0))(_._2 < max) { case ((o, count), i) =>
+      f(o, i).map((_, count + 1))
+    }.map(_._1)
+
+  /**
+   * Creates a sink that folds elements of type `In` into a structure
+   * of type `S`, until `max` worth of elements (determined by the `costFn`)
+   * have been folded.
+   *
+   * @note Elements that have an individual cost larger than `max` will
+   * force the sink to cross the `max` cost. See [[foldWeightedDecompose]]
+   * for a variant that can handle these cases.
+   */
+  def foldWeighted[Err, In, S](z: S)(costFn: (S, In) => Long, max: Long)(
+    f: (S, In) => S
+  ): ZSink[Any, Err, In, Err, In, S] =
+    foldWeightedDecompose[Err, In, S](z)(costFn, max, Chunk.single(_))(f)
+
+  /**
+   * Creates a sink that folds elements of type `In` into a structure
+   * of type `S`, until `max` worth of elements (determined by the `costFn`)
+   * have been folded.
+   *
+   * The `decompose` function will be used for decomposing elements that
+   * cause an `S` aggregate to cross `max` into smaller elements. For
+   * example:
+   * {{{
+   * Stream(1, 5, 1)
+   *  .transduce(
+   *    ZSink
+   *      .foldWeightedDecompose(List[Int]())((i: Int) => i.toLong, 4,
+   *        (i: Int) => Chunk(i - 1, 1)) { (acc, el) =>
+   *        el :: acc
+   *      }
+   *      .map(_.reverse)
+   *  )
+   *  .runCollect
+   * }}}
+   *
+   * The stream would emit the elements `List(1), List(4), List(1, 1)`.
+   *
+   * Be vigilant with this function, it has to generate "simpler" values
+   * or the fold may never end. A value is considered indivisible if
+   * `decompose` yields the empty chunk or a single-valued chunk. In
+   * these cases, there is no other choice than to yield a value that
+   * will cross the threshold.
+   *
+   * The [[foldWeightedDecomposeM]] allows the decompose function
+   * to return a `ZIO` value, and consequently it allows the sink
+   * to fail.
+   */
+  def foldWeightedDecompose[Err, In, S](
+    z: S
+  )(costFn: (S, In) => Long, max: Long, decompose: In => Chunk[In])(
+    f: (S, In) => S
+  ): ZSink[Any, Err, In, Err, In, S] = {
+    def go(s: S, cost: Long, dirty: Boolean): ZChannel[Any, Err, Chunk[In], Any, Err, Chunk[In], S] =
+      ZChannel.readWith(
+        (in: Chunk[In]) => {
+          def fold(in: Chunk[In], s: S, dirty: Boolean, cost: Long, idx: Int): (S, Long, Boolean, Chunk[In]) =
+            if (idx == in.length) (s, cost, dirty, Chunk.empty)
+            else {
+              val elem  = in(idx)
+              val total = cost + costFn(s, elem)
+
+              if (total <= max) fold(in, f(s, elem), true, total, idx + 1)
+              else {
+                val decomposed = decompose(elem)
+
+                if (decomposed.length <= 1 && !dirty)
+                  // If `elem` cannot be decomposed, we need to cross the `max` threshold. To
+                  // minimize "injury", we only allow this when we haven't added anything else
+                  // to the aggregate (dirty = false).
+                  (f(s, elem), total, true, in.drop(idx + 1))
+                else if (decomposed.length <= 1 && dirty)
+                  // If the state is dirty and `elem` cannot be decomposed, we stop folding
+                  // and include `elem` in th leftovers.
+                  (s, cost, dirty, in.drop(idx))
+                else
+                  // `elem` got decomposed, so we will recurse with the decomposed elements pushed
+                  // into the chunk we're processing and see if we can aggregate further.
+                  fold(decomposed ++ in.drop(idx + 1), s, dirty, cost, 0)
+              }
+            }
+
+          val (nextS, nextCost, nextDirty, leftovers) = fold(in, s, dirty, cost, 0)
+
+          if (cost >= max && leftovers.nonEmpty) ZChannel.write(leftovers) *> ZChannel.end(nextS)
+          else if (cost <= max && leftovers.nonEmpty) ZChannel.write(leftovers) *> ZChannel.end(nextS)
+          else if (cost >= max && leftovers.isEmpty) ZChannel.end(nextS)
+          else go(nextS, nextCost, nextDirty)
+        },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.end(s)
+      )
+
+    new ZSink(go(z, 0, false))
+  }
+
+  /**
+   * Creates a sink that effectfully folds elements of type `In` into a structure
+   * of type `S`, until `max` worth of elements (determined by the `costFn`) have
+   * been folded.
+   *
+   * @note Elements that have an individual cost larger than `max` will
+   * force the sink to cross the `max` cost. See [[foldWeightedDecomposeM]]
+   * for a variant that can handle these cases.
+   */
+  def foldWeightedM[Env, Err, In, S](
+    z: S
+  )(costFn: (S, In) => ZIO[Env, Err, Long], max: Long)(
+    f: (S, In) => ZIO[Env, Err, S]
+  ): ZSink[Env, Err, In, Err, In, S] =
+    foldWeightedDecomposeM(z)(costFn, max, (i: In) => UIO.succeedNow(Chunk.single(i)))(f)
+
+  /**
+   * Creates a sink that effectfully folds elements of type `In` into a structure
+   * of type `S`, until `max` worth of elements (determined by the `costFn`) have
+   * been folded.
+   *
+   * The `decompose` function will be used for decomposing elements that
+   * cause an `S` aggregate to cross `max` into smaller elements. Be vigilant with
+   * this function, it has to generate "simpler" values or the fold may never end.
+   * A value is considered indivisible if `decompose` yields the empty chunk or a
+   * single-valued chunk. In these cases, there is no other choice than to yield
+   * a value that will cross the threshold.
+   *
+   * See [[foldWeightedDecompose]] for an example.
+   */
+  def foldWeightedDecomposeM[Env, Err, In, S](z: S)(
+    costFn: (S, In) => ZIO[Env, Err, Long],
+    max: Long,
+    decompose: In => ZIO[Env, Err, Chunk[In]]
+  )(f: (S, In) => ZIO[Env, Err, S]): ZSink[Env, Err, In, Err, In, S] = {
+    def go(s: S, cost: Long, dirty: Boolean): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[In], S] =
+      ZChannel.readWith(
+        (in: Chunk[In]) => {
+          def fold(
+            in: Chunk[In],
+            s: S,
+            dirty: Boolean,
+            cost: Long,
+            idx: Int
+          ): ZIO[Env, Err, (S, Long, Boolean, Chunk[In])] =
+            if (idx == in.length) UIO.succeed((s, cost, dirty, Chunk.empty))
+            else {
+              val elem = in(idx)
+              costFn(s, elem).map(cost + _).flatMap { total =>
+                if (total <= max) f(s, elem).flatMap(fold(in, _, true, total, idx + 1))
+                else
+                  decompose(elem).flatMap { decomposed =>
+                    if (decomposed.length <= 1 && !dirty)
+                      // If `elem` cannot be decomposed, we need to cross the `max` threshold. To
+                      // minimize "injury", we only allow this when we haven't added anything else
+                      // to the aggregate (dirty = false).
+                      f(s, elem).map((_, total, true, in.drop(idx + 1)))
+                    else if (decomposed.length <= 1 && dirty)
+                      // If the state is dirty and `elem` cannot be decomposed, we stop folding
+                      // and include `elem` in th leftovers.
+                      UIO.succeed((s, cost, dirty, in.drop(idx)))
+                    else
+                      // `elem` got decomposed, so we will recurse with the decomposed elements pushed
+                      // into the chunk we're processing and see if we can aggregate further.
+                      fold(decomposed ++ in.drop(idx + 1), s, dirty, cost, 0)
+                  }
+              }
+            }
+
+          ZChannel.fromEffect(fold(in, s, dirty, cost, 0)).flatMap { case (nextS, nextCost, nextDirty, leftovers) =>
+            if (cost >= max && leftovers.nonEmpty) ZChannel.write(leftovers) *> ZChannel.end(nextS)
+            else if (cost <= max && leftovers.nonEmpty) ZChannel.write(leftovers) *> ZChannel.end(nextS)
+            else if (cost >= max && leftovers.isEmpty) ZChannel.end(nextS)
+            else go(nextS, nextCost, nextDirty)
+          }
+        },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.end(s)
+      )
+
+    new ZSink(go(z, 0, false))
+  }
+
+  /**
+   * A sink that executes the provided effectful function for every element fed to it.
+   */
+  def foreach[R, Err, In](f: In => ZIO[R, Err, Any]): ZSink[R, Err, In, Err, In, Unit] =
+    foreachWhile(f(_).as(true))
+
+  /**
+   * A sink that executes the provided effectful function for every chunk fed to it.
+   */
+  def foreachChunk[R, Err, In](
+    f: Chunk[In] => ZIO[R, Err, Any]
+  ): ZSink[R, Err, In, Err, In, Unit] =
+    foreachChunkWhile(f(_).as(true))
+
+  /**
+   * A sink that executes the provided effectful function for every element fed to it
+   * until `f` evaluates to `false`.
+   */
+  final def foreachWhile[R, Err, In](
+    f: In => ZIO[R, Err, Boolean]
+  ): ZSink[R, Err, In, Err, In, Unit] = {
+    def go(
+      chunk: Chunk[In],
+      idx: Int,
+      len: Int,
+      cont: ZChannel[R, Err, Chunk[In], Any, Err, Chunk[In], Unit]
+    ): ZChannel[R, Err, Chunk[In], Any, Err, Chunk[In], Unit] =
+      if (idx == len)
+        cont
+      else
+        ZChannel
+          .fromEffect(f(chunk(idx)))
+          .flatMap(b => if (b) go(chunk, idx + 1, len, cont) else ZChannel.writeAll(chunk.drop(idx)))
+          .catchAll(e => ZChannel.writeAll(chunk.drop(idx)) *> ZChannel.fail(e))
+
+    lazy val process: ZChannel[R, Err, Chunk[In], Any, Err, Chunk[In], Unit] =
+      ZChannel.readWithCause[R, Err, Chunk[In], Any, Err, Chunk[In], Unit](
+        in => go(in, 0, in.length, process),
+        halt => ZChannel.halt(halt),
+        _ => ZChannel.end(())
+      )
+
+    new ZSink(process)
+  }
+
+  /**
+   * A sink that executes the provided effectful function for every chunk fed to it
+   * until `f` evaluates to `false`.
+   */
+  def foreachChunkWhile[R, Err, In](
+    f: Chunk[In] => ZIO[R, Err, Boolean]
+  ): ZSink[R, Err, In, Err, In, Unit] = {
+    lazy val reader: ZChannel[R, Err, Chunk[In], Any, Err, Nothing, Unit] =
+      ZChannel.readWith(
+        (in: Chunk[In]) =>
+          ZChannel.fromEffect(f(in)).flatMap { continue =>
+            if (continue) reader
+            else ZChannel.end(())
+          },
+        (err: Err) => ZChannel.fail(err),
+        (_: Any) => ZChannel.unit
+      )
+
+    new ZSink(reader)
+  }
+
+  /**
+   * Creates a single-value sink produced from an effect
+   */
+  def fromEffect[R, E, Z](b: => ZIO[R, E, Z]): ZSink[R, Any, Any, E, Nothing, Z] =
+    new ZSink(ZChannel.fromEffect(b))
+
+  /**
+   * Creates a sink halting with a specified cause.
+   */
+  def halt[E](e: => Cause[E]): ZSink[Any, Any, Any, E, Nothing, Nothing] =
+    new ZSink(ZChannel.halt(e))
+
+  /**
+   * Creates a sink containing the first value.
+   */
+  def head[Err, In]: ZSink[Any, Err, In, Err, In, Option[In]] =
+    fold(None: Option[In])(_.isEmpty) {
+      case (s @ Some(_), _) => s
+      case (None, in)       => Some(in)
+    }
+
+  /**
+   * Creates a sink containing the last value.
+   */
+  def last[Err, In]: ZSink[Any, Err, In, Err, In, Option[In]] =
+    foldLeft(None: Option[In])((_, in) => Some(in))
+
+  def leftover[L](c: Chunk[L]): ZSink[Any, Any, Any, Nothing, L, Unit] =
+    new ZSink(ZChannel.write(c))
+
+  def managed[R, InErr, In, OutErr >: InErr, A, L <: In, Z](resource: ZManaged[R, OutErr, A])(
+    fn: A => ZSink[R, InErr, In, OutErr, L, Z]
+  ): ZSink[R, InErr, In, OutErr, In, Z] =
+    ???
+
+  val never: ZSink[Any, Any, Any, Nothing, Nothing, Nothing] = new ZSink(ZChannel.fromEffect(ZIO.never))
+
+  /**
+   * A sink that immediately ends with the specified value.
+   */
+  def succeed[Z](z: => Z): ZSink[Any, Any, Any, Nothing, Nothing, Z] = new ZSink(ZChannel.succeed(z))
+
+  /**
+   * A sink that sums incoming numeric values.
+   */
+  def sum[Err, A](implicit A: Numeric[A]): ZSink[Any, Err, A, Err, Nothing, A] =
+    foldLeft(A.zero)(A.plus)
+
+  /**
+   * A sink that takes the specified number of values.
+   */
+  def take[Err, In](n: Int): ZSink[Any, Err, In, Err, In, Chunk[In]] =
+    ZSink.foldChunks[Err, In, Chunk[In]](Chunk.empty)(_.length < n)(_ ++ _).flatMap { acc =>
+      val (taken, leftover) = acc.splitAt(n)
+      new ZSink(
+        ZChannel.write(leftover) *> ZChannel.end(taken)
+      )
+    }
+
+  def timed[Err]: ZSink[Clock, Err, Nothing, Err, Nothing, Duration] = ZSink.drain.timed.map(_._2)
+
+  final class AccessSinkPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[InErr, In, OutErr, L, Z](f: R => ZSink[R, InErr, In, OutErr, L, Z]): ZSink[R, InErr, In, OutErr, L, Z] =
+      new ZSink(ZChannel.unwrap(ZIO.access[R](f(_).channel)))
+  }
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -1,0 +1,3277 @@
+package zio.stream.experimental
+
+import scala.reflect.ClassTag
+import zio._
+import zio.clock._
+import zio.duration._
+import zio.internal.UniqueKey
+import zio.stm._
+import zio.stream.experimental.ZStream.BufferedPull
+import zio.stream.experimental.internal.Utils.zipChunks
+
+class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], Any]) { self =>
+
+  import ZStream.TerminationStrategy
+
+  /**
+   * Symbolic alias for [[ZStream#cross]].
+   */
+  final def <*>[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, (A, A2)] =
+    self cross that
+
+  /**
+   * Symbolic alias for [[ZStream#crossLeft]].
+   */
+  final def <*[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A] =
+    self crossLeft that
+
+  /**
+   * Symbolic alias for [[ZStream#crossRight]].
+   */
+  final def *>[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A2] =
+    self crossRight that
+
+  /**
+   * Symbolic alias for [[ZStream#zip]].
+   */
+  final def <&>[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, (A, A2)] =
+    self zip that
+
+  /**
+   * Symbolic alias for [[ZStream#zipLeft]].
+   */
+  final def <&[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A] =
+    self zipLeft that
+
+  /**
+   * Symbolic alias for [[ZStream#zipRight]].
+   */
+  final def &>[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A2] =
+    self zipRight that
+
+  /**
+   * Symbolic alias for [[ZStream#flatMap]].
+   */
+  def >>=[R1 <: R, E1 >: E, A2](f0: A => ZStream[R1, E1, A2]): ZStream[R1, E1, A2] = flatMap(f0)
+
+  // /**
+  //  * Symbolic alias for [[ZStream#transduce]].
+  //  */
+  // def >>>[R1 <: R, E1 >: E, A2 >: A, A3](transducer: ZTransducer[R1, E1, A2, A3]) =
+  //   transduce(transducer)
+
+  /**
+   * Symbolic alias for [[[zio.stream.ZStream!.run[R1<:R,E1>:E,B]*]]].
+   */
+  def >>>[R1 <: R, E2, A2 >: A, Z](sink: ZSink[R1, E, A2, E2, Any, Z]): ZIO[R1, E2, Z] =
+    self.run(sink)
+
+  /**
+   * Symbolic alias for [[ZStream#concat]].
+   */
+  def ++[R1 <: R, E1 >: E, A1 >: A](that: => ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    self concat that
+
+  /**
+   * Symbolic alias for [[ZStream#orElse]].
+   */
+  final def <>[R1 <: R, E2, A1 >: A](that: => ZStream[R1, E2, A1])(implicit ev: CanFail[E]): ZStream[R1, E2, A1] =
+    self orElse that
+
+  /**
+   * Returns a stream that submerges the error case of an `Either` into the `ZStream`.
+   */
+  final def absolve[R1 <: R, E1, A1](implicit
+    ev: ZStream[R, E, A] <:< ZStream[R1, E1, Either[E1, A1]]
+  ): ZStream[R1, E1, A1] =
+    ZStream.absolve(ev(self))
+
+  /**
+   * Aggregates elements of this stream using the provided sink for as long
+   * as the downstream operators on the stream are busy.
+   *
+   * This operator divides the stream into two asynchronous "islands". Operators upstream
+   * of this operator run on one fiber, while downstream operators run on another. Whenever
+   * the downstream fiber is busy processing elements, the upstream fiber will feed elements
+   * into the sink until it signals completion.
+   *
+   * Any sink can be used here, but see [[ZSink.foldWeightedM]] and [[ZSink.foldUntilM]] for
+   * sinks that cover the common usecases.
+   */
+  final def aggregateAsync[R1 <: R, E1 >: E, E2, A1 >: A, B](
+    sink: ZSink[R1, E1, A1, E2, A1, B]
+  ): ZStream[R1 with Clock, E2, B] =
+    aggregateAsyncWithin(sink, Schedule.forever)
+
+  /**
+   * Like `aggregateAsyncWithinEither`, but only returns the `Right` results.
+   *
+   * @param sink used for the aggregation
+   * @param schedule signalling for when to stop the aggregation
+   * @return `ZStream[R1 with Clock, E2, B]`
+   */
+  final def aggregateAsyncWithin[R1 <: R, E1 >: E, E2, A1 >: A, B](
+    sink: ZSink[R1, E1, A1, E2, A1, B],
+    schedule: Schedule[R1, Option[B], Any]
+  ): ZStream[R1 with Clock, E2, B] =
+    aggregateAsyncWithinEither(sink, schedule).collect { case Right(v) =>
+      v
+    }
+
+  /**
+   * Aggregates elements using the provided sink until it completes, or until the
+   * delay signalled by the schedule has passed.
+   *
+   * This operator divides the stream into two asynchronous islands. Operators upstream
+   * of this operator run on one fiber, while downstream operators run on another. Elements
+   * will be aggregated by the sink until the downstream fiber pulls the aggregated value,
+   * or until the schedule's delay has passed.
+   *
+   * Aggregated elements will be fed into the schedule to determine the delays between
+   * pulls.
+   *
+   * @param sink used for the aggregation
+   * @param schedule signalling for when to stop the aggregation
+   * @return `ZStream[R1 with Clock, E2, Either[C, B]]`
+   */
+  def aggregateAsyncWithinEither[R1 <: R, E1 >: E, A1 >: A, E2, B, C](
+    sink: ZSink[R1, E1, A1, E2, A1, B],
+    schedule: Schedule[R1, Option[B], C]
+  ): ZStream[R1 with Clock, E2, Either[C, B]] = {
+    sealed trait SinkEndReason
+    case object SinkEnd          extends SinkEndReason
+    case object ScheduleTimeout  extends SinkEndReason
+    case class ScheduleEnd(c: C) extends SinkEndReason
+    case object UpstreamEnd      extends SinkEndReason
+
+    sealed trait HandoffSignal
+    case class Emit(els: Chunk[A])        extends HandoffSignal
+    case class Halt(error: Cause[E1])     extends HandoffSignal
+    case class End(reason: SinkEndReason) extends HandoffSignal
+
+    val deps =
+      ZIO.mapN(
+        ZStream.Handoff.make[HandoffSignal],
+        Ref.make[SinkEndReason](SinkEnd),
+        Ref.make(Chunk[A1]()),
+        schedule.driver
+      )((_, _, _, _))
+
+    ZStream.fromEffect(deps).flatMap { case (handoff, sinkEndReason, sinkLeftovers, scheduleDriver) =>
+      lazy val handoffProducer: ZChannel[Any, E1, Chunk[A], Any, Nothing, Nothing, Any] =
+        ZChannel.readWithCause(
+          (in: Chunk[A]) => ZChannel.fromEffect(handoff.offer(Emit(in))) *> handoffProducer,
+          (cause: Cause[E1]) => ZChannel.fromEffect(handoff.offer(Halt(cause))),
+          (_: Any) => ZChannel.fromEffect(handoff.offer(End(UpstreamEnd)))
+        )
+
+      lazy val handoffConsumer: ZChannel[Any, Any, Any, Any, E1, Chunk[A1], Unit] =
+        ZChannel.unwrap(
+          sinkLeftovers.getAndSet(Chunk.empty).flatMap { leftovers =>
+            if (leftovers.nonEmpty) {
+              UIO.succeed(ZChannel.write(leftovers) *> handoffConsumer)
+            } else
+              handoff.take.map {
+                case Emit(chunk) => ZChannel.write(chunk) *> handoffConsumer
+                case Halt(cause) => ZChannel.halt(cause)
+                case End(reason) => ZChannel.fromEffect(sinkEndReason.set(reason))
+              }
+          }
+        )
+
+      def scheduledAggregator(
+        lastB: Option[B]
+      ): ZChannel[R1 with Clock, Any, Any, Any, E2, Chunk[Either[C, B]], Any] = {
+        val timeout =
+          scheduleDriver
+            .next(lastB)
+            .foldCauseM(
+              _.failureOrCause match {
+                case Left(_)      => handoff.offer(End(ScheduleTimeout))
+                case Right(cause) => handoff.offer(Halt(cause))
+              },
+              c => handoff.offer(End(ScheduleEnd(c)))
+            )
+
+        ZChannel
+          .managed(timeout.forkManaged) { fiber =>
+            (handoffConsumer >>> sink.channel).doneCollect.flatMap { case (leftovers, b) =>
+              ZChannel.fromEffect(fiber.interrupt *> sinkLeftovers.set(leftovers.flatten)) *>
+                ZChannel.unwrap {
+                  sinkEndReason.modify {
+                    case ScheduleEnd(c) =>
+                      (ZChannel.write(Chunk(Right(b), Left(c))).as(Some(b)), SinkEnd)
+
+                    case ScheduleTimeout =>
+                      (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
+
+                    case SinkEnd =>
+                      (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
+
+                    case UpstreamEnd =>
+                      (ZChannel.write(Chunk(Right(b))).as(None), UpstreamEnd) // leftovers??
+                  }
+                }
+            }
+          }
+          .flatMap {
+            case None        => ZChannel.unit
+            case s @ Some(_) => scheduledAggregator(s)
+          }
+      }
+
+      ZStream.managed((self.channel >>> handoffProducer).runManaged.fork) *>
+        new ZStream(scheduledAggregator(None))
+    }
+  }
+
+  /**
+   * Maps the success values of this stream to the specified constant value.
+   */
+  def as[A2](A2: => A2): ZStream[R, E, A2] =
+    map(_ => A2)
+
+  /**
+   * Returns a stream whose failure and success channels have been mapped by
+   * the specified pair of functions, `f` and `g`.
+   */
+  def bimap[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZStream[R, E1, A1] =
+    mapError(f).map(g)
+
+  /**
+   * Fan out the stream, producing a list of streams that have the same elements as this stream.
+   * The driver stream will only ever advance of the `maximumLag` chunks before the
+   * slowest downstream stream.
+   */
+  final def broadcast(n: Int, maximumLag: Int): ZManaged[R, Nothing, List[ZStream[Any, E, A]]] =
+    self
+      .broadcastedQueues(n, maximumLag)
+      .map(
+        _.map(
+          ZStream
+            .fromQueueWithShutdown(_)
+            .flattenExitOption
+        )
+      )
+
+  /**
+   * Fan out the stream, producing a dynamic number of streams that have the same elements as this stream.
+   * The driver stream will only ever advance of the `maximumLag` chunks before the
+   * slowest downstream stream.
+   */
+  final def broadcastDynamic(
+    maximumLag: Int
+  ): ZManaged[R, Nothing, UIO[ZStream[Any, E, A]]] =
+    distributedWithDynamic(maximumLag, _ => ZIO.succeedNow(_ => true), _ => ZIO.unit)
+      .map(_.map(_._2))
+      .map(
+        _.map(
+          ZStream
+            .fromQueueWithShutdown(_)
+            .flattenExitOption
+        )
+      )
+
+  /**
+   * Converts the stream to a managed list of queues. Every value will be replicated to every queue with the
+   * slowest queue being allowed to buffer `maximumLag` chunks before the driver is backpressured.
+   * The downstream queues will be provided with chunks in the same order they are returned, so
+   * the fastest queue might have seen up to (`maximumLag` + 1) chunks more than the slowest queue if it
+   * has a lower index than the slowest queue.
+   *
+   * Queues can unsubscribe from upstream by shutting down.
+   */
+  final def broadcastedQueues(
+    n: Int,
+    maximumLag: Int
+  ): ZManaged[R, Nothing, List[Dequeue[Exit[Option[E], A]]]] = {
+    val decider = ZIO.succeedNow((_: Int) => true)
+    distributedWith(n, maximumLag, _ => decider)
+  }
+
+  /**
+   * Converts the stream to a managed dynamic amount of queues. Every chunk will be replicated to every queue with the
+   * slowest queue being allowed to buffer `maximumLag` chunks before the driver is backpressured.
+   * The downstream queues will be provided with chunks in the same order they are returned, so
+   * the fastest queue might have seen up to (`maximumLag` + 1) chunks more than the slowest queue if it
+   * has a lower index than the slowest queue.
+   *
+   * Queues can unsubscribe from upstream by shutting down.
+   */
+  final def broadcastedQueuesDynamic(
+    maximumLag: Int
+  ): ZManaged[R, Nothing, UIO[Dequeue[Exit[Option[E], A]]]] = {
+    val decider = ZIO.succeedNow((_: UniqueKey) => true)
+    distributedWithDynamic(maximumLag, _ => decider, _ => ZIO.unit).map(_.map(_._2))
+  }
+
+  /**
+   * Allows a faster producer to progress independently of a slower consumer by buffering
+   * up to `capacity` chunks in a queue.
+   *
+   * @note Prefer capacities that are powers of 2 for better performance.
+   */
+  final def buffer(capacity: Int): ZStream[R, E, A] = {
+    val queue = self.toQueue(capacity)
+    new ZStream(
+      ZChannel.managed(queue) { queue =>
+        lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+          ZChannel.fromEffect {
+            queue.take
+          }.flatMap { (take: Take[E, A]) =>
+            take.fold(
+              ZChannel.end(()),
+              error => ZChannel.halt(error),
+              value => ZChannel.write(value) *> process
+            )
+          }
+
+        process
+      }
+    )
+  }
+
+  /**
+   * Allows a faster producer to progress independently of a slower consumer by buffering
+   * up to `capacity` elements in a dropping queue.
+   *
+   * @note Prefer capacities that are powers of 2 for better performance.
+   */
+  final def bufferDropping(capacity: Int): ZStream[R, E, A] =
+    ???
+
+  /**
+   * Allows a faster producer to progress independently of a slower consumer by buffering
+   * up to `capacity` elements in a sliding queue.
+   *
+   * @note Prefer capacities that are powers of 2 for better performance.
+   */
+  final def bufferSliding(capacity: Int): ZStream[R, E, A] =
+    ???
+
+  /**
+   * Allows a faster producer to progress independently of a slower consumer by buffering
+   * elements into an unbounded queue.
+   */
+  final def bufferUnbounded: ZStream[R, E, A] = {
+    val queue = self.toQueueUnbounded
+    new ZStream(
+      ZChannel.managed(queue) { queue =>
+        lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+          ZChannel.fromEffect {
+            queue.take
+          }.flatMap { (take: Take[E, A]) =>
+            take.fold(
+              ZChannel.end(()),
+              error => ZChannel.halt(error),
+              value => ZChannel.write(value) *> process
+            )
+          }
+
+        process
+      }
+    )
+  }
+
+  /**
+   * Switches over to the stream produced by the provided function in case this one
+   * fails with a typed error.
+   */
+  final def catchAll[R1 <: R, E2, A1 >: A](f: E => ZStream[R1, E2, A1])(implicit ev: CanFail[E]): ZStream[R1, E2, A1] =
+    catchAllCause(_.failureOrCause.fold(f, ZStream.halt(_)))
+
+  /**
+   * Switches over to the stream produced by the provided function in case this one
+   * fails. Allows recovery from all causes of failure, including interruption if the
+   * stream is uninterruptible.
+   */
+  final def catchAllCause[R1 <: R, E2, A1 >: A](f: Cause[E] => ZStream[R1, E2, A1]): ZStream[R1, E2, A1] =
+    new ZStream(channel.catchAllCause(f(_).channel))
+
+  /**
+   * Switches over to the stream produced by the provided function in case this one
+   * fails with some typed error.
+   */
+  final def catchSome[R1 <: R, E1 >: E, A1 >: A](pf: PartialFunction[E, ZStream[R1, E1, A1]]): ZStream[R1, E1, A1] =
+    catchAll(pf.applyOrElse[E, ZStream[R1, E1, A1]](_, ZStream.fail(_)))
+
+  /**
+   * Switches over to the stream produced by the provided function in case this one
+   * fails with some errors. Allows recovery from all causes of failure, including interruption if the
+   * stream is uninterruptible.
+   */
+  final def catchSomeCause[R1 <: R, E1 >: E, A1 >: A](
+    pf: PartialFunction[Cause[E], ZStream[R1, E1, A1]]
+  ): ZStream[R1, E1, A1] =
+    catchAllCause(pf.applyOrElse[Cause[E], ZStream[R1, E1, A1]](_, ZStream.halt(_)))
+
+  /**
+   * Re-chunks the elements of the stream into chunks of
+   * `n` elements each.
+   * The last chunk might contain less than `n` elements
+   */
+  def chunkN(n: Int): ZStream[R, E, A] =
+    ZStream.unwrap {
+      ZIO.effectTotal {
+        val rechunker = new ZStream.Rechunker[A](n)
+        lazy val process: ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Unit] =
+          ZChannel.readWithCause(
+            (chunk: Chunk[A]) =>
+              if (chunk.size > 0) {
+                var chunks: List[Chunk[A]] = Nil
+                var result: Chunk[A]       = null
+                var i                      = 0
+
+                while (i < chunk.size) {
+                  while (i < chunk.size && (result eq null)) {
+                    result = rechunker.write(chunk(i))
+                    i += 1
+                  }
+
+                  if (result ne null) {
+                    chunks = result :: chunks
+                    result = null
+                  }
+                }
+
+                ZChannel.writeAll(chunks.reverse: _*) *> process
+              } else process,
+            (cause: Cause[E]) => rechunker.emitIfNotEmpty() *> ZChannel.halt(cause),
+            (_: Any) => rechunker.emitIfNotEmpty()
+          )
+
+        new ZStream(channel >>> process)
+      }
+    }
+
+  /**
+   * Exposes the underlying chunks of the stream as a stream of chunks of elements
+   */
+  def chunks: ZStream[R, E, Chunk[A]] =
+    mapChunks(Chunk.single)
+
+  /**
+   * Performs a filter and map in a single step.
+   */
+  final def collect[B](f: PartialFunction[A, B]): ZStream[R, E, B] =
+    mapChunks(_.collect(f))
+
+  /**
+   * Filters any `Right` values.
+   */
+  final def collectLeft[L1, A1](implicit ev: A <:< Either[L1, A1]): ZStream[R, E, L1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Either[L1, A1]]].collect { case Left(a) => a }
+  }
+
+  /**
+   * Filters any 'None' values.
+   */
+  final def collectSome[A1](implicit ev: A <:< Option[A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Option[A1]]].collect { case Some(a) => a }
+  }
+
+  /**
+   * Filters any `Exit.Failure` values.
+   */
+  final def collectSuccess[L1, A1](implicit ev: A <:< Exit[L1, A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Exit[L1, A1]]].collect { case Exit.Success(a) => a }
+  }
+
+  /**
+   * Filters any `Left` values.
+   */
+  final def collectRight[L1, A1](implicit ev: A <:< Either[L1, A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Either[L1, A1]]].collect { case Right(a) => a }
+  }
+
+  private def loopOnChunks[R1 <: R, E1 >: E, A1](
+    f: Chunk[A] => ZChannel[R1, E1, Chunk[A], Any, E1, Chunk[A1], Boolean]
+  ): ZStream[R1, E1, A1] = {
+    lazy val loop: ZChannel[R1, E1, Chunk[A], Any, E1, Chunk[A1], Boolean] =
+      ZChannel.readWith[R1, E1, Chunk[A], Any, E1, Chunk[A1], Boolean](
+        chunk => f(chunk).flatMap(continue => if (continue) loop else ZChannel.Done(false)),
+        ZChannel.fail(_),
+        _ => ZChannel.succeed(false)
+      )
+    new ZStream(self.channel >>> loop)
+  }
+
+  private def loopOnPartialChunks[R1 <: R, E1 >: E, A1](
+    f: (Chunk[A], A1 => UIO[Unit]) => ZIO[R1, E1, Boolean]
+  ): ZStream[R1, E1, A1] =
+    loopOnChunks(chunk =>
+      ZChannel.unwrap {
+        ZIO.effectSuspendTotal {
+          val outputChunk           = ChunkBuilder.make[A1](chunk.size)
+          val emit: A1 => UIO[Unit] = (a: A1) => UIO(outputChunk += a).unit
+          f(chunk, emit).map { continue =>
+            ZChannel.write(outputChunk.result()) *> ZChannel.end(continue)
+          }.catchAll { failure =>
+            ZIO.succeed {
+              val partialResult = outputChunk.result()
+              if (partialResult.nonEmpty)
+                ZChannel.write(partialResult) *> ZChannel.fail(failure)
+              else
+                ZChannel.fail(failure)
+            }
+          }
+        }
+      }
+    )
+
+  private def loopOnPartialChunksElements[R1 <: R, E1 >: E, A1](
+    f: (A, A1 => UIO[Unit]) => ZIO[R1, E1, Unit]
+  ): ZStream[R1, E1, A1] =
+    loopOnPartialChunks((chunk, emit) => ZIO.foreach_(chunk)(value => f(value, emit)).as(true))
+
+  /**
+   * Performs an effectful filter and map in a single step.
+   */
+  final def collectM[R1 <: R, E1 >: E, A1](pf: PartialFunction[A, ZIO[R1, E1, A1]]): ZStream[R1, E1, A1] =
+    loopOnPartialChunksElements((a, emit) => pf.andThen(_.flatMap(emit).unit).applyOrElse(a, (_: A) => ZIO.unit))
+
+  /**
+   * Transforms all elements of the stream for as long as the specified partial function is defined.
+   */
+  def collectWhile[A1](pf: PartialFunction[A, A1]): ZStream[R, E, A1] = {
+    lazy val loop: ZChannel[R, E, Chunk[A], Any, E, Chunk[A1], Any] =
+      ZChannel.readWith[R, E, Chunk[A], Any, E, Chunk[A1], Any](
+        in => {
+          val mapped = in.collectWhile(pf)
+          if (mapped.size == in.size)
+            ZChannel.write(mapped) *> loop
+          else
+            ZChannel.write(mapped)
+        },
+        ZChannel.fail(_),
+        ZChannel.succeed(_)
+      )
+    new ZStream(self.channel >>> loop)
+  }
+
+  /**
+   * Terminates the stream when encountering the first `Right`.
+   */
+  final def collectWhileLeft[L1, A1](implicit ev: A <:< Either[L1, A1]): ZStream[R, E, L1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Either[L1, A1]]].collectWhile { case Left(a) => a }
+  }
+
+  /**
+   * Effectfully transforms all elements of the stream for as long as the specified partial function is defined.
+   */
+  final def collectWhileM[R1 <: R, E1 >: E, A1](pf: PartialFunction[A, ZIO[R1, E1, A1]]): ZStream[R1, E1, A1] =
+    loopOnPartialChunks { (chunk, emit) =>
+      val pfSome = (a: A) => pf.andThen(_.flatMap(emit).as(true)).applyOrElse(a, (_: A) => ZIO.succeed(false))
+
+      def loop(chunk: Chunk[A]): ZIO[R1, E1, Boolean] =
+        if (chunk.isEmpty) ZIO.succeed(true)
+        else
+          pfSome(chunk.head).flatMap(continue => if (continue) loop(chunk.tail) else ZIO.succeed(false))
+
+      loop(chunk)
+    }
+
+  /**
+   * Terminates the stream when encountering the first `None`.
+   */
+  final def collectWhileSome[A1](implicit ev: A <:< Option[A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Option[A1]]].collectWhile { case Some(a) => a }
+  }
+
+  /**
+   * Terminates the stream when encountering the first `Left`.
+   */
+  final def collectWhileRight[L1, A1](implicit ev: A <:< Either[L1, A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Either[L1, A1]]].collectWhile { case Right(a) => a }
+  }
+
+  /**
+   * Terminates the stream when encountering the first `Exit.Failure`.
+   */
+  final def collectWhileSuccess[L1, A1](implicit ev: A <:< Exit[L1, A1]): ZStream[R, E, A1] = {
+    val _ = ev
+    self.asInstanceOf[ZStream[R, E, Exit[L1, A1]]].collectWhile { case Exit.Success(a) => a }
+  }
+
+  /**
+   * Combines the elements from this stream and the specified stream by repeatedly applying the
+   * function `f` to extract an element using both sides and conceptually "offer"
+   * it to the destination stream. `f` can maintain some internal state to control
+   * the combining process, with the initial state being specified by `s`.
+   *
+   * Where possible, prefer [[ZStream#combineChunks]] for a more efficient implementation.
+   */
+  final def combine[R1 <: R, E1 >: E, S, A2, A3](that: ZStream[R1, E1, A2])(s: S)(
+    f: (S, ZIO[R, Option[E], A], ZIO[R1, Option[E1], A2]) => ZIO[R1, Nothing, Exit[Option[E1], (A3, S)]]
+  ): ZStream[R1, E1, A3] =
+    ZStream.unwrapManaged {
+      for {
+        left  <- self.toPull.mapM(BufferedPull.make[R, E, A](_)) // type annotation required for Dotty
+        right <- that.toPull.mapM(BufferedPull.make[R1, E1, A2](_))
+      } yield ZStream.unfoldM(s)(s => f(s, left.pullElement, right.pullElement).flatMap(ZIO.done(_).optional))
+    }
+
+  /**
+   * Combines the chunks from this stream and the specified stream by repeatedly applying the
+   * function `f` to extract a chunk using both sides and conceptually "offer"
+   * it to the destination stream. `f` can maintain some internal state to control
+   * the combining process, with the initial state being specified by `s`.
+   */
+  final def combineChunks[R1 <: R, E1 >: E, S, A2, A3](that: ZStream[R1, E1, A2])(s: S)(
+    f: (
+      S,
+      ZIO[R, Option[E], Chunk[A]],
+      ZIO[R1, Option[E1], Chunk[A2]]
+    ) => ZIO[R1, Nothing, Exit[Option[E1], (Chunk[A3], S)]]
+  ): ZStream[R1, E1, A3] =
+    ZStream.unwrapManaged {
+      for {
+        pullLeft  <- self.toPull
+        pullRight <- that.toPull
+      } yield ZStream.unfoldChunkM(s)(s => f(s, pullLeft, pullRight).flatMap(ZIO.done(_).optional))
+    }
+
+  /**
+   * Concatenates the specified stream with this stream, resulting in a stream
+   * that emits the elements from this stream and then the elements from the specified stream.
+   */
+  def concat[R1 <: R, E1 >: E, A1 >: A](that: => ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    new ZStream(channel *> that.channel)
+
+  /**
+   * Composes this stream with the specified stream to create a cartesian product of elements.
+   * The `that` stream would be run multiple times, for every element in the `this` stream.
+   *
+   * See also [[ZStream#zip]] and [[ZStream#<&>]] for the more common point-wise variant.
+   */
+  final def cross[R1 <: R, E1 >: E, B](that: => ZStream[R1, E1, B]): ZStream[R1, E1, (A, B)] =
+    new ZStream(self.channel.concatMap(a => that.channel.mapOut(b => a.flatMap(a => b.map(b => (a, b))))))
+
+  /**
+   * Composes this stream with the specified stream to create a cartesian product of elements,
+   * but keeps only elements from this stream.
+   * The `that` stream would be run multiple times, for every element in the `this` stream.
+   *
+   * See also [[ZStream#zip]] and [[ZStream#<&>]] for the more common point-wise variant.
+   */
+  final def crossLeft[R1 <: R, E1 >: E, B](that: => ZStream[R1, E1, B]): ZStream[R1, E1, A] =
+    (self cross that).map(_._1)
+
+  /**
+   * Composes this stream with the specified stream to create a cartesian product of elements,
+   * but keeps only elements from the other stream.
+   * The `that` stream would be run multiple times, for every element in the `this` stream.
+   *
+   * See also [[ZStream#zip]] and [[ZStream#<&>]] for the more common point-wise variant.
+   */
+  def crossRight[R1 <: R, E1 >: E, B](that: => ZStream[R1, E1, B]): ZStream[R1, E1, B] =
+    (self cross that).map(_._2)
+
+  /**
+   * Composes this stream with the specified stream to create a cartesian product of elements
+   * with a specified function.
+   * The `that` stream would be run multiple times, for every element in the `this` stream.
+   *
+   * See also [[ZStream#zip]] and [[ZStream#<&>]] for the more common point-wise variant.
+   */
+  final def crossWith[R1 <: R, E1 >: E, A2, C](that: ZStream[R1, E1, A2])(f: (A, A2) => C): ZStream[R1, E1, C] =
+    self.flatMap(l => that.map(r => f(l, r)))
+
+  /**
+   * More powerful version of `ZStream#broadcast`. Allows to provide a function that determines what
+   * queues should receive which elements. The decide function will receive the indices of the queues
+   * in the resulting list.
+   */
+  final def distributedWith[E1 >: E](
+    n: Int,
+    maximumLag: Int,
+    decide: A => UIO[Int => Boolean]
+  ): ZManaged[R, Nothing, List[Dequeue[Exit[Option[E1], A]]]] =
+    Promise.make[Nothing, A => UIO[UniqueKey => Boolean]].toManaged_.flatMap { prom =>
+      distributedWithDynamic(maximumLag, (a: A) => prom.await.flatMap(_(a)), _ => ZIO.unit).flatMap { next =>
+        ZIO.collectAll {
+          Range(0, n).map(id => next.map { case (key, queue) => ((key -> id), queue) })
+        }.flatMap { entries =>
+          val (mappings, queues) =
+            entries.foldRight((Map.empty[UniqueKey, Int], List.empty[Dequeue[Exit[Option[E1], A]]])) {
+              case ((mapping, queue), (mappings, queues)) =>
+                (mappings + mapping, queue :: queues)
+            }
+          prom.succeed((a: A) => decide(a).map(f => (key: UniqueKey) => f(mappings(key)))).as(queues)
+        }.toManaged_
+      }
+    }
+
+  /**
+   * More powerful version of `ZStream#distributedWith`. This returns a function that will produce
+   * new queues and corresponding indices.
+   * You can also provide a function that will be executed after the final events are enqueued in all queues.
+   * Shutdown of the queues is handled by the driver.
+   * Downstream users can also shutdown queues manually. In this case the driver will
+   * continue but no longer backpressure on them.
+   */
+  final def distributedWithDynamic(
+    maximumLag: Int,
+    decide: A => UIO[UniqueKey => Boolean],
+    done: Exit[Option[E], Nothing] => UIO[Any] = (_: Any) => UIO.unit
+  ): ZManaged[R, Nothing, UIO[(UniqueKey, Dequeue[Exit[Option[E], A]])]] =
+    for {
+      queuesRef <- Ref
+                     .make[Map[UniqueKey, Queue[Exit[Option[E], A]]]](Map())
+                     .toManaged(_.get.flatMap(qs => ZIO.foreach(qs.values)(_.shutdown)))
+      add <- {
+        val offer = (a: A) =>
+          for {
+            shouldProcess <- decide(a)
+            queues        <- queuesRef.get
+            _ <- ZIO
+                   .foldLeft(queues)(List[UniqueKey]()) { case (acc, (id, queue)) =>
+                     if (shouldProcess(id)) {
+                       queue
+                         .offer(Exit.succeed(a))
+                         .foldCauseM(
+                           {
+                             // we ignore all downstream queues that were shut down and remove them later
+                             case c if c.interrupted => ZIO.succeedNow(id :: acc)
+                             case c                  => ZIO.halt(c)
+                           },
+                           _ => ZIO.succeedNow(acc)
+                         )
+                     } else ZIO.succeedNow(acc)
+                   }
+                   .flatMap(ids => if (ids.nonEmpty) queuesRef.update(_ -- ids) else ZIO.unit)
+          } yield ()
+
+        for {
+          queuesLock <- Semaphore.make(1).toManaged_
+          newQueue <- Ref
+                        .make[UIO[(UniqueKey, Queue[Exit[Option[E], A]])]] {
+                          for {
+                            queue <- Queue.bounded[Exit[Option[E], A]](maximumLag)
+                            id     = UniqueKey()
+                            _     <- queuesRef.update(_ + (id -> queue))
+                          } yield (id, queue)
+                        }
+                        .toManaged_
+          finalize = (endTake: Exit[Option[E], Nothing]) =>
+                       // we need to make sure that no queues are currently being added
+                       queuesLock.withPermit {
+                         for {
+                           // all newly created queues should end immediately
+                           _ <- newQueue.set {
+                                  for {
+                                    queue <- Queue.bounded[Exit[Option[E], A]](1)
+                                    _     <- queue.offer(endTake)
+                                    id     = UniqueKey()
+                                    _     <- queuesRef.update(_ + (id -> queue))
+                                  } yield (id, queue)
+                                }
+                           queues <- queuesRef.get.map(_.values)
+                           _ <- ZIO.foreach(queues) { queue =>
+                                  queue.offer(endTake).catchSomeCause {
+                                    case c if c.interrupted => ZIO.unit
+                                  }
+                                }
+                           _ <- done(endTake)
+                         } yield ()
+                       }
+          _ <- self
+                 .runForeachManaged(offer)
+                 .foldCauseM(
+                   cause => finalize(Exit.halt(cause.map(Some(_)))).toManaged_,
+                   _ => finalize(Exit.fail(None)).toManaged_
+                 )
+                 .fork
+        } yield queuesLock.withPermit(newQueue.get.flatten)
+      }
+    } yield add
+
+  /**
+   * Converts this stream to a stream that executes its effects but emits no
+   * elements. Useful for sequencing effects using streams:
+   *
+   * {{{
+   * (Stream(1, 2, 3).tap(i => ZIO(println(i))) ++
+   *   Stream.fromEffect(ZIO(println("Done!"))).drain ++
+   *   Stream(4, 5, 6).tap(i => ZIO(println(i)))).run(Sink.drain)
+   * }}}
+   */
+  final def drain: ZStream[R, E, Nothing] =
+    new ZStream(channel.drain)
+
+  /**
+   * Drains the provided stream in the background for as long as this stream is running.
+   * If this stream ends before `other`, `other` will be interrupted. If `other` fails,
+   * this stream will fail with that error.
+   */
+  final def drainFork[R1 <: R, E1 >: E](other: ZStream[R1, E1, Any]): ZStream[R1, E1, A] =
+    ZStream.fromEffect(Promise.make[E1, Nothing]).flatMap { bgDied =>
+      ZStream
+        .managed(other.runForeachManaged(_ => ZIO.unit).catchAllCause(bgDied.halt(_).toManaged_).fork) *>
+        self.interruptWhen(bgDied)
+    }
+
+  def drop(n: Int): ZStream[R, E, A] = {
+    def loop(n: Int): ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] =
+      ZChannel
+        .read[Chunk[A]]
+        .map(chunk => (true, chunk))
+        .catchAll(_ => ZChannel.succeed((false, Chunk.empty)))
+        .flatMap { case (notEnded, chunk) =>
+          val dropped  = chunk.drop(n)
+          val leftover = (n - dropped.length).min(0)
+          val more     = notEnded && leftover > 0
+
+          if (more) loop(leftover) else ZChannel.write(dropped) *> ZChannel.identity[E, Chunk[A], Any]
+        }
+    new ZStream(channel >>> loop(n))
+  }
+
+  /**
+   * Drops all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  final def dropWhile(f: A => Boolean): ZStream[R, E, A] = {
+    def loop(f: A => Boolean): ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] =
+      ZChannel
+        .read[Chunk[A]]
+        .map(chunk => (true, chunk))
+        .catchAll(_ => ZChannel.succeed((false, Chunk.empty)))
+        .flatMap { case (notEnded, chunk) =>
+          val leftover = chunk.dropWhile(f)
+          val more     = notEnded && (leftover.length == 0)
+
+          if (more) loop(f) else ZChannel.write(leftover) *> ZChannel.identity[E, Chunk[A], Any]
+        }
+    new ZStream(channel >>> loop(f))
+  }
+
+  /**
+   * Drops all elements of the stream until the specified predicate evaluates
+   * to `true`.
+   */
+  final def dropUntil(pred: A => Boolean): ZStream[R, E, A] =
+    dropWhile(!pred(_)).drop(1)
+
+  /**
+   * Returns a stream whose failures and successes have been lifted into an
+   * `Either`. The resulting stream cannot fail, because the failures have
+   * been exposed as part of the `Either` success case.
+   *
+   * @note the stream will end as soon as the first error occurs.
+   */
+  final def either(implicit ev: CanFail[E]): ZStream[R, Nothing, Either[E, A]] =
+    self.map(Right(_)).catchAll(e => ZStream(Left(e)))
+
+  /**
+   * Executes the provided finalizer after this stream's finalizers run.
+   */
+  final def ensuring[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
+    new ZStream(channel.ensuring(fin))
+
+  /**
+   * Executes the provided finalizer before this stream's finalizers run.
+   */
+  final def ensuringFirst[R1 <: R](fin: ZIO[R1, Nothing, Any]): ZStream[R1, E, A] =
+    ???
+
+  /**
+   * Filters the elements emitted by this stream using the provided function.
+   */
+  final def filter[B](f: A => Boolean): ZStream[R, E, A] =
+    mapChunks(_.filter(f))
+
+  /**
+   * Executes a pure fold over the stream of values - reduces all elements in the stream to a value of type `S`.
+   */
+  final def runFold[S](s: S)(f: (S, A) => S): ZIO[R, E, S] =
+    runFoldWhileManaged(s)(_ => true)((s, a) => f(s, a)).use(ZIO.succeedNow)
+
+  /**
+   * Executes an effectful fold over the stream of values.
+   */
+  final def runFoldM[R1 <: R, E1 >: E, S](s: S)(f: (S, A) => ZIO[R1, E1, S]): ZIO[R1, E1, S] =
+    runFoldWhileManagedM[R1, E1, S](s)(_ => true)(f).use(ZIO.succeedNow)
+
+  /**
+   * Executes a pure fold over the stream of values.
+   * Returns a Managed value that represents the scope of the stream.
+   */
+  final def runFoldManaged[S](s: S)(f: (S, A) => S): ZManaged[R, E, S] =
+    runFoldWhileManaged(s)(_ => true)((s, a) => f(s, a))
+
+  /**
+   * Executes an effectful fold over the stream of values.
+   * Returns a Managed value that represents the scope of the stream.
+   */
+  final def runFoldManagedM[R1 <: R, E1 >: E, S](s: S)(f: (S, A) => ZIO[R1, E1, S]): ZManaged[R1, E1, S] =
+    runFoldWhileManagedM[R1, E1, S](s)(_ => true)(f)
+
+  /**
+   * Reduces the elements in the stream to a value of type `S`.
+   * Stops the fold early when the condition is not fulfilled.
+   * Example:
+   * {{{
+   *  Stream(1).forever.foldWhile(0)(_ <= 4)(_ + _) // UIO[Int] == 5
+   * }}}
+   */
+  final def runFoldWhile[S](s: S)(cont: S => Boolean)(f: (S, A) => S): ZIO[R, E, S] =
+    runFoldWhileManaged(s)(cont)((s, a) => f(s, a)).use(ZIO.succeedNow)
+
+  /**
+   * Executes an effectful fold over the stream of values.
+   * Stops the fold early when the condition is not fulfilled.
+   * Example:
+   * {{{
+   *   Stream(1)
+   *     .forever                                // an infinite Stream of 1's
+   *     .fold(0)(_ <= 4)((s, a) => UIO(s + a))  // UIO[Int] == 5
+   * }}}
+   *
+   * @param cont function which defines the early termination condition
+   */
+  final def runFoldWhileM[R1 <: R, E1 >: E, S](s: S)(cont: S => Boolean)(f: (S, A) => ZIO[R1, E1, S]): ZIO[R1, E1, S] =
+    runFoldWhileManagedM[R1, E1, S](s)(cont)(f).use(ZIO.succeedNow)
+
+  /**
+   * Executes a pure fold over the stream of values.
+   * Returns a Managed value that represents the scope of the stream.
+   * Stops the fold early when the condition is not fulfilled.
+   */
+  def runFoldWhileManaged[S](s: S)(cont: S => Boolean)(f: (S, A) => S): ZManaged[R, E, S] = {
+    def fold(s1: S): ZChannel[R, E, Chunk[A], Any, E, Nothing, S] =
+      if (!cont(s1)) ZChannel.succeed(s1)
+      else
+        ZChannel.readWithCause(
+          (in: Chunk[A]) => fold(in.foldWhile(s1)(cont)(f)),
+          (halt: Cause[E]) => ZChannel.halt(halt),
+          _ => ZChannel.end(s1)
+        )
+
+    (channel >>> fold(s)).runManaged
+  }
+
+  /**
+   * Executes an effectful fold over the stream of values.
+   * Returns a Managed value that represents the scope of the stream.
+   * Stops the fold early when the condition is not fulfilled.
+   * Example:
+   * {{{
+   *   Stream(1)
+   *     .forever                                // an infinite Stream of 1's
+   *     .fold(0)(_ <= 4)((s, a) => UIO(s + a))  // Managed[Nothing, Int]
+   *     .use(ZIO.succeed)                       // UIO[Int] == 5
+   * }}}
+   *
+   * @param cont function which defines the early termination condition
+   */
+  final def runFoldWhileManagedM[R1 <: R, E1 >: E, S](
+    s: S
+  )(cont: S => Boolean)(f: (S, A) => ZIO[R1, E1, S]): ZManaged[R1, E1, S] = {
+    def fold(s1: S): ZChannel[R1, E, Chunk[A], Any, E1, Nothing, S] =
+      if (!cont(s1)) ZChannel.succeed(s1)
+      else
+        ZChannel.readWithCause[R1, E, Chunk[A], Any, E1, Nothing, S](
+          in => ZChannel.fromEffect(in.foldM(s1)(f)).flatMap(fold),
+          halt => ZChannel.halt(halt),
+          _ => ZChannel.end(s1)
+        )
+
+    (channel >>> fold(s)).runManaged
+  }
+
+  /**
+   * Consumes all elements of the stream, passing them to the specified callback.
+   */
+  final def foreach[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZIO[R1, E1, Unit] =
+    runForeach(f)
+
+  /**
+   * Consumes all elements of the stream, passing them to the specified callback.
+   */
+  final def runForeach[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZIO[R1, E1, Unit] =
+    channel.mapOutM(chunk => ZIO.foreach_(chunk)(f)).runDrain.unit
+
+  /**
+   * Consumes all elements of the stream, passing them to the specified callback.
+   */
+  final def runForeachChunk[R1 <: R, E1 >: E](f: Chunk[A] => ZIO[R1, E1, Any]): ZIO[R1, E1, Unit] =
+    channel.mapOutM(f).runDrain.unit
+
+  /**
+   * Like [[ZStream#foreachChunk]], but returns a `ZManaged` so the finalization order
+   * can be controlled.
+   */
+  final def runForeachChunkManaged[R1 <: R, E1 >: E](f: Chunk[A] => ZIO[R1, E1, Any]): ZManaged[R1, E1, Unit] =
+    channel.mapOutM(f).drain.runManaged.unit
+
+  /**
+   * Like [[ZStream#foreach]], but returns a `ZManaged` so the finalization order
+   * can be controlled.
+   */
+  final def runForeachManaged[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any]): ZManaged[R1, E1, Unit] =
+    channel.mapOutM(chunk => ZIO.foreach_(chunk)(f)).drain.runManaged.unit
+
+  /**
+   * Consumes elements of the stream, passing them to the specified callback,
+   * and terminating consumption when the callback returns `false`.
+   */
+  final def runForeachWhile[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZIO[R1, E1, Unit] =
+    run(ZSink.foreachWhile(f))
+
+  /**
+   * Like [[ZStream#foreachWhile]], but returns a `ZManaged` so the finalization order
+   * can be controlled.
+   */
+  final def runForeachWhileManaged[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZManaged[R1, E1, Unit] =
+    runManaged(ZSink.foreachWhile(f))
+
+  /**
+   * Repeats this stream forever.
+   */
+  def forever: ZStream[R, E, A] =
+    new ZStream(channel.repeated)
+
+  /**
+   * Effectfully filters the elements emitted by this stream.
+   */
+  def filterM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZStream[R1, E1, A] =
+    loopOnPartialChunksElements((a, emit) => f(a).flatMap(r => if (r) emit(a) else ZIO.unit))
+
+  /**
+   * Filters this stream by the specified predicate, removing all elements for
+   * which the predicate evaluates to true.
+   */
+  final def filterNot(pred: A => Boolean): ZStream[R, E, A] = filter(a => !pred(a))
+
+  /**
+   * Emits elements of this stream with a fixed delay in between, regardless of how long it
+   * takes to produce a value.
+   */
+  final def fixed(duration: Duration): ZStream[R with Clock, E, A] =
+    schedule(Schedule.fixed(duration))
+
+  /**
+   * Returns a stream made of the concatenation in strict order of all the streams
+   * produced by passing each element of this stream to `f0`
+   */
+  final def flatMap[R1 <: R, E1 >: E, B](f: A => ZStream[R1, E1, B]): ZStream[R1, E1, B] =
+    new ZStream(channel.concatMap(as => as.map(f).map(_.channel).fold(ZChannel.unit)(_ *> _)))
+
+  /**
+   * Maps each element of this stream to another stream and returns the
+   * non-deterministic merge of those streams, executing up to `n` inner streams
+   * concurrently. Up to `outputBuffer` elements of the produced streams may be
+   * buffered in memory by this operator.
+   */
+  def flatMapPar[R1 <: R, E1 >: E, B](n: Long)(f: A => ZStream[R1, E1, B]): ZStream[R1, E1, B] =
+    new ZStream[R1, E1, B](
+      channel.mergeMap[R1, Any, Any, Any, E1, Chunk[B]](n) { as =>
+        as.map(f).map(_.channel).fold(ZChannel.unit)(_ *> _)
+      }
+    )
+
+  /**
+   * Maps each element of this stream to another stream and returns the non-deterministic merge
+   * of those streams, executing up to `n` inner streams concurrently. When a new stream is created
+   * from an element of the source stream, the oldest executing stream is cancelled. Up to `bufferSize`
+   * elements of the produced streams may be buffered in memory by this operator.
+   */
+  final def flatMapParSwitch[R1 <: R, E1 >: E, A2](n: Int, bufferSize: Int = 16)(
+    f: A => ZStream[R1, E1, A2]
+  ): ZStream[R1, E1, A2] =
+    ???
+
+  /**
+   * Flattens this stream-of-streams into a stream made of the concatenation in
+   * strict order of all the streams.
+   */
+  def flatten[R1 <: R, E1 >: E, A1](implicit ev: A <:< ZStream[R1, E1, A1]): ZStream[R1, E1, A1] = flatMap(ev(_))
+
+  /**
+   * Submerges the chunks carried by this stream into the stream's structure, while
+   * still preserving them.
+   */
+  def flattenChunks[A1](implicit ev: A <:< Chunk[A1]): ZStream[R, E, A1] =
+    new ZStream(self.channel.mapOut(_.flatten))
+
+  /**
+   * Flattens [[Exit]] values. `Exit.Failure` values translate to stream failures
+   * while `Exit.Success` values translate to stream elements.
+   */
+  def flattenExit[E1 >: E, A1](implicit ev: A <:< Exit[E1, A1]): ZStream[R, E1, A1] =
+    mapM(a => ZIO.done(ev(a)))
+
+  /**
+   * Unwraps [[Exit]] values that also signify end-of-stream by failing with `None`.
+   *
+   * For `Exit[E, A]` values that do not signal end-of-stream, prefer:
+   * {{{
+   * stream.mapM(ZIO.done(_))
+   * }}}
+   */
+  def flattenExitOption[E1 >: E, A1](implicit ev: A <:< Exit[Option[E1], A1]): ZStream[R, E1, A1] = {
+    def processChunk(
+      chunk: Chunk[Exit[Option[E1], A1]],
+      cont: ZChannel[R, E, Chunk[Exit[Option[E1], A1]], Any, E1, Chunk[A1], Any]
+    ): ZChannel[R, E, Chunk[Exit[Option[E1], A1]], Any, E1, Chunk[A1], Any] = {
+      val (toEmit, rest) = chunk.splitWhere(!_.succeeded)
+      val next = rest.headOption match {
+        case Some(Exit.Success(_)) => ZChannel.end(())
+        case Some(Exit.Failure(cause)) =>
+          Cause.flipCauseOption(cause) match {
+            case Some(cause) => ZChannel.halt(cause)
+            case None        => ZChannel.end(())
+          }
+        case None => cont
+      }
+      ZChannel.write(toEmit.collect { case Exit.Success(a) => a }) *> next
+    }
+
+    lazy val process: ZChannel[R, E, Chunk[Exit[Option[E1], A1]], Any, E1, Chunk[A1], Any] =
+      ZChannel.readWithCause[R, E, Chunk[Exit[Option[E1], A1]], Any, E1, Chunk[A1], Any](
+        chunk => processChunk(chunk, process),
+        cause => ZChannel.halt(cause),
+        _ => ZChannel.end(())
+      )
+
+    new ZStream(channel.asInstanceOf[ZChannel[R, Any, Any, Any, E, Chunk[Exit[Option[E1], A1]], Any]] >>> process)
+  }
+
+  /**
+   * Submerges the iterables carried by this stream into the stream's structure, while
+   * still preserving them.
+   */
+  def flattenIterables[A1](implicit ev: A <:< Iterable[A1]): ZStream[R, E, A1] =
+    map(a => Chunk.fromIterable(ev(a))).flattenChunks
+
+  /**
+   * Flattens a stream of streams into a stream by executing a non-deterministic
+   * concurrent merge. Up to `n` streams may be consumed in parallel and up to
+   * `outputBuffer` elements may be buffered by this operator.
+   */
+  def flattenPar[R1 <: R, E1 >: E, A1](n: Int, outputBuffer: Int = 16)(implicit
+    ev: A <:< ZStream[R1, E1, A1]
+  ): ZStream[R1, E1, A1] = {
+    val _ = outputBuffer
+    flatMapPar[R1, E1, A1](n.toLong)(ev(_))
+  }
+
+  /**
+   * Like [[flattenPar]], but executes all streams concurrently.
+   */
+  def flattenParUnbounded[R1 <: R, E1 >: E, A1](
+    outputBuffer: Int = 16
+  )(implicit ev: A <:< ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    flattenPar[R1, E1, A1](Int.MaxValue, outputBuffer)
+
+  /**
+   * Unwraps [[Exit]] values and flatten chunks that also signify end-of-stream by failing with `None`.
+   */
+  final def flattenTake[E1 >: E, A1](implicit ev: A <:< Take[E1, A1]): ZStream[R, E1, A1] =
+    map(_.exit).flattenExitOption[E1, Chunk[A1]].flattenChunks
+
+  /**
+   * More powerful version of [[ZStream.groupByKey]]
+   */
+  final def groupBy[R1 <: R, E1 >: E, K, V](
+    f: A => ZIO[R1, E1, (K, V)],
+    buffer: Int = 16
+  ): ZStream.GroupBy[R1, E1, K, V] = {
+    val qstream = ZStream.unwrapManaged {
+      for {
+        decider <- Promise.make[Nothing, (K, V) => UIO[UniqueKey => Boolean]].toManaged_
+        out <- Queue
+                 .bounded[Exit[Option[E1], (K, Dequeue[Exit[Option[E1], V]])]](buffer)
+                 .toManaged(_.shutdown)
+        ref <- Ref.make[Map[K, UniqueKey]](Map()).toManaged_
+        add <- self
+                 .mapM(f)
+                 .distributedWithDynamic(
+                   buffer,
+                   (kv: (K, V)) => decider.await.flatMap(_.tupled(kv)),
+                   out.offer
+                 )
+        _ <- decider.succeed { case (k, _) =>
+               ref.get.map(_.get(k)).flatMap {
+                 case Some(idx) => ZIO.succeedNow(_ == idx)
+                 case None =>
+                   add.flatMap { case (idx, q) =>
+                     (ref.update(_ + (k -> idx)) *>
+                       out.offer(Exit.succeed(k -> q.map(_.map(_._2))))).as(_ == idx)
+                   }
+               }
+             }.toManaged_
+      } yield ZStream.fromQueueWithShutdown(out).flattenExitOption
+    }
+    new ZStream.GroupBy(qstream, buffer)
+  }
+
+  /**
+   * Partition a stream using a function and process each stream individually.
+   * This returns a data structure that can be used
+   * to further filter down which groups shall be processed.
+   *
+   * After calling apply on the GroupBy object, the remaining groups will be processed
+   * in parallel and the resulting streams merged in a nondeterministic fashion.
+   *
+   * Up to `buffer` elements may be buffered in any group stream before the producer
+   * is backpressured. Take care to consume from all streams in order
+   * to prevent deadlocks.
+   *
+   * Example:
+   * Collect the first 2 words for every starting letter
+   * from a stream of words.
+   * {{{
+   * ZStream.fromIterable(List("hello", "world", "hi", "holla"))
+   *  .groupByKey(_.head) { case (k, s) => s.take(2).map((k, _)) }
+   *  .runCollect
+   *  .map(_ == List(('h', "hello"), ('h', "hi"), ('w', "world"))
+   * }}}
+   */
+  final def groupByKey[K](
+    f: A => K,
+    buffer: Int = 16
+  ): ZStream.GroupBy[R, E, K, A] =
+    self.groupBy(a => ZIO.succeedNow((f(a), a)), buffer)
+
+  /**
+   * Halts the evaluation of this stream when the provided IO completes. The given IO
+   * will be forked as part of the returned stream, and its success will be discarded.
+   *
+   * An element in the process of being pulled will not be interrupted when the IO
+   * completes. See `interruptWhen` for this behavior.
+   *
+   * If the IO completes with a failure, the stream will emit that failure.
+   */
+  final def haltWhen[R1 <: R, E1 >: E](io: ZIO[R1, E1, Any]): ZStream[R1, E1, A] =
+    ???
+
+  /**
+   * Specialized version of haltWhen which halts the evaluation of this stream
+   * after the given duration.
+   *
+   * An element in the process of being pulled will not be interrupted when the
+   * given duration completes. See `interruptAfter` for this behavior.
+   */
+  final def haltAfter(duration: Duration): ZStream[R with Clock, E, A] =
+    haltWhen(clock.sleep(duration))
+
+  /**
+   * Partitions the stream with specified chunkSize
+   * @param chunkSize size of the chunk
+   */
+  def grouped(chunkSize: Int): ZStream[R, E, Chunk[A]] =
+    ???
+
+  /**
+   * Partitions the stream with the specified chunkSize or until the specified
+   * duration has passed, whichever is satisfied first.
+   */
+  def groupedWithin(chunkSize: Int, within: Duration): ZStream[R with Clock, E, Chunk[A]] =
+    ???
+
+  /**
+   * Halts the evaluation of this stream when the provided promise resolves.
+   *
+   * If the promise completes with a failure, the stream will emit that failure.
+   */
+  final def haltWhen[E1 >: E](p: Promise[E1, _]): ZStream[R, E1, A] =
+    ???
+
+  /**
+   * Interleaves this stream and the specified stream deterministically by
+   * alternating pulling values from this stream and the specified stream.
+   * When one stream is exhausted all remaining values in the other stream
+   * will be pulled.
+   */
+  final def interleave[R1 <: R, E1 >: E, A1 >: A](that: ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    self.interleaveWith(that)(ZStream(true, false).forever)
+
+  /**
+   * Combines this stream and the specified stream deterministically using the
+   * stream of boolean values `b` to control which stream to pull from next.
+   * `true` indicates to pull from this stream and `false` indicates to pull
+   * from the specified stream. Only consumes as many elements as requested by
+   * `b`. If either this stream or the specified stream are exhausted further
+   * requests for values from that stream will be ignored.
+   */
+  final def interleaveWith[R1 <: R, E1 >: E, A1 >: A](
+    that: ZStream[R1, E1, A1]
+  )(b: ZStream[R1, E1, Boolean]): ZStream[R1, E1, A1] =
+    ???
+
+  /**
+   * Intersperse stream with provided element similar to <code>List.mkString</code>.
+   */
+  final def intersperse[A1 >: A](middle: A1): ZStream[R, E, A1] =
+    ???
+
+  /**
+   * Intersperse and also add a prefix and a suffix
+   */
+  final def intersperse[A1 >: A](start: A1, middle: A1, end: A1): ZStream[R, E, A1] =
+    ZStream(start) ++ intersperse(middle) ++ ZStream(end)
+
+  /**
+   * Interrupts the evaluation of this stream when the provided IO completes. The given
+   * IO will be forked as part of this stream, and its success will be discarded. This
+   * combinator will also interrupt any in-progress element being pulled from upstream.
+   *
+   * If the IO completes with a failure before the stream completes, the returned stream
+   * will emit that failure.
+   */
+  final def interruptWhen[R1 <: R, E1 >: E](io: ZIO[R1, E1, Any]): ZStream[R1, E1, A] =
+    new ZStream(channel.interruptWhen(io))
+
+  /**
+   * Interrupts the evaluation of this stream when the provided promise resolves. This
+   * combinator will also interrupt any in-progress element being pulled from upstream.
+   *
+   * If the promise completes with a failure, the stream will emit that failure.
+   */
+  final def interruptWhen[E1 >: E](p: Promise[E1, _]): ZStream[R, E1, A] =
+    new ZStream(channel.interruptWhen(p.asInstanceOf[Promise[E1, Any]]))
+
+  /**
+   * Specialized version of interruptWhen which interrupts the evaluation of this stream
+   * after the given duration.
+   */
+  final def interruptAfter(duration: Duration): ZStream[R with Clock, E, A] =
+    interruptWhen(clock.sleep(duration))
+
+  /**
+   * Enqueues elements of this stream into a queue. Stream failure and ending will also be
+   * signalled.
+   */
+  final def runInto[R1 <: R, E1 >: E](
+    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, A], Any]
+  ): ZIO[R1, E1, Unit] =
+    runIntoManaged(queue).use_(UIO.unit)
+
+  /**
+   * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow for scope
+   * composition.
+   */
+  final def runIntoManaged[R1 <: R, E1 >: E](
+    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, A], Any]
+  ): ZManaged[R1, E1, Unit] = {
+    lazy val writer: ZChannel[R, E, Chunk[A], Any, E, Take[E1, A], Any] = ZChannel
+      .readWithCause[R, E, Chunk[A], Any, E, Take[E1, A], Any](
+        in => ZChannel.write(Take.chunk(in)) *> writer,
+        cause => ZChannel.write(Take.halt(cause)),
+        _ => ZChannel.write(Take.end)
+      )
+
+    (self.channel >>> writer)
+      .mapOutM(queue.offer)
+      .drain
+      .runManaged
+      .unit
+  }
+
+  /**
+   * Transforms the elements of this stream using the supplied function.
+   */
+  final def map[B](f: A => B): ZStream[R, E, B] =
+    new ZStream(channel.mapOut(_.map(f)))
+
+  /**
+   * Statefully maps over the elements of this stream to produce new elements.
+   */
+  def mapAccum[S, A1](s: S)(f: (S, A) => (S, A1)): ZStream[R, E, A1] = {
+    def accumulator(currS: S): ZChannel[Any, E, Chunk[A], Any, E, Chunk[A1], Unit] =
+      ZChannel.readWith(
+        (in: Chunk[A]) => {
+          val (nextS, a1s) = in.mapAccum(currS)(f)
+          ZChannel.write(a1s) *> accumulator(nextS)
+        },
+        (err: E) => ZChannel.fail(err),
+        (_: Any) => ZChannel.unit
+      )
+
+    new ZStream(self.channel >>> accumulator(s))
+  }
+
+  /**
+   * Statefully and effectfully maps over the elements of this stream to produce
+   * new elements.
+   */
+  final def mapAccumM[R1 <: R, E1 >: E, S, A1](s: S)(f: (S, A) => ZIO[R1, E1, (S, A1)]): ZStream[R1, E1, A1] =
+    ???
+
+  /**
+   * Transforms the chunks emitted by this stream.
+   */
+  def mapChunks[A2](f: Chunk[A] => Chunk[A2]): ZStream[R, E, A2] =
+    new ZStream(channel.mapOut(f))
+
+  /**
+   * Effectfully transforms the chunks emitted by this stream.
+   */
+  def mapChunksM[R1 <: R, E1 >: E, A2](f: Chunk[A] => ZIO[R1, E1, Chunk[A2]]): ZStream[R1, E1, A2] =
+    new ZStream(channel.mapOutM(f))
+
+  /**
+   * Maps each element to an iterable, and flattens the iterables into the
+   * output of this stream.
+   */
+  def mapConcat[A2](f: A => Iterable[A2]): ZStream[R, E, A2] =
+    mapConcatChunk(a => Chunk.fromIterable(f(a)))
+
+  /**
+   * Maps each element to a chunk, and flattens the chunks into the output of
+   * this stream.
+   */
+  def mapConcatChunk[A2](f: A => Chunk[A2]): ZStream[R, E, A2] =
+    mapChunks(_.flatMap(f))
+
+  /**
+   * Effectfully maps each element to a chunk, and flattens the chunks into
+   * the output of this stream.
+   */
+  final def mapConcatChunkM[R1 <: R, E1 >: E, A2](f: A => ZIO[R1, E1, Chunk[A2]]): ZStream[R1, E1, A2] =
+    mapM(f).mapConcatChunk(identity)
+
+  /**
+   * Effectfully maps each element to an iterable, and flattens the iterables into
+   * the output of this stream.
+   */
+  final def mapConcatM[R1 <: R, E1 >: E, A2](f: A => ZIO[R1, E1, Iterable[A2]]): ZStream[R1, E1, A2] =
+    mapM(a => f(a).map(Chunk.fromIterable(_))).mapConcatChunk(identity)
+
+  /**
+   * Transforms the errors emitted by this stream using `f`.
+   */
+  def mapError[E2](f: E => E2): ZStream[R, E2, A] =
+    ???
+
+  /**
+   * Transforms the full causes of failures emitted by this stream.
+   */
+  def mapErrorCause[E2](f: Cause[E] => Cause[E2]): ZStream[R, E2, A] =
+    ???
+
+  /**
+   * Maps over elements of the stream with the specified effectful function.
+   */
+  def mapM[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1]): ZStream[R1, E1, A1] =
+    loopOnPartialChunksElements((a, emit) => f(a) >>= emit)
+
+  /**
+   * Maps over elements of the stream with the specified effectful function,
+   * executing up to `n` invocations of `f` concurrently. Transformed elements
+   * will be emitted in the original order.
+   */
+  final def mapMPar[R1 <: R, E1 >: E, A2](n: Int)(f: A => ZIO[R1, E1, A2]): ZStream[R1, E1, A2] =
+    ???
+
+  /**
+   * Maps over elements of the stream with the specified effectful function,
+   * executing up to `n` invocations of `f` concurrently. The element order
+   * is not enforced by this combinator, and elements may be reordered.
+   */
+  final def mapMParUnordered[R1 <: R, E1 >: E, A2](n: Int)(f: A => ZIO[R1, E1, A2]): ZStream[R1, E1, A2] =
+    flatMapPar[R1, E1, A2](n.toLong)(a => ZStream.fromEffect(f(a)))
+
+  /**
+   * Maps over elements of the stream with the specified effectful function,
+   * partitioned by `p` executing invocations of `f` concurrently. The number
+   * of concurrent invocations of `f` is determined by the number of different
+   * outputs of type `K`. Up to `buffer` elements may be buffered per partition.
+   * Transformed elements may be reordered but the order within a partition is maintained.
+   */
+  final def mapMPartitioned[R1 <: R, E1 >: E, A2, K](
+    keyBy: A => K,
+    buffer: Int = 16
+  )(f: A => ZIO[R1, E1, A2]): ZStream[R1, E1, A2] =
+    groupByKey(keyBy, buffer).apply { case (_, s) => s.mapM(f) }
+
+  /**
+   * Merges this stream and the specified stream together.
+   *
+   * New produced stream will terminate when both specified stream terminate if no termination
+   * strategy is specified.
+   */
+  final def merge[R1 <: R, E1 >: E, A1 >: A](
+    that: ZStream[R1, E1, A1],
+    strategy: TerminationStrategy = TerminationStrategy.Both
+  ): ZStream[R1, E1, A1] =
+    self.mergeWith[R1, E1, A1, A1](that, strategy)(identity, identity) // TODO: Dotty doesn't infer this properly
+
+  /**
+   * Merges this stream and the specified stream together. New produced stream will
+   * terminate when either stream terminates.
+   */
+  final def mergeTerminateEither[R1 <: R, E1 >: E, A1 >: A](that: ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    self.merge[R1, E1, A1](that, TerminationStrategy.Either)
+
+  /**
+   * Merges this stream and the specified stream together. New produced stream will
+   * terminate when this stream terminates.
+   */
+  final def mergeTerminateLeft[R1 <: R, E1 >: E, A1 >: A](that: ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    self.merge[R1, E1, A1](that, TerminationStrategy.Left)
+
+  /**
+   * Merges this stream and the specified stream together. New produced stream will
+   * terminate when the specified stream terminates.
+   */
+  final def mergeTerminateRight[R1 <: R, E1 >: E, A1 >: A](that: ZStream[R1, E1, A1]): ZStream[R1, E1, A1] =
+    self.merge[R1, E1, A1](that, TerminationStrategy.Right)
+
+  /**
+   * Merges this stream and the specified stream together to produce a stream of
+   * eithers.
+   */
+  final def mergeEither[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, Either[A, A2]] =
+    self.mergeWith(that)(Left(_), Right(_))
+
+  /**
+   * Merges this stream and the specified stream together to a common element
+   * type with the specified mapping functions.
+   *
+   * New produced stream will terminate when both specified stream terminate if
+   * no termination strategy is specified.
+   */
+  final def mergeWith[R1 <: R, E1 >: E, A2, A3](
+    that: ZStream[R1, E1, A2],
+    strategy: TerminationStrategy = TerminationStrategy.Both
+  )(l: A => A3, r: A2 => A3): ZStream[R1, E1, A3] =
+    ???
+
+  /**
+   * Runs the specified effect if this stream fails, providing the error to the effect if it exists.
+   *
+   * Note: Unlike [[ZIO.onError]], there is no guarantee that the provided effect will not be interrupted.
+   */
+  final def onError[R1 <: R](cleanup: Cause[E] => URIO[R1, Any]): ZStream[R1, E, A] =
+    catchAllCause(cause => ZStream.fromEffect(cleanup(cause) *> ZIO.halt(cause)))
+
+  /**
+   * Switches to the provided stream in case this one fails with a typed error.
+   *
+   * See also [[ZStream#catchAll]].
+   */
+  def orElse[R1 <: R, E1, A1 >: A](that: => ZStream[R1, E1, A1])(implicit ev: CanFail[E]): ZStream[R1, E1, A1] =
+    new ZStream(self.channel.orElse(that.channel))
+
+  /**
+   * Switches to the provided stream in case this one fails with a typed error.
+   *
+   * See also [[ZStream#catchAll]].
+   */
+  final def orElseEither[R1 <: R, E2, A2](
+    that: => ZStream[R1, E2, A2]
+  )(implicit ev: CanFail[E]): ZStream[R1, E2, Either[A, A2]] =
+    self.map(Left(_)) orElse that.map(Right(_))
+
+  /**
+   * Fails with given error in case this one fails with a typed error.
+   *
+   * See also [[ZStream#catchAll]].
+   */
+  final def orElseFail[E1](e1: => E1)(implicit ev: CanFail[E]): ZStream[R, E1, A] =
+    orElse(ZStream.fail(e1))
+
+  /**
+   * Switches to the provided stream in case this one fails with the `None` value.
+   *
+   * See also [[ZStream#catchAll]].
+   */
+  final def orElseOptional[R1 <: R, E1, A1 >: A](
+    that: => ZStream[R1, Option[E1], A1]
+  )(implicit ev: E <:< Option[E1]): ZStream[R1, Option[E1], A1] =
+    catchAll(ev(_).fold(that)(e => ZStream.fail(Some(e))))
+
+  /**
+   * Succeeds with the specified value if this one fails with a typed error.
+   */
+  final def orElseSucceed[A1 >: A](A1: => A1)(implicit ev: CanFail[E]): ZStream[R, Nothing, A1] =
+    orElse(ZStream.succeed(A1))
+
+  /**
+   * Partition a stream using a predicate. The first stream will contain all element evaluated to true
+   * and the second one will contain all element evaluated to false.
+   * The faster stream may advance by up to buffer elements further than the slower one.
+   */
+  def partition(p: A => Boolean, buffer: Int = 16): ZManaged[R, E, (ZStream[Any, E, A], ZStream[Any, E, A])] =
+    self.partitionEither(a => if (p(a)) ZIO.succeedNow(Left(a)) else ZIO.succeedNow(Right(a)), buffer)
+
+  /**
+   * Split a stream by a predicate. The faster stream may advance by up to buffer elements further than the slower one.
+   */
+  final def partitionEither[R1 <: R, E1 >: E, A2, A3](
+    p: A => ZIO[R1, E1, Either[A2, A3]],
+    buffer: Int = 16
+  ): ZManaged[R1, E1, (ZStream[Any, E1, A2], ZStream[Any, E1, A3])] =
+    self
+      .mapM(p)
+      .distributedWith(
+        2,
+        buffer,
+        {
+          case Left(_)  => ZIO.succeedNow(_ == 0)
+          case Right(_) => ZIO.succeedNow(_ == 1)
+        }
+      )
+      .flatMap {
+        case q1 :: q2 :: Nil =>
+          ZManaged.succeedNow {
+            (
+              ZStream.fromQueueWithShutdown(q1).flattenExitOption.collectLeft,
+              ZStream.fromQueueWithShutdown(q2).flattenExitOption.collectRight
+            )
+          }
+        case otherwise => ZManaged.dieMessage(s"partitionEither: expected two streams but got ${otherwise}")
+      }
+
+  /**
+   * Peels off enough material from the stream to construct a `Z` using the
+   * provided [[ZSink]] and then returns both the `Z` and the rest of the
+   * [[ZStream]] in a managed resource. Like all [[ZManaged]] values, the provided
+   * stream is valid only within the scope of [[ZManaged]].
+   */
+  def peel[R1 <: R, E1 >: E, A1 >: A, Z](
+    sink: ZSink[R1, E1, A1, E1, A1, Z]
+  ): ZManaged[R1, E1, (Z, ZStream[R1, E1, A1])] =
+    self.toPull.flatMap { pull =>
+      val stream = ZStream.repeatEffectChunkOption(pull)
+      val s      = sink.exposeLeftover
+      stream.run(s).toManaged_.map(e => (e._1, ZStream.fromChunk(e._2) ++ stream))
+    }
+
+  /**
+   * Provides the stream with its required environment, which eliminates
+   * its dependency on `R`.
+   */
+  final def provide(r: R)(implicit ev: NeedsEnv[R]): ZStream[Any, E, A] =
+    new ZStream(channel.provide(r))
+
+  /**
+   * Provides the part of the environment that is not part of the `ZEnv`,
+   * leaving a stream that only depends on the `ZEnv`.
+   *
+   * {{{
+   * val loggingLayer: ZLayer[Any, Nothing, Logging] = ???
+   *
+   * val stream: ZStream[ZEnv with Logging, Nothing, Unit] = ???
+   *
+   * val stream2 = stream.provideCustomLayer(loggingLayer)
+   * }}}
+   */
+  def provideCustomLayer[E1 >: E, R1 <: Has[_]](
+    layer: ZLayer[ZEnv, E1, R1]
+  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZStream[ZEnv, E1, A] =
+    provideSomeLayer[ZEnv](layer)
+
+  /**
+   * Provides a layer to the stream, which translates it to another level.
+   */
+  final def provideLayer[E1 >: E, R0, R1](
+    layer: ZLayer[R0, E1, R1]
+  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZStream[R0, E1, A] =
+    new ZStream(ZChannel.managed(layer.build) { r =>
+      self.channel.provide(r)
+    })
+
+  /**
+   * Provides some of the environment required to run this effect,
+   * leaving the remainder `R0`.
+   */
+  final def provideSome[R0](env: R0 => R)(implicit ev: NeedsEnv[R]): ZStream[R0, E, A] =
+    ZStream.environment[R0].flatMap { r0 =>
+      self.provide(env(r0))
+    }
+
+  /**
+   * Splits the environment into two parts, providing one part using the
+   * specified layer and leaving the remainder `R0`.
+   *
+   * {{{
+   * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
+   *
+   * val stream: ZStream[Clock with Random, Nothing, Unit] = ???
+   *
+   * val stream2 = stream.provideSomeLayer[Random](clockLayer)
+   * }}}
+   */
+  final def provideSomeLayer[R0 <: Has[_]]: ZStream.ProvideSomeLayer[R0, R, E, A] =
+    new ZStream.ProvideSomeLayer[R0, R, E, A](self)
+
+  /**
+   * Keeps some of the errors, and terminates the fiber with the rest
+   */
+  final def refineOrDie[E1](
+    pf: PartialFunction[E, E1]
+  )(implicit ev1: E <:< Throwable, ev2: CanFail[E]): ZStream[R, E1, A] =
+    ???
+
+  /**
+   * Keeps some of the errors, and terminates the fiber with the rest, using
+   * the specified function to convert the `E` into a `Throwable`.
+   */
+  final def refineOrDieWith[E1](
+    pf: PartialFunction[E, E1]
+  )(f: E => Throwable)(implicit ev: CanFail[E]): ZStream[R, E1, A] =
+    ???
+
+  /**
+   * Repeats the entire stream using the specified schedule. The stream will execute normally,
+   * and then repeat again according to the provided schedule.
+   */
+  final def repeat[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZStream[R1 with Clock, E, A] =
+    repeatEither(schedule) collect { case Right(a) => a }
+
+  /**
+   * Repeats the entire stream using the specified schedule. The stream will execute normally,
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at
+   * the end of each repetition.
+   */
+  final def repeatEither[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZStream[R1 with Clock, E, Either[B, A]] =
+    repeatWith(schedule)(Right(_), Left(_))
+
+  /**
+   * Repeats each element of the stream using the provided schedule. Repetitions are done in
+   * addition to the first execution, which means using `Schedule.recurs(1)` actually results in
+   * the original effect, plus an additional recurrence, for a total of two repetitions of each
+   * value in the stream.
+   */
+  final def repeatElements[R1 <: R](schedule: Schedule[R1, A, Any]): ZStream[R1 with Clock, E, A] =
+    repeatElementsEither(schedule).collect { case Right(a) => a }
+
+  /**
+   * Repeats each element of the stream using the provided schedule. When the schedule is finished,
+   * then the output of the schedule will be emitted into the stream. Repetitions are done in
+   * addition to the first execution, which means using `Schedule.recurs(1)` actually results in
+   * the original effect, plus an additional recurrence, for a total of two repetitions of each
+   * value in the stream.
+   */
+  final def repeatElementsEither[R1 <: R, E1 >: E, B](
+    schedule: Schedule[R1, A, B]
+  ): ZStream[R1 with Clock, E1, Either[B, A]] =
+    repeatElementsWith(schedule)(Right.apply, Left.apply)
+
+  /**
+   * Repeats each element of the stream using the provided schedule. When the schedule is finished,
+   * then the output of the schedule will be emitted into the stream. Repetitions are done in
+   * addition to the first execution, which means using `Schedule.recurs(1)` actually results in
+   * the original effect, plus an additional recurrence, for a total of two repetitions of each
+   * value in the stream.
+   *
+   * This function accepts two conversion functions, which allow the output of this stream and the
+   * output of the provided schedule to be unified into a single type. For example, `Either` or
+   * similar data type.
+   */
+  final def repeatElementsWith[R1 <: R, E1 >: E, B, C](
+    schedule: Schedule[R1, A, B]
+  )(f: A => C, g: B => C): ZStream[R1 with Clock, E1, C] =
+    ???
+
+  /**
+   * Repeats the entire stream using the specified schedule. The stream will execute normally,
+   * and then repeat again according to the provided schedule. The schedule output will be emitted at
+   * the end of each repetition and can be unified with the stream elements using the provided functions.
+   */
+  final def repeatWith[R1 <: R, B, C](
+    schedule: Schedule[R1, Any, B]
+  )(f: A => C, g: B => C): ZStream[R1 with Clock, E, C] =
+    ???
+
+  /**
+   * Fails with the error `None` if value is `Left`.
+   */
+  final def right[A1, A2](implicit ev: A <:< Either[A1, A2]): ZStream[R, Option[E], A2] =
+    self.mapError(Some(_)).rightOrFail(None)
+
+  /**
+   * Fails with given error 'e' if value is `Left`.
+   */
+  final def rightOrFail[A1, A2, E1 >: E](e: => E1)(implicit ev: A <:< Either[A1, A2]): ZStream[R, E1, A2] =
+    self.mapM(ev(_).fold(_ => ZIO.fail(e), ZIO.succeedNow(_)))
+
+  /**
+   * Runs the sink on the stream to produce either the sink's result or an error.
+   */
+  def run[R1 <: R, E2, Z](sink: ZSink[R1, E, A, E2, Any, Z]): ZIO[R1, E2, Z] =
+    (channel pipeTo sink.channel).runDrain
+
+  def runManaged[R1 <: R, E2, B](sink: ZSink[R1, E, A, E2, Any, B]): ZManaged[R1, E2, B] =
+    (channel pipeTo sink.channel).drain.runManaged
+
+  /**
+   * Runs the stream and collects all of its elements to a chunk.
+   */
+  def runCollect: ZIO[R, E, Chunk[A]] =
+    channel.runCollect.map(_._1.flatten)
+
+  /**
+   * Runs the stream and emits the number of elements processed
+   *
+   * Equivalent to `run(ZSink.count)`
+   */
+  final def runCount: ZIO[R, E, Long] = self.run(???)
+
+  /**
+   * Runs the stream only for its effects. The emitted elements are discarded.
+   */
+  def runDrain: ZIO[R, E, Unit] =
+    foreach(_ => ZIO.unit)
+
+  /**
+   * Runs the stream to completion and yields the first value emitted by it,
+   * discarding the rest of the elements.
+   */
+  def runHead: ZIO[R, E, Option[A]] =
+    run(ZSink.head)
+
+  /**
+   * Runs the stream to completion and yields the last value emitted by it,
+   * discarding the rest of the elements.
+   */
+  def runLast: ZIO[R, E, Option[A]] =
+    run(???)
+
+  /**
+   * Runs the stream to a sink which sums elements, provided they are Numeric.
+   *
+   * Equivalent to `run(Sink.sum[A])`
+   */
+  final def runSum[A1 >: A](implicit ev: Numeric[A1]): ZIO[R, E, A1] = run(???)
+
+  /**
+   * Statefully maps over the elements of this stream to produce all intermediate results
+   * of type `S` given an initial S.
+   */
+  def scan[S](s: S)(f: (S, A) => S): ZStream[R, E, S] =
+    scanM(s)((s, a) => ZIO.succeedNow(f(s, a)))
+
+  /**
+   * Statefully and effectfully maps over the elements of this stream to produce all
+   * intermediate results of type `S` given an initial S.
+   */
+  def scanM[R1 <: R, E1 >: E, S](s: S)(f: (S, A) => ZIO[R1, E1, S]): ZStream[R1, E1, S] =
+    ZStream(s) ++ mapAccumM[R1, E1, S, S](s)((s, a) => f(s, a).map(s => (s, s)))
+
+  /**
+   * Statefully maps over the elements of this stream to produce all intermediate results.
+   *
+   * See also [[ZStream#scan]].
+   */
+  def scanReduce[A1 >: A](f: (A1, A) => A1): ZStream[R, E, A1] =
+    scanReduceM[R, E, A1]((curr, next) => ZIO.succeedNow(f(curr, next)))
+
+  /**
+   * Statefully and effectfully maps over the elements of this stream to produce all
+   * intermediate results.
+   *
+   * See also [[ZStream#scanM]].
+   */
+  def scanReduceM[R1 <: R, E1 >: E, A1 >: A](f: (A1, A) => ZIO[R1, E1, A1]): ZStream[R1, E1, A1] =
+    ???
+
+  /**
+   * Schedules the output of the stream using the provided `schedule`.
+   */
+  final def schedule[R1 <: R](schedule: Schedule[R1, A, Any]): ZStream[R1 with Clock, E, A] =
+    scheduleEither(schedule).collect { case Right(a) => a }
+
+  /**
+   * Schedules the output of the stream using the provided `schedule` and emits its output at
+   * the end (if `schedule` is finite).
+   */
+  final def scheduleEither[R1 <: R, E1 >: E, B](
+    schedule: Schedule[R1, A, B]
+  ): ZStream[R1 with Clock, E1, Either[B, A]] =
+    scheduleWith(schedule)(Right.apply, Left.apply)
+
+  /**
+   * Schedules the output of the stream using the provided `schedule` and emits its output at
+   * the end (if `schedule` is finite).
+   * Uses the provided function to align the stream and schedule outputs on the same type.
+   */
+  final def scheduleWith[R1 <: R, E1 >: E, B, C](
+    schedule: Schedule[R1, A, B]
+  )(f: A => C, g: B => C): ZStream[R1 with Clock, E1, C] =
+    ???
+
+  /**
+   * Converts an option on values into an option on errors.
+   */
+  final def some[A2](implicit ev: A <:< Option[A2]): ZStream[R, Option[E], A2] =
+    self.mapError(Some(_)).someOrFail(None)
+
+  /**
+   * Extracts the optional value, or returns the given 'default'.
+   */
+  final def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2]): ZStream[R, E, A2] =
+    map(_.getOrElse(default))
+
+  /**
+   * Extracts the optional value, or fails with the given error 'e'.
+   */
+  final def someOrFail[A2, E1 >: E](e: => E1)(implicit ev: A <:< Option[A2]): ZStream[R, E1, A2] =
+    self.mapM(ev(_).fold[IO[E1, A2]](ZIO.fail(e))(ZIO.succeedNow(_)))
+
+  /**
+   * Takes the specified number of elements from this stream.
+   */
+  def take(n: Long): ZStream[R, E, A] = {
+    def loop(n: Long): ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] =
+      ZChannel
+        .readWith[R, E, Chunk[A], Any, E, Chunk[A], Any](
+          (chunk: Chunk[A]) => {
+            val taken    = chunk.take(n.min(Int.MaxValue).toInt)
+            val leftover = (n - taken.length).max(0)
+            val more     = leftover > 0
+
+            if (more) ZChannel.write(taken) *> loop(leftover)
+            else ZChannel.write(taken)
+          },
+          ZChannel.fail(_),
+          ZChannel.succeed(_)
+        )
+
+    if (0 < n)
+      new ZStream(self.channel >>> loop(n))
+    else
+      ZStream.empty
+  }
+
+  /**
+   * Takes the last specified number of elements from this stream.
+   */
+  def takeRight(n: Int): ZStream[R, E, A] =
+    ???
+
+  /**
+   * Takes all elements of the stream until the specified predicate evaluates
+   * to `true`.
+   */
+  def takeUntil(f: A => Boolean): ZStream[R, E, A] = {
+    lazy val loop: ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] =
+      ZChannel
+        .readWith[R, E, Chunk[A], Any, E, Chunk[A], Any](
+          (chunk: Chunk[A]) => {
+            val taken = chunk.takeWhile(!f(_))
+            val last  = chunk.drop(taken.length).take(1)
+
+            if (last.isEmpty) ZChannel.write(taken) *> loop
+            else ZChannel.write(taken ++ last)
+          },
+          ZChannel.fail(_),
+          ZChannel.succeed(_)
+        )
+
+    new ZStream(channel >>> loop)
+  }
+
+  /**
+   * Takes all elements of the stream until the specified effectual predicate
+   * evaluates to `true`.
+   */
+  def takeUntilM[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Boolean]): ZStream[R1, E1, A] =
+    loopOnPartialChunks { (chunk, emit) =>
+      for {
+        taken <- chunk.takeWhileM(v => emit(v) *> f(v).map(!_))
+        last   = chunk.drop(taken.length).take(1)
+      } yield last.isEmpty
+    }
+
+  /**
+   * Takes all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  def takeWhile(f: A => Boolean): ZStream[R, E, A] = {
+    lazy val loop: ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] =
+      ZChannel
+        .readWith[R, E, Chunk[A], Any, E, Chunk[A], Any](
+          (chunk: Chunk[A]) => {
+            val taken = chunk.takeWhile(f)
+            val more  = taken.length == chunk.length
+
+            if (more) ZChannel.write(taken) *> loop else ZChannel.write(taken)
+          },
+          ZChannel.fail(_),
+          ZChannel.succeed(_)
+        )
+
+    new ZStream(channel >>> loop)
+  }
+
+  /**
+   * Adds an effect to consumption of every element of the stream.
+   */
+  final def tap[R1 <: R, E1 >: E](f0: A => ZIO[R1, E1, Any]): ZStream[R1, E1, A] =
+    mapM(a => f0(a).as(a))
+
+  /**
+   * Throttles the chunks of this stream according to the given bandwidth parameters using the token bucket
+   * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
+   * tokens up to a `units + burst` threshold. Chunks that do not meet the bandwidth constraints are dropped.
+   * The weight of each chunk is determined by the `costFn` function.
+   */
+  final def throttleEnforce(units: Long, duration: Duration, burst: Long = 0)(
+    costFn: Chunk[A] => Long
+  ): ZStream[R with Clock, E, A] =
+    throttleEnforceM(units, duration, burst)(as => UIO.succeedNow(costFn(as)))
+
+  /**
+   * Throttles the chunks of this stream according to the given bandwidth parameters using the token bucket
+   * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
+   * tokens up to a `units + burst` threshold. Chunks that do not meet the bandwidth constraints are dropped.
+   * The weight of each chunk is determined by the `costFn` effectful function.
+   */
+  final def throttleEnforceM[R1 <: R, E1 >: E](units: Long, duration: Duration, burst: Long = 0)(
+    costFn: Chunk[A] => ZIO[R1, E1, Long]
+  ): ZStream[R1 with Clock, E1, A] =
+    ???
+
+  /**
+   * Delays the chunks of this stream according to the given bandwidth parameters using the token bucket
+   * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
+   * tokens up to a `units + burst` threshold. The weight of each chunk is determined by the `costFn`
+   * function.
+   */
+  final def throttleShape(units: Long, duration: Duration, burst: Long = 0)(
+    costFn: Chunk[A] => Long
+  ): ZStream[R with Clock, E, A] =
+    throttleShapeM(units, duration, burst)(os => UIO.succeedNow(costFn(os)))
+
+  /**
+   * Delays the chunks of this stream according to the given bandwidth parameters using the token bucket
+   * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
+   * tokens up to a `units + burst` threshold. The weight of each chunk is determined by the `costFn`
+   * effectful function.
+   */
+  final def throttleShapeM[R1 <: R, E1 >: E](units: Long, duration: Duration, burst: Long = 0)(
+    costFn: Chunk[A] => ZIO[R1, E1, Long]
+  ): ZStream[R1 with Clock, E1, A] =
+    ???
+
+  final def debounce[E1 >: E, A2 >: A](d: Duration): ZStream[R with Clock, E1, A2] =
+    ???
+
+  /**
+   * Ends the stream if it does not produce a value after d duration.
+   */
+  final def timeout(d: Duration): ZStream[R with Clock, E, A] =
+    ZStream.fromPull {
+      self.toPull.map(pull => pull.timeoutFail(None)(d))
+    }
+
+  /**
+   * Fails the stream with given error if it does not produce a value after d duration.
+   */
+  final def timeoutFail[E1 >: E](e: => E1)(d: Duration): ZStream[R with Clock, E1, A] =
+    timeoutHalt(Cause.fail(e))(d)
+
+  /**
+   * Halts the stream with given cause if it does not produce a value after d duration.
+   */
+  final def timeoutHalt[E1 >: E](cause: Cause[E1])(d: Duration): ZStream[R with Clock, E1, A] =
+    ZStream.fromPull {
+      self.toPull.map(pull => pull.timeoutHalt(cause.map(Some(_)))(d))
+    }
+
+  /**
+   * Switches the stream if it does not produce a value after d duration.
+   */
+  final def timeoutTo[R1 <: R, E1 >: E, A2 >: A](
+    d: Duration
+  )(that: ZStream[R1, E1, A2]): ZStream[R1 with Clock, E1, A2] = {
+    final case class StreamTimeout() extends Throwable
+    self.timeoutHalt(Cause.die(StreamTimeout()))(d).catchSomeCause { case Cause.Die(StreamTimeout()) => that }
+  }
+
+  /**
+   * Converts this stream of bytes into a `java.io.InputStream` wrapped in a [[ZManaged]].
+   * The returned input stream will only be valid within the scope of the ZManaged.
+   */
+  def toInputStream(implicit ev0: E <:< Throwable, ev1: A <:< Byte): ZManaged[R, E, java.io.InputStream] =
+    ???
+
+  /**
+   * Converts this stream into a `scala.collection.Iterator` wrapped in a [[ZManaged]].
+   * The returned iterator will only be valid within the scope of the ZManaged.
+   */
+  def toIterator: ZManaged[R, Nothing, Iterator[Either[E, A]]] =
+    ???
+
+  def toPull: ZManaged[R, Nothing, ZIO[R, Option[E], Chunk[A]]] =
+    channel.toPull.map { pull =>
+      pull.mapError(_.left.toOption)
+    }
+
+  /**
+   * Converts this stream of chars into a `java.io.Reader` wrapped in a [[ZManaged]].
+   * The returned reader will only be valid within the scope of the ZManaged.
+   */
+  def toReader(implicit ev0: E <:< Throwable, ev1: A <:< Char): ZManaged[R, E, java.io.Reader] =
+    ???
+
+  /**
+   * Converts the stream to a managed queue of chunks. After the managed queue is used,
+   * the queue will never again produce values and should be discarded.
+   */
+  final def toQueue(capacity: Int = 2): ZManaged[R, Nothing, Dequeue[Take[E, A]]] =
+    for {
+      queue <- Queue.bounded[Take[E, A]](capacity).toManaged(_.shutdown)
+      _     <- self.runIntoManaged(queue).fork
+    } yield queue
+
+  /**
+   * Converts the stream into an unbounded managed queue. After the managed queue
+   * is used, the queue will never again produce values and should be discarded.
+   */
+  final def toQueueUnbounded: ZManaged[R, Nothing, Dequeue[Take[E, A]]] =
+    for {
+      queue <- Queue.unbounded[Take[E, A]].toManaged(_.shutdown)
+      _     <- self.runIntoManaged(queue).fork
+    } yield queue
+
+  /**
+   * Applies the transducer to the stream and emits its outputs.
+   */
+  def transduce[R1 <: R, E1, A1 >: A, Z](sink: ZSink[R1, E, A1, E1, A1, Z]): ZStream[R1, E1, Z] =
+    new ZStream(ZChannel.fromEffect(Ref.make[Chunk[A1]](Chunk.empty).zip(Ref.make(false))).flatMap {
+      case (leftovers, upstreamDone) =>
+        val buffer = ZChannel.bufferChunk[E, A1, Any](leftovers)
+        lazy val upstreamMarker: ZChannel[Any, E, Chunk[A], Any, E, Chunk[A], Any] =
+          ZChannel.readWith(
+            (in: Chunk[A]) => ZChannel.write(in) *> upstreamMarker,
+            (err: E) => ZChannel.fail(err),
+            (done: Any) => ZChannel.fromEffect(upstreamDone.set(true)) *> ZChannel.end(done)
+          )
+
+        lazy val transducer: ZChannel[R1, E, Chunk[A1], Any, E1, Chunk[Z], Unit] =
+          sink.channel.doneCollect.flatMap { case (leftover, z) =>
+            ZChannel.fromEffect(leftovers.set(leftover.flatten)) *>
+              ZChannel.write(Chunk.single(z)) *>
+              ZChannel.fromEffect(upstreamDone.get).flatMap { done =>
+                if (done) ZChannel.end(())
+                else transducer
+              }
+          }
+
+        channel >>>
+          upstreamMarker >>>
+          buffer >>>
+          transducer
+    })
+
+  /**
+   * Updates a service in the environment of this effect.
+   */
+  final def updateService[M] =
+    new ZStream.UpdateService[R, E, A, M](self)
+
+  /**
+   * Threads the stream through the transformation function `f`.
+   */
+  final def via[R2, E2, A2](f: ZStream[R, E, A] => ZStream[R2, E2, A2]): ZStream[R2, E2, A2] = f(self)
+
+  /**
+   * Equivalent to [[filter]] but enables the use of filter clauses in for-comprehensions
+   */
+  def withFilter(predicate: A => Boolean): ZStream[R, E, A] =
+    filter(predicate)
+
+  /**
+   * Zips this stream with another point-wise, but keeps only the outputs of this stream.
+   *
+   * The new stream will end when one of the sides ends.
+   */
+  def zipLeft[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A] = zipWith(that)((o, _) => o)
+
+  /**
+   * Zips this stream with another point-wise, but keeps only the outputs of the other stream.
+   *
+   * The new stream will end when one of the sides ends.
+   */
+  def zipRight[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, A2] = zipWith(that)((_, A2) => A2)
+
+  /**
+   * Zips this stream with another point-wise and emits tuples of elements from both streams.
+   *
+   * The new stream will end when one of the sides ends.
+   */
+  def zip[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2]): ZStream[R1, E1, (A, A2)] = zipWith(that)((_, _))
+
+  /**
+   * Zips this stream with another point-wise, creating a new stream of pairs of elements
+   * from both sides.
+   *
+   * The defaults `defaultLeft` and `defaultRight` will be used if the streams have different lengths
+   * and one of the streams has ended before the other.
+   */
+  def zipAll[R1 <: R, E1 >: E, A1 >: A, A2](
+    that: ZStream[R1, E1, A2]
+  )(defaultLeft: A1, defaultRight: A2): ZStream[R1, E1, (A1, A2)] =
+    zipAllWith(that)((_, defaultRight), (defaultLeft, _))((_, _))
+
+  /**
+   * Zips this stream with another point-wise, and keeps only elements from this stream.
+   *
+   * The provided default value will be used if the other stream ends before this one.
+   */
+  def zipAllLeft[R1 <: R, E1 >: E, A1 >: A, A2](that: ZStream[R1, E1, A2])(default: A1): ZStream[R1, E1, A1] =
+    zipAllWith(that)(identity, _ => default)((o, _) => o)
+
+  /**
+   * Zips this stream with another point-wise, and keeps only elements from the other stream.
+   *
+   * The provided default value will be used if this stream ends before the other one.
+   */
+  def zipAllRight[R1 <: R, E1 >: E, A2](that: ZStream[R1, E1, A2])(default: A2): ZStream[R1, E1, A2] =
+    zipAllWith(that)(_ => default, identity)((_, A2) => A2)
+
+  /**
+   * Zips this stream with another point-wise. The provided functions will be used to create elements
+   * for the composed stream.
+   *
+   * The functions `left` and `right` will be used if the streams have different lengths
+   * and one of the streams has ended before the other.
+   */
+  def zipAllWith[R1 <: R, E1 >: E, A2, A3](
+    that: ZStream[R1, E1, A2]
+  )(left: A => A3, right: A2 => A3)(both: (A, A2) => A3): ZStream[R1, E1, A3] =
+    zipAllWithExec(that)(ExecutionStrategy.Parallel)(left, right)(both)
+
+  /**
+   * Zips this stream with another point-wise. The provided functions will be used to create elements
+   * for the composed stream.
+   *
+   * The functions `left` and `right` will be used if the streams have different lengths
+   * and one of the streams has ended before the other.
+   *
+   * The execution strategy `exec` will be used to determine whether to pull
+   * from the streams sequentially or in parallel.
+   */
+  def zipAllWithExec[R1 <: R, E1 >: E, A2, A3](
+    that: ZStream[R1, E1, A2]
+  )(exec: ExecutionStrategy)(left: A => A3, right: A2 => A3)(both: (A, A2) => A3): ZStream[R1, E1, A3] = {
+    sealed trait Status
+    case object Running   extends Status
+    case object LeftDone  extends Status
+    case object RightDone extends Status
+    case object End       extends Status
+    type State = (Status, Either[Chunk[A], Chunk[A2]])
+
+    def handleSuccess(
+      maybeO: Option[Chunk[A]],
+      maybeA2: Option[Chunk[A2]],
+      excess: Either[Chunk[A], Chunk[A2]]
+    ): Exit[Nothing, (Chunk[A3], State)] = {
+      val (excessL, excessR) = excess.fold(l => (l, Chunk.empty), r => (Chunk.empty, r))
+      val chunkL             = maybeO.fold(excessL)(upd => excessL ++ upd)
+      val chunkR             = maybeA2.fold(excessR)(upd => excessR ++ upd)
+      val (emit, newExcess)  = zipChunks(chunkL, chunkR, both)
+      val (fullEmit, status) = (maybeO.isDefined, maybeA2.isDefined) match {
+        case (true, true) => (emit, Running)
+        case (false, false) =>
+          val leftover: Chunk[A3] = newExcess.fold[Chunk[A3]](_.map(left), _.map(right))
+          (emit ++ leftover, End)
+        case (false, true) => (emit, LeftDone)
+        case (true, false) => (emit, RightDone)
+      }
+      Exit.succeed((fullEmit, (status, newExcess)))
+    }
+
+    combineChunks(that)((Running, Left(Chunk())): State) {
+      case ((Running, excess), pullL, pullR) =>
+        exec match {
+          case ExecutionStrategy.Sequential =>
+            pullL.optional
+              .zipWith(pullR.optional)(handleSuccess(_, _, excess))
+              .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+          case _ =>
+            pullL.optional
+              .zipWithPar(pullR.optional)(handleSuccess(_, _, excess))
+              .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        }
+      case ((LeftDone, excess), _, pullR) =>
+        pullR.optional
+          .map(handleSuccess(None, _, excess))
+          .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+      case ((RightDone, excess), pullL, _) =>
+        pullL.optional
+          .map(handleSuccess(_, None, excess))
+          .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+      case ((End, _), _, _) => UIO.succeedNow(Exit.fail(None))
+    }
+  }
+
+  /**
+   * Zips this stream with another point-wise and applies the function to the paired elements.
+   *
+   * The new stream will end when one of the sides ends.
+   */
+  def zipWith[R1 <: R, E1 >: E, A2, A3](
+    that: ZStream[R1, E1, A2]
+  )(f: (A, A2) => A3): ZStream[R1, E1, A3] = {
+    sealed trait State[+W1, +W2]
+    case class Running[W1, W2](excess: Either[Chunk[W1], Chunk[W2]]) extends State[W1, W2]
+    case class LeftDone[W1](excessL: NonEmptyChunk[W1])              extends State[W1, Nothing]
+    case class RightDone[W2](excessR: NonEmptyChunk[W2])             extends State[Nothing, W2]
+    case object End                                                  extends State[Nothing, Nothing]
+
+    def handleSuccess(
+      leftUpd: Option[Chunk[A]],
+      rightUpd: Option[Chunk[A2]],
+      excess: Either[Chunk[A], Chunk[A2]]
+    ): Exit[Option[Nothing], (Chunk[A3], State[A, A2])] = {
+      val (left, right) = {
+        val (leftExcess, rightExcess) = excess.fold(l => (l, Chunk.empty), r => (Chunk.empty, r))
+        val l                         = leftUpd.fold(leftExcess)(upd => leftExcess ++ upd)
+        val r                         = rightUpd.fold(rightExcess)(upd => rightExcess ++ upd)
+        (l, r)
+      }
+      val (emit, newExcess): (Chunk[A3], Either[Chunk[A], Chunk[A2]]) = zipChunks(left, right, f)
+      (leftUpd.isDefined, rightUpd.isDefined) match {
+        case (true, true)   => Exit.succeed((emit, Running(newExcess)))
+        case (false, false) => Exit.fail(None)
+        case _ => {
+          val newState = newExcess match {
+            case Left(l)  => l.nonEmptyOrElse[State[A, A2]](End)(LeftDone(_))
+            case Right(r) => r.nonEmptyOrElse[State[A, A2]](End)(RightDone(_))
+          }
+          Exit.succeed((emit, newState))
+        }
+      }
+    }
+
+    combineChunks(that)(Running(Left(Chunk.empty)): State[A, A2]) { (st, p1, p2) =>
+      st match {
+        case Running(excess) =>
+          {
+            p1.optional.zipWithPar(p2.optional) { case (l, r) =>
+              handleSuccess(l, r, excess)
+            }
+          }.catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        case LeftDone(excessL) =>
+          {
+            p2.optional.map(handleSuccess(None, _, Left(excessL)))
+          }.catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        case RightDone(excessR) => {
+          p1.optional
+            .map(handleSuccess(_, None, Right(excessR)))
+            .catchAllCause(e => UIO.succeedNow(Exit.halt(e.map(Some(_)))))
+        }
+        case End => {
+          UIO.succeedNow(Exit.fail(None))
+        }
+      }
+    }
+  }
+
+  /**
+   * Zips this stream together with the index of elements.
+   */
+  final def zipWithIndex: ZStream[R, E, (A, Long)] =
+    mapAccum(0L)((index, a) => (index + 1, (a, index)))
+
+  /**
+   * Zips the two streams so that when a value is emitted by either of the two streams,
+   * it is combined with the latest value from the other stream to produce a result.
+   *
+   * Note: tracking the latest value is done on a per-chunk basis. That means that
+   * emitted elements that are not the last value in chunks will never be used for zipping.
+   */
+  final def zipWithLatest[R1 <: R, E1 >: E, A2, A3](
+    that: ZStream[R1, E1, A2]
+  )(f: (A, A2) => A3): ZStream[R1, E1, A3] =
+    ???
+
+  /**
+   * Zips each element with the next element if present.
+   */
+  final def zipWithNext: ZStream[R, E, (A, Option[A])] =
+    ???
+
+  /**
+   * Zips each element with the previous element. Initially accompanied by `None`.
+   */
+  final def zipWithPrevious: ZStream[R, E, (Option[A], A)] =
+    mapAccum[Option[A], (Option[A], A)](None)((prev, next) => (Some(next), (prev, next)))
+
+  /**
+   * Zips each element with both the previous and next element.
+   */
+  final def zipWithPreviousAndNext: ZStream[R, E, (Option[A], A, Option[A])] =
+    zipWithPrevious.zipWithNext.map { case ((prev, curr), next) => (prev, curr, next.map(_._2)) }
+}
+
+object ZStream {
+  def fromPull[R, E, A](zio: ZManaged[R, Nothing, ZIO[R, Option[E], Chunk[A]]]): ZStream[R, E, A] =
+    ZStream.unwrapManaged(zio.map(pull => repeatEffectChunkOption(pull)))
+
+  /**
+   * The default chunk size used by the various combinators and constructors of [[ZStream]].
+   */
+  final val DefaultChunkSize = 4096
+
+  /**
+   * Submerges the error case of an `Either` into the `ZStream`.
+   */
+  def absolve[R, E, O](xs: ZStream[R, E, Either[E, O]]): ZStream[R, E, O] =
+    xs.mapM(ZIO.fromEither(_))
+
+  /**
+   * Accesses the environment of the stream.
+   */
+  def access[R]: AccessPartiallyApplied[R] =
+    new AccessPartiallyApplied[R]
+
+  /**
+   * Accesses the environment of the stream in the context of an effect.
+   */
+  def accessM[R]: AccessMPartiallyApplied[R] =
+    new AccessMPartiallyApplied[R]
+
+  /**
+   * Accesses the environment of the stream in the context of a stream.
+   */
+  def accessStream[R]: AccessStreamPartiallyApplied[R] =
+    new AccessStreamPartiallyApplied[R]
+
+  /**
+   * Creates a pure stream from a variable list of values
+   */
+  def apply[A](as: A*): ZStream[Any, Nothing, A] = fromIterable(as)
+
+  /**
+   * Creates a stream from a single value that will get cleaned up after the
+   * stream is consumed
+   */
+  def bracket[R, E, A](acquire: ZIO[R, E, A])(release: A => URIO[R, Any]): ZStream[R, E, A] =
+    managed(ZManaged.make(acquire)(release))
+
+  /**
+   * Creates a stream from a single value that will get cleaned up after the
+   * stream is consumed
+   */
+  def bracketExit[R, E, A](
+    acquire: ZIO[R, E, A]
+  )(release: (A, Exit[Any, Any]) => URIO[R, Any]): ZStream[R, E, A] =
+    managed(ZManaged.makeExit(acquire)(release))
+
+  /**
+   * Composes the specified streams to create a cartesian product of elements
+   * with a specified function. Subsequent streams would be run multiple times,
+   * for every combination of elements in the prior streams.
+   *
+   * See also [[ZStream#zipN[R,E,A,B,C]*]] for the more common point-wise variant.
+   */
+  def crossN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
+    f: (A, B) => C
+  ): ZStream[R, E, C] =
+    zStream1.crossWith(zStream2)(f)
+
+  /**
+   * Composes the specified streams to create a cartesian product of elements
+   * with a specified function. Subsequent stream would be run multiple times,
+   * for every combination of elements in the prior streams.
+   *
+   * See also [[ZStream#zipN[R,E,A,B,C,D]*]] for the more common point-wise variant.
+   */
+  def crossN[R, E, A, B, C, D](
+    zStream1: ZStream[R, E, A],
+    zStream2: ZStream[R, E, B],
+    zStream3: ZStream[R, E, C]
+  )(
+    f: (A, B, C) => D
+  ): ZStream[R, E, D] =
+    for {
+      a <- zStream1
+      b <- zStream2
+      c <- zStream3
+    } yield f(a, b, c)
+
+  /**
+   * Composes the specified streams to create a cartesian product of elements
+   * with a specified function. Subsequent stream would be run multiple times,
+   * for every combination of elements in the prior streams.
+   *
+   * See also [[ZStream#zipN[R,E,A,B,C,D,F]*]] for the more common point-wise variant.
+   */
+  def crossN[R, E, A, B, C, D, F](
+    zStream1: ZStream[R, E, A],
+    zStream2: ZStream[R, E, B],
+    zStream3: ZStream[R, E, C],
+    zStream4: ZStream[R, E, D]
+  )(
+    f: (A, B, C, D) => F
+  ): ZStream[R, E, F] =
+    for {
+      a <- zStream1
+      b <- zStream2
+      c <- zStream3
+      d <- zStream4
+    } yield f(a, b, c, d)
+
+  /**
+   * Concatenates all of the streams in the chunk to one stream.
+   */
+  def concatAll[R, E, O](streams: Chunk[ZStream[R, E, O]]): ZStream[R, E, O] =
+    streams.foldLeft[ZStream[R, E, O]](empty)(_ ++ _)
+
+  /**
+   * The stream that dies with the `ex`.
+   */
+  def die(ex: => Throwable): ZStream[Any, Nothing, Nothing] =
+    fromEffect(ZIO.die(ex))
+
+  /**
+   * The stream that dies with an exception described by `msg`.
+   */
+  def dieMessage(msg: => String): ZStream[Any, Nothing, Nothing] =
+    fromEffect(ZIO.dieMessage(msg))
+
+  /**
+   * The stream that ends with the [[zio.Exit]] value `exit`.
+   */
+  def done[E, A](exit: Exit[E, A]): ZStream[Any, E, A] =
+    fromEffect(ZIO.done(exit))
+
+  /**
+   * The empty stream
+   */
+  val empty: ZStream[Any, Nothing, Nothing] =
+    new ZStream(ZChannel.write(Chunk.empty))
+
+  /**
+   * Accesses the whole environment of the stream.
+   */
+  def environment[R]: ZStream[R, Nothing, R] =
+    fromEffect(ZIO.environment[R])
+
+  /**
+   * The stream that always fails with the `error`
+   */
+  def fail[E](error: => E): ZStream[Any, E, Nothing] =
+    fromEffect(ZIO.fail(error))
+
+  /**
+   * Creates a one-element stream that never fails and executes the finalizer when it ends.
+   */
+  def finalizer[R](finalizer: URIO[R, Any]): ZStream[R, Nothing, Any] =
+    bracket[R, Nothing, Unit](UIO.unit)(_ => finalizer)
+
+  /**
+   * Creates a stream from a [[zio.Chunk]] of values
+   *
+   * @param c a chunk of values
+   * @return a finite stream of values
+   */
+  def fromChunk[O](c: => Chunk[O]): ZStream[Any, Nothing, O] =
+    new ZStream(ZChannel.unwrap(ZIO.effectTotal(ZChannel.write(c))))
+
+  /**
+   * Creates a stream from a [[zio.ZQueue]] of values
+   */
+  def fromChunkQueue[R, E, O](queue: ZQueue[Nothing, R, Any, E, Nothing, Chunk[O]]): ZStream[R, E, O] =
+    repeatEffectChunkOption {
+      queue.take
+        .catchAllCause(c =>
+          queue.isShutdown.flatMap { down =>
+            if (down && c.interrupted) Pull.end
+            else Pull.halt(c)
+          }
+        )
+    }
+
+  /**
+   * Creates a stream from a [[zio.ZQueue]] of values. The queue will be shutdown once the stream is closed.
+   */
+  def fromChunkQueueWithShutdown[R, E, O](queue: ZQueue[Nothing, R, Any, E, Nothing, Chunk[O]]): ZStream[R, E, O] =
+    fromChunkQueue(queue).ensuringFirst(queue.shutdown)
+
+  /**
+   * Creates a stream from an arbitrary number of chunks.
+   */
+  def fromChunks[O](cs: Chunk[O]*): ZStream[Any, Nothing, O] =
+    fromIterable(cs).flatMap(fromChunk(_))
+
+  /**
+   * Creates a stream from an effect producing a value of type `A`
+   */
+  def fromEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
+    fromEffectOption(fa.mapError(Some(_)))
+
+  /**
+   * Creates a stream from an effect producing a value of type `A` or an empty Stream
+   */
+  def fromEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
+    new ZStream(
+      ZChannel.unwrap(
+        fa.fold(
+          {
+            case Some(e) => ZChannel.fail(e)
+            case None    => ZChannel.end(())
+          },
+          a => ZChannel.write(Chunk(a))
+        )
+      )
+    )
+
+  /**
+   * Creates a stream from an iterable collection of values
+   */
+  def fromIterable[O](as: => Iterable[O]): ZStream[Any, Nothing, O] =
+    fromChunk(Chunk.fromIterable(as))
+
+  /**
+   * Creates a stream from an effect producing a value of type `Iterable[A]`
+   */
+  def fromIterableM[R, E, O](iterable: ZIO[R, E, Iterable[O]]): ZStream[R, E, O] =
+    fromEffect(iterable).mapConcat(identity)
+
+  def fromIterator[A](iterator: => Iterator[A]): ZStream[Any, Throwable, A] = {
+    object StreamEnd extends Throwable
+
+    ZStream.fromEffect(Task(iterator) <*> ZIO.runtime[Any]).flatMap { case (it, rt) =>
+      ZStream.repeatEffectOption {
+        Task {
+          val hasNext: Boolean =
+            try it.hasNext
+            catch {
+              case e: Throwable if !rt.platform.fatal(e) =>
+                throw e
+            }
+
+          if (hasNext) {
+            try it.next()
+            catch {
+              case e: Throwable if !rt.platform.fatal(e) =>
+                throw e
+            }
+          } else throw StreamEnd
+        }.mapError {
+          case StreamEnd => None
+          case e         => Some(e)
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates a stream from an iterator that may potentially throw exceptions
+   */
+  def fromIteratorEffect[R, A](
+    iterator: ZIO[R, Throwable, Iterator[A]]
+  ): ZStream[R, Throwable, A] =
+    fromEffect(iterator).flatMap(fromIterator(_))
+
+  /**
+   * Creates a stream from a managed iterator
+   */
+  def fromIteratorManaged[R, A](iterator: ZManaged[R, Throwable, Iterator[A]]): ZStream[R, Throwable, A] =
+    managed(iterator).flatMap(fromIterator(_))
+
+  /**
+   * Creates a stream from an iterator
+   */
+  def fromIteratorTotal[A](iterator: => Iterator[A]): ZStream[Any, Nothing, A] = {
+    def loop(iterator: Iterator[A]): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
+      ZChannel.unwrap {
+        UIO {
+          if (iterator.hasNext)
+            ZChannel.write(Chunk.single(iterator.next())) *> loop(iterator)
+          else ZChannel.end(())
+        }
+      }
+
+    new ZStream(loop(iterator))
+  }
+
+  /**
+   * Creates a stream from a Java iterator that may throw exceptions
+   */
+  def fromJavaIterator[A](iterator: => java.util.Iterator[A]): ZStream[Any, Throwable, A] =
+    fromIterator {
+      val it = iterator // Scala 2.13 scala.collection.Iterator has `iterator` in local scope
+      new Iterator[A] {
+        def next(): A        = it.next
+        def hasNext: Boolean = it.hasNext
+      }
+    }
+
+  /**
+   * Creates a stream from a Java iterator that may potentially throw exceptions
+   */
+  def fromJavaIteratorEffect[R, A](
+    iterator: ZIO[R, Throwable, java.util.Iterator[A]]
+  ): ZStream[R, Throwable, A] =
+    fromEffect(iterator).flatMap(fromJavaIterator(_))
+
+  /**
+   * Creates a stream from a managed iterator
+   */
+  def fromJavaIteratorManaged[R, A](iterator: ZManaged[R, Throwable, java.util.Iterator[A]]): ZStream[R, Throwable, A] =
+    managed(iterator).flatMap(fromJavaIterator(_))
+
+  /**
+   * Creates a stream from a Java iterator
+   */
+  def fromJavaIteratorTotal[A](iterator: => java.util.Iterator[A]): ZStream[Any, Nothing, A] =
+    fromIteratorTotal {
+      val it = iterator // Scala 2.13 scala.collection.Iterator has `iterator` in local scope
+      new Iterator[A] {
+        def next(): A        = it.next
+        def hasNext: Boolean = it.hasNext
+      }
+    }
+
+  /**
+   * Creates a stream from a [[zio.ZQueue]] of values
+   *
+   * @param maxChunkSize Maximum number of queued elements to put in one chunk in the stream
+   */
+  def fromQueue[R, E, O](
+    queue: ZQueue[Nothing, R, Any, E, Nothing, O],
+    maxChunkSize: Int = DefaultChunkSize
+  ): ZStream[R, E, O] =
+    repeatEffectChunkOption {
+      queue
+        .takeBetween(1, maxChunkSize)
+        .map(Chunk.fromIterable)
+        .catchAllCause(c =>
+          queue.isShutdown.flatMap { down =>
+            if (down && c.interrupted) Pull.end
+            else Pull.halt(c)
+          }
+        )
+    }
+
+  /**
+   * Creates a stream from a [[zio.ZQueue]] of values. The queue will be shutdown once the stream is closed.
+   *
+   * @param maxChunkSize Maximum number of queued elements to put in one chunk in the stream
+   */
+  def fromQueueWithShutdown[R, E, O](
+    queue: ZQueue[Nothing, R, Any, E, Nothing, O],
+    maxChunkSize: Int = DefaultChunkSize
+  ): ZStream[R, E, O] =
+    fromQueue(queue, maxChunkSize).ensuringFirst(queue.shutdown)
+
+  /**
+   * Creates a stream from a [[zio.Schedule]] that does not require any further
+   * input. The stream will emit an element for each value output from the
+   * schedule, continuing for as long as the schedule continues.
+   */
+  def fromSchedule[R, A](schedule: Schedule[R, Any, A]): ZStream[R with Clock, Nothing, A] =
+    unwrap(schedule.driver.map(driver => repeatEffectOption(driver.next(()))))
+
+  /**
+   * Creates a stream from a [[zio.stm.TQueue]] of values.
+   */
+  def fromTQueue[A](queue: TQueue[A]): ZStream[Any, Nothing, A] =
+    repeatEffectChunk(queue.take.map(Chunk.single(_)).commit)
+
+  /**
+   * The stream that always halts with `cause`.
+   */
+  def halt[E](cause: => Cause[E]): ZStream[Any, E, Nothing] =
+    fromEffect(ZIO.halt(cause))
+
+  /**
+   * The infinite stream of iterative function application: a, f(a), f(f(a)), f(f(f(a))), ...
+   */
+  def iterate[A](a: A)(f: A => A): ZStream[Any, Nothing, A] =
+    unfold(a)(a => Some((a, f(a))))
+
+  /**
+   * Creates a single-valued stream from a managed resource
+   */
+  def managed[R, E, A](managed: ZManaged[R, E, A]): ZStream[R, E, A] =
+    new ZStream(ZChannel.managedOut(managed.map(Chunk.single)))
+
+  /**
+   * Merges a variable list of streams in a non-deterministic fashion.
+   * Up to `n` streams may be consumed in parallel and up to
+   * `outputBuffer` chunks may be buffered by this operator.
+   */
+  def mergeAll[R, E, O](n: Int, outputBuffer: Int = 16)(
+    streams: ZStream[R, E, O]*
+  ): ZStream[R, E, O] =
+    fromIterable(streams).flattenPar(n, outputBuffer)
+
+  /**
+   * Like [[mergeAll]], but runs all streams concurrently.
+   */
+  def mergeAllUnbounded[R, E, O](outputBuffer: Int = 16)(
+    streams: ZStream[R, E, O]*
+  ): ZStream[R, E, O] = mergeAll(Int.MaxValue, outputBuffer)(streams: _*)
+
+  /**
+   * The stream that never produces any value or fails with any error.
+   */
+  val never: ZStream[Any, Nothing, Nothing] =
+    ZStream.fromEffect(ZIO.never)
+
+  /**
+   * Like [[unfoldM]], but allows the emission of values to end one step further than
+   * the unfolding of the state. This is useful for embedding paginated APIs,
+   * hence the name.
+   */
+  def paginate[R, E, A, S](s: S)(f: S => (A, Option[S])): ZStream[Any, Nothing, A] =
+    paginateM(s)(s => ZIO.succeedNow(f(s)))
+
+  /**
+   * Like [[unfoldM]], but allows the emission of values to end one step further than
+   * the unfolding of the state. This is useful for embedding paginated APIs,
+   * hence the name.
+   */
+  def paginateM[R, E, A, S](s: S)(f: S => ZIO[R, E, (A, Option[S])]): ZStream[R, E, A] =
+    paginateChunkM(s)(f(_).map { case (a, s) => Chunk.single(a) -> s })
+
+  /**
+   * Like [[unfoldChunk]], but allows the emission of values to end one step further than
+   * the unfolding of the state. This is useful for embedding paginated APIs,
+   * hence the name.
+   */
+  def paginateChunk[A, S](s: S)(f: S => (Chunk[A], Option[S])): ZStream[Any, Nothing, A] =
+    paginateChunkM(s)(s => ZIO.succeedNow(f(s)))
+
+  /**
+   * Like [[unfoldChunkM]], but allows the emission of values to end one step further than
+   * the unfolding of the state. This is useful for embedding paginated APIs,
+   * hence the name.
+   */
+  def paginateChunkM[R, E, A, S](s: S)(f: S => ZIO[R, E, (Chunk[A], Option[S])]): ZStream[R, E, A] = {
+    def loop(s: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+      ZChannel.unwrap {
+        f(s).map { case (as, s) =>
+          ZChannel.write(as) *>
+            s.fold[ZChannel[R, Any, Any, Any, E, Chunk[A], Any]](ZChannel.end(()))(loop)
+        }
+      }
+
+    new ZStream(loop(s))
+  }
+
+  /**
+   * Constructs a stream from a range of integers (lower bound included, upper bound not included)
+   */
+  def range(min: Int, max: Int, chunkSize: Int = DefaultChunkSize): ZStream[Any, Nothing, Int] = {
+    def go(current: Int): ZChannel[Any, Any, Any, Any, Nothing, Chunk[Int], Any] = {
+      val remaining = max - current
+
+      if (remaining > chunkSize)
+        ZChannel.write(Chunk.fromArray(Array.range(current, current + chunkSize))) *> go(current + chunkSize)
+      else {
+        ZChannel.write(Chunk.fromArray(Array.range(current, current + remaining)))
+      }
+    }
+
+    new ZStream(go(min))
+  }
+
+  /**
+   * Repeats the provided value infinitely.
+   */
+  def repeat[A](a: => A): ZStream[Any, Nothing, A] =
+    repeatEffect(UIO.succeed(a))
+
+  /**
+   * Creates a stream from an effect producing a value of type `A` which repeats forever.
+   */
+  def repeatEffect[R, E, A](fa: ZIO[R, E, A]): ZStream[R, E, A] =
+    repeatEffectOption(fa.mapError(Some(_)))
+
+  /**
+   * Creates a stream from an effect producing values of type `A` until it fails with None.
+   */
+  def repeatEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] =
+    repeatEffectChunkOption(fa.map(Chunk.single(_)))
+
+  /**
+   * Creates a stream from an effect producing chunks of `A` values which repeats forever.
+   */
+  def repeatEffectChunk[R, E, A](fa: ZIO[R, E, Chunk[A]]): ZStream[R, E, A] =
+    repeatEffectChunkOption(fa.mapError(Some(_)))
+
+  /**
+   * Creates a stream from an effect producing chunks of `A` values until it fails with None.
+   */
+  def repeatEffectChunkOption[R, E, A](fa: ZIO[R, Option[E], Chunk[A]]): ZStream[R, E, A] =
+    unfoldChunkM(())(_ =>
+      fa.map(chunk => Some((chunk, ()))).catchAll {
+        case None    => ZIO.none
+        case Some(e) => ZIO.fail(e)
+      }
+    )
+
+  /**
+   * Creates a stream from an effect producing a value of type `A`, which is repeated using the
+   * specified schedule.
+   */
+  def repeatEffectWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, Any]): ZStream[R with Clock, E, A] =
+    ZStream.fromEffect(effect zip schedule.driver).flatMap { case (a, driver) =>
+      ZStream.succeed(a) ++
+        ZStream.unfoldM(a)(driver.next(_).foldM(ZIO.succeed(_), _ => effect.map(nextA => Some(nextA -> nextA))))
+    }
+
+  /**
+   * Repeats the value using the provided schedule.
+   */
+  def repeatWith[R, A](a: => A, schedule: Schedule[R, A, _]): ZStream[R with Clock, Nothing, A] =
+    repeatEffectWith(UIO.succeed(a), schedule)
+
+  /**
+   * Accesses the specified service in the environment of the effect.
+   */
+  def service[A: Tag]: ZStream[Has[A], Nothing, A] =
+    ZStream.access(_.get[A])
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tag, B: Tag]: ZStream[Has[A] with Has[B], Nothing, (A, B)] =
+    ZStream.access(r => (r.get[A], r.get[B]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tag, B: Tag, C: Tag]: ZStream[Has[A] with Has[B] with Has[C], Nothing, (A, B, C)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C]))
+
+  /**
+   * Accesses the specified services in the environment of the effect.
+   */
+  def services[A: Tag, B: Tag, C: Tag, D: Tag]
+    : ZStream[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
+    ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
+
+  /**
+   * Creates a single-valued pure stream
+   */
+  def succeed[A](a: => A): ZStream[Any, Nothing, A] =
+    fromChunk(Chunk.single(a))
+
+  /**
+   * A stream that emits Unit values spaced by the specified duration.
+   */
+  def tick(interval: Duration): ZStream[Clock, Nothing, Unit] =
+    repeatWith((), Schedule.spaced(interval))
+
+  /**
+   * A stream that contains a single `Unit` value.
+   */
+  val unit: ZStream[Any, Nothing, Unit] =
+    succeed(())
+
+  /**
+   * Creates a stream by peeling off the "layers" of a value of type `S`
+   */
+  def unfold[S, A](s: S)(f: S => Option[(A, S)]): ZStream[Any, Nothing, A] =
+    unfoldM(s)(s => ZIO.succeedNow(f(s)))
+
+  /**
+   * Creates a stream by effectfully peeling off the "layers" of a value of type `S`
+   */
+  def unfoldM[R, E, A, S](s: S)(f: S => ZIO[R, E, Option[(A, S)]]): ZStream[R, E, A] =
+    unfoldChunkM(s)(f(_).map(_.map { case (a, s) =>
+      Chunk.single(a) -> s
+    }))
+
+  /**
+   * Creates a stream by peeling off the "layers" of a value of type `S`.
+   */
+  def unfoldChunk[S, A](s: S)(f: S => Option[(Chunk[A], S)]): ZStream[Any, Nothing, A] =
+    unfoldChunkM(s)(s => ZIO.succeedNow(f(s)))
+
+  /**
+   * Creates a stream by effectfully peeling off the "layers" of a value of type `S`
+   */
+  def unfoldChunkM[R, E, A, S](s: S)(f: S => ZIO[R, E, Option[(Chunk[A], S)]]): ZStream[R, E, A] = {
+    def loop(s: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+      ZChannel.unwrap {
+        f(s).map {
+          case Some((as, s)) => ZChannel.write(as) *> loop(s)
+          case None          => ZChannel.end(())
+        }
+      }
+
+    new ZStream(loop(s))
+  }
+
+  /**
+   * Creates a stream produced from an effect
+   */
+  def unwrap[R, E, A](fa: ZIO[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
+    fromEffect(fa).flatten
+
+  /**
+   * Creates a stream produced from a [[ZManaged]]
+   */
+  def unwrapManaged[R, E, A](fa: ZManaged[R, E, ZStream[R, E, A]]): ZStream[R, E, A] =
+    managed(fa).flatten
+
+  /**
+   * Zips the specified streams together with the specified function.
+   */
+  def zipN[R, E, A, B, C](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B])(
+    f: (A, B) => C
+  ): ZStream[R, E, C] =
+    zStream1.zipWith(zStream2)(f)
+
+  /**
+   * Zips with specified streams together with the specified function.
+   */
+  def zipN[R, E, A, B, C, D](zStream1: ZStream[R, E, A], zStream2: ZStream[R, E, B], zStream3: ZStream[R, E, C])(
+    f: (A, B, C) => D
+  ): ZStream[R, E, D] =
+    (zStream1 <&> zStream2 <&> zStream3).map { case ((a, b), c) =>
+      f(a, b, c)
+    }
+
+  /**
+   * Returns an effect that executes the specified effects in parallel,
+   * combining their results with the specified `f` function. If any effect
+   * fails, then the other effects will be interrupted.
+   */
+  def zipN[R, E, A, B, C, D, F](
+    zStream1: ZStream[R, E, A],
+    zStream2: ZStream[R, E, B],
+    zStream3: ZStream[R, E, C],
+    zStream4: ZStream[R, E, D]
+  )(f: (A, B, C, D) => F): ZStream[R, E, F] =
+    (zStream1 <&> zStream2 <&> zStream3 <&> zStream4).map { case (((a, b), c), d) =>
+      f(a, b, c, d)
+    }
+
+  final class AccessPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[A](f: R => A): ZStream[R, Nothing, A] =
+      ZStream.environment[R].map(f)
+  }
+
+  final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: R => ZIO[R, E, A]): ZStream[R, E, A] =
+      ZStream.environment[R].mapM(f)
+  }
+
+  final class AccessStreamPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: R => ZStream[R, E, A]): ZStream[R, E, A] =
+      ZStream.environment[R].flatMap(f)
+  }
+
+  /**
+   * Representation of a grouped stream.
+   * This allows to filter which groups will be processed.
+   * Once this is applied all groups will be processed in parallel and the results will
+   * be merged in arbitrary order.
+   */
+  final class GroupBy[-R, +E, +K, +V](
+    private val grouped: ZStream[R, E, (K, Dequeue[Exit[Option[E], V]])],
+    private val buffer: Int
+  ) {
+
+    /**
+     * Only consider the first n groups found in the stream.
+     */
+    def first(n: Int): GroupBy[R, E, K, V] = {
+      val g1 = grouped.zipWithIndex.filterM { case elem @ ((_, q), i) =>
+        if (i < n) ZIO.succeedNow(elem).as(true)
+        else q.shutdown.as(false)
+      }.map(_._1)
+      new GroupBy(g1, buffer)
+    }
+
+    /**
+     * Filter the groups to be processed.
+     */
+    def filter(f: K => Boolean): GroupBy[R, E, K, V] = {
+      val g1 = grouped.filterM { case elem @ (k, q) =>
+        if (f(k)) ZIO.succeedNow(elem).as(true)
+        else q.shutdown.as(false)
+      }
+      new GroupBy(g1, buffer)
+    }
+
+    /**
+     * Run the function across all groups, collecting the results in an arbitrary order.
+     */
+    def apply[R1 <: R, E1 >: E, A](f: (K, ZStream[Any, E, V]) => ZStream[R1, E1, A]): ZStream[R1, E1, A] =
+      grouped.flatMapPar[R1, E1, A](Int.MaxValue) { case (k, q) =>
+        f(k, ZStream.fromQueueWithShutdown(q).flattenExitOption)
+      }
+  }
+
+  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZStream[R, E, A]) extends AnyVal {
+    def apply[E1 >: E, R1 <: Has[_]](
+      layer: ZLayer[R0, E1, R1]
+    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZStream[R0, E1, A] =
+      self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
+  }
+
+  final class UpdateService[-R, +E, +A, M](private val self: ZStream[R, E, A]) extends AnyVal {
+    def apply[R1 <: R with Has[M]](f: M => M)(implicit ev: Has.IsHas[R1], tag: Tag[M]): ZStream[R1, E, A] =
+      self.provideSome(ev.update(_, f))
+  }
+
+  type Pull[-R, +E, +A] = ZIO[R, Option[E], Chunk[A]]
+
+  private[zio] object Pull {
+    def emit[A](a: A): IO[Nothing, Chunk[A]]                                      = UIO(Chunk.single(a))
+    def emit[A](as: Chunk[A]): IO[Nothing, Chunk[A]]                              = UIO(as)
+    def fromDequeue[E, A](d: Dequeue[stream.Take[E, A]]): IO[Option[E], Chunk[A]] = d.take.flatMap(_.done)
+    def fail[E](e: E): IO[Option[E], Nothing]                                     = IO.fail(Some(e))
+    def halt[E](c: Cause[E]): IO[Option[E], Nothing]                              = IO.halt(c).mapError(Some(_))
+    def empty[A]: IO[Nothing, Chunk[A]]                                           = UIO(Chunk.empty)
+    val end: IO[Option[Nothing], Nothing]                                         = IO.fail(None)
+  }
+
+  @deprecated("use zio.stream.Take instead", "1.0.0")
+  type Take[+E, +A] = Exit[Option[E], Chunk[A]]
+
+  object Take {
+    @deprecated("use zio.stream.Take.end instead", "1.0.0")
+    val End: Exit[Option[Nothing], Nothing] = Exit.fail(None)
+  }
+
+  private[zio] case class BufferedPull[R, E, A](
+    upstream: ZIO[R, Option[E], Chunk[A]],
+    done: Ref[Boolean],
+    cursor: Ref[(Chunk[A], Int)]
+  ) {
+    def ifNotDone[R1, E1, A1](fa: ZIO[R1, Option[E1], A1]): ZIO[R1, Option[E1], A1] =
+      done.get.flatMap(
+        if (_) Pull.end
+        else fa
+      )
+
+    def update: ZIO[R, Option[E], Unit] =
+      ifNotDone {
+        upstream.foldM(
+          {
+            case None    => done.set(true) *> Pull.end
+            case Some(e) => Pull.fail(e)
+          },
+          chunk => cursor.set(chunk -> 0)
+        )
+      }
+
+    def pullElement: ZIO[R, Option[E], A] =
+      ifNotDone {
+        cursor.modify { case (chunk, idx) =>
+          if (idx >= chunk.size) (update *> pullElement, (Chunk.empty, 0))
+          else (UIO.succeedNow(chunk(idx)), (chunk, idx + 1))
+        }.flatten
+      }
+
+    def pullChunk: ZIO[R, Option[E], Chunk[A]] =
+      ifNotDone {
+        cursor.modify { case (chunk, idx) =>
+          if (idx >= chunk.size) (update *> pullChunk, (Chunk.empty, 0))
+          else (UIO.succeedNow(chunk.drop(idx)), (Chunk.empty, 0))
+        }.flatten
+      }
+
+  }
+
+  private[zio] object BufferedPull {
+    def make[R, E, A](
+      pull: ZIO[R, Option[E], Chunk[A]]
+    ): ZIO[R, Nothing, BufferedPull[R, E, A]] =
+      for {
+        done   <- Ref.make(false)
+        cursor <- Ref.make[(Chunk[A], Int)](Chunk.empty -> 0)
+      } yield BufferedPull(pull, done, cursor)
+  }
+
+  /**
+   * A synchronous queue-like abstraction that allows a producer to offer
+   * an element and wait for it to be taken, and allows a consumer to wait
+   * for an element to be available.
+   */
+  private[zio] class Handoff[A](ref: Ref[Handoff.State[A]]) {
+    def offer(a: A): UIO[Unit] =
+      Promise.make[Nothing, Unit].flatMap { p =>
+        ref.modify {
+          case s @ Handoff.State.Full(_, notifyProducer) => (notifyProducer.await *> offer(a), s)
+          case Handoff.State.Empty(notifyConsumer)       => (notifyConsumer.succeed(()) *> p.await, Handoff.State.Full(a, p))
+        }.flatten
+      }
+
+    def take: UIO[A] =
+      Promise.make[Nothing, Unit].flatMap { p =>
+        ref.modify {
+          case Handoff.State.Full(a, notifyProducer)   => (notifyProducer.succeed(()).as(a), Handoff.State.Empty(p))
+          case s @ Handoff.State.Empty(notifyConsumer) => (notifyConsumer.await *> take, s)
+        }.flatten
+      }
+
+    def poll: UIO[Option[A]] =
+      Promise.make[Nothing, Unit].flatMap { p =>
+        ref.modify {
+          case Handoff.State.Full(a, notifyProducer) => (notifyProducer.succeed(()).as(Some(a)), Handoff.State.Empty(p))
+          case s @ Handoff.State.Empty(_)            => (ZIO.succeedNow(None), s)
+        }.flatten
+      }
+  }
+
+  private[zio] object Handoff {
+    def make[A]: UIO[Handoff[A]] =
+      Promise
+        .make[Nothing, Unit]
+        .flatMap(p => Ref.make[State[A]](State.Empty(p)))
+        .map(new Handoff(_))
+
+    sealed trait State[+A]
+    object State {
+      case class Empty(notifyConsumer: Promise[Nothing, Unit])          extends State[Nothing]
+      case class Full[+A](a: A, notifyProducer: Promise[Nothing, Unit]) extends State[A]
+    }
+  }
+
+  sealed trait TerminationStrategy
+  object TerminationStrategy {
+    case object Left   extends TerminationStrategy
+    case object Right  extends TerminationStrategy
+    case object Both   extends TerminationStrategy
+    case object Either extends TerminationStrategy
+  }
+
+  implicit final class RefineToOrDieOps[R, E <: Throwable, A](private val self: ZStream[R, E, A]) extends AnyVal {
+
+    /**
+     * Keeps some of the errors, and terminates the fiber with the rest.
+     */
+    def refineToOrDie[E1 <: E: ClassTag](implicit ev: CanFail[E]): ZStream[R, E1, A] =
+      self.refineOrDie { case e: E1 => e }
+  }
+
+  private[zio] class Rechunker[A](n: Int) {
+    private var builder: ChunkBuilder[A] = ChunkBuilder.make(n)
+    private var pos: Int                 = 0
+
+    def write(elem: A): Chunk[A] = {
+      builder += elem
+      pos += 1
+      if (pos == n) {
+        val result = builder.result()
+        builder = ChunkBuilder.make(n)
+        pos = 0
+        result
+      } else {
+        null
+      }
+    }
+
+    def emitIfNotEmpty(): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Unit] =
+      if (pos != 0) {
+        ZChannel.write(builder.result())
+      } else {
+        ZChannel.unit
+      }
+  }
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
@@ -1,0 +1,728 @@
+package zio.stream.experimental.internal
+
+import zio._
+import zio.stream.experimental.ZChannel
+
+class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+  initialChannel: () => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
+  @volatile private var providedEnv: Any
+) {
+  import ChannelExecutor._
+
+  private[this] def restorePipe(exit: Exit[Any, Any], prev: ErasedExecutor[Env]) = {
+    val currInput = input
+    input = prev
+
+    currInput.close(exit)
+  }
+
+  private[this] final def popAllFinalizers(exit: Exit[Any, Any]): URIO[Env, Exit[Any, Any]] = {
+    def unwind(acc: Exit[Any, Any], conts: List[ErasedContinuation[Env]]): ZIO[Env, Any, Any] =
+      conts match {
+        case Nil                                => ZIO.done(acc)
+        case ZChannel.Fold.K(_, _) :: rest      => unwind(acc, rest)
+        case ZChannel.Fold.Finalizer(f) :: rest => f(exit).run.flatMap(finExit => unwind(acc *> finExit, rest))
+      }
+
+    val effect = unwind(Exit.unit, doneStack).run
+    doneStack = Nil
+    storeInProgressFinalizer(effect)
+    effect
+  }
+
+  private[this] final def popNextFinalizers(): List[ZChannel.Fold.Finalizer[Env, Any, Any]] = {
+    val builder = List.newBuilder[ZChannel.Fold.Finalizer[Env, Any, Any]]
+
+    def go(stack: List[ErasedContinuation[Env]]): List[ErasedContinuation[Env]] =
+      stack match {
+        case Nil                        => Nil
+        case ZChannel.Fold.K(_, _) :: _ => stack
+        case (finalizer @ ZChannel.Fold.Finalizer(_)) :: rest =>
+          builder += finalizer
+          go(rest)
+      }
+
+    doneStack = go(doneStack)
+    builder.result()
+  }
+
+  private[this] final def storeInProgressFinalizer(finalizer: URIO[Env, Exit[Any, Any]]): Unit =
+    inProgressFinalizer = finalizer
+
+  private[this] final def clearInProgressFinalizer(): Unit =
+    inProgressFinalizer = null
+
+  def close(ex: Exit[Any, Any]): ZIO[Env, Nothing, Any] = {
+    def ifNotNull[R, E](zio: URIO[R, Exit[E, Any]]): URIO[R, Exit[E, Any]] =
+      if (zio ne null) zio else UIO.succeed(Exit.unit)
+
+    val runInProgressFinalizers = {
+      val finalizer = inProgressFinalizer
+
+      if (finalizer ne null) finalizer.ensuring(UIO(clearInProgressFinalizer()))
+      else null
+    }
+
+    val closeSubexecutors =
+      if (subexecutorStack eq null) null
+      else
+        subexecutorStack match {
+          case exec: SubexecutorStack.Inner[Env] =>
+            exec.close(ex)
+
+          case SubexecutorStack.FromKAnd(fromK, rest) =>
+            val fin1 = fromK.close(ex)
+            val fin2 = rest.close(ex)
+
+            if ((fin1 eq null) && (fin2 eq null)) null
+            else if ((fin1 ne null) && (fin2 ne null)) fin1.run.zipWith(fin2.run)(_ *> _)
+            else if (fin1 ne null) fin1.run
+            else fin2.run
+        }
+
+    val closeSelf: URIO[Env, Exit[Any, Any]] = {
+      val selfFinalizers = popAllFinalizers(ex)
+
+      if (selfFinalizers ne null) selfFinalizers.ensuring(UIO(clearInProgressFinalizer()))
+      else null
+    }
+
+    if ((closeSubexecutors eq null) && (runInProgressFinalizers eq null) && (closeSelf eq null)) null
+    else
+      ZIO
+        .mapN(
+          ifNotNull(closeSubexecutors),
+          ifNotNull(runInProgressFinalizers),
+          ifNotNull(closeSelf)
+        )(_ *> _ *> _)
+        .uninterruptible
+  }
+
+  def getDone: Exit[OutErr, OutDone] = done.asInstanceOf[Exit[OutErr, OutDone]]
+
+  def getEmit: OutElem = emitted.asInstanceOf[OutElem]
+
+  def cancelWith(exit: Exit[OutErr, OutDone]): Unit =
+    cancelled = exit
+
+  final def run(): ChannelState[Env, Any] = {
+    var result: ChannelState[Env, Any] = null
+
+    while (result eq null) {
+      if (cancelled ne null) {
+        result = processCancellation()
+      } else if (subexecutorStack ne null) {
+        result = drainSubexecutor()
+      } else {
+        currentChannel match {
+          case null =>
+            result = ChannelState.Done
+
+          case ZChannel.Bridge(bridgeInput, channel) =>
+            // PipeTo(left, Bridge(queue, channel))
+            // In a fiber: repeatedly run left and push its outputs to the queue
+            // Add a finalizer to interrupt the fiber and close the executor
+            currentChannel = channel
+
+            if (input ne null) {
+              val inputExecutor = input
+              input = null
+
+              lazy val drainer: URIO[Env, Any] =
+                ZIO.effectSuspendTotal {
+                  val state = inputExecutor.run()
+
+                  state match {
+                    case ChannelState.Done =>
+                      val sendInput = inputExecutor.getDone match {
+                        case Exit.Failure(cause) => bridgeInput.error(cause)
+                        case Exit.Success(value) => bridgeInput.done(value)
+                      }
+
+                      sendInput
+
+                    case ChannelState.Emit =>
+                      bridgeInput.emit(inputExecutor.getEmit) *> drainer
+
+                    case ChannelState.Effect(zio) =>
+                      zio.foldCauseM(
+                        cause => bridgeInput.error(cause),
+                        _ => drainer
+                      )
+                  }
+                }
+
+              result = ChannelState.Effect(
+                drainer.fork.flatMap { fiber =>
+                  UIO(addFinalizer { exit =>
+                    fiber.interrupt *>
+                      ZIO.effectSuspendTotal {
+                        val effect = restorePipe(exit, inputExecutor)
+
+                        if (effect ne null) effect
+                        else UIO.unit
+                      }
+                  })
+                }
+              )
+            }
+
+          case ZChannel.PipeTo(left, right) =>
+            val previousInput = input
+
+            val leftExec: ErasedExecutor[Env] = new ChannelExecutor(left, providedEnv)
+            leftExec.input = previousInput
+            input = leftExec
+
+            addFinalizer { exit =>
+              val effect = restorePipe(exit, previousInput)
+
+              if (effect ne null) effect
+              else UIO.unit
+            }
+
+            currentChannel = right()
+
+          case read @ ZChannel.Read(_, _) =>
+            result = runRead(read)
+
+          case ZChannel.Done(terminal) =>
+            result = doneSucceed(terminal)
+
+          case ZChannel.Halt(error) =>
+            result = doneHalt(error())
+
+          case ZChannel.Effect(zio) =>
+            val pzio = (if (providedEnv == null) zio else zio.provide(providedEnv.asInstanceOf[Env]))
+              .asInstanceOf[ZIO[Env, OutErr, OutDone]]
+
+            result = ChannelState.Effect(
+              pzio
+                .foldCauseM(
+                  cause =>
+                    doneHalt(cause) match {
+                      case ChannelState.Effect(zio) => zio
+                      case _                        => ZIO.unit
+                    },
+                  z =>
+                    doneSucceed(z) match {
+                      case ChannelState.Effect(zio) => zio
+                      case _                        => ZIO.unit
+                    }
+                )
+            )
+
+          case ZChannel.Emit(out) =>
+            emitted = out
+            currentChannel = ZChannel.end(())
+            result = ChannelState.Emit
+
+          case ensuring @ ZChannel.Ensuring(_, _) =>
+            runEnsuring(ensuring)
+
+          case ZChannel.ConcatAll(combineSubK, combineSubKAndInner, value, k) =>
+            val exec: ErasedExecutor[Env] = new ChannelExecutor(() => value, providedEnv)
+            exec.input = input
+
+            subexecutorStack = SubexecutorStack.Inner(exec, k, lastDone = null, combineSubK, combineSubKAndInner)
+            currentChannel = null
+
+          case ZChannel.Fold(value, k) =>
+            doneStack = k.asInstanceOf[ErasedContinuation[Env]] :: doneStack
+            currentChannel = value
+
+          case bracketOut @ ZChannel.BracketOut(_, _) =>
+            result = runBracketOut(bracketOut)
+
+          case ZChannel.Provide(env, inner) =>
+            val previousEnv = providedEnv
+            providedEnv = env
+            currentChannel = inner
+
+            addFinalizer { _ =>
+              URIO {
+                providedEnv = previousEnv
+              }
+            }
+        }
+      }
+    }
+
+    result
+  }
+
+  private[this] var currentChannel: Channel[Env] = erase(initialChannel())
+
+  private[this] var done: Exit[Any, Any] = _
+
+  private[this] var doneStack: List[ErasedContinuation[Env]] = Nil
+
+  private[this] var emitted: Any = _
+
+  @volatile
+  private[this] var inProgressFinalizer: URIO[Env, Exit[Any, Any]] = _
+
+  @volatile
+  var input: ErasedExecutor[Env] = _
+
+  private[this] var subexecutorStack: SubexecutorStack[Env] = _
+
+  private[this] var cancelled: Exit[OutErr, OutDone] = _
+
+  private[this] def doneSucceed(z: Any): ChannelState[Env, Any] =
+    doneStack match {
+      case Nil =>
+        done = Exit.succeed(z)
+        currentChannel = null
+        ChannelState.Done
+
+      case ZChannel.Fold.K(onSuccess, _) :: rest =>
+        doneStack = rest
+        currentChannel = onSuccess(z)
+        null
+
+      case ZChannel.Fold.Finalizer(_) :: _ =>
+        val finalizers = popNextFinalizers()
+
+        if (doneStack.isEmpty) {
+          doneStack = finalizers
+          done = Exit.succeed(z)
+          currentChannel = null
+          ChannelState.Done
+        } else {
+          val finalizerEffect = runFinalizers(finalizers.map(_.finalizer), Exit.succeed(z))
+          storeInProgressFinalizer(finalizerEffect)
+
+          ChannelState.Effect(
+            finalizerEffect
+              .ensuring(UIO(clearInProgressFinalizer()))
+              .uninterruptible *> UIO(doneSucceed(z))
+          )
+        }
+    }
+
+  private[this] def doneHalt(cause: Cause[Any]): ChannelState[Env, Any] =
+    doneStack match {
+      case Nil =>
+        done = Exit.halt(cause)
+        currentChannel = null
+        ChannelState.Done
+
+      case ZChannel.Fold.K(_, onHalt) :: rest =>
+        doneStack = rest
+        currentChannel = onHalt(cause)
+        null
+
+      case ZChannel.Fold.Finalizer(_) :: _ =>
+        val finalizers = popNextFinalizers()
+
+        if (doneStack.isEmpty) {
+          doneStack = finalizers
+          done = Exit.halt(cause)
+          currentChannel = null
+          ChannelState.Done
+        } else {
+          val finalizerEffect = runFinalizers(finalizers.map(_.finalizer), Exit.halt(cause))
+          storeInProgressFinalizer(finalizerEffect)
+
+          ChannelState.Effect(
+            finalizerEffect
+              .ensuring(UIO(clearInProgressFinalizer()))
+              .uninterruptible *> UIO(doneHalt(cause))
+          )
+        }
+    }
+
+  private[this] def processCancellation(): ChannelState[Env, Any] = {
+    currentChannel = null
+    done = cancelled
+    cancelled = null
+    ChannelState.Done
+  }
+
+  private def runRead(
+    read: ZChannel.Read[Env, Any, Any, Any, Any, Any, Any, Any, Any, Any]
+  ): ChannelState.Effect[Env, Any] =
+    if (input eq null) {
+      currentChannel = read.more(())
+      null
+    } else {
+      def go(state: ChannelState[Env, Any]): URIO[Env, Unit] =
+        state match {
+          case ChannelState.Emit =>
+            UIO {
+              currentChannel = read.more(input.getEmit)
+            }
+
+          case ChannelState.Done =>
+            UIO {
+              currentChannel = read.done.onExit(input.getDone)
+            }
+
+          case ChannelState.Effect(zio) =>
+            zio.foldCauseM(
+              cause =>
+                UIO {
+                  currentChannel = read.done.onHalt(cause)
+                },
+              _ => go(input.run())
+            )
+        }
+
+      input.run() match {
+        case ChannelState.Emit =>
+          currentChannel = read.more(input.getEmit)
+          null
+
+        case ChannelState.Done =>
+          currentChannel = read.done.onExit(input.getDone)
+          null
+
+        case ChannelState.Effect(zio) =>
+          ChannelState.Effect(
+            zio.foldCauseM(
+              cause =>
+                UIO {
+                  currentChannel = read.done.onHalt(cause)
+                },
+              _ => go(input.run())
+            )
+          )
+      }
+    }
+
+  private def runBracketOut(bracketOut: ZChannel.BracketOut[Env, Any, Any]): ChannelState.Effect[Env, Any] =
+    ChannelState.Effect {
+      ZIO.uninterruptibleMask { restore =>
+        restore(bracketOut.acquire).foldCauseM(
+          cause => UIO { currentChannel = ZChannel.halt(cause) },
+          out =>
+            UIO {
+              addFinalizer(bracketOut.finalizer(out, _))
+              currentChannel = ZChannel.write(out)
+            }
+        )
+      }
+    }
+
+  private[this] def runEnsuring(ensuring: ZChannel.Ensuring[Env, Any, Any, Any, Any, Any, Any]) = {
+    addFinalizer(ensuring.finalizer)
+    currentChannel = ensuring.channel
+  }
+
+  private[this] def addFinalizer(f: Finalizer[Env]): Unit =
+    doneStack = ZChannel.Fold.Finalizer(f) :: doneStack
+
+  private[this] def runFinalizers(finalizers: List[Finalizer[Env]], ex: Exit[Any, Any]): URIO[Env, Exit[Any, Any]] =
+    if (finalizers.isEmpty) null
+    else
+      ZIO
+        .foreach(finalizers)(_.apply(ex).run)
+        .map(results => Exit.collectAll(results) getOrElse Exit.unit)
+
+  private[this] def drainSubexecutor(): ChannelState[Env, Any] =
+    subexecutorStack match {
+      case inner @ SubexecutorStack.Inner(_, _, _, _, _) =>
+        drainInnerSubexecutor(inner.asInstanceOf[SubexecutorStack.Inner[Env]])
+
+      case SubexecutorStack.FromKAnd(exec, rest) =>
+        drainFromKAndSubexecutor(exec.asInstanceOf[ErasedExecutor[Env]], rest.asInstanceOf[SubexecutorStack.Inner[Env]])
+    }
+
+  private def replaceSubexecutor(nextSubExec: SubexecutorStack.Inner[Env]): Unit = {
+    currentChannel = null
+    subexecutorStack = nextSubExec
+  }
+
+  def finishWithExit(exit: Exit[Any, Any]): ZIO[Env, Any, Any] = {
+    val state = exit.fold(doneHalt, doneSucceed)
+    subexecutorStack = null
+
+    if (state eq null) UIO.unit
+    else state.effect
+  }
+
+  private def finishSubexecutorWithCloseEffect(
+    subexecDone: Exit[Any, Any],
+    closeEffect: ZIO[Env, Nothing, Any]
+  ): ChannelState[Env, Any] =
+    if (closeEffect eq null) {
+      val state = subexecDone.fold(doneHalt, doneSucceed)
+      subexecutorStack = null
+      state
+    } else
+      ChannelState.Effect(
+        closeEffect.foldCauseM(
+          cause => finishWithExit(Exit.halt(subexecDone.fold(identity, _ => Cause.empty) ++ cause)),
+          _ => finishWithExit(subexecDone)
+        )
+      )
+
+  private def drainFromKAndSubexecutor(
+    exec: ErasedExecutor[Env],
+    rest: SubexecutorStack.Inner[Env]
+  ): ChannelState[Env, Any] = {
+    def handleSubexecFailure(cause: Cause[Any]): ChannelState[Env, Any] = {
+      val closeEffect = ChannelExecutor
+        .maybeCloseBoth(
+          exec.close(Exit.halt(cause)),
+          rest.exec.close(Exit.halt(cause))
+        )
+
+      finishSubexecutorWithCloseEffect(
+        Exit.halt(cause),
+        if (closeEffect ne null) closeEffect.flatMap(ZIO.done(_)) else null
+      )
+    }
+
+    exec.run() match {
+      case ChannelState.Emit =>
+        emitted = exec.getEmit
+        ChannelState.Emit
+
+      case ChannelState.Effect(zio) =>
+        ChannelState.Effect(
+          zio.catchAllCause(cause => handleSubexecFailure(cause).effect)
+        )
+
+      case ChannelState.Done =>
+        exec.getDone match {
+          case Exit.Failure(cause) => handleSubexecFailure(cause)
+          case e @ Exit.Success(doneValue) =>
+            val closeEffect = exec.close(e)
+            val modifiedRest =
+              rest.copy(lastDone =
+                if (rest.lastDone != null) rest.combineSubK(rest.lastDone, doneValue)
+                else doneValue
+              )
+
+            if (closeEffect eq null) {
+              replaceSubexecutor(modifiedRest)
+              null
+            } else
+              ChannelState.Effect(
+                closeEffect.foldCauseM(
+                  cause => {
+                    val restClose = rest.exec.close(Exit.halt(cause))
+
+                    if (restClose eq null) finishWithExit(Exit.halt(cause))
+                    else
+                      restClose.foldCauseM(
+                        restCause => finishWithExit(Exit.halt(cause ++ restCause)),
+                        _ => finishWithExit(Exit.halt(cause))
+                      )
+                  },
+                  _ => UIO(replaceSubexecutor(nextSubExec = modifiedRest))
+                )
+              )
+        }
+    }
+  }
+
+  private final def drainInnerSubexecutor(inner: SubexecutorStack.Inner[Env]): ChannelState[Env, Any] =
+    inner.exec.run() match {
+      case ChannelState.Emit =>
+        val fromK: ErasedExecutor[Env] = new ChannelExecutor(() => inner.subK(inner.exec.getEmit), providedEnv)
+        fromK.input = input
+
+        subexecutorStack = SubexecutorStack.FromKAnd[Env](fromK, inner)
+        null
+
+      case ChannelState.Done =>
+        inner.exec.getDone match {
+          case e @ Exit.Failure(_) =>
+            finishSubexecutorWithCloseEffect(
+              e,
+              inner.exec.close(e)
+            )
+
+          case Exit.Success(innerDoneValue) =>
+            val doneValue =
+              Exit.succeed(inner.combineSubKAndInner(inner.lastDone, innerDoneValue))
+
+            finishSubexecutorWithCloseEffect(
+              doneValue,
+              inner.exec.close(doneValue)
+            )
+
+        }
+
+      case ChannelState.Effect(zio) =>
+        ChannelState.Effect(
+          zio.catchAllCause(cause =>
+            finishSubexecutorWithCloseEffect(
+              Exit.halt(cause),
+              inner.exec.close(Exit.halt(cause))
+            ).effect
+          )
+        )
+    }
+}
+
+object ChannelExecutor {
+  type Channel[R]            = ZChannel[R, Any, Any, Any, Any, Any, Any]
+  type ErasedExecutor[Env]   = ChannelExecutor[Env, Any, Any, Any, Any, Any, Any]
+  type ErasedContinuation[R] = ZChannel.Fold.Continuation[R, Any, Any, Any, Any, Any, Any, Any, Any]
+  type Finalizer[R]          = Exit[Any, Any] => URIO[R, Any]
+
+  sealed trait ChannelState[-R, +E] { self =>
+    def effect: ZIO[R, E, Any] =
+      self match {
+        case ChannelState.Effect(zio) => zio
+        case _                        => UIO.unit
+      }
+  }
+
+  object ChannelState {
+    def unroll[R, E](
+      runStep: () => ChannelState[R, E]
+    ): ZIO[R, E, Either[ChannelState.Emit.type, ChannelState.Done.type]] =
+      runStep() match {
+        case Done        => UIO.succeed(Right(Done))
+        case Emit        => UIO.succeed(Left(Emit))
+        case Effect(zio) => zio *> unroll(runStep)
+      }
+
+    case object Emit                                   extends ChannelState[Any, Nothing]
+    case object Done                                   extends ChannelState[Any, Nothing]
+    final case class Effect[R, E](zio: ZIO[R, E, Any]) extends ChannelState[R, E]
+  }
+
+  def maybeCloseBoth[Env](l: ZIO[Env, Nothing, Any], r: ZIO[Env, Nothing, Any]): URIO[Env, Exit[Nothing, Any]] =
+    if ((l eq null) && (r eq null)) null
+    else if ((l ne null) && (r ne null)) l.run.zipWith(r.run)(_ *> _)
+    else if (l ne null) l.run
+    else r.run
+
+  sealed abstract class SubexecutorStack[-R]
+  object SubexecutorStack {
+    case class FromKAnd[R](fromK: ErasedExecutor[R], rest: Inner[R]) extends SubexecutorStack[R]
+    final case class Inner[R](
+      exec: ErasedExecutor[R],
+      subK: Any => Channel[R],
+      lastDone: Any,
+      combineSubK: (Any, Any) => Any,
+      combineSubKAndInner: (Any, Any) => Any
+    ) extends SubexecutorStack[R] { self =>
+      def close(ex: Exit[Any, Any]): URIO[R, Exit[Any, Any]] = {
+        val fin = exec.close(ex)
+
+        if (fin ne null) fin.run
+        else null
+      }
+    }
+  }
+
+  private def erase[R](conduit: ZChannel[R, _, _, _, _, _, _]): Channel[R] =
+    conduit.asInstanceOf[Channel[R]]
+}
+
+/**
+ * Consumer-side view of [[SingleProducerAsyncInput]] for variance purposes.
+ */
+private[zio] trait AsyncInputConsumer[+Err, +Elem, +Done] {
+  def takeWith[A](
+    onError: Cause[Err] => A,
+    onElement: Elem => A,
+    onDone: Done => A
+  ): UIO[A]
+}
+
+/**
+ * Producer-side view of [[SingleProducerAsyncInput]] for variance purposes.
+ */
+private[zio] trait AsyncInputProducer[-Err, -Elem, -Done] {
+  def emit(el: Elem): UIO[Any]
+  def done(a: Done): UIO[Any]
+  def error(cause: Cause[Err]): UIO[Any]
+}
+
+/**
+ * An MVar-like abstraction for sending data to channels asynchronously. Designed
+ * for one producer and multiple consumers.
+ *
+ * Features the following semantics:
+ * - Buffer of size 1
+ * - When emitting, the producer waits for a consumer to pick up the value
+ *   to prevent "reading ahead" too much.
+ * - Once an emitted element is read by a consumer, it is cleared from the buffer, so that
+ *   at most one consumer sees every emitted element.
+ * - When sending a done or error signal, the producer does not wait for a consumer
+ *   to pick up the signal. The signal stays in the buffer after being read by a consumer,
+ *   so it can be propagated to multiple consumers.
+ * - Trying to publish another emit/error/done after an error/done have already been published
+ *   results in an interruption.
+ */
+private[zio] class SingleProducerAsyncInput[Err, Elem, Done](
+  ref: Ref[SingleProducerAsyncInput.State[Err, Elem, Done]]
+) extends AsyncInputConsumer[Err, Elem, Done]
+    with AsyncInputProducer[Err, Elem, Done] {
+  import SingleProducerAsyncInput.State
+
+  def emit(el: Elem): UIO[Any] =
+    Promise.make[Nothing, Unit].flatMap { p =>
+      ref.modify {
+        case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> emit(el), s)
+        case s @ State.Error(_)                => (ZIO.interrupt, s)
+        case s @ State.Done(_)                 => (ZIO.interrupt, s)
+        case State.Empty(notifyConsumer) =>
+          (notifyConsumer.succeed(()) *> p.await, State.Emit(el, p))
+      }.flatten
+    }
+
+  def done(a: Done): UIO[Any] =
+    ref.modify {
+      case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> done(a), s)
+      case s @ State.Error(_)                => (ZIO.interrupt, s)
+      case s @ State.Done(_)                 => (ZIO.interrupt, s)
+      case State.Empty(notifyConsumer) =>
+        (notifyConsumer.succeed(()), State.Done(a))
+    }.flatten
+
+  def error(cause: Cause[Err]): UIO[Any] =
+    ref.modify {
+      case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> error(cause), s)
+      case s @ State.Error(_)                => (ZIO.interrupt, s)
+      case s @ State.Done(_)                 => (ZIO.interrupt, s)
+      case State.Empty(notifyConsumer) =>
+        (notifyConsumer.succeed(()), SingleProducerAsyncInput.State.Error(cause))
+    }.flatten
+
+  def takeWith[A](
+    onError: Cause[Err] => A,
+    onElement: Elem => A,
+    onDone: Done => A
+  ): UIO[A] =
+    Promise.make[Nothing, Unit].flatMap { p =>
+      ref.modify {
+        case State.Emit(a, notifyProducer) =>
+          (notifyProducer.succeed(()).as(onElement(a)), State.Empty(p))
+        case s @ State.Error(a) => (UIO.succeed(onError(a)), s)
+        case s @ State.Done(a)  => (UIO.succeed(onDone(a)), s)
+        case s @ State.Empty(notifyConsumer) =>
+          (notifyConsumer.await *> takeWith(onError, onElement, onDone), s)
+      }.flatten
+    }
+
+  def take[A]: UIO[Exit[Either[Err, Done], Elem]] =
+    takeWith(c => Exit.halt(c.map(Left(_))), Exit.succeed(_), d => Exit.fail(Right(d)))
+
+  def close: UIO[Any] =
+    ZIO.fiberId.flatMap(id => error(Cause.interrupt(id)))
+}
+
+private[zio] object SingleProducerAsyncInput {
+  def make[Err, Elem, Done]: UIO[SingleProducerAsyncInput[Err, Elem, Done]] =
+    Promise
+      .make[Nothing, Unit]
+      .flatMap(p => Ref.make[State[Err, Elem, Done]](State.Empty(p)))
+      .map(new SingleProducerAsyncInput(_))
+
+  sealed trait State[+Err, +Elem, +Done]
+  object State {
+    case class Empty(notifyConsumer: Promise[Nothing, Unit])                extends State[Nothing, Nothing, Nothing]
+    case class Emit[+Elem](a: Elem, notifyProducer: Promise[Nothing, Unit]) extends State[Nothing, Elem, Nothing]
+    case class Error[+Err](a: Cause[Err])                                   extends State[Err, Nothing, Nothing]
+    case class Done[+A](a: A)                                               extends State[Nothing, Nothing, A]
+  }
+}

--- a/streams/shared/src/main/scala/zio/stream/experimental/internal/Utils.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/internal/Utils.scala
@@ -1,0 +1,11 @@
+package zio.stream.experimental.internal
+
+import zio.Chunk
+
+object Utils {
+  def zipChunks[A, B, C](cl: Chunk[A], cr: Chunk[B], f: (A, B) => C): (Chunk[C], Either[Chunk[A], Chunk[B]]) =
+    if (cl.size > cr.size)
+      (cl.take(cr.size).zipWith(cr)(f), Left(cl.drop(cr.size)))
+    else
+      (cl.zipWith(cr.take(cl.size))(f), Right(cr.drop(cl.size)))
+}


### PR DESCRIPTION
An initial implementation of channels that will go into `zio.stream.experimental` in the 2.x series until it is complete. I'll open a ticket with follow-up work soon.