### PR TITLE
Fix wrong link name

### DIFF
--- a/docs/usecases/testing.md
+++ b/docs/usecases/testing.md
@@ -103,6 +103,6 @@ To get the runner, add the equivalent of following dependency definition under y
 
 To make your spec appear as a JUnit test to build tools and IDEs, convert it to a `class` (JUnit won't run scala objects) and 
 annotate it with `@RunWith(classOf[zio.test.junit.ZTestJUnitRunner])` or simply extend `zio.test.junit.JUnitRunnableSpec`.
-See [MockingExampleSpecWithJUnit](https://github.com/zio/zio/blob/master/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala)
+See [ExampleSpecWithJUnit](https://github.com/zio/zio/blob/master/examples/jvm/src/test/scala/zio/examples/test/ExampleSpecWithJUnit.scala)
 
 SBT (and thus Scala.JS) is not supported, as the JUnit Test Framework for SBT doesn't seem to support custom runners.


### PR DESCRIPTION
This PR fixes a small naming issue in our documentation.