### PR TITLE
Add ZTransducer.groupAdjacentBy

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -341,6 +341,21 @@ object ZTransducerSpec extends ZIOBaseSpec {
             .runCollect
         )(equalTo(Chunk(3, 4, 5, 1, 2, 3, 4, 5)))
       ),
+      testM("groupAdjacentBy")(
+        assertM(
+          ZStream((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (1, 4))
+            .aggregate(ZTransducer.groupAdjacentBy(_._1))
+            .runCollect
+        )(
+          equalTo(
+            Chunk(
+              (1, Chunk((1, 1), (1, 2), (1, 3))),
+              (2, Chunk((2, 1), (2, 2))),
+              (1, Chunk((1, 4)))
+            )
+          )
+        )
+      ),
       suite("dropWhileM")(
         testM("happy path")(
           assertM(

--- a/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZTransducer.scala
@@ -630,6 +630,32 @@ object ZTransducer extends ZTransducerPlatformSpecificConstructors {
     ZTransducer(Managed.succeed(push))
 
   /**
+   * Creates a transducer that groups on adjacent keys, calculated by function f.<br>
+   * With this transducer we can mimic fs2 groupAdjacentBy.<br>
+   * This can be used like e.g. zstream.aggregate(groupAdjacentBy(_._1))
+   */
+  def groupAdjacentBy[I, K](f: I => K): ZTransducer[Any, Nothing, I, (K, Chunk[I])] =
+    ZTransducer {
+      def go(in: Chunk[I], state: Option[(K, Chunk[I])]): (Chunk[(K, Chunk[I])], Option[(K, Chunk[I])]) =
+        in.foldLeft[(Chunk[(K, Chunk[I])], Option[(K, Chunk[I])])]((Chunk.empty, state)) { case ((os0, state), i) =>
+          state match {
+            case None => (os0, Some((f(i), Chunk(i))))
+            case Some((key, aggregated)) =>
+              val newKey = f(i)
+              if (key == newKey) (os0, Some((key, aggregated :+ i)))
+              else (os0.appended((key, aggregated)), Some((newKey, Chunk(i))))
+          }
+        }
+
+      ZRef.makeManaged[Option[(K, Chunk[I])]](None).map { state =>
+        {
+          case Some(in) => state.modify(go(in, _))
+          case None     => state.getAndSet(None).map(_.fold[Chunk[(K, Chunk[I])]](Chunk.empty)(Chunk.single(_)))
+        }
+      }
+    }
+
+  /**
    * Creates a transducer that returns the first element of the stream, if it exists.
    */
   def head[O]: ZTransducer[Any, Nothing, O, Option[O]] =


### PR DESCRIPTION
I needed something similar to fs2.groupAdjacentBy but didn't manage to figure out how to do it without creating this low level transducer. Not sure about the naming and if there should be a convenience function in ZStream as well.

The use case for me is that I get a stream of left joined database rows from skunk (Postgres driver) and I prefer to use zio instead of fs2 / cats effect. I need to aggregate the rows by the columns from the "left" table.

A left join with 3 outer join tables now looks like:

```
def leftJoin3[A, B, C, D](
      s: ZStream[Any, Throwable, (A ~ Option[B] ~ Option[C] ~ Option[D])]
  ): ZStream[Any, Throwable, (A, Chunk[B], Chunk[C], Chunk[D])] = {
    s.aggregate(groupAdjacentBy { case a ~ _ ~ _ ~ _ => a }).map { case (a, s) =>
      val b = s.collect { case _ ~ Some(b) ~ _ ~ _ => b }
      val c = s.collect { case _ ~ _ ~ Some(c) ~ _ => c }
      val d = s.collect { case _ ~ _ ~ _ ~ Some(d) => d }
      (a, b, c, d)
    }
  }```
 