### PR TITLE
Add ZIO#tapEither and tests

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3175,8 +3175,8 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           ref <- Ref.make(0)
           _ <- Task(42).tapEither {
-                 case Left(value) => ref.set(-1)
-                 case Right(_)    => ref.set(42)
+                 case Left(_)      => ref.set(-1)
+                 case Right(value) => ref.set(value)
                }.run
           effect <- ref.get
         } yield assert(effect)(equalTo(42))

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3158,6 +3158,30 @@ object ZIOSpec extends ZIOBaseSpec {
           assert(effect)(equalTo(42))
       }
     ),
+    suite("tapEither")(
+      testM("effectually peeks at the failure of this effect") {
+        for {
+          ref <- Ref.make(0)
+          _ <- IO.fail(42)
+                 .tapEither {
+                   case Left(value) => ref.set(value)
+                   case Right(_)    => ref.set(-1)
+                 }
+                 .run
+          effect <- ref.get
+        } yield assert(effect)(equalTo(42))
+      },
+      testM("effectually peeks at the success of this effect") {
+        for {
+          ref <- Ref.make(0)
+          _ <- Task(42).tapEither {
+                 case Left(value) => ref.set(-1)
+                 case Right(_)    => ref.set(42)
+               }.run
+          effect <- ref.get
+        } yield assert(effect)(equalTo(42))
+      }
+    ),
     suite("tapCause")(
       testM("effectually peeks at the cause of the failure of this effect") {
         for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1873,7 +1873,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Returns an effect that effectfully "peeks" at the result of this effect.
    * {{{
-   * readFile("data.json").tapEither(result => log(result.fold("Error: " + _, "Success: " + _))))
+   * readFile("data.json").tapEither(result => log(result.fold("Error: " + _, "Success: " + _)))
    * }}}
    */
   final def tapEither[R1 <: R, E1 >: E](f: Either[E, A] => ZIO[R1, E1, Any])(implicit

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1871,6 +1871,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     self.foldCauseM(new ZIO.TapErrorRefailFn(f), new ZIO.TapFn(g))
 
   /**
+   * Returns an effect that effectfully "peeks" at the result of this effect.
+   * {{{
+   * readFile("data.json").tapEither(result => log(result.fold("Error: " + _, "Success: " + _))))
+   * }}}
+   */
+  final def tapEither[R1 <: R, E1 >: E](f: Either[E, A] => ZIO[R1, E1, Any])(implicit
+    ev: CanFail[E]
+  ): ZIO[R1, E1, A] =
+    self.foldCauseM(new ZIO.TapErrorRefailFn(e => f(Left(e))), new ZIO.TapFn(a => f(Right(a))))
+
+  /**
    * Returns an effect that effectually "peeks" at the cause of the failure of
    * this effect.
    * {{{


### PR DESCRIPTION
I came across of a use case where I need to report the result of effect to slack.
`tapBoth` was the first option but it simply required me to write a function or duplicate codes.
Through `tapEither`, we can execute an effect with the execution result information in one lambda.

Similar function exists in [typelevel/cats/MonadError](https://github.com/typelevel/cats/blob/adf6680362224509d0b2a50c40bb6e59a32dc45b/core/src/main/scala/cats/MonadError.scala#L104)