### PR TITLE
ZIO 2.0: Implement left, right, unleft, and unright

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1121,34 +1121,10 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeed(Left("Left")).left)(equalTo("Left"))
       },
       testM("on Right value") {
-        assertM(ZIO.succeed(Right("Right")).left.either)(isLeft(isNone))
+        assertM(ZIO.succeed(Right("Right")).left.exit)(fails(isRight(equalTo("Right"))))
       },
       testM("on failure") {
-        assertM(ZIO.fail("Fail").left.either)(isLeft(isSome(equalTo("Fail"))))
-      } @@ zioTag(errors)
-    ),
-    suite("leftOrFail")(
-      testM("on Left value") {
-        assertM(UIO(Left(42)).leftOrFail(ExampleError))(equalTo(42))
-      },
-      testM("on Right value") {
-        assertM(UIO(Right(12)).leftOrFail(ExampleError).flip)(equalTo(ExampleError))
-      } @@ zioTag(errors)
-    ),
-    suite("leftOrFailWith")(
-      testM("on Left value") {
-        assertM(Task(Left(42)).leftOrFailWith((x: Throwable) => x))(equalTo(42))
-      },
-      testM("on Right value") {
-        assertM(Task(Right(ExampleError)).leftOrFailWith((x: Throwable) => x).flip)(equalTo(ExampleError))
-      } @@ zioTag(errors)
-    ),
-    suite("leftOrFailException")(
-      testM("on Left value") {
-        assertM(ZIO.succeed(Left(42)).leftOrFailException)(equalTo(42))
-      },
-      testM("on Right value") {
-        assertM(ZIO.succeed(Right(2)).leftOrFailException.exit)(fails(Assertion.anything))
+        assertM(ZIO.fail("Fail").left.exit)(fails(isLeft(equalTo("Fail"))))
       } @@ zioTag(errors)
     ),
     suite("loop")(
@@ -1447,15 +1423,15 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("optional")(
       testM("fails when given Some error") {
-        val task: IO[String, Option[Int]] = IO.fail(Some("Error")).optional
+        val task: IO[String, Option[Int]] = IO.fail(Some("Error")).unoption
         assertM(task.exit)(fails(equalTo("Error")))
       } @@ zioTag(errors),
       testM("succeeds with None given None error") {
-        val task: IO[String, Option[Int]] = IO.fail(None).optional
+        val task: IO[String, Option[Int]] = IO.fail(None).unoption
         assertM(task)(isNone)
       } @@ zioTag(errors),
       testM("succeeds with Some given a value") {
-        val task: IO[String, Option[Int]] = IO.succeed(1).optional
+        val task: IO[String, Option[Int]] = IO.succeed(1).unoption
         assertM(task)(isSome(equalTo(1)))
       }
     ),
@@ -1798,10 +1774,10 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeed(Right("Right")).right)(equalTo("Right"))
       },
       testM("on Left value") {
-        assertM(ZIO.succeed(Left("Left")).right.either)(isLeft(isNone))
+        assertM(ZIO.succeed(Left("Left")).right.exit)(fails(isLeft(equalTo("Left"))))
       },
       testM("on failure") {
-        assertM(ZIO.fail("Fail").right.either)(isLeft(isSome(equalTo("Fail"))))
+        assertM(ZIO.fail("Fail").right.exit)(fails(isRight(equalTo("Fail"))))
       } @@ zioTag(errors)
     ),
     suite("refineToOrDie")(
@@ -1818,30 +1794,6 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(result)(isLeft(equalTo(expected)))
       } @@ scala2Only
     ) @@ zioTag(errors),
