### PR TITLE
Docs: Fixing misc typos

### DIFF
--- a/docs/datatypes/concurrency/index.md
+++ b/docs/datatypes/concurrency/index.md
@@ -92,7 +92,7 @@ By using these two simple primitives, we can build lots of other asynchronous co
 
 ### Others
 
-- **[Semaphore](semaphore.md)** — A `Semaphore` is an asynchronous (non-blocking) semaphore that plays well with ZIO's interruption. `Semahore` is a generalization of a mutex. It has a certain number of permits, which can be held and released concurrently by different parties. Attempts to acquire more permits than available result in the acquiring fiber being suspended until the specified number of permits become available.
+- **[Semaphore](semaphore.md)** — A `Semaphore` is an asynchronous (non-blocking) semaphore that plays well with ZIO's interruption. `Semaphore` is a generalization of a mutex. It has a certain number of permits, which can be held and released concurrently by different parties. Attempts to acquire more permits than available result in the acquiring fiber being suspended until the specified number of permits become available.
 
 - **[Queue](queue.md)** — A `Queue` is an asynchronous queue that never blocks, which is safe for multiple concurrent producers and consumers.
 

--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -117,9 +117,9 @@ def update(f: A => A): IO[E, Unit]
 Assume we have a counter, we can increase its value with the `update` method:
 
 ```scala mdoc:silent:nest
-val counterInital = 0
+val counterInitial = 0
 for {
-  counterRef <- Ref.make(counterInital)
+  counterRef <- Ref.make(counterInitial)
   _          <- counterRef.update(_ + 1)
   value <- counterRef.get
 } yield assert(value == 1)
@@ -309,7 +309,7 @@ object S {
 }
 ```
 
-Let's rock these crocodile boots we found the other day at the market and test our semaphore at the night club, yiihaa:
+Let's rock these crocodile boots we found the other day at the market and test our semaphore at the night club, yee-haw:
 
 ```scala mdoc:silent
 import zio.duration.Duration

--- a/docs/datatypes/contextual/has.md
+++ b/docs/datatypes/contextual/has.md
@@ -109,7 +109,7 @@ val RandomIntLive: RandomInt = new RandomInt {
 Great! Now, we are ready to inject these two dependencies into our application `myApp` through `ZIO.provide` function.  
 
 ```scala mdoc:silent:nest
-val mainApp = myApp.provide(???) //What to provide?
+lazy val mainApp = myApp.provide(???) //What to provide?
 ```
 
 As the type of `myApp` effect is `ZIO[Logging with RandomInt, Nothing, Unit]`, we should provide an object with a type of `Logging with RandomInt`. Oh! How can we combine `LoggingLive` and `RandomIntLive` objects together? Unfortunately, we don't have a way to combine these two objects to create a required service (`Logging with RandomInt`).

--- a/docs/datatypes/contextual/has.md
+++ b/docs/datatypes/contextual/has.md
@@ -108,7 +108,7 @@ val RandomIntLive: RandomInt = new RandomInt {
 
 Great! Now, we are ready to inject these two dependencies into our application `myApp` through `ZIO.provide` function.  
 
-```scala mddoc:silent:nest
+```scala mdoc:silent:nest
 val mainApp = myApp.provide(???) //What to provide?
 ```
 

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -445,7 +445,7 @@ val loggingImpl = Has(new Logging {
 val effect = app.provide(loggingImpl)
 ```
 
-Most of the time, we don't use `Has` directly to implement our services, instead; we use `ZLyaer` to construct the dependency graph of our application, then we use methods like `ZIO#provideLayer` to propagate dependencies into the environment of our ZIO effect.
+Most of the time, we don't use `Has` directly to implement our services, instead; we use `ZLayer` to construct the dependency graph of our application, then we use methods like `ZIO#provideLayer` to propagate dependencies into the environment of our ZIO effect.
 
 #### Using `provideLayer` Method
 

--- a/docs/datatypes/stm/index.md
+++ b/docs/datatypes/stm/index.md
@@ -49,10 +49,10 @@ for {
 
 As the above program runs 10 concurrent fibers to increase the counter value. However, we cannot expect this program to always return 10 as a result. 
 
-To fix this issue, we need to perform the `get` and `set` operation atomically. The `Ref` data type some other api like `update` and `modify` which perform the reading and writing atomically:
+To fix this issue, we need to perform the `get` and `set` operation atomically. The `Ref` data type some other api like `update`, `updateAndGet`, and `modify` which perform the reading and writing atomically:
 
-```scala mdoc:silent
-def inc(counter: Ref[Int], amount: Int) = counter.update(_ + amount)
+```scala mdoc:nest
+def inc(counter: Ref[Int], amount: Int) = counter.updateAndGet(_ + amount)
 ```
 
 The most important note about the `modify` operation is that it doesn't use pessimistic locking. It doesn't use any locking primitives for the critical section. It has an optimistic assumption on occurring collisions.

--- a/docs/datatypes/stm/index.md
+++ b/docs/datatypes/stm/index.md
@@ -51,7 +51,7 @@ As the above program runs 10 concurrent fibers to increase the counter value. Ho
 
 To fix this issue, we need to perform the `get` and `set` operation atomically. The `Ref` data type some other api like `update` and `modify` which perform the reading and writing atomically:
 
-```scama mdoc:silent
+```scala mdoc:silent
 def inc(counter: Ref[Int], amount: Int) = counter.update(_ + amount)
 ```
 

--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -451,7 +451,7 @@ no impact on other parts of the system.
 
 Test aspects are used to modify existing tests or even entire suites that you have already created. Test aspects are
 applied to a test or suite using the `@@` operator. This is an example test suite showing the use of aspects to modify 
-test behaviour:
+test behavior:
 
 ```scala mdoc:reset
 import zio.duration._

--- a/docs/services/console.md
+++ b/docs/services/console.md
@@ -23,7 +23,7 @@ import java.io.IOException
 import zio.ZIO
 import zio.console._
 
-object MyHeloApp extends zio.App {
+object MyHelloApp extends zio.App {
   val program: ZIO[Console, IOException, Unit] = for {
     _ <- putStrLn("Hello, what is you name?")
     name <- getStrLn

--- a/docs/services/random.md
+++ b/docs/services/random.md
@@ -3,7 +3,7 @@ id: random
 title: "Random"
 ---
 
-Random service provides utilities to generate random numbers. It's a functional wrapper of `scala.util.Random`. This service contains various different pseudo-random generators like `nextInt`, `nextBolean` and `nextDouble`. Each random number generator functions return a `URIO[Random, T]` value.
+Random service provides utilities to generate random numbers. It's a functional wrapper of `scala.util.Random`. This service contains various different pseudo-random generators like `nextInt`, `nextBoolean` and `nextDouble`. Each random number generator functions return a `URIO[Random, T]` value.
 
 ```scala mdoc:silent
 import zio.random._


### PR DESCRIPTION
This was cherrypicked from a PR against series/2.0, found some typos and incorrect mdoc commands. After fixing those, some code blocks were failing, so I fixed that as well.