### PR TITLE
Implement ZIO.debug

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -243,6 +243,12 @@ object IO {
     ZIO.cond(predicate, result, error)
 
   /**
+   * @see See [[zio.ZIO.cond]]
+   */
+  def debug(message: String): UIO[Unit] =
+    ZIO.debug(message)
+
+  /**
    * @see See [[zio.ZIO.descriptor]]
    */
   def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -249,6 +249,12 @@ object Task extends TaskPlatformSpecific {
     ZIO.cond(predicate, result, error)
 
   /**
+   * @see See [[zio.ZIO.cond]]
+   */
+  def debug(message: String): UIO[Unit] =
+    ZIO.debug(message)
+
+  /**
    * @see See [[zio.ZIO.die]]
    */
   def die(t: => Throwable): UIO[Nothing] = ZIO.die(t)

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -238,6 +238,12 @@ object UIO {
     ZIO.collectParN(n)(in)(f)
 
   /**
+   * @see See [[zio.ZIO.cond]]
+   */
+  def debug(message: String): UIO[Unit] =
+    ZIO.debug(message)
+
+  /**
    * @see See [[zio.ZIO.descriptor]]
    */
   def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -255,6 +255,12 @@ object URIO {
     ZIO.collectParN(n)(in)(f)
 
   /**
+   * @see See [[zio.ZIO.cond]]
+   */
+  def debug(message: String): UIO[Unit] =
+    ZIO.debug(message)
+
+  /**
    * @see [[zio.ZIO.descriptor]]
    */
   def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2576,6 +2576,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     if (predicate) ZIO.succeed(result) else ZIO.fail(error)
 
   /**
+   * Prints the specified message to the console for debugging purposes.
+   */
+  def debug(message: String): UIO[Unit] =
+    ZIO.effectTotal(println(message))
+
+  /**
    * Returns information about the current fiber, such as its identity.
    */
   def descriptor: UIO[Fiber.Descriptor] = descriptorWith(succeedNow)


### PR DESCRIPTION
Static version of `debug` for when you just want to print something to the console for debugging purposes without introducing additional environmental requirements or error types.