### PR TITLE
Add constructor for managed queues/hubs

### DIFF
--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -24,9 +24,19 @@ object Queue {
   def bounded[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.bounded(requestedCapacity)
 
   /**
+   * @see See [[zio.ZQueue.boundedManaged]]
+   */
+  def boundedManaged[A](requestedCapacity: Int): UManaged[Queue[A]] = ZQueue.boundedManaged(requestedCapacity)
+
+  /**
    * @see See [[zio.ZQueue.dropping]]
    */
   def dropping[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.dropping(requestedCapacity)
+
+  /**
+   * @see See [[zio.ZQueue.droppingManaged]]
+   */
+  def droppingManaged[A](requestedCapacity: Int): UManaged[Queue[A]] = ZQueue.droppingManaged(requestedCapacity)
 
   /**
    * @see See [[zio.ZQueue.sliding]]
@@ -34,8 +44,18 @@ object Queue {
   def sliding[A](requestedCapacity: Int): UIO[Queue[A]] = ZQueue.sliding(requestedCapacity)
 
   /**
+   * @see See [[zio.ZQueue.slidingManaged]]
+   */
+  def slidingManaged[A](requestedCapacity: Int): UManaged[Queue[A]] = ZQueue.slidingManaged(requestedCapacity)
+
+  /**
    * @see See [[zio.ZQueue.unbounded]]
    */
   def unbounded[A]: UIO[Queue[A]] = ZQueue.unbounded
+
+  /**
+   * @see See [[zio.ZQueue.unboundedManaged]]
+   */
+  def unboundedManaged[A]: UManaged[Queue[A]] = ZQueue.unboundedManaged
 
 }

--- a/core/shared/src/main/scala/zio/ZHub.scala
+++ b/core/shared/src/main/scala/zio/ZHub.scala
@@ -240,6 +240,14 @@ object ZHub {
     ZIO.effectTotal(internal.Hub.bounded[A](requestedCapacity)).flatMap(makeHub(_, Strategy.BackPressure()))
 
   /**
+   * Managed version of [[zio.ZHub.bounded]] that shuts down the queue on release
+   *
+   * @return `UManaged[Hub[A]]
+   */
+  def boundedManaged[A](requestedCapacity: Int): UManaged[Hub[A]] =
+    bounded(requestedCapacity).toManaged(_.shutdown)
+
+  /**
    * Creates a bounded hub with the dropping strategy. The hub will drop new
    * messages if the hub is at capacity.
    *
@@ -247,6 +255,14 @@ object ZHub {
    */
   def dropping[A](requestedCapacity: Int): UIO[Hub[A]] =
     ZIO.effectTotal(internal.Hub.bounded[A](requestedCapacity)).flatMap(makeHub(_, Strategy.Dropping()))
+
+  /**
+   * Managed version of [[zio.ZHub.dropping]] that shuts down the queue on release
+   *
+   * @return `UManaged[Hub[A]]
+   */
+  def droppingManaged[A](requestedCapacity: Int): UManaged[Hub[A]] =
+    dropping(requestedCapacity).toManaged(_.shutdown)
 
   /**
    * Creates a bounded hub with the sliding strategy. The hub will add new
@@ -258,10 +274,26 @@ object ZHub {
     ZIO.effectTotal(internal.Hub.bounded[A](requestedCapacity)).flatMap(makeHub(_, Strategy.Sliding()))
 
   /**
+   * Managed version of [[zio.ZHub.sliding]] that shuts down the queue on release
+   *
+   * @return `UManaged[Hub[A]]
+   */
+  def slidingManaged[A](requestedCapacity: Int): UManaged[Hub[A]] =
+    sliding(requestedCapacity).toManaged(_.shutdown)
+
+  /**
    * Creates an unbounded hub.
    */
   def unbounded[A]: UIO[Hub[A]] =
     ZIO.effectTotal(internal.Hub.unbounded[A]).flatMap(makeHub(_, Strategy.Dropping()))
+
+  /**
+   * Managed version of [[zio.ZHub.unbounded]] that shuts down the queue on release
+   *
+   * @return `UManaged[Hub[A]]
+   */
+  def unboundedManaged[A]: UManaged[Hub[A]] =
+    unbounded.toManaged(_.shutdown)
 
   /**
    * Creates a hub with the specified strategy.

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -716,6 +716,14 @@ object ZQueue {
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, BackPressure()))
 
   /**
+   * Managed version of [[zio.ZQueue.bounded]] that shuts down the queue on release
+   *
+   * @return `UManaged[Queue[A]]
+   */
+  def boundedManaged[A](requestedCapacity: Int): UManaged[Queue[A]] =
+    bounded(requestedCapacity).toManaged(_.shutdown)
+
+  /**
    * Makes a new bounded queue with the dropping strategy.
    * When the capacity of the queue is reached, new elements will be dropped.
    *
@@ -729,6 +737,14 @@ object ZQueue {
    */
   def dropping[A](requestedCapacity: Int): UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, Dropping()))
+
+  /**
+   * Managed version of [[zio.ZQueue.dropping]] that shuts down the queue on release
+   *
+   * @return `UManaged[Queue[A]]
+   */
+  def droppingManaged[A](requestedCapacity: Int): UManaged[Queue[A]] =
+    dropping(requestedCapacity).toManaged(_.shutdown)
 
   /**
    * Makes a new bounded queue with sliding strategy.
@@ -747,6 +763,14 @@ object ZQueue {
     IO.effectTotal(MutableConcurrentQueue.bounded[A](requestedCapacity)).flatMap(createQueue(_, Sliding()))
 
   /**
+   * Managed version of [[zio.ZQueue.sliding]] that shuts down the queue on release
+   *
+   * @return `UManaged[Queue[A]]
+   */
+  def slidingManaged[A](requestedCapacity: Int): UManaged[Queue[A]] =
+    sliding(requestedCapacity).toManaged(_.shutdown)
+
+  /**
    * Makes a new unbounded queue.
    *
    * @tparam A type of the `Queue`
@@ -754,6 +778,14 @@ object ZQueue {
    */
   def unbounded[A]: UIO[Queue[A]] =
     IO.effectTotal(MutableConcurrentQueue.unbounded[A]).flatMap(createQueue(_, Dropping()))
+
+  /**
+   * Managed version of [[zio.ZQueue.unbounded]] that shuts down the queue on release
+   *
+   * @return `UManaged[Queue[A]]
+   */
+  def unboundedManaged[A]: UManaged[Queue[A]] =
+    unbounded[A].toManaged(_.shutdown)
 
   private def createQueue[A](queue: MutableConcurrentQueue[A], strategy: Strategy[A]): UIO[Queue[A]] =
     Promise

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -54,7 +54,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         eitherStream <- ZManaged.effectTotal {
                           register(k =>
@@ -91,7 +91,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     managed {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         _ <- register { k =>
                try {
@@ -123,7 +123,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         maybeStream <- ZManaged.effectTotal {
                          register { k =>

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -130,7 +130,7 @@ trait ZStreamPlatformSpecificConstructors {
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         eitherStream <- ZManaged.effectTotal {
                           register(k =>
@@ -167,7 +167,7 @@ trait ZStreamPlatformSpecificConstructors {
   ): ZStream[R, E, A] =
     managed {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         _ <- register { k =>
                try {
@@ -199,7 +199,7 @@ trait ZStreamPlatformSpecificConstructors {
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         maybeStream <- ZManaged.effectTotal {
                          register { k =>

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -54,7 +54,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         eitherStream <- ZManaged.effectTotal {
                           register(k =>
@@ -91,7 +91,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     managed {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         _ <- register { k =>
                try {
@@ -123,7 +123,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
+        output  <- Queue.boundedManaged[stream.Take[E, A]](outputBuffer)
         runtime <- ZIO.runtime[R].toManaged_
         maybeStream <- ZManaged.effectTotal {
                          register { k =>


### PR DESCRIPTION
Seems to me it is very rare when you don't want a managed queue/hub, plus I started using queues all over the place at work and was looking at `Ref.makeManaged` with envy 😅 