### PR TITLE
Implement debounce

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2692,12 +2692,12 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .tap(_ => c.proceed)
 
               assertM(for {
-                fiber <- stream.runCollect.fork
-                _ <- c.offer.fork
-                _ <- (clock.sleep(500.millis) *> c.offer).fork
-                _ <- (clock.sleep(2.seconds) *> c.offer).fork
-                _ <- (clock.sleep(2500.millis) *> c.offer).fork
-                _ <- TestClock.adjust(3500.millis)
+                fiber  <- stream.runCollect.fork
+                _      <- c.offer.fork
+                _      <- (clock.sleep(500.millis) *> c.offer).fork
+                _      <- (clock.sleep(2.seconds) *> c.offer).fork
+                _      <- (clock.sleep(2500.millis) *> c.offer).fork
+                _      <- TestClock.adjust(3500.millis)
                 result <- fiber.join
               } yield result)(equalTo(Chunk(Chunk(3, 4), Chunk(6, 7))))
             }
@@ -2711,9 +2711,9 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .tap(_ => c.proceed)
 
               assertM(for {
-                fiber <- stream.runCollect.fork
-                _ <- c.offer *> c.offer *> c.offer
-                _ <- TestClock.adjust(1.second)
+                fiber  <- stream.runCollect.fork
+                _      <- c.offer *> c.offer *> c.offer
+                _      <- TestClock.adjust(1.second)
                 result <- fiber.join
               } yield result)(equalTo(Chunk(Chunk(5, 6))))
             }
@@ -2727,17 +2727,17 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .tap(_ => c.proceed)
 
               assertM(for {
-                fiber <- stream.runCollect.fork
-                _ <- ZIO.collectAllPar_(List(c.offer, c.offer, c.offer))
-                _ <- TestClock.adjust(1.second)
+                fiber  <- stream.runCollect.fork
+                _      <- ZIO.collectAllPar_(List(c.offer, c.offer, c.offer))
+                _      <- TestClock.adjust(1.second)
                 result <- fiber.join
               } yield result)(hasSize(equalTo(1)))
             }
           },
           testM("should handle empty chunks properly") {
             for {
-              fiber <- ZStream(1, 2, 3).fixed(500.millis).debounce(1.second).runCollect.fork
-              _ <- TestClock.adjust(3.seconds)
+              fiber  <- ZStream(1, 2, 3).fixed(500.millis).debounce(1.second).runCollect.fork
+              _      <- TestClock.adjust(3.seconds)
               result <- fiber.join
             } yield assert(result)(equalTo(Chunk(3)))
           },
@@ -2751,8 +2751,8 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           testM("should pick last element from every chunk") {
             assertM(for {
-              fiber <- ZStream(1, 2, 3).debounce(1.second).runCollect.fork
-              _ <- TestClock.adjust(1.second)
+              fiber  <- ZStream(1, 2, 3).debounce(1.second).runCollect.fork
+              _      <- TestClock.adjust(1.second)
               result <- fiber.join
             } yield result)(equalTo(Chunk(3)))
           },
@@ -2760,17 +2760,17 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertWithChunkCoordination(List(Chunk(1), Chunk(2), Chunk(3))) { c =>
               for {
                 fib <- ZStream
-                  .fromQueue(c.queue)
-                  .tap(_ => c.proceed)
-                  .flatMap(ex => ZStream.fromEffectOption(ZIO.done(ex)))
-                  .flattenChunks
-                  .debounce(200.millis)
-                  .interruptWhen(ZIO.never)
-                  .take(1)
-                  .runCollect
-                  .fork
-                _ <- (c.offer *> TestClock.adjust(100.millis) *> c.awaitNext).repeatN(3)
-                _ <- TestClock.adjust(100.millis)
+                         .fromQueue(c.queue)
+                         .tap(_ => c.proceed)
+                         .flatMap(ex => ZStream.fromEffectOption(ZIO.done(ex)))
+                         .flattenChunks
+                         .debounce(200.millis)
+                         .interruptWhen(ZIO.never)
+                         .take(1)
+                         .runCollect
+                         .fork
+                _       <- (c.offer *> TestClock.adjust(100.millis) *> c.awaitNext).repeatN(3)
+                _       <- TestClock.adjust(100.millis)
                 results <- fib.join
               } yield assert(results)(equalTo(Chunk(3)))
             }
@@ -2779,11 +2779,11 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               ref <- Ref.make(false)
               fiber <- (ZStream.fromEffect(ZIO.unit) ++ ZStream.fromEffect(ZIO.never.onInterrupt(ref.set(true))))
-                .debounce(800.millis)
-                .runDrain
-                .fork
-              _ <- TestClock.adjust(1.minute)
-              _ <- fiber.interrupt
+                         .debounce(800.millis)
+                         .runDrain
+                         .fork
+              _     <- TestClock.adjust(1.minute)
+              _     <- fiber.interrupt
               value <- ref.get
             } yield assert(value)(equalTo(true))
           }


### PR DESCRIPTION
Relates to #4886 

Borrowed some ideas from `aggregateAsyncWithinEither` to create a `producer` and `consumer` channel in order to be able to race between the read and a running fiber. State machine from the previous implementation stayed pretty much intact because I couldn't think of a better way to represent the control flow.