### PR TITLE
Adding missing && to some assertions in MyersDiffSpec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
@@ -10,28 +10,28 @@ object MyersDiffSpec extends ZIOBaseSpec {
       val original = ""
       val modified = "ADDITIONS"
 
-      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified))
+      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified)) &&
       assert(MyersDiff.diff(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for only deletions both ways") {
       val original = "DELETIONS"
       val modified = ""
 
-      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified))
+      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified)) &&
       assert(MyersDiff.diff(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for two empty strings both ways") {
       val original = ""
       val modified = ""
 
-      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified))
+      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified)) &&
       assert(MyersDiff.diff(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for Myers example both ways") {
       val original = "ABCABBA"
       val modified = "CBABAC"
 
-      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified))
+      assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified)) &&
       assert(MyersDiff.diff(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing for Myers example produces a sane DiffResult") {
@@ -59,7 +59,7 @@ object MyersDiffSpec extends ZIOBaseSpec {
     },
     testM("diffing works for all random strings both ways") {
       check(Gen.anyString, Gen.anyString) { (original, modified) =>
-        assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified))
+        assert(MyersDiff.diff(original, modified).applyChanges(original))(equalTo(modified)) &&
         assert(MyersDiff.diff(original, modified).invert.applyChanges(modified))(equalTo(original))
       }
     }


### PR DESCRIPTION
Discovered using a certain IntelliJ plugin :) 
![image](https://user-images.githubusercontent.com/601206/121772618-15aee280-cb7f-11eb-9bca-411599245414.png)

I ran this inspection on the entire project - the only other place two ZIO effects appear without an operator between them is `succeed must be lazy` and `effectSuspend must be lazy` in ZIOSpec, which I decided to leave alone.