### PR TITLE
Docs: fixing mdoc compilation error + broken links

### DIFF
--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -258,7 +258,7 @@ object logging {
           new Service {
             override def log(line: String): UIO[Unit] =
               for {
-                current <- clock.currentDateTime.orDie
+                current <- clock.currentDateTime
                 _ <- console.putStrLn(current.toString + "--" + line)
               } yield ()
           }
@@ -332,7 +332,7 @@ import zio.clock.Clock
 case class LoggingLive(console: Console.Service, clock: Clock.Service) extends Logging {
   override def log(line: String): UIO[Unit] = 
     for {
-      current <- clock.currentDateTime.orDie
+      current <- clock.currentDateTime
       _       <- console.putStrLn(current.toString + "--" + line)
     } yield ()
 }
@@ -461,7 +461,7 @@ import zio.random._
 val myApp: ZIO[Random with Console with Clock, Nothing, Unit] = for {
   random  <- nextInt 
   _       <- putStrLn(s"A random number: ${random.toString}")
-  current <- currentDateTime.orDie
+  current <- currentDateTime
   _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```
@@ -527,7 +527,7 @@ object LoggingLive {
 
 val myApp: ZIO[Has[Logging] with Console with Clock, Nothing, Unit] = for {
   _       <- Logging.log("Application Started!")
-  current <- currentDateTime.orDie
+  current <- currentDateTime
   _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -73,7 +73,7 @@ val getStrLn: ZIO[Console, IOException, String] =
 - [Timeout](#timeout)
 - [Resource Management](#resource-management)
   * [Finalizing](#finalizing)
-    + [Asynchronous Try / Finally](#asynchronous-try---finally)
+    + [Asynchronous Try / Finally](#asynchronous-try--finally)
     + [Unstoppable Finalizers](#unstoppable-finalizers)
   * [Brackets](#brackets)
 - [Unswallowed Exceptions](#unswallowed-exceptions)

--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -10,9 +10,8 @@ ZIO contains a few data types that can help you solve complex problems in asynch
 3. [Concurrency Primitives](#concurrency-primitives)
 4. [STM](#stm)
 5. [Resource Safety](#resource-safety)
-6. [Runtime](#runtime)
-7. [Streaming](#streaming)
-8. [Miscellaneous](#miscellaneous)
+6. [Streaming](#streaming)
+7. [Miscellaneous](#miscellaneous)
 
 ## Core Data Types
  - **[ZIO](core/zio.md)** — A `ZIO` is a value that models an effectful program, which might fail or succeed.
@@ -55,10 +54,6 @@ ZIO contains a few data types that can help you solve complex problems in asynch
  
  ## Resource Safety
  - **[Managed](resource/managed.md)** — A `Managed` is a value that describes a perishable resource that may be consumed only once inside a given scope.
- 
-## Runtime
- - **[Runtime](runtime.md)**
- - **[Platform](platform.md)**
  
 ## Streaming
 The following datatypes can be found in ZIO streams library:

--- a/docs/usecases/index.md
+++ b/docs/usecases/index.md
@@ -5,13 +5,13 @@ title:  "Summary"
 
 The ZIO library lets you easily solve problems in a variety of areas, including:
 
- - [**Asynchronous Programming**](./usecases_asynchronous) — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
- - [**Concurrent Programming**](./usecases_concurrency) — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
- - [**Parallelism**](./usecases_parallelism) — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
- - [**Queuing**](./usecases_queueing) — Build work processing flows and ration scarce resources with powerful asynchronous queues.
- - [**Retrying**](./usecases_retrying) — Create and test robust retry strategies that make your application resilient to transient failures.
- - [**Scheduling**](./usecases_scheduling) — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
- - [**Streaming**](./usecases_streaming) — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
- - [**Testing**](./usecases_testing) - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
+ - [**Asynchronous Programming**](asynchronous.md) — Write asynchronous code as easily as synchronous code, handling all errors and never leaking resources.
+ - [**Concurrent Programming**](concurrency.md) — Write concurrent code that scales easily, without locks or deadlocks, with maximal laziness and resource safety.
+ - [**Parallelism**](parallelism.md) — Trivially partition work among many parallel fibers to make short work of CPU-intensive processing.
+ - [**Queueing**](queueing.md) — Build work processing flows and ration scarce resources with powerful asynchronous queues.
+ - [**Retrying**](retrying.md) — Create and test robust retry strategies that make your application resilient to transient failures.
+ - [**Scheduling**](scheduling.md) — Schedule repeating work, like report generation or email notifications, using flexible, composable schedules.
+ - [**Streaming**](streaming.md) — Handle huge or infinite amounts of data in constant heap space with efficient, lazy, concurrent streams.
+ - [**Testing**](testing.md) - Easily test effectual programs with powerful combinators, built-in property based testing, and seamless mocking capabilities.
 
 Explore the pages above and learn how the simple, powerful building blocks in ZIO help you solve problems in these critical areas.

--- a/docs/usecases/queueing.md
+++ b/docs/usecases/queueing.md
@@ -1,5 +1,5 @@
 ---
-id: usecases_queuing
+id: usecases_queueing
 title:  "Queueing"
 ---
 


### PR DESCRIPTION
This fixes a compilation error due to `clock.currentDateTime.orDie`, since `currentDateTime` is now `UIO`. This also cherrypicks https://github.com/zio/zio/pull/5043/commits/187c8e5bb119529ec0e62b8f897f2f0cb9e4f313 to fix broken links for series/2.0