### PR TITLE
Cause: Then distributes over Both even in the presence of Empty

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.Cause.{Both, Then}
+import zio.Cause.{Both, Then, empty}
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._
@@ -43,6 +43,16 @@ object CauseSpec extends ZIOBaseSpec {
           assert(Then(a, Both(b, c)))(equalTo(Both(Then(a, b), Then(a, c)))) &&
           assert(Then(Both(a, b), c))(equalTo(Both(Then(a, c), Then(b, c))))
         }
+      },
+      testM("`Then.equals` distributes `Then` over `Both` even in the presence of `Empty`") {
+        check(causes, causes) { (a, b) =>
+          assert(Then(a, Both(empty, b)))(equalTo(Both(a, Then(a, b)))) &&
+          assert(Then(a, Both(b, empty)))(equalTo(Both(Then(a, b), a))) &&
+          assert(Then(a, Both(empty, empty)))(equalTo(Both(a, a))) &&
+          assert(Then(Both(empty, b), a))(equalTo(Both(a, Then(b, a)))) &&
+          assert(Then(Both(b, empty), a))(equalTo(Both(Then(b, a), a))) &&
+          assert(Then(Both(empty, empty), a))(equalTo(Both(a, a)))
+        }
       }
     ),
     suite("Both")(
@@ -60,6 +70,16 @@ object CauseSpec extends ZIOBaseSpec {
       },
       testM("`Both.equals` satisfies commutativity") {
         check(causes, causes)((a, b) => assert(Both(a, b))(equalTo(Both(b, a))))
+      },
+      testM("`Both.equals` distributes `Then` over `Both` even in the presence of `Empty`") {
+        check(causes, causes) { (a, b) =>
+          assert(Both(a, Then(a, b)))(equalTo(Then(a, Both(empty, b)))) &&
+          assert(Both(Then(a, b), a))(equalTo(Then(a, Both(b, empty)))) &&
+          assert(Both(a, a))(equalTo(Then(a, Both(empty, empty)))) &&
+          assert(Both(a, Then(b, a)))(equalTo(Then(Both(empty, b), a))) &&
+          assert(Both(Then(b, a), a))(equalTo(Then(Both(b, empty), a))) &&
+          assert(Both(a, a))(equalTo(Then(Both(empty, empty), a)))
+        }
       }
     ),
     suite("Meta")(

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -797,13 +797,9 @@ object Cause extends Serializable {
       }
 
       private def dist(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
-        case (Then(al, Both(bl, cl)), Both(Then(ar1, br), Then(ar2, cr)))
-            if ar1 == ar2 && al == ar1 && bl == br && cl == cr =>
-          true
-        case (Then(Both(al, bl), cl), Both(Then(ar, cr1), Then(br, cr2)))
-            if cr1 == cr2 && al == ar && bl == br && cl == cr1 =>
-          true
-        case _ => false
+        case (Then(al, Both(bl, cl)), Both(ar, br)) if Then(al, bl) == ar && Then(al, cl) == br => true
+        case (Then(Both(al, bl), cl), Both(ar, br)) if Then(al, cl) == ar && Then(bl, cl) == br => true
+        case _                                                                                  => false
       }
     }
 
@@ -828,13 +824,9 @@ object Cause extends Serializable {
       }
 
       private def dist(l: Cause[Any], r: Cause[Any]): Boolean = (l, r) match {
-        case (Both(Then(al1, bl), Then(al2, cl)), Then(ar, Both(br, cr)))
-            if al1 == al2 && al1 == ar && bl == br && cl == cr =>
-          true
-        case (Both(Then(al, cl1), Then(bl, cl2)), Then(Both(ar, br), cr))
-            if cl1 == cl2 && al == ar && bl == br && cl1 == cr =>
-          true
-        case _ => false
+        case (Both(al, bl), Then(ar, Both(br, cr))) if al == Then(ar, br) && bl == Then(ar, cr) => true
+        case (Both(al, bl), Then(Both(ar, br), cr)) if al == Then(ar, cr) && bl == Then(br, cr) => true
+        case _                                                                                  => false
       }
 
       private def comm(that: Cause[Any]): Boolean = (self, that) match {


### PR DESCRIPTION
Thanks @jdegoes for the very thought-provoking talk on FP without Type Classes. There you promoted using free structures, like `Cause`, which should be a semiring.
So I've tried to implement a semiring instance over at our playground in ZIO Prelude: https://github.com/zio/zio-prelude/pull/351 (has been stale for some time, but I would like to get back to it sooner or later).
And something interesting happened -- the automated test uncovered an edge case in distributivity.

This PR fixes `equals` in `Then` and `Both` so that `Then` truly distributes over `Both`, even in the presence of `Empty` (a neutral element).

/cc @adamgfraser 
