### PR TITLE
Implement scheduleWith

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2348,25 +2348,25 @@ object ZStreamSpec extends ZIOBaseSpec {
         //         } yield assert(streamResult)(equalTo(chunkResult))
         //       })
         //     ),
-        //     suite("schedule")(
-        //       testM("scheduleWith")(
-        //         assertM(
-        //           ZStream("A", "B", "C", "A", "B", "C")
-        //             .scheduleWith(Schedule.recurs(2) *> Schedule.fromFunction((_) => "Done"))(
-        //               _.toLowerCase,
-        //               identity
-        //             )
-        //             .runCollect
-        //         )(equalTo(Chunk("a", "b", "c", "Done", "a", "b", "c", "Done")))
-        //       ),
-        //       testM("scheduleEither")(
-        //         assertM(
-        //           ZStream("A", "B", "C")
-        //             .scheduleEither(Schedule.recurs(2) *> Schedule.fromFunction((_) => "!"))
-        //             .runCollect
-        //         )(equalTo(Chunk(Right("A"), Right("B"), Right("C"), Left("!"))))
-        //       )
-        //     ),
+             suite("schedule")(
+               testM("scheduleWith")(
+                 assertM(
+                   ZStream("A", "B", "C", "A", "B", "C")
+                     .scheduleWith(Schedule.recurs(2) *> Schedule.fromFunction((_) => "Done"))(
+                       _.toLowerCase,
+                       identity
+                     )
+                     .runCollect
+                 )(equalTo(Chunk("a", "b", "c", "Done", "a", "b", "c", "Done")))
+               ),
+               testM("scheduleEither")(
+                 assertM(
+                   ZStream("A", "B", "C")
+                     .scheduleEither(Schedule.recurs(2) *> Schedule.fromFunction((_) => "!"))
+                     .runCollect
+                 )(equalTo(Chunk(Right("A"), Right("B"), Right("C"), Left("!"))))
+               )
+             ),
         //     suite("repeatElements")(
         //       testM("repeatElementsWith")(
         //         assertM(


### PR DESCRIPTION
Part of #4886 

I'm not actually sure about this implementation, but it _seems_ to be functionally similar to the previous implementation (which used a buffered pull).