### PR TITLE
Make ZRef.Atomic Package Private

### DIFF
--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -17,6 +17,7 @@
 package zio
 
 object Ref extends Serializable {
+  private[zio] type Atomic[A] = ZRef.Atomic[A]
 
   /**
    * @see [[zio.ZRef.make]]
@@ -29,4 +30,10 @@ object Ref extends Serializable {
    */
   def makeManaged[A](a: A): UManaged[Ref[A]] =
     ZRef.makeManaged(a)
+
+  /**
+   * @see [[zio.ZRef.unsafeMake]]
+   */
+  private[zio] def unsafeMake[A](a: A): Ref.Atomic[A] =
+    ZRef.unsafeMake(a)
 }

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -195,7 +195,7 @@ object ZRef extends Serializable {
   def make[A](a: A): UIO[Ref[A]] =
     UIO.effectTotal(unsafeMake(a))
 
-  private[zio] def unsafeMake[A](a: A): Ref[A] =
+  private[zio] def unsafeMake[A](a: A): Ref.Atomic[A] =
     Atomic(new AtomicReference(a))
 
   /**
@@ -771,7 +771,7 @@ object ZRef extends Serializable {
     }
   }
 
-  private final case class Atomic[A](value: AtomicReference[A]) extends Ref[A] { self =>
+  private[zio] final case class Atomic[A](value: AtomicReference[A]) extends Ref[A] { self =>
 
     def fold[EC, ED, C, D](
       ea: Nothing => EC,


### PR DESCRIPTION
To support its use in implementing channel operators.