### PR TITLE
Fix array reference in foldWhileM

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -467,7 +467,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
 
     def loop(s: S, iterator: Iterator[Array[A]], array: Array[A], i: Int, length: Int): ZIO[R, E, S] =
       if (i < length) {
-        if (pred(s)) f(s, self(i)).flatMap(loop(_, iterator, array, i + 1, length))
+        if (pred(s)) f(s, array(i)).flatMap(loop(_, iterator, array, i + 1, length))
         else IO.succeedNow(s)
       } else if (iterator.hasNext) {
         val array  = iterator.next()


### PR DESCRIPTION
As per discord discussion `foldWhileM` in `Chunk` should reference `array` and not `self`