### PR TITLE
Update Documentation Regarding ZStream#runHead

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2582,8 +2582,8 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     foreach(_ => ZIO.unit)
 
   /**
-   * Runs the stream to completion and yields the first value emitted by it,
-   * discarding the rest of the elements.
+   * Runs the stream to collect the first value emitted by it without running
+   * the rest of the stream.
    */
   def runHead: ZIO[R, E, Option[O]] =
     run(ZSink.head)


### PR DESCRIPTION
It currently says it runs the stream to completion, which I don't think is correct or at least is not very clear. If we do `ZStream.iterate(0)(_ + 1).runHead`, for example, the program terminates, which would not be the case if we tried to evaluate an infinite stream to completion.