-    suite("rightOrFail")(
-      testM("on Right value") {
-        assertM(UIO(Right(42)).rightOrFail(ExampleError))(equalTo(42))
-      },
-      testM("on Left value") {
-        assertM(UIO(Left(1)).rightOrFail(ExampleError).flip)(equalTo(ExampleError))
-      } @@ zioTag(errors)
-    ),
-    suite("rightOrFailWith")(
-      testM("on Right value") {
-        assertM(Task(Right(42)).rightOrFailWith((x: Throwable) => x))(equalTo(42))
-      },
-      testM("on Left value") {
-        assertM(Task(Left(ExampleError)).rightOrFailWith((x: Throwable) => x).flip)(equalTo(ExampleError))
-      } @@ zioTag(errors)
-    ),
-    suite("rightOrFailException")(
-      testM("on Right value") {
-        assertM(ZIO.succeed(Right(42)).rightOrFailException)(equalTo(42))
-      },
-      testM("on Left value") {
-        assertM(ZIO.succeed(Left(2)).rightOrFailException.exit)(fails(Assertion.anything))
-      } @@ zioTag(errors)
-    ),
     suite("some")(
       testM("extracts the value from Some") {
         val task: IO[Option[Throwable], Int] = Task(Some(1)).some
@@ -3276,6 +3228,14 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assertCompletes
       }
     ),
+    testM("unleft") {
+      checkM(Gen.oneOf(Gen.failures(Gen.anyInt), Gen.successes(Gen.either(Gen.anyInt, Gen.anyInt)))) { zio =>
+        for {
+          actual   <- zio.left.unleft.exit
+          expected <- zio.exit
+        } yield assert(actual)(equalTo(expected))
+      }
+    },
     suite("unless")(
       testM("executes correct branch only") {
         for {
@@ -3377,6 +3337,14 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(zio2.exit)(fails(isNone))
       }
     ) @@ zioTag(errors),
+    testM("right") {
+      checkM(Gen.oneOf(Gen.failures(Gen.anyInt), Gen.successes(Gen.either(Gen.anyInt, Gen.anyInt)))) { zio =>
+        for {
+          actual   <- zio.right.unright.exit
+          expected <- zio.exit
+        } yield assert(actual)(equalTo(expected))
+      }
+    },
     suite("unsandbox")(
       testM("unwraps exception") {
         val failure: IO[Cause[Exception], String] = IO.fail(fail(new Exception("fail")))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -269,6 +269,30 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def as[B](b: => B): ZIO[R, E, B] = self.flatMap(new ZIO.ConstZIOFn(() => b))
 
   /**
+   * Maps the success value of this effect to a left value.
+   */
+  final def asLeft: ZIO[R, E, Either[A, Nothing]] =
+    map(Left(_))
+
+  /**
+   * Maps the error value of this effect to a left value.
+   */
+  final def asLeftError: ZIO[R, Either[E, Nothing], A] =
+    mapError(Left(_))
+
+  /**
+   * Maps the success value of this effect to a right value.
+   */
+  final def asRight: ZIO[R, E, Either[Nothing, A]] =
+    map(Right(_))
+
+  /**
+   * Maps the error value of this effect to a right value.
+   */
+  final def asRightError: ZIO[R, Either[Nothing, E], A] =
+    mapError(Right(_))
+
+  /**
    * Maps the success value of this effect to a service.
    */
   final def asService[A1 >: A: Tag]: ZIO[R, E, Has[A1]] =
@@ -1869,7 +1893,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Converts an option on values into an option on errors.
    */
-  // <:
   final def some[B](implicit ev: A IsSubtypeOfOutput Option[B]): ZIO[R, Option[E], B] =
     self.foldZIO(
       e => ZIO.fail(Some(e)),

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1031,6 +1031,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def join[R1, E1 >: E, A1 >: A](that: ZIO[R1, E1, A1]): ZIO[Either[R, R1], E1, A1] = self ||| that
 
   /**
+   * "Zooms in" on the value in the `Left` side of an `Either`, moving the
+   * possibility that the value is a `Right` to the error channel.
+   */
+  final def left[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Either[E, C], B] =
+    self.foldZIO(
+      e => ZIO.fail(Left(e)),
+      a => ev(a).fold(b => ZIO.succeedNow(b), c => ZIO.fail(Right(c)))
+    )
+
+  /**
    * Returns an effect which is guaranteed to be executed on the specified
    * executor. The specified effect will always run on the specified executor,
    * even in the presence of asynchronous boundaries.
@@ -1226,6 +1236,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Converts an option on errors into an option on values.
    */
+  @deprecated("use unoption", "2.0.0")
   final def optional[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZIO[R, E1, Option[A]] =
     self.foldZIO(
       e => ev(e).fold[ZIO[R, E1, Option[A]]](ZIO.succeedNow(Option.empty[A]))(ZIO.fail(_)),
@@ -1383,89 +1394,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     new ZIO.ProvideSomeLayer[R0, R, E, A](self)
 
   /**
-   * Returns a successful effect if the value is `Left`, or fails with the error `None`.
-   */
-  final def left[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Option[E], B] =
-    self.foldZIO(
-      e => ZIO.fail(Some(e)),
-      a => ev(a).fold(ZIO.succeedNow, _ => ZIO.fail(None))
-    )
-
-  /**
-   * Returns a successful effect if the value is `Left`, or fails with the error e.
-   */
-  final def leftOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, B] =
-    self.flatMap(ev(_) match {
-      case Right(_)    => ZIO.fail(e)
-      case Left(value) => ZIO.succeedNow(value)
-    })
-
-  /**
-   * Returns a successful effect if the value is `Left`, or fails with the given error function 'e'.
-   */
-  final def leftOrFailWith[B, C, E1 >: E](e: C => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, B] =
-    self.flatMap(ev(_) match {
-      case Left(value) => ZIO.succeedNow(value)
-      case Right(err)  => ZIO.fail(e(err))
-    })
-
-  /**
-   * Returns a successful effect if the value is `Left`, or fails with a [[java.util.NoSuchElementException]].
-   */
-  final def leftOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A IsSubtypeOfOutput Either[B, C],
-    ev2: E IsSubtypeOfError E1
-  ): ZIO[R, E1, B] =
-    self.foldZIO(
-      e => ZIO.fail(ev2(e)),
-      a => ev(a).fold(ZIO.succeedNow(_), _ => ZIO.fail(new NoSuchElementException("Either.left.get on Right")))
-    )
-
-  /**
    * Returns a new effect that will utilize the default scope (fiber scope) to
    * supervise any fibers forked within the original effect.
    */
   final def resetForkScope: ZIO[R, E, A] =
     new ZIO.OverrideForkScope(self, None)
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with the error `None`.
-   */
-  final def right[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Option[E], C] =
-    self.foldZIO(
-      e => ZIO.fail(Some(e)),
-      a => ev(a).fold(_ => ZIO.fail(None), ZIO.succeedNow)
-    )
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with the given error 'e'.
-   */
-  final def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, C] =
-    self.flatMap(ev(_) match {
-      case Right(value) => ZIO.succeedNow(value)
-      case Left(_)      => ZIO.fail(e)
-    })
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with the given error function 'e'.
-   */
-  final def rightOrFailWith[B, C, E1 >: E](e: B => E1)(implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, E1, C] =
-    self.flatMap(ev(_) match {
-      case Right(value) => ZIO.succeedNow(value)
-      case Left(err)    => ZIO.fail(e(err))
-    })
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with a [[java.util.NoSuchElementException]].
-   */
-  final def rightOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A IsSubtypeOfOutput Either[B, C],
-    ev2: E IsSubtypeOfError E1
-  ): ZIO[R, E1, C] =
-    self.foldZIO(
-      e => ZIO.fail(ev2(e)),
-      a => ev(a).fold(_ => ZIO.fail(new NoSuchElementException("Either.right.get on Left")), ZIO.succeedNow(_))
-    )
 
   /**
    * Returns an effect that races this effect with the specified effect,
@@ -1872,6 +1805,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def retryWhileZIO[R1 <: R](f: E => URIO[R1, Boolean])(implicit ev: CanFail[E]): ZIO[R1, E, A] =
     retryUntilZIO(e => f(e).map(!_))
+
+  /**
+   * "Zooms in" on the value in the `Right` side of an `Either`, moving the
+   * possibility that the value is a `Left` to the error channel.
+   */
+  final def right[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZIO[R, Either[B, E], C] =
+    self.foldZIO(
+      e => ZIO.fail(Right(e)),
+      a => ev(a).fold(b => ZIO.fail(Left(b)), c => ZIO.succeedNow(c))
+    )
 
   /**
    * Returns an effect that semantically runs the effect on a fiber,
@@ -2288,6 +2231,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def unit: ZIO[R, E, Unit] = as(())
 
   /**
+   * Converts a `ZIO[R, Either[E, B], A]` into a `ZIO[R, E, Either[A, B]]`. The
+   * inverse of `left`.
+   */
+  final def unleft[E1, B](implicit ev: E IsSubtypeOfError Either[E1, B]): ZIO[R, E1, Either[A, B]] =
+    self.foldZIO(
+      e => ev(e).fold(e1 => ZIO.fail(e1), b => ZIO.succeedNow(Right(b))),
+      a => ZIO.succeedNow(Left(a))
+    )
+
+  /**
    * The moral equivalent of `if (!p) exp`
    */
   final def unless(b: => Boolean): ZIO[R, E, Unit] =
@@ -2305,6 +2258,15 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def unlessZIO[R1 <: R, E1 >: E](b: ZIO[R1, E1, Boolean]): ZIO[R1, E1, Unit] =
     ZIO.unlessZIO(b)(self)
+
+  /**
+   * Converts an option on errors into an option on values.
+   */
+  final def unoption[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZIO[R, E1, Option[A]] =
+    self.foldZIO(
+      e => ev(e).fold[ZIO[R, E1, Option[A]]](ZIO.succeedNow(Option.empty[A]))(ZIO.fail(_)),
+      a => ZIO.succeedNow(Some(a))
+    )
 
   /**
    * Takes some fiber failures and converts them into errors.
@@ -2328,6 +2290,16 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
         case Cause.Die(t) if pf.isDefinedAt(t) => pf(t)
       }.fold(ZIO.failCause(cause.map(f)))(ZIO.fail(_))
     }
+
+  /**
+   * Converts a `ZIO[R, Either[B, E], A]` into a `ZIO[R, E, Either[B, A]]`. The
+   * inverse of `right`.
+   */
+  final def unright[E1, B](implicit ev: E IsSubtypeOfError Either[B, E1]): ZIO[R, E1, Either[B, A]] =
+    self.foldZIO(
+      e => ev(e).fold(b => ZIO.succeedNow(Left(b)), e1 => ZIO.fail(e1)),
+      a => ZIO.succeedNow(Right(a))
+    )
 
   /**
    * Updates a service in the environment of this effect.
@@ -2930,7 +2902,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collect[R, E, A, B, Collection[+Element] <: Iterable[Element]](
     in: Collection[A]
   )(f: A => ZIO[R, Option[E], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] =
-    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).optional).map(_.flatten).map(bf.fromSpecific(in))
+    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Evaluate each effect in the structure from left to right, and collect the
@@ -3132,7 +3104,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collectPar[R, E, A, B, Collection[+Element] <: Iterable[Element]](
     in: Collection[A]
   )(f: A => ZIO[R, Option[E], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] =
-    foreachPar[R, E, A, Option[B], Iterable](in)(a => f(a).optional).map(_.flatten).map(bf.fromSpecific(in))
+    foreachPar[R, E, A, Option[B], Iterable](in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Evaluate each effect in the structure in parallel, collecting the
@@ -3143,7 +3115,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def collectParN[R, E, A, B, Collection[+Element] <: Iterable[Element]](n: Int)(
     in: Collection[A]
   )(f: A => ZIO[R, Option[E], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] =
-    foreachParN[R, E, A, Option[B], Iterable](n)(in)(a => f(a).optional).map(_.flatten).map(bf.fromSpecific(in))
+    foreachParN[R, E, A, Option[B], Iterable](n)(in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Similar to Either.cond, evaluate the predicate,

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -445,34 +445,13 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     fold(_ => false, _ => true)
 
   /**
-   * Returns a successful effect if the value is `Left`, or fails with the error `None`.
+   * "Zooms in" on the value in the `Left` side of an `Either`, moving the
+   * possibility that the value is a `Right` to the error channel.
    */
-  def left[B, C](implicit ev: A <:< Either[B, C]): ZSTM[R, Option[E], B] =
-    foldSTM(
-      e => ZSTM.fail(Some(e)),
-      a => ev(a).fold(ZSTM.succeedNow, _ => ZSTM.fail(None))
-    )
-
-  /**
-   * Returns a successful effect if the value is `Left`, or fails with the error e.
-   */
-  def leftOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A <:< Either[B, C]): ZSTM[R, E1, B] =
-    flatMap(ev(_) match {
-      case Right(_)    => ZSTM.fail(e)
-      case Left(value) => ZSTM.succeedNow(value)
-    })
-
-  /**
-   * Returns a successful effect if the value is `Left`, or fails with
-   * a [[java.util.NoSuchElementException]].
-   */
-  def leftOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A <:< Either[B, C],
-    ev2: E <:< E1
-  ): ZSTM[R, E1, B] =
-    foldSTM(
-      e => ZSTM.fail(ev2(e)),
-      a => ev(a).fold(ZSTM.succeedNow(_), _ => ZSTM.fail(new NoSuchElementException("Either.left.get on Right")))
+  def left[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZSTM[R, Either[E, C], B] =
+    self.foldSTM(
+      e => ZSTM.fail(Left(e)),
+      a => ev(a).fold(b => ZSTM.succeedNow(b), c => ZSTM.fail(Right(c)))
     )
 
   /**
@@ -567,6 +546,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Converts an option on errors into an option on values.
    */
+  @deprecated("use unoption", "2.0.0")
   def optional[E1](implicit ev: E <:< Option[E1]): ZSTM[R, E1, Option[A]] =
     foldSTM(
       _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.fail(_)),
@@ -707,35 +687,13 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     }
 
   /**
-   * Returns a successful effect if the value is `Right`, or fails with the error `None`.
+   * "Zooms in" on the value in the `Right` side of an `Either`, moving the
+   * possibility that the value is a `Left` to the error channel.
    */
-  def right[B, C](implicit ev: A <:< Either[B, C]): ZSTM[R, Option[E], C] =
+  final def right[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C]): ZSTM[R, Either[B, E], C] =
     self.foldSTM(
-      e => ZSTM.fail(Some(e)),
-      a => ev(a).fold(_ => ZSTM.fail(None), ZSTM.succeedNow)
-    )
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with the
-   * given error 'e'.
-   */
-  def rightOrFail[B, C, E1 >: E](e: => E1)(implicit ev: A <:< Either[B, C]): ZSTM[R, E1, C] =
-    self.flatMap(ev(_) match {
-      case Right(value) => ZSTM.succeedNow(value)
-      case Left(_)      => ZSTM.fail(e)
-    })
-
-  /**
-   * Returns a successful effect if the value is `Right`, or fails with
-   * a [[java.util.NoSuchElementException]].
-   */
-  def rightOrFailException[B, C, E1 >: NoSuchElementException](implicit
-    ev: A <:< Either[B, C],
-    ev2: E <:< E1
-  ): ZSTM[R, E1, C] =
-    self.foldSTM(
-      e => ZSTM.fail(ev2(e)),
-      a => ev(a).fold(_ => ZSTM.fail(new NoSuchElementException("Either.right.get on Left")), ZSTM.succeedNow(_))
+      e => ZSTM.fail(Right(e)),
+      a => ev(a).fold(b => ZSTM.fail(Left(b)), c => ZSTM.succeedNow(c))
     )
 
   /**
@@ -844,6 +802,35 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    */
   def unlessSTM[R1 <: R, E1 >: E](b: ZSTM[R1, E1, Boolean]): ZSTM[R1, E1, Unit] =
     ZSTM.unlessSTM(b)(self)
+
+  /**
+   * Converts a `ZSTM[R, Either[E, B], A]` into a `ZSTM[R, E, Either[A, B]]`. The
+   * inverse of `left`.
+   */
+  final def unleft[E1, B](implicit ev: E IsSubtypeOfError Either[E1, B]): ZSTM[R, E1, Either[A, B]] =
+    self.foldSTM(
+      e => ev(e).fold(e1 => ZSTM.fail(e1), b => ZSTM.succeedNow(Right(b))),
+      a => ZSTM.succeedNow(Left(a))
+    )
+
+  /**
+   * Converts an option on errors into an option on values.
+   */
+  def unoption[E1](implicit ev: E <:< Option[E1]): ZSTM[R, E1, Option[A]] =
+    foldSTM(
+      _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.fail(_)),
+      a => ZSTM.succeedNow(Some(a))
+    )
+
+  /**
+   * Converts a `ZSTM[R, Either[B, E], A]` into a `ZSTM[R, E, Either[B, A]]`. The
+   * inverse of `right`.
+   */
+  final def unright[E1, B](implicit ev: E IsSubtypeOfError Either[B, E1]): ZSTM[R, E1, Either[B, A]] =
+    self.foldSTM(
+      e => ev(e).fold(b => ZSTM.succeedNow(Left(b)), e1 => ZSTM.fail(e1)),
+      a => ZSTM.succeedNow(Right(a))
+    )
 
   /**
    * Updates a service in the environment of this effect.
@@ -1064,7 +1051,7 @@ object ZSTM {
   def collect[R, E, A, B, Collection[+Element] <: Iterable[Element]](
     in: Collection[A]
   )(f: A => ZSTM[R, Option[E], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZSTM[R, E, Collection[B]] =
-    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).optional).map(_.flatten).map(bf.fromSpecific(in))
+    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Collects all the transactional effects in a collection, returning a single

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -165,7 +165,7 @@ val result: IO[Throwable, Option[(User, Team)]] = (for {
   id   <- maybeId
   user <- getUser(id).some
   team <- getTeam(user.teamId).asSomeError 
-} yield (user, team)).optional 
+} yield (user, team)).unoption 
 ```
 
 #### Either

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -77,7 +77,7 @@ val result: IO[Throwable, Option[(User, Team)]] = (for {
   id   <- maybeId
   user <- getUser(id).some
   team <- getTeam(user.teamId).asSomeError 
-} yield (user, team)).optional 
+} yield (user, team)).unoption 
 ```
 
 ### Either

--- a/test/shared/src/main/scala/zio/test/FunctionVariants.scala
+++ b/test/shared/src/main/scala/zio/test/FunctionVariants.scala
@@ -64,7 +64,7 @@ trait FunctionVariants {
         for {
           lock    <- Semaphore.make(1)
           bufPull <- BufferedPull.make[R, Nothing, Sample[R, B]](pull)
-          fun     <- Fun.makeHash((_: A) => lock.withPermit(bufPull.pullElement).optional.map(_.get.value))(hash)
+          fun     <- Fun.makeHash((_: A) => lock.withPermit(bufPull.pullElement).unoption.map(_.get.value))(hash)
         } yield fun
       }
     }


### PR DESCRIPTION
Changes signatures of `left` and` right` to preserve the value in the other side of the `Either` and implements `unleft` and `unright` operators that are the inverse of these. This allows you to ergonomically work with values inside an `Either` by calling `left` or `right`, performing some operations, and then calling `unleft` or `unright`.