### PR TITLE
Bug fix: `ZStream#timeoutError` has a by-name error parameter that is eagerly evaluated

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
@@ -2,6 +2,7 @@ package zio.stream
 
 import zio.test._
 import zio.{UIO, ZIOBaseSpec}
+import zio.duration._
 
 object StreamLazinessSpec extends ZIOBaseSpec {
 
@@ -25,7 +26,12 @@ object StreamLazinessSpec extends ZIOBaseSpec {
       testM("fromChunk")(assertLazy(ZStream.fromChunk)),
       testM("fromIterable")(assertLazy(ZStream.fromIterable)),
       testM("halt")(assertLazy(ZStream.halt)),
-      testM("succeed")(assertLazy(ZStream.succeed))
+      testM("succeed")(assertLazy(ZStream.succeed)),
+      testM("timeoutError")(
+        assertLazy(
+          ZStream.succeed(1).timeoutError(_)(Duration.Infinity)
+        )
+      )
     )
   )
 }

--- a/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/StreamLazinessSpec.scala
@@ -1,8 +1,8 @@
 package zio.stream
 
+import zio.duration._
 import zio.test._
 import zio.{UIO, ZIOBaseSpec}
-import zio.duration._
 
 object StreamLazinessSpec extends ZIOBaseSpec {
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3017,7 +3017,9 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Fails the stream with given error if it does not produce a value after d duration.
    */
   final def timeoutError[E1 >: E](e: => E1)(d: Duration): ZStream[R with Clock, E1, O] =
-    timeoutErrorCause(Cause.fail(e))(d)
+    self
+      .timeoutErrorCause(Cause.empty)(d)
+      .mapErrorCause(_ => Cause.fail(e))
 
   /**
    * Halts the stream with given cause if it does not produce a value after d duration.


### PR DESCRIPTION
Resolves #4725.