### PR TITLE
Simplify Signature of ZStream#broadcastDynamic

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -332,15 +332,14 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   final def broadcastDynamic(
     maximumLag: Int
-  ): ZManaged[R, Nothing, ZManaged[Any, Nothing, ZStream[Any, E, O]]] =
+  ): ZManaged[R, Nothing, ZStream[Any, E, O]] =
     self
       .broadcastedQueuesDynamic(maximumLag)
       .map(
-        _.map(
-          ZStream
-            .fromQueueWithShutdown(_)
-            .flattenTake
-        )
+        ZStream
+          .managed(_)
+          .flatMap(queue => ZStream.fromQueue(queue))
+          .flattenTake
       )
 
   /**


### PR DESCRIPTION
Currently we return a `ZManaged` returning a `ZManaged` returning a `ZStream`. The first `ZManaged` represents the scope of resources used by the original stream whereas the inner represents the scope of a single subscription to the broadcast. But since a stream can be resourceful we don't need the inner `ZManaged` and the returned stream can simply describe the workflow of subscribing to the broadcast, consuming values from it, and unsubscribing when done.