### PR TITLE
ZIO Test: IntelliJ test reporter

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -59,6 +59,6 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
             a && exists(matchesRegex(expectedLine.stripLineEnd))
           }
         )
-      } @@ ignore
+      }
     ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -1,0 +1,277 @@
+package zio.test
+
+import zio.clock.Clock
+import zio.test.Assertion._
+import zio.test.ReportingTestUtils._
+import zio.test.TestAspect.silent
+import zio.test.environment.{TestClock, TestConsole, TestEnvironment, testEnvironment}
+import zio.test.render.IntelliJRenderer
+import zio.{Layer, ZIO}
+
+object IntellijRendererSpec extends ZIOBaseSpec {
+  import IntelliJRenderUtils._
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("IntelliJ Renderer")(
+      testM("correctly reports a successful test") {
+        assertM(runLog(test1))(equalTo(test1Expected.mkString))
+      },
+      testM("correctly reports a failed test") {
+        assertM(runLog(test3))(equalTo(test3Expected.mkString))
+      },
+      testM("correctly reports an error in a test") {
+        assertM(runLog(test4))(equalTo(test4Expected.mkString))
+      },
+      testM("correctly reports successful test suite") {
+        assertM(runLog(suite1))(equalTo(suite1Expected.mkString))
+      },
+      testM("correctly reports failed test suite") {
+        assertM(runLog(suite2))(equalTo(suite2Expected.mkString))
+      },
+      testM("correctly reports multiple test suites") {
+        assertM(runLog(suite3))(equalTo(suite3Expected.mkString))
+      },
+      testM("correctly reports empty test suite") {
+        assertM(runLog(suite4))(equalTo(suite4Expected.mkString))
+      },
+      testM("correctly reports failure of simple assertion") {
+        assertM(runLog(test5))(equalTo(test5Expected.mkString))
+      },
+      testM("correctly reports multiple nested failures") {
+        assertM(runLog(test6))(equalTo(test6Expected.mkString))
+      },
+      testM("correctly reports labeled failures") {
+        assertM(runLog(test7))(equalTo(test7Expected.mkString))
+      },
+      testM("correctly reports negated failures") {
+        assertM(runLog(test8))(equalTo(test8Expected.mkString))
+      },
+      testM("correctly reports mock failure of invalid call") {
+        assertM(runLog(mock1))(equalTo(mock1Expected.mkString))
+      },
+      testM("correctly reports mock failure of unmet expectations") {
+        assertM(runLog(mock2))(equalTo(mock2Expected.mkString))
+      },
+      testM("correctly reports mock failure of unexpected call") {
+        assertM(runLog(mock3))(equalTo(mock3Expected.mkString))
+      },
+      testM("correctly reports mock failure of invalid range") {
+        assertM(runLog(mock4))(equalTo(mock4Expected.mkString))
+      }
+    ) @@ silent
+
+  val test1Expected: Vector[String] = Vector(
+    testStarted("Addition works fine"),
+    testFinished("Addition works fine")
+  )
+
+  val test2Expected: Vector[String] = Vector(
+    testStarted("Subtraction works fine"),
+    testFinished("Subtraction works fine")
+  )
+
+  val test3Expected: Vector[String] = Vector(
+    testStarted("Value falls within range"),
+    testFailed(
+      "Value falls within range",
+      Vector(
+        withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
+        withOffset(2)(
+          s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
+        ),
+        withOffset(4)(assertSourceLocation() + "\n"),
+        withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
+        withOffset(2)(
+          s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
+        ),
+        withOffset(4)(assertSourceLocation())
+      )
+    )
+  )
+
+  val test4Expected: Vector[String] = Vector(
+    testStarted("Failing test", location = None),
+    testFailed(
+      "Failing test",
+      Vector(
+        withOffset(2)("Fiber failed.\n") +
+          withOffset(2)("A checked error was not handled.\n") +
+          withOffset(2)("Fail\n") +
+          withOffset(2)("No ZIO Trace available.")
+      )
+    )
+  )
+
+  val suite1Expected: Vector[String] = Vector(
+    suiteStarted("Suite1")
+  ) ++ test1Expected ++ test2Expected ++
+    Vector(
+      suiteFinished("Suite1")
+    )
+
+  val suite2Expected: Vector[String] = Vector(
+    suiteStarted("Suite2")
+  ) ++ test1Expected ++ test2Expected ++ test3Expected ++
+    Vector(
+      suiteFinished("Suite2")
+    )
+
+  val suite3Expected: Vector[String] = Vector(
+    suiteStarted("Suite3")
+  ) ++ suite1Expected ++ suite2Expected ++ test3Expected ++ Vector(
+    suiteFinished("Suite3")
+  )
+
+  val suite4Expected: Vector[String] = Vector(
+    suiteStarted("Suite4")
+  ) ++ suite1Expected ++ Vector(suiteStarted("Empty"), suiteFinished("Empty")) ++
+    test3Expected ++ Vector(suiteFinished("Suite4"))
+
+  val test5Expected: Vector[String] = Vector(
+    testStarted("Addition works fine"),
+    testFailed(
+      "Addition works fine",
+      Vector(
+        withOffset(2)(
+          s"${blue(expressionIfNotRedundant(showExpression(1 + 1), 2))} did not satisfy ${cyan("equalTo(3)")}\n"
+        ),
+        withOffset(4)(assertSourceLocation())
+      )
+    )
+  )
+
+  val test6Expected: Vector[String] = Vector(
+    testStarted("Multiple nested failures"),
+    testFailed(
+      "Multiple nested failures",
+      Vector(
+        withOffset(2)(s"${blue("3")} did not satisfy ${cyan("isGreaterThan(4)")}\n"),
+        withOffset(2)(
+          s"${blue("Some(3)")} did not satisfy ${cyan("isSome(") + yellow("isGreaterThan(4)") + cyan(")")}\n"
+        ),
+        withOffset(2)(
+          s"${blue(s"Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
+        ),
+        withOffset(4)(assertSourceLocation())
+      )
+    )
+  )
+
+  val test7Expected: Vector[String] = Vector(
+    testStarted("labeled failures"),
+    testFailed(
+      "labeled failures",
+      Vector(
+        withOffset(2)(s"${blue("0")} did not satisfy ${cyan("equalTo(1)")}\n"),
+        withOffset(2)(
+          s"${blue("`c` = Some(0)")} did not satisfy ${cyan("(isSome(") + yellow("equalTo(1)") + cyan(") ?? \"third\")")}\n"
+        ),
+        withOffset(4)(assertSourceLocation())
+      )
+    )
+  )
+
+  val test8Expected: Vector[String] = Vector(
+    testStarted("Not combinator"),
+    testFailed(
+      "Not combinator",
+      Vector(
+        withOffset(2)(s"${blue("100")} satisfied ${cyan("equalTo(100)")}\n"),
+        withOffset(2)(
+          s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}\n"
+        ),
+        withOffset(4)(assertSourceLocation())
+      )
+    )
+  )
+
+  val mock1Expected: Vector[String] = Vector(
+    testStarted("Invalid call"),
+    testFailed(
+      "Invalid call",
+      Vector(
+        withOffset(2)(s"${red("- could not find a matching expectation")}\n"),
+        withOffset(4)(
+          s"${red("- zio.test.mock.module.PureModuleMock.ParameterizedCommand called with invalid arguments")}\n"
+        ),
+        withOffset(6)(s"${blue("2")} did not satisfy ${cyan("equalTo(1)")}\n"),
+        withOffset(4)(s"${red("- invalid call to zio.test.mock.module.PureModuleMock.SingleParam")}\n"),
+        withOffset(6)(
+          s"expected zio.test.mock.module.PureModuleMock.ParameterizedCommand with arguments ${cyan("equalTo(1)")}"
+        )
+      )
+    )
+  )
+
+  val mock2Expected: Vector[String] = Vector(
+    testStarted("Unsatisfied expectations"),
+    testFailed(
+      "Unsatisfied expectations",
+      Vector(
+        withOffset(2)(s"${red("- unsatisfied expectations")}\n"),
+        withOffset(4)(s"in sequential order\n"),
+        withOffset(6)(s"""zio.test.mock.module.PureModuleMock.SingleParam with arguments ${cyan("equalTo(2)")}\n"""),
+        withOffset(6)(s"""zio.test.mock.module.PureModuleMock.SingleParam with arguments ${cyan("equalTo(3)")}""")
+      )
+    )
+  )
+
+  val mock3Expected: Vector[String] = Vector(
+    testStarted("Extra calls"),
+    testFailed(
+      "Extra calls",
+      Vector(
+        withOffset(2)(
+          s"${red("- unexpected call to zio.test.mock.module.PureModuleMock.ManyParams with arguments")}\n"
+        ),
+        withOffset(4)(s"${cyan("(2,3,4)")}")
+      )
+    )
+  )
+
+  val mock4Expected: Vector[String] = Vector(
+    testStarted("Invalid range"),
+    testFailed(
+      "Invalid range",
+      Vector(
+        withOffset(2)(s"""${red("- invalid repetition range 4 to 2 by -1")}""")
+      )
+    )
+  )
+}
+object IntelliJRenderUtils {
+  import IntelliJRenderer.escape
+
+  def suiteStarted(name: String): String =
+    s"##teamcity[testSuiteStarted name='$name']" + "\n"
+
+  def suiteFinished(name: String): String =
+    s"##teamcity[testSuiteFinished name='$name']" + "\n"
+
+  def testStarted(name: String, location: Option[String] = Some(ReportingTestUtils.sourceFilePath)): String = {
+    val loc = location.fold("")(s => s"file://$s:XXX")
+    s"##teamcity[testStarted name='$name' locationHint='$loc']" + "\n"
+  }
+
+  def testFinished(name: String): String =
+    s"##teamcity[testFinished name='$name' duration='']" + "\n"
+
+  def testFailed(name: String, error: Vector[String]): String =
+    s"##teamcity[testFailed name='$name' message='Assertion failed:' details='${escape(error.mkString)}']" + "\n"
+
+  def runLog(spec: ZSpec[TestEnvironment, String]): ZIO[TestEnvironment, Nothing, String] =
+    for {
+      _ <- IntelliJTestRunner(testEnvironment)
+             .run(spec)
+             .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](
+               TestLogger.fromConsole ++ TestClock.default
+             )
+      output <- TestConsole.output
+    } yield output.mkString.withNoLineNumbers
+
+  private[this] def IntelliJTestRunner(testEnvironment: Layer[Nothing, TestEnvironment]) =
+    TestRunner[TestEnvironment, String](
+      executor = TestExecutor.default[TestEnvironment, String](testEnvironment),
+      reporter = DefaultTestReporter(IntelliJRenderer, TestAnnotationRenderer.default)
+    )
+}

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -1,61 +1,60 @@
 package zio.test
 
-import zio.clock.Clock
-import zio.test.Assertion._
+import zio.test.Assertion.equalTo
 import zio.test.ReportingTestUtils._
 import zio.test.TestAspect.silent
 import zio.test.environment.{TestClock, TestConsole, TestEnvironment, testEnvironment}
 import zio.test.render.IntelliJRenderer
-import zio.{Layer, ZIO}
+import zio.{Clock, Has, Layer, ZIO}
 
 object IntellijRendererSpec extends ZIOBaseSpec {
   import IntelliJRenderUtils._
 
   def spec: ZSpec[Environment, Failure] =
     suite("IntelliJ Renderer")(
-      testM("correctly reports a successful test") {
+      test("correctly reports a successful test") {
         assertM(runLog(test1))(equalTo(test1Expected.mkString))
       },
-      testM("correctly reports a failed test") {
+      test("correctly reports a failed test") {
         assertM(runLog(test3))(equalTo(test3Expected.mkString))
       },
-      testM("correctly reports an error in a test") {
+      test("correctly reports an error in a test") {
         assertM(runLog(test4))(equalTo(test4Expected.mkString))
       },
-      testM("correctly reports successful test suite") {
+      test("correctly reports successful test suite") {
         assertM(runLog(suite1))(equalTo(suite1Expected.mkString))
       },
-      testM("correctly reports failed test suite") {
+      test("correctly reports failed test suite") {
         assertM(runLog(suite2))(equalTo(suite2Expected.mkString))
       },
-      testM("correctly reports multiple test suites") {
+      test("correctly reports multiple test suites") {
         assertM(runLog(suite3))(equalTo(suite3Expected.mkString))
       },
-      testM("correctly reports empty test suite") {
+      test("correctly reports empty test suite") {
         assertM(runLog(suite4))(equalTo(suite4Expected.mkString))
       },
-      testM("correctly reports failure of simple assertion") {
+      test("correctly reports failure of simple assertion") {
         assertM(runLog(test5))(equalTo(test5Expected.mkString))
       },
-      testM("correctly reports multiple nested failures") {
+      test("correctly reports multiple nested failures") {
         assertM(runLog(test6))(equalTo(test6Expected.mkString))
       },
-      testM("correctly reports labeled failures") {
+      test("correctly reports labeled failures") {
         assertM(runLog(test7))(equalTo(test7Expected.mkString))
       },
-      testM("correctly reports negated failures") {
+      test("correctly reports negated failures") {
         assertM(runLog(test8))(equalTo(test8Expected.mkString))
       },
-      testM("correctly reports mock failure of invalid call") {
+      test("correctly reports mock failure of invalid call") {
         assertM(runLog(mock1))(equalTo(mock1Expected.mkString))
       },
-      testM("correctly reports mock failure of unmet expectations") {
+      test("correctly reports mock failure of unmet expectations") {
         assertM(runLog(mock2))(equalTo(mock2Expected.mkString))
       },
-      testM("correctly reports mock failure of unexpected call") {
+      test("correctly reports mock failure of unexpected call") {
         assertM(runLog(mock3))(equalTo(mock3Expected.mkString))
       },
-      testM("correctly reports mock failure of invalid range") {
+      test("correctly reports mock failure of invalid range") {
         assertM(runLog(mock4))(equalTo(mock4Expected.mkString))
       }
     ) @@ silent
@@ -79,12 +78,12 @@ object IntellijRendererSpec extends ZIOBaseSpec {
         withOffset(2)(
           s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
         ),
-        withOffset(4)(assertSourceLocation() + "\n"),
+        withOffset(2)(assertSourceLocation() + "\n"),
         withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
         withOffset(2)(
           s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
         ),
-        withOffset(4)(assertSourceLocation())
+        withOffset(2)(assertSourceLocation())
       )
     )
   )
@@ -135,7 +134,7 @@ object IntellijRendererSpec extends ZIOBaseSpec {
         withOffset(2)(
           s"${blue(expressionIfNotRedundant(showExpression(1 + 1), 2))} did not satisfy ${cyan("equalTo(3)")}\n"
         ),
-        withOffset(4)(assertSourceLocation())
+        withOffset(2)(assertSourceLocation())
       )
     )
   )
@@ -152,7 +151,7 @@ object IntellijRendererSpec extends ZIOBaseSpec {
         withOffset(2)(
           s"${blue(s"Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}\n"
         ),
-        withOffset(4)(assertSourceLocation())
+        withOffset(2)(assertSourceLocation())
       )
     )
   )
@@ -166,7 +165,7 @@ object IntellijRendererSpec extends ZIOBaseSpec {
         withOffset(2)(
           s"${blue("`c` = Some(0)")} did not satisfy ${cyan("(isSome(") + yellow("equalTo(1)") + cyan(") ?? \"third\")")}\n"
         ),
-        withOffset(4)(assertSourceLocation())
+        withOffset(2)(assertSourceLocation())
       )
     )
   )
@@ -180,7 +179,7 @@ object IntellijRendererSpec extends ZIOBaseSpec {
         withOffset(2)(
           s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}\n"
         ),
-        withOffset(4)(assertSourceLocation())
+        withOffset(2)(assertSourceLocation())
       )
     )
   )
@@ -263,7 +262,7 @@ object IntelliJRenderUtils {
     for {
       _ <- IntelliJTestRunner(testEnvironment)
              .run(spec)
-             .provideLayer[Nothing, TestEnvironment, TestLogger with Clock](
+             .provideLayer[Nothing, TestEnvironment, Has[TestLogger] with Has[Clock]](
                TestLogger.fromConsole ++ TestClock.default
              )
       output <- TestConsole.output

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -133,9 +133,9 @@ object DefaultTestReporter {
 
   def apply[E](testRenderer: TestRenderer, testAnnotationRenderer: TestAnnotationRenderer): TestReporter[E] = {
     (duration: Duration, executedSpec: ExecutedSpec[E]) =>
-      val rendered = render(executedSpec, true).map(result => testRenderer.render(result, testAnnotationRenderer))
-      val stats    = testRenderer.render(logStats(duration, executedSpec), testAnnotationRenderer)
-      TestLogger.logLine((rendered ++ Seq(stats)).mkString("\n"))
+      val rendered = testRenderer.render(render(executedSpec, true), testAnnotationRenderer)
+      val stats    = testRenderer.render(logStats(duration, executedSpec) :: Nil, testAnnotationRenderer)
+      TestLogger.logLine((rendered ++ stats).mkString("\n"))
   }
 
   private def logStats[E](duration: Duration, executedSpec: ExecutedSpec[E]): ExecutionResult = {

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio._
+import zio.test.render._
 
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
@@ -25,29 +26,32 @@ abstract class RunnableSpec[R, E] extends AbstractRunnableSpec {
   override type Environment = R
   override type Failure     = E
 
-  private def run(spec: ZSpec[Environment, Failure]): URIO[Has[TestLogger] with Has[Clock], Int] =
+  private def run(spec: ZSpec[Environment, Failure], testArgs: TestArgs): URIO[Has[TestLogger] with Has[Clock], Int] = {
+    val filteredSpec = FilteredSpec(spec, testArgs)
+    val testReporter = testArgs.testRenderer.fold(runner.reporter)(createTestReporter)
     for {
-      results <- runSpec(spec)
+      results <- runner.withReporter(testReporter).run(aspects.foldLeft(filteredSpec)(_ @@ _))
       hasFailures = results.exists {
                       case ExecutedSpec.TestCase(test, _) => test.isLeft
                       case _                              => false
                     }
-      summary = SummaryBuilder.buildSummary(results)
-      _      <- TestLogger.logLine(summary.summary)
+      _ <- TestLogger
+             .logLine(SummaryBuilder.buildSummary(results).summary)
+             .when(testArgs.printSummary)
     } yield if (hasFailures) 1 else 0
+  }
 
   /**
    * A simple main function that can be used to run the spec.
    */
   final def main(args: Array[String]): Unit = {
-    val testArgs     = TestArgs.parse(args)
-    val filteredSpec = FilteredSpec(spec, testArgs)
-    val runtime      = runner.runtime
+    val testArgs = TestArgs.parse(args)
+    val runtime  = runner.runtime
     if (TestPlatform.isJVM) {
-      val exitCode = runtime.unsafeRun(run(filteredSpec).provideLayer(runner.bootstrap))
+      val exitCode = runtime.unsafeRun(run(spec, testArgs).provideLayer(runner.bootstrap))
       doExit(exitCode)
     } else if (TestPlatform.isJS) {
-      runtime.unsafeRunAsyncWith[Nothing, Int](run(filteredSpec).provideLayer(runner.bootstrap)) { exit =>
+      runtime.unsafeRunAsyncWith[Nothing, Int](run(spec, testArgs).provideLayer(runner.bootstrap)) { exit =>
         val exitCode = exit.getOrElse(_ => 1)
         doExit(exitCode)
       }
@@ -62,4 +66,12 @@ abstract class RunnableSpec[R, E] extends AbstractRunnableSpec {
     sys.env.exists { case (k, v) =>
       k.contains("JAVA_MAIN_CLASS") && v == "ammonite.Main"
     }
+
+  private def createTestReporter(rendererName: String): TestReporter[Failure] = {
+    val renderer = rendererName match {
+      case "intellij" => IntelliJRenderer
+      case _          => TestRenderer.default
+    }
+    DefaultTestReporter(renderer, TestAnnotationRenderer.default)
+  }
 }

--- a/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
+++ b/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
@@ -31,9 +31,8 @@ object SummaryBuilder {
       case _                          => false
     }
     val failures = extractFailures(executedSpec)
-    val rendered = failures
-      .flatMap(DefaultTestReporter.render(_, false))
-      .map(result => ConsoleRenderer.render(result, TestAnnotationRenderer.silent))
+    val rendered = ConsoleRenderer
+      .render(failures.flatMap(DefaultTestReporter.render(_, false)), TestAnnotationRenderer.silent)
       .mkString("\n")
     Summary(success, fail, ignore, rendered)
   }

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -16,19 +16,27 @@
 
 package zio.test
 
-final case class TestArgs(testSearchTerms: List[String], tagSearchTerms: List[String], testTaskPolicy: Option[String])
+final case class TestArgs(
+  testSearchTerms: List[String],
+  tagSearchTerms: List[String],
+  testTaskPolicy: Option[String],
+  testRenderer: Option[String],
+  printSummary: Boolean
+)
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String], None)
+  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String], None, None, printSummary = true)
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term)      => ("testSearchTerm", term)
-        case Array("-tags", term)   => ("tagSearchTerm", term)
-        case Array("-policy", name) => ("policy", name)
+        case Array("-t", term)        => ("testSearchTerm", term)
+        case Array("-tags", term)     => ("tagSearchTerm", term)
+        case Array("-policy", name)   => ("policy", name)
+        case Array("-renderer", name) => ("renderer", name)
+        case Array("-summary", flag)  => ("summary", flag)
       }
       .toList
       .groupBy(_._1)
@@ -39,6 +47,8 @@ object TestArgs {
     val terms          = parsedArgs.getOrElse("testSearchTerm", Nil)
     val tags           = parsedArgs.getOrElse("tagSearchTerm", Nil)
     val testTaskPolicy = parsedArgs.getOrElse("policy", Nil).headOption
-    TestArgs(terms, tags, testTaskPolicy)
+    val testRenderer   = parsedArgs.getOrElse("renderer", Nil).headOption.map(_.toLowerCase)
+    val printSummary   = parsedArgs.getOrElse("summary", Nil).headOption.forall(_.toBoolean)
+    TestArgs(terms, tags, testTaskPolicy, testRenderer, printSummary)
   }
 }

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -29,7 +29,7 @@ final case class TestRunner[R, E](
   executor: TestExecutor[R, E],
   platform: Platform = Platform.makeDefault().withReportFailure(_ => ()),
   reporter: TestReporter[E] = DefaultTestReporter(TestRenderer.default, TestAnnotationRenderer.default),
-  bootstrap: Layer[Nothing, Has[TestLogger] with Has[Clock]] = ((Console.live >>> TestLogger.fromConsole) ++ Clock.live)
+  bootstrap: Layer[Nothing, Has[TestLogger] with Has[Clock]] = (Console.live >>> TestLogger.fromConsole) ++ Clock.live
 ) { self =>
 
   lazy val runtime: Runtime[Unit] = Runtime((), platform)

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -22,6 +22,7 @@ import zio.test.render.LogLine.{Fragment, Line, Message}
 import zio.test.{ConsoleUtils, TestAnnotation, TestAnnotationMap, TestAnnotationRenderer}
 
 trait ConsoleRenderer extends TestRenderer {
+  private val tabSize = 2
 
   override def render(result: ExecutionResult, testAnnotationRenderer: TestAnnotationRenderer): String = {
     val message = Message(result.lines).intersperse(Line.fromString("\n"))
@@ -87,6 +88,6 @@ trait ConsoleRenderer extends TestRenderer {
     }
 
   private def renderOffset(n: Int)(s: String) =
-    " " * n + s
+    " " * (n * tabSize) + s
 }
 object ConsoleRenderer extends ConsoleRenderer

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -24,21 +24,22 @@ import zio.test.{ConsoleUtils, TestAnnotation, TestAnnotationMap, TestAnnotation
 trait ConsoleRenderer extends TestRenderer {
   private val tabSize = 2
 
-  override def render(result: ExecutionResult, testAnnotationRenderer: TestAnnotationRenderer): String = {
-    val message = Message(result.lines).intersperse(Line.fromString("\n"))
+  override def render(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String] =
+    results.map { result =>
+      val message = Message(result.lines).intersperse(Line.fromString("\n"))
 
-    val output = result.resultType match {
-      case ResultType.Suite =>
-        renderSuite(result.status, result.offset, message)
-      case ResultType.Test =>
-        renderTest(result.status, result.offset, message)
-      case ResultType.Other =>
-        Message(result.lines)
+      val output = result.resultType match {
+        case ResultType.Suite =>
+          renderSuite(result.status, result.offset, message)
+        case ResultType.Test =>
+          renderTest(result.status, result.offset, message)
+        case ResultType.Other =>
+          Message(result.lines)
+      }
+
+      val renderedAnnotations = renderAnnotations(result.annotations, testAnnotationRenderer)
+      renderToStringLines(output ++ renderedAnnotations).mkString
     }
-
-    val renderedAnnotations = renderAnnotations(result.annotations, testAnnotationRenderer)
-    renderToStringLines(output ++ renderedAnnotations).mkString
-  }
 
   private def renderSuite(status: Status, offset: Int, message: Message): Message =
     status match {

--- a/test/shared/src/main/scala/zio/test/render/IntelliJRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/IntelliJRenderer.scala
@@ -1,0 +1,126 @@
+package zio.test.render
+import zio.test.TestAnnotationRenderer.LeafRenderer
+import zio.test.render.ExecutionResult.{ResultType, Status}
+import zio.test.render.LogLine.Message
+import zio.test.{TestAnnotation, TestAnnotationRenderer}
+
+import scala.annotation.tailrec
+import scala.util.Try
+
+trait IntelliJRenderer extends TestRenderer {
+  import IntelliJRenderer._
+
+  override def render(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String] =
+    mkTree(results).flatMap(renderTree)
+
+  private def renderTree(t: Node[ExecutionResult]): List[String] =
+    t.value.resultType match {
+      case ResultType.Suite =>
+        onSuiteStarted(t.value) +: t.children.flatMap(renderTree) :+ onSuiteFinished(t.value)
+      case ResultType.Test =>
+        onTestStarted(t.value) +: t.children.flatMap(renderTree) :+
+          (t.value.status match {
+            case Status.Passed  => onTestFinished(t.value, None)
+            case Status.Failed  => onTestFailed(t.value)
+            case Status.Ignored => onTestIgnored(t.value)
+          })
+
+      case ResultType.Other => Nil
+    }
+
+  private def onSuiteStarted(result: ExecutionResult) =
+    tc(s"testSuiteStarted name='${escape(result.label)}'")
+
+  private def onSuiteFinished(result: ExecutionResult) =
+    tc(s"testSuiteFinished name='${escape(result.label)}'")
+
+  private def onTestStarted(result: ExecutionResult) =
+    tc(s"testStarted name='${escape(result.label)}' locationHint='${escape(location(result))}'")
+
+  private def onTestFinished(result: ExecutionResult, timing: Option[String]) =
+    tc(s"testFinished name='${escape(result.label)}' duration='${timing.getOrElse("")}'")
+
+  private def onTestIgnored(result: ExecutionResult) =
+    tc(s"testIgnored name='${escape(result.label)}'")
+
+  private def onTestFailed(result: ExecutionResult) = {
+    val message = Message(result.lines.drop(1)).withOffset(-result.offset)
+    val error   = ConsoleRenderer.renderToStringLines(message).mkString("\n")
+
+    tc(s"testFailed name='${escape(result.label)}' message='Assertion failed:' details='${escape(error)}'")
+  }
+
+  private def tc(message: String): String =
+    s"##teamcity[$message]"
+
+  def escape(str: String): String =
+    str
+      .replaceAll("[|]", "||")
+      .replaceAll("[']", "|'")
+      .replaceAll("[\n]", "|n")
+      .replaceAll("[\r]", "|r")
+      .replaceAll("]", "|]")
+      .replaceAll("\\[", "|[")
+
+  private def location(result: ExecutionResult) =
+    result.annotations match {
+      case annotations :: _ => locationRenderer.run(Nil, annotations).mkString
+      case Nil              => ""
+    }
+}
+object IntelliJRenderer extends IntelliJRenderer {
+  private type Graph[A] = Map[Int, List[Node[A]]]
+
+  val locationRenderer: TestAnnotationRenderer =
+    LeafRenderer(TestAnnotation.location) { case child :: _ =>
+      if (child.isEmpty) None
+      else child.headOption.map(s => s"file://${s.path}:${s.line}")
+    }
+
+  private case class Node[A](value: A, children: List[Node[A]]) {
+    def find(value: A): Option[Node[A]] = children.find(_.value == value)
+
+    def replace(n: Node[A], r: Node[A]): List[Node[A]] = children.updated(children.indexOf(n), r)
+  }
+
+  private def mkTree(results: Seq[ExecutionResult]): List[Node[ExecutionResult]] = {
+    def add(result: ExecutionResult)(graph: Graph[ExecutionResult]): Graph[ExecutionResult] = {
+      @tailrec
+      def buildGraph(id: Int, node: Node[ExecutionResult], graph: Graph[ExecutionResult]): Graph[ExecutionResult] =
+        graph.get(id) match {
+          case None => graph
+          case Some(nodes) =>
+            nodes match {
+              case Nil => throw new Exception("Unexpected empty node")
+              case _ =>
+                val last  = nodes.last
+                val child = last.find(node.value)
+                val newNode = last.copy(children = child match {
+                  case None    => last.children :+ node
+                  case Some(c) => last.replace(c, node)
+                })
+                buildGraph(id - 1, newNode, graph.updated(id, nodes.init :+ newNode))
+            }
+        }
+
+      val id = result.offset match {
+        case 0                         => Try(graph.keys.max).getOrElse(0)
+        case size if size > graph.size => graph.size
+        case size                      => size
+      }
+      val node = Node(result, Nil)
+
+      val g = graph.get(id) match {
+        case None        => graph + (id -> List(node))
+        case Some(nodes) => graph.updated(id, nodes :+ node)
+      }
+      buildGraph(id - 1, node, g)
+    }
+
+    results
+      .foldLeft[Graph[ExecutionResult]](Map.empty) { case (g, res) =>
+        add(res)(g)
+      }
+      .getOrElse(0, Nil)
+  }
+}

--- a/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
@@ -22,5 +22,5 @@ trait TestRenderer {
   def render(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String]
 }
 object TestRenderer {
-  lazy val default = ConsoleRenderer
+  lazy val default: TestRenderer = ConsoleRenderer
 }

--- a/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
@@ -19,7 +19,7 @@ package zio.test.render
 import zio.test.TestAnnotationRenderer
 
 trait TestRenderer {
-  def render(result: ExecutionResult, testAnnotationRenderer: TestAnnotationRenderer): String
+  def render(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String]
 }
 object TestRenderer {
   lazy val default = ConsoleRenderer


### PR DESCRIPTION
This PR introduces a test output renderer that produces IntelliJ-specific output. When run from IntelliJ, it will use this output to render the test results in the integrated test runner.

This functionality is currently implemented externally via the zio-test-intellij project, which I want to retire once this PR is merged into ZIO 2.0.

A command-line argument is passed to the spec runner, specifying the renderer to use. If no command-line arg is passed, the default (console) renderer is used instead.

@adamgfraser, would love your input.

See also: #2771, #3133