### PR TITLE
Scalafix rule to rename method `halt` to `failCause` for ZIO2.0 migration.

### DIFF
--- a/scalafix/input/src/main/scala/fix/HaltToFailCause.scala
+++ b/scalafix/input/src/main/scala/fix/HaltToFailCause.scala
@@ -1,0 +1,31 @@
+/*
+rule = HaltToFailCause
+*/
+package fix
+
+import zio.Exit.{Failure, Success}
+import zio.{Cause, Exit, ZIO}
+import zio.duration.durationInt
+
+object HaltToFailCause {
+
+  // Add code that needs fixing here.
+  def halt(s : String): Int = ???
+
+  object Halt {
+
+    def zipWith[E, A, B, C](a: Exit[E, A], b: Exit[E, B])(
+      f: (A, B) => C,
+      g: (Cause[E], Cause[E]) => Cause[E]
+    ): Exit[E, C] =
+      (a, b) match {
+        case (Success(a), Success(b)) => Exit.succeed(f(a, b))
+        case (Failure(l), Failure(r)) => Exit.halt(g(l, r))
+        case (e@Failure(_), _) => e
+        case (_, e@Failure(_)) => e
+      }
+
+    val io = ZIO.succeed(true).timeoutHalt(10.millis)
+  }
+
+}

--- a/scalafix/output/src/main/scala/fix/HaltToFailCause.scala
+++ b/scalafix/output/src/main/scala/fix/HaltToFailCause.scala
@@ -1,0 +1,28 @@
+package fix
+
+import zio.Exit.{Failure, Success}
+import zio.{Cause, Exit, ZIO}
+import zio.duration.durationInt
+
+object HaltToFailCause {
+
+  // Add code that needs fixing here.
+  def halt(s : String): Int = ???
+
+  object Halt {
+
+    def zipWith[E, A, B, C](a: Exit[E, A], b: Exit[E, B])(
+      f: (A, B) => C,
+      g: (Cause[E], Cause[E]) => Cause[E]
+    ): Exit[E, C] =
+      (a, b) match {
+        case (Success(a), Success(b)) => Exit.succeed(f(a, b))
+        case (Failure(l), Failure(r)) => Exit.failCause(g(l, r))
+        case (e@Failure(_), _) => e
+        case (_, e@Failure(_)) => e
+      }
+
+    val io = ZIO.succeed(true).timeoutFailCause(10.millis)
+  }
+
+}

--- a/scalafix/rules/src/main/scala/fix/HaltToFailCause.scala
+++ b/scalafix/rules/src/main/scala/fix/HaltToFailCause.scala
@@ -1,0 +1,29 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+class HaltToFailCause extends SemanticRule("HaltToFailCause") {
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    val halt = SymbolMatcher.normalized("zio.Exit.halt", "zio.ZIO.halt", "zio.IO.halt", "zio.Managed.halt", "zio.RIO.halt",
+      "zio.Task.halt", "zio.UIO.halt", "zio.URIO.halt", "zio.ZManaged.halt", "zio.Fiber.halt", "zio.Promise.halt",
+      "zio.ZSink.halt", "zio.ZStream.halt", "zio.stream.experimental.ZChannel.halt", "zio.stream.experimental.Take.halt",
+      "zio.stream.experimental.ZPipeline.halt", "zio.test.TestFailure.halt"
+    )
+    val timeoutHalt = SymbolMatcher.normalized("zio.ZIO.timeoutHalt")
+    val haltWith = SymbolMatcher.normalized("zio.ZIO.haltWith", "zio.IO.haltWith", "zio.RIO.haltWith", "zio.Task.haltWith",
+      "zio.UIO.haltWith", "zio.URIO.haltWith")
+
+    doc.tree.collect {
+      case halt(name@Name(_)) =>
+        Patch.renameSymbol(name.symbol, "failCause")
+
+      case haltWith(name @Name(_)) =>
+        Patch.renameSymbol(name.symbol, "failCauseWith")
+
+      case timeoutHalt(name@Name(_)) =>
+        Patch.renameSymbol(name.symbol, "timeoutFailCause")
+    }.asPatch
+  }
+}


### PR DESCRIPTION
This PR only addresses the renames handled in [#5239](https://github.com/zio/zio/pull/5239)

The rest of the method renames as referenced in [#5226](https://github.com/zio/zio/pull/5226) and [#5229](https://github.com/zio/zio/pull/5229) will be completed later