### PR TITLE
Rename Extension Method To Avoid Shadowing

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4118,7 +4118,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     /**
      * Converts this ZIO value to a ZManaged value. See [[ZManaged.fromAutoCloseable]].
      */
-    def toManaged: ZManaged[R, E, A] = ZManaged.fromAutoCloseable(io)
+    def toManagedAuto: ZManaged[R, E, A] =
+      ZManaged.fromAutoCloseable(io)
   }
 
   implicit final class ZioRefineToOrDieOps[R, E <: Throwable, A](private val self: ZIO[R, E, A]) extends AnyVal {


### PR DESCRIPTION
Renames `toManaged` extension method for where the value is a subtype of `AutoClosable` to `toManagedAuto` to avoid shadowing by existing `toManaged` operator.