### PR TITLE
Fix Flaky Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSpec.scala
@@ -523,7 +523,7 @@ object ZChannelSpec extends ZIOBaseSpec {
 
               }
             }
-          } @@ TestAspect.nonFlaky,
+          } @@ TestAspect.nonFlaky(50),
           testM("nested concurrent reads") {
             val capacity      = 128
             val f: Int => Int = _ + 1
@@ -545,7 +545,7 @@ object ZChannelSpec extends ZIOBaseSpec {
                 }
               }
             }
-          } @@ TestAspect.nonFlaky
+          } @@ TestAspect.nonFlaky(50)
         ),
         suite("ZChannel#mapError") {
           testM("mapError structure confusion") {


### PR DESCRIPTION
This test appears to be flaky because the number of repetitions is too high and is causing the test to time out. I tested locally and was not able to observe any flakiness in the code being tested. 