### PR TITLE
Implement serviceWith

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3060,6 +3060,12 @@ object ZIOSpec extends ZIOBaseSpec {
         io.lock(executor)
       } @@ jvm(nonFlaky(100))
     ),
+    suite("serviceWith")(
+      testM("effectfully accesses a service in the environment") {
+        val zio = ZIO.serviceWith[Int](int => UIO(int + 3))
+        assertM(zio.provideLayer(ZLayer.succeed(0)))(equalTo(3))
+      }
+    ),
     suite("schedule")(
       testM("runs effect for each recurrence of the schedule") {
         for {

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -901,6 +901,12 @@ object RIO {
     ZIO.services[A, B, C, D]
 
   /**
+   * @see See [[zio.ZIO.serviceWith]]
+   */
+  def serviceWith[Service]: ZIO.ServiceWithPartiallyApplied[Service] =
+    ZIO.serviceWith[Service]
+
+  /**
    * @see See [[zio.ZIO.sleep]]
    */
   def sleep(duration: => Duration): RIO[Clock, Unit] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -805,6 +805,12 @@ object URIO {
     ZIO.services[A, B, C, D]
 
   /**
+   * @see See [[zio.ZIO.serviceWith]]
+   */
+  def serviceWith[Service]: ZIO.ServiceWithPartiallyApplied[Service] =
+    new ZIO.ServiceWithPartiallyApplied[Service]
+
+  /**
    * @see [[zio.ZIO.sleep]]
    */
   def sleep(duration: => Duration): URIO[Clock, Unit] = ZIO.sleep(duration)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3868,7 +3868,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Effectfully accesses the specified service in the environment of the effect.
    *
-   * Especially, useful for creating "accessor" methods on Services' companion objects.
+   * Especially useful for creating "accessor" methods on Services' companion objects.
    *
    * {{{
    * def foo(int: Int) = ZIO.serviceWith[Foo](_.foo(int))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3866,6 +3866,18 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
+   * Effectfully accesses the specified service in the environment of the effect.
+   *
+   * Especially, useful for creating "accessor" methods on Services' companion objects.
+   *
+   * {{{
+   * def foo(int: Int) = ZIO.serviceWith[Foo](_.foo(int))
+   * }}}
+   */
+  def serviceWith[Service]: ServiceWithPartiallyApplied[Service] =
+    new ServiceWithPartiallyApplied[Service]
+
+  /**
    * Returns an effect that shifts execution to the specified executor. This
    * is useful to specify a default executor that effects sequenced after this
    * one will be run on if they are not shifted somewhere else. It can also be
@@ -4229,6 +4241,11 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: R => ZIO[R, E, A]): ZIO[R, E, A] =
       new ZIO.Read(f)
+  }
+
+  final class ServiceWithPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: Service => ZIO[Has[Service], E, A])(implicit tag: Tag[Service]): ZIO[Has[Service], E, A] =
+      new ZIO.Read(r => f(r.get))
   }
 
   @inline

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1181,6 +1181,13 @@ object ZManaged extends ZManagedPlatformSpecific {
       ZManaged.environment.flatMap(f)
   }
 
+  final class ServiceWithPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: Service => ZIO[Has[Service], E, A])(implicit
+      tag: Tag[Service]
+    ): ZManaged[Has[Service], E, A] =
+      ZManaged.fromEffect(ZIO.serviceWith[Service](f))
+  }
+
   /**
    * A finalizer used in a [[ReleaseMap]]. The [[Exit]] value passed to
    * it is the result of executing [[ZManaged#use]] or an arbitrary value
@@ -2310,6 +2317,16 @@ object ZManaged extends ZManagedPlatformSpecific {
   def services[A: Tag, B: Tag, C: Tag, D: Tag]
     : ZManaged[Has[A] with Has[B] with Has[C] with Has[D], Nothing, (A, B, C, D)] =
     ZManaged.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
+
+  /**
+   * Effectfully accesses the specified service in the environment of the effect.
+   *
+   * {{{
+   * def foo(int: Int) = ZManaged.serviceWith[Foo](_.foo(int))
+   * }}}
+   */
+  def serviceWith[Service]: ServiceWithPartiallyApplied[Service] =
+    new ServiceWithPartiallyApplied[Service]
 
   /**
    *  Returns an effect with the optional value.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1425,6 +1425,12 @@ object ZSTM {
     ZSTM.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
+   * Effectfully accesses the specified service in the environment of the effect.
+   */
+  def serviceWith[Service]: ServiceWithPartiallyApplied[Service] =
+    new ServiceWithPartiallyApplied[Service]
+
+  /**
    * Returns an effect with the optional value.
    */
   def some[A](a: => A): USTM[Option[A]] =
@@ -1524,6 +1530,11 @@ object ZSTM {
   final class AccessMPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: R => ZSTM[R, E, A]): ZSTM[R, E, A] =
       ZSTM.environment.flatMap(f)
+  }
+
+  final class ServiceWithPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: Service => ZSTM[Has[Service], E, A])(implicit tag: Tag[Service]): ZSTM[Has[Service], E, A] =
+      ZSTM.service[Service].flatMap(f)
   }
 
   final class IfM[R, E](private val b: ZSTM[R, E, Boolean]) {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3989,6 +3989,12 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     ZStream.access(r => (r.get[A], r.get[B], r.get[C], r.get[D]))
 
   /**
+   * Effectfully accesses the specified service in the environment of the effect.
+   */
+  def serviceWith[Service]: ServiceWithPartiallyApplied[Service] =
+    new ServiceWithPartiallyApplied[Service]
+
+  /**
    * Creates a single-valued pure stream
    */
   def succeed[A](a: => A): ZStream[Any, Nothing, A] =
@@ -4134,6 +4140,13 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   final class AccessStreamPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: R => ZStream[R, E, A]): ZStream[R, E, A] =
       ZStream.environment[R].flatMap(f)
+  }
+
+  final class ServiceWithPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[E, A](f: Service => ZIO[Has[Service], E, A])(implicit
+      tag: Tag[Service]
+    ): ZStream[Has[Service], E, A] =
+      ZStream.fromEffect(ZIO.serviceWith(f))
   }
 
   /**


### PR DESCRIPTION
`serviceWith` is merely a terser variant of `accessM`, that takes care of the `_.get` behind the scenes.