### PR TITLE
Don't Expose Error Type In Console Operators

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -20,7 +20,6 @@ import zio.console.Console
 import zio.internal.stacktracer.ZTraceElement
 import zio.internal.{Executor, FiberRenderer}
 
-import java.io.IOException
 import scala.concurrent.Future
 
 /**
@@ -751,7 +750,7 @@ object Fiber extends FiberPlatformSpecific {
    * Collects a complete dump of the specified fibers and all children of the
    * fibers and renders it to the console.
    */
-  def putDumpStr(label: String, fibers: Fiber.Runtime[_, _]*): ZIO[Console, IOException, Unit] =
+  def putDumpStr(label: String, fibers: Fiber.Runtime[_, _]*): URIO[Console, Unit] =
     dumpStr(fibers: _*).flatMap(str => console.putStrLn(s"$label: ${str}"))
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -570,7 +570,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def exitCode: URIO[R with console.Console, ExitCode] =
     self.foldCauseM(
-      cause => console.putStrLnErr(cause.prettyPrint).ignore as ExitCode.failure,
+      cause => console.putStrLnErr(cause.prettyPrint) as ExitCode.failure,
       _ => ZIO.succeedNow(ExitCode.success)
     )
 

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -25,32 +25,32 @@ package object console {
 
   object Console extends Serializable {
     trait Service extends Serializable {
-      def putStr(line: String): IO[IOException, Unit]
+      def putStr(line: String): UIO[Unit]
 
-      def putStrErr(line: String): IO[IOException, Unit]
+      def putStrErr(line: String): UIO[Unit]
 
-      def putStrLn(line: String): IO[IOException, Unit]
+      def putStrLn(line: String): UIO[Unit]
 
-      def putStrLnErr(line: String): IO[IOException, Unit]
+      def putStrLnErr(line: String): UIO[Unit]
 
       def getStrLn: IO[IOException, String]
     }
 
     object Service {
-      private def putStr(stream: PrintStream)(line: String): IO[IOException, Unit] =
-        IO.effect(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
+      private def putStr(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream)(SConsole.print(line)))
 
-      private def putStrLn(stream: PrintStream)(line: String): IO[IOException, Unit] =
-        IO.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
+      private def putStrLn(stream: PrintStream)(line: String): UIO[Unit] =
+        IO.effectTotal(SConsole.withOut(stream)(SConsole.println(line)))
 
       val live: Service = new Service {
-        def putStr(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
+        def putStr(line: String): UIO[Unit] = Service.putStr(SConsole.out)(line)
 
-        def putStrErr(line: String): IO[IOException, Unit] = Service.putStr(SConsole.err)(line)
+        def putStrErr(line: String): UIO[Unit] = Service.putStr(SConsole.err)(line)
 
-        def putStrLnErr(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.err)(line)
+        def putStrLnErr(line: String): UIO[Unit] = Service.putStrLn(SConsole.err)(line)
 
-        def putStrLn(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
+        def putStrLn(line: String): UIO[Unit] = Service.putStrLn(SConsole.out)(line)
 
         val getStrLn: IO[IOException, String] =
           IO.effect {
@@ -72,25 +72,25 @@ package object console {
   /**
    * Prints text to the console.
    */
-  def putStr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStr line)
 
   /**
    * Prints text to the standard error console.
    */
-  def putStrErr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrErr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrErr line)
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  def putStrLn(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrLn(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrLn line)
 
   /**
    * Prints a line of text to the standard error console, including a newline character.
    */
-  def putStrLnErr(line: => String): ZIO[Console, IOException, Unit] =
+  def putStrLnErr(line: => String): URIO[Console, Unit] =
     ZIO.accessM(_.get putStrLnErr line)
 
   /**

--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -194,7 +194,7 @@ val hub: Hub[Int] = ???
 val hubWithLogging: ZHub[Any, Clock with Console, Nothing, Nothing, Int, Int] =
   hub.mapM { n =>
     clock.currentDateTime.orDie.flatMap { currentDateTime =>
-      console.putStrLn(s"Took message $n from the hub at $currentDateTime").orDie
+      console.putStrLn(s"Took message $n from the hub at $currentDateTime")
     }.as(n)
   }
 ```

--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -165,7 +165,7 @@ object CountRequests extends zio.App {
     for {
       _ <- counter.update(_ + 1)
       reqNumber <- counter.get
-      _ <- putStrLn(s"request number: $reqNumber").orDie
+      _ <- putStrLn(s"request number: $reqNumber")
     } yield ()
   }
 
@@ -175,7 +175,7 @@ object CountRequests extends zio.App {
       ref <- Ref.make(initial)
       _ <- request(ref) zipPar request(ref)
       rn <- ref.get
-      _ <- putStrLn(s"total requests performed: $rn").orDie
+      _ <- putStrLn(s"total requests performed: $rn")
     } yield ()
 
   override def run(args: List[String]) = program.exitCode

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -18,7 +18,7 @@ import zio.console._
 ```
 
 ```scala mdoc:silent
-val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!").orDie
+val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!")
 ```
 
 So finally when we provide a live version of `Console` service to our `effect`, it will be converted to an effect that doesn't require any environmental service:
@@ -34,7 +34,7 @@ import zio.{ExitCode, ZEnv, ZIO}
 import zio.console._
 
 object MainApp extends zio.App {
-  val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!").orDie
+  val effect: ZIO[Console, Nothing, Unit] = putStrLn("Hello, World!")
   val mainApp: ZIO[Any, Nothing, Unit] = effect.provideLayer(Console.live)
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = 
@@ -50,7 +50,7 @@ import zio.random._
 
 val effect: ZIO[Console with Random, Nothing, Unit] = for {
   r <- nextInt
-  _ <- putStrLn(s"random number: $r").orDie
+  _ <- putStrLn(s"random number: $r")
 } yield ()
 
 val mainApp: ZIO[Any, Nothing, Unit] = effect.provideLayer(Console.live ++ Random.live)
@@ -66,7 +66,7 @@ import zio.{ExitCode, ZEnv, ZIO}
 object MainApp extends zio.App {
   val effect: ZIO[Console with Random, Nothing, Unit] = for {
     r <- nextInt
-    _ <- putStrLn(s"random number: $r").orDie
+    _ <- putStrLn(s"random number: $r")
   } yield ()
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
@@ -259,7 +259,7 @@ object logging {
             override def log(line: String): UIO[Unit] =
               for {
                 current <- clock.currentDateTime.orDie
-                _ <- console.putStrLn(current.toString + "--" + line).orDie
+                _ <- console.putStrLn(current.toString + "--" + line)
               } yield ()
           }
       }
@@ -333,7 +333,7 @@ case class LoggingLive(console: Console.Service, clock: Clock.Service) extends L
   override def log(line: String): UIO[Unit] = 
     for {
       current <- clock.currentDateTime.orDie
-      _       <- console.putStrLn(current.toString + "--" + line).orDie
+      _       <- console.putStrLn(current.toString + "--" + line)
     } yield ()
 }
 ```
@@ -460,9 +460,9 @@ import zio.random._
 
 val myApp: ZIO[Random with Console with Clock, Nothing, Unit] = for {
   random  <- nextInt 
-  _       <- putStrLn(s"A random number: ${random.toString}").orDie
+  _       <- putStrLn(s"A random number: ${random.toString}")
   current <- currentDateTime.orDie
-  _       <- putStrLn(s"Current Data Time: ${current.toString}").orDie
+  _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```
 
@@ -528,7 +528,7 @@ object LoggingLive {
 val myApp: ZIO[Has[Logging] with Console with Clock, Nothing, Unit] = for {
   _       <- Logging.log("Application Started!")
   current <- currentDateTime.orDie
-  _       <- putStrLn(s"Current Data Time: ${current.toString}").orDie
+  _       <- putStrLn(s"Current Data Time: ${current.toString}")
 } yield ()
 ```
 

--- a/docs/datatypes/contextual/zlayer.md
+++ b/docs/datatypes/contextual/zlayer.md
@@ -228,7 +228,7 @@ import logging.Logging._
 ```scala mdoc:silent:nest
 val live: ZLayer[Console, Nothing, Logging] = ZLayer.fromService(console =>
   new Service {
-    override def log(msg: String): UIO[Unit] = console.putStrLn(msg).orDie
+    override def log(msg: String): UIO[Unit] = console.putStrLn(msg)
   }
 )
 ```
@@ -356,8 +356,8 @@ object Logging {
   import zio.console.Console
   val consoleLogger: ZLayer[Console, Nothing, Logging] = ZLayer.fromFunction( console =>
     new Service {
-      def info(s: String): UIO[Unit]  = console.get.putStrLn(s"info - $s").orDie
-      def error(s: String): UIO[Unit] = console.get.putStrLn(s"error - $s").orDie
+      def info(s: String): UIO[Unit]  = console.get.putStrLn(s"info - $s")
+      def error(s: String): UIO[Unit] = console.get.putStrLn(s"error - $s")
     }
   )
 

--- a/docs/datatypes/core/urio.md
+++ b/docs/datatypes/core/urio.md
@@ -26,12 +26,10 @@ In following example, the type of `putStrLn` is `URIO[Console, Unit]` which mean
 ```scala mdoc:invisible:reset
 import zio._
 import zio.console._
-
-import java.io.IOException
 ```
 
 ```scala mdoc:silent
-def putStrLn(line: => String): ZIO[Console, IOException, Unit] =
+def putStrLn(line: => String): URIO[Console, Unit] =
   ZIO.accessM(_.get putStrLn line)
 ```
 

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -437,7 +437,7 @@ Asynchronous ZIO effects are much easier to use than callback-based APIs, and th
 A `RIO[R, A]` effect can be suspended using `effectSuspend` function:
 
 ```scala mdoc:silent
-val suspendedEffect: RIO[Any, ZIO[Console, IOException, Unit]] =
+val suspendedEffect: RIO[Any, URIO[Console, Unit]] =
   ZIO.effectSuspend(ZIO.effect(putStrLn("Suspended Hello World!")))
 ```
 

--- a/docs/datatypes/misc/schedule.md
+++ b/docs/datatypes/misc/schedule.md
@@ -314,7 +314,7 @@ Whenever we need to effectfully process each schedule input/output, we can use `
 We can use these two functions for logging purposes:
 
 ```scala mdoc:silent
-val tappedSchedule = Schedule.count.whileOutput(_ < 5).tapOutput(o => putStrLn(s"retrying $o").orDie)
+val tappedSchedule = Schedule.count.whileOutput(_ < 5).tapOutput(o => putStrLn(s"retrying $o"))
 ```
 
 

--- a/docs/datatypes/resource/managed.md
+++ b/docs/datatypes/resource/managed.md
@@ -55,8 +55,8 @@ val managedFromValue: Managed[Nothing, Int] = Managed.succeed(3)
 import zio._
 import zio.console._
 
-val zManagedResource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring").orDie)(_ => console.putStrLn("releasing").orDie)
-val zUsedResource: URIO[Console, Unit] = zManagedResource.use { _ => console.putStrLn("running").orDie }
+val zManagedResource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring"))(_ => console.putStrLn("releasing"))
+val zUsedResource: URIO[Console, Unit] = zManagedResource.use { _ => console.putStrLn("running") }
 ```
 
 ## Combining Managed

--- a/docs/datatypes/stm/treentrantlock.md
+++ b/docs/datatypes/stm/treentrantlock.md
@@ -115,9 +115,9 @@ import zio.duration._
 
 val writeLockDemoProgram: URIO[Console with Clock, Unit] = for {
   l  <- TReentrantLock.make.commit
-  _  <- putStrLn("Beginning test").orDie
+  _  <- putStrLn("Beginning test")
   f1 <- (l.acquireRead.commit *> ZIO.sleep(5.seconds) *> l.releaseRead.commit).fork
-  f2 <- (l.acquireRead.commit *> putStrLn("read-lock").orDie *> l.acquireWrite.commit *> putStrLn("I have upgraded!").orDie).fork
+  f2 <- (l.acquireRead.commit *> putStrLn("read-lock") *> l.acquireWrite.commit *> putStrLn("I have upgraded!")).fork
   _  <- (f1 zip f2).join
 } yield ()
 ```
@@ -143,8 +143,8 @@ import zio.duration._
 
 val saferProgram: URIO[Console with Clock, Unit] = for {
   lock <- TReentrantLock.make.commit
-  f1   <- lock.readLock.use_(ZIO.sleep(5.seconds) *> putStrLn("Powering down").orDie).fork
-  f2   <- lock.readLock.use_(lock.writeLock.use_(putStrLn("Huzzah, writes are mine").orDie)).fork
+  f1   <- lock.readLock.use_(ZIO.sleep(5.seconds) *> putStrLn("Powering down")).fork
+  f2   <- lock.readLock.use_(lock.writeLock.use_(putStrLn("Huzzah, writes are mine"))).fork
   _    <- (f1 zip f2).join
 } yield ()
 ```

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -49,7 +49,7 @@ import zio._
 import zio.console.Console
 
 def processEvent(event: Event): URIO[Console, Unit] =
-  console.putStrLn(s"Got $event").orDie
+  console.putStrLn(s"Got $event")
 ```
 
 With ZIO, we've regained to ability to reason about the effects called. We know that `processEvent` can only call on _capabilities_ of `Console`, so even though we still have `Unit` as the result, we have narrowed the possible effects space to a few.
@@ -215,13 +215,13 @@ object AccountObserver {
       new Service {
         def processEvent(event: AccountEvent): UIO[Unit] =
           for {
-            _    <- console.putStrLn(s"Got $event").orDie
+            _    <- console.putStrLn(s"Got $event")
             line <- console.getStrLn.orDie
-            _    <- console.putStrLn(s"You entered: $line").orDie
+            _    <- console.putStrLn(s"You entered: $line")
           } yield ()
 
         def runCommand(): UIO[Unit] =
-          console.putStrLn("Done!").orDie
+          console.putStrLn("Done!")
       }
     }
 }

--- a/docs/services/blocking.md
+++ b/docs/services/blocking.md
@@ -14,7 +14,7 @@ In the following example, we create 20 blocking tasks to run parallel on the pri
 import zio.{ZIO, URIO}
 import zio.console._
 def blockingTask(n: Int): URIO[Console, Unit] =
-  putStrLn(s"running blocking task number $n").orDie *>
+  putStrLn(s"running blocking task number $n") *>
     ZIO.effectTotal(Thread.sleep(3000)) *>
     blockingTask(n)
 

--- a/docs/services/clock.md
+++ b/docs/services/clock.md
@@ -28,7 +28,7 @@ Also, the Clock service has a very useful functionality for sleeping and creatin
 In following example we are going to print the current time periodically by placing a one second`sleep` between each print call:
 
 ```scala mdoc:silent
-def printTimeForever: ZIO[Console with Clock, Throwable, Nothing] =
+def printTimeForever: ZIO[Console with Clock, DateTimeException, Nothing] =
   currentDateTime.flatMap(time => putStrLn(time.toString)) *>
     sleep(1.seconds) *> printTimeForever
 ```

--- a/docs/usecases/scheduling.md
+++ b/docs/usecases/scheduling.md
@@ -56,8 +56,8 @@ import zio.Schedule.Decision
 
 object ScheduleUtil {
   def schedule[A] = Schedule.spaced(1.second) && Schedule.recurs(4).onDecision({
-    case Decision.Done(_)                 => putStrLn(s"done trying").orDie
-    case Decision.Continue(attempt, _, _) => putStrLn(s"attempt #$attempt").orDie
+    case Decision.Done(_)                 => putStrLn(s"done trying")
+    case Decision.Continue(attempt, _, _) => putStrLn(s"attempt #$attempt")
   })
 }
 ```

--- a/docs/usecases/testing.md
+++ b/docs/usecases/testing.md
@@ -23,12 +23,10 @@ import zio.test._
 import zio.test.Assertion._
 import zio.test.environment._
 
-import java.io.IOException
-
 import HelloWorld._
 
 object HelloWorld {
-  def sayHello: ZIO[Console, IOException, Unit] =
+  def sayHello: URIO[Console, Unit] =
     console.putStrLn("Hello, World!")
 }
 

--- a/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2.x/zio/examples/macros/AccessibleMacroExample.scala
@@ -43,7 +43,7 @@ object AccessibleMacroExample {
         val foo: UIO[Unit]                                              = UIO.unit
         def foo2: UIO[Unit]                                             = UIO.unit
         def foo3(): UIO[Unit]                                           = UIO.unit
-        def bar(n: Int): UIO[Unit]                                      = console.putStrLn(s"bar $n").orDie
+        def bar(n: Int): UIO[Unit]                                      = console.putStrLn(s"bar $n")
         def baz(x: Int, y: Int): IO[String, Int]                        = UIO.succeed(x + y)
         def poly[A](a: A): IO[Long, A]                                  = UIO.succeed(a)
         def poly2[A <: Foo](a: Wrapped[A]): IO[String, List[A]]         = UIO.succeed(List(a.value))

--- a/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
@@ -12,7 +12,7 @@ object LayerDefinitionExample extends App {
       (FooLive.apply _).toLayer
 
     case class FooLive(console: Console.Service, string: String, int: Int) extends Foo {
-      override def bar: UIO[Unit] = console.putStrLn(s"$string and $int").orDie
+      override def bar: UIO[Unit] = console.putStrLn(s"$string and $int")
     }
   }
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -8,8 +8,6 @@ import zio.system.System
 import zio.test.{Assertion, ZIOBaseSpec, ZSpec, assertM}
 import zio.{Has, Tag, ULayer, ZIO, clock, console, random, system}
 
-import java.io.IOException
-
 object ComposedMockSpec extends ZIOBaseSpec {
 
   import Assertion._
@@ -37,7 +35,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
             _    <- console.putStrLn(time.toString)
           } yield ()
 
-        testValueComposed[Clock with Console, IOException, Unit]("Console with Clock")(composed, program, isUnit)
+        testValueComposed[Clock with Console, Nothing, Unit]("Console with Clock")(composed, program, isUnit)
       }, {
         val cmd1 = MockRandom.NextInt(value(42))
         val cmd2 = MockClock.Sleep(equalTo(42.seconds))

--- a/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
@@ -5,8 +5,6 @@ import zio.test.mock.internal.MockException
 import zio.test.{Assertion, ZIOBaseSpec, ZSpec}
 import zio.{ZIO, console}
 
-import java.io.IOException
-
 object EmptyMockSpec extends ZIOBaseSpec with MockSpecUtils[Console] {
 
   import Assertion._
@@ -20,8 +18,8 @@ object EmptyMockSpec extends ZIOBaseSpec with MockSpecUtils[Console] {
         isUnit
       ), {
 
-        type M = Capability[Console, String, IOException, Unit]
-        type X = UnexpectedCallException[Console, String, IOException, Unit]
+        type M = Capability[Console, String, Nothing, Unit]
+        type X = UnexpectedCallException[Console, String, Nothing, Unit]
 
         testDied("should fail when call happened")(
           MockConsole.empty,

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -224,7 +224,7 @@ object TestAspect extends TimeoutVariants {
             )
           }
         def dump[E, A](label: String): URIO[Live with Annotations, Unit] =
-          Annotations.supervisedFibers.flatMap(fibers => Live.live(Fiber.putDumpStr(label, fibers.toSeq: _*).orDie))
+          Annotations.supervisedFibers.flatMap(fibers => Live.live(Fiber.putDumpStr(label, fibers.toSeq: _*)))
         spec.transform[R, TestFailure[E], TestSuccess] {
           case c @ Spec.SuiteCase(_, _, _) => c
           case Spec.TestCase(label, test, annotations) =>

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -62,7 +62,7 @@ trait TimeoutVariants {
     testLabel: String,
     duration: Duration
   ): URIO[Live, Unit] =
-    Live.live(console.putStrLn(renderWarning(suiteLabels, testLabel, duration)).orDie)
+    Live.live(console.putStrLn(renderWarning(suiteLabels, testLabel, duration)))
 
   private def renderWarning(suiteLabels: List[String], testLabel: String, duration: Duration): String =
     (renderSuiteLabels(suiteLabels) + renderTest(testLabel, duration)).capitalize

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -563,9 +563,9 @@ package object environment extends PlatformSpecific {
 
     object WarningData {
 
-      case object Start                                         extends WarningData
-      final case class Pending(fiber: Fiber[IOException, Unit]) extends WarningData
-      case object Done                                          extends WarningData
+      case object Start                                     extends WarningData
+      final case class Pending(fiber: Fiber[Nothing, Unit]) extends WarningData
+      case object Done                                      extends WarningData
 
       /**
        * State indicating that a test has not used time.
@@ -577,7 +577,7 @@ package object environment extends PlatformSpecific {
        * `TestClock` with a reference to the fiber that will display the
        * warning message.
        */
-      def pending(fiber: Fiber[IOException, Unit]): WarningData = Pending(fiber)
+      def pending(fiber: Fiber[Nothing, Unit]): WarningData = Pending(fiber)
 
       /**
        * State indicating that a test has used time or the warning message has
@@ -713,7 +713,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the output buffer.
        */
-      override def putStr(line: String): IO[IOException, Unit] =
+      override def putStr(line: String): UIO[Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ line, data.errOutput)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -721,7 +721,7 @@ package object environment extends PlatformSpecific {
       /**
        * Writes the specified string to the error buffer.
        */
-      override def putStrErr(line: String): IO[IOException, Unit] =
+      override def putStrErr(line: String): UIO[Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ line)
         } *> live.provide(console.putStr(line)).whenM(debugState.get)
@@ -730,7 +730,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the output buffer followed by a newline
        * character.
        */
-      override def putStrLn(line: String): IO[IOException, Unit] =
+      override def putStrLn(line: String): UIO[Unit] =
         consoleState.update { data =>
           Data(data.input, data.output :+ s"$line\n", data.errOutput)
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)
@@ -739,7 +739,7 @@ package object environment extends PlatformSpecific {
        * Writes the specified string to the error buffer followed by a newline
        * character.
        */
-      override def putStrLnErr(line: String): IO[IOException, Unit] =
+      override def putStrLnErr(line: String): UIO[Unit] =
         consoleState.update { data =>
           Data(data.input, data.output, data.errOutput :+ s"$line\n")
         } *> live.provide(console.putStrLn(line)).whenM(debugState.get)

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -17,26 +17,26 @@
 package zio.test.mock
 
 import zio.console.Console
-import zio.{Has, IO, URLayer, ZLayer}
+import zio.{Has, IO, UIO, URLayer, ZLayer}
 
 import java.io.IOException
 
 object MockConsole extends Mock[Console] {
 
-  object PutStr      extends Effect[String, IOException, Unit]
-  object PutStrErr   extends Effect[String, IOException, Unit]
-  object PutStrLn    extends Effect[String, IOException, Unit]
-  object PutStrLnErr extends Effect[String, IOException, Unit]
+  object PutStr      extends Effect[String, Nothing, Unit]
+  object PutStrErr   extends Effect[String, Nothing, Unit]
+  object PutStrLn    extends Effect[String, Nothing, Unit]
+  object PutStrLnErr extends Effect[String, Nothing, Unit]
   object GetStrLn    extends Effect[Unit, IOException, String]
 
   val compose: URLayer[Has[Proxy], Console] =
     ZLayer.fromService(proxy =>
       new Console.Service {
-        def putStr(line: String): IO[IOException, Unit]      = proxy(PutStr, line)
-        def putStrErr(line: String): IO[IOException, Unit]   = proxy(PutStrErr, line)
-        def putStrLn(line: String): IO[IOException, Unit]    = proxy(PutStrLn, line)
-        def putStrLnErr(line: String): IO[IOException, Unit] = proxy(PutStrLnErr, line)
-        val getStrLn: IO[IOException, String]                = proxy(GetStrLn)
+        def putStr(line: String): UIO[Unit]      = proxy(PutStr, line)
+        def putStrErr(line: String): UIO[Unit]   = proxy(PutStrErr, line)
+        def putStrLn(line: String): UIO[Unit]    = proxy(PutStrLn, line)
+        def putStrLnErr(line: String): UIO[Unit] = proxy(PutStrLnErr, line)
+        val getStrLn: IO[IOException, String]    = proxy(GetStrLn)
       }
     )
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -762,7 +762,7 @@ package object test extends CompileVariants {
     def fromConsole: ZLayer[Console, Nothing, TestLogger] =
       ZLayer.fromService { (console: Console.Service) =>
         new Service {
-          def logLine(line: String): UIO[Unit] = console.putStrLn(line).orDie
+          def logLine(line: String): UIO[Unit] = console.putStrLn(line)
         }
       }
 


### PR DESCRIPTION
I opened a separate PR against the `series/2.x` branch to expose separate fallible and infallible variants of console operators. I think given binary compatibility constraints it makes the most sense to revert to the previous behavior on `master` and explore improvements to the `Console` service on the `series/2.x` branch.