### PR TITLE
Deprecating `.bimap`, adding `.mapBoth` instead

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -38,14 +38,6 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeed(1).absorbWith(_ => ExampleError))(equalTo(1))
       }
     ) @@ zioTag(errors),
-    suite("bimap")(
-      testM("maps over both error and value channels") {
-        checkM(Gen.anyInt) { i =>
-          val res = IO.fail(i).bimap(_.toString, identity).either
-          assertM(res)(isLeft(equalTo(i.toString)))
-        }
-      }
-    ),
     suite("bracket")(
       testM("bracket happy path") {
         for {
@@ -1180,6 +1172,14 @@ object ZIOSpec extends ZIOBaseSpec {
           _      <- ZIO.loop_(0)(_ < 5, _ + 1)(a => ref.update(a :: _))
           result <- ref.get.map(_.reverse)
         } yield assert(result)(equalTo(List(0, 1, 2, 3, 4)))
+      }
+    ),
+    suite("mapBoth")(
+      testM("maps over both error and value channels") {
+        checkM(Gen.anyInt) { i =>
+          val res = IO.fail(i).mapBoth(_.toString, identity).either
+          assertM(res)(isLeft(equalTo(i.toString)))
+        }
       }
     ),
     suite("mapEffect")(

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -28,15 +28,6 @@ object ZSTMSpec extends ZIOBaseSpec {
         val tx    = (add >>> print).provide(1)
         assertM(tx.commit)(equalTo("2 is the sum"))
       },
-      suite("bimap when")(
-        testM("having a success value") {
-          implicit val canFail = CanFail
-          assertM(STM.succeed(1).bimap(_ => -1, s => s"$s as string").commit)(equalTo("1 as string"))
-        },
-        testM("having a fail value") {
-          assertM(STM.fail(-1).bimap(s => s"$s as string", _ => 0).commit.run)(fails(equalTo("-1 as string")))
-        }
-      ),
       testM("catchAll errors") {
         val tx =
           for {
@@ -331,6 +322,15 @@ object ZSTMSpec extends ZIOBaseSpec {
         },
         testM("on Right value") {
           assertM(ZSTM.succeed(Right(2)).leftOrFailException.commit.run)(fails(Assertion.anything))
+        }
+      ),
+      suite("mapBoth when")(
+        testM("having a success value") {
+          implicit val canFail = CanFail
+          assertM(STM.succeed(1).mapBoth(_ => -1, s => s"$s as string").commit)(equalTo("1 as string"))
+        },
+        testM("having a fail value") {
+          assertM(STM.fail(-1).mapBoth(s => s"$s as string", _ => 0).commit.run)(fails(equalTo("-1 as string")))
         }
       ),
       testM("mapError to map from one error to another") {

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -61,7 +61,9 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Maps over both the error and value type.
    */
-  final def bimap[E1, A1](f: E => E1, g: A => A1): Exit[E1, A1] = mapError(f).map(g)
+  @deprecated("use mapBoth", "2.0.0")
+  final def bimap[E1, A1](f: E => E1, g: A => A1): Exit[E1, A1] =
+    mapBoth(f, g)
 
   final def exists(p: A => Boolean): Boolean =
     fold(_ => false, p)
@@ -136,6 +138,12 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
       case Success(v)     => Exit.succeed(f(v))
       case e @ Failure(_) => e
     }
+
+  /**
+   * Maps over both the error and value type.
+   */
+  final def mapBoth[E1, A1](f: E => E1, g: A => A1): Exit[E1, A1] =
+    mapError(f).map(g)
 
   /**
    * Maps over the error type.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -227,8 +227,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
+  @deprecated("use mapBoth", "2.0.0")
   final def bimap[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZIO[R, E2, B] =
-    foldM(e => ZIO.fail(f(e)), a => ZIO.succeedNow(g(a)))
+    mapBoth(f, g)
 
   /**
    * Shorthand for the uncurried version of `ZIO.bracket`.
@@ -904,6 +905,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect whose success is mapped by the specified `f` function.
    */
   def map[B](f: A => B): ZIO[R, E, B] = new ZIO.FlatMap(self, new ZIO.MapFn(f))
+
+  /**
+   * Returns an effect whose failure and success channels have been mapped by
+   * the specified pair of functions, `f` and `g`.
+   */
+  final def mapBoth[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZIO[R, E2, B] =
+    foldM(e => ZIO.fail(f(e)), a => ZIO.succeedNow(g(a)))
 
   /**
    * Returns an effect whose success is mapped by the specified side effecting

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -213,8 +213,9 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
+  @deprecated("use mapBoth", "2.0.0")
   def bimap[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZManaged[R, E1, A1] =
-    mapError(f).map(g)
+    mapBoth(f, g)
 
   /**
    * Recovers from all errors.
@@ -472,6 +473,13 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    */
   def map[B](f: A => B): ZManaged[R, E, B] =
     ZManaged(zio.map { case (fin, a) => (fin, f(a)) })
+
+  /**
+   * Returns an effect whose failure and success channels have been mapped by
+   * the specified pair of functions, `f` and `g`.
+   */
+  def mapBoth[E1, A1](f: E => E1, g: A => A1)(implicit ev: CanFail[E]): ZManaged[R, E1, A1] =
+    mapError(f).map(g)
 
   /**
    * Returns an effect whose success is mapped by the specified side effecting

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -198,8 +198,9 @@ final class ZSTM[-R, +E, +A] private[stm] (
    * Returns an `STM` effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
+  @deprecated("use mapBoth", "2.0.0")
   def bimap[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZSTM[R, E2, B] =
-    foldM(e => ZSTM.fail(f(e)), a => ZSTM.succeedNow(g(a)))
+    mapBoth(f, g)
 
   /**
    * Recovers from all errors.
@@ -488,6 +489,13 @@ final class ZSTM[-R, +E, +A] private[stm] (
       case TExit.Die(t)     => ZSTM.die(t)
       case TExit.Retry      => ZSTM.retry
     }
+
+  /**
+   * Returns an `STM` effect whose failure and success channels have been mapped by
+   * the specified pair of functions, `f` and `g`.
+   */
+  def mapBoth[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E]): ZSTM[R, E2, B] =
+    foldM(e => ZSTM.fail(f(e)), a => ZSTM.succeedNow(g(a)))
 
   /**
    * Maps from one error type to another.

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -10,7 +10,6 @@ ZIO provides a variety of combinators to handle errors such as `orElse`, `catchA
 Code | Rewrite 
 --- | ---
 `uio <> zio` | `uio`
-`uio.bimap(f, g)` |  `uio.map(g)`
 `uio.catchAll(f)` | `uio`
 `uio.catchSome(pf)` | `uio`
 `uio.either` | `uio`*
@@ -18,6 +17,7 @@ Code | Rewrite
 `uio.flatMapError(f)` | `uio`
 `uio.fold(f, g)` | `uio.map(g)`
 `uio.foldM(f, g)` | `uio.flatMap(g)`
+`uio.mapBoth(f, g)` |  `uio.map(g)`
 `uio.mapError(f)` | `uio`
 `uio.option` | `uio`*
 `uio.orDie` | `uio`
@@ -45,13 +45,13 @@ Code | Rewrite
 Code | Rewrite 
 --- | ---
 `umanaged <> zmanaged` | `umanaged`
-`umanaged.bimap(f, g)` | `umanaged.map(g)`
 `umanaged.catchAll(f)` | `umanaged`
 `umanaged.catchSome(pf)` | `umanaged`
 `umanaged.either` | `umanaged`*
 `umanaged.flatMapError(f)` | `umanaged`
 `umanaged.fold(f, g)` | `umanaged.map(f)`
 `umanaged.foldM(f, g)` | `umanaged.flatMap(g)`
+`umanaged.mapBoth(f, g)` | `umanaged.map(g)`
 `umanaged.mapError(f)` | `umanaged`
 `umanaged.option` | `umanaged`*
 `umanaged.orDie` | `umanaged`
@@ -69,9 +69,9 @@ Code | Rewrite
 
 Code | Rewrite 
 --- | ---
-`ustream.bimap(f, g)` | `ustream.map(g)`
 `ustream.catchAll(f)` | `ustream`
 `ustream.either` | `ustream`*
+`ustream.mapBoth(f, g)` | `ustream.map(g)`
 `ustream.mapError(f)` | `ustream`
 `ustream.orElse(zstream)` | `ustream`
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -353,8 +353,9 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Returns a stream whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
+  @deprecated("use mapBoth", "2.0.0")
   def bimap[E1, O1](f: E => E1, g: O => O1)(implicit ev: CanFail[E]): ZStream[R, E1, O1] =
-    mapError(f).map(g)
+    mapBoth(f, g)
 
   /**
    * Fan out the stream, producing a list of streams that have the same
@@ -706,7 +707,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     ZStream {
       for {
         os    <- self.process.mapM(BufferedPull.make(_))
-        pfSome = pf.andThen(_.bimap(Some(_), Chunk.single(_)))
+        pfSome = pf.andThen(_.mapBoth(Some(_), Chunk.single(_)))
         pull = {
           def go: ZIO[R1, Option[E1], Chunk[O1]] =
             os.pullElement.flatMap(o => pfSome.applyOrElse(o, (_: O) => go))
@@ -753,7 +754,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
       for {
         os   <- self.process.mapM(BufferedPull.make(_))
         done <- Ref.make(false).toManaged_
-        pfIO  = pf.andThen(_.bimap(Some(_), Chunk.single(_)))
+        pfIO  = pf.andThen(_.mapBoth(Some(_), Chunk.single(_)))
         pull = done.get.flatMap {
                  if (_) Pull.end
                  else
@@ -2019,6 +2020,13 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     mapM(a => f(a).map(Chunk.fromIterable(_))).mapConcatChunk(identity)
 
   /**
+   * Returns a stream whose failure and success channels have been mapped by
+   * the specified pair of functions, `f` and `g`.
+   */
+  def mapBoth[E1, O1](f: E => E1, g: O => O1)(implicit ev: CanFail[E]): ZStream[R, E1, O1] =
+    mapError(f).map(g)
+
+  /**
    * Transforms the errors emitted by this stream using `f`.
    */
   def mapError[E2](f: E => E2): ZStream[R, E2, O] =
@@ -2045,7 +2053,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   def mapM[R1 <: R, E1 >: E, O2](f: O => ZIO[R1, E1, O2]): ZStream[R1, E1, O2] =
     ZStream {
       self.process.mapM(BufferedPull.make(_)).map { pull =>
-        pull.pullElement.flatMap(f(_).bimap(Some(_), Chunk.single(_)))
+        pull.pullElement.flatMap(f(_).mapBoth(Some(_), Chunk.single(_)))
       }
     }
 

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -63,11 +63,9 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
   /**
    * Returns a new spec with remapped errors and tests.
    */
+  @deprecated("use mapBoth", "2.0.0")
   final def bimap[E1, T1](f: E => E1, g: T => T1)(implicit ev: CanFail[E]): Spec[R, E1, T1] =
-    transform[R, E1, T1] {
-      case SuiteCase(label, specs, exec)      => SuiteCase(label, specs.mapError(f), exec)
-      case TestCase(label, test, annotations) => TestCase(label, test.bimap(f, g), annotations)
-    }
+    mapBoth(f, g)
 
   /**
    * Returns the number of tests in the spec that satisfy the specified
@@ -223,6 +221,15 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
     n: Int
   )(failure: Cause[E] => ZIO[R1, E1, A], success: T => ZIO[R1, E1, A]): ZManaged[R1, Nothing, Spec[R1, E1, A]] =
     foreachExec(ExecutionStrategy.ParallelN(n))(failure, success)
+
+  /**
+   * Returns a new spec with remapped errors and tests.
+   */
+  final def mapBoth[E1, T1](f: E => E1, g: T => T1)(implicit ev: CanFail[E]): Spec[R, E1, T1] =
+    transform[R, E1, T1] {
+      case SuiteCase(label, specs, exec)      => SuiteCase(label, specs.mapError(f), exec)
+      case TestCase(label, test, annotations) => TestCase(label, test.mapBoth(f, g), annotations)
+    }
 
   /**
    * Returns a new spec with remapped errors.


### PR DESCRIPTION
Fixes #5207

This PR adds a deprecation for `.bimap` and forwards it to the new `.mapBoth` (having the same exact signature).

Should be more consistent with the ZIO naming.