### PR TITLE
Generalize ZIO.debug

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -243,10 +243,10 @@ object IO {
     ZIO.cond(predicate, result, error)
 
   /**
-   * @see See [[zio.ZIO.cond]]
+   * @see See [[zio.ZIO.debug]]
    */
-  def debug(message: String): UIO[Unit] =
-    ZIO.debug(message)
+  def debug(value: Any): UIO[Unit] =
+    ZIO.debug(value)
 
   /**
    * @see See [[zio.ZIO.descriptor]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -266,6 +266,12 @@ object RIO {
     ZIO.cond(predicate, result, error)
 
   /**
+   * @see See [[zio.ZIO.debug]]
+   */
+  def debug(value: Any): UIO[Unit] =
+    ZIO.debug(value)
+
+  /**
    * @see See [[zio.ZIO.descriptor]]
    */
   def descriptor: UIO[Fiber.Descriptor] = ZIO.descriptor

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -249,10 +249,10 @@ object Task extends TaskPlatformSpecific {
     ZIO.cond(predicate, result, error)
 
   /**
-   * @see See [[zio.ZIO.cond]]
+   * @see See [[zio.ZIO.debug]]
    */
-  def debug(message: String): UIO[Unit] =
-    ZIO.debug(message)
+  def debug(value: Any): UIO[Unit] =
+    ZIO.debug(value)
 
   /**
    * @see See [[zio.ZIO.die]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -238,10 +238,10 @@ object UIO {
     ZIO.collectParN(n)(in)(f)
 
   /**
-   * @see See [[zio.ZIO.cond]]
+   * @see See [[zio.ZIO.debug]]
    */
-  def debug(message: String): UIO[Unit] =
-    ZIO.debug(message)
+  def debug(value: Any): UIO[Unit] =
+    ZIO.debug(value)
 
   /**
    * @see See [[zio.ZIO.descriptor]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -255,10 +255,10 @@ object URIO {
     ZIO.collectParN(n)(in)(f)
 
   /**
-   * @see See [[zio.ZIO.cond]]
+   * @see See [[zio.ZIO.debug]]
    */
-  def debug(message: String): UIO[Unit] =
-    ZIO.debug(message)
+  def debug(value: Any): UIO[Unit] =
+    ZIO.debug(value)
 
   /**
    * @see [[zio.ZIO.descriptor]]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2592,8 +2592,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Prints the specified message to the console for debugging purposes.
    */
-  def debug(message: String): UIO[Unit] =
-    ZIO.effectTotal(println(message))
+  def debug(value: Any): UIO[Unit] =
+    ZIO.effectTotal(println(value))
 
   /**
    * Returns information about the current fiber, such as its identity.


### PR DESCRIPTION
We can print an arbitrary value for debugging purposes without requiring that it be a string.