### PR TITLE
Separate Fallible and Infallible Console Operators

### DIFF
--- a/core-tests/shared/src/test/scala/zio/AutoLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/AutoLayerSpec.scala
@@ -117,7 +117,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
         ),
         suite("injectCustom")(
           testM("automatically constructs a layer from its dependencies, leaving off ZEnv") {
-            val stringLayer = console.getStrLn.orDie.toLayer
+            val stringLayer = console.getStrLn.toLayer
             val program     = ZIO.service[String].zipWith(random.nextInt)((str, int) => s"$str $int")
             val provided = TestConsole.feedLines("Your Lucky Number is:") *>
               program.injectCustom(stringLayer)
@@ -127,7 +127,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
         ),
         suite("injectSome")(
           testM("automatically constructs a layer from its dependencies, leaving off some environment") {
-            val stringLayer = console.getStrLn.orDie.toLayer
+            val stringLayer = console.getStrLn.toLayer
             val program     = ZIO.service[String].zipWith(random.nextInt)((str, int) => s"$str $int")
             val provided = TestConsole.feedLines("Your Lucky Number is:") *>
               program.injectSome[Random with Console](stringLayer)
@@ -268,7 +268,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
         ),
         suite("injectCustom")(
           testM("automatically constructs a layer from its dependencies, leaving off ZEnv") {
-            val stringLayer = console.getStrLn.orDie.toLayer
+            val stringLayer = console.getStrLn.toLayer
             val program     = ZManaged.service[String].zipWith(random.nextInt.toManaged_)((str, int) => s"$str $int")
             val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged_ *>
               program.injectCustom(stringLayer)
@@ -278,7 +278,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
         ),
         suite("injectSome")(
           testM("automatically constructs a layer from its dependencies, leaving off some environment") {
-            val stringLayer = console.getStrLn.orDie.toLayer
+            val stringLayer = console.getStrLn.toLayer
             val program     = ZManaged.service[String].zipWith(random.nextInt.toManaged_)((str, int) => s"$str $int")
             val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged_ *>
               program.injectSome[Random with Console](stringLayer)

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -25,30 +25,27 @@ package object console {
 
   object Console extends Serializable {
     trait Service extends Serializable {
-      def putStrIO(line: String): IO[IOException, Unit]
+      def putStrOrFail(line: String): IO[IOException, Unit]
 
-      def putStrErrIO(line: String): IO[IOException, Unit]
+      def putStrErrOrFail(line: String): IO[IOException, Unit]
 
-      def putStrLnIO(line: String): IO[IOException, Unit]
+      def putStrLnOrFail(line: String): IO[IOException, Unit]
 
-      def putStrLnErrIO(line: String): IO[IOException, Unit]
+      def putStrLnErrOrFail(line: String): IO[IOException, Unit]
 
-      def getStrLnIO: IO[IOException, String]
+      def getStrLn: IO[IOException, String]
 
       def putStr(line: String): UIO[Unit] =
-        putStrIO(line).orDie
+        putStrOrFail(line).orDie
 
       def putStrErr(line: String): UIO[Unit] =
-        putStrErrIO(line).orDie
+        putStrErrOrFail(line).orDie
 
       def putStrLn(line: String): UIO[Unit] =
-        putStrLnIO(line).orDie
+        putStrLnOrFail(line).orDie
 
       def putStrLnErr(line: String): UIO[Unit] =
-        putStrLnErrIO(line).orDie
-
-      def getStrLn: UIO[String] =
-        getStrLnIO.orDie
+        putStrLnErrOrFail(line).orDie
     }
 
     object Service {
@@ -59,15 +56,15 @@ package object console {
         IO.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
 
       val live: Service = new Service {
-        def putStrIO(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
+        def putStrOrFail(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
 
-        def putStrErrIO(line: String): IO[IOException, Unit] = Service.putStr(SConsole.err)(line)
+        def putStrErrOrFail(line: String): IO[IOException, Unit] = Service.putStr(SConsole.err)(line)
 
-        def putStrLnErrIO(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.err)(line)
+        def putStrLnErrOrFail(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.err)(line)
 
-        def putStrLnIO(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
+        def putStrLnOrFail(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
 
-        val getStrLnIO: IO[IOException, String] =
+        val getStrLn: IO[IOException, String] =
           IO.effect {
             val line = StdIn.readLine()
 
@@ -93,8 +90,8 @@ package object console {
   /**
    * Prints text to the console.
    */
-  def putStrIO(line: => String): ZIO[Console, IOException, Unit] =
-    ZIO.accessM(_.get putStrIO line)
+  def putStrOrFail(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrOrFail line)
 
   /**
    * Prints text to the standard error console.
@@ -105,8 +102,8 @@ package object console {
   /**
    * Prints text to the standard error console.
    */
-  def putStrErrIO(line: => String): ZIO[Console, IOException, Unit] =
-    ZIO.accessM(_.get putStrErrIO line)
+  def putStrErrOrFail(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrErrOrFail line)
 
   /**
    * Prints a line of text to the console, including a newline character.
@@ -117,8 +114,8 @@ package object console {
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  def putStrLnIO(line: => String): ZIO[Console, IOException, Unit] =
-    ZIO.accessM(_.get putStrLnIO line)
+  def putStrLnOrFail(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrLnOrFail line)
 
   /**
    * Prints a line of text to the standard error console, including a newline character.
@@ -129,22 +126,14 @@ package object console {
   /**
    * Prints a line of text to the standard error console, including a newline character.
    */
-  def putStrLnErrIO(line: => String): ZIO[Console, IOException, Unit] =
-    ZIO.accessM(_.get putStrLnErrIO line)
-
-  /**
-   * Retrieves a line of input from the console.
-   * Dies with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
-   * returns null.
-   */
-  val getStrLn: URIO[Console, String] =
-    ZIO.accessM(_.get.getStrLn)
+  def putStrLnErrOrFail(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrLnErrOrFail line)
 
   /**
    * Retrieves a line of input from the console.
    * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
    * returns null.
    */
-  val getStrLnIO: ZIO[Console, IOException, String] =
-    ZIO.accessM(_.get.getStrLnIO)
+  val getStrLn: ZIO[Console, IOException, String] =
+    ZIO.accessM(_.get.getStrLn)
 }

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -25,15 +25,30 @@ package object console {
 
   object Console extends Serializable {
     trait Service extends Serializable {
-      def putStr(line: String): IO[IOException, Unit]
+      def putStrIO(line: String): IO[IOException, Unit]
 
-      def putStrErr(line: String): IO[IOException, Unit]
+      def putStrErrIO(line: String): IO[IOException, Unit]
 
-      def putStrLn(line: String): IO[IOException, Unit]
+      def putStrLnIO(line: String): IO[IOException, Unit]
 
-      def putStrLnErr(line: String): IO[IOException, Unit]
+      def putStrLnErrIO(line: String): IO[IOException, Unit]
 
-      def getStrLn: IO[IOException, String]
+      def getStrLnIO: IO[IOException, String]
+
+      def putStr(line: String): UIO[Unit] =
+        putStrIO(line).orDie
+
+      def putStrErr(line: String): UIO[Unit] =
+        putStrErrIO(line).orDie
+
+      def putStrLn(line: String): UIO[Unit] =
+        putStrLnIO(line).orDie
+
+      def putStrLnErr(line: String): UIO[Unit] =
+        putStrLnErrIO(line).orDie
+
+      def getStrLn: UIO[String] =
+        getStrLnIO.orDie
     }
 
     object Service {
@@ -44,15 +59,15 @@ package object console {
         IO.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
 
       val live: Service = new Service {
-        def putStr(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
+        def putStrIO(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
 
-        def putStrErr(line: String): IO[IOException, Unit] = Service.putStr(SConsole.err)(line)
+        def putStrErrIO(line: String): IO[IOException, Unit] = Service.putStr(SConsole.err)(line)
 
-        def putStrLnErr(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.err)(line)
+        def putStrLnErrIO(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.err)(line)
 
-        def putStrLn(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
+        def putStrLnIO(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
 
-        val getStrLn: IO[IOException, String] =
+        val getStrLnIO: IO[IOException, String] =
           IO.effect {
             val line = StdIn.readLine()
 
@@ -72,32 +87,64 @@ package object console {
   /**
    * Prints text to the console.
    */
-  def putStr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStr line)
+
+  /**
+   * Prints text to the console.
+   */
+  def putStrIO(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrIO line)
 
   /**
    * Prints text to the standard error console.
    */
-  def putStrErr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrErr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrErr line)
+
+  /**
+   * Prints text to the standard error console.
+   */
+  def putStrErrIO(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrErrIO line)
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  def putStrLn(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrLn(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrLn line)
+
+  /**
+   * Prints a line of text to the console, including a newline character.
+   */
+  def putStrLnIO(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrLnIO line)
 
   /**
    * Prints a line of text to the standard error console, including a newline character.
    */
-  def putStrLnErr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrLnErr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrLnErr line)
+
+  /**
+   * Prints a line of text to the standard error console, including a newline character.
+   */
+  def putStrLnErrIO(line: => String): ZIO[Console, IOException, Unit] =
+    ZIO.accessM(_.get putStrLnErrIO line)
+
+  /**
+   * Retrieves a line of input from the console.
+   * Dies with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
+   * returns null.
+   */
+  val getStrLn: URIO[Console, String] =
+    ZIO.accessM(_.get.getStrLn)
 
   /**
    * Retrieves a line of input from the console.
    * Fails with an [[java.io.EOFException]] when the underlying [[java.io.Reader]]
    * returns null.
    */
-  val getStrLn: ZIO[Console, IOException, String] =
-    ZIO.accessM(_.get.getStrLn)
+  val getStrLnIO: ZIO[Console, IOException, String] =
+    ZIO.accessM(_.get.getStrLnIO)
 }

--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -194,7 +194,7 @@ val hub: Hub[Int] = ???
 val hubWithLogging: ZHub[Any, Clock with Console, Nothing, Nothing, Int, Int] =
   hub.mapM { n =>
     clock.currentDateTime.flatMap { currentDateTime =>
-      console.putStrLn(s"Took message $n from the hub at $currentDateTime").orDie
+      console.putStrLn(s"Took message $n from the hub at $currentDateTime")
     }.as(n)
   }
 ```

--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -165,7 +165,7 @@ object CountRequests extends zio.App {
     for {
       _ <- counter.update(_ + 1)
       reqNumber <- counter.get
-      _ <- putStrLn(s"request number: $reqNumber").orDie
+      _ <- putStrLn(s"request number: $reqNumber")
     } yield ()
   }
 
@@ -175,7 +175,7 @@ object CountRequests extends zio.App {
       ref <- Ref.make(initial)
       _ <- request(ref) zipPar request(ref)
       rn <- ref.get
-      _ <- putStrLn(s"total requests performed: $rn").orDie
+      _ <- putStrLn(s"total requests performed: $rn")
     } yield ()
 
   override def run(args: List[String]) = program.exitCode

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -18,7 +18,7 @@ import zio.console._
 ```
 
 ```scala mdoc:silent
-val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!").orDie
+val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!")
 ```
 
 So finally when we provide a live version of `Console` service to our `effect`, it will be converted to an effect that doesn't require any environmental service:
@@ -34,7 +34,7 @@ import zio.{ExitCode, ZEnv, ZIO}
 import zio.console._
 
 object MainApp extends zio.App {
-  val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!").orDie
+  val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!")
   val mainApp: ZIO[Any, Nothing, Unit] = effect.provideLayer(Console.live)
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = 
@@ -50,7 +50,7 @@ import zio.random._
 
 val effect: ZIO[Console with Random, Nothing, Unit] = for {
   r <- nextInt
-  _ <- putStrLn(s"random number: $r").orDie
+  _ <- putStrLn(s"random number: $r")
 } yield ()
 
 val mainApp: ZIO[Any, Nothing, Unit] = effect.provideLayer(Console.live ++ Random.live)
@@ -66,7 +66,7 @@ import zio.{ExitCode, ZEnv, ZIO}
 object MainApp extends zio.App {
   val effect: ZIO[Console with Random, Nothing, Unit] = for {
     r <- nextInt
-    _ <- putStrLn(s"random number: $r").orDie
+    _ <- putStrLn(s"random number: $r")
   } yield ()
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
@@ -259,7 +259,7 @@ object logging {
             override def log(line: String): UIO[Unit] =
               for {
                 current <- clock.currentDateTime
-                _ <- console.putStrLn(current.toString + "--" + line).orDie
+                _ <- console.putStrLn(current.toString + "--" + line)
               } yield ()
           }
       }
@@ -333,7 +333,7 @@ case class LoggingLive(console: Console.Service, clock: Clock.Service) extends L
   override def log(line: String): UIO[Unit] = 
     for {
       current <- clock.currentDateTime
-      _       <- console.putStrLn(current.toString + "--" + line).orDie
+      _       <- console.putStrLn(current.toString + "--" + line)
     } yield ()
 }
 ```
@@ -460,9 +460,9 @@ import zio.random._
 
 val myApp: ZIO[Random with Console with Clock, Nothing, Unit] = for {
   random  <- nextInt 
-  _       <- putStrLn(s"A random number: ${random.toString}").orDie
+  _       <- putStrLn(s"A random number: ${random.toString}")
   current <- currentDateTime
-  _       <- putStrLn(s"Current Data Time: ${current.toString}").orDie
+  _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```
 
@@ -528,7 +528,7 @@ object LoggingLive {
 val myApp: ZIO[Has[Logging] with Console with Clock, Nothing, Unit] = for {
   _       <- Logging.log("Application Started!")
   current <- currentDateTime
-  _       <- putStrLn(s"Current Data Time: ${current.toString}").orDie
+  _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```
 

--- a/docs/datatypes/contextual/zlayer.md
+++ b/docs/datatypes/contextual/zlayer.md
@@ -227,7 +227,7 @@ import logging.Logging._
 ```scala mdoc:silent:nest
 val live: ZLayer[Console, Nothing, Logging] = ZLayer.fromService(console =>
   new Service {
-    override def log(msg: String): UIO[Unit] = console.putStrLn(msg).orDie
+    override def log(msg: String): UIO[Unit] = console.putStrLn(msg)
   }
 )
 ```
@@ -354,8 +354,8 @@ object Logging {
   import zio.console.Console
   val consoleLogger: ZLayer[Console, Nothing, Logging] = ZLayer.fromFunction( console =>
     new Service {
-      def info(s: String): UIO[Unit]  = console.get.putStrLn(s"info - $s").orDie
-      def error(s: String): UIO[Unit] = console.get.putStrLn(s"error - $s").orDie
+      def info(s: String): UIO[Unit]  = console.get.putStrLn(s"info - $s")
+      def error(s: String): UIO[Unit] = console.get.putStrLn(s"error - $s")
     }
   )
 

--- a/docs/datatypes/hub.md
+++ b/docs/datatypes/hub.md
@@ -194,7 +194,7 @@ val hub: Hub[Int] = ???
 val hubWithLogging: ZHub[Any, Clock with Console, Nothing, Nothing, Int, Int] =
   hub.mapM { n =>
     clock.currentDateTime.flatMap { currentDateTime =>
-      console.putStrLn(s"Took message $n from the hub at $currentDateTime").orDie
+      console.putStrLn(s"Took message $n from the hub at $currentDateTime")
     }.as(n)
   }
 ```

--- a/docs/datatypes/misc/schedule.md
+++ b/docs/datatypes/misc/schedule.md
@@ -314,7 +314,7 @@ Whenever we need to effectfully process each schedule input/output, we can use `
 We can use these two functions for logging purposes:
 
 ```scala mdoc:silent
-val tappedSchedule = Schedule.count.whileOutput(_ < 5).tapOutput(o => putStrLn(s"retrying $o").orDie)
+val tappedSchedule = Schedule.count.whileOutput(_ < 5).tapOutput(o => putStrLn(s"retrying $o"))
 ```
 
 

--- a/docs/datatypes/resource/managed.md
+++ b/docs/datatypes/resource/managed.md
@@ -55,8 +55,8 @@ val managedFromValue: Managed[Nothing, Int] = Managed.succeed(3)
 import zio._
 import zio.console._
 
-val zManagedResource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring").orDie)(_ => console.putStrLn("releasing").orDie)
-val zUsedResource: URIO[Console, Unit] = zManagedResource.use { _ => console.putStrLn("running").orDie }
+val zManagedResource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring"))(_ => console.putStrLn("releasing"))
+val zUsedResource: URIO[Console, Unit] = zManagedResource.use { _ => console.putStrLn("running") }
 ```
 
 ## Combining Managed

--- a/docs/datatypes/stm/treentrantlock.md
+++ b/docs/datatypes/stm/treentrantlock.md
@@ -115,9 +115,9 @@ import zio.duration._
 
 val writeLockDemoProgram: URIO[Console with Clock, Unit] = for {
   l  <- TReentrantLock.make.commit
-  _  <- putStrLn("Beginning test").orDie
+  _  <- putStrLn("Beginning test")
   f1 <- (l.acquireRead.commit *> ZIO.sleep(5.seconds) *> l.releaseRead.commit).fork
-  f2 <- (l.acquireRead.commit *> putStrLn("read-lock").orDie *> l.acquireWrite.commit *> putStrLn("I have upgraded!").orDie).fork
+  f2 <- (l.acquireRead.commit *> putStrLn("read-lock") *> l.acquireWrite.commit *> putStrLn("I have upgraded!")).fork
   _  <- (f1 zip f2).join
 } yield ()
 ```
@@ -143,8 +143,8 @@ import zio.duration._
 
 val saferProgram: URIO[Console with Clock, Unit] = for {
   lock <- TReentrantLock.make.commit
-  f1   <- lock.readLock.use_(ZIO.sleep(5.seconds) *> putStrLn("Powering down").orDie).fork
-  f2   <- lock.readLock.use_(lock.writeLock.use_(putStrLn("Huzzah, writes are mine").orDie)).fork
+  f1   <- lock.readLock.use_(ZIO.sleep(5.seconds) *> putStrLn("Powering down")).fork
+  f2   <- lock.readLock.use_(lock.writeLock.use_(putStrLn("Huzzah, writes are mine"))).fork
   _    <- (f1 zip f2).join
 } yield ()
 ```

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -49,7 +49,7 @@ import zio._
 import zio.console.Console
 
 def processEvent(event: Event): URIO[Console, Unit] =
-  console.putStrLn(s"Got $event").orDie
+  console.putStrLn(s"Got $event")
 ```
 
 With ZIO, we've regained to ability to reason about the effects called. We know that `processEvent` can only call on _capabilities_ of `Console`, so even though we still have `Unit` as the result, we have narrowed the possible effects space to a few.
@@ -215,13 +215,13 @@ object AccountObserver {
       new Service {
         def processEvent(event: AccountEvent): UIO[Unit] =
           for {
-            _    <- console.putStrLn(s"Got $event").orDie
-            line <- console.getStrLn.orDie
-            _    <- console.putStrLn(s"You entered: $line").orDie
+            _    <- console.putStrLn(s"Got $event")
+            line <- console.getStrLn
+            _    <- console.putStrLn(s"You entered: $line")
           } yield ()
 
         def runCommand(): UIO[Unit] =
-          console.putStrLn("Done!").orDie
+          console.putStrLn("Done!")
       }
     }
 }
@@ -397,7 +397,7 @@ val combinedEnv: ULayer[Console with Random] = (
 val combinedApp =
   for {
     _    <- console.putStrLn("What is your name?")
-    name <- console.getStrLn.orDie
+    name <- console.getStrLn
     num  <- random.nextInt
     _    <- console.putStrLn(s"$name, your lucky number today is $num!")
   } yield ()

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -216,7 +216,7 @@ object AccountObserver {
         def processEvent(event: AccountEvent): UIO[Unit] =
           for {
             _    <- console.putStrLn(s"Got $event")
-            line <- console.getStrLn
+            line <- console.getStrLn.orDie
             _    <- console.putStrLn(s"You entered: $line")
           } yield ()
 

--- a/docs/services/blocking.md
+++ b/docs/services/blocking.md
@@ -14,7 +14,7 @@ In the following example, we create 20 blocking tasks to run parallel on the pri
 import zio.{ZIO, URIO}
 import zio.console._
 def blockingTask(n: Int): URIO[Console, Unit] =
-  putStrLn(s"running blocking task number $n").orDie *>
+  putStrLn(s"running blocking task number $n") *>
     ZIO.effectTotal(Thread.sleep(3000)) *>
     blockingTask(n)
 

--- a/docs/usecases/scheduling.md
+++ b/docs/usecases/scheduling.md
@@ -56,8 +56,8 @@ import zio.Schedule.Decision
 
 object ScheduleUtil {
   def schedule[A] = Schedule.spaced(1.second) && Schedule.recurs(4).onDecision({
-    case Decision.Done(_)                 => putStrLn(s"done trying").orDie
-    case Decision.Continue(attempt, _, _) => putStrLn(s"attempt #$attempt").orDie
+    case Decision.Done(_)                 => putStrLn(s"done trying")
+    case Decision.Continue(attempt, _, _) => putStrLn(s"attempt #$attempt")
   })
 }
 ```

--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -43,7 +43,7 @@ object AccessibleMacroExample {
         val foo: UIO[Unit]                                              = UIO.unit
         def foo2: UIO[Unit]                                             = UIO.unit
         def foo3(): UIO[Unit]                                           = UIO.unit
-        def bar(n: Int): UIO[Unit]                                      = console.putStrLn(s"bar $n").orDie
+        def bar(n: Int): UIO[Unit]                                      = console.putStrLn(s"bar $n")
         def baz(x: Int, y: Int): IO[String, Int]                        = UIO.succeed(x + y)
         def poly[A](a: A): IO[Long, A]                                  = UIO.succeed(a)
         def poly2[A <: Foo](a: Wrapped[A]): IO[String, List[A]]         = UIO.succeed(List(a.value))

--- a/examples/shared/src/main/scala-3.x/Example.scala
+++ b/examples/shared/src/main/scala-3.x/Example.scala
@@ -13,7 +13,7 @@ object Example extends App {
     ZLayer.succeed(1) ++ ZLayer.succeed("hello")
 
   val program: ZIO[Has[String] with Has[Int] with Console, Nothing, Unit] =
-    ZIO.services[String, Int].flatMap(in => putStrLn(in.toString).orDie)
+    ZIO.services[String, Int].flatMap(in => putStrLn(in.toString))
 
 
 

--- a/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
@@ -12,7 +12,7 @@ object LayerDefinitionExample extends App {
       (FooLive.apply _).toLayer
 
     case class FooLive(console: Console.Service, string: String, int: Int) extends Foo {
-      override def bar: UIO[Unit] = console.putStrLn(s"$string and $int").orDie
+      override def bar: UIO[Unit] = console.putStrLn(s"$string and $int")
     }
   }
 

--- a/examples/shared/src/main/scala/zio/examples/ProvideLayerAutoExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/ProvideLayerAutoExample.scala
@@ -67,7 +67,7 @@ object ProvideLayerAutoExample extends App {
     def live: URLayer[Console, Has[Fly]] = {
       println("FLY")
 
-      console.putStrLn("Bzzzzzzzzzz...").orDie.as(new Fly {}).toLayer
+      console.putStrLn("Bzzzzzzzzzz...").as(new Fly {}).toLayer
     }
   }
 }

--- a/examples/shared/src/test/scala/zio/examples/test/ProvideLayerAutoExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ProvideLayerAutoExampleSpec.scala
@@ -10,7 +10,7 @@ object ProvideLayerAutoExampleSpec extends DefaultRunnableSpec {
 
   private val exampleZio: ZIO[Console with Has[OldLady], Nothing, Unit] =
     OldLady.contentsOfStomach.flatMap { contents =>
-      console.putStrLn(s"There was an old who lady swallowed:\n- ${contents.mkString("\n- ")}").orDie
+      console.putStrLn(s"There was an old who lady swallowed:\n- ${contents.mkString("\n- ")}")
     }
 
   def spec =

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -7,6 +7,8 @@ import zio.test.TestAspect.{nonFlaky, silent}
 import zio.test._
 import zio.test.environment.TestConsole._
 
+import java.io.IOException
+
 object ConsoleSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] =
@@ -42,9 +44,9 @@ object ConsoleSpec extends ZIOBaseSpec {
           }
         }.provideLayer(TestConsole.make(Data(List("Input 1", "Input 2"), Vector.empty)))
       },
-      testM("fails on empty input") {
+      testM("dies on empty input") {
         for {
-          failed <- getStrLn.either
+          failed <- getStrLn.unrefineTo[IOException].either
           message = failed.fold(_.getMessage, identity)
         } yield {
           assert(failed.isLeft)(isTrue) &&
@@ -65,7 +67,7 @@ object ConsoleSpec extends ZIOBaseSpec {
         for {
           _      <- feedLines("Input 1", "Input 2")
           _      <- clearInput
-          failed <- getStrLn.either
+          failed <- getStrLn.unrefineTo[IOException].either
           message = failed.fold(_.getMessage, identity)
         } yield {
           assert(failed.isLeft)(isTrue) &&

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -46,7 +46,7 @@ object ConsoleSpec extends ZIOBaseSpec {
       },
       testM("dies on empty input") {
         for {
-          failed <- getStrLn.unrefineTo[IOException].either
+          failed <- getStrLn.either
           message = failed.fold(_.getMessage, identity)
         } yield {
           assert(failed.isLeft)(isTrue) &&
@@ -67,7 +67,7 @@ object ConsoleSpec extends ZIOBaseSpec {
         for {
           _      <- feedLines("Input 1", "Input 2")
           _      <- clearInput
-          failed <- getStrLn.unrefineTo[IOException].either
+          failed <- getStrLn.either
           message = failed.fold(_.getMessage, identity)
         } yield {
           assert(failed.isLeft)(isTrue) &&

--- a/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ConsoleSpec.scala
@@ -7,8 +7,6 @@ import zio.test.TestAspect.{nonFlaky, silent}
 import zio.test._
 import zio.test.environment.TestConsole._
 
-import java.io.IOException
-
 object ConsoleSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] =

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -62,7 +62,7 @@ trait TimeoutVariants {
     testLabel: String,
     duration: Duration
   ): URIO[Live, Unit] =
-    Live.live(console.putStrLn(renderWarning(suiteLabels, testLabel, duration)).orDie)
+    Live.live(console.putStrLn(renderWarning(suiteLabels, testLabel, duration)))
 
   private def renderWarning(suiteLabels: List[String], testLabel: String, duration: Duration): String =
     (renderSuiteLabels(suiteLabels) + renderTest(testLabel, duration)).capitalize

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -710,7 +710,7 @@ package object environment extends PlatformSpecific {
        * Takes the first value from the input buffer, if one exists, or else
        * fails with an `EOFException`.
        */
-      val getStrLnIO: IO[IOException, String] = {
+      val getStrLn: IO[IOException, String] = {
         for {
           input <- consoleState.get.flatMap(d =>
                      IO.fromOption(d.input.headOption)
@@ -737,7 +737,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the output buffer.
        */
-      override def putStrIO(line: String): IO[IOException, Unit] =
+      override def putStrOrFail(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ line, data.errOutput)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -745,7 +745,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the error buffer.
        */
-      override def putStrErrIO(line: String): IO[IOException, Unit] =
+      override def putStrErrOrFail(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ line)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -754,7 +754,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the output buffer followed by a newline
        * character.
        */
-      override def putStrLnIO(line: String): IO[IOException, Unit] =
+      override def putStrLnOrFail(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ s"$line\n", data.errOutput)
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)
@@ -763,7 +763,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the error buffer followed by a newline
        * character.
        */
-      override def putStrLnErrIO(line: String): IO[IOException, Unit] =
+      override def putStrLnErrOrFail(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ s"$line\n")
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -710,7 +710,7 @@ package object environment extends PlatformSpecific {
        * Takes the first value from the input buffer, if one exists, or else
        * fails with an `EOFException`.
        */
-      val getStrLn: IO[IOException, String] = {
+      val getStrLnIO: IO[IOException, String] = {
         for {
           input <- consoleState.get.flatMap(d =>
                      IO.fromOption(d.input.headOption)
@@ -737,7 +737,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the output buffer.
        */
-      override def putStr(line: String): IO[IOException, Unit] =
+      override def putStrIO(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ line, data.errOutput)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -745,7 +745,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the error buffer.
        */
-      override def putStrErr(line: String): IO[IOException, Unit] =
+      override def putStrErrIO(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ line)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -754,7 +754,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the output buffer followed by a newline
        * character.
        */
-      override def putStrLn(line: String): IO[IOException, Unit] =
+      override def putStrLnIO(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ s"$line\n", data.errOutput)
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)
@@ -763,7 +763,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the error buffer followed by a newline
        * character.
        */
-      override def putStrLnErr(line: String): IO[IOException, Unit] =
+      override def putStrLnErrIO(line: String): IO[IOException, Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ s"$line\n")
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -32,11 +32,11 @@ object MockConsole extends Mock[Console] {
   val compose: URLayer[Has[Proxy], Console] =
     ZLayer.fromService(proxy =>
       new Console.Service {
-        def putStr(line: String): IO[IOException, Unit]      = proxy(PutStr, line)
-        def putStrErr(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
-        def putStrLn(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
-        def putStrLnErr(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
-        val getStrLn: IO[IOException, String]                = proxy(GetStrLn)
+        def putStrIO(line: String): IO[IOException, Unit]      = proxy(PutStr, line)
+        def putStrErrIO(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
+        def putStrLnIO(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
+        def putStrLnErrIO(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
+        val getStrLnIO: IO[IOException, String]                = proxy(GetStrLn)
       }
     )
 }

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -32,11 +32,11 @@ object MockConsole extends Mock[Console] {
   val compose: URLayer[Has[Proxy], Console] =
     ZLayer.fromService(proxy =>
       new Console.Service {
-        def putStrIO(line: String): IO[IOException, Unit]      = proxy(PutStr, line)
-        def putStrErrIO(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
-        def putStrLnIO(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
-        def putStrLnErrIO(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
-        val getStrLnIO: IO[IOException, String]                = proxy(GetStrLn)
+        def putStrOrFail(line: String): IO[IOException, Unit]      = proxy(PutStr, line)
+        def putStrErrOrFail(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
+        def putStrLnOrFail(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
+        def putStrLnErrOrFail(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
+        val getStrLn: IO[IOException, String]                = proxy(GetStrLn)
       }
     )
 }

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -36,7 +36,7 @@ object MockConsole extends Mock[Console] {
         def putStrErrOrFail(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
         def putStrLnOrFail(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
         def putStrLnErrOrFail(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
-        val getStrLn: IO[IOException, String]                = proxy(GetStrLn)
+        val getStrLn: IO[IOException, String]                      = proxy(GetStrLn)
       }
     )
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -762,7 +762,7 @@ package object test extends CompileVariants {
     def fromConsole: ZLayer[Console, Nothing, TestLogger] =
       ZLayer.fromService { (console: Console.Service) =>
         new Service {
-          def logLine(line: String): UIO[Unit] = console.putStrLn(line).orDie
+          def logLine(line: String): UIO[Unit] = console.putStrLn(line)
         }
       }
 


### PR DESCRIPTION
Creates fallible variants of console operators suffixed with `IO` since they can fail with an `IOException`, similar to the existing `effectBlockingIO` operator. Normal variants become infallible again.