### PR TITLE
Enable snapshot releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ env:
 on:
   pull_request:
   push:
-    branches: ['master']
+    branches:
+      - 'master'
+      - 'series/2.x'
   release:
     types:
       - published


### PR DESCRIPTION
I have created a marker release [2.0.0-RC0]( https://github.com/zio/zio/releases/tag/v2.0.0-RC0) required by [sbt-dynver](https://github.com/dwijnand/sbt-dynver#detail) to work properly.

cc @vigoo 