### PR TITLE
Allow using ZLayer#launch with any environment

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -159,8 +159,8 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    * Builds this layer and uses it until it is interrupted. This is useful when
    * your entire application is a layer, such as an HTTP server.
    */
-  final def launch(implicit ev: Any <:< RIn): IO[E, Nothing] =
-    build.provide(ev).useForever
+  final def launch: ZIO[RIn, E, Nothing] =
+    build.useForever
 
   /**
    * Returns a new layer whose output is mapped by the specified function.


### PR DESCRIPTION
`ZLayer#launch` currently forces you to eliminate the environment first, but you might want some part of the environment to come from the `Runtime`.

Submitted to the 2.x series branch as it breaks binary compatibility.