### PR TITLE
Fix IO operations returning Tasks

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1978,7 +1978,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       testM("effect, bind, map") {
         def fibIo(n: Int): Task[BigInt] =
-          if (n <= 1) IO.effect(n)
+          if (n <= 1) Task.effect(n)
           else
             for {
               a <- fibIo(n - 1)
@@ -2043,7 +2043,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("RTS failure")(
       testM("error in sync effect") {
-        val io = IO.effect[Unit](throw ExampleError).fold[Option[Throwable]](Some(_), _ => None)
+        val io = Task.effect[Unit](throw ExampleError).fold[Option[Throwable]](Some(_), _ => None)
         assertM(io)(isSome(equalTo(ExampleError)))
       } @@ zioTag(errors),
       testM("attempt . fail") {
@@ -3791,7 +3791,7 @@ object ZIOSpec extends ZIOBaseSpec {
   }
 
   def deepErrorEffect(n: Int): Task[Unit] =
-    if (n == 0) IO.effect(throw ExampleError)
+    if (n == 0) Task.effect(throw ExampleError)
     else IO.unit *> deepErrorEffect(n - 1)
 
   def deepErrorFail(n: Int): Task[Unit] =

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -38,7 +38,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): Task[A] = ZIO.apply(a)
+  def apply[A](a: => A): IO[Any, A] = ZIO.apply(a)
 
   /**
    * @see See bracket [[zio.ZIO]]
@@ -277,7 +277,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  def effect[A](effect: => A): IO[Any, A] = ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
@@ -593,7 +593,7 @@ object IO {
   /**
    * @see [[zio.ZIO.fromFunctionFuture]]
    */
-  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
+  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): IO[Throwable, A] =
     ZIO.fromFunctionFuture(f)
 
   /**
@@ -604,13 +604,13 @@ object IO {
   /**
    * @see See [[zio.ZIO.fromFuture]]
    */
-  def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): IO[Throwable, A] =
     ZIO.fromFuture(make)
 
   /**
    * @see See [[zio.ZIO.fromFutureInterrupt]]
    */
-  def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
+  def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): IO[Throwable, A] =
     ZIO.fromFutureInterrupt(make)
 
   /**
@@ -626,7 +626,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.fromTry]]
    */
-  def fromTry[A](value: => scala.util.Try[A]): Task[A] =
+  def fromTry[A](value: => scala.util.Try[A]): IO[Throwable, A] =
     ZIO.fromTry(value)
 
   /**

--- a/core/shared/src/main/scala/zio/console/package.scala
+++ b/core/shared/src/main/scala/zio/console/package.scala
@@ -38,10 +38,10 @@ package object console {
 
     object Service {
       private def putStr(stream: PrintStream)(line: String): IO[IOException, Unit] =
-        IO.effect(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
+        Task.effect(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
 
       private def putStrLn(stream: PrintStream)(line: String): IO[IOException, Unit] =
-        IO.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
+        Task.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
 
       val live: Service = new Service {
         def putStr(line: String): IO[IOException, Unit] = Service.putStr(SConsole.out)(line)
@@ -53,7 +53,7 @@ package object console {
         def putStrLn(line: String): IO[IOException, Unit] = Service.putStrLn(SConsole.out)(line)
 
         val getStrLn: IO[IOException, String] =
-          IO.effect {
+          Task.effect {
             val line = StdIn.readLine()
 
             if (line ne null) line

--- a/core/shared/src/main/scala/zio/system/package.scala
+++ b/core/shared/src/main/scala/zio/system/package.scala
@@ -50,7 +50,7 @@ package object system {
       val live: Service = new Service {
 
         def env(variable: String): IO[SecurityException, Option[String]] =
-          IO.effect(Option(JSystem.getenv(variable))).refineToOrDie[SecurityException]
+          Task.effect(Option(JSystem.getenv(variable))).refineToOrDie[SecurityException]
 
         def envOrElse(variable: String, alt: => String): IO[SecurityException, String] =
           envOrElseWith(variable, alt)(env)
@@ -60,21 +60,21 @@ package object system {
 
         @silent("JavaConverters")
         val envs: IO[SecurityException, Map[String, String]] =
-          IO.effect(JSystem.getenv.asScala.toMap).refineToOrDie[SecurityException]
+          Task.effect(JSystem.getenv.asScala.toMap).refineToOrDie[SecurityException]
 
         val lineSeparator: UIO[String] = IO.effectTotal(JSystem.lineSeparator)
 
         @silent("JavaConverters")
-        val properties: IO[Throwable, Map[String, String]] =
-          IO.effect(JSystem.getProperties.asScala.toMap)
+        val properties: Task[Map[String, String]] =
+          Task.effect(JSystem.getProperties.asScala.toMap)
 
-        def property(prop: String): IO[Throwable, Option[String]] =
-          IO.effect(Option(JSystem.getProperty(prop)))
+        def property(prop: String): Task[Option[String]] =
+          Task.effect(Option(JSystem.getProperty(prop)))
 
-        def propertyOrElse(prop: String, alt: => String): IO[Throwable, String] =
+        def propertyOrElse(prop: String, alt: => String): Task[String] =
           propertyOrElseWith(prop, alt)(property)
 
-        def propertyOrOption(prop: String, alt: => Option[String]): IO[Throwable, Option[String]] =
+        def propertyOrOption(prop: String, alt: => Option[String]): Task[Option[String]] =
           propertyOrOptionWith(prop, alt)(property)
       }
     }


### PR DESCRIPTION
Some of the `IO` operations such as `apply` and `effect` were returning `Task`, effectively setting the error as `Throwable` instead of `Any`. This caused some confusion when working with error hierarchies that does not descend from `Throwable` or `Exception`. This fix corrects the return types in `IO.scala` and follows up in all compiler related issues.