### PR TITLE
Implement ZStream.fromHubManaged

### DIFF
--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -341,7 +341,9 @@ object ZStream {
 }
 ```
 
-The managed effect here describes subscribing to receive messages from the hub while the stream describes taking messages from the hub. This can be useful when we need to ensure that a consumer has subscribed before a producer begins publishing values. Here is an example of using it:
+The managed effect here describes subscribing to receive messages from the hub while the stream describes taking messages from the hub. This can be useful when we need to ensure that a consumer has subscribed before a producer begins publishing values.
+
+Here is an example of using it:
 
 ```scala mdoc:reset:invisible
 import zio._

--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -323,9 +323,7 @@ We can create a `ZStream` from a subscription to a hub using the `fromHub` opera
 import zio.stream._
 
 object ZStream {
-  def fromHub[R, E, O](
-    hub: ZHub[Nothing, R, Any, E, Nothing, O]
-  ): ZStream[R, E, O] =
+  def fromHub[R, E, O](hub: ZHub[Nothing, R, Any, E, Nothing, O]): ZStream[R, E, O] =
     ???
 }
 ```


### PR DESCRIPTION
Resolves #5047.

Currently `ZStream.fromHub` returns a stream directly, where the stream handles subscribing to the hub. While this creates a simple type signature, it can make it somewhat awkward in situations where we need to wait for a subscription to be acquired before performing further actions because we can't signal that the subscription has been completed. This PR changes the signature to return a managed effect producing a stream, where the outer managed effect describes subscribing to the hub and the inner stream describes taking elements from the hub.

Example before:

```scala
import zio._
import zio.stream._

object Example extends App {

  def run(args: List[String]): URIO[ZEnv, ExitCode] =
    for {
      promise <- Promise.make[Nothing, Unit]
      hub     <- Hub.bounded[String](2)
      stream = ZStream.managed(hub.subscribe).flatMap { queue =>
                 ZStream.fromEffect(promise.succeed(())) *>
                   ZStream.fromQueue(queue)
               }
      fiber     <- stream.take(2).runCollect.fork
      _         <- promise.await
      _         <- hub.publish("Hello")
      _         <- hub.publish("World")
      collected <- fiber.join
      _         <- ZIO.foreach(collected)(console.putStrLn(_)).orDie
    } yield ExitCode.success
}
```

And after:

```scala
import zio._
import zio.stream._

object Example extends App {

  def run(args: List[String]): URIO[ZEnv, ExitCode] =
    for {
      promise   <- Promise.make[Nothing, Unit]
      hub       <- Hub.bounded[String](2)
      stream     = ZStream.unwrapManaged(ZStream.fromHub(hub).tapM(_ => promise.succeed(())))
      fiber     <- stream.take(2).runCollect.fork
      _         <- promise.await
      _         <- hub.publish("Hello")
      _         <- hub.publish("World")
      collected <- fiber.join
      _         <- ZIO.foreach(collected)(console.putStrLn(_)).orDie
    } yield ExitCode.success
}
```