### PR TITLE
[Docs] Add Scala 3 + Zio /w VS Code Github Template

### DIFF
--- a/docs/resources/ecosystem/templates.md
+++ b/docs/resources/ecosystem/templates.md
@@ -7,3 +7,4 @@ List of project starters, bootstrap tools or, templates.
 
 - [zio-akka-quickstart.g8](https://github.com/ScalaConsultants/zio-akka-quickstart.g8) — A Giter8 template for a basic Scala application build using ZIO, Akka HTTP and Slick
 - [zio-dotty-quickstart.g8](https://github.com/ScalaConsultants/zio-dotty-quickstart.g8) — A Giter8 template for a basic Dotty application build using ZIO
+- [electronjoe/zio_scala3_vscode_template](https://github.com/electronjoe/zio_scala3_vscode_template) - A Scala 3 + ZIO Github Template that enables ~one-click environment setup via VS Code's Remote-Containers extension


### PR DESCRIPTION
As a complete newcomer to Scala (and ZIO), I wanted to explore ZIO while
learning  on Scala 3.  Getting my environment set up for this was some
work, so I have put together a Github Template that, with VS Code's
Remote-Container extension - will automatically build the developer
environment with no dependencies other than Docker and VS Code.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>