### PR TITLE
Make TestAspect.fibers public

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -355,7 +355,12 @@ object TestAspect extends TimeoutVariants {
 
   import scala.collection.immutable.SortedSet
 
-  private[zio] lazy val fibers: TestAspect[Nothing, Annotations, Nothing, Any] =
+  /**
+   * An aspect that records the state of fibers spawned by the current test in [[TestAnnotation.fibers]].
+   * Applied by default in [[DefaultRunnableSpec]] and [[MutableRunnableSpec]] but not in [[RunnableSpec]].
+   * This aspect is required for the proper functioning of `TestClock.adjust`.
+   */
+  lazy val fibers: TestAspect[Nothing, Annotations, Nothing, Any] =
     new TestAspect.PerTest[Nothing, Annotations, Nothing, Any] {
       def perTest[R <: Annotations, E](
         test: ZIO[R, TestFailure[E], TestSuccess]


### PR DESCRIPTION
It's required for the proper functioning of `TestClock.adjust`
but we can't apply it in `AbstractRunnableSpec` because it doesn't
constrain the environment in any way (we need `Annotations`).

For projects that extend `RunnableSpec` to customize their
test environment and test runner, currently the only option to make
`TestClock.adjust` work is to hack around the access restriction.

See #3840 for more detailed discussion