### PR TITLE
Gzip channel

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/DeflateSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/DeflateSpec.scala
@@ -9,7 +9,7 @@ import java.util.zip.Deflater
 
 object DeflateSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[Environment, Failure] =
-    suite("CompressionSpec")(
+    suite("DeflateSpec")(
       testM("JDK inflates what was deflated")(
         checkM(Gen.listOfBounded(0, `1K`)(Gen.anyByte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case ((input, n), bufferSize) =>

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/GzipSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/GzipSpec.scala
@@ -1,0 +1,61 @@
+package zio.stream.experimental
+
+import zio.stream.compression.TestData._
+import zio.test.Assertion._
+import zio.test._
+
+object GzipSpec extends DefaultRunnableSpec {
+  override def spec: ZSpec[Environment, Failure] =
+    suite("GzipSpec")(
+      testM("JDK gunzips what was gzipped")(
+        checkM(Gen.listOfBounded(0, `1K`)(Gen.anyByte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          case ((input, n), bufferSize) =>
+            assertM(for {
+              gzipped <- (ZStream.fromIterable(input).chunkN(n).channel >>> Gzip.makeGzipper(bufferSize)).runCollect
+                           .map(_._1.flatten)
+              inflated <- jdkGunzip(gzipped)
+            } yield inflated)(equalTo(input))
+        }
+      ),
+      testM("gzip empty bytes, small buffer")(
+        assertM(for {
+          gzipped      <- (ZStream.empty.channel >>> Gzip.makeGzipper(1)).runCollect.map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(isEmpty)
+      ),
+      testM("gzip empty bytes")(
+        assertM(for {
+          gzipped      <- (ZStream.empty.channel >>> Gzip.makeGzipper(`1K`)).runCollect.map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(isEmpty)
+      ),
+      testM("gzips, small chunks, small buffer")(
+        assertM(for {
+          gzipped <-
+            (ZStream.fromIterable(longText).chunkN(1).channel >>> Gzip.makeGzipper(1)).runCollect.map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(equalTo(longText.toList))
+      ),
+      testM("gzips, small chunks, 1k buffer")(
+        assertM(for {
+          gzipped <-
+            (ZStream.fromIterable(longText).chunkN(1).channel >>> Gzip.makeGzipper(`1K`)).runCollect.map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(equalTo(longText.toList))
+      ),
+      testM("chunks bigger than buffer")(
+        assertM(for {
+          gzipped <- (ZStream.fromIterable(longText).chunkN(`1K`).channel >>> Gzip.makeGzipper(64)).runCollect
+                       .map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(equalTo(longText.toList))
+      ),
+      testM("input >= 2^32")(
+        assertM(for {
+          gzipped <- (ZStream.fromIterable(longText).forever.take(65536).channel >>> Gzip.makeGzipper()).runCollect
+                       .map(_._1.flatten)
+          jdkGunzipped <- jdkGunzip(gzipped)
+        } yield jdkGunzipped)(hasSize(equalTo(65536)))
+      )
+    )
+}

--- a/streams/jvm/src/main/scala/zio/stream/experimental/Gzip.scala
+++ b/streams/jvm/src/main/scala/zio/stream/experimental/Gzip.scala
@@ -1,0 +1,39 @@
+package zio.stream.experimental
+
+import zio.stream.compression.{CompressionLevel, CompressionStrategy, FlushMode, Gzipper}
+import zio.{Chunk, ZIO, ZManaged}
+
+object Gzip {
+  def makeGzipper[Err, Done](
+    bufferSize: Int = 64 * 1024,
+    level: CompressionLevel = CompressionLevel.DefaultCompression,
+    strategy: CompressionStrategy = CompressionStrategy.DefaultStrategy,
+    flushMode: FlushMode = FlushMode.NoFlush
+  ): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
+    ZChannel.managed {
+      ZManaged
+        .make(
+          Gzipper.make(bufferSize, level, strategy, flushMode)
+        ) { gzipper =>
+          ZIO.effectTotal(gzipper.close())
+        }
+    } {
+      case gzipper => {
+
+        def loop(): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
+          ZChannel.readWithCause(
+            chunk =>
+              ZChannel.fromEffect {
+                gzipper.onChunk(chunk)
+              }.flatMap(chunk => ZChannel.write(chunk) *> loop()),
+            ZChannel.halt(_),
+            done =>
+              ZChannel.fromEffect {
+                gzipper.onNone
+              }.flatMap(chunk => ZChannel.write(chunk).as(done))
+          )
+
+        loop()
+      }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/zio/zio/issues/4886

I haven't ported this test https://github.com/zio/zio/blob/master/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala#L266

I'm not sure what would reusable mean in terms of a channel. 

I'm using Gzipper implementation from non experimental compression package https://github.com/zio/zio/blob/master/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala

Should I move that implementation in experimental package?

