### PR TITLE
Show all failures in the presence of a mock exception in the report

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -56,7 +56,7 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
       testM("correctly reports failures in presence of a mock") {
         assertM(runLog(mock5).map(_.linesIterator.toSet))(
           mock5Expected.foldLeft[Assertion[Iterable[String]]](anything) { case (a, expectedLine) =>
-            a && contains(expectedLine.stripTrailing())
+            a && contains(expectedLine.stripLineEnd)
           }
         )
       }

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -52,6 +52,13 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
       },
       testM("correctly reports mock failure of invalid range") {
         assertM(runLog(mock4))(equalTo(mock4Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports failures in presence of a mock") {
+        assertM(runLog(mock5).map(_.linesIterator.toSet))(
+          mock5Expected.foldLeft[Assertion[Iterable[String]]](anything) { case (a, expectedLine) =>
+            a && contains(expectedLine.stripTrailing())
+          }
+        )
       }
     ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -56,7 +56,7 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
       testM("correctly reports failures in presence of a mock") {
         assertM(runLog(mock5).map(_.linesWithSeparators.map(_.stripLineEnd).toSet))(
           mock5Expected.foldLeft[Assertion[Iterable[String]]](anything) { case (a, expectedLine) =>
-            a && contains(expectedLine.stripLineEnd)
+            a && exists(matchesRegex(expectedLine.stripLineEnd))
           }
         )
       }

--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -54,7 +54,7 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
         assertM(runLog(mock4))(equalTo(mock4Expected.mkString + reportStats(0, 0, 1)))
       },
       testM("correctly reports failures in presence of a mock") {
-        assertM(runLog(mock5).map(_.linesIterator.toSet))(
+        assertM(runLog(mock5).map(_.linesWithSeparators.map(_.stripLineEnd).toSet))(
           mock5Expected.foldLeft[Assertion[Iterable[String]]](anything) { case (a, expectedLine) =>
             a && contains(expectedLine.stripLineEnd)
           }

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -255,12 +255,12 @@ object ReportingTestUtils {
   }
 
   val mock5Expected: Vector[String] = Vector(
-    expectedFailure("Failing layer"),
-    withOffset(2)(s"${red("- unsatisfied expectations")}"),
-    withOffset(4)(s"""zio.test.mock.module.PureModuleMock.ZeroParams with arguments ${cyan("isUnit()")}"""),
-    withOffset(2)("Fiber failed."),
-    withOffset(2)("║  ╠─A checked error was not handled."),
-    withOffset(2)("║  ║ failed!")
+    """.*Failing layer.*""",
+    """.*- unsatisfied expectations.*""",
+    """\s*zio\.test\.mock\.module\.PureModuleMock\.ZeroParams with arguments.*""",
+    """\s*Fiber failed\.""",
+    """[\s║╠]*─A checked error was not handled.""",
+    """[\s║]*failed!"""
   )
 
   def assertSourceLocation(): String = cyan(s"☛ $sourceFilePath:XXX")

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -259,7 +259,7 @@ object ReportingTestUtils {
     """.*- unsatisfied expectations.*""",
     """\s*zio\.test\.mock\.module\.PureModuleMock\.ZeroParams with arguments.*""",
     """\s*Fiber failed\.""",
-    """[\s║╠]*─A checked error was not handled.""",
+    """[\s║╠─]*A checked error was not handled.""",
     """[\s║]*failed!"""
   )
 

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -394,19 +394,38 @@ object FailureRenderer {
     if (assertionValue.result.isSuccess) Fragment(" satisfied ")
     else Fragment(" did not satisfy ")
 
-  def renderCause(cause: Cause[Any], offset: Int): Message =
-    cause.dieOption match {
-      case Some(TestTimeoutException(message)) => Message(message)
-      case Some(exception: MockException) =>
-        renderMockException(exception).map(withOffset(offset + tabSize))
-      case _ =>
-        Message(
-          cause.prettyPrint
+  def renderCause(cause: Cause[Any], offset: Int): Message = {
+    val defects = cause.defects
+    val timeouts = defects.collect { case TestTimeoutException(message) =>
+      Message(message)
+    }
+    val mockExceptions = defects.collect { case exception: MockException =>
+      renderMockException(exception).map(withOffset(offset + tabSize))
+    }
+    val remaining =
+      cause.stripSomeDefects {
+        case TestTimeoutException(_) => true
+        case _: MockException        => true
+      }
+    val prefix = if (timeouts.nonEmpty) {
+      // In case of timeout we don't show the mock exceptions
+      timeouts.foldLeft(Message.empty)(_ ++ _)
+    } else {
+      mockExceptions.foldLeft(Message.empty)(_ ++ _)
+    }
+
+    remaining match {
+      case Some(remainingCause) =>
+        prefix ++ Message(
+          remainingCause.prettyPrint
             .split("\n")
             .map(s => withOffset(offset + tabSize)(Line.fromString(s)))
             .toVector
         )
+      case None =>
+        prefix
     }
+  }
 
   private def renderMockException(exception: MockException): Message =
     exception match {


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/5187

- In case of mock exceptions it renders all of them, and also the remaining failures in the cause if there is any
- In case of a test timeout exception it does not render the mock exceptions (because unsatisfied expectations are very likely) but still renders the cause dump if it contains any other information
