### PR TITLE
feat(zio-test): include duration in JUnit test reports

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -1,7 +1,8 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.UIO
+import zio.duration._
+import zio.test.environment.Live
 import zio.test.sbt.TestingSupport._
 import zio.test.{
   Annotations,
@@ -15,6 +16,7 @@ import zio.test.{
   TestSuccess,
   ZSpec
 }
+import zio.{UIO, ZIO}
 
 import java.util.regex.Pattern
 import scala.collection.mutable.ArrayBuffer
@@ -28,6 +30,7 @@ object ZTestFrameworkSpec {
   def tests: Seq[Try[Unit]] = Seq(
     test("should return correct fingerprints")(testFingerprints()),
     test("should report events")(testReportEvents()),
+    test("should report durations")(testReportDurations()),
     test("should log messages")(testLogMessages()),
     test("should correctly display colorized output for multi-line strings")(testColored()),
     test("should test only selected test")(testTestSelection()),
@@ -55,6 +58,13 @@ object ZTestFrameworkSpec {
 
   private def sbtEvent(fqn: String, label: String, status: Status) =
     ZTestEvent(fqn, new TestSelector(label), status, None, 0, RunnableSpecFingerprint)
+
+  def testReportDurations(): Unit = {
+    val reported = ArrayBuffer[Event]()
+    loadAndExecute(timedSpecFQN, reported.append(_))
+
+    assert(reported.forall(_.duration() > 0), s"reported events should have positive durations: $reported")
+  }
 
   def testLogMessages(): Unit = {
     val loggers = Seq.fill(3)(new MockLogger)
@@ -163,7 +173,7 @@ object ZTestFrameworkSpec {
     loggers: Seq[Logger] = Nil,
     testArgs: Array[String] = Array.empty
   ) = {
-    val taskDef = new TaskDef(fqn, RunnableSpecFingerprint, false, Array())
+    val taskDef = new TaskDef(fqn, RunnableSpecFingerprint, false, Array(new SuiteSelector))
     val task = new ZTestFramework()
       .runner(testArgs, Array(), getClass.getClassLoader)
       .tasks(Array(taskDef))
@@ -192,6 +202,13 @@ object ZTestFrameworkSpec {
         zio.test.assert(1)(Assertion.equalTo(2))
       } @@ TestAspect.ignore
     )
+  }
+
+  lazy val timedSpecFQN = TimedSpec.getClass.getName
+  object TimedSpec extends DefaultRunnableSpec {
+    override def spec: ZSpec[Environment, Failure] = test("timed passing test") {
+      zio.test.assertCompletes
+    } @@ TestAspect.before(Live.live(ZIO.sleep(5.millis))) @@ TestAspect.timed
   }
 
   lazy val multiLineSpecFQN = MultiLineSpec.getClass.getName

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.test.{ExecutedSpec, TestFailure, TestSuccess}
+import zio.test.{ExecutedSpec, TestAnnotation, TestFailure, TestSuccess}
 
 final case class ZTestEvent(
   fullyQualifiedName: String,
@@ -24,8 +24,17 @@ object ZTestEvent {
     executedSpec.fold[Seq[ZTestEvent]] { c =>
       (c: @unchecked) match {
         case ExecutedSpec.SuiteCase(_, results) => results.flatten
-        case ExecutedSpec.TestCase(label, result, _) =>
-          Seq(ZTestEvent(fullyQualifiedName, new TestSelector(label), toStatus(result), None, 0, fingerprint))
+        case ExecutedSpec.TestCase(label, result, annotations) =>
+          Seq(
+            ZTestEvent(
+              fullyQualifiedName,
+              new TestSelector(label),
+              toStatus(result),
+              None,
+              annotations.get(TestAnnotation.timing).toMillis,
+              fingerprint
+            )
+          )
       }
     }
 


### PR DESCRIPTION
Include durations of individual tests in JUnit reports generated by sbt. Addresses https://github.com/zio/zio/issues/4803.

This is still WIP and I'd like to get some feedback before I move forward. Basically, my idea is to:
- Add a `duration` field to `TestSuccess` and `TestFailure`.
- Time an assertion in `ZTest#apply` and pass the duration to `TestSuccess`/`TestFailure`.
- In `ZTestEvent#from`, pass the duration to `ZTestEvent`.

A couple of questions about this approach:
- Is it ok to always time tests, or should we give users the option to disable this?
- Are `TestSuccess` and `TestFailure` the right places to store duration?
- Timing the `assertion` in `ZTest#apply` produces expected results, but maybe there's a better place to do it?