### PR TITLE
Optimize unfold* combinators

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -3708,6 +3708,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               .runCollect
           )(equalTo(Chunk.fromIterable(0 to 9)))
         },
+        testM("unfoldChunkM") {
+          assertM(
+            ZStream
+              .unfoldChunkM(0) { i =>
+                if (i < 10) IO.succeed(Some((Chunk(i, i + 1), i + 2)))
+                else IO.succeed(None)
+              }
+              .runCollect
+          )(equalTo(Chunk.fromIterable(0 to 9)))
+        },
         testM("unfoldM") {
           assertM(
             ZStream

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -3025,9 +3025,7 @@ object ZStream {
    * Creates a stream by effectfully peeling off the "layers" of a value of type `S`
    */
   def unfoldM[R, E, A, S](s: S)(f: S => ZIO[R, E, Option[(A, S)]]): ZStream[R, E, A] =
-    unfoldChunkM(s)(f(_).map(_.map { case (a, s) =>
-      Chunk.single(a) -> s
-    }))
+    unfoldChunkM(s)(f(_).map(_.map { case (a, s) => Chunk.single(a) -> s }))
 
   /**
    * Creates a stream by peeling off the "layers" of a value of type `S`.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -3019,7 +3019,7 @@ object ZStream {
    * Creates a stream by peeling off the "layers" of a value of type `S`
    */
   def unfold[S, A](s: S)(f: S => Option[(A, S)]): ZStream[Any, Nothing, A] =
-    unfoldM(s)(s => ZIO.succeedNow(f(s)))
+    unfoldChunk(s)(f(_).map { case (a, s) => Chunk.single(a) -> s })
 
   /**
    * Creates a stream by effectfully peeling off the "layers" of a value of type `S`


### PR DESCRIPTION
Part of #4886 

### Summary

- Implemented `unfold` without going through `unfoldM`.
- Implemented `unfoldChunk` without going through `unfoldChunkM`.