### PR TITLE
Implement Accessor trait for simple macro-less accessor methods

### DIFF
--- a/core/shared/src/main/scala/zio/Accessor.scala
+++ b/core/shared/src/main/scala/zio/Accessor.scala
@@ -1,0 +1,28 @@
+package zio
+
+/**
+ * A simple, macro-less means of creating accessors from Services. Extend
+ * the companion object with `Accessor[ServiceName]`, then simply call
+ * `Companion(_.someMethod)`, to return a ZIO effect that requires the
+ * Service in its environment.
+ *
+ * Example:
+ * {{{
+ *   trait FooService {
+ *     def magicNumber: UIO[Int]
+ *     def castSpell(chant: String): UIO[Boolean]
+ *   }
+ *
+ *   object FooService extends Accessor[FooService]
+ *
+ *   val example: ZIO[Has[FooService], Nothing, String] =
+ *     for {
+ *       int  <- FooService(_.magicNumber)
+ *       bool <- FooService(_.castSpell("Oogabooga!"))
+ *     } yield s"$int and $bool"
+ * }}}
+ */
+trait Accessor[R] {
+  def apply[E, A](f: R => ZIO[Any, E, A])(implicit tag: Tag[R]): ZIO[Has[R], E, A] =
+    ZIO.serviceWith[R](f)
+}

--- a/core/shared/src/main/scala/zio/Accessor.scala
+++ b/core/shared/src/main/scala/zio/Accessor.scala
@@ -15,11 +15,11 @@ package zio
  *
  *   object FooService extends Accessor[FooService]
  *
- *   val example: ZIO[Has[FooService], Nothing, String] =
+ *   val example: ZIO[Has[FooService], Nothing, Unit] =
  *     for {
  *       int  <- FooService(_.magicNumber)
  *       bool <- FooService(_.castSpell("Oogabooga!"))
- *     } yield s"$int and $bool"
+ *     } yield ()
  * }}}
  */
 trait Accessor[R] {


### PR DESCRIPTION
A simple, macro-less means of creating accessors from Services. Extend the companion object with `Accessor[ServiceName]`, then simply call`Companion(_.someMethod)`, to return a ZIO effect that requires the Service in its environment.

Example: 
```scala
trait FooService {
  def magicNumber: UIO[Int]
  def castSpell(chant: String): UIO[Boolean]
}

object FooService extends Accessor[FooService]

object Example {
  val program: ZIO[Has[FooService], Nothing, String] = for {
    int  <- FooService(_.magicNumber)
    bool <- FooService(_.castSpell("Oogabooga!"))
  } yield s"$int and $bool"
}
```