### PR TITLE
Rename Operators For ZIO 2.0

### DIFF
--- a/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ArrayFillBenchmark.scala
@@ -24,7 +24,7 @@ class ArrayFillBenchmark {
 
     unsafeRun(
       for {
-        array <- IO.effectTotal[Array[Int]](createTestArray)
+        array <- IO.succeed[Array[Int]](createTestArray)
         _     <- arrayFill(array)(0)
       } yield ()
     )

--- a/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/BubbleSortBenchmarks.scala
@@ -25,9 +25,9 @@ class BubbleSortBenchmarks {
 
     unsafeRun(
       for {
-        array <- IO.effectTotal[Array[Int]](createTestArray)
+        array <- IO.succeed[Array[Int]](createTestArray)
         _     <- bubbleSort[Int](_ <= _)(array)
-        _     <- IO.effectTotal[Unit](assertSorted(array))
+        _     <- IO.succeed[Unit](assertSorted(array))
       } yield ()
     )
   }

--- a/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepFlatMapBenchmark.scala
@@ -107,9 +107,9 @@ class IODeepFlatMapBenchmark {
 
   private[this] def zioDeepFlatMap(runtime: Runtime[Any]): BigInt = {
     def fib(n: Int): UIO[BigInt] =
-      if (n <= 1) ZIO.effectTotal[BigInt](n)
+      if (n <= 1) ZIO.succeed[BigInt](n)
       else
-        fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.effectTotal(a + b)))
+        fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.succeed(a + b)))
 
     runtime.unsafeRun(fib(depth))
   }

--- a/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IODeepLeftBindBenchmark.scala
@@ -34,9 +34,9 @@ class IODeepLeftBindBenchmark {
 
   def zioDeepLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     var i  = 0
-    var io = IO.effectTotal(i)
+    var io = IO.succeed(i)
     while (i < depth) {
-      io = io.flatMap(i => IO.effectTotal(i))
+      io = io.flatMap(i => IO.succeed(i))
       i += 1
     }
 

--- a/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOEmptyRaceBenchmark.scala
@@ -46,7 +46,7 @@ class IOEmptyRaceBenchmark {
 
   private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) IO.never.raceFirst(IO.effectTotal(i + 1)).flatMap(loop)
+      if (i < size) IO.never.raceFirst(IO.succeed(i + 1)).flatMap(loop)
       else IO.succeedNow(i)
 
     runtime.unsafeRun(loop(0))

--- a/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOLeftBindBenchmark.scala
@@ -119,11 +119,11 @@ class IOLeftBindBenchmark {
 
   private[this] def zioLeftBindBenchmark(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i % depth == 0) IO.effectTotal[Int](i + 1).flatMap(loop)
-      else if (i < size) loop(i + 1).flatMap(i => IO.effectTotal(i))
-      else IO.effectTotal(i)
+      if (i % depth == 0) IO.succeed[Int](i + 1).flatMap(loop)
+      else if (i < size) loop(i + 1).flatMap(i => IO.succeed(i))
+      else IO.succeed(i)
 
-    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOMapBenchmark.scala
@@ -112,7 +112,7 @@ class IOMapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    runtime.unsafeRun(sumTo(IO.effectTotal(0), depth))
+    runtime.unsafeRun(sumTo(IO.succeed(0), depth))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IONarrowFlatMapBenchmark.scala
@@ -111,10 +111,10 @@ class IONarrowFlatMapBenchmark {
 
   private[this] def zioNarrowFlatMap(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) IO.effectTotal[Int](i + 1).flatMap(loop)
-      else IO.effectTotal(i)
+      if (i < size) IO.succeed[Int](i + 1).flatMap(loop)
+      else IO.succeed(i)
 
-    runtime.unsafeRun(IO.effectTotal(0).flatMap[Any, Nothing, Int](loop))
+    runtime.unsafeRun(IO.succeed(0).flatMap[Any, Nothing, Int](loop))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/IOShallowAttemptBenchmark.scala
@@ -131,7 +131,7 @@ class IOShallowAttemptBenchmark {
   def zioShallowAttempt(): BigInt = {
     def throwup(n: Int): IO[ZIOError, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.effectTotal(1)
+      else if (n == depth) IO.succeed(1)
       else throwup(n + 1).foldM[Any, ZIOError, BigInt](_ => IO.succeedNow(0), _ => IO.fail(ZIOError("Oh noes!")))
 
     unsafeRun(throwup(0))
@@ -141,7 +141,7 @@ class IOShallowAttemptBenchmark {
   def zioShallowAttemptBaseline(): BigInt = {
     def throwup(n: Int): IO[Error, BigInt] =
       if (n == 0) throwup(n + 1).fold[BigInt](_ => 50, identity)
-      else if (n == depth) IO.effectTotal(1)
+      else if (n == depth) IO.succeed(1)
       else throwup(n + 1).foldM[Any, Error, BigInt](_ => IO.succeedNow(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafeRun(throwup(0))

--- a/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParSequenceBenchmark.scala
@@ -76,21 +76,21 @@ class ParSequenceBenchmark {
 
   @Benchmark
   def zioSequence(): Long = {
-    val tasks  = (0 until count).map(_ => ZIO.effectTotal(1)).toList
+    val tasks  = (0 until count).map(_ => ZIO.succeed(1)).toList
     val result = ZIO.collectAll(tasks).map(_.sum.toLong)
     unsafeRun(result)
   }
 
   @Benchmark
   def zioParSequence(): Long = {
-    val tasks  = (0 until count).map(_ => ZIO.effectTotal(1)).toList
+    val tasks  = (0 until count).map(_ => ZIO.succeed(1)).toList
     val result = ZIO.collectAllPar(tasks).map(_.sum.toLong)
     unsafeRun(result)
   }
 
   @Benchmark
   def zioParSequenceN(): Long = {
-    val tasks  = (0 until count).map(_ => ZIO.effectTotal(1)).toList
+    val tasks  = (0 until count).map(_ => ZIO.succeed(1)).toList
     val result = ZIO.collectAllParN(parallelism)(tasks).map(_.sum.toLong)
     unsafeRun(result)
   }

--- a/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/TReentrantLockBenchmark.scala
@@ -141,7 +141,7 @@ class TReentrantLockBenchmark {
   }
 
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-  def doWorkM(): UIO[Unit] = ZIO.effectTotal(doWork())
+  def doWorkM(): UIO[Unit] = ZIO.succeed(doWork())
 
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   def doWork(): Unit = Blackhole.consumeCPU(100L)

--- a/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
+++ b/core-tests/js/src/test/scala/zio/interop/JSSpec.scala
@@ -17,12 +17,12 @@ object JSSpec extends ZIOBaseSpec {
       testM("catch exceptions thrown by lazy block") {
         val ex                              = new Exception("no promise for you!")
         lazy val noPromise: JSPromise[Unit] = throw ex
-        assertM(Task.fromPromiseJS(noPromise).run)(dies(equalTo(ex)))
+        assertM(Task.fromPromiseJS(noPromise).exit)(dies(equalTo(ex)))
       },
       testM("return a Task that fails if Promise is rejected") {
         val ex                            = new Exception("no value for you!")
         lazy val noValue: JSPromise[Unit] = JSPromise.reject(ex)
-        assertM(Task.fromPromiseJS(noValue).run)(fails(equalTo(ex)))
+        assertM(Task.fromPromiseJS(noValue).exit)(fails(equalTo(ex)))
       },
       testM("return a Task that produces the value from the Promise") {
         lazy val someValue: JSPromise[Int] = JSPromise.resolve[Int](42)
@@ -42,12 +42,12 @@ object JSSpec extends ZIOBaseSpec {
       testM("catch exceptions thrown by lazy block") {
         val ex                              = new Exception("no promise for you!")
         lazy val noPromise: JSPromise[Unit] = throw ex
-        assertM(ZIO.fromPromiseJS(noPromise).run)(dies(equalTo(ex)))
+        assertM(ZIO.fromPromiseJS(noPromise).exit)(dies(equalTo(ex)))
       },
       testM("return a ZIO that fails if Promise is rejected") {
         val ex                            = new Exception("no value for you!")
         lazy val noValue: JSPromise[Unit] = JSPromise.reject(ex)
-        assertM(ZIO.fromPromiseJS(noValue).run)(fails(equalTo(ex)))
+        assertM(ZIO.fromPromiseJS(noValue).exit)(fails(equalTo(ex)))
       },
       testM("return a ZIO that produces the value from the Promise") {
         lazy val someValue: JSPromise[Int] = JSPromise.resolve[Int](42)
@@ -63,7 +63,7 @@ object JSSpec extends ZIOBaseSpec {
         val ex                          = new Exception("Ouch")
         val failedZIO: Task[Unit]       = Task.fail(ex)
         val rejectedPromise: Task[Unit] = failedZIO.toPromiseJS.flatMap(p => ZIO.fromFuture(_ => p.toFuture))
-        assertM(rejectedPromise.run)(fails(equalTo(ex)))
+        assertM(rejectedPromise.exit)(fails(equalTo(ex)))
       },
       testM("produce a resolved Promise from a successful ZIO") {
         val zio                        = Task.succeed(42)

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -337,7 +337,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
   }
 
   object foreachTraceFixture {
-    def effectTotal: UIO[Unit] = ZIO.effectTotal(())
+    def succeed: UIO[Unit] = ZIO.succeed(())
   }
 
   def foreachFail: ZIO[Any, Throwable, (ZTrace, ZTrace)] =
@@ -456,7 +456,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
         case 0 =>
           UIO(throw new Exception("oops!"))
         case _ =>
-          UIO.effectSuspendTotal(recursiveFork(i - 1)).fork.flatMap(_.join)
+          UIO.suspendSucceed(recursiveFork(i - 1)).fork.flatMap(_.join)
       }
   }
 
@@ -473,7 +473,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
     (for {
       _ <- ZIO.unit
       _ <- ZIO.unit
-      _ <- ZIO.effect(traceThis()).traced.traced.traced
+      _ <- ZIO.attempt(traceThis()).traced.traced.traced
       _ <- ZIO.unit
       _ <- ZIO.unit
       _ <- ZIO.fail("end")
@@ -601,7 +601,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
 
   object singleEffectTotalWithForCompFixture {
     def asyncDbCall(): Task[Unit] =
-      Task.effectSuspendTotal(throw new Exception)
+      Task.suspendSucceed(throw new Exception)
 
     val selectHumans: Task[Unit] = for {
       _ <- asyncDbCall()

--- a/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12/zio/StacktracesSpec.scala
@@ -30,7 +30,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
         assert(trace.stackTrace.exists(_.prettyPrint.contains("foreachTest")))(isTrue) &&
         assert(trace.executionTrace.exists(_.prettyPrint.contains("foreachTest")))(isTrue) &&
         assert(trace.executionTrace.exists(_.prettyPrint.contains("foreach_")))(isTrue) &&
-        assert(trace.executionTrace.exists(_.prettyPrint.contains("effectTotal")))(isTrue)
+        assert(trace.executionTrace.exists(_.prettyPrint.contains("succeed")))(isTrue)
       }
     },
     testM("foreach fail") {
@@ -330,7 +330,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
   def foreachTest: UIO[ZTrace] = {
     import foreachTraceFixture._
     for {
-      _     <- effectTotal
+      _     <- succeed
       _     <- ZIO.foreach_(1 to 10)(_ => ZIO.unit *> ZIO.trace)
       trace <- ZIO.trace
     } yield trace

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -200,7 +200,7 @@ object SerializableSpec extends ZIOBaseSpec {
     },
     testM("ZManaged is serializable") {
       for {
-        managed <- serializeAndBack(ZManaged.make(UIO.unit)(_ => UIO.unit))
+        managed <- serializeAndBack(ZManaged.bracket(UIO.unit)(_ => UIO.unit))
         result  <- managed.use(_ => UIO.unit)
       } yield assert(result)(equalTo(()))
     },
@@ -238,8 +238,8 @@ object SerializableSpec extends ZIOBaseSpec {
 object SerializableSpecHelpers {
   def serializeAndBack[T](a: T): IO[Any, T] =
     for {
-      obj       <- IO.effectTotal(serializeToBytes(a))
-      returnObj <- IO.effectTotal(getObjFromBytes[T](obj))
+      obj       <- IO.succeed(serializeToBytes(a))
+      returnObj <- IO.succeed(getObjFromBytes[T](obj))
     } yield returnObj
 
   def serializeToBytes[T](a: T): Array[Byte] = {

--- a/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZManagedPlatformSpecificSpec.scala
@@ -155,7 +155,7 @@ object ZManagedPlatformSpecificSpec extends ZIOBaseSpec {
 object ZManagedPlatformSpecificSpecHelper {
   def tempFileResource(): ZManaged[Any, IOException, File] =
     ZManaged
-      .make(
-        ZIO.effect(File.createTempFile(ju.UUID.randomUUID().toString(), null)).refineToOrDie[IOException]
-      )(f => ZIO.effect(Files.delete(f.toPath)).orDie)
+      .bracket(
+        ZIO.attempt(File.createTempFile(ju.UUID.randomUUID().toString(), null)).refineToOrDie[IOException]
+      )(f => ZIO.attempt(Files.delete(f.toPath)).orDie)
 }

--- a/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/blocking/BlockingSpec.scala
@@ -28,7 +28,7 @@ object BlockingSpec extends ZIOBaseSpec {
       },
       testM("effectBlockingCancelable can be interrupted") {
         val release = new AtomicBoolean(false)
-        val cancel  = UIO.effectTotal(release.set(true))
+        val cancel  = UIO.succeed(release.set(true))
         assertM(ZIO.effectBlockingCancelable(blockingAtomic(release))(cancel).timeout(Duration.Zero))(isNone)
       },
       testM("effectBlockingInterrupt completes successfully") {

--- a/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/clock/ClockSpecJVM.scala
@@ -29,9 +29,9 @@ object ClockSpecJVM extends ZIOBaseSpec {
       testM("currentTime has correct time") {
         val unit = TimeUnit.MICROSECONDS
         for {
-          start  <- ZIO.effectTotal(Instant.now).map(_.toEpochMilli)
+          start  <- ZIO.succeed(Instant.now).map(_.toEpochMilli)
           time   <- Clock.currentTime(unit).map(TimeUnit.MILLISECONDS.convert(_, unit))
-          finish <- ZIO.effectTotal(Instant.now).map(_.toEpochMilli)
+          finish <- ZIO.succeed(Instant.now).map(_.toEpochMilli)
         } yield assert(time)(isGreaterThanEqualTo(start) && isLessThanEqualTo(finish))
       }.provideLayer(Clock.live)
         @@ TestAspect.nonFlaky

--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -24,22 +24,22 @@ object JavaSpec extends ZIOBaseSpec {
       testM("execute the `Future` parameter only once") {
         var count            = 0
         def ftr: Future[Int] = CompletableFuture.supplyAsync { () => count += 1; count }
-        assertM(ZIO.fromFutureJava(ftr).run)(succeeds(equalTo(1)))
+        assertM(ZIO.fromFutureJava(ftr).exit)(succeeds(equalTo(1)))
       },
       testM("catch exceptions thrown by lazy block") {
         val ex                          = new Exception("no future for you!")
         lazy val noFuture: Future[Unit] = throw ex
-        assertM(ZIO.fromFutureJava(noFuture).run)(fails(equalTo(ex)))
+        assertM(ZIO.fromFutureJava(noFuture).exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (failedFuture)") {
         val ex                         = new Exception("no value for you!")
         lazy val noValue: Future[Unit] = CompletableFuture_.failedFuture(ex)
-        assertM(ZIO.fromFutureJava(noValue).run)(fails(equalTo(ex)))
+        assertM(ZIO.fromFutureJava(noValue).exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (supplyAsync)") {
         val ex                         = new Exception("no value for you!")
         lazy val noValue: Future[Unit] = CompletableFuture.supplyAsync(() => throw ex)
-        assertM(ZIO.fromFutureJava(noValue).run)(fails(equalTo(ex)))
+        assertM(ZIO.fromFutureJava(noValue).exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that produces the value from `Future`") {
         lazy val someValue: Future[Int] = CompletableFuture.completedFuture(42)
@@ -67,17 +67,17 @@ object JavaSpec extends ZIOBaseSpec {
       testM("catch exceptions thrown by lazy block") {
         val ex                                   = new Exception("no future for you!")
         lazy val noFuture: CompletionStage[Unit] = throw ex
-        assertM(ZIO.fromCompletionStage(noFuture).run)(fails(equalTo(ex)))
+        assertM(ZIO.fromCompletionStage(noFuture).exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (failedFuture)") {
         val ex                                  = new Exception("no value for you!")
         lazy val noValue: CompletionStage[Unit] = CompletableFuture_.failedFuture(ex)
-        assertM(ZIO.fromCompletionStage(noValue).run)(fails[Throwable](equalTo(ex)))
+        assertM(ZIO.fromCompletionStage(noValue).exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (supplyAsync)") {
         val ex                                  = new Exception("no value for you!")
         lazy val noValue: CompletionStage[Unit] = CompletableFuture.supplyAsync(() => throw ex)
-        assertM(ZIO.fromCompletionStage(noValue).run)(fails[Throwable](equalTo(ex)))
+        assertM(ZIO.fromCompletionStage(noValue).exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that produces the value from `Future`") {
         lazy val someValue: CompletionStage[Int] = CompletableFuture.completedFuture(42)
@@ -110,7 +110,7 @@ object JavaSpec extends ZIOBaseSpec {
         val ex                       = new Exception("IOs also can fail")
         val failedIO: Task[Unit]     = IO.fail[Throwable](ex)
         val failedFuture: Task[Unit] = failedIO.toCompletableFuture.flatMap(f => Task(f.get()))
-        assertM(failedFuture.run)(
+        assertM(failedFuture.exit)(
           fails[Throwable](hasField("message", _.getMessage, equalTo("java.lang.Exception: IOs also can fail")))
         )
       } @@ zioTag(errors),
@@ -124,7 +124,7 @@ object JavaSpec extends ZIOBaseSpec {
         val failedIO: IO[String, Unit] = IO.fail[String]("IOs also can fail")
         val failedFuture: Task[Unit] =
           failedIO.toCompletableFutureWith(new Exception(_)).flatMap(f => Task(f.get()))
-        assertM(failedFuture.run)(
+        assertM(failedFuture.exit)(
           fails[Throwable](hasField("message", _.getMessage, equalTo("java.lang.Exception: IOs also can fail")))
         )
       } @@ zioTag(errors)
@@ -139,21 +139,21 @@ object JavaSpec extends ZIOBaseSpec {
       testM("catch exceptions thrown by lazy block") {
         val ex                              = new Exception("no future for you!")
         def noFuture: CompletionStage[Unit] = throw ex
-        assertM(Fiber.fromCompletionStage(noFuture).join.run)(fails(equalTo(ex)))
+        assertM(Fiber.fromCompletionStage(noFuture).join.exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (failedFuture)") {
         val ex                             = new Exception("no value for you!")
         def noValue: CompletionStage[Unit] = CompletableFuture_.failedFuture(ex)
-        assertM(Fiber.fromCompletionStage(noValue).join.run)(fails[Throwable](equalTo(ex)))
+        assertM(Fiber.fromCompletionStage(noValue).join.exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (supplyAsync)") {
         val ex                             = new Exception("no value for you!")
         def noValue: CompletionStage[Unit] = CompletableFuture.supplyAsync(() => throw ex)
-        assertM(Fiber.fromCompletionStage(noValue).join.run)(fails[Throwable](equalTo(ex)))
+        assertM(Fiber.fromCompletionStage(noValue).join.exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that produces the value from `Future`") {
         def someValue: CompletionStage[Int] = CompletableFuture.completedFuture(42)
-        assertM(Fiber.fromCompletionStage(someValue).join.run)(succeeds(equalTo(42)))
+        assertM(Fiber.fromCompletionStage(someValue).join.exit)(succeeds(equalTo(42)))
       }
     ) @@ zioTag(future),
     suite("`Fiber.fromFutureJava` must")(
@@ -166,21 +166,21 @@ object JavaSpec extends ZIOBaseSpec {
       testM("catch exceptions thrown by lazy block") {
         val ex                     = new Exception("no future for you!")
         def noFuture: Future[Unit] = throw ex
-        assertM(Fiber.fromFutureJava(noFuture).join.run)(fails(equalTo(ex)))
+        assertM(Fiber.fromFutureJava(noFuture).join.exit)(fails(equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (failedFuture)") {
         val ex                    = new Exception("no value for you!")
         def noValue: Future[Unit] = CompletableFuture_.failedFuture(ex)
-        assertM(Fiber.fromFutureJava(noValue).join.run)(fails[Throwable](equalTo(ex)))
+        assertM(Fiber.fromFutureJava(noValue).join.exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that fails if `Future` fails (failedFuture)") {
         val ex                    = new Exception("no value for you!")
         def noValue: Future[Unit] = CompletableFuture.supplyAsync(() => throw ex)
-        assertM(Fiber.fromFutureJava(noValue).join.run)(fails[Throwable](equalTo(ex)))
+        assertM(Fiber.fromFutureJava(noValue).join.exit)(fails[Throwable](equalTo(ex)))
       } @@ zioTag(errors),
       testM("return an `IO` that produces the value from `Future`") {
         def someValue: Future[Int] = CompletableFuture.completedFuture(42)
-        assertM(Fiber.fromFutureJava(someValue).join.run)(succeeds(equalTo(42)))
+        assertM(Fiber.fromFutureJava(someValue).join.exit)(succeeds(equalTo(42)))
       }
     ) @@ zioTag(future),
     suite("`Task.withCompletionHandler` must")(
@@ -206,10 +206,10 @@ object JavaSpec extends ZIOBaseSpec {
           fiberClient  <- taskClient.fork
           resultServer <- fiberServer.join
           resultClient <- fiberClient.join
-          _            <- ZIO.effectTotal(server.close())
+          _            <- ZIO.succeed(server.close())
         } yield (resultServer, resultClient)
 
-        assertM(task.run)(
+        assertM(task.exit)(
           succeeds[(Integer, (Integer, List[Byte]))](equalTo((Integer.valueOf(1), (Integer.valueOf(1), list))))
         )
       }

--- a/core-tests/shared/src/test/scala/zio/AutoLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/AutoLayerSpec.scala
@@ -203,9 +203,9 @@ object AutoLayerSpec extends ZIOBaseSpec {
             val layerB: URLayer[Has[String], Has[Boolean]] = ZLayer.succeed(true)
 
             (for {
-              ref    <- Ref.make(0).toManaged_
+              ref    <- Ref.make(0).toManaged
               _      <- ZManaged.services[Int, Boolean].inject(layerA, layerB, sideEffectingLayer(ref))
-              result <- ref.get.toManaged_
+              result <- ref.get.toManaged
             } yield assert(result)(equalTo(1))).useNow
           },
           testM("reports missing top-level layers") {
@@ -226,7 +226,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
           } @@ TestAspect.exceptDotty,
           testM("reports missing transitive dependencies") {
             import TestLayers._
-            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged_)
+            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged)
             val _                                         = program
 
             val checked = typeCheck("program.inject(OldLady.live)")
@@ -239,7 +239,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
           } @@ TestAspect.exceptDotty,
           testM("reports nested missing transitive dependencies") {
             import TestLayers._
-            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged_)
+            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged)
             val _                                         = program
 
             val checked = typeCheck("program.inject(OldLady.live, Fly.live)")
@@ -252,7 +252,7 @@ object AutoLayerSpec extends ZIOBaseSpec {
           } @@ TestAspect.exceptDotty,
           testM("reports circular dependencies") {
             import TestLayers._
-            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged_)
+            val program: URManaged[Has[OldLady], Boolean] = ZManaged.service[OldLady].flatMap(_.willDie.toManaged)
             val _                                         = program
 
             val checked = typeCheck("program.inject(OldLady.live, Fly.manEatingFly)")
@@ -267,8 +267,8 @@ object AutoLayerSpec extends ZIOBaseSpec {
         suite("injectCustom")(
           testM("automatically constructs a layer from its dependencies, leaving off ZEnv") {
             val stringLayer = Console.readLine.orDie.toLayer
-            val program     = ZManaged.service[String].zipWith(Random.nextInt.toManaged_)((str, int) => s"$str $int")
-            val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged_ *>
+            val program     = ZManaged.service[String].zipWith(Random.nextInt.toManaged)((str, int) => s"$str $int")
+            val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged *>
               program.injectCustom(stringLayer)
 
             assertM(provided.useNow)(equalTo("Your Lucky Number is: -1295463240"))
@@ -277,8 +277,8 @@ object AutoLayerSpec extends ZIOBaseSpec {
         suite("injectSome")(
           testM("automatically constructs a layer from its dependencies, leaving off some environment") {
             val stringLayer = Console.readLine.orDie.toLayer
-            val program     = ZManaged.service[String].zipWith(Random.nextInt.toManaged_)((str, int) => s"$str $int")
-            val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged_ *>
+            val program     = ZManaged.service[String].zipWith(Random.nextInt.toManaged)((str, int) => s"$str $int")
+            val provided = TestConsole.feedLines("Your Lucky Number is:").toManaged *>
               program.injectSome[Has[Random] with Has[Console]](stringLayer)
 
             assertM(provided.useNow)(equalTo("Your Lucky Number is: -1295463240"))

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -46,7 +46,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
           runtime <- ZIO.runtime[Any]
           f        = runtime.unsafeRunToFuture(UIO.never)
           _       <- UIO(f.cancel())
-          r       <- ZIO.fromFuture(_ => f).run
+          r       <- ZIO.fromFuture(_ => f).exit
         } yield assert(r.succeeded)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.
       } @@ nonFlaky @@ zioTag(interruption),
       testM("roundtrip preserves interruptibility") {

--- a/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBufferSpec.scala
@@ -10,14 +10,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ChunkBufferSpec")(
     suite("ByteBuffer")(
       testM("byte array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toByte)
           val buffer = ByteBuffer.wrap(array)
           assert(Chunk.fromByteBuffer(buffer))(equalTo(byteChunk(1, 2, 3)))
         }
       },
       testM("byte array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = ByteBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -30,7 +30,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("byte array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = ByteBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -44,7 +44,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct byte buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = ByteBuffer.allocateDirect(10)
           var i      = 0
           while (i < 10) {
@@ -59,14 +59,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("CharBuffer")(
       testM("char array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toChar)
           val buffer = CharBuffer.wrap(array)
           assert(Chunk.fromCharBuffer(buffer))(equalTo(charChunk(1, 2, 3)))
         }
       },
       testM("char array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = CharBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -79,7 +79,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("char array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = CharBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -93,7 +93,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct char buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Character.BYTES * 10)
           var i          = 0
           while (i < java.lang.Character.BYTES * 10) {
@@ -115,14 +115,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("DoubleBuffer")(
       testM("double array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toDouble)
           val buffer = DoubleBuffer.wrap(array)
           assert(Chunk.fromDoubleBuffer(buffer))(equalTo(doubleChunk(1, 2, 3)))
         }
       },
       testM("double array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = DoubleBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -135,7 +135,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("double array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = DoubleBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -149,7 +149,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct double buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Double.BYTES * 10)
           var i          = 0
           while (i < java.lang.Double.BYTES * 10) {
@@ -171,14 +171,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("FloatBuffer")(
       testM("float array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toFloat)
           val buffer = FloatBuffer.wrap(array)
           assert(Chunk.fromFloatBuffer(buffer))(equalTo(floatChunk(1, 2, 3)))
         }
       },
       testM("float array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = FloatBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -191,7 +191,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("float array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = FloatBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -205,7 +205,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct float buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Float.BYTES * 10)
           var i          = 0
           while (i < java.lang.Float.BYTES * 10) {
@@ -227,14 +227,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("IntBuffer")(
       testM("int array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3)
           val buffer = IntBuffer.wrap(array)
           assert(Chunk.fromIntBuffer(buffer))(equalTo(Chunk(1, 2, 3)))
         }
       },
       testM("int array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = IntBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -247,7 +247,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("int array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = IntBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -261,7 +261,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct int buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Integer.BYTES * 10)
           var i          = 0
           while (i < java.lang.Integer.BYTES * 10) {
@@ -283,14 +283,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("LongBuffer")(
       testM("long array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toLong)
           val buffer = LongBuffer.wrap(array)
           assert(Chunk.fromLongBuffer(buffer))(equalTo(longChunk(1, 2, 3)))
         }
       },
       testM("long array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = LongBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -303,7 +303,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("long array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = LongBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -317,7 +317,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct long buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Long.BYTES * 10)
           var i          = 0
           while (i < java.lang.Long.BYTES * 10) {
@@ -339,14 +339,14 @@ object ChunkBufferSpec extends ZIOBaseSpec {
     ),
     suite("ShortBuffer")(
       testM("short array buffer no copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val array  = Array(1, 2, 3).map(_.toShort)
           val buffer = ShortBuffer.wrap(array)
           assert(Chunk.fromShortBuffer(buffer))(equalTo(shortChunk(1, 2, 3)))
         }
       },
       testM("short array buffer partial copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = ShortBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -359,7 +359,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("short array buffer slice copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val buffer = ShortBuffer.allocate(10)
           var i      = 0
           while (i < 10) {
@@ -373,7 +373,7 @@ object ChunkBufferSpec extends ZIOBaseSpec {
         }
       },
       testM("direct short buffer copying") {
-        UIO.effectTotal {
+        UIO.succeed {
           val byteBuffer = ByteBuffer.allocateDirect(java.lang.Short.BYTES * 10)
           var i          = 0
           while (i < java.lang.Short.BYTES * 10) {

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -60,7 +60,7 @@ object FiberSpec extends ZIOBaseSpec {
           val fiberId = Fiber.Id(0L, 123L)
 
           for {
-            exit <- Fiber.interruptAs(fiberId).join.run
+            exit <- Fiber.interruptAs(fiberId).join.exit
           } yield assert(exit)(equalTo(Exit.interrupt(fiberId)))
         }
       ) @@ zioTag(interruption),
@@ -72,17 +72,17 @@ object FiberSpec extends ZIOBaseSpec {
         },
         testM("`join`") {
           for {
-            exit <- Fiber.fail("fail").zip(Fiber.never).join.run
+            exit <- Fiber.fail("fail").zip(Fiber.never).join.exit
           } yield assert(exit)(fails(equalTo("fail")))
         },
         testM("`awaitAll`") {
           for {
-            exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).run
+            exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).exit
           } yield assert(exit)(succeeds(isUnit))
         },
         testM("`joinAll`") {
           for {
-            exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).run
+            exit <- Fiber.awaitAll(Fiber.fail("fail") :: List.fill(100)(Fiber.never)).exit
           } yield assert(exit)(succeeds(isUnit))
         },
         testM("shard example") {
@@ -94,7 +94,7 @@ object FiberSpec extends ZIOBaseSpec {
             queue <- Queue.unbounded[Int]
             _     <- queue.offerAll(1 to 100)
             worker = (n: Int) => if (n == 100) ZIO.fail("fail") else queue.offer(n).unit
-            exit  <- shard(queue, 4, worker).run
+            exit  <- shard(queue, 4, worker).exit
             _     <- queue.shutdown
           } yield assert(exit)(fails(equalTo("fail")))
         }

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -41,7 +41,7 @@ object PromiseSpec extends ZIOBaseSpec {
       for {
         p <- Promise.make[String, Int]
         s <- p.fail("error with fail")
-        v <- p.await.run
+        v <- p.await.exit
       } yield assert(s)(isTrue) && assert(v)(fails(equalTo("error with fail")))
     } @@ zioTag(errors),
     testM("fail a promise using complete") {
@@ -49,8 +49,8 @@ object PromiseSpec extends ZIOBaseSpec {
         p  <- Promise.make[String, Int]
         r  <- Ref.make(List("first error", "second error"))
         s  <- p.complete(r.modify(as => (as.head, as.tail)).flip)
-        v1 <- p.await.run
-        v2 <- p.await.run
+        v1 <- p.await.exit
+        v2 <- p.await.exit
       } yield assert(s)(isTrue) &&
         assert(v1)(fails(equalTo("first error"))) &&
         assert(v2)(fails(equalTo("first error")))
@@ -60,8 +60,8 @@ object PromiseSpec extends ZIOBaseSpec {
         p  <- Promise.make[String, Int]
         r  <- Ref.make(List("first error", "second error"))
         s  <- p.completeWith(r.modify(as => (as.head, as.tail)).flip)
-        v1 <- p.await.run
-        v2 <- p.await.run
+        v1 <- p.await.exit
+        v2 <- p.await.exit
       } yield assert(s)(isTrue) &&
         assert(v1)(fails(equalTo("first error"))) &&
         assert(v2)(fails(equalTo("second error")))
@@ -90,21 +90,21 @@ object PromiseSpec extends ZIOBaseSpec {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.succeed(12)
-        result <- p.poll.someOrFail("fail").flatten.run
+        result <- p.poll.someOrFail("fail").flatten.exit
       } yield assert(result)(succeeds(equalTo(12)))
     },
     testM("poll a promise that is failed") {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.fail("failure")
-        result <- p.poll.someOrFail("fail").flatten.run
+        result <- p.poll.someOrFail("fail").flatten.exit
       } yield assert(result)(fails(equalTo("failure")))
     },
     testM("poll a promise that is interrupted") {
       for {
         p      <- Promise.make[String, Int]
         _      <- p.interrupt
-        result <- p.poll.someOrFail("fail").flatten.run
+        result <- p.poll.someOrFail("fail").flatten.exit
       } yield assert(result)(isInterrupted)
     } @@ zioTag(interruption),
     testM("isDone when a promise is completed") {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -189,7 +189,7 @@ object ScheduleSpec extends ZIOBaseSpec {
       },
       testM("fixed delay with error predicate") {
         var i = 0
-        val io = IO.effectTotal(i += 1).flatMap[Any, String, Unit] { _ =>
+        val io = IO.succeed(i += 1).flatMap[Any, String, Unit] { _ =>
           if (i < 5) IO.fail("KeepTryingError") else IO.fail("GiveUpError")
         }
         val strategy = Schedule.spaced(200.millis).whileInput[String](_ == "KeepTryingError")
@@ -258,7 +258,7 @@ object ScheduleSpec extends ZIOBaseSpec {
       testM("for up to 10 times") {
         var i        = 0
         val strategy = Schedule.recurs(10)
-        val io       = IO.effectTotal(i += 1).flatMap(_ => if (i < 5) IO.fail("KeepTryingError") else IO.succeed(i))
+        val io       = IO.succeed(i += 1).flatMap(_ => if (i < 5) IO.fail("KeepTryingError") else IO.succeed(i))
         assertM(io.retry(strategy))(equalTo(5))
       }
     ) @@ zioTag(errors),

--- a/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
@@ -5,7 +5,7 @@ import zio.test._
 object ZIOLazinessSpec extends ZIOBaseSpec {
 
   def assertLazy(f: (=> Nothing) => Any): UIO[TestResult] =
-    UIO.effectTotal {
+    UIO.succeed {
       val _ = f(throw new RuntimeException("not lazy"))
       assertCompletes
     }

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -758,7 +758,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       for {
         q <- Queue.bounded[IO[String, Int]](100).map(_.mapM(identity))
         _ <- q.offer(IO.fail("Ouch"))
-        v <- q.take.run
+        v <- q.take.exit
       } yield assert(v)(fails(equalTo("Ouch")))
     } @@ zioTag(errors),
     testM("queue contramap") {

--- a/core-tests/shared/src/test/scala/zio/ZRefMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZRefMSpec.scala
@@ -20,14 +20,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdate") {
         for {
           refM   <- RefM.make(current)
-          value1 <- refM.getAndUpdateM(_ => IO.effectTotal(update))
+          value1 <- refM.getAndUpdateM(_ => IO.succeed(update))
           value2 <- refM.get
         } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
       },
       testM("getAndUpdate with failure") {
         for {
           refM  <- RefM.make[String](current)
-          value <- refM.getAndUpdateM(_ => IO.fail(failure)).run
+          value <- refM.getAndUpdateM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("getAndUpdateSome") {
@@ -51,7 +51,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdateSome with failure") {
         for {
           refM  <- RefM.make[State](Active)
-          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.run
+          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("interrupt parent fiber and update") {
@@ -68,14 +68,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modify") {
         for {
           refM  <- RefM.make(current)
-          r     <- refM.modifyM(_ => IO.effectTotal(("hello", update)))
+          r     <- refM.modifyM(_ => IO.succeed(("hello", update)))
           value <- refM.get
         } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
       },
       testM("modify with failure") {
         for {
           refM <- RefM.make[String](current)
-          r    <- refM.modifyM(_ => IO.fail(failure)).run
+          r    <- refM.modifyM(_ => IO.fail(failure)).exit
         } yield assert(r)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modify twice") {
@@ -110,13 +110,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modifySome with failure") {
         for {
           refM  <- RefM.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modifySome with fatal error") {
         for {
           refM  <- RefM.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.exit
         } yield assert(value)(dies(hasMessage(equalTo(fatalError))))
       } @@ zioTag(errors),
       testM("set") {
@@ -129,13 +129,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateAndGet") {
         for {
           refM  <- RefM.make(current)
-          value <- refM.updateAndGetM(_ => IO.effectTotal(update))
+          value <- refM.updateAndGetM(_ => IO.succeed(update))
         } yield assert(value)(equalTo(update))
       },
       testM("updateAndGet with failure") {
         for {
           refM  <- RefM.make[String](current)
-          value <- refM.updateAndGetM(_ => IO.fail(failure)).run
+          value <- refM.updateAndGetM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("updateSomeAndGet") {
@@ -157,7 +157,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateSomeAndGet with failure") {
         for {
           refM  <- RefM.make[State](Active)
-          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.run
+          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors)
     ),
@@ -178,14 +178,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdate") {
         for {
           refM   <- Derived.make(current)
-          value1 <- refM.getAndUpdateM(_ => IO.effectTotal(update))
+          value1 <- refM.getAndUpdateM(_ => IO.succeed(update))
           value2 <- refM.get
         } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
       },
       testM("getAndUpdate with failure") {
         for {
           refM  <- Derived.make[String](current)
-          value <- refM.getAndUpdateM(_ => IO.fail(failure)).run
+          value <- refM.getAndUpdateM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("getAndUpdateSome") {
@@ -209,7 +209,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdateSome with failure") {
         for {
           refM  <- Derived.make[State](Active)
-          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.run
+          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("interrupt parent fiber and update") {
@@ -226,14 +226,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modify") {
         for {
           refM  <- Derived.make(current)
-          r     <- refM.modifyM(_ => IO.effectTotal(("hello", update)))
+          r     <- refM.modifyM(_ => IO.succeed(("hello", update)))
           value <- refM.get
         } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
       },
       testM("modify with failure") {
         for {
           refM <- Derived.make[String](current)
-          r    <- refM.modifyM(_ => IO.fail(failure)).run
+          r    <- refM.modifyM(_ => IO.fail(failure)).exit
         } yield assert(r)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modify twice") {
@@ -268,13 +268,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modifySome with failure") {
         for {
           refM  <- Derived.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modifySome with fatal error") {
         for {
           refM  <- Derived.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.exit
         } yield assert(value)(dies(hasMessage(equalTo(fatalError))))
       } @@ zioTag(errors),
       testM("set") {
@@ -287,13 +287,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateAndGet") {
         for {
           refM  <- Derived.make(current)
-          value <- refM.updateAndGetM(_ => IO.effectTotal(update))
+          value <- refM.updateAndGetM(_ => IO.succeed(update))
         } yield assert(value)(equalTo(update))
       },
       testM("updateAndGet with failure") {
         for {
           refM  <- Derived.make[String](current)
-          value <- refM.updateAndGetM(_ => IO.fail(failure)).run
+          value <- refM.updateAndGetM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("updateSomeAndGet") {
@@ -315,7 +315,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateSomeAndGet with failure") {
         for {
           refM  <- Derived.make[State](Active)
-          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.run
+          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors)
     ),
@@ -336,14 +336,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdate") {
         for {
           refM   <- DerivedAll.make(current)
-          value1 <- refM.getAndUpdateM(_ => IO.effectTotal(update))
+          value1 <- refM.getAndUpdateM(_ => IO.succeed(update))
           value2 <- refM.get
         } yield assert(value1)(equalTo(current)) && assert(value2)(equalTo(update))
       },
       testM("getAndUpdate with failure") {
         for {
           refM  <- DerivedAll.make[String](current)
-          value <- refM.getAndUpdateM(_ => IO.fail(failure)).run
+          value <- refM.getAndUpdateM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("getAndUpdateSome") {
@@ -367,7 +367,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("getAndUpdateSome with failure") {
         for {
           refM  <- DerivedAll.make[State](Active)
-          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.run
+          value <- refM.getAndUpdateSomeM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       },
       testM("interrupt parent fiber and update") {
@@ -384,14 +384,14 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modify") {
         for {
           refM  <- DerivedAll.make(current)
-          r     <- refM.modifyM(_ => IO.effectTotal(("hello", update)))
+          r     <- refM.modifyM(_ => IO.succeed(("hello", update)))
           value <- refM.get
         } yield assert(r)(equalTo("hello")) && assert(value)(equalTo(update))
       },
       testM("modify with failure") {
         for {
           refM <- DerivedAll.make[String](current)
-          r    <- refM.modifyM(_ => IO.fail(failure)).run
+          r    <- refM.modifyM(_ => IO.fail(failure)).exit
         } yield assert(r)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modify twice") {
@@ -426,13 +426,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("modifySome with failure") {
         for {
           refM  <- DerivedAll.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("modifySome with fatal error") {
         for {
           refM  <- DerivedAll.make[State](Active)
-          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.run
+          value <- refM.modifySomeM("State doesn't change") { case Active => IO.dieMessage(fatalError) }.exit
         } yield assert(value)(dies(hasMessage(equalTo(fatalError))))
       } @@ zioTag(errors),
       testM("set") {
@@ -445,13 +445,13 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateAndGet") {
         for {
           refM  <- DerivedAll.make(current)
-          value <- refM.updateAndGetM(_ => IO.effectTotal(update))
+          value <- refM.updateAndGetM(_ => IO.succeed(update))
         } yield assert(value)(equalTo(update))
       },
       testM("updateAndGet with failure") {
         for {
           refM  <- DerivedAll.make[String](current)
-          value <- refM.updateAndGetM(_ => IO.fail(failure)).run
+          value <- refM.updateAndGetM(_ => IO.fail(failure)).exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors),
       testM("updateSomeAndGet") {
@@ -473,7 +473,7 @@ object ZRefMSpec extends ZIOBaseSpec {
       testM("updateSomeAndGet with failure") {
         for {
           refM  <- DerivedAll.make[State](Active)
-          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.run
+          value <- refM.updateSomeAndGetM { case Active => IO.fail(failure) }.exit
         } yield assert(value)(fails(equalTo(failure)))
       } @@ zioTag(errors)
     ),

--- a/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
@@ -66,7 +66,7 @@ object HubSpec extends ZIOBaseSpec {
     Gen.int(1, 10)
 
   def offerAll[A](hub: Hub[A], values: List[A]): UIO[Unit] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       values match {
         case h :: t =>
           if (hub.publish(h)) offerAll(hub, t)
@@ -76,7 +76,7 @@ object HubSpec extends ZIOBaseSpec {
     }
 
   def offerAllChunks[A](hub: Hub[A], chunks: List[Chunk[A]]): UIO[Unit] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       chunks match {
         case h :: t =>
           val remaining = hub.publishAll(h)
@@ -87,7 +87,7 @@ object HubSpec extends ZIOBaseSpec {
     }
 
   def takeN[A](subscription: Hub.Subscription[A], n: Int, acc: List[A] = List.empty): UIO[List[A]] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       if (n <= 0) ZIO.succeed(acc.reverse)
       else {
         val a = subscription.poll(null.asInstanceOf[A])
@@ -102,7 +102,7 @@ object HubSpec extends ZIOBaseSpec {
     chunkSize: Int,
     acc: List[A] = List.empty
   ): UIO[List[A]] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       if (n <= 0) ZIO.succeed(acc.reverse)
       else {
         val as        = subscription.pollUpTo(chunkSize)
@@ -113,7 +113,7 @@ object HubSpec extends ZIOBaseSpec {
     }
 
   def offerAll_[A](hub: Hub[A], values: List[A]): UIO[Unit] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       values match {
         case h :: t =>
           if (hub.publish(h)) offerAll(hub, t)
@@ -123,7 +123,7 @@ object HubSpec extends ZIOBaseSpec {
     }
 
   def takeN_[A](subscription: Hub.Subscription[A], n: Int, acc: List[A] = List.empty): UIO[List[A]] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       if (n <= 0) ZIO.succeed(acc.reverse)
       else {
         val a = subscription.poll(null.asInstanceOf[A])
@@ -133,7 +133,7 @@ object HubSpec extends ZIOBaseSpec {
     }
 
   def slidingOffer[A](hub: Hub[A], value: A): UIO[Unit] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       if (hub.publish(value)) {
         ZIO.unit
       } else {
@@ -146,7 +146,7 @@ object HubSpec extends ZIOBaseSpec {
     ZIO.foreach_(values)(slidingOffer(hub, _) *> ZIO.yieldNow)
 
   def slidingOfferAllChunks[A](hub: Hub[A], chunks: List[Chunk[A]]): UIO[Unit] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       chunks match {
         case h :: t =>
           val remaining = hub.publishAll(h)
@@ -261,7 +261,7 @@ object HubSpec extends ZIOBaseSpec {
         for {
           publisher  <- offerAll(hub, as).fork
           subscriber <- takeN(subscription, as.length).fork
-          _          <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _          <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           _          <- publisher.join
           values     <- subscriber.join
         } yield assert(values)(equalTo(as)) &&
@@ -282,7 +282,7 @@ object HubSpec extends ZIOBaseSpec {
           publisher   <- offerAll(hub, as).fork
           subscriber1 <- takeN(subscription1, as.length).fork
           subscriber2 <- takeN(subscription2, as.length).fork
-          _           <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _           <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           _           <- publisher.join
           values1     <- subscriber1.join
           values2     <- subscriber2.join
@@ -308,7 +308,7 @@ object HubSpec extends ZIOBaseSpec {
           publisher2  <- offerAll(hub, as.map(-_)).fork
           subscriber1 <- takeN(subscription1, as.length * 2).fork
           subscriber2 <- takeN(subscription2, as.length * 2).fork
-          _           <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _           <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           _           <- publisher1.join
           _           <- publisher2.join
           values1     <- subscriber1.join
@@ -338,11 +338,11 @@ object HubSpec extends ZIOBaseSpec {
           publisher2  <- offerAll_(hub, as.map(-_)).fork
           subscriber1 <- takeN(subscription1, as.length).fork
           subscriber2 <- takeN(subscription2, as.length).fork
-          fiber1      <- ZIO.foreach(1 to 100)(_ => ZIO.effectTotal(subscription1.isEmpty())).map(_.forall(a => !a)).fork
-          fiber2      <- ZIO.foreach(1 to 100)(_ => ZIO.effectTotal(subscription2.isEmpty())).map(_.forall(a => !a)).fork
+          fiber1      <- ZIO.foreach(1 to 100)(_ => ZIO.succeed(subscription1.isEmpty())).map(_.forall(a => !a)).fork
+          fiber2      <- ZIO.foreach(1 to 100)(_ => ZIO.succeed(subscription2.isEmpty())).map(_.forall(a => !a)).fork
           _ <- ZIO
-                 .effectTotal(hub.subscribe())
-                 .flatMap(subscription => ZIO.yieldNow *> ZIO.effectTotal(subscription.unsubscribe()))
+                 .succeed(hub.subscribe())
+                 .flatMap(subscription => ZIO.yieldNow *> ZIO.succeed(subscription.unsubscribe()))
           _       <- publisher1.join
           _       <- publisher2.join
           _       <- subscriber1.join
@@ -364,10 +364,10 @@ object HubSpec extends ZIOBaseSpec {
           publisher2  <- offerAll_(hub, as.map(-_)).fork
           subscriber1 <- takeN(subscription1, as.length).fork
           subscriber2 <- takeN(subscription2, as.length).fork
-          fiber       <- ZIO.foreach(1 to 100)(_ => ZIO.effectTotal(hub.isFull())).map(_.forall(a => !a)).fork
+          fiber       <- ZIO.foreach(1 to 100)(_ => ZIO.succeed(hub.isFull())).map(_.forall(a => !a)).fork
           _ <- ZIO
-                 .effectTotal(hub.subscribe())
-                 .flatMap(subscription => ZIO.yieldNow *> ZIO.effectTotal(subscription.unsubscribe()))
+                 .succeed(hub.subscribe())
+                 .flatMap(subscription => ZIO.yieldNow *> ZIO.succeed(subscription.unsubscribe()))
           _      <- publisher1.join
           _      <- publisher2.join
           _      <- subscriber1.join
@@ -389,8 +389,8 @@ object HubSpec extends ZIOBaseSpec {
           subscriber1 <- takeN(subscription1, as.length).fork
           subscriber2 <- takeN(subscription2, as.length).fork
           _ <- ZIO
-                 .effectTotal(hub.subscribe())
-                 .flatMap(subscription => ZIO.yieldNow *> ZIO.effectTotal(subscription.unsubscribe()))
+                 .succeed(hub.subscribe())
+                 .flatMap(subscription => ZIO.yieldNow *> ZIO.succeed(subscription.unsubscribe()))
           _ <- publisher1.join
           _ <- publisher2.join
           _ <- subscriber1.join
@@ -412,8 +412,8 @@ object HubSpec extends ZIOBaseSpec {
           subscriber1 <- takeN_(subscription1, as.length * 2).fork
           subscriber2 <- takeN_(subscription2, as.length * 2).fork
           _ <- ZIO
-                 .effectTotal(hub.subscribe())
-                 .flatMap(subscription => ZIO.yieldNow *> ZIO.effectTotal(subscription.unsubscribe()))
+                 .succeed(hub.subscribe())
+                 .flatMap(subscription => ZIO.yieldNow *> ZIO.succeed(subscription.unsubscribe()))
           _ <- publisher1.join
           _ <- publisher2.join
           _ <- subscriber1.join
@@ -483,7 +483,7 @@ object HubSpec extends ZIOBaseSpec {
         for {
           _          <- slidingOfferAll(hub, as.sorted).fork
           subscriber <- takeN(subscription, n).fork
-          _          <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _          <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           values     <- subscriber.join
         } yield assert(values)(hasSize(equalTo(n))) &&
           assert(values)(isSorted)
@@ -501,7 +501,7 @@ object HubSpec extends ZIOBaseSpec {
           _           <- slidingOfferAll(hub, as.sorted).fork
           subscriber1 <- takeN(subscription1, n).fork
           subscriber2 <- takeN(subscription2, n).fork
-          _           <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _           <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           values1     <- subscriber1.join
           values2     <- subscriber2.join
         } yield assert(values1)(hasSize(equalTo(n))) &&
@@ -524,7 +524,7 @@ object HubSpec extends ZIOBaseSpec {
           publisher2  <- slidingOfferAll(hub, as.map(-_).sorted).fork
           subscriber1 <- takeN(subscription1, n).fork
           subscriber2 <- takeN(subscription2, n).fork
-          _           <- ZIO.when(dynamic)(ZIO.effectTotal(hub.subscribe().unsubscribe()))
+          _           <- ZIO.when(dynamic)(ZIO.succeed(hub.subscribe().unsubscribe()))
           _           <- publisher1.join
           _           <- publisher2.join
           values1     <- subscriber1.join
@@ -579,14 +579,14 @@ object HubSpec extends ZIOBaseSpec {
       val hub          = makeHub(2)
       val subscription = hub.subscribe()
       for {
-        unsubscribe  <- ZIO.effectTotal(subscription.unsubscribe()).fork
-        publish      <- ZIO.effectTotal(hub.publish(1)).fork
+        unsubscribe  <- ZIO.succeed(subscription.unsubscribe()).fork
+        publish      <- ZIO.succeed(hub.publish(1)).fork
         _            <- unsubscribe.join
         _            <- publish.join
-        empty        <- ZIO.effectTotal(hub.isEmpty())
-        full         <- ZIO.effectTotal(hub.isFull())
-        size         <- ZIO.effectTotal(hub.size())
-        subscription <- ZIO.effectTotal(hub.subscribe())
+        empty        <- ZIO.succeed(hub.isEmpty())
+        full         <- ZIO.succeed(hub.isFull())
+        size         <- ZIO.succeed(hub.size())
+        subscription <- ZIO.succeed(hub.subscribe())
         _            <- offerAll(hub, List(2, 3, 4, 5, 6)).fork
         values       <- takeN(subscription, 5)
       } yield assert(empty)(isTrue) &&
@@ -601,14 +601,14 @@ object HubSpec extends ZIOBaseSpec {
       val subscription = hub.subscribe()
       hub.publish(1)
       for {
-        unsubscribe  <- ZIO.effectTotal(subscription.unsubscribe()).fork
-        poll         <- ZIO.effectTotal(subscription.poll(-1)).fork
+        unsubscribe  <- ZIO.succeed(subscription.unsubscribe()).fork
+        poll         <- ZIO.succeed(subscription.poll(-1)).fork
         _            <- unsubscribe.join
         _            <- poll.join
-        empty        <- ZIO.effectTotal(hub.isEmpty())
-        full         <- ZIO.effectTotal(hub.isFull())
-        size         <- ZIO.effectTotal(hub.size())
-        subscription <- ZIO.effectTotal(hub.subscribe())
+        empty        <- ZIO.succeed(hub.isEmpty())
+        full         <- ZIO.succeed(hub.isFull())
+        size         <- ZIO.succeed(hub.size())
+        subscription <- ZIO.succeed(hub.subscribe())
         _            <- offerAll(hub, List(2, 3, 4, 5, 6)).fork
         values       <- takeN(subscription, 5)
       } yield assert(empty)(isTrue) &&

--- a/core-tests/shared/src/test/scala/zio/stm/STMLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/STMLazinessSpec.scala
@@ -6,7 +6,7 @@ import zio.{UIO, ZIOBaseSpec}
 object STMLazinessSpec extends ZIOBaseSpec {
 
   def assertLazy(f: (=> Nothing) => Any): UIO[TestResult] =
-    UIO.effectTotal {
+    UIO.succeed {
       val _ = f(throw new RuntimeException("not lazy"))
       assertCompletes
     }

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -20,7 +20,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
-          result <- tArray(-1).commit.run
+          result <- tArray(-1).commit.exit
         } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       }
     ),
@@ -733,7 +733,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(1)(42).commit
-          result <- tArray.update(-1, identity).commit.run
+          result <- tArray.update(-1, identity).commit.exit
         } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       }
     ),
@@ -747,7 +747,7 @@ object TArraySpec extends ZIOBaseSpec {
       testM("dies with ArrayIndexOutOfBounds when index is out of bounds") {
         for {
           tArray <- makeTArray(10)(0).commit
-          result <- tArray.updateM(10, STM.succeed(_)).commit.run
+          result <- tArray.updateM(10, STM.succeed(_)).commit.exit
         } yield assert(result)(dies(isArrayIndexOutOfBoundsException))
       },
       testM("updateM failure") {

--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -334,7 +334,7 @@ object TMapSpec extends ZIOBaseSpec {
                         _ <- map.toChunk.commit
                       } yield ()
                     }
-                    .run
+                    .exit
         } yield assert(exit)(succeeds(isUnit))
       } @@ nonFlaky
     )

--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -56,7 +56,7 @@ trait App extends BootstrapRuntime {
       unsafeRun(
         for {
           fiber <- run(args0.toList).fork
-          _ <- IO.effectTotal(java.lang.Runtime.getRuntime.addShutdownHook(new Thread {
+          _ <- IO.succeed(java.lang.Runtime.getRuntime.addShutdownHook(new Thread {
                  override def run() =
                    if (FiberContext.fatal.get) {
                      println(

--- a/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZManagedPlatformSpecific.scala
@@ -29,14 +29,14 @@ private[zio] trait ZManagedPlatformSpecific {
    * `release` action.
    */
   val blocking: ZManaged[Any, Nothing, Unit] =
-    ZIO.blockingExecutor.toManaged_.flatMap(executor => ZManaged.lock(executor))
+    ZIO.blockingExecutor.toManaged.flatMap(executor => ZManaged.lock(executor))
 
   def readFile(path: Path): ZManaged[Any, IOException, ZInputStream] =
     readFile(path.toString())
 
   def readFile(path: String): ZManaged[Any, IOException, ZInputStream] =
     ZManaged
-      .make(
+      .bracket(
         ZIO.effectBlockingIO {
           val fis = new io.FileInputStream(path)
           (fis, ZInputStream.fromInputStream(fis))
@@ -46,7 +46,7 @@ private[zio] trait ZManagedPlatformSpecific {
 
   def readURL(url: URL): ZManaged[Any, IOException, ZInputStream] =
     ZManaged
-      .make(
+      .bracket(
         ZIO.effectBlockingIO {
           val fis = url.openStream()
           (fis, ZInputStream.fromInputStream(fis))
@@ -55,7 +55,7 @@ private[zio] trait ZManagedPlatformSpecific {
       .map(_._2)
 
   def readURL(url: String): ZManaged[Any, IOException, ZInputStream] =
-    ZManaged.fromEffect(ZIO.effectTotal(new URL(url))).flatMap(readURL)
+    ZManaged.fromEffect(ZIO.succeed(new URL(url))).flatMap(readURL)
 
   def readURI(uri: URI): ZManaged[Any, IOException, ZInputStream] =
     for {
@@ -65,7 +65,7 @@ private[zio] trait ZManagedPlatformSpecific {
 
   def writeFile(path: String): ZManaged[Any, IOException, ZOutputStream] =
     ZManaged
-      .make(
+      .bracket(
         ZIO.effectBlockingIO {
           val fos = new io.FileOutputStream(path)
           (fos, ZOutputStream.fromOutputStream(fos))

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -24,7 +24,7 @@ import scala.concurrent.ExecutionException
 
 private[zio] object javaz {
   def effectAsyncWithCompletionHandler[T](op: CompletionHandler[T, Any] => Any): Task[T] =
-    Task.effectSuspendTotalWith[T] { (p, _) =>
+    Task.suspendSucceedWith[T] { (p, _) =>
       Task.effectAsync { k =>
         val handler = new CompletionHandler[T, Any] {
           def completed(result: T, u: Any): Unit = k(Task.succeedNow(result))
@@ -60,8 +60,8 @@ private[zio] object javaz {
     } catch catchFromGet(isFatal)
 
   def fromCompletionStage[A](thunk: => CompletionStage[A]): Task[A] =
-    Task.effect(thunk).flatMap { cs =>
-      Task.effectSuspendTotalWith { (p, _) =>
+    Task.attempt(thunk).flatMap { cs =>
+      Task.suspendSucceedWith { (p, _) =>
         val cf = cs.toCompletableFuture
         if (cf.isDone) {
           unwrapDone(p.fatal)(cf)
@@ -80,12 +80,12 @@ private[zio] object javaz {
 
   /** WARNING: this uses the blocking Future#get, consider using `fromCompletionStage` */
   def fromFutureJava[A](thunk: => Future[A]): Task[A] =
-    RIO.effect(thunk).flatMap { future =>
-      RIO.effectSuspendTotalWith { (p, _) =>
+    RIO.attempt(thunk).flatMap { future =>
+      RIO.suspendSucceedWith { (p, _) =>
         if (future.isDone) {
           unwrapDone(p.fatal)(future)
         } else {
-          ZIO.blocking(Task.effectSuspend(unwrapDone(p.fatal)(future)))
+          ZIO.blocking(Task.suspend(unwrapDone(p.fatal)(future)))
         }
       }
     }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -218,7 +218,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     drop(i)
   }
 
-  def dropWhileM[R, E](p: A => ZIO[R, E, Boolean]): ZIO[R, E, Chunk[A]] = ZIO.effectSuspendTotal {
+  def dropWhileM[R, E](p: A => ZIO[R, E, Boolean]): ZIO[R, E, Chunk[A]] = ZIO.suspendSucceed {
     val length  = self.length
     val builder = ChunkBuilder.make[A]()
     builder.sizeHint(length)
@@ -336,7 +336,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * Filters this chunk by the specified effectful predicate, retaining all elements for
    * which the predicate evaluates to true.
    */
-  final def filterM[R, E](f: A => ZIO[R, E, Boolean]): ZIO[R, E, Chunk[A]] = ZIO.effectSuspendTotal {
+  final def filterM[R, E](f: A => ZIO[R, E, Boolean]): ZIO[R, E, Chunk[A]] = ZIO.suspendSucceed {
     val iterator = arrayIterator
     val builder  = ChunkBuilder.make[A]()
     builder.sizeHint(length)
@@ -628,7 +628,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * new elements.
    */
   final def mapAccumM[R, E, S1, B](s1: S1)(f1: (S1, A) => ZIO[R, E, (S1, B)]): ZIO[R, E, (S1, Chunk[B])] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       val iterator = arrayIterator
       val builder  = ChunkBuilder.make[B]()
       builder.sizeHint(length)
@@ -822,7 +822,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * Takes all elements so long as the effectual predicate returns true.
    */
   def takeWhileM[R, E](p: A => ZIO[R, E, Boolean]): ZIO[R, E, Chunk[A]] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       val length  = self.length
       val builder = ChunkBuilder.make[A]()
       builder.sizeHint(length)
@@ -1304,7 +1304,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    * long as it returns `Some`.
    */
   def unfoldM[R, E, A, S](s: S)(f: S => ZIO[R, E, Option[(A, S)]]): ZIO[R, E, Chunk[A]] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
 
       def go(s: S, builder: ChunkBuilder[A]): ZIO[R, E, Chunk[A]] =
         f(s).flatMap {
@@ -1412,7 +1412,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def apply(n: Int): A =
       array(n)
 
-    override def collectM[R, E, B](pf: PartialFunction[A, ZIO[R, E, B]]): ZIO[R, E, Chunk[B]] = ZIO.effectSuspendTotal {
+    override def collectM[R, E, B](pf: PartialFunction[A, ZIO[R, E, B]]): ZIO[R, E, Chunk[B]] = ZIO.suspendSucceed {
       val len     = array.length
       val builder = ChunkBuilder.make[B]()
       builder.sizeHint(len)
@@ -1457,7 +1457,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
 
     override def collectWhileM[R, E, B](pf: PartialFunction[A, ZIO[R, E, B]]): ZIO[R, E, Chunk[B]] =
-      ZIO.effectSuspendTotal {
+      ZIO.suspendSucceed {
         val len     = self.length
         val builder = ChunkBuilder.make[B]()
         builder.sizeHint(len)

--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -158,22 +158,22 @@ object Clock extends ClockPlatformSpecific with Serializable {
         }
       }
 
-    val nanoTime: UIO[Long] = IO.effectTotal(JSystem.nanoTime)
+    val nanoTime: UIO[Long] = IO.succeed(JSystem.nanoTime)
 
     def sleep(duration: Duration): UIO[Unit] =
       UIO.effectAsyncInterrupt { cb =>
         val canceler = globalScheduler.schedule(() => cb(UIO.unit), duration)
-        Left(UIO.effectTotal(canceler()))
+        Left(UIO.succeed(canceler()))
       }
 
     def currentDateTime: UIO[OffsetDateTime] =
-      ZIO.effectTotal(OffsetDateTime.now())
+      ZIO.succeed(OffsetDateTime.now())
 
     override def instant: UIO[Instant] =
-      ZIO.effectTotal(Instant.now())
+      ZIO.succeed(Instant.now())
 
     override def localDateTime: UIO[LocalDateTime] =
-      ZIO.effectTotal(LocalDateTime.now())
+      ZIO.succeed(LocalDateTime.now())
 
   }
 

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -68,7 +68,7 @@ object Console extends Serializable {
     def printLineError(line: String): IO[IOException, Unit] = printLine(SConsole.err)(line)
 
     def readLine: IO[IOException, String] =
-      IO.effect {
+      IO.attempt {
         val line = StdIn.readLine()
 
         if (line ne null) line
@@ -76,10 +76,10 @@ object Console extends Serializable {
       }.refineToOrDie[IOException]
 
     private def print(stream: PrintStream)(line: String): IO[IOException, Unit] =
-      IO.effect(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
+      IO.attempt(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
 
     private def printLine(stream: PrintStream)(line: String): IO[IOException, Unit] =
-      IO.effect(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
+      IO.attempt(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
   }
 
   // Accessor Methods

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -112,7 +112,7 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
    * returns the result in a new `Exit`.
    */
   final def foreach[R, E1 >: E, B](f: A => ZIO[R, E1, B]): ZIO[R, Nothing, Exit[E1, B]] =
-    fold(c => ZIO.succeedNow(halt(c)), a => f(a).run)
+    fold(c => ZIO.succeedNow(halt(c)), a => f(a).exit)
 
   /**
    * Retrieves the `A` if succeeded, or else returns the specified default `A`.

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -42,6 +42,12 @@ object IO {
   def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
+   * @see See [[zio.ZIO.attempt]]
+   */
+  def attempt[A](effect: => A): Task[A] =
+    ZIO.attempt(effect)
+
+  /**
    * @see See [[zio.ZIO.blocking]]
    */
   def blocking[E, A](zio: IO[E, A]): IO[E, A] =
@@ -290,7 +296,9 @@ object IO {
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  @deprecated("use attempt", "2.0.0")
+  def effect[A](effect: => A): Task[A] =
+    ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
@@ -349,28 +357,37 @@ object IO {
   /**
    * @see [[zio.ZIO.effectSuspend]]
    */
-  def effectSuspend[A](io: => IO[Throwable, A]): IO[Throwable, A] = ZIO.effectSuspend(io)
+  @deprecated("use suspend", "2.0.0")
+  def effectSuspend[A](io: => IO[Throwable, A]): IO[Throwable, A] =
+    ZIO.effectSuspend(io)
 
   /**
    * @see [[zio.ZIO.effectSuspendWith]]
    */
+  @deprecated("use suspendWith", "2.0.0")
   def effectSuspendWith[A](p: (Platform, Fiber.Id) => IO[Throwable, A]): IO[Throwable, A] =
     ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  def effectSuspendTotal[E, A](io: => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotal(io)
+  @deprecated("use suspendSucceed", "2.0.0")
+  def effectSuspendTotal[E, A](io: => IO[E, A]): IO[E, A] =
+    ZIO.effectSuspendTotal(io)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  def effectSuspendTotalWith[E, A](p: (Platform, Fiber.Id) => IO[E, A]): IO[E, A] = ZIO.effectSuspendTotalWith(p)
+  @deprecated("use suspendSucceedWith", "2.0.0")
+  def effectSuspendTotalWith[E, A](p: (Platform, Fiber.Id) => IO[E, A]): IO[E, A] =
+    ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.executor]]
@@ -913,6 +930,30 @@ object IO {
    * @see See [[zio.ZIO.succeed]]
    */
   def succeed[A](a: => A): UIO[A] = ZIO.succeed(a)
+
+  /**
+   * @see [[zio.ZIO.suspend]]
+   */
+  def suspend[A](io: => IO[Throwable, A]): IO[Throwable, A] =
+    ZIO.suspend(io)
+
+  /**
+   * @see [[zio.ZIO.suspendWith]]
+   */
+  def suspendWith[A](p: (Platform, Fiber.Id) => IO[Throwable, A]): IO[Throwable, A] =
+    ZIO.suspendWith(p)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceed]]
+   */
+  def suspendSucceed[E, A](io: => IO[E, A]): IO[E, A] =
+    ZIO.suspendSucceed(io)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceedWith]]
+   */
+  def suspendSucceedWith[E, A](p: (Platform, Fiber.Id) => IO[E, A]): IO[E, A] =
+    ZIO.suspendSucceedWith(p)
 
   /**
    * @see See [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/ManagedApp.scala
+++ b/core/shared/src/main/scala/zio/ManagedApp.scala
@@ -26,7 +26,7 @@ trait ManagedApp extends BootstrapRuntime { ma =>
 
   private val app = new App {
     override def run(args: List[String]): URIO[ZEnv, ExitCode] =
-      ma.run(args).use(exit => ZIO.effectTotal(exit))
+      ma.run(args).use(exit => ZIO.succeed(exit))
   }
 
   final def main(args: Array[String]): Unit = app.main(args)

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -110,7 +110,7 @@ final class Promise[E, A] private (
    * [[Promise.complete]].
    */
   def completeWith(io: IO[E, A]): UIO[Boolean] =
-    IO.effectTotal {
+    IO.succeed {
       var action: () => Boolean = null.asInstanceOf[() => Boolean]
       var retry                 = true
 
@@ -164,7 +164,7 @@ final class Promise[E, A] private (
    * already been completed with a value or an error and false otherwise.
    */
   def isDone: UIO[Boolean] =
-    IO.effectTotal(state.get() match {
+    IO.succeed(state.get() match {
       case Done(_)    => true
       case Pending(_) => false
     })
@@ -174,7 +174,7 @@ final class Promise[E, A] private (
    * promise has already been completed or a `None` otherwise.
    */
   def poll: UIO[Option[IO[E, A]]] =
-    IO.effectTotal(state.get).flatMap {
+    IO.succeed(state.get).flatMap {
       case Pending(_) => IO.succeedNow(None)
       case Done(io)   => IO.succeedNow(Some(io))
     }
@@ -184,7 +184,7 @@ final class Promise[E, A] private (
    */
   def succeed(a: A): UIO[Boolean] = completeWith(IO.succeedNow(a))
 
-  private def interruptJoiner(joiner: IO[E, A] => Any): Canceler[Any] = IO.effectTotal {
+  private def interruptJoiner(joiner: IO[E, A] => Any): Canceler[Any] = IO.succeed {
     var retry = true
 
     while (retry) {
@@ -241,13 +241,13 @@ object Promise {
    * Makes a new promise to be completed by the fiber with the specified id.
    */
   def makeAs[E, A](fiberId: Fiber.Id): UIO[Promise[E, A]] =
-    ZIO.effectTotal(unsafeMake(fiberId))
+    ZIO.succeed(unsafeMake(fiberId))
 
   /**
    * Makes a new managed promise to be completed by the fiber creating the promise.
    */
   def makeManaged[E, A]: UManaged[Promise[E, A]] =
-    make[E, A].toManaged_
+    make[E, A].toManaged
 
   private[zio] def unsafeMake[E, A](fiberId: Fiber.Id): Promise[E, A] =
     new Promise[E, A](new AtomicReference[State[E, A]](new internal.Pending[E, A](Nil)), fiberId :: Nil)

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -53,6 +53,12 @@ object RIO {
     ZIO.accessM
 
   /**
+   * @see See [[zio.ZIO.attempt]]
+   */
+  def attempt[A](effect: => A): Task[A] =
+    ZIO.attempt(effect)
+
+  /**
    * @see See [[zio.ZIO.blocking]]
    */
   def blocking[R, A](zio: RIO[R, A]): RIO[R, A] =
@@ -310,7 +316,9 @@ object RIO {
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  @deprecated("use attempt", "2.0.0")
+  def effect[A](effect: => A): Task[A] =
+    ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
@@ -364,29 +372,37 @@ object RIO {
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */
-  def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspend(rio)
+  @deprecated("use suspend", "2.0.0")
+  def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    ZIO.effectSuspend(rio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  def effectSuspendTotal[R, A](rio: => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendTotal(rio)
+  @deprecated("use suspendSucceed", "2.0.0")
+  def effectSuspendTotal[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    ZIO.effectSuspendTotal(rio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
+  @deprecated("use suspendSucceedWith", "2.0.0")
   def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
     ZIO.effectSuspendTotalWith(p)
 
   /**
-   * Returns a lazily constructed effect, whose construction may itself require effects.
-   * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
+   * @see See [[zio.ZIO.effectSuspendWith]]
    */
-  def effectSuspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] = ZIO.effectSuspendWith(p)
+  @deprecated("use suspendWith", "2.0.0")
+  def effectSuspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
+    ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.environment]]
@@ -1007,6 +1023,30 @@ object RIO {
    * @see See [[zio.ZIO.succeed]]
    */
   def succeed[A](a: => A): UIO[A] = ZIO.succeed(a)
+
+  /**
+   * @see See [[zio.ZIO.suspend]]
+   */
+  def suspend[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    ZIO.suspend(rio)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceed]]
+   */
+  def suspendSucceed[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    ZIO.suspendSucceed(rio)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceedWith]]
+   */
+  def suspendSucceedWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
+    ZIO.suspendSucceedWith(p)
+
+  /**
+   * @see See [[zio.ZIO.suspendWith]]
+   */
+  def suspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
+    ZIO.suspendWith(p)
 
   /**
    * @see See [[zio.ZIO.swap]]

--- a/core/shared/src/main/scala/zio/Random.scala
+++ b/core/shared/src/main/scala/zio/Random.scala
@@ -46,41 +46,41 @@ object Random extends Serializable {
     import scala.util.{Random => SRandom}
 
     val nextBoolean: UIO[Boolean] =
-      ZIO.effectTotal(SRandom.nextBoolean())
+      ZIO.succeed(SRandom.nextBoolean())
     def nextBytes(length: Int): UIO[Chunk[Byte]] =
-      ZIO.effectTotal {
+      ZIO.succeed {
         val array = Array.ofDim[Byte](length)
         SRandom.nextBytes(array)
         Chunk.fromArray(array)
       }
     val nextDouble: UIO[Double] =
-      ZIO.effectTotal(SRandom.nextDouble())
+      ZIO.succeed(SRandom.nextDouble())
     def nextDoubleBetween(minInclusive: Double, maxExclusive: Double): UIO[Double] =
       nextDoubleBetweenWith(minInclusive, maxExclusive)(nextDouble)
     val nextFloat: UIO[Float] =
-      ZIO.effectTotal(SRandom.nextFloat())
+      ZIO.succeed(SRandom.nextFloat())
     def nextFloatBetween(minInclusive: Float, maxExclusive: Float): UIO[Float] =
       nextFloatBetweenWith(minInclusive, maxExclusive)(nextFloat)
     val nextGaussian: UIO[Double] =
-      ZIO.effectTotal(SRandom.nextGaussian())
+      ZIO.succeed(SRandom.nextGaussian())
     val nextInt: UIO[Int] =
-      ZIO.effectTotal(SRandom.nextInt())
+      ZIO.succeed(SRandom.nextInt())
     def nextIntBetween(minInclusive: Int, maxExclusive: Int): UIO[Int] =
       nextIntBetweenWith(minInclusive, maxExclusive)(nextInt, nextIntBounded)
     def nextIntBounded(n: Int): UIO[Int] =
-      ZIO.effectTotal(SRandom.nextInt(n))
+      ZIO.succeed(SRandom.nextInt(n))
     val nextLong: UIO[Long] =
-      ZIO.effectTotal(SRandom.nextLong())
+      ZIO.succeed(SRandom.nextLong())
     def nextLongBetween(minInclusive: Long, maxExclusive: Long): UIO[Long] =
       nextLongBetweenWith(minInclusive, maxExclusive)(nextLong, nextLongBounded)
     def nextLongBounded(n: Long): UIO[Long] =
       Random.nextLongBoundedWith(n)(nextLong)
     val nextPrintableChar: UIO[Char] =
-      ZIO.effectTotal(SRandom.nextPrintableChar())
+      ZIO.succeed(SRandom.nextPrintableChar())
     def nextString(length: Int): UIO[String] =
-      ZIO.effectTotal(SRandom.nextString(length))
+      ZIO.succeed(SRandom.nextString(length))
     def setSeed(seed: Long): UIO[Unit] =
-      ZIO.effectTotal(SRandom.setSeed(seed))
+      ZIO.succeed(SRandom.setSeed(seed))
     def shuffle[A, Collection[+Element] <: Iterable[Element]](
       collection: Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]]): UIO[Collection[A]] =
@@ -172,12 +172,12 @@ object Random extends Serializable {
     collection: Collection[A]
   )(implicit bf: BuildFrom[Collection[A], A, Collection[A]]): UIO[Collection[A]] =
     for {
-      buffer <- ZIO.effectTotal {
+      buffer <- ZIO.succeed {
                   val buffer = new scala.collection.mutable.ArrayBuffer[A]
                   buffer ++= collection
                 }
       swap = (i1: Int, i2: Int) =>
-               ZIO.effectTotal {
+               ZIO.succeed {
                  val tmp = buffer(i1)
                  buffer(i1) = buffer(i2)
                  buffer(i2) = tmp

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -298,7 +298,7 @@ object Runtime {
               releaseMap.releaseAll(Exit.unit, ExecutionStrategy.Sequential).uninterruptible.unit
             }
 
-          UIO.effectTotal(Platform.addShutdownHook(finalizer)).as((acquire, finalizer))
+          UIO.succeed(Platform.addShutdownHook(finalizer)).as((acquire, finalizer))
         }
       }
     }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1107,7 +1107,7 @@ object Schedule {
     def loop(a: A): StepFunction[Any, Any, A] =
       (now, _) => ZIO.succeed(Decision.Continue(a, now, loop(f(a))))
 
-    Schedule((now, _) => ZIO.effectTotal(a).map(a => Decision.Continue(a, now, loop(f(a)))))
+    Schedule((now, _) => ZIO.succeed(a).map(a => Decision.Continue(a, now, loop(f(a)))))
   }
 
   /**

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -139,7 +139,7 @@ object Supervisor {
 
     new Supervisor[Chunk[Fiber.Runtime[Any, Any]]] {
       def value: UIO[Chunk[Fiber.Runtime[Any, Any]]] =
-        UIO.effectTotal(
+        UIO.succeed(
           Sync(set)(Chunk.fromArray(set.toArray[Fiber.Runtime[Any, Any]](Array[Fiber.Runtime[Any, Any]]())))
         )
 
@@ -172,7 +172,7 @@ object Supervisor {
 
       new Supervisor[SortedSet[Fiber.Runtime[Any, Any]]] {
         def value: UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
-          ZIO.effectTotal(ref.get)
+          ZIO.succeed(ref.get)
 
         def unsafeOnStart[R, E, A](
           environment: R,

--- a/core/shared/src/main/scala/zio/System.scala
+++ b/core/shared/src/main/scala/zio/System.scala
@@ -53,7 +53,7 @@ object System extends Serializable {
 
   object SystemLive extends System {
     def env(variable: String): IO[SecurityException, Option[String]] =
-      IO.effect(Option(JSystem.getenv(variable))).refineToOrDie[SecurityException]
+      IO.attempt(Option(JSystem.getenv(variable))).refineToOrDie[SecurityException]
 
     def envOrElse(variable: String, alt: => String): IO[SecurityException, String] =
       envOrElseWith(variable, alt)(env)
@@ -63,16 +63,17 @@ object System extends Serializable {
 
     @silent("JavaConverters")
     val envs: IO[SecurityException, Map[String, String]] =
-      IO.effect(JSystem.getenv.asScala.toMap).refineToOrDie[SecurityException]
+      IO.attempt(JSystem.getenv.asScala.toMap).refineToOrDie[SecurityException]
 
-    val lineSeparator: UIO[String] = IO.effectTotal(JSystem.lineSeparator)
+    val lineSeparator: UIO[String] =
+      IO.succeed(JSystem.lineSeparator)
 
     @silent("JavaConverters")
     val properties: IO[Throwable, Map[String, String]] =
-      IO.effect(JSystem.getProperties.asScala.toMap)
+      IO.attempt(JSystem.getProperties.asScala.toMap)
 
     def property(prop: String): IO[Throwable, Option[String]] =
-      IO.effect(Option(JSystem.getProperty(prop)))
+      IO.attempt(Option(JSystem.getProperty(prop)))
 
     def propertyOrElse(prop: String, alt: => String): IO[Throwable, String] =
       propertyOrElseWith(prop, alt)(property)

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -41,6 +41,12 @@ object Task extends TaskPlatformSpecific {
   def apply[A](a: => A): Task[A] = ZIO.apply(a)
 
   /**
+   * @see See [[zio.ZIO.attempt]]
+   */
+  def attempt[A](effect: => A): Task[A] =
+    ZIO.attempt(effect)
+
+  /**
    * @see See [[zio.ZIO.blocking]]
    */
   def blocking[A](zio: Task[A]): Task[A] =
@@ -295,7 +301,9 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.effect]]
    */
-  def effect[A](effect: => A): Task[A] = ZIO.effect(effect)
+  @deprecated("use attempt", "2.0.0")
+  def effect[A](effect: => A): Task[A] =
+    ZIO.effect(effect)
 
   /**
    * @see See [[zio.ZIO.effectAsync]]
@@ -348,27 +356,37 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.RIO.effectSuspend]]
    */
-  def effectSuspend[A](task: => Task[A]): Task[A] = ZIO.effectSuspend(task)
+  @deprecated("use suspend", "2.0.0")
+  def effectSuspend[A](task: => Task[A]): Task[A] =
+    ZIO.effectSuspend(task)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  def effectSuspendTotal[A](task: => Task[A]): Task[A] = ZIO.effectSuspendTotal(task)
+  @deprecated("use suspendSucceed", "2.0.0")
+  def effectSuspendTotal[A](task: => Task[A]): Task[A] =
+    ZIO.effectSuspendTotal(task)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendTotalWith(p)
+  @deprecated("use suspendSucceedWith", "2.0.0")
+  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] =
+    ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see See [[zio.RIO.effectSuspendWith]]
    */
-  def effectSuspendWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] = ZIO.effectSuspendWith(p)
+  @deprecated("use suspendWith", "2.0.0")
+  def effectSuspendWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] =
+    ZIO.effectSuspendWith(p)
 
   /**
    * @see See [[zio.ZIO.effectTotal]]
    */
-  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    ZIO.effectTotal(effect)
 
   /**
    * @see See [[zio.ZIO.executor]]
@@ -896,14 +914,39 @@ object Task extends TaskPlatformSpecific {
   def runtime: UIO[Runtime[Any]] = ZIO.runtime
 
   /**
+   *  @see [[zio.ZIO.some]]
+   */
+  def some[A](a: => A): Task[Option[A]] =
+    ZIO.some(a)
+
+  /**
    * @see See [[zio.ZIO.succeed]]
    */
   def succeed[A](a: => A): UIO[A] = ZIO.succeed(a)
 
   /**
-   *  @see [[zio.ZIO.some]]
+   * @see See [[zio.ZIO.suspend]]
    */
-  def some[A](a: => A): Task[Option[A]] = ZIO.some(a)
+  def suspend[A](task: => Task[A]): Task[A] =
+    ZIO.suspend(task)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceed]]
+   */
+  def suspendSucceed[A](task: => Task[A]): Task[A] =
+    ZIO.suspendSucceed(task)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceedWith]]
+   */
+  def suspendSucceedWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] =
+    ZIO.suspendSucceedWith(p)
+
+  /**
+   * @see See [[zio.RIO.suspendWith]]
+   */
+  def suspendWith[A](p: (Platform, Fiber.Id) => Task[A]): Task[A] =
+    ZIO.suspendWith(p)
 
   /**
    * @see See [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -37,7 +37,8 @@ object UIO {
   /**
    * @see See [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
+  def apply[A](a: => A): UIO[A] =
+    ZIO.succeed(a)
 
   /**
    * @see See [[zio.ZIO.blocking]]
@@ -282,11 +283,6 @@ object UIO {
   def done[A](r: => Exit[Nothing, A]): UIO[A] = ZIO.done(r)
 
   /**
-   * @see See [[zio.ZIO.effectTotal]]
-   */
-  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
-
-  /**
    * @see See [[zio.ZIO.effectAsync]]
    */
   def effectAsync[A](register: (UIO[A] => Unit) => Any, blockingOn: List[Fiber.Id] = Nil): UIO[A] =
@@ -319,12 +315,23 @@ object UIO {
   /**
    * @see See [[zio.ZIO.effectSuspendTotal]]
    */
-  def effectSuspendTotal[A](uio: => UIO[A]): UIO[A] = ZIO.effectSuspendTotal(uio)
+  @deprecated("use suspendSucceed", "2.0.0")
+  def effectSuspendTotal[A](uio: => UIO[A]): UIO[A] =
+    ZIO.effectSuspendTotal(uio)
 
   /**
    * @see See [[zio.ZIO.effectSuspendTotalWith]]
    */
-  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => UIO[A]): UIO[A] = ZIO.effectSuspendTotalWith(p)
+  @deprecated("use suspendSucceedWith", "2.0.0")
+  def effectSuspendTotalWith[A](p: (Platform, Fiber.Id) => UIO[A]): UIO[A] =
+    ZIO.effectSuspendTotalWith(p)
+
+  /**
+   * @see See [[zio.ZIO.effectTotal]]
+   */
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    ZIO.succeed(effect)
 
   /**
    * @see See [[zio.ZIO.executor]]
@@ -783,6 +790,18 @@ object UIO {
    * @see See [[zio.ZIO.succeed]]
    */
   def succeed[A](a: => A): UIO[A] = ZIO.succeed(a)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceed]]
+   */
+  def suspendSucceed[A](uio: => UIO[A]): UIO[A] =
+    ZIO.suspendSucceed(uio)
+
+  /**
+   * @see See [[zio.ZIO.suspendSucceedWith]]
+   */
+  def suspendSucceedWith[A](p: (Platform, Fiber.Id) => UIO[A]): UIO[A] =
+    ZIO.suspendSucceedWith(p)
 
   /**
    * @see See [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -46,7 +46,8 @@ object URIO {
   /**
    * @see [[zio.ZIO.apply]]
    */
-  def apply[A](a: => A): UIO[A] = ZIO.effectTotal(a)
+  def apply[A](a: => A): UIO[A] =
+    ZIO.succeed(a)
 
   /**
    * @see See [[zio.ZIO.blocking]]
@@ -329,18 +330,23 @@ object URIO {
   /**
    * @see [[zio.ZIO.effectSuspendTotal]]
    */
-  def effectSuspendTotal[R, A](rio: => URIO[R, A]): URIO[R, A] = ZIO.effectSuspendTotal(rio)
+  @deprecated("use suspendSucceed", "2.0.0")
+  def effectSuspendTotal[R, A](rio: => URIO[R, A]): URIO[R, A] =
+    ZIO.effectSuspendTotal(rio)
 
   /**
    * @see [[zio.ZIO.effectSuspendTotalWith]]
    */
+  @deprecated("use suspendSucceedWith", "2.0.0")
   def effectSuspendTotalWith[R, A](p: (Platform, Fiber.Id) => URIO[R, A]): URIO[R, A] =
     ZIO.effectSuspendTotalWith(p)
 
   /**
    * @see [[zio.ZIO.effectTotal]]
    */
-  def effectTotal[A](effect: => A): UIO[A] = ZIO.effectTotal(effect)
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    ZIO.effectTotal(effect)
 
   /**
    * @see [[zio.ZIO.environment]]
@@ -889,9 +895,22 @@ object URIO {
   def some[R, A](a: => A): URIO[R, Option[A]] = ZIO.some(a)
 
   /**
+   * @see [[zio.ZIO.suspendSucceed]]
+   */
+  def suspendSucceed[R, A](rio: => URIO[R, A]): URIO[R, A] =
+    ZIO.suspendSucceed(rio)
+
+  /**
+   * @see [[zio.ZIO.suspendSucceedWith]]
+   */
+  def suspendSucceedWith[R, A](p: (Platform, Fiber.Id) => URIO[R, A]): URIO[R, A] =
+    ZIO.suspendSucceedWith(p)
+
+  /**
    * @see [[zio.ZIO.succeed]]
    */
-  def succeed[A](a: => A): UIO[A] = ZIO.succeed(a)
+  def succeed[A](effect: => A): UIO[A] =
+    ZIO.succeed(effect)
 
   /**
    * @see [[zio.ZIO.swap]]

--- a/core/shared/src/main/scala/zio/ZFiberRef.scala
+++ b/core/shared/src/main/scala/zio/ZFiberRef.scala
@@ -302,7 +302,7 @@ object ZFiberRef {
      * currently managed by ZIO, and behave like an ordinary `ThreadLocal` on all other threads.
      */
     def unsafeAsThreadLocal: UIO[ThreadLocal[A]] =
-      ZIO.effectTotal {
+      ZIO.succeed {
         new ThreadLocal[A] {
           override def get(): A = {
             val fiberContext = Fiber._currentFiber.get()

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2924,7 +2924,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   @deprecated("use succeed", "2.0.0")
   def effectTotal[A](effect: => A): UIO[A] =
-    new ZIO.EffectTotal(() => effect)
+    succeed(effect)
 
   /**
    * Accesses the whole environment of the effect.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -581,6 +581,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     self <> ZIO.yieldNow *> eventually
 
   /**
+   * Returns an effect that semantically runs the effect on a fiber,
+   * producing an [[zio.Exit]] for the completion value of the fiber.
+   */
+  final def exit: URIO[R, Exit[E, A]] =
+    new ZIO.Fold[R, E, Nothing, A, Exit[E, A]](
+      self,
+      cause => ZIO.succeedNow(Exit.halt(cause)),
+      success => ZIO.succeedNow(Exit.succeed(success))
+    )
+
+  /**
    * Maps this effect to the default exit codes.
    */
   final def exitCode: URIO[R with Has[Console], ExitCode] =
@@ -792,7 +803,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * execute the effect in the fiber, while ensuring its interruption when
    * the effect supplied to [[ZManaged#use]] completes.
    */
-  final def forkManaged: ZManaged[R, Nothing, Fiber.Runtime[E, A]] = self.toManaged_.fork
+  final def forkManaged: ZManaged[R, Nothing, Fiber.Runtime[E, A]] =
+    self.toManaged.fork
 
   /**
    * Forks an effect that will be executed on the specified `ExecutionContext`.
@@ -931,7 +943,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * `f` function, translating any thrown exceptions into typed failed effects.
    */
   final def mapEffect[B](f: A => B)(implicit ev: E IsSubtypeOfError Throwable): RIO[R, B] =
-    foldM(e => ZIO.fail(ev(e)), a => ZIO.effect(f(a)))
+    foldM(e => ZIO.fail(ev(e)), a => ZIO.attempt(f(a)))
 
   /**
    * Returns an effect with its error channel mapped using the specified
@@ -1419,7 +1431,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * in the background.
    */
   final def raceFirst[R1 <: R, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[R1, E1, A1] =
-    (self.run race that.run).flatMap(ZIO.done(_)).refailWithTrace
+    (self.exit race that.exit).flatMap(ZIO.done(_)).refailWithTrace
 
   /**
    * Returns an effect that races this effect with the specified effect,
@@ -1681,12 +1693,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Returns an effect that semantically runs the effect on a fiber,
    * producing an [[zio.Exit]] for the completion value of the fiber.
    */
+  @deprecated("use exit", "2.0.0")
   final def run: URIO[R, Exit[E, A]] =
-    new ZIO.Fold[R, E, Nothing, A, Exit[E, A]](
-      self,
-      cause => ZIO.succeedNow(Exit.halt(cause)),
-      success => ZIO.succeedNow(Exit.succeed(success))
-    )
+    exit
 
   /**
    * Exposes the full cause of failure of this effect.
@@ -1695,7 +1704,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * final case class DomainError()
    *
    * val veryBadIO: IO[DomainError, Unit] =
-   *   IO.effectTotal(5 / 0) *> IO.fail(DomainError())
+   *   IO.succeed(5 / 0) *> IO.fail(DomainError())
    *
    * val caught: IO[DomainError, Unit] =
    *   veryBadIO.sandbox.mapError(_.untraced).catchAll {
@@ -1788,7 +1797,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * case class DomainError()
    *
    * val veryBadIO: IO[DomainError, Unit] =
-   *   IO.effectTotal(5 / 0) *> IO.fail(DomainError())
+   *   IO.succeed(5 / 0) *> IO.fail(DomainError())
    *
    * val caught: IO[DomainError, Unit] =
    *   veryBadIO.sandboxWith(_.catchSome {
@@ -1968,7 +1977,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * the specified promise will be interrupted, too.
    */
   final def to[E1 >: E, A1 >: A](p: Promise[E1, A1]): URIO[R, Boolean] =
-    ZIO.uninterruptibleMask(restore => restore(self).run.flatMap(p.done(_)))
+    ZIO.uninterruptibleMask(restore => restore(self).exit.flatMap(p.done(_)))
 
   /**
    * Converts the effect into a [[scala.concurrent.Future]].
@@ -1999,14 +2008,14 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Converts this ZIO to [[zio.Managed]]. This ZIO and the provided release action
    * will be performed uninterruptibly.
    */
-  final def toManaged[R1 <: R](release: A => URIO[R1, Any]): ZManaged[R1, E, A] =
-    ZManaged.make(this)(release)
+  final def toManagedWith[R1 <: R](release: A => URIO[R1, Any]): ZManaged[R1, E, A] =
+    ZManaged.bracket(this)(release)
 
   /**
    * Converts this ZIO to [[zio.ZManaged]] with no release action. It will be performed
    * interruptibly.
    */
-  final def toManaged_ : ZManaged[R, E, A] =
+  final def toManaged: ZManaged[R, E, A] =
     ZManaged.fromEffect[R, E, A](this)
 
   /**
@@ -2146,7 +2155,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * specified combiner function. Combines the causes in case both effect fail.
    */
   final def validateWith[R1 <: R, E1 >: E, B, C](that: ZIO[R1, E1, B])(f: (A, B) => C): ZIO[R1, E1, C] =
-    self.run.zipWith(that.run)(_.zipWith(_)(f, _ ++ _)).flatMap(ZIO.done(_))
+    self.exit.zipWith(that.exit)(_.zipWith(_)(f, _ ++ _)).flatMap(ZIO.done(_))
 
   /**
    * Returns an effect that executes both this effect and the specified effect,
@@ -2154,7 +2163,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * both sides fail, then the cause will be combined.
    */
   final def validateWithPar[R1 <: R, E1 >: E, B, C](that: ZIO[R1, E1, B])(f: (A, B) => C): ZIO[R1, E1, C] =
-    self.run.zipWithPar(that.run)(_.zipWith(_)(f, _ && _)).flatMap(ZIO.done(_))
+    self.exit.zipWithPar(that.exit)(_.zipWith(_)(f, _ && _)).flatMap(ZIO.done(_))
 
   /**
    * The moral equivalent of `if (p) exp`
@@ -2279,6 +2288,17 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     descriptorWith(d => if (d.interrupters.nonEmpty) interrupt else ZIO.unit)
 
   /**
+   * Imports a synchronous side-effect into a pure `ZIO` value, translating any
+   * thrown exceptions into typed failed effects creating with `ZIO.fail`.
+   *
+   * {{{
+   * def printLine(line: String): Task[Unit] = Task.attempt(println(line))
+   * }}}
+   */
+  def attempt[A](effect: => A): Task[A] =
+    new ZIO.EffectPartial(() => effect)
+
+  /**
    * Locks the specified effect to the blocking thread pool.
    */
   def blocking[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
@@ -2288,7 +2308,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Retrieves the executor for all blocking tasks.
    */
   def blockingExecutor: UIO[Executor] =
-    ZIO.effectSuspendTotalWith((platform, _) => ZIO.succeedNow(platform.blockingExecutor))
+    ZIO.suspendSucceedWith((platform, _) => ZIO.succeedNow(platform.blockingExecutor))
 
   /**
    * When this effect represents acquisition of a resource (for example,
@@ -2357,11 +2377,11 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.uninterruptibleMask[R, E, B](restore =>
       acquire.flatMap(ZIOFn(traceAs = use) { a =>
         ZIO
-          .effectSuspendTotal(restore(use(a)))
-          .run
+          .suspendSucceed(restore(use(a)))
+          .exit
           .flatMap(ZIOFn(traceAs = release) { e =>
             ZIO
-              .effectSuspendTotal(release(a, e))
+              .suspendSucceed(release(a, e))
               .foldCauseM(
                 cause2 => ZIO.halt(e.fold(_ ++ cause2, _ => cause2)),
                 _ => ZIO.done(e)
@@ -2499,7 +2519,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collectAllSuccesses[R, E, A, Collection[+Element] <: Iterable[Element]](
     in: Collection[ZIO[R, E, A]]
   )(implicit bf: BuildFrom[Collection[ZIO[R, E, A]], A, Collection[A]]): URIO[R, Collection[A]] =
-    collectAllWith(in.map(_.run)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
+    collectAllWith(in.map(_.exit)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
 
   /**
    * Evaluate and run each effect in the structure in parallel, and collect discarding failed ones.
@@ -2507,7 +2527,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collectAllSuccessesPar[R, E, A, Collection[+Element] <: Iterable[Element]](
     in: Collection[ZIO[R, E, A]]
   )(implicit bf: BuildFrom[Collection[ZIO[R, E, A]], A, Collection[A]]): URIO[R, Collection[A]] =
-    collectAllWithPar(in.map(_.run)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
+    collectAllWithPar(in.map(_.exit)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
 
   /**
    * Evaluate and run each effect in the structure in parallel, and collect discarding failed ones.
@@ -2517,7 +2537,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collectAllSuccessesParN[R, E, A, Collection[+Element] <: Iterable[Element]](n: Int)(
     in: Collection[ZIO[R, E, A]]
   )(implicit bf: BuildFrom[Collection[ZIO[R, E, A]], A, Collection[A]]): URIO[R, Collection[A]] =
-    collectAllWithParN(n)(in.map(_.run)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
+    collectAllWithParN(n)(in.map(_.exit)) { case zio.Exit.Success(a) => a }.map(bf.fromSpecific(in))
 
   /**
    * Evaluate each effect in the structure with `collectAll`, and collect
@@ -2553,7 +2573,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * function `f` returns `Some`.
    */
   def collectFirst[R, E, A, B](as: Iterable[A])(f: A => ZIO[R, E, Option[B]]): ZIO[R, E, Option[B]] =
-    effectTotal(as.iterator).flatMap { iterator =>
+    succeed(as.iterator).flatMap { iterator =>
       def loop: ZIO[R, E, Option[B]] =
         if (iterator.hasNext) f(iterator.next()).flatMap(_.fold(loop)(some(_)))
         else none
@@ -2593,7 +2613,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Prints the specified message to the console for debugging purposes.
    */
   def debug(value: Any): UIO[Unit] =
-    ZIO.effectTotal(println(value))
+    ZIO.succeed(println(value))
 
   /**
    * Returns information about the current fiber, such as its identity.
@@ -2627,7 +2647,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns an effect from a [[zio.Exit]] value.
    */
   def done[E, A](r: => Exit[E, A]): IO[E, A] =
-    ZIO.effectSuspendTotal {
+    ZIO.suspendSucceed {
       r match {
         case Exit.Success(b)     => succeedNow(b)
         case Exit.Failure(cause) => halt(cause)
@@ -2642,7 +2662,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * def printLine(line: String): Task[Unit] = Task.effect(println(line))
    * }}}
    */
-  def effect[A](effect: => A): Task[A] = new ZIO.EffectPartial(() => effect)
+  @deprecated("use attempt", "2.0.0")
+  def effect[A](effect: => A): Task[A] =
+    attempt(effect)
 
   /**
    * Imports an asynchronous side-effect into a pure `ZIO` value. See
@@ -2689,7 +2711,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   ): ZIO[R, E, A] = {
     import java.util.concurrent.atomic.AtomicBoolean
 
-    effectTotal((new AtomicBoolean(false), OneShot.make[Canceler[R]])).flatMap { case (started, cancel) =>
+    succeed((new AtomicBoolean(false), OneShot.make[Canceler[R]])).flatMap { case (started, cancel) =>
       flatten {
         effectAsyncMaybe(
           ZIOFn(register) { (k: UIO[ZIO[R, E, A]] => Unit) =>
@@ -2704,7 +2726,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
           },
           blockingOn
         )
-      }.onInterrupt(effectSuspendTotal(if (started.getAndSet(true)) cancel.get() else ZIO.unit))
+      }.onInterrupt(suspendSucceed(if (started.getAndSet(true)) cancel.get() else ZIO.unit))
     }
   }
 
@@ -2746,7 +2768,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Imports a synchronous effect that does blocking IO into a pure value.
    */
   def effectBlocking[A](effect: => A): Task[A] =
-    blocking(ZIO.effect(effect))
+    blocking(ZIO.attempt(effect))
 
   /**
    * Imports a synchronous effect that does blocking IO into a pure value,
@@ -2756,7 +2778,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * synchronous effect will be interrupted via the cancel effect.
    */
   def effectBlockingCancelable[A](effect: => A)(cancel: UIO[Unit]): Task[A] =
-    blocking(ZIO.effect(effect)).fork.flatMap(_.join).onInterrupt(cancel)
+    blocking(ZIO.attempt(effect)).fork.flatMap(_.join).onInterrupt(cancel)
 
   /**
    * Imports a synchronous effect that does blocking IO into a pure value,
@@ -2778,7 +2800,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def effectBlockingInterrupt[A](effect: => A): Task[A] =
     // Reference user's lambda for the tracer
     ZIOFn.recordTrace(() => effect) {
-      ZIO.effectSuspendTotal {
+      ZIO.suspendSucceed {
         import java.util.concurrent.atomic.AtomicReference
         import java.util.concurrent.locks.ReentrantLock
 
@@ -2795,7 +2817,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
           } finally lock.unlock()
 
         val interruptThread: UIO[Unit] =
-          ZIO.effectTotal {
+          ZIO.succeed {
             begin.get()
 
             var looping = true
@@ -2819,7 +2841,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
         blocking(
           ZIO.uninterruptibleMask(restore =>
             for {
-              fiber <- ZIO.effectSuspend {
+              fiber <- ZIO.suspend {
                          val current = Some(Thread.currentThread)
 
                          withMutex(thread.set(current))
@@ -2851,7 +2873,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */
-  def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] = new ZIO.EffectSuspendPartialWith((_, _) => rio)
+  @deprecated("use suspend", "2.0.0")
+  def effectSuspend[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    suspend(rio)
 
   /**
    * A variant of `effectiveSuspendTotalWith` that allows optionally returning
@@ -2866,8 +2890,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * it is conceptually equivalent to `flatten(effectTotal(zio))`. If you wonder if the effect throws exceptions,
    * do not use this method, use [[Task.effectSuspend]] or [[ZIO.effectSuspend]].
    */
+  @deprecated("use suspendSucceed", "2.0.0")
   def effectSuspendTotal[R, E, A](zio: => ZIO[R, E, A]): ZIO[R, E, A] =
-    new ZIO.EffectSuspendTotalWith((_, _) => zio)
+    suspendSucceed(zio)
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require effects.
@@ -2875,15 +2900,17 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * it is conceptually equivalent to `flatten(effectTotal(zio))`. If you wonder if the effect throws exceptions,
    * do not use this method, use [[Task.effectSuspend]] or [[ZIO.effectSuspend]].
    */
+  @deprecated("use suspendSucceedWith", "2.0.0")
   def effectSuspendTotalWith[R, E, A](f: (Platform, Fiber.Id) => ZIO[R, E, A]): ZIO[R, E, A] =
-    new ZIO.EffectSuspendTotalWith(f)
+    suspendSucceedWith(f)
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require effects.
    * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
    */
+  @deprecated("use suspendWith", "2.0.0")
   def effectSuspendWith[R, A](f: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
-    new ZIO.EffectSuspendPartialWith(f)
+    suspendWith(f)
 
   /**
    * Imports a total synchronous effect into a pure `ZIO` value.
@@ -2892,10 +2919,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * [[IO.effect]], or [[ZIO.effect]].
    *
    * {{{
-   * val nanoTime: UIO[Long] = IO.effectTotal(System.nanoTime())
+   * val nanoTime: UIO[Long] = IO.succeed(System.nanoTime())
    * }}}
    */
-  def effectTotal[A](effect: => A): UIO[A] = new ZIO.EffectTotal(() => effect)
+  @deprecated("use succeed", "2.0.0")
+  def effectTotal[A](effect: => A): UIO[A] =
+    new ZIO.EffectTotal(() => effect)
 
   /**
    * Accesses the whole environment of the effect.
@@ -2913,7 +2942,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * effectual predicate `f`.
    */
   def exists[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Boolean]): ZIO[R, E, Boolean] =
-    effectTotal(as.iterator).flatMap { iterator =>
+    succeed(as.iterator).flatMap { iterator =>
       def loop: ZIO[R, E, Boolean] =
         if (iterator.hasNext) f(iterator.next()).flatMap(b => if (b) succeedNow(b) else loop)
         else succeedNow(false)
@@ -2938,7 +2967,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def filter[R, E, A, Collection[+Element] <: Iterable[Element]](
     as: Collection[A]
   )(f: A => ZIO[R, E, Boolean])(implicit bf: BuildFrom[Collection[A], A, Collection[A]]): ZIO[R, E, Collection[A]] =
-    as.foldLeft[ZIO[R, E, Builder[A, Collection[A]]]](ZIO.effectTotal(bf.newBuilder(as))) { (zio, a) =>
+    as.foldLeft[ZIO[R, E, Builder[A, Collection[A]]]](ZIO.succeed(bf.newBuilder(as))) { (zio, a) =>
       zio.zipWith(f(a))((as, p) => if (p) as += a else as)
     }.map(_.result())
 
@@ -3052,16 +3081,15 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def foreach[R, E, A, B, Collection[+Element] <: Iterable[Element]](
     in: Collection[A]
   )(f: A => ZIO[R, E, B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] =
-    in.foldLeft[ZIO[R, E, Builder[B, Collection[B]]]](effectTotal(bf.newBuilder(in)))((io, a) =>
-      io.zipWith(f(a))(_ += _)
-    ).map(_.result())
+    in.foldLeft[ZIO[R, E, Builder[B, Collection[B]]]](succeed(bf.newBuilder(in)))((io, a) => io.zipWith(f(a))(_ += _))
+      .map(_.result())
 
   /**
    * Determines whether all elements of the `Iterable[A]` satisfy the effectual
    * predicate `f`.
    */
   def forall[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Boolean]): ZIO[R, E, Boolean] =
-    effectTotal(as.iterator).flatMap { iterator =>
+    succeed(as.iterator).flatMap { iterator =>
       def loop: ZIO[R, E, Boolean] =
         if (iterator.hasNext) f(iterator.next()).flatMap(b => if (b) loop else succeedNow(b))
         else succeedNow(true)
@@ -3125,7 +3153,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * the list of results.
    */
   def foreach_[R, E, A](as: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit] =
-    ZIO.effectTotal(as.iterator).flatMap { i =>
+    ZIO.succeed(as.iterator).flatMap { i =>
       def loop: ZIO[R, E, Unit] =
         if (i.hasNext) f(i.next()) *> loop
         else ZIO.unit
@@ -3155,13 +3183,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     as: Collection[A]
   )(f: A => ZIO[R, E, B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] = {
     val size = as.size
-    effectTotal(Array.ofDim[AnyRef](size)).flatMap { array =>
+    succeed(Array.ofDim[AnyRef](size)).flatMap { array =>
       val zioFunction: ZIOFn1[(A, Int), ZIO[R, E, Any]] =
         ZIOFn(f) { case (a, i) =>
-          f(a).flatMap(b => effectTotal(array(i) = b.asInstanceOf[AnyRef]))
+          f(a).flatMap(b => succeed(array(i) = b.asInstanceOf[AnyRef]))
         }
       foreachPar_(as.zipWithIndex)(zioFunction) *>
-        effectTotal(bf.newBuilder(as).++=(array.asInstanceOf[Array[B]]).result())
+        succeed(bf.newBuilder(as).++=(array.asInstanceOf[Array[B]]).result())
     }
   }
 
@@ -3245,7 +3273,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
                  ZIO
                    .ifM(startTask)(
                      ZIO
-                       .effectSuspendTotal(f(a))
+                       .suspendSucceed(f(a))
                        .interruptible
                        .tapCause(c => causes.update(_ && c) *> startFailure)
                        .ensuring {
@@ -3294,12 +3322,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
         def worker(queue: Queue[(A, Int)], array: Array[AnyRef]): ZIO[R, E, Unit] =
           queue.poll.flatMap {
             case Some((a, n)) =>
-              fn(a).tap(b => ZIO.effectTotal(array(n) = b.asInstanceOf[AnyRef])) *> worker(queue, array)
+              fn(a).tap(b => ZIO.succeed(array(n) = b.asInstanceOf[AnyRef])) *> worker(queue, array)
             case None => ZIO.unit
           }
 
         for {
-          array <- ZIO.effectTotal(Array.ofDim[AnyRef](size))
+          array <- ZIO.succeed(Array.ofDim[AnyRef](size))
           queue <- Queue.bounded[(A, Int)](size)
           _     <- queue.offerAll(as.zipWithIndex)
           _     <- ZIO.collectAllPar_(ZIO.replicate(n)(worker(queue, array)))
@@ -3355,20 +3383,20 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Lifts an `Either` into a `ZIO` value.
    */
   def fromEither[E, A](v: => Either[E, A]): IO[E, A] =
-    effectTotal(v).flatMap(_.fold(fail(_), succeedNow))
+    succeed(v).flatMap(_.fold(fail(_), succeedNow))
 
   /**
    * Lifts an `Either` into a `ZIO` value.
    */
   def fromEitherCause[E, A](v: => Either[Cause[E], A]): IO[E, A] =
-    effectTotal(v).flatMap(_.fold(halt(_), succeedNow))
+    succeed(v).flatMap(_.fold(halt(_), succeedNow))
 
   /**
    * Creates a `ZIO` value that represents the exit value of the specified
    * fiber.
    */
   def fromFiber[E, A](fiber: => Fiber[E, A]): IO[E, A] =
-    effectTotal(fiber).flatMap(_.join)
+    succeed(fiber).flatMap(_.join)
 
   /**
    * Creates a `ZIO` value that represents the exit value of the specified
@@ -3403,10 +3431,10 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     Task.descriptorWith { d =>
       val ec = d.executor.asEC
-      ZIO.effect(make(ec)).flatMap { f =>
+      ZIO.attempt(make(ec)).flatMap { f =>
         val canceler: UIO[Unit] = f match {
           case cancelable: CancelableFuture[A] =>
-            UIO.effectSuspendTotal(if (f.isCompleted) ZIO.unit else ZIO.fromFuture(_ => cancelable.cancel()).ignore)
+            UIO.suspendSucceed(if (f.isCompleted) ZIO.unit else ZIO.fromFuture(_ => cancelable.cancel()).ignore)
           case _ => ZIO.unit
         }
 
@@ -3454,7 +3482,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
         def reportFailure(cause: Throwable): Unit =
           ec.reportFailure(cause)
       }
-      effect(make(interruptibleEC)).flatMap { f =>
+      attempt(make(interruptibleEC)).flatMap { f =>
         f.value
           .fold(
             Task.effectAsync { (cb: Task[A] => Any) =>
@@ -3465,7 +3493,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
             }
           )(Task.fromTry(_))
       }.onInterrupt(
-        Task.effectTotal(interrupted.set(true)) *> Task.fromFuture(_ => latch.future).orDie
+        Task.succeed(interrupted.set(true)) *> Task.fromFuture(_ => latch.future).orDie
       )
     }
 
@@ -3474,13 +3502,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * in some scenarios.
    */
   def fromOption[A](v: => Option[A]): IO[Option[Nothing], A] =
-    effectTotal(v).flatMap(_.fold[IO[Option[Nothing], A]](fail(None))(succeedNow))
+    succeed(v).flatMap(_.fold[IO[Option[Nothing], A]](fail(None))(succeedNow))
 
   /**
    * Lifts a `Try` into a `ZIO`.
    */
   def fromTry[A](value: => scala.util.Try[A]): Task[A] =
-    effect(value).flatMap {
+    attempt(value).flatMap {
       case scala.util.Success(v) => ZIO.succeedNow(v)
       case scala.util.Failure(t) => ZIO.fail(t)
     }
@@ -3521,7 +3549,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Lifts an Option into a ZIO. If the option is not defined, fail with the `e` value.
    */
   final def getOrFailWith[E, A](e: => E)(v: => Option[A]): IO[E, A] =
-    effectSuspendTotal(v match {
+    suspendSucceed(v match {
       case None    => IO.fail(e)
       case Some(v) => ZIO.succeedNow(v)
     })
@@ -4024,7 +4052,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def runtime[R]: URIO[R, Runtime[R]] =
     for {
       environment <- environment[R]
-      platform    <- effectSuspendTotalWith((p, _) => ZIO.succeedNow(p))
+      platform    <- suspendSucceedWith((p, _) => ZIO.succeedNow(p))
       executor    <- executor
     } yield Runtime(environment, platform.withExecutor(executor))
 
@@ -4111,7 +4139,39 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: => A): UIO[A] =
-    effectTotal(a)
+    new ZIO.EffectTotal(() => a)
+
+  /**
+   * Returns a lazily constructed effect, whose construction may itself require effects.
+   * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
+   */
+  def suspend[R, A](rio: => RIO[R, A]): RIO[R, A] =
+    new ZIO.EffectSuspendPartialWith((_, _) => rio)
+
+  /**
+   * Returns a lazily constructed effect, whose construction may itself require
+   * effects. The effect must not throw any exceptions. When no environment is required (i.e., when R == Any)
+   * it is conceptually equivalent to `flatten(effectTotal(zio))`. If you wonder if the effect throws exceptions,
+   * do not use this method, use [[Task.suspend]] or [[ZIO.suspend]].
+   */
+  def suspendSucceed[R, E, A](zio: => ZIO[R, E, A]): ZIO[R, E, A] =
+    new ZIO.EffectSuspendTotalWith((_, _) => zio)
+
+  /**
+   * Returns a lazily constructed effect, whose construction may itself require effects.
+   * The effect must not throw any exceptions. When no environment is required (i.e., when R == Any)
+   * it is conceptually equivalent to `flatten(effectTotal(zio))`. If you wonder if the effect throws exceptions,
+   * do not use this method, use [[Task.suspend]] or [[ZIO.suspend]].
+   */
+  def suspendSucceedWith[R, E, A](f: (Platform, Fiber.Id) => ZIO[R, E, A]): ZIO[R, E, A] =
+    new ZIO.EffectSuspendTotalWith(f)
+
+  /**
+   * Returns a lazily constructed effect, whose construction may itself require effects.
+   * When no environment is required (i.e., when R == Any) it is conceptually equivalent to `flatten(effect(io))`.
+   */
+  def suspendWith[R, A](f: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
+    new ZIO.EffectSuspendPartialWith(f)
 
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
@@ -4166,7 +4226,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * The moral equivalent of `if (!p) exp`
    */
   def unless[R, E](b: => Boolean)(zio: => ZIO[R, E, Any]): ZIO[R, E, Unit] =
-    effectSuspendTotal(if (b) unit else zio.unit)
+    suspendSucceed(if (b) unit else zio.unit)
 
   /**
    * The moral equivalent of `if (!p) exp` when `p` has side-effects
@@ -4299,13 +4359,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * The moral equivalent of `if (p) exp`
    */
   def when[R, E](b: => Boolean)(zio: => ZIO[R, E, Any]): ZIO[R, E, Unit] =
-    effectSuspendTotal(if (b) zio.unit else unit)
+    suspendSucceed(if (b) zio.unit else unit)
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given value, otherwise does nothing.
    */
   def whenCase[R, E, A](a: => A)(pf: PartialFunction[A, ZIO[R, E, Any]]): ZIO[R, E, Unit] =
-    effectSuspendTotal(pf.applyOrElse(a, (_: A) => unit).unit)
+    suspendSucceed(pf.applyOrElse(a, (_: A) => unit).unit)
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given effectful value, otherwise does nothing.
@@ -4337,7 +4397,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   lazy val yieldNow: UIO[Unit] = ZIO.Yield
 
-  def apply[A](a: => A): Task[A] = effect(a)
+  def apply[A](a: => A): Task[A] = attempt(a)
 
   private lazy val _IdentityFn: Any => Any = (a: Any) => a
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -111,7 +111,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    */
   final def build: ZManaged[RIn, E, ROut] =
     for {
-      memoMap <- ZLayer.MemoMap.make.toManaged_
+      memoMap <- ZLayer.MemoMap.make.toManaged
       run     <- self.scope
       value   <- run(memoMap)
     } yield value
@@ -351,7 +351,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * release actions will be performed uninterruptibly.
    */
   def fromAcquireRelease[R, E, A: Tag](acquire: ZIO[R, E, A])(release: A => URIO[R, Any]): ZLayer[R, E, Has[A]] =
-    fromManaged(ZManaged.make(acquire)(release))
+    fromManaged(ZManaged.bracket(acquire)(release))
 
   /**
    * Constructs a layer from acquire and release actions, which must return one
@@ -359,7 +359,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * uninterruptibly.
    */
   def fromAcquireReleaseMany[R, E, A](acquire: ZIO[R, E, A])(release: A => URIO[R, Any]): ZLayer[R, E, A] =
-    fromManagedMany(ZManaged.make(acquire)(release))
+    fromManagedMany(ZManaged.bracket(acquire)(release))
 
   /**
    * Constructs a layer from the specified effect.
@@ -385,7 +385,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * function.
    */
   def fromFunctionM[A, E, B: Tag](f: A => IO[E, B]): ZLayer[A, E, Has[B]] =
-    fromFunctionManaged(a => f(a).toManaged_)
+    fromFunctionManaged(a => f(a).toManaged)
 
   /**
    * Constructs a layer from the environment using the specified effectful
@@ -406,7 +406,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * function, which must return one or more services.
    */
   def fromFunctionManyM[A, E, B](f: A => IO[E, B]): ZLayer[A, E, B] =
-    fromFunctionManyManaged(a => f(a).toManaged_)
+    fromFunctionManyManaged(a => f(a).toManaged)
 
   /**
    * Constructs a layer from the environment using the specified effectful
@@ -901,7 +901,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * Constructs a layer that effectfully depends on the specified service.
    */
   def fromServiceM[A: Tag, R, E, B: Tag](f: A => ZIO[R, E, B]): ZLayer[R with Has[A], E, Has[B]] =
-    fromServiceManaged(a => f(a).toManaged_)
+    fromServiceManaged(a => f(a).toManaged)
 
   /**
    * Constructs a layer that effectfully depends on the specified services.
@@ -909,7 +909,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, R, E, B: Tag](
     f: (A0, A1) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -919,7 +919,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, A2: Tag, R, E, B: Tag](
     f: (A0, A1, A2) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -929,7 +929,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, R, E, B: Tag](
     f: (A0, A1, A2, A3) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -939,7 +939,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, R, E, B: Tag](
     f: (A0, A1, A2, A3, A4) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -949,7 +949,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, A5: Tag, R, E, B: Tag](
     f: (A0, A1, A2, A3, A4, A5) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -959,7 +959,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, A5: Tag, A6: Tag, R, E, B: Tag](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -971,7 +971,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -983,7 +983,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1009,7 +1009,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1036,7 +1036,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1064,7 +1064,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1093,7 +1093,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1123,7 +1123,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1154,7 +1154,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1188,7 +1188,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1223,7 +1223,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1259,7 +1259,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1296,7 +1296,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1334,7 +1334,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1373,7 +1373,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -1436,7 +1436,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, Has[B]] = {
-    val layer = fromServicesManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2595,7 +2595,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * returns a single service see `fromServiceM`.
    */
   def fromServiceManyM[A: Tag, R, E, B](f: A => ZIO[R, E, B]): ZLayer[R with Has[A], E, B] =
-    fromServiceManyManaged(a => f(a).toManaged_)
+    fromServiceManyManaged(a => f(a).toManaged)
 
   /**
    * Constructs a layer that effectfully depends on the specified services,
@@ -2605,7 +2605,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, R, E, B](
     f: (A0, A1) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2617,7 +2617,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, A2: Tag, R, E, B](
     f: (A0, A1, A2) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2629,7 +2629,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, R, E, B](
     f: (A0, A1, A2, A3) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2641,7 +2641,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, R, E, B](
     f: (A0, A1, A2, A3, A4) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2653,7 +2653,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, A5: Tag, R, E, B](
     f: (A0, A1, A2, A3, A4, A5) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2665,7 +2665,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def fromServicesManyM[A0: Tag, A1: Tag, A2: Tag, A3: Tag, A4: Tag, A5: Tag, A6: Tag, R, E, B](
     f: (A0, A1, A2, A3, A4, A5, A6) => ZIO[R, E, B]
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2679,7 +2679,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2693,7 +2693,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2721,7 +2721,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2750,7 +2750,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2780,7 +2780,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2811,7 +2811,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2843,7 +2843,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2876,7 +2876,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[R with Has[A0] with Has[A1] with Has[A2] with Has[A3] with Has[A4] with Has[A5] with Has[A6] with Has[
     A7
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2912,7 +2912,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2949,7 +2949,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -2987,7 +2987,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -3026,7 +3026,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -3066,7 +3066,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -3107,7 +3107,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -3172,7 +3172,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ] with Has[A8] with Has[A9] with Has[A10] with Has[A11] with Has[A12] with Has[A13] with Has[A14] with Has[
     A15
   ] with Has[A16] with Has[A17] with Has[A18] with Has[A19] with Has[A20] with Has[A21], E, B] = {
-    val layer = fromServicesManyManaged(andThen(f)(_.toManaged_))
+    val layer = fromServicesManyManaged(andThen(f)(_.toManaged))
     layer
   }
 
@@ -4216,7 +4216,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
                                        innerReleaseMap     <- ZManaged.ReleaseMap.make
                                        tp <- restore(
                                                layer.scope.flatMap(_.apply(self)).zio.provide((a, innerReleaseMap))
-                                             ).run.flatMap {
+                                             ).exit.flatMap {
                                                case e @ Exit.Failure(cause) =>
                                                  promise.halt(cause) *> innerReleaseMap.releaseAll(
                                                    e,

--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -193,7 +193,7 @@ object ZRef extends Serializable {
    * Creates a new `ZRef` with the specified value.
    */
   def make[A](a: A): UIO[Ref[A]] =
-    UIO.effectTotal(unsafeMake(a))
+    UIO.succeed(unsafeMake(a))
 
   private[zio] def unsafeMake[A](a: A): Ref.Atomic[A] =
     Atomic(new AtomicReference(a))
@@ -202,7 +202,7 @@ object ZRef extends Serializable {
    * Creates a new managed `ZRef` with the specified value
    */
   def makeManaged[A](a: A): Managed[Nothing, Ref[A]] =
-    make(a).toManaged_
+    make(a).toManaged
 
   implicit class UnifiedSyntax[-R, +E, A](private val self: ZRef[R, R, E, E, A, A]) extends AnyVal {
 
@@ -705,7 +705,7 @@ object ZRef extends Serializable {
      * `Managed.`
      */
     def makeManaged[A](a: A): UManaged[RefM[A]] =
-      make(a).toManaged_
+      make(a).toManaged
 
     implicit class UnifiedSyntax[-R, +E, A](private val self: ZRefM[R, R, E, E, A, A]) extends AnyVal {
 
@@ -807,10 +807,10 @@ object ZRef extends Serializable {
       }
 
     def get: UIO[A] =
-      UIO.effectTotal(value.get)
+      UIO.succeed(value.get)
 
     def getAndSet(a: A): UIO[A] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop       = true
         var current: A = null.asInstanceOf[A]
         while (loop) {
@@ -821,7 +821,7 @@ object ZRef extends Serializable {
       }
 
     def getAndUpdate(f: A => A): UIO[A] =
-      UIO.effectTotal {
+      UIO.succeed {
         {
           var loop       = true
           var current: A = null.asInstanceOf[A]
@@ -835,7 +835,7 @@ object ZRef extends Serializable {
       }
 
     def getAndUpdateSome(pf: PartialFunction[A, A]): UIO[A] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop       = true
         var current: A = null.asInstanceOf[A]
         while (loop) {
@@ -847,7 +847,7 @@ object ZRef extends Serializable {
       }
 
     def modify[B](f: A => (B, A)): UIO[B] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop = true
         var b: B = null.asInstanceOf[B]
         while (loop) {
@@ -860,7 +860,7 @@ object ZRef extends Serializable {
       }
 
     def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)]): UIO[B] =
-      UIO.effectTotal {
+      UIO.succeed {
         {
           var loop = true
           var b: B = null.asInstanceOf[B]
@@ -875,16 +875,16 @@ object ZRef extends Serializable {
       }
 
     def set(a: A): UIO[Unit] =
-      UIO.effectTotal(value.set(a))
+      UIO.succeed(value.set(a))
 
     def setAsync(a: A): UIO[Unit] =
-      UIO.effectTotal(value.lazySet(a))
+      UIO.succeed(value.lazySet(a))
 
     override def toString: String =
       s"Ref(${value.get})"
 
     def update(f: A => A): UIO[Unit] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop    = true
         var next: A = null.asInstanceOf[A]
         while (loop) {
@@ -896,7 +896,7 @@ object ZRef extends Serializable {
       }
 
     def updateAndGet(f: A => A): UIO[A] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop    = true
         var next: A = null.asInstanceOf[A]
         while (loop) {
@@ -908,7 +908,7 @@ object ZRef extends Serializable {
       }
 
     def updateSome(pf: PartialFunction[A, A]): UIO[Unit] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop    = true
         var next: A = null.asInstanceOf[A]
         while (loop) {
@@ -920,7 +920,7 @@ object ZRef extends Serializable {
       }
 
     def updateSomeAndGet(pf: PartialFunction[A, A]): UIO[A] =
-      UIO.effectTotal {
+      UIO.succeed {
         var loop    = true
         var next: A = null.asInstanceOf[A]
         while (loop) {

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -173,7 +173,7 @@ object ZScope {
 
     Open[A](
       (a: A) =>
-        UIO.effectSuspendTotal {
+        UIO.suspendSucceed {
           val result = scope0.unsafeClose(a)
 
           if (result eq null) UIO(false) else result as true
@@ -202,7 +202,7 @@ object ZScope {
     def ensure(finalizer: A => UIO[Any], mode: ZScope.Mode = ZScope.Mode.Strong): UIO[Either[A, Key]] =
       UIO(unsafeEnsure(finalizer, mode))
 
-    def release: UIO[Boolean] = UIO.effectSuspendTotal {
+    def release: UIO[Boolean] = UIO.suspendSucceed {
       val result = unsafeRelease()
 
       if (result eq null) UIO(false) else result as true

--- a/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
+++ b/core/shared/src/main/scala/zio/stm/TReentrantLock.scala
@@ -82,7 +82,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
    * Obtains a read lock in a managed context.
    */
   lazy val readLock: UManaged[Int] =
-    Managed.make(acquireRead.commit)(_ => releaseRead.commit)
+    Managed.bracket(acquireRead.commit)(_ => releaseRead.commit)
 
   /**
    * Retrieves the total number of acquired read locks.
@@ -132,7 +132,7 @@ final class TReentrantLock private (data: TRef[LockState]) {
    * Obtains a write lock in a managed context.
    */
   lazy val writeLock: UManaged[Int] =
-    Managed.make(acquireWrite.commit)(_ => releaseWrite.commit)
+    Managed.bracket(acquireWrite.commit)(_ => releaseWrite.commit)
 
   /**
    * Determines if a write lock is held by some fiber.

--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -250,7 +250,7 @@ val hub: Hub[Int] = ???
 
 val hubWithLogging: ZHub[Any, Any, String, Nothing, String, Int] =
   hub.contramapM { (s: String) =>
-    ZIO.effect(s.toInt).orElseFail(s"$s is not a valid message")
+    ZIO.attempt(s.toInt).orElseFail(s"$s is not a valid message")
   }
 ```
 

--- a/docs/datatypes/concurrency/index.md
+++ b/docs/datatypes/concurrency/index.md
@@ -46,7 +46,7 @@ import zio.UIO
 
 ```scala mdoc:silent
   final case class Ref[A](value: AtomicReference[A]) { self =>
-    def modify[B](f: A => (B, A)): UIO[B] = UIO.effectTotal {
+    def modify[B](f: A => (B, A)): UIO[B] = UIO.succeed {
       var loop = true
       var b: B = null.asInstanceOf[B]
       while (loop) {

--- a/docs/datatypes/concurrency/refm.md
+++ b/docs/datatypes/concurrency/refm.md
@@ -16,7 +16,7 @@ In the following example, we should pass in `updateEffect` to it which is the de
 import zio._
 for {
   refM   <- RefM.make("current")
-  updateEffect = IO.effectTotal("update")
+  updateEffect = IO.succeed("update")
   _ <- refM.updateM(_ => updateEffect)
   value <- refM.get
 } yield assert(value == "update")

--- a/docs/datatypes/concurrency/semaphore.md
+++ b/docs/datatypes/concurrency/semaphore.md
@@ -34,7 +34,7 @@ val program = for {
 
   sem <- Semaphore.make(permits = 1)
 
-  seq <- ZIO.effectTotal(semTaskSeq(sem))
+  seq <- ZIO.succeed(semTaskSeq(sem))
 
   _ <- ZIO.collectAllPar(seq)
 

--- a/docs/datatypes/contextual/has.md
+++ b/docs/datatypes/contextual/has.md
@@ -97,12 +97,12 @@ To run this program, we need to implement a live version of `Logging` and `Rando
 ```scala mdoc:silent:nest
 val LoggingLive: Logging = new Logging {
   override def log(line: String): UIO[Unit] =
-    ZIO.effectTotal(println(line))
+    ZIO.succeed(println(line))
 }
 
 val RandomIntLive: RandomInt = new RandomInt {
   override def random: UIO[Int] =
-    ZIO.effectTotal(scala.util.Random.nextInt())
+    ZIO.succeed(scala.util.Random.nextInt())
 }
 ```
 
@@ -119,10 +119,10 @@ But, there is a workaround, we can throw away these implementations and write a 
 ```scala mdoc:silent:nest
 val LoggingWithRandomIntLive = new Logging with RandomInt {
   override def log(line: String): UIO[Unit] =
-    ZIO.effectTotal(println(line))
+    ZIO.succeed(println(line))
 
   override def random: UIO[Int] =
-    ZIO.effectTotal(scala.util.Random.nextInt())
+    ZIO.succeed(scala.util.Random.nextInt())
 }
 ```
 
@@ -195,12 +195,12 @@ Let's implement `Logging` and `RandomInt` services:
 ```scala mdoc:silent:nest
 case class LoggingLive() extends Logging {
   override def log(line: String): UIO[Unit] =
-    ZIO.effectTotal(println(line))
+    ZIO.succeed(println(line))
 }
 
 case class RandomIntLive() extends RandomInt {
   override def random: UIO[Int] =
-    ZIO.effectTotal(scala.util.Random.nextInt())
+    ZIO.succeed(scala.util.Random.nextInt())
 }
 ```
 
@@ -235,12 +235,12 @@ val myApp: ZIO[Has[Logging] with Has[RandomInt], Nothing, Unit] =
 
 case class LoggingLive() extends Logging {
   override def log(line: String): UIO[Unit] =
-    ZIO.effectTotal(println(line))
+    ZIO.succeed(println(line))
 }
 
 case class RandomIntLive() extends RandomInt {
   override def random: UIO[Int] =
-    ZIO.effectTotal(scala.util.Random.nextInt())
+    ZIO.succeed(scala.util.Random.nextInt())
 }
 ```
 

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -225,7 +225,7 @@ object logging {
     val live: ULayer[Logging] = ZLayer.succeed {
       new Service {
         override def log(line: String): UIO[Unit] =
-          ZIO.effectTotal(println(line))
+          ZIO.succeed(println(line))
       }
     }
   }
@@ -307,7 +307,7 @@ trait Logging {
 ```scala mdoc:silent:nest
 case class LoggingLive() extends Logging {
   override def log(line: String): UIO[Unit] = 
-    ZIO.effectTotal(print(line))
+    ZIO.succeed(print(line))
 }
 ```
 
@@ -432,7 +432,7 @@ We can `provide` implementation of `Logging` service into the `app` effect:
 ```scala mdoc:silent:nest
 val loggingImpl = Has(new Logging {
   override def log(line: String): UIO[Unit] =
-    UIO.effectTotal(println(line))
+    UIO.succeed(println(line))
 })
 
 val effect = app.provide(loggingImpl)

--- a/docs/datatypes/contextual/zlayer.md
+++ b/docs/datatypes/contextual/zlayer.md
@@ -86,7 +86,7 @@ object terminal {
     object Service {
       val live: Service = new Service {
         override def printLine(line: String): UIO[Unit] =
-          ZIO.effectTotal(println(line))
+          ZIO.succeed(println(line))
       }
     }
   }
@@ -116,7 +116,7 @@ import scala.io.BufferedSource
 
 ```scala mdoc:silent:nest
 val managedFile = ZManaged.fromAutoCloseable(
-  ZIO.effect(scala.io.Source.fromFile("file.txt"))
+  ZIO.attempt(scala.io.Source.fromFile("file.txt"))
 )
 val fileLayer: ZLayer[Any, Throwable, Has[BufferedSource]] = 
   ZLayer.fromManaged(managedFile)
@@ -139,8 +139,8 @@ import java.io.{FileInputStream, FileOutputStream, Closeable}
 trait DBConfig
 trait Transactor
 
-def dbConfig: Task[DBConfig] = Task.effect(???)
-def initializeDb(config: DBConfig): Task[Unit] = Task.effect(???)
+def dbConfig: Task[DBConfig] = Task.attempt(???)
+def initializeDb(config: DBConfig): Task[Unit] = Task.attempt(???)
 def makeTransactor(config: DBConfig): ZManaged[Any, Throwable, Transactor] = ???
 
 case class UserRepository(xa: Transactor)
@@ -151,8 +151,8 @@ object UserRepository {
 
 ```scala mdoc:silent:nest
 def userRepository: ZManaged[Has[Console], Throwable, UserRepository] = for {
-  cfg <- dbConfig.toManaged_
-  _ <- initializeDb(cfg).toManaged_
+  cfg <- dbConfig.toManaged
+  _ <- initializeDb(cfg).toManaged
   xa <- makeTransactor(cfg)
 } yield new UserRepository(xa)
 ```
@@ -167,8 +167,8 @@ val usersLayer_ = ZLayer.fromManaged(userRepository)
 Also, we can create a `ZLayer` directly from `acquire` and `release` actions of a managed resource:
 
 ```scala mdoc:nest
-def acquire = ZIO.effect(new FileInputStream("file.txt"))
-def release(resource: Closeable) = ZIO.effectTotal(resource.close())
+def acquire = ZIO.attempt(new FileInputStream("file.txt"))
+def release(resource: Closeable) = ZIO.succeed(resource.close())
 
 val inputStreamLayer = ZLayer.fromAcquireRelease(acquire)(release)
 ```
@@ -189,7 +189,7 @@ trait AppConfig
 ```
 
 ```scala mdoc:nest
-def loadConfig: Task[AppConfig] = Task.effect(???)
+def loadConfig: Task[AppConfig] = Task.attempt(???)
 val configLayer = ZLayer.fromEffect(loadConfig)
 ```
 

--- a/docs/datatypes/core/cause.md
+++ b/docs/datatypes/core/cause.md
@@ -29,13 +29,13 @@ Let's try to create some of these causes:
 ```scala mdoc:silent
 import zio._
 for {
-  failExit <- ZIO.fail("Oh! Error!").run
-  dieExit  <- ZIO.effectTotal(5 / 0).run
-  thenExit <- ZIO.fail("first").ensuring(ZIO.die(throw new Exception("second"))).run
-  bothExit <- ZIO.fail("first").zipPar(ZIO.die(throw new Exception("second"))).run
+  failExit <- ZIO.fail("Oh! Error!").exit
+  dieExit  <- ZIO.succeed(5 / 0).exit
+  thenExit <- ZIO.fail("first").ensuring(ZIO.die(throw new Exception("second"))).exit
+  bothExit <- ZIO.fail("first").zipPar(ZIO.die(throw new Exception("second"))).exit
   fiber    <- ZIO.sleep(1.second).fork
   _        <- fiber.interrupt
-  interruptionExit <- fiber.join.run
+  interruptionExit <- fiber.join.exit
 } yield ()
 ```
 

--- a/docs/datatypes/core/exit.md
+++ b/docs/datatypes/core/exit.md
@@ -14,7 +14,7 @@ import zio._
 import zio.Console._
 
 for {
-  successExit <- ZIO.succeed(1).run
+  successExit <- ZIO.succeed(1).exit
   _ <- successExit match {
     case Exit.Success(value) =>
       printLine(s"exited with success value: ${value}")

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -163,12 +163,12 @@ We are going to implement a live version of `Logging` service and also a mock ve
 ```scala mdoc:silent:nest
 case class LoggingLive() extends Logging {
   override def log(line: String): UIO[Unit] =
-    ZIO.effectTotal(print(line))
+    ZIO.succeed(print(line))
 }
 
 case class EmailMock() extends Email {
   override def send(user: String, content: String): Task[Unit] =
-    ZIO.effect(println(s"sending email to $user"))
+    ZIO.attempt(println(s"sending email to $user"))
 }
 ```
 

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -203,7 +203,7 @@ Separately from errors of type `E`, a fiber may be terminated for the following 
  * The fiber failed to handle some error of type `E`. This can happen only when an `IO.fail` is not handled. For values of type `UIO[A]`, this type of failure is impossible.
  * The fiber has a defect that leads to a non-recoverable error. There are only two ways this can happen:
      1. A partial function is passed to a higher-order function such as `map` or `flatMap`. For example, `io.map(_ => throw e)`, or `io.flatMap(a => throw e)`. The solution to this problem is to not to pass impure functions to purely functional libraries like ZIO, because doing so leads to violations of laws and destruction of equational reasoning.
-     2. Error-throwing code was embedded into some value via `IO.effectTotal`, etc. For importing partial effects into `IO`, the proper solution is to use a method such as `IO.effect`, which safely translates exceptions into values.
+     2. Error-throwing code was embedded into some value via `IO.succeed`, etc. For importing partial effects into `IO`, the proper solution is to use a method such as `IO.attempt`, which safely translates exceptions into values.
 
 When a fiber is terminated, the reason for the termination, expressed as a `Throwable`, is passed to the fiber's supervisor, which may choose to log, print the stack trace, restart the fiber, or perform some other action appropriate to the context.
 

--- a/docs/datatypes/stm/index.md
+++ b/docs/datatypes/stm/index.md
@@ -74,7 +74,7 @@ import zio.UIO
 
 ```scala mdoc:silent:nest
   final case class Ref[A](value: AtomicReference[A]) { self =>
-    def modify[B](f: A => (B, A)): UIO[B] = UIO.effectTotal {
+    def modify[B](f: A => (B, A)): UIO[B] = UIO.succeed {
       var loop = true
       var b: B = null.asInstanceOf[B]
       while (loop) {

--- a/docs/datatypes/stream/zsink.md
+++ b/docs/datatypes/stream/zsink.md
@@ -386,10 +386,10 @@ case class Record()
 
 ```scala mdoc:silent:nest
 val kafkaSink: ZSink[Any, Throwable, Record, Record, Unit] =
-  ZSink.foreach[Any, Throwable, Record](record => ZIO.effect(???))
+  ZSink.foreach[Any, Throwable, Record](record => ZIO.attempt(???))
 
 val pulsarSink: ZSink[Any, Throwable, Record, Record, Unit] =
-  ZSink.foreach[Any, Throwable, Record](record => ZIO.effect(???))
+  ZSink.foreach[Any, Throwable, Record](record => ZIO.attempt(???))
 
 val stream: ZSink[Any, Throwable, Record, Record, (Unit, Unit)] =
   kafkaSink zipPar pulsarSink 

--- a/docs/howto/interop/with-java.md
+++ b/docs/howto/interop/with-java.md
@@ -73,7 +73,7 @@ Java libraries using channels from the NIO API for asynchronous, interruptible I
 ```scala
 def readFile(file: AsynchronousFileChannel): Task[Chunk[Byte]] = for {
     pos <- Ref.make(0)
-    buf <- ZIO.effectTotal(ByteBuffer.allocate(1024))
+    buf <- ZIO.succeed(ByteBuffer.allocate(1024))
     contents <- Ref.make[Chunk[Byte]](Chunk.empty)
     def go = pos.get.flatMap { p =>
         ZIO.effectAsyncWithCompletionHandler[Chunk[Byte]] { handler =>
@@ -81,7 +81,7 @@ def readFile(file: AsynchronousFileChannel): Task[Chunk[Byte]] = for {
         }.flatMap {
             case -1 => contents.get
             case n  =>
-                ZIO.effectTotal {
+                ZIO.succeed {
                     val arr = Array.ofDim[Byte](n)
                     buf.get(arr, 0, n)
                     buf.clear()

--- a/docs/howto/interop/with-javascript.md
+++ b/docs/howto/interop/with-javascript.md
@@ -29,17 +29,17 @@ object Main extends App {
   def run(args: List[String]) = {
     for {
       _      <- Console.printLine("Starting progress bar demo.")  // Outputs on browser console log.
-      target <- IO.effectTotal(document.createElement("pre"))
+      target <- IO.succeed(document.createElement("pre"))
       _      <- update(target).repeat(Schedule.spaced(1.seconds))
-      _      <- IO.effectTotal(node.appendChild(target)) // "node" is provided in this page by mdoc.
+      _      <- IO.succeed(node.appendChild(target)) // "node" is provided in this page by mdoc.
     } yield ExitCode.success
   }
 
   def update(target: raw.Element) = {
       for {
         time   <- currentTime(TimeUnit.SECONDS)
-        output <- UIO.effectTotal(progress((time % 11).toInt, 10))
-        _      <- UIO.effectTotal(target.innerHTML = output)
+        output <- UIO.succeed(progress((time % 11).toInt, 10))
+        _      <- UIO.succeed(target.innerHTML = output)
       } yield ()
   }
 

--- a/docs/howto/migrate/from-monix.md
+++ b/docs/howto/migrate/from-monix.md
@@ -52,7 +52,7 @@ of your logic at a higher level of abstraction, with more powerful combinators a
 | `async` | `effectAsync` |
 | `cancelable` | `effectAsyncInterrupt` |
 | `deferFuture` | `fromFuture` |
-| `defer` | `effectSuspend` |
+| `defer` | `suspend` |
 | `delay` | `effect` |
 | `eval` | `effect` |
 | `fromEither` | `fromEither` |
@@ -75,7 +75,7 @@ of your logic at a higher level of abstraction, with more powerful combinators a
 | `sequence` | `collectAll` |
 | `shift` | `yield` |
 | `sleep` | `sleep` |
-| `suspend` | `effectSuspend` |
+| `suspend` | `suspend` |
 | `traverse` | `foreach` |
 | `unit` | `unit` |
 

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -206,7 +206,7 @@ object AccountObserver {
     ZIO.accessM[AccountObserver](_.get.processEvent(event))
 
   def runCommand() =
-    ZIO.accessM[AccountObserver](_.get.runCommand)
+    ZIO.accessM[AccountObserver](_.get.runCommand())
 
   val live: ZLayer[Has[Console], Nothing, AccountObserver] =
     { (console: Console) =>

--- a/docs/howto/test_effects.md
+++ b/docs/howto/test_effects.md
@@ -346,7 +346,7 @@ testM("One can control time for failing effects too") {
   val testCase =
     for {
       promise <- Promise.make[Unit, Int]
-      result  <- ZIO.service[SchedulingService].flatMap(_.schedule(promise)).run.fork
+      result  <- ZIO.service[SchedulingService].flatMap(_.schedule(promise)).exit.fork
       _       <- TestClock.adjust(10.seconds)
       readRef <- promise.await
       result  <- result.join

--- a/docs/overview/handling_errors.md
+++ b/docs/overview/handling_errors.md
@@ -38,7 +38,7 @@ If you want to catch and recover from all types of errors and effectfully attemp
 import java.io.{ FileNotFoundException, IOException }
 
 def openFile(s: String): IO[IOException, Array[Byte]] = 
-  ZIO.effect(???).refineToOrDie[IOException]
+  ZIO.attempt(???).refineToOrDie[IOException]
 ```
 
 ```scala mdoc:silent

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -19,7 +19,7 @@ Like `try` / `finally`, the `ensuring` operation guarantees that if an effect be
 
 ```scala mdoc
 val finalizer = 
-  UIO.effectTotal(println("Finalizing!"))
+  UIO.succeed(println("Finalizing!"))
 
 val finalized: IO[String, Unit] = 
   IO.fail("Failed!").ensuring(finalizer)
@@ -51,7 +51,7 @@ The release effect is guaranteed to be executed by the runtime system, even in t
 import zio._
 import java.io.{ File, IOException }
 
-def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]
+def openFile(s: String): IO[IOException, File] = IO.attempt(???).refineToOrDie[IOException]
 def closeFile(f: File): UIO[Unit] = UIO.unit
 def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit

--- a/docs/overview/testing_effects.md
+++ b/docs/overview/testing_effects.md
@@ -192,7 +192,7 @@ class TestService extends Database.Service {
     Task(map(id))
 
   def update(id: UserID, profile: UserProfile): Task[Unit] = 
-    Task.effect { map = map + (id -> profile) }
+    Task.attempt { map = map + (id -> profile) }
 }
 trait TestDatabase extends Database {
   val database: TestService = new TestService

--- a/docs/services/blocking.md
+++ b/docs/services/blocking.md
@@ -15,7 +15,7 @@ import zio._
 import zio.Console._
 def blockingTask(n: Int): URIO[Has[Console], Unit] =
   printLine(s"running blocking task number $n").orDie *>
-    ZIO.effectTotal(Thread.sleep(3000)) *>
+    ZIO.succeed(Thread.sleep(3000)) *>
     blockingTask(n)
 
 val program = ZIO.foreachPar((1 to 100).toArray)(blockingTask)

--- a/docs/usecases/scheduling.md
+++ b/docs/usecases/scheduling.md
@@ -14,7 +14,7 @@ import zio.Task
 import java.util.Random
 
 object API {
-  def makeRequest = Task.effect {
+  def makeRequest = Task.attempt {
     if (new Random().nextInt(10) < 7) "some value" else throw new Exception("hi")
   }
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
@@ -6,7 +6,7 @@ import zio.{UIO, ZIOBaseSpec}
 object StreamLazinessSpec extends ZIOBaseSpec {
 
   def assertLazy(f: (=> Nothing) => Any): UIO[TestResult] =
-    UIO.effectTotal {
+    UIO.succeed {
       val _ = f(throw new RuntimeException("not lazy"))
       assertCompletes
     }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -72,7 +72,7 @@ object ZSinkSpec extends ZIOBaseSpec {
         testM("happy path") {
           for {
             closed <- Ref.make[Boolean](false)
-            res     = ZManaged.make(ZIO.succeed(100))(_ => closed.set(true))
+            res     = ZManaged.bracket(ZIO.succeed(100))(_ => closed.set(true))
             sink: ZSink[Any, Nothing, Int, Int, (Long, Boolean)] =
               ZSink.managed(res)(m => ZSink.count.mapM(cnt => closed.get.map(cl => (cnt + m, cl))))
             resAndState <- ZStream(1, 2, 3).run(sink)
@@ -84,7 +84,7 @@ object ZSinkSpec extends ZIOBaseSpec {
         testM("sad path") {
           for {
             closed     <- Ref.make[Boolean](false)
-            res         = ZManaged.make(ZIO.succeed(100))(_ => closed.set(true))
+            res         = ZManaged.bracket(ZIO.succeed(100))(_ => closed.set(true))
             sink        = ZSink.managed(res)(_ => ZSink.succeed[Int, String]("ok"))
             r          <- ZStream.fail("fail").run(sink).either
             finalState <- closed.get
@@ -137,7 +137,7 @@ object ZSinkSpec extends ZIOBaseSpec {
               foldResult <- s.fold(List[Int]())((acc, el) => el :: acc)
                               .map(_.reverse)
                               .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
-                              .run
+                              .exit
             } yield assert(foldResult.succeeded)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
           }
         }
@@ -309,7 +309,7 @@ object ZSinkSpec extends ZIOBaseSpec {
             .fromChunks(chunks: _*)
             .peel(ZSink.take[Int](n))
             .flatMap { case (chunk, stream) =>
-              stream.runCollect.toManaged_.map { leftover =>
+              stream.runCollect.toManaged.map { leftover =>
                 assert(chunk)(equalTo(chunks.flatten.take(n))) &&
                 assert(leftover)(equalTo(chunks.flatten.drop(n)))
               }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -188,7 +188,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                         })
                         .runCollect
               result <- effects.get
-            } yield (exit, result)).run
+            } yield (exit, result)).exit
 
           (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
             assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
@@ -223,7 +223,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                         })
                         .runCollect
               result <- effects.get
-            } yield exit -> result).run
+            } yield exit -> result).exit
 
           (assertM(run(empty))(succeeds(equalTo((Chunk(0), Nil)))) <*>
             assertM(run(single))(succeeds(equalTo((Chunk(30), List(1))))) <*>
@@ -598,7 +598,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   }
                 }
                 .runCollect
-            assertM(test.run)(succeeds(equalTo(data)))
+            assertM(test.exit)(succeeds(equalTo(data)))
           }
         },
         testM("finalizes transducers") {
@@ -612,7 +612,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                       values.toList match {
                         case _ =>
                           ZTransducer {
-                            Managed.make(
+                            Managed.bracket(
                               ref
                                 .update(_ + 1)
                                 .as[Option[Chunk[Int]] => UIO[Chunk[Int]]]({
@@ -626,7 +626,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   }
                   .runDrain *> ref.get
               }
-            assertM(test.run)(succeeds(equalTo(0)))
+            assertM(test.exit)(succeeds(equalTo(0)))
           }
         },
         testM("finalizes transducers - inner transducer fails") {
@@ -640,7 +640,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                       values.toList match {
                         case _ =>
                           ZTransducer {
-                            Managed.make(
+                            Managed.bracket(
                               ref
                                 .update(_ + 1)
                                 .as[Option[Chunk[Int]] => IO[String, Chunk[Int]]]({ case _ =>
@@ -654,7 +654,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   .runDrain
                   .ignore *> ref.get
               }
-            assertM(test.run)(succeeds(equalTo(0)))
+            assertM(test.exit)(succeeds(equalTo(0)))
           }
         },
         testM("emits data if less than n are collected") {
@@ -672,7 +672,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
                   ZTransducer.branchAfter(n)(ZTransducer.prepend)
                 }
                 .runCollect
-            assertM(test.run)(succeeds(equalTo(data)))
+            assertM(test.exit)(succeeds(equalTo(data)))
           }
         }
       ),

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
@@ -11,16 +11,16 @@ object ZChannelSimulatedChecks extends ZIOBaseSpec {
       testM("done channel")(
         checkM(gen) { sim =>
           for {
-            channelResult <- sim.asDoneChannel.run.run
-            effectResult  <- sim.asEffect.run
+            channelResult <- sim.asDoneChannel.run.exit
+            effectResult  <- sim.asEffect.exit
           } yield assert(channelResult)(equalTo(effectResult))
         }
       ),
       testM("out channel")(
         checkM(gen) { sim =>
           for {
-            channelResult <- sim.asOutChannel.runCollect.map(_._1).run
-            effectResult  <- sim.asEffect.run.map(_.map(Chunk.single))
+            channelResult <- sim.asOutChannel.runCollect.map(_._1).exit
+            effectResult  <- sim.asEffect.exit.map(_.map(Chunk.single))
           } yield assert(channelResult)(equalTo(effectResult))
         }
       )

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -54,9 +54,9 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
-        runtime <- ZIO.runtime[R].toManaged_
-        eitherStream <- ZManaged.effectTotal {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManagedWith(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged
+        eitherStream <- ZManaged.succeed {
                           register(k =>
                             try {
                               runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
@@ -75,7 +75,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                       else
                         output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
                     }).ensuring(canceler)
-                  case Right(stream) => output.shutdown.toManaged_ *> stream.process
+                  case Right(stream) => output.shutdown.toManaged *> stream.process
                 }
       } yield pull
     }
@@ -91,8 +91,8 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     managed {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
-        runtime <- ZIO.runtime[R].toManaged_
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManagedWith(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged
         _ <- register { k =>
                try {
                  runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
@@ -100,7 +100,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                  case FiberFailure(c) if c.interrupted =>
                    Future.successful(false)
                }
-             }.toManaged_
+             }.toManaged
         done <- ZRef.makeManaged(false)
         pull = done.get.flatMap {
                  if (_)
@@ -123,9 +123,9 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[R, E, A] =
     ZStream {
       for {
-        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManaged(_.shutdown)
-        runtime <- ZIO.runtime[R].toManaged_
-        maybeStream <- ZManaged.effectTotal {
+        output  <- Queue.bounded[stream.Take[E, A]](outputBuffer).toManagedWith(_.shutdown)
+        runtime <- ZIO.runtime[R].toManaged
+        maybeStream <- ZManaged.succeed {
                          register { k =>
                            try {
                              runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
@@ -136,7 +136,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                          }
                        }
         pull <- maybeStream match {
-                  case Some(stream) => output.shutdown.toManaged_ *> stream.process
+                  case Some(stream) => output.shutdown.toManaged *> stream.process
                   case None =>
                     for {
                       done <- ZRef.makeManaged(false)
@@ -159,8 +159,8 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
   ): ZStream[Any, IOException, Byte] =
     ZStream {
       for {
-        done       <- Ref.make(false).toManaged_
-        capturedIs <- Managed.effectTotal(is)
+        done       <- Ref.make(false).toManaged
+        capturedIs <- Managed.succeed(is)
         pull = {
           def go: ZIO[Any, Option[IOException], Chunk[Byte]] = done.get.flatMap {
             if (_) Pull.end
@@ -194,7 +194,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
     is: ZIO[R, IOException, InputStream],
     chunkSize: Int = ZStream.DefaultChunkSize
   ): ZStream[R, IOException, Byte] =
-    fromInputStreamManaged(is.toManaged(is => ZIO.effectTotal(is.close())), chunkSize)
+    fromInputStreamManaged(is.toManagedWith(is => ZIO.succeed(is.close())), chunkSize)
 
   /**
    * Creates a stream from a managed `java.io.InputStream` value.

--- a/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Deflate.scala
@@ -32,22 +32,22 @@ object Deflate {
     flushMode: FlushMode
   ): ZManaged[Any, Nothing, Option[Chunk[Byte]] => ZIO[Any, Nothing, Chunk[Byte]]] =
     ZManaged
-      .make(ZIO.effectTotal {
+      .bracket(ZIO.succeed {
         val deflater = new Deflater(level.jValue, noWrap)
         deflater.setStrategy(strategy.jValue)
         (deflater, new Array[Byte](bufferSize))
       }) { case (deflater, _) =>
-        ZIO.effectTotal(deflater.end())
+        ZIO.succeed(deflater.end())
       }
       .map {
         case (deflater, buffer) => {
           case Some(chunk) =>
-            ZIO.effectTotal {
+            ZIO.succeed {
               deflater.setInput(chunk.toArray)
               Deflate.pullOutput(deflater, buffer, flushMode)
             }
           case None =>
-            ZIO.effectTotal {
+            ZIO.succeed {
               deflater.finish()
               val out = Deflate.pullOutput(deflater, buffer, flushMode)
               deflater.reset()

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gunzipper.scala
@@ -35,7 +35,7 @@ private[compression] class Gunzipper private (bufferSize: Int) {
   def close(): Unit = state.close()
 
   def onChunk(c: Chunk[Byte]): ZIO[Any, CompressionException, Chunk[Byte]] =
-    ZIO.effect {
+    ZIO.attempt {
       val (newState, output) = state.feed(c.toArray)
       state = newState
       output
@@ -46,7 +46,7 @@ private[compression] class Gunzipper private (bufferSize: Int) {
 
   def onNone: ZIO[Any, CompressionException, Chunk[Byte]] =
     if (state.isInProgress) ZIO.fail(CompressionException("Stream closed before completion."))
-    else ZIO.effectTotal(Chunk.empty)
+    else ZIO.succeed(Chunk.empty)
 
   private def nextStep(
     acc: Array[Byte],

--- a/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
+++ b/streams/jvm/src/main/scala/zio/stream/compression/Gzipper.scala
@@ -37,7 +37,7 @@ private[compression] class Gzipper(
     deflater
   }
 
-  def onNone: ZIO[Any, Nothing, Chunk[Byte]] = ZIO.effectTotal {
+  def onNone: ZIO[Any, Nothing, Chunk[Byte]] = ZIO.succeed {
     deflater.finish()
     val restAndTrailer = Deflate.pullOutput(deflater, buffer, flushMode) ++ getTrailer
     val lastChunk      = if (headerSent) restAndTrailer else header ++ restAndTrailer
@@ -48,7 +48,7 @@ private[compression] class Gzipper(
     lastChunk
   }
 
-  def onChunk(chunk: Chunk[Byte]): ZIO[Any, Nothing, Chunk[Byte]] = ZIO.effectTotal {
+  def onChunk(chunk: Chunk[Byte]): ZIO[Any, Nothing, Chunk[Byte]] = ZIO.succeed {
     val input = chunk.toArray
     inputSize += input.length
     crc.update(input)

--- a/streams/jvm/src/main/scala/zio/stream/experimental/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/experimental/Deflate.scala
@@ -17,12 +17,12 @@ object Deflate {
   ): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
     ZChannel.managed {
       ZManaged
-        .make(ZIO.effectTotal {
+        .bracket(ZIO.succeed {
           val deflater = new Deflater(level.jValue, noWrap)
           deflater.setStrategy(strategy.jValue)
           (deflater, new Array[Byte](bufferSize))
         }) { case (deflater, _) =>
-          ZIO.effectTotal(deflater.end())
+          ZIO.succeed(deflater.end())
         }
     } {
       case (deflater, buffer) => {

--- a/streams/jvm/src/main/scala/zio/stream/experimental/Gzip.scala
+++ b/streams/jvm/src/main/scala/zio/stream/experimental/Gzip.scala
@@ -12,10 +12,10 @@ object Gzip {
   ): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
     ZChannel.managed {
       ZManaged
-        .make(
+        .bracket(
           Gzipper.make(bufferSize, level, strategy, flushMode)
         ) { gzipper =>
-          ZIO.effectTotal(gzipper.close())
+          ZIO.succeed(gzipper.close())
         }
     } {
       case gzipper => {

--- a/streams/jvm/src/main/scala/zio/stream/experimental/Inflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/experimental/Inflate.scala
@@ -14,15 +14,15 @@ object Inflate {
   ): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
     ZChannel.managed {
       ZManaged
-        .make(ZIO.effectTotal((new Array[Byte](bufferSize), new Inflater(noWrap)))) { case (_, inflater) =>
-          ZIO.effectTotal(inflater.end())
+        .bracket(ZIO.succeed((new Array[Byte](bufferSize), new Inflater(noWrap)))) { case (_, inflater) =>
+          ZIO.succeed(inflater.end())
         }
     } { case (buffer, inflater) =>
       lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
         ZChannel.readWithCause(
           chunk =>
             ZChannel.fromEffect {
-              ZIO.effect {
+              ZIO.attempt {
                 inflater.setInput(chunk.toArray)
                 pullAllOutput(inflater, buffer, chunk)
               }.refineOrDie { case e: DataFormatException =>
@@ -32,7 +32,7 @@ object Inflate {
           ZChannel.halt(_),
           done =>
             ZChannel.fromEffect {
-              ZIO.effect {
+              ZIO.attempt {
                 if (inflater.finished()) {
                   inflater.reset()
                   Chunk.empty

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -19,7 +19,7 @@ package zio.test.junit
 import org.junit.runner.manipulation.{Filter, Filterable}
 import org.junit.runner.notification.{Failure, RunNotifier}
 import org.junit.runner.{Description, RunWith, Runner}
-import zio.ZIO.effectTotal
+import zio.ZIO.succeed
 import zio._
 import zio.test.DefaultTestReporter.rendered
 import zio.test.Spec.{SpecCase, SuiteCase, TestCase}
@@ -62,12 +62,12 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Boot
       spec.caseValue match {
         case SuiteCase(label, specs, _) =>
           val suiteDesc = Description.createSuiteDescription(label, path.mkString(":"))
-          ZManaged.effectTotal(description.addChild(suiteDesc)) *>
+          ZManaged.succeed(description.addChild(suiteDesc)) *>
             specs
               .flatMap(ZManaged.foreach(_)(traverse(_, suiteDesc, path :+ label)))
               .ignore
         case TestCase(label, _, _) =>
-          ZManaged.effectTotal(description.addChild(testDescription(label, path)))
+          ZManaged.succeed(description.addChild(testDescription(label, path)))
       }
 
     unsafeRun(
@@ -165,21 +165,21 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable with Boot
       renderedText: String,
       throwable: Throwable = null
     ): UIO[Unit] =
-      effectTotal {
+      succeed {
         notifier.fireTestFailure(
           new Failure(testDescription(label, path), new TestFailed(renderedText, throwable))
         )
       }
 
-    def fireTestStarted(label: String, path: Vector[String]): UIO[Unit] = effectTotal {
+    def fireTestStarted(label: String, path: Vector[String]): UIO[Unit] = succeed {
       notifier.fireTestStarted(testDescription(label, path))
     }
 
-    def fireTestFinished(label: String, path: Vector[String]): UIO[Unit] = effectTotal {
+    def fireTestFinished(label: String, path: Vector[String]): UIO[Unit] = succeed {
       notifier.fireTestFinished(testDescription(label, path))
     }
 
-    def fireTestIgnored(label: String, path: Vector[String]): UIO[Unit] = effectTotal {
+    def fireTestIgnored(label: String, path: Vector[String]): UIO[Unit] = succeed {
       notifier.fireTestIgnored(testDescription(label, path))
     }
   }

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -86,7 +86,7 @@ final class ZTestTask(
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
     Runtime((), specInstance.platform)
-      .unsafeRunAsync((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged_).use_(ZIO.unit)) { exit =>
+      .unsafeRunAsync((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged).use_(ZIO.unit)) { exit =>
         exit match {
           case Exit.Failure(cause) => Console.err.println(s"$runnerType failed: " + cause.prettyPrint)
           case _                   =>

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -27,7 +27,7 @@ final class ZTestRunner(val args: Array[String], val remoteArgs: Array[String], 
   val summaries: AtomicReference[Vector[Summary]] = new AtomicReference(Vector.empty)
 
   val sendSummary: SendSummary = SendSummary.fromSendM(summary =>
-    ZIO.effectTotal {
+    ZIO.succeed {
       summaries.updateAndGet(_ :+ summary)
       ()
     }

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -86,7 +86,7 @@ final class ZTestTask(
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
     Runtime((), specInstance.platform)
-      .unsafeRunAsync((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged_).use_(ZIO.unit)) { exit =>
+      .unsafeRunAsync((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged).use_(ZIO.unit)) { exit =>
         exit match {
           case Exit.Failure(cause) => Console.err.println(s"$runnerType failed: " + cause.prettyPrint)
           case _                   =>

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -27,13 +27,13 @@ abstract class BaseTestTask(
       summary = SummaryBuilder.buildSummary(spec)
       _      <- sendSummary.provide(summary)
       events  = ZTestEvent.from(spec, taskDef.fullyQualifiedName(), taskDef.fingerprint())
-      _      <- ZIO.foreach(events)(e => ZIO.effect(eventHandler.handle(e)))
+      _      <- ZIO.foreach(events)(e => ZIO.attempt(eventHandler.handle(e)))
     } yield ()
 
   protected def sbtTestLayer(loggers: Array[Logger]): Layer[Nothing, Has[TestLogger] with Has[Clock]] =
     ZLayer.succeed[TestLogger](new TestLogger {
       def logLine(line: String): UIO[Unit] =
-        ZIO.effect(loggers.foreach(_.info(colored(line)))).ignore
+        ZIO.attempt(loggers.foreach(_.info(colored(line)))).ignore
     }) ++ Clock.live
 
   override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] =

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
@@ -10,7 +10,7 @@ package object sbt {
 
   object SendSummary {
     def fromSend(send: Summary => Unit): SendSummary =
-      URIO.fromFunctionM(summary => URIO.effectTotal(send(summary)))
+      URIO.fromFunctionM(summary => URIO.succeed(send(summary)))
 
     def fromSendM(send: Summary => UIO[Unit]): SendSummary =
       URIO.fromFunctionM(send)

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -10,7 +10,7 @@ object CheckSpec extends ZIOBaseSpec {
     testM("checkM is polymorphic in error type") {
       checkM(Gen.int(1, 100)) { n =>
         for {
-          _ <- ZIO.effect(())
+          _ <- ZIO.attempt(())
           r <- Random.nextIntBounded(n)
         } yield assert(r)(isLessThan(n))
       }

--- a/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/FunSpec.scala
@@ -17,7 +17,7 @@ object FunSpec extends ZIOBaseSpec {
     testM("fun does not have race conditions") {
       for {
         f       <- Fun.make((_: Int) => Random.nextIntBounded(6))
-        results <- ZIO.foreachPar(List.range(0, 1000))(n => ZIO.effectTotal((n % 6, f(n % 6))))
+        results <- ZIO.foreachPar(List.range(0, 1000))(n => ZIO.succeed((n % 6, f(n % 6))))
       } yield assert(results.distinct.length)(equalTo(6))
     },
     testM("fun is showable") {

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -89,7 +89,7 @@ object GenUtils {
     gen: Gen[Has[Random] with Has[Sized], ZIO[Has[Random] with Has[Sized], E, A]],
     size: Int = 100
   ): ZIO[Has[Random], Nothing, List[Exit[E, A]]] =
-    provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.run)))(size)
+    provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.exit)))(size)
 
   def shrink[R, A](gen: Gen[R, A]): URIO[R, A] =
     gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(1000).runLast.map(_.get)

--- a/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ManagedSpec.scala
@@ -17,7 +17,7 @@ object ManagedSpec extends ZIOBaseSpec {
     val live: Layer[Nothing, Counter] =
       Ref
         .make(1)
-        .toManaged(_.set(-10))
+        .toManagedWith(_.set(-10))
         .map { ref =>
           new Counter.Service {
             val incrementAndGet: UIO[Int] = ref.updateAndGet(_ + 1)

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -136,10 +136,10 @@ object ReportingTestUtils {
 
   val test7: ZSpec[Any, Nothing] = testM("labeled failures") {
     for {
-      a <- ZIO.effectTotal(Some(1))
-      b <- ZIO.effectTotal(Some(1))
-      c <- ZIO.effectTotal(Some(0))
-      d <- ZIO.effectTotal(Some(1))
+      a <- ZIO.succeed(Some(1))
+      b <- ZIO.succeed(Some(1))
+      c <- ZIO.succeed(Some(0))
+      d <- ZIO.succeed(Some(1))
     } yield assert(a)(isSome(equalTo(1)).label("first")) &&
       assert(b)(isSome(equalTo(1)).label("second")) &&
       assert(c)(isSome(equalTo(1)).label("third")) &&

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -134,7 +134,7 @@ object SpecSpec extends ZIOBaseSpec {
           acquire = ref.update("Acquiring" :: _)
           release = ref.update("Releasing" :: _)
           update  = ZIO.service[Ref[Int]].flatMap(_.updateAndGet(_ + 1))
-          layer   = ZManaged.make(acquire *> Ref.make(0))(_ => release).toLayer
+          layer   = ZManaged.bracket(acquire *> Ref.make(0))(_ => release).toLayer
           spec = suite("spec")(
                    suite("suite1")(
                      testM("test1") {
@@ -172,7 +172,7 @@ object SpecSpec extends ZIOBaseSpec {
                 }
               )
             )
-          ).provideCustomLayerShared(ZManaged.make(Ref.make(0))(_.set(-1)).toLayer)
+          ).provideCustomLayerShared(ZManaged.bracket(Ref.make(0))(_.set(-1)).toLayer)
         assertM(succeeded(spec))(isTrue)
       }
     )

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -20,7 +20,7 @@ object TestSpec extends ZIOBaseSpec {
     } @@ failing,
     testM("testM is polymorphic in error type") {
       for {
-        _      <- ZIO.effect(())
+        _      <- ZIO.attempt(())
         result <- ZIO.succeed("succeed")
       } yield assert(result)(equalTo("succeed"))
     },

--- a/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/ClockSpec.scala
@@ -78,7 +78,7 @@ object ClockSpec extends ZIOBaseSpec {
       },
       testM("setDateTime correctly sets currentDateTime") {
         for {
-          expected <- UIO.effectTotal(OffsetDateTime.now(ZoneId.of("UTC+9")))
+          expected <- UIO.succeed(OffsetDateTime.now(ZoneId.of("UTC+9")))
           _        <- setDateTime(expected)
           actual   <- Clock.currentDateTime
         } yield assert(actual.toInstant.toEpochMilli)(equalTo(expected.toInstant.toEpochMilli))

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -87,14 +87,14 @@ object RandomSpec extends ZIOBaseSpec {
   )(extract: ZRandom => UIO[A]): URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
-        value      <- ZIO.effectTotal(generate(sRandom))
+        value      <- ZIO.succeed(generate(sRandom))
         _          <- feed(testRandom, List(value))
         _          <- clear(testRandom)
         random     <- extract(testRandom)
-        expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
+        expected   <- ZIO.succeed(generate(new SRandom(seed)))
       } yield assert(random)(equalTo(expected))
     }
 
@@ -103,14 +103,14 @@ object RandomSpec extends ZIOBaseSpec {
   )(extract: ZRandom => UIO[A]): URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
-        values     <- ZIO.effectTotal(List.fill(100)(generate(sRandom)))
+        values     <- ZIO.succeed(List.fill(100)(generate(sRandom)))
         _          <- feed(testRandom, values)
         results    <- UIO.foreach(List.range(0, 100))(_ => extract(testRandom))
         random     <- extract(testRandom)
-        expected   <- ZIO.effectTotal(generate(new SRandom(seed)))
+        expected   <- ZIO.succeed(generate(new SRandom(seed)))
       } yield {
         assert(results)(equalTo(values)) &&
         assert(random)(equalTo(expected))
@@ -128,22 +128,22 @@ object RandomSpec extends ZIOBaseSpec {
   )(g: SRandom => A): URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- UIO.foreach(List.fill(100)(()))(_ => f(testRandom))
-        expected   <- ZIO.effectTotal(List.fill(100)(g(sRandom)))
+        expected   <- ZIO.succeed(List.fill(100)(g(sRandom)))
       } yield assert(actual)(equalTo(expected))
     }
 
   def forAllEqualBytes: URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- UIO.foreach(List.range(0, 100))(testRandom.nextBytes(_))
-        expected <- ZIO.effectTotal(List.range(0, 100).map(new Array[Byte](_)).map { arr =>
+        expected <- ZIO.succeed(List.range(0, 100).map(new Array[Byte](_)).map { arr =>
                       sRandom.nextBytes(arr)
                       Chunk.fromArray(arr)
                     })
@@ -153,11 +153,11 @@ object RandomSpec extends ZIOBaseSpec {
   def forAllEqualGaussian: URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong) { seed =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- testRandom.nextGaussian
-        expected   <- ZIO.effectTotal(sRandom.nextGaussian())
+        expected   <- ZIO.succeed(sRandom.nextGaussian())
       } yield assert(actual)(approximatelyEquals(expected, 0.01))
     }
 
@@ -166,11 +166,11 @@ object RandomSpec extends ZIOBaseSpec {
   )(g: (SRandom, Int) => A): URIO[Has[Random] with Has[TestConfig], TestResult] =
     checkM(Gen.anyLong, Gen.int(1, 100)) { (seed, size) =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, size)
-        expected   <- ZIO.effectTotal(g(sRandom, size))
+        expected   <- ZIO.succeed(g(sRandom, size))
       } yield assert(actual)(equalTo(expected))
     }
 
@@ -179,11 +179,11 @@ object RandomSpec extends ZIOBaseSpec {
   )(g: (SRandom, List[Int]) => List[Int]): ZIO[Has[Random] with Has[Sized] with Has[TestConfig], Nothing, TestResult] =
     checkM(Gen.anyLong, Gen.listOf(Gen.anyInt)) { (seed, testList) =>
       for {
-        sRandom    <- ZIO.effectTotal(new SRandom(seed))
+        sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
         _          <- testRandom.setSeed(seed)
         actual     <- f(testRandom, testList)
-        expected   <- ZIO.effectTotal(g(sRandom, testList))
+        expected   <- ZIO.succeed(g(sRandom, testList))
       } yield assert(actual)(equalTo(expected))
     }
 

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -61,7 +61,7 @@ object Annotations {
               case Left(_) => ZIO.succeedNow(SortedSet.empty[Fiber.Runtime[Any, Any]])
               case Right(refs) =>
                 ZIO
-                  .foreach(refs)(ref => ZIO.effectTotal(ref.get))
+                  .foreach(refs)(ref => ZIO.succeed(ref.get))
                   .map(_.foldLeft(SortedSet.empty[Fiber.Runtime[Any, Any]])(_ ++ _))
                   .map(_.filter(_.id != descriptor.id))
             }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -748,7 +748,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * when creating generators that refer to themselves.
    */
   def suspend[R, A](gen: => Gen[R, A]): Gen[R, A] =
-    fromEffect(ZIO.effectTotal(gen)).flatten
+    fromEffect(ZIO.succeed(gen)).flatten
 
   /**
    * A generator of throwables.

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -98,7 +98,7 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
     val shrink = self.shrink
       .combine[R1, Nothing, State, Sample[R1, B], Sample[R1, C]](that.shrink)((false, false, None, None)) {
         case ((leftDone, rightDone, s1, s2), left, right) =>
-          left.run.zipWith(right.run) {
+          left.exit.zipWith(right.exit) {
             case (Exit.Success(l), Exit.Success(r)) =>
               Exit.succeed((zipWith(r)(f), (leftDone, rightDone, Some(l), Some(r))))
 

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -75,7 +75,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   final def countTests(f: T => Boolean): ZManaged[R, E, Int] =
     fold[ZManaged[R, E, Int]] {
       case SuiteCase(_, specs, _) => specs.flatMap(ZManaged.collectAll(_).map(_.sum))
-      case TestCase(_, test, _)   => test.map(t => if (f(t)) 1 else 0).toManaged_
+      case TestCase(_, test, _)   => test.map(t => if (f(t)) 1 else 0).toManaged
     }
 
   /**
@@ -90,8 +90,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   final def exists[R1 <: R, E1 >: E](f: SpecCase[R, E, T, Any] => ZIO[R1, E1, Boolean]): ZManaged[R1, E1, Boolean] =
     fold[ZManaged[R1, E1, Boolean]] {
       case c @ SuiteCase(_, specs, _) =>
-        specs.flatMap(ZManaged.collectAll(_).map(_.exists(identity))).zipWith(f(c).toManaged_)(_ || _)
-      case c @ TestCase(_, _, _) => f(c).toManaged_
+        specs.flatMap(ZManaged.collectAll(_).map(_.exists(identity))).zipWith(f(c).toManaged)(_ || _)
+      case c @ TestCase(_, _, _) => f(c).toManaged
     }
 
   /**
@@ -167,8 +167,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   final def forall[R1 <: R, E1 >: E](f: SpecCase[R, E, T, Any] => ZIO[R1, E1, Boolean]): ZManaged[R1, E1, Boolean] =
     fold[ZManaged[R1, E1, Boolean]] {
       case c @ SuiteCase(_, specs, _) =>
-        specs.flatMap(ZManaged.collectAll(_).map(_.forall(identity))).zipWith(f(c).toManaged_)(_ && _)
-      case c @ TestCase(_, _, _) => f(c).toManaged_
+        specs.flatMap(ZManaged.collectAll(_).map(_.forall(identity))).zipWith(f(c).toManaged)(_ && _)
+      case c @ TestCase(_, _, _) => f(c).toManaged
     }
 
   /**
@@ -188,7 +188,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
       case TestCase(label, test, annotations) =>
         test
           .foldCause(e => Spec.test(label, failure(e), annotations), t => Spec.test(label, success(t), annotations))
-          .toManaged_
+          .toManaged
     }
 
   /**
@@ -436,7 +436,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
       case SuiteCase(label, specs, exec) =>
         Spec.suite(
           label,
-          b.toManaged_.flatMap(b =>
+          b.toManaged.flatMap(b =>
             if (b) specs.asInstanceOf[ZManaged[R1, E1, Vector[Spec[R1, E1, TestSuccess]]]]
             else ZManaged.succeedNow(Vector.empty)
           ),

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -50,7 +50,7 @@ object TestExecutor {
           case Spec.TestCase(label, test, staticAnnotations) =>
             test.map { case (result, dynamicAnnotations) =>
               ExecutedSpec.test(label, result, staticAnnotations ++ dynamicAnnotations)
-            }.toManaged_
+            }.toManaged
         }.useNow)
     val environment = env
   }

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -345,7 +345,7 @@ object Expectation {
   implicit def toLayer[R <: Has[_]: Tag](trunk: Expectation[R]): ULayer[R] =
     ZLayer(
       for {
-        state <- Managed.make(MockState.make(trunk))(MockState.checkUnmetExpectations)
+        state <- Managed.bracket(MockState.make(trunk))(MockState.checkUnmetExpectations)
         env   <- (ProxyFactory.mockProxy(state) >>> trunk.mock.compose).build
       } yield env
     )

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -105,7 +105,7 @@ package object test extends CompileVariants {
      */
     def apply[R, E](assertion: => ZIO[R, E, TestResult]): ZIO[R, TestFailure[E], TestSuccess] =
       ZIO
-        .effectSuspendTotal(assertion)
+        .suspendSucceed(assertion)
         .foldCauseM(
           cause => ZIO.fail(TestFailure.Runtime(cause)),
           _.failures match {
@@ -573,13 +573,13 @@ package object test extends CompileVariants {
    * Builds an effectual suite containing a number of other specs.
    */
   def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Spec[R, E, T] =
-    Spec.suite(label, specs.map(_.toVector).toManaged_, None)
+    Spec.suite(label, specs.map(_.toVector).toManaged, None)
 
   /**
    * Builds a spec with a single pure test.
    */
   def test(label: String)(assertion: => TestResult)(implicit loc: SourceLocation): ZSpec[Any, Nothing] =
-    testM(label)(ZIO.effectTotal(assertion))
+    testM(label)(ZIO.succeed(assertion))
 
   /**
    * Builds a spec with a single effectful test.


### PR DESCRIPTION
Resolves #5221. Covers the items listed there. Still need to look at other effect constructors and eliminate more `_` suffix variants but may make sense to merge given the scope of the changes and do those as a follow up.