### PR TITLE
Pull TestAspect.fibers up to AbstractRunnableSpec

### DIFF
--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -41,8 +41,9 @@ abstract class AbstractRunnableSpec {
    */
   private[zio] def runSpec(
     spec: ZSpec[Environment, Failure]
-  ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
-    runner.run(aspects.foldLeft(spec)(_ @@ _))
+  ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] = runner.run(
+    (aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers).provideSomeLayerShared[Environment](Annotations.live)
+  )
 
   /**
    * the platform used by the runner

--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -16,10 +16,9 @@
 
 package zio.test
 
-import zio.clock.Clock
 import zio.duration._
 import zio.test.environment.TestEnvironment
-import zio.{URIO, ZIO}
+import zio.ZIO
 
 /**
  * A default runnable spec that provides testable versions of all of the
@@ -32,14 +31,6 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
 
   override def runner: TestRunner[TestEnvironment, Any] =
     defaultTestRunner
-
-  /**
-   * Returns an effect that executes a given spec, producing the results of the execution.
-   */
-  private[zio] override def runSpec(
-    spec: ZSpec[Environment, Failure]
-  ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
-    runner.run(aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers)
 
   /**
    * Builds a suite containing a number of other specs.

--- a/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
@@ -17,10 +17,9 @@
 package zio.test
 
 import izumi.reflect.Tag
-import zio.clock.Clock
 import zio.duration._
 import zio.test.environment.TestEnvironment
-import zio.{Chunk, Has, URIO, ZIO, ZLayer}
+import zio.{Chunk, Has, ZIO, ZLayer}
 
 import scala.util.control.NoStackTrace
 
@@ -155,12 +154,4 @@ class MutableRunnableSpec[R <: Has[_]: Tag](
 
   override def runner: TestRunner[TestEnvironment, Any] =
     defaultTestRunner
-
-  /**
-   * Returns an effect that executes a given spec, producing the results of the execution.
-   */
-  private[zio] override def runSpec(
-    spec: ZSpec[Environment, Failure]
-  ): URIO[TestLogger with Clock, ExecutedSpec[Failure]] =
-    runner.run(aspects.foldLeft(spec)(_ @@ _) @@ TestAspect.fibers)
 }


### PR DESCRIPTION
Without it `TestClock.adjust` doesn't work correctly.
If someone is extending `RunnableSpec` to customize their test env,
they would have a hard time figuring out time related flakiness.