### PR TITLE
Add methods to access socket addresses on Connection

### DIFF
--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -21,7 +21,7 @@ import zio.blocking.{Blocking, effectBlocking, effectBlockingIO}
 import zio.stream.compression._
 
 import java.io._
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import java.nio.channels.{AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler, FileChannel}
 import java.nio.file.StandardOpenOption._
 import java.nio.file.{OpenOption, Path}
@@ -488,6 +488,17 @@ trait ZStreamPlatformSpecificConstructors {
    * Accepted connection made to a specific channel `AsynchronousServerSocketChannel`
    */
   class Connection(socket: AsynchronousSocketChannel) {
+
+    /**
+     * The remote address, i.e. the connected client
+     */
+    def remoteAddress: SocketAddress = socket.getRemoteAddress
+
+    /**
+     * The local address, i.e. our server
+     *
+     */
+    def localAddress: SocketAddress = socket.getLocalAddress
 
     /**
      * Read the entire `AsynchronousSocketChannel` by emitting a `Chunk[Byte]`

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -492,13 +492,20 @@ trait ZStreamPlatformSpecificConstructors {
     /**
      * The remote address, i.e. the connected client
      */
-    def remoteAddress: SocketAddress = socket.getRemoteAddress
+    def remoteAddress: IO[IOException, Option[SocketAddress]] = IO
+      .effect(
+        Option(socket.getRemoteAddress)
+      )
+      .refineToOrDie[IOException]
 
     /**
      * The local address, i.e. our server
-     *
      */
-    def localAddress: SocketAddress = socket.getLocalAddress
+    def localAddress: IO[IOException, Option[SocketAddress]] = IO
+      .effect(
+        Option(socket.getLocalAddress)
+      )
+      .refineToOrDie[IOException]
 
     /**
      * Read the entire `AsynchronousSocketChannel` by emitting a `Chunk[Byte]`


### PR DESCRIPTION
Some use cases need the identity of the connected client.
That is provided by `remoteAddress`.

Added `localAddress` for completeness.