### PR TITLE
Reimplement SubscriptionRef in Terms of ZHub

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZRefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZRefMSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+import com.github.ghik.silencer.silent
 import zio.test.Assertion._
 import zio.test._
 
@@ -478,7 +479,7 @@ object ZRefMSpec extends ZIOBaseSpec {
     suite("combinators")(
       testM("dequeueRef") {
         for {
-          data        <- RefM.dequeueRef(0)
+          data        <- RefM.dequeueRef(0): @silent("deprecated")
           (ref, queue) = data
           _           <- ZIO.collectAllPar(ZIO.replicate(100)(ref.update(n => ZIO.succeed(n + 1))))
           value       <- ZIO.collectAll(ZIO.replicate(100)(queue.take))

--- a/core/shared/src/main/scala/zio/RefM.scala
+++ b/core/shared/src/main/scala/zio/RefM.scala
@@ -5,6 +5,7 @@ object RefM {
   /**
    * @see [[zio.ZRefM.dequeueRef]]
    */
+  @deprecated("use SubscriptionRef", "2.0.0")
   def dequeueRef[A](a: A): UIO[(RefM[A], Dequeue[A])] =
     ZRefM.dequeueRef(a)
 

--- a/core/shared/src/main/scala/zio/ZRefM.scala
+++ b/core/shared/src/main/scala/zio/ZRefM.scala
@@ -487,6 +487,7 @@ object ZRefM {
    * Creates a new `RefM` and a `Dequeue` that will emit every change to the
    * `RefM`.
    */
+  @deprecated("use SubscriptionRef", "2.0.0")
   def dequeueRef[A](a: A): UIO[(RefM[A], Dequeue[A])] =
     for {
       ref   <- make(a)

--- a/streams-tests/shared/src/test/scala/zio/stream/SubscriptionRefSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/SubscriptionRefSpec.scala
@@ -1,0 +1,44 @@
+package zio.stream
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object SubscriptionRefSpec extends DefaultRunnableSpec {
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("SubscriptionRefSpec")(
+      testM("multiple subscribers can receive changes") {
+        for {
+          subscriptionRef <- SubscriptionRef.make(0)
+          promise1        <- Promise.make[Nothing, Unit]
+          promise2        <- Promise.make[Nothing, Unit]
+          subscriber1     <- subscriptionRef.changes.tap(_ => promise1.succeed(())).take(3).runCollect.fork
+          _               <- promise1.await
+          _               <- subscriptionRef.ref.update(n => ZIO.succeed(n + 1))
+          subscriber2     <- subscriptionRef.changes.tap(_ => promise2.succeed(())).take(2).runCollect.fork
+          _               <- promise2.await
+          _               <- subscriptionRef.ref.update(n => ZIO.succeed(n + 1))
+          values1         <- subscriber1.join
+          values2         <- subscriber2.join
+        } yield assert(values1)(equalTo(Chunk(0, 1, 2))) &&
+          assert(values2)(equalTo(Chunk(1, 2)))
+      },
+      testM("subscriptions are interruptible") {
+        for {
+          subscriptionRef <- SubscriptionRef.make(0)
+          promise1        <- Promise.make[Nothing, Unit]
+          promise2        <- Promise.make[Nothing, Unit]
+          subscriber1     <- subscriptionRef.changes.tap(_ => promise1.succeed(())).take(5).runCollect.fork
+          _               <- promise1.await
+          _               <- subscriptionRef.ref.update(n => ZIO.succeed(n + 1))
+          subscriber2     <- subscriptionRef.changes.tap(_ => promise2.succeed(())).take(2).runCollect.fork
+          _               <- promise2.await
+          _               <- subscriptionRef.ref.update(n => ZIO.succeed(n + 1))
+          values1         <- subscriber1.interrupt
+          values2         <- subscriber2.join
+        } yield assert(values1)(isInterrupted) &&
+          assert(values2)(equalTo(Chunk(1, 2)))
+      }
+    )
+}

--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -16,11 +16,12 @@
 
 package zio.stream
 
-import zio.{RefM, UIO}
+import zio._
 
 /**
- * A `SubscriptionRef[A]` contains a `RefM[A]` and a `Stream` that will emit
- * every change to the `RefM`.
+ * A `SubscriptionRef[A]` contains a `RefM` with a value of type `A` and a
+ * `ZStream` that can be subscribed to in order to receive the current value as
+ * well as all changes to the value.
  */
 final class SubscriptionRef[A] private (val ref: RefM[A], val changes: Stream[Nothing, A])
 
@@ -30,7 +31,17 @@ object SubscriptionRef {
    * Creates a new `SubscriptionRef` with the specified value.
    */
   def make[A](a: A): UIO[SubscriptionRef[A]] =
-    RefM.dequeueRef(a).map { case (ref, queue) =>
-      new SubscriptionRef(ref, ZStream.fromQueue(queue))
-    }
+    for {
+      ref <- RefM.make(a)
+      hub <- Hub.unbounded[A]
+      changes = ZStream.unwrapManaged {
+                  ZManaged {
+                    ref.modify { a =>
+                      ZIO.succeedNow(a).zipWith(hub.subscribe.zio) { case (a, (finalizer, queue)) =>
+                        (finalizer, ZStream(a) ++ ZStream.fromQueue(queue))
+                      } <*> ZIO.succeedNow(a)
+                    }.uninterruptible
+                  }
+                }
+    } yield new SubscriptionRef(ref.tapInput(hub.publish), changes)
 }


### PR DESCRIPTION
One issue with the current implementation of `SubscriptionRef` is that since it is backed by a `Queue`, if more than one subscriber is observing changes to the `Ref` each subscriber will miss changes, since each time a value is taken from the queue by one subscriber it is no longer available to other subscribers. We can address this by backing `SubscriptionRef` with a `Hub` . This way each subscriber can receive the current value of the `Ref` and all changes after they have subscribed. 

This allows `SubscriptionRef ` to function much like a `Var` in functional reactive programming frameworks, where the `SubscriptionRef` represents some state that can be changes and multiple processes can subscribe to take actions in response to any changes in that state.