### PR TITLE
Improve Connection API - address and shutdownWrite

### DIFF
--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -492,19 +492,15 @@ trait ZStreamPlatformSpecificConstructors {
     /**
      * The remote address, i.e. the connected client
      */
-    def remoteAddress: IO[IOException, Option[SocketAddress]] = IO
-      .effect(
-        Option(socket.getRemoteAddress)
-      )
+    def remoteAddress: IO[IOException, SocketAddress] = IO
+      .effect(socket.getRemoteAddress)
       .refineToOrDie[IOException]
 
     /**
      * The local address, i.e. our server
      */
-    def localAddress: IO[IOException, Option[SocketAddress]] = IO
-      .effect(
-        Option(socket.getLocalAddress)
-      )
+    def localAddress: IO[IOException, SocketAddress] = IO
+      .effect(socket.getLocalAddress)
       .refineToOrDie[IOException]
 
     /**
@@ -559,6 +555,11 @@ trait ZStreamPlatformSpecificConstructors {
      * Close the underlying socket
      */
     def close(): UIO[Unit] = ZIO.effectTotal(socket.close())
+
+    /**
+     * Close only the write, so the remote end will see EOF
+     */
+    def closeWrite(): UIO[Unit] = ZIO.effectTotal(socket.shutdownOutput()).unit
   }
 
   object Connection {


### PR DESCRIPTION
Addresses cannot be null in this context.
The Option[SocketAddress] thus unnecessarily complicates the client code.
The original code was inspired by nio-zio, which (presumably) has the goal of exposing the entire NIO API.
This code is part of ZStream and should not unnecessarily expose platform details.

A common TCP interaction pattern uses EOF when writing to indicate the end of the request.
That avoids the need to specify size or parse the request looking for an end marker.
shutdownWrite provides the required functionality.