### PR TITLE
Generalize Console Operators

### DIFF
--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -21,13 +21,13 @@ import scala.io.StdIn
 import scala.{Console => SConsole}
 
 trait Console extends Serializable {
-  def print(line: String): IO[IOException, Unit]
+  def print(line: Any): IO[IOException, Unit]
 
-  def printError(line: String): IO[IOException, Unit]
+  def printError(line: Any): IO[IOException, Unit]
 
-  def printLine(line: String): IO[IOException, Unit]
+  def printLine(line: Any): IO[IOException, Unit]
 
-  def printLineError(line: String): IO[IOException, Unit]
+  def printLineError(line: Any): IO[IOException, Unit]
 
   def readLine: IO[IOException, String]
 
@@ -59,13 +59,13 @@ object Console extends Serializable {
 
   object ConsoleLive extends Console {
 
-    def print(line: String): IO[IOException, Unit] = print(SConsole.out)(line)
+    def print(line: Any): IO[IOException, Unit] = print(SConsole.out)(line)
 
-    def printError(line: String): IO[IOException, Unit] = print(SConsole.err)(line)
+    def printError(line: Any): IO[IOException, Unit] = print(SConsole.err)(line)
 
-    def printLine(line: String): IO[IOException, Unit] = printLine(SConsole.out)(line)
+    def printLine(line: Any): IO[IOException, Unit] = printLine(SConsole.out)(line)
 
-    def printLineError(line: String): IO[IOException, Unit] = printLine(SConsole.err)(line)
+    def printLineError(line: Any): IO[IOException, Unit] = printLine(SConsole.err)(line)
 
     def readLine: IO[IOException, String] =
       IO.attempt {
@@ -75,10 +75,10 @@ object Console extends Serializable {
         else throw new EOFException("There is no more input left to read")
       }.refineToOrDie[IOException]
 
-    private def print(stream: PrintStream)(line: String): IO[IOException, Unit] =
+    private def print(stream: PrintStream)(line: Any): IO[IOException, Unit] =
       IO.attempt(SConsole.withOut(stream)(SConsole.print(line))).refineToOrDie[IOException]
 
-    private def printLine(stream: PrintStream)(line: String): IO[IOException, Unit] =
+    private def printLine(stream: PrintStream)(line: Any): IO[IOException, Unit] =
       IO.attempt(SConsole.withOut(stream)(SConsole.println(line))).refineToOrDie[IOException]
   }
 
@@ -87,25 +87,25 @@ object Console extends Serializable {
   /**
    * Prints text to the console.
    */
-  def print(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def print(line: => Any): ZIO[Has[Console], IOException, Unit] =
     ZIO.serviceWith(_.print(line))
 
   /**
    * Prints text to the standard error console.
    */
-  def printError(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def printError(line: => Any): ZIO[Has[Console], IOException, Unit] =
     ZIO.serviceWith(_.printError(line))
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  def printLine(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def printLine(line: => Any): ZIO[Has[Console], IOException, Unit] =
     ZIO.serviceWith(_.printLine(line))
 
   /**
    * Prints a line of text to the standard error console, including a newline character.
    */
-  def printLineError(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def printLineError(line: => Any): ZIO[Has[Console], IOException, Unit] =
     ZIO.serviceWith(_.printLineError(line))
 
   /**
@@ -120,28 +120,28 @@ object Console extends Serializable {
    * Prints text to the console.
    */
   @deprecated("use `print`", "2.0.0")
-  def putStr(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def putStr(line: => Any): ZIO[Has[Console], IOException, Unit] =
     print(line)
 
   /**
    * Prints text to the standard error console.
    */
   @deprecated("use `printError`", "2.0.0")
-  def putStrErr(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def putStrErr(line: => Any): ZIO[Has[Console], IOException, Unit] =
     printError(line)
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
   @deprecated("use `printLine`", "2.0.0")
-  def putStrLn(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def putStrLn(line: => Any): ZIO[Has[Console], IOException, Unit] =
     printLine(line)
 
   /**
    * Prints a line of text to the standard error console, including a newline character.
    */
   @deprecated("use `printLineError`", "2.0.0")
-  def putStrLnErr(line: => String): ZIO[Has[Console], IOException, Unit] =
+  def putStrLnErr(line: => Any): ZIO[Has[Console], IOException, Unit] =
     printLineError(line)
 
   /**

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -255,7 +255,7 @@ object logging {
             override def log(line: String): UIO[Unit] =
               for {
                 current <- clock.currentDateTime
-                _ <- console.printLine(current.toString + "--" + line).orDie
+                _ <- console.printLine(s"$current--$line").orDie
               } yield ()
           }
       }
@@ -326,7 +326,7 @@ case class LoggingLive(console: Console, clock: Clock) extends Logging {
   override def log(line: String): UIO[Unit] = 
     for {
       current <- clock.currentDateTime
-      _       <- console.printLine(current.toString + "--" + line).orDie
+      _       <- console.printLine(s"$current--$line").orDie
     } yield ()
 }
 ```
@@ -453,9 +453,9 @@ import zio.Random._
 
 val myApp: ZIO[Has[Random] with Has[Console] with Has[Clock], Nothing, Unit] = for {
   random  <- nextInt 
-  _       <- printLine(s"A random number: ${random.toString}").orDie
+  _       <- printLine(s"A random number: $random").orDie
   current <- currentDateTime
-  _       <- printLine(s"Current Data Time: ${current.toString}").orDie
+  _       <- printLine(s"Current Data Time: $current").orDie
 } yield ()
 ```
 
@@ -521,7 +521,7 @@ object LoggingLive {
 val myApp: ZIO[Has[Logging] with Has[Console] with Has[Clock], Nothing, Unit] = for {
   _       <- Logging.log("Application Started!")
   current <- currentDateTime
-  _       <- printLine(s"Current Data Time: ${current.toString}").orDie
+  _       <- printLine(s"Current Data Time: $current").orDie
 } yield ()
 ```
 

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -193,7 +193,7 @@ All fibers are interruptible by default. To make an effect uninterruptible we ca
 ```scala mdoc:silent:nest
 for {
   fiber <- Clock.currentDateTime
-    .flatMap(time => printLine(time.toString))
+    .flatMap(time => printLine(time))
     .schedule(Schedule.fixed(1.seconds))
     .uninterruptible
     .fork

--- a/docs/datatypes/stream/subscriptionref.md
+++ b/docs/datatypes/stream/subscriptionref.md
@@ -62,7 +62,7 @@ for {
   server          <- server(subscriptionRef.ref).fork
   chunks          <- ZIO.collectAllPar(List.fill(100)(client(subscriptionRef.changes)))
   _               <- server.interrupt
-  _               <- ZIO.foreach(chunks)(chunk => Console.printLine(chunk.toString))
+  _               <- ZIO.foreach(chunks)(chunk => Console.printLine(chunk))
 } yield ()
 ```
 

--- a/docs/datatypes/stream/zsink.md
+++ b/docs/datatypes/stream/zsink.md
@@ -90,7 +90,7 @@ val stream: ZIO[Has[Clock], Nothing, Long] =
 
 ```scala mdoc:silent:nest
 val printer: ZSink[Has[Console], IOException, Int, Int, Unit] =
-  ZSink.foreach((i: Int) => printLine(i.toString))
+  ZSink.foreach((i: Int) => printLine(i))
 val stream : ZIO[Has[Console], IOException, Unit]             =
   ZStream(1, 2, 3, 4, 5).run(printer)
 ```
@@ -204,7 +204,7 @@ val myApp: ZIO[Has[Console] with Has[Clock], IOException, Unit] =
       .fixed(200.millis)
       .run(ZSink.fromQueue(queue))
       .fork
-    consumer <- queue.take.flatMap(x => printLine(x.toString)).forever
+    consumer <- queue.take.flatMap(printLine(_)).forever
     _        <- producer.zip(consumer).join
   } yield ()
 ```

--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -575,7 +575,7 @@ for {
   hub     <- ZHub.unbounded[Chunk[Int]]
   managed = ZStream.fromChunkHubManaged(hub).tapZIO(_ => promise.succeed(()))
   stream  = ZStream.unwrapManaged(managed)
-  fiber   <- stream.foreach(i => printLine(i.toString)).fork
+  fiber   <- stream.foreach(printLine(_)).fork
   _       <- promise.await
   _       <- hub.publish(Chunk(1, 2, 3))
   _       <- fiber.join
@@ -590,7 +590,7 @@ Also, we can lift a `TQueue` to the ZIO Stream:
 for {
   q <- STM.atomically(TQueue.unbounded[Int])
   stream = ZStream.fromTQueue(q)
-  fiber <- stream.foreach(i => printLine(i.toString)).fork
+  fiber <- stream.foreach(printLine(_)).fork
   _     <- STM.atomically(q.offer(1))
   _     <- STM.atomically(q.offer(2))
   _     <- fiber.join
@@ -1704,7 +1704,7 @@ import zio._
 import zio.Console._
 import zio.stream._
 
-val result: RIO[Has[Console], Unit] = Stream.fromIterable(0 to 100).foreach(i => printLine(i.toString))
+val result: RIO[Has[Console], Unit] = Stream.fromIterable(0 to 100).foreach(printLine(_))
 ```
 
 ### Using a Sink
@@ -1729,7 +1729,7 @@ val s2: ZIO[Any, Nothing, Int] = ZStream.iterate(1)(_ + 1).foldWhile(0)(_ <= 5)(
 Using `ZStream#foreach` is another way of consuming elements of a stream. It takes a callback of type `O => ZIO[R1, E1, Any]` which passes each element of a stream to this callback:
 
 ```scala mdoc:silent:nest
-ZStream(1, 2, 3).foreach(x => printLine(x.toString))
+ZStream(1, 2, 3).foreach(printLine(_))
 ```
 
 ## Error Handling

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -313,14 +313,13 @@ For methods that may return `Unit`, we may skip the predefined result (it will d
 ```scala mdoc:silent
 import zio.test.mock.MockConsole
 
-val exp03 = MockConsole.PrintLine(equalTo[String, Any]("Welcome to ZIO!"))
-val exp04 = MockConsole.PrintLine(equalTo("Welcome to ZIO!"), unit)
+val exp03 = MockConsole.PrintLine(equalTo("Welcome to ZIO!"), unit)
 ```
 
 For methods that may return `Unit` and take no input we can skip both:
 
 ```scala mdoc:silent
-val exp05 = AccountObserverMock.RunCommand()
+val exp04 = AccountObserverMock.RunCommand()
 ```
 
 Finally we're all set and can create ad-hoc mock environments with our services.
@@ -333,7 +332,7 @@ val app: URIO[AccountObserver, Unit] = AccountObserver.processEvent(event)
 val mockEnv: ULayer[Has[Console]] = (
   MockConsole.PrintLine(equalTo(s"Got $event"), unit) ++
   MockConsole.ReadLine(value("42")) ++
-  MockConsole.PrintLine(equalTo[String, Any]("You entered: 42"))
+  MockConsole.PrintLine(equalTo("You entered: 42"), unit)
 )
 ```
 
@@ -372,7 +371,7 @@ object MaybeConsoleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(false).provideSomeLayer(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).provideSomeLayer(MockConsole.PrintLine(equalTo[String, Any]("foo")))
+      val maybeTest2 = maybeConsole(true).provideSomeLayer(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     }
   )
@@ -387,10 +386,10 @@ In some cases we have more than one collaborating service being called. You can 
 import zio.test.mock.MockRandom
 
 val combinedEnv: ULayer[Has[Console] with Has[Random]] = (
-  MockConsole.PrintLine(equalTo[String, Any]("What is your name?")) ++
+  MockConsole.PrintLine(equalTo("What is your name?"), unit) ++
   MockConsole.ReadLine(value("Mike")) ++
   MockRandom.NextInt(value(42)) ++
-  MockConsole.PrintLine(equalTo[String, Any]("Mike, your lucky number today is 42!"))
+  MockConsole.PrintLine(equalTo("Mike, your lucky number today is 42!"), unit)
 )
 
 val combinedApp =

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -313,7 +313,7 @@ For methods that may return `Unit`, we may skip the predefined result (it will d
 ```scala mdoc:silent
 import zio.test.mock.MockConsole
 
-val exp03 = MockConsole.PrintLine(equalTo("Welcome to ZIO!"))
+val exp03 = MockConsole.PrintLine(equalTo[String, Any]("Welcome to ZIO!"))
 val exp04 = MockConsole.PrintLine(equalTo("Welcome to ZIO!"), unit)
 ```
 
@@ -333,7 +333,7 @@ val app: URIO[AccountObserver, Unit] = AccountObserver.processEvent(event)
 val mockEnv: ULayer[Has[Console]] = (
   MockConsole.PrintLine(equalTo(s"Got $event"), unit) ++
   MockConsole.ReadLine(value("42")) ++
-  MockConsole.PrintLine(equalTo("You entered: 42"))
+  MockConsole.PrintLine(equalTo[String, Any]("You entered: 42"))
 )
 ```
 
@@ -372,7 +372,7 @@ object MaybeConsoleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(false).provideSomeLayer(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).provideSomeLayer(MockConsole.PrintLine(equalTo("foo")))
+      val maybeTest2 = maybeConsole(true).provideSomeLayer(MockConsole.PrintLine(equalTo[String, Any]("foo")))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     }
   )
@@ -387,10 +387,10 @@ In some cases we have more than one collaborating service being called. You can 
 import zio.test.mock.MockRandom
 
 val combinedEnv: ULayer[Has[Console] with Has[Random]] = (
-  MockConsole.PrintLine(equalTo("What is your name?")) ++
+  MockConsole.PrintLine(equalTo[String, Any]("What is your name?")) ++
   MockConsole.ReadLine(value("Mike")) ++
   MockRandom.NextInt(value(42)) ++
-  MockConsole.PrintLine(equalTo("Mike, your lucky number today is 42!"))
+  MockConsole.PrintLine(equalTo[String, Any]("Mike, your lucky number today is 42!"))
 )
 
 val combinedApp =

--- a/docs/services/clock.md
+++ b/docs/services/clock.md
@@ -26,7 +26,7 @@ In following example we are going to print the current time periodically by plac
 
 ```scala mdoc:silent
 def printTimeForever: ZIO[Has[Console] with Has[Clock], Throwable, Nothing] =
-  Clock.currentDateTime.flatMap(time => Console.printLine(time.toString)) *>
+  Clock.currentDateTime.flatMap(Console.printLine(_)) *>
     ZIO.sleep(1.seconds) *> printTimeForever
 ```
 

--- a/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
@@ -18,7 +18,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
     },
     testM("expect call with input satisfying assertion") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo("foo"))
+      val env = MockConsole.PrintLine(equalTo[String, Any]("foo"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -47,7 +47,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
           _ <- Console.printLine(n.toString)
         } yield ()
 
-      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo("42"))
+      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo[String, Any]("42"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -83,7 +83,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
     },
     testM("failure if invalid arguments") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo("bar"))
+      val env = MockConsole.PrintLine(equalTo[String, Any]("bar"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },

--- a/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
+++ b/examples/jvm/src/test/scala/zio/examples/test/MockExampleSpecWithJUnit.scala
@@ -2,7 +2,7 @@ package zio.examples.test
 
 import zio.test.Assertion._
 import zio.test.junit.JUnitRunnableSpec
-import zio.test.mock.Expectation.{value, valueF}
+import zio.test.mock.Expectation.{unit, value, valueF}
 import zio.test.mock.{MockClock, MockConsole, MockRandom}
 import zio.test.assertM
 import zio.{Console, Random, Clock}
@@ -18,7 +18,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
     },
     testM("expect call with input satisfying assertion") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo[String, Any]("foo"))
+      val env = MockConsole.PrintLine(equalTo("foo"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -47,7 +47,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
           _ <- Console.printLine(n.toString)
         } yield ()
 
-      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo[String, Any]("42"))
+      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo("42"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -83,7 +83,7 @@ class MockExampleSpecWithJUnit extends JUnitRunnableSpec {
     },
     testM("failure if invalid arguments") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo[String, Any]("bar"))
+      val env = MockConsole.PrintLine(equalTo("bar"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },

--- a/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
@@ -1,7 +1,7 @@
 package zio.examples.test
 
 import zio.test.Assertion._
-import zio.test.mock.Expectation.{value, valueF}
+import zio.test.mock.Expectation.{unit, value, valueF}
 import zio.test.mock.{MockClock, MockConsole, MockRandom}
 import zio.test.{assertM, DefaultRunnableSpec}
 import zio.{Clock, Console, Random, ZIO}
@@ -14,7 +14,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(false).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).inject(MockConsole.PrintLine(equalTo[String, Any]("foo")))
+      val maybeTest2 = maybeConsole(true).inject(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     testM("expect no call on skipped branch") {
@@ -56,7 +56,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(true).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(false).inject(MockConsole.PrintLine(equalTo[String, Any]("foo")))
+      val maybeTest2 = maybeConsole(false).inject(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     testM("expect call returning output") {
@@ -67,7 +67,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
     },
     testM("expect call with input satisfying assertion") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo[String, Any]("foo"))
+      val env = MockConsole.PrintLine(equalTo("foo"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -96,7 +96,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
           _ <- Console.printLine(n.toString)
         } yield ()
 
-      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo[String, Any]("42"))
+      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo("42"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -132,7 +132,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
     },
     testM("failure if invalid arguments") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo[String, Any]("bar"))
+      val env = MockConsole.PrintLine(equalTo("bar"), unit)
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },

--- a/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
@@ -14,7 +14,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(false).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).inject(MockConsole.PrintLine(equalTo("foo")))
+      val maybeTest2 = maybeConsole(true).inject(MockConsole.PrintLine(equalTo[String, Any]("foo")))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     testM("expect no call on skipped branch") {
@@ -56,7 +56,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
       val maybeTest1 = maybeConsole(true).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(false).inject(MockConsole.PrintLine(equalTo("foo")))
+      val maybeTest2 = maybeConsole(false).inject(MockConsole.PrintLine(equalTo[String, Any]("foo")))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     testM("expect call returning output") {
@@ -67,7 +67,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
     },
     testM("expect call with input satisfying assertion") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo("foo"))
+      val env = MockConsole.PrintLine(equalTo[String, Any]("foo"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -96,7 +96,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
           _ <- Console.printLine(n.toString)
         } yield ()
 
-      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo("42"))
+      val env = MockRandom.NextInt(value(42)) andThen MockConsole.PrintLine(equalTo[String, Any]("42"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },
@@ -132,7 +132,7 @@ object MockExampleSpec extends DefaultRunnableSpec {
     },
     testM("failure if invalid arguments") {
       val app = Console.printLine("foo")
-      val env = MockConsole.PrintLine(equalTo("bar"))
+      val env = MockConsole.PrintLine(equalTo[String, Any]("bar"))
       val out = app.provideLayer(env)
       assertM(out)(isUnit)
     },

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -23,7 +23,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
     suite("mocking composed environments")(
       {
         val cmd1     = MockClock.NanoTime(value(42L))
-        val cmd2     = MockConsole.PrintLine(equalTo("42"))
+        val cmd2     = MockConsole.PrintLine(equalTo[String, Any]("42"))
         val composed = cmd1 ++ cmd2
 
         val program =
@@ -41,7 +41,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
         val cmd1 = MockRandom.NextInt(value(42))
         val cmd2 = MockClock.Sleep(equalTo(42.seconds))
         val cmd3 = MockSystem.Property(equalTo("foo"), value(None))
-        val cmd4 = MockConsole.PrintLine(equalTo("None"))
+        val cmd4 = MockConsole.PrintLine(equalTo[String, Any]("None"))
 
         val composed = cmd1 ++ cmd2 ++ cmd3 ++ cmd4
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ComposedMockSpec.scala
@@ -23,7 +23,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
     suite("mocking composed environments")(
       {
         val cmd1     = MockClock.NanoTime(value(42L))
-        val cmd2     = MockConsole.PrintLine(equalTo[String, Any]("42"))
+        val cmd2     = MockConsole.PrintLine(equalTo("42"), unit)
         val composed = cmd1 ++ cmd2
 
         val program =
@@ -41,7 +41,7 @@ object ComposedMockSpec extends ZIOBaseSpec {
         val cmd1 = MockRandom.NextInt(value(42))
         val cmd2 = MockClock.Sleep(equalTo(42.seconds))
         val cmd3 = MockSystem.Property(equalTo("foo"), value(None))
-        val cmd4 = MockConsole.PrintLine(equalTo[String, Any]("None"))
+        val cmd4 = MockConsole.PrintLine(equalTo("None"), unit)
 
         val composed = cmd1 ++ cmd2 ++ cmd3 ++ cmd4
 

--- a/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
@@ -19,8 +19,8 @@ object EmptyMockSpec extends ZIOBaseSpec with MockSpecUtils[Has[Console]] {
         isUnit
       ), {
 
-        type M = Capability[Has[Console], String, IOException, Unit]
-        type X = UnexpectedCallException[Has[Console], String, IOException, Unit]
+        type M = Capability[Has[Console], Any, IOException, Unit]
+        type X = UnexpectedCallException[Has[Console], Any, IOException, Unit]
 
         testDied("should fail when call happened")(
           MockConsole.empty,

--- a/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
@@ -138,24 +138,24 @@ object TestConsole extends Serializable {
     /**
      * Writes the specified string to the output buffer.
      */
-    override def print(line: String): IO[IOException, Unit] =
+    override def print(line: Any): IO[IOException, Unit] =
       consoleState.update { data =>
-        Data(data.input, data.output :+ line, data.errOutput)
+        Data(data.input, data.output :+ line.toString, data.errOutput)
       } *> live.provide(Console.print(line)).whenZIO(debugState.get)
 
     /**
      * Writes the specified string to the error buffer.
      */
-    override def printError(line: String): IO[IOException, Unit] =
+    override def printError(line: Any): IO[IOException, Unit] =
       consoleState.update { data =>
-        Data(data.input, data.output, data.errOutput :+ line)
+        Data(data.input, data.output, data.errOutput :+ line.toString)
       } *> live.provide(Console.printError(line)).whenZIO(debugState.get)
 
     /**
      * Writes the specified string to the output buffer followed by a newline
      * character.
      */
-    override def printLine(line: String): IO[IOException, Unit] =
+    override def printLine(line: Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output :+ s"$line\n", data.errOutput)
       } *> live.provide(Console.printLine(line)).whenZIO(debugState.get)
@@ -164,7 +164,7 @@ object TestConsole extends Serializable {
      * Writes the specified string to the error buffer followed by a newline
      * character.
      */
-    override def printLineError(line: String): IO[IOException, Unit] =
+    override def printLineError(line: Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output, data.errOutput :+ s"$line\n")
       } *> live.provide(Console.printLineError(line)).whenZIO(debugState.get)

--- a/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
+++ b/test/shared/src/main/scala/zio/test/mock/MockConsole.scala
@@ -22,10 +22,10 @@ import java.io.IOException
 
 object MockConsole extends Mock[Has[Console]] {
 
-  object Print          extends Effect[String, IOException, Unit]
-  object PrintError     extends Effect[String, IOException, Unit]
-  object PrintLine      extends Effect[String, IOException, Unit]
-  object PrintLineError extends Effect[String, IOException, Unit]
+  object Print          extends Effect[Any, IOException, Unit]
+  object PrintError     extends Effect[Any, IOException, Unit]
+  object PrintLine      extends Effect[Any, IOException, Unit]
+  object PrintLineError extends Effect[Any, IOException, Unit]
   object ReadLine       extends Effect[Unit, IOException, String]
 
   val compose: URLayer[Has[Proxy], Has[Console]] =
@@ -33,11 +33,11 @@ object MockConsole extends Mock[Has[Console]] {
       .service[Proxy]
       .map(proxy =>
         new Console {
-          def print(line: String): IO[IOException, Unit]          = proxy(Print, line)
-          def printError(line: String): IO[IOException, Unit]     = proxy(PrintError, line)
-          def printLine(line: String): IO[IOException, Unit]      = proxy(PrintLine, line)
-          def printLineError(line: String): IO[IOException, Unit] = proxy(PrintLineError, line)
-          val readLine: IO[IOException, String]                   = proxy(ReadLine)
+          def print(line: Any): IO[IOException, Unit]          = proxy(Print, line)
+          def printError(line: Any): IO[IOException, Unit]     = proxy(PrintError, line)
+          def printLine(line: Any): IO[IOException, Unit]      = proxy(PrintLine, line)
+          def printLineError(line: Any): IO[IOException, Unit] = proxy(PrintLineError, line)
+          val readLine: IO[IOException, String]                = proxy(ReadLine)
         }
       )
       .toLayer


### PR DESCRIPTION
Generalizes `printLine` to accept `Any` instead of `String`.