### PR TITLE
Fix #5152: include .sjsir files when publishing for scalajs on scala 3

### DIFF
--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -18,8 +18,8 @@ package zio
 
 import zio.internal.Sync
 
-import java.util.Map
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.{Comparator, Map}
 
 /**
  * A `ZScope[A]` is a value that allows adding finalizers identified by a key.
@@ -304,11 +304,10 @@ object ZScope {
             weakFinalizers.clear()
             strongFinalizers.clear()
 
-            java.util.Arrays.sort(
-              array,
-              (l: OrderedFinalizer, r: OrderedFinalizer) =>
-                if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
-            )
+            val comparator: Comparator[OrderedFinalizer] = (l: OrderedFinalizer, r: OrderedFinalizer) =>
+              if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
+
+            java.util.Arrays.sort(array, comparator)
 
             val a = exitValue.get()
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -227,7 +227,7 @@ object BuildHelper {
     name := s"$prjName",
     crossScalaVersions := Seq(Scala211, Scala212, Scala213),
     ThisBuild / scalaVersion := Scala213,
-    scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
+    scalacOptions ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= {
       if (scalaVersion.value == ScalaDotty)
         Seq(


### PR DESCRIPTION
Fixes #5152

The problem was that the .sjsir files are only generated when the compiler gets passed the `-scalajs` option, this option is correctly added by the scalajs plugin but was then lost when setting scalac options.

I also had to add a type signature in ZScope.scala as it would not compile with -scalajs, showing this error:

```
[error] -- Error: \zio\core\shared\src\main\scala\zio\ZScope.scala:309:57
[error] 309 |              (l: OrderedFinalizer, r: OrderedFinalizer) => if (l eq null) -1 else if (r eq null) 1 else l.order - r.order
[error]     |                                                         ^
[error]     |object creation impossible, since def compare(x$0: T, x$1: T): Int in trait Comparator in package java.util is not defined
[error]     |(The class implements a member with a different type: final def compare
[error]     |  (l: zio.ZScope.OrderedFinalizer, r: zio.ZScope.OrderedFinalizer): Int in anonymous class Object with
[error]     |  java.util.Comparator[? >: zio.ZScope.OrderedFinalizer]
[error]     | {...})
[error] one error found
```

this is probably a compiler bug? I didn't want to invest a lot of time figuring this out since the workaround is pretty easy.

To validate my change I did a publishLocal and checked that the files are included.
I also verified with println that the original scalac options are always empty except for when they contain the single `-scalajs` switch, this means that the rest of the build should not be impacted by this change.