### PR TITLE
Fix #5244: don't expand package definitions in the assertTrue macro for scala 3

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -285,6 +285,9 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         val string = "Sunday Everyday"
         assertTrue(string == "Saturday Todays")
       } @@ failing
-    )
+    ),
+    test("Package qualified identifiers") {
+      assertTrue(zio.duration.Duration.fromNanos(0) == zio.duration.Duration.Zero)
+    }
   )
 }


### PR DESCRIPTION
This is my humble attempt at fixing #5244