### PR TITLE
Improve Support For Layers Run For Their Effects

### DIFF
--- a/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/NeedsEnvSpec.scala
@@ -23,7 +23,7 @@ object NeedsEnvSpec extends ZIOBaseSpec {
             import zio._
             import zio.console._
             val uio = UIO.succeed("Hello, World!")
-            uio.provideLayer(Console.live)
+            uio.provideLayer(Console.Service.live)
             """
       }
       assertM(result)(isLeft(anything))

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -288,10 +288,7 @@ object Runtime {
    * legacy code, but other applications should investigate using
    * [[ZIO.provideLayer]] directly in their application entry points.
    */
-  def unsafeFromLayer[R <: Has[_]](
-    layer: Layer[Any, R],
-    platform: Platform = Platform.default
-  ): Runtime.Managed[R] = {
+  def unsafeFromLayer[R](layer: Layer[Any, R], platform: Platform = Platform.default): Runtime.Managed[R] = {
     val runtime = Runtime((), platform)
     val (environment, shutdown) = runtime.unsafeRun {
       ZManaged.ReleaseMap.make.flatMap { releaseMap =>

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -561,7 +561,7 @@ sealed abstract class Schedule[-Env, -In, +Out] private (
    */
   def provideLayer[Env0, Env1](
     layer: ZLayer[Env0, Nothing, Env1]
-  )(implicit ev1: Env1 <:< Env, ev2: NeedsEnv[Env]): Schedule[Env0, In, Out] = {
+  )(implicit ev: Env1 <:< Env): Schedule[Env0, In, Out] = {
     def loop(self: StepFunction[Env, In, Out]): StepFunction[Env0, In, Out] =
       (now: OffsetDateTime, in: In) =>
         self(now, in).map {
@@ -591,16 +591,16 @@ sealed abstract class Schedule[-Env, -In, +Out] private (
    * Provides the part of the environment that is not part of the `ZEnv`,
    * leaving a schedule that only depends on the `ZEnv`.
    */
-  final def provideCustomLayer[Env1 <: Has[_]](
+  final def provideCustomLayer[Env1](
     layer: ZLayer[ZEnv, Nothing, Env1]
-  )(implicit ev: ZEnv with Env1 <:< Env, tagged: Tag[Env1]): Schedule[ZEnv, In, Out] =
+  )(implicit ev1: ZEnv with Env1 <:< Env, ev2: Has.Union[ZEnv, Env1], tagged: Tag[Env1]): Schedule[ZEnv, In, Out] =
     provideSomeLayer[ZEnv](layer)
 
   /**
    * Splits the environment into two parts, providing one part using the
    * specified layer and leaving the remainder `Env0`.
    */
-  final def provideSomeLayer[Env0 <: Has[_]]: Schedule.ProvideSomeLayer[Env0, Env, In, Out] =
+  final def provideSomeLayer[Env0]: Schedule.ProvideSomeLayer[Env0, Env, In, Out] =
     new Schedule.ProvideSomeLayer[Env0, Env, In, Out](self)
 
   /**
@@ -1403,11 +1403,10 @@ object Schedule {
     ) extends Decision[Env, In, Out]
   }
 
-  final class ProvideSomeLayer[Env0 <: Has[_], -Env, -In, +Out](private val self: Schedule[Env, In, Out])
-      extends AnyVal {
-    def apply[Env1 <: Has[_]](
+  final class ProvideSomeLayer[Env0, -Env, -In, +Out](private val self: Schedule[Env, In, Out]) extends AnyVal {
+    def apply[Env1](
       layer: ZLayer[Env0, Nothing, Env1]
-    )(implicit ev1: Env0 with Env1 <:< Env, ev2: NeedsEnv[Env], tagged: Tag[Env1]): Schedule[Env0, In, Out] =
+    )(implicit ev1: Env0 with Env1 <:< Env, ev2: Has.Union[Env0, Env1], tagged: Tag[Env1]): Schedule[Env0, In, Out] =
       self.provideLayer[Env0, Env0 with Env1](ZLayer.identity[Env0] ++ layer)
   }
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2101,7 +2101,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .run
                 .map(_.interrupted)
             )(equalTo(false))
-          } @@ nonFlaky(10) @@ TestAspect.jvmOnly,
+          } @@ TestAspect.jvmOnly,
           testM("interrupts pending tasks when one of the tasks fails") {
             for {
               interrupted <- Ref.make(0)

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -1809,17 +1809,15 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * val stream2 = stream.provideCustomLayer(loggingLayer)
    * }}}
    */
-  def provideCustomLayer[E1 >: E, R1 <: Has[_]](
+  def provideCustomLayer[E1 >: E, R1](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZStream[ZEnv, E1, A] =
+  )(implicit ev1: ZEnv with R1 <:< R, ev2: Has.Union[ZEnv, R1], tagged: Tag[R1]): ZStream[ZEnv, E1, A] =
     provideSomeLayer[ZEnv](layer)
 
   /**
    * Provides a layer to the stream, which translates it to another level.
    */
-  final def provideLayer[E1 >: E, R0, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZStream[R0, E1, A] =
+  final def provideLayer[E1 >: E, R0, R1](layer: ZLayer[R0, E1, R1])(implicit ev: R1 <:< R): ZStream[R0, E1, A] =
     new ZStream(ZChannel.managed(layer.build) { r =>
       self.channel.provide(r)
     })
@@ -1845,7 +1843,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * val stream2 = stream.provideSomeLayer[Random](clockLayer)
    * }}}
    */
-  final def provideSomeLayer[R0 <: Has[_]]: ZStream.ProvideSomeLayer[R0, R, E, A] =
+  final def provideSomeLayer[R0]: ZStream.ProvideSomeLayer[R0, R, E, A] =
     new ZStream.ProvideSomeLayer[R0, R, E, A](self)
 
   /**
@@ -3604,10 +3602,10 @@ object ZStream {
       }
   }
 
-  final class ProvideSomeLayer[R0 <: Has[_], -R, +E, +A](private val self: ZStream[R, E, A]) extends AnyVal {
-    def apply[E1 >: E, R1 <: Has[_]](
+  final class ProvideSomeLayer[R0, -R, +E, +A](private val self: ZStream[R, E, A]) extends AnyVal {
+    def apply[E1 >: E, R1](
       layer: ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZStream[R0, E1, A] =
+    )(implicit ev1: R0 with R1 <:< R, ev2: Has.Union[R0, R1], tagged: Tag[R1]): ZStream[R0, E1, A] =
       self.provideLayer[E1, R0, R0 with R1](ZLayer.identity[R0] ++ layer)
   }
 

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -29,7 +29,6 @@ object SpecSpec extends ZIOBaseSpec {
     ),
     suite("provideLayerShared")(
       testM("gracefully handles fiber death") {
-        implicit val needsEnv = NeedsEnv
         val spec = suite("suite")(
           test("test") {
             assert(true)(isTrue)

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -23,7 +23,7 @@ import zio.{Has, URIO}
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {
 
-  type Environment <: Has[_]
+  type Environment
   type Failure
 
   def aspects: List[TestAspect[Nothing, Environment, Nothing, Any]]

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -17,8 +17,8 @@
 package zio.test
 
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
-import zio.clock.Clock
 import zio.URIO
+import zio.clock.Clock
 
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
 import zio.clock.Clock
-import zio.{Has, URIO}
+import zio.URIO
 
 @EnableReflectiveInstantiation
 abstract class AbstractRunnableSpec {

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.clock.Clock
-import zio.{Has, URIO}
+import zio.URIO
 
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -16,8 +16,8 @@
 
 package zio.test
 
-import zio.clock.Clock
 import zio.URIO
+import zio.clock.Clock
 
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -22,7 +22,7 @@ import zio.{Has, URIO}
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
  */
-abstract class RunnableSpec[R <: Has[_], E] extends AbstractRunnableSpec {
+abstract class RunnableSpec[R, E] extends AbstractRunnableSpec {
   override type Environment = R
   override type Failure     = E
 

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -16,13 +16,13 @@
 
 package zio.test
 
-import zio.{ExecutionStrategy, Has, Layer, UIO, ZIO}
+import zio.{ExecutionStrategy, Layer, UIO, ZIO}
 
 /**
  * A `TestExecutor[R, E]` is capable of executing specs that require an
  * environment `R` and may fail with an `E`.
  */
-abstract class TestExecutor[+R <: Has[_], E] {
+abstract class TestExecutor[+R, E] {
   def run(spec: ZSpec[R, E], defExec: ExecutionStrategy): UIO[ExecutedSpec[E]]
   def environment: Layer[Nothing, R]
 }

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -27,7 +27,7 @@ import zio.test.render.TestRenderer
  * require an environment `R` and may fail with an error `E`. Test runners
  * require a test executor, a platform, and a reporter.
  */
-final case class TestRunner[R <: Has[_], E](
+final case class TestRunner[R, E](
   executor: TestExecutor[R, E],
   platform: Platform = Platform.makeDefault().withReportFailure(_ => ()),
   reporter: TestReporter[E] = DefaultTestReporter(TestRenderer.default, TestAnnotationRenderer.default),


### PR DESCRIPTION
We are seeing more uses for layers provided purely for their effects (e.g starting some background process). Ideally we would like these layers to produce a value of type `Any` but this does not compose well with many existing operators that expect the environment to be a subtype of `Has`. We already have the tool to deal with this in the form of the `Has.Union` abstraction but we are not using this as broadly as we could be.

This PR addresses that by replacing constraints that the environment is a subtype of `Has` with constraints that an instance of `Has.Union` exists. It also lifts the requirement that layers cannot be provided to an effect with an environment type of `Any` since it can still make sense to provide a layer for its effects.