### PR TITLE
Added find and findM for ZStream

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -972,6 +972,28 @@ object ZStreamSpec extends ZIOBaseSpec {
             execution <- log.get
           } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
         },
+        suite("find")(
+          testM("fist element matching")(
+            assertM(ZStream(1, 2, 3, 4).find(_ > 0))(equalTo(Some(1)))
+          ),
+          testM("empty stream")(
+            assertM(ZStream[Int]().find(_ > 0))(equalTo(None))
+          ),
+          testM("Matching element is not the first") {
+            assertM(ZStream(1, 2, 3, 4).find(_ > 1))(equalTo(Some(2)))
+          }
+        ),
+        suite("findM")(
+          testM("fist element matching")(
+            assertM(ZStream(1, 2, 3, 4).findM(i => ZIO.succeed(i > 0)))(equalTo(Some(1)))
+          ),
+          testM("empty stream")(
+            assertM(ZStream[Int]().findM(i => ZIO.succeed(i > 0)))(equalTo(None))
+          ),
+          testM("Matching element is not the first") {
+            assertM(ZStream(1, 2, 3, 4).findM(i => ZIO.succeed(i > 1)))(equalTo(Some(2)))
+          }
+        ),
         testM("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             res1 <- s.filter(p).runCollect

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1126,6 +1126,18 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     ZStream(self.process.ensuringFirst(fin))
 
   /**
+   * Yields the first element matching the provided predicate or `None` if no element satisfies the predicate
+   */
+  final def find(pred: O => Boolean): ZIO[R, E, Option[O]] =
+    self.filter(pred).runHead
+
+  /**
+   * Effecfully yields the first element matching the provided predicate or `None` if no element satisfies the predicate
+   */
+  final def findM[R1 <: R, E1 >: E](pred: O => ZIO[R1, E1, Boolean]): ZIO[R1, E1, Option[O]] =
+    self.filterM(pred).runHead
+
+  /**
    * Executes a pure fold over the stream of values - reduces all elements in the stream to a value of type `S`.
    */
   final def fold[S](s: S)(f: (S, O) => S): ZIO[R, E, S] =


### PR DESCRIPTION
Find is a really useful operation for all kind of collections. Its common in codebases to attempt to get the first element matching a predicate.

This pull request adds two methods. The fist is find returning the first element in a stream matching a predicate and the second findM which does it effectfully.

If I should add something else please tell me!