### PR TITLE
Introduce ZApp, an App with custom R

### DIFF
--- a/core/js/src/main/scala/zio/App.scala
+++ b/core/js/src/main/scala/zio/App.scala
@@ -16,17 +16,4 @@
 
 package zio
 
-trait App extends BootstrapRuntime {
-
-  /**
-   * The main function of the application, which will be passed the command-line
-   * arguments to the program.
-   */
-  def run(args: List[String]): URIO[ZEnv, ExitCode]
-
-  /**
-   * The Scala main function, intended to be called only by the Scala runtime.
-   */
-  final def main(args0: Array[String]): Unit =
-    unsafeRunAsync(run(args0.toList))
-}
+trait App extends ZApp[ZEnv] with BootstrapRuntime

--- a/core/js/src/main/scala/zio/ZApp.scala
+++ b/core/js/src/main/scala/zio/ZApp.scala
@@ -16,6 +16,17 @@
 
 package zio
 
-trait BootstrapRuntime extends ZBootstrapRuntime[ZEnv] {
-  def environment: ZEnv = ZEnv.Services.live
+trait ZApp[R] extends Runtime[R] {
+
+  /**
+   * The main function of the application, which will be passed the command-line
+   * arguments to the program.
+   */
+  def run(args: List[String]): URIO[R, ExitCode]
+
+  /**
+   * The Scala main function, intended to be called only by the Scala runtime.
+   */
+  final def main(args0: Array[String]): Unit =
+    unsafeRunAsync(run(args0.toList))
 }

--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -16,8 +16,6 @@
 
 package zio
 
-import zio.internal.FiberContext
-
 /**
  * The entry point for a purely-functional application on the JVM.
  *
@@ -39,42 +37,4 @@ import zio.internal.FiberContext
  * }
  * }}}
  */
-trait App extends BootstrapRuntime {
-
-  /**
-   * The main function of the application, which will be passed the command-line
-   * arguments to the program and has to return an `IO` with the errors fully handled.
-   */
-  def run(args: List[String]): URIO[ZEnv, ExitCode]
-
-  /**
-   * The Scala main function, intended to be called only by the Scala runtime.
-   */
-  // $COVERAGE-OFF$ Bootstrap to `Unit`
-  final def main(args0: Array[String]): Unit =
-    try sys.exit(
-      unsafeRun(
-        for {
-          fiber <- run(args0.toList).fork
-          _ <- IO.succeed(java.lang.Runtime.getRuntime.addShutdownHook(new Thread {
-                 override def run() =
-                   if (FiberContext.fatal.get) {
-                     println(
-                       "**** WARNING ***\n" +
-                         "Catastrophic JVM error encountered. " +
-                         "Application not safely interrupted. " +
-                         "Resources may be leaked. " +
-                         "Check the logs for more details and consider overriding `Platform.reportFatal` to capture context."
-                     )
-                   } else {
-                     val _ = unsafeRunSync(fiber.interrupt)
-                   }
-               }))
-          result <- fiber.join
-          _      <- fiber.interrupt
-        } yield result.code
-      )
-    )
-    catch { case _: SecurityException => }
-  // $COVERAGE-ON$
-}
+trait App extends ZApp[ZEnv] with BootstrapRuntime

--- a/core/jvm/src/main/scala/zio/ZApp.scala
+++ b/core/jvm/src/main/scala/zio/ZApp.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import zio.internal.FiberContext
+
+/**
+ * The entry point for a purely-functional application on the JVM.
+ *
+ * {{{
+ * import zio.App
+ * import zio.console._
+ *
+ * object MyApp extends App {
+ *
+ *   final def run(args: List[String]) =
+ *     myAppLogic.exitCode
+ *
+ *   def myAppLogic =
+ *     for {
+ *       _ <- putStrLn("Hello! What is your name?")
+ *       n <- getStrLn
+ *       _ <- putStrLn("Hello, " + n + ", good to meet you!")
+ *     } yield ()
+ * }
+ * }}}
+ */
+trait ZApp[R] extends ZBootstrapRuntime[R] {
+
+  /**
+   * The main function of the application, which will be passed the command-line
+   * arguments to the program and has to return an `IO` with the errors fully handled.
+   */
+  def run(args: List[String]): URIO[R, ExitCode]
+
+  /**
+   * The Scala main function, intended to be called only by the Scala runtime.
+   */
+  // $COVERAGE-OFF$ Bootstrap to `Unit`
+  final def main(args0: Array[String]): Unit =
+    try sys.exit(
+      unsafeRun(
+        for {
+          fiber <- run(args0.toList).fork
+          _ <- IO.succeed(java.lang.Runtime.getRuntime.addShutdownHook(new Thread {
+                 override def run() =
+                   if (FiberContext.fatal.get) {
+                     println(
+                       "**** WARNING ***\n" +
+                         "Catastrophic JVM error encountered. " +
+                         "Application not safely interrupted. " +
+                         "Resources may be leaked. " +
+                         "Check the logs for more details and consider overriding `Platform.reportFatal` to capture context."
+                     )
+                   } else {
+                     val _ = unsafeRunSync(fiber.interrupt)
+                   }
+               }))
+          result <- fiber.join
+          _      <- fiber.interrupt
+        } yield result.code
+      )
+    )
+    catch { case _: SecurityException => }
+  // $COVERAGE-ON$
+}

--- a/core/jvm/src/main/scala/zio/ZApp.scala
+++ b/core/jvm/src/main/scala/zio/ZApp.scala
@@ -22,19 +22,21 @@ import zio.internal.FiberContext
  * The entry point for a purely-functional application on the JVM.
  *
  * {{{
- * import zio.App
- * import zio.console._
+ * import zio.ZApp
+ * import zio.Console._
  *
- * object MyApp extends App {
+ * object MyApp extends ZApp[Has[Console]] {
+ *
+ *   def environment: Has[Console] = Has(ConsoleLive)
  *
  *   final def run(args: List[String]) =
  *     myAppLogic.exitCode
  *
  *   def myAppLogic =
  *     for {
- *       _ <- putStrLn("Hello! What is your name?")
- *       n <- getStrLn
- *       _ <- putStrLn("Hello, " + n + ", good to meet you!")
+ *       _ <- printLine("Hello! What is your name?")
+ *       n <- readLine
+ *       _ <- printLine("Hello, " + n + ", good to meet you!")
  *     } yield ()
  * }
  * }}}

--- a/core/native/src/main/scala/zio/App.scala
+++ b/core/native/src/main/scala/zio/App.scala
@@ -16,17 +16,4 @@
 
 package zio
 
-trait App extends BootstrapRuntime {
-
-  /**
-   * The main function of the application, which will be passed the command-line
-   * arguments to the program.
-   */
-  def run(args: List[String]): URIO[ZEnv, ExitCode]
-
-  /**
-   * The Scala main function, intended to be called only by the Scala runtime.
-   */
-  final def main(args0: Array[String]): Unit =
-    unsafeRunAsync(run(args0.toList))
-}
+trait App extends ZApp[ZEnv] with BootstrapRuntime

--- a/core/native/src/main/scala/zio/ZApp.scala
+++ b/core/native/src/main/scala/zio/ZApp.scala
@@ -16,6 +16,17 @@
 
 package zio
 
-trait BootstrapRuntime extends ZBootstrapRuntime[ZEnv] {
-  def environment: ZEnv = ZEnv.Services.live
+trait ZApp[R] extends ZBootstrapRuntime[R] {
+
+  /**
+   * The main function of the application, which will be passed the command-line
+   * arguments to the program.
+   */
+  def run(args: List[String]): URIO[R, ExitCode]
+
+  /**
+   * The Scala main function, intended to be called only by the Scala runtime.
+   */
+  final def main(args0: Array[String]): Unit =
+    unsafeRunAsync(run(args0.toList))
 }

--- a/core/shared/src/main/scala/zio/ZBootstrapRuntime.scala
+++ b/core/shared/src/main/scala/zio/ZBootstrapRuntime.scala
@@ -16,6 +16,13 @@
 
 package zio
 
-trait BootstrapRuntime extends ZBootstrapRuntime[ZEnv] {
-  def environment: ZEnv = ZEnv.Services.live
+import zio.internal.Platform
+
+trait ZBootstrapRuntime[R] extends Runtime[R] {
+
+  /**
+   * The platform of the runtime, which provides the essential capabilities
+   * necessary to bootstrap execution of tasks.
+   */
+  def platform: Platform = Platform.default
 }


### PR DESCRIPTION
The current `App` is not usable if you want your `Runtime` to have an environment different from `ZEnv` which is quite annoying as you have to duplicate the code of `App` into your own project. I introduced `ZApp` which lets you use any environment.

Unfortunately this breaks mima checks, so I submitted this to the 2.x series branch. It could be made compatible by duplicating the code from `App` and not changing the trait inheritance, but it's probably not worth it.