### PR TITLE
Implement SingleThreadedRingBuffer#toChunk

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/SingleThreadedRingBufferSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/SingleThreadedRingBufferSpec.scala
@@ -1,0 +1,21 @@
+package zio.internal
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object SingleThreadedRingBufferSpec extends ZIOBaseSpec {
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("SingleThreadedRingBufferSpec")(
+      testM("use SingleThreadedRingBuffer as a sliding buffer") {
+        check(Gen.chunkOf(Gen.anyInt), Gen.size) { (as, n) =>
+          val queue = SingleThreadedRingBuffer[Int](n)
+          as.foreach(queue.put)
+          val actual   = queue.toChunk
+          val expected = as.takeRight(n)
+          assert(actual)(equalTo(expected))
+        }
+      }
+    )
+}


### PR DESCRIPTION
Implements `toChunk` operator on `SingleThreadedRingBuffer` to support using it as a sliding buffer. To support generic code I removed the constraint that `A` is a subtype of `AnyRef`.