### PR TITLE
Harden ZHub Implementation

### DIFF
--- a/core/shared/src/main/scala/zio/ZHub.scala
+++ b/core/shared/src/main/scala/zio/ZHub.scala
@@ -484,8 +484,8 @@ object ZHub {
         val poller = pollers.poll(nullPoller)
         if (poller eq nullPoller) {
           subscribers.remove(subscription -> pollers)
-          if (!pollers.isEmpty()) subscribers.add(subscription -> pollers)
-          keepPolling = false
+          if (pollers.isEmpty()) keepPolling = false
+          else subscribers.add(subscription -> pollers)
         } else {
           subscription.poll(empty) match {
             case null =>


### PR DESCRIPTION
If we tentatively remove a subscriber and have to add it back we need to check for pollers again since another fiber may not have done so.