### PR TITLE
[resource/managed][documentation] Fix minor documentation typo Managed -> ZManaged

### DIFF
--- a/docs/datatypes/resource/managed.md
+++ b/docs/datatypes/resource/managed.md
@@ -3,7 +3,7 @@ id: managed
 title: "Managed"
 ---
 
-`Managed[E, A]` is a type alias for `Managed[Any, E, A]`, which represents a managed resource that has no requirements, and may fail with an `E`, or succeed with an `A`.
+`Managed[E, A]` is a type alias for `ZManaged[Any, E, A]`, which represents a managed resource that has no requirements, and may fail with an `E`, or succeed with an `A`.
 
 ```scala mdoc:invisible
 import zio.ZManaged


### PR DESCRIPTION
Noticed a minor typo when reading the documentation https://zio.dev/docs/datatypes/resource/managed

> `Managed[E, A]` is a type alias for `Managed[Any, E, A]`

should read as

> `Managed[E, A]` is a type alias for `ZManaged[Any, E, A]`

This PR fixes this minor typo.