### PR TITLE
Optimize paginate* combinators

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -2869,7 +2869,10 @@ object ZStream {
    * hence the name.
    */
   def paginate[R, E, A, S](s: S)(f: S => (A, Option[S])): ZStream[Any, Nothing, A] =
-    paginateM(s)(s => ZIO.succeedNow(f(s)))
+    paginateChunk(s) { s =>
+      val page = f(s)
+      Chunk.single(page._1) -> page._2
+    }
 
   /**
    * Like [[unfoldM]], but allows the emission of values to end one step further than

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -2902,9 +2902,9 @@ object ZStream {
   def paginateChunkM[R, E, A, S](s: S)(f: S => ZIO[R, E, (Chunk[A], Option[S])]): ZStream[R, E, A] = {
     def loop(s: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
       ZChannel.unwrap {
-        f(s).map { case (as, s) =>
-          ZChannel.write(as) *>
-            s.fold[ZChannel[R, Any, Any, Any, E, Chunk[A], Any]](ZChannel.end(()))(loop)
+        f(s).map {
+          case (as, Some(s)) => ZChannel.write(as) *> loop(s)
+          case (as, None)    => ZChannel.write(as) *> ZChannel.end(())
         }
       }
 


### PR DESCRIPTION
Part of #4886 

### Summary

- Implemented `paginate` without going through `paginateM`.
- Implemented `paginateChunk` without going through `paginateChunkM`.
