### PR TITLE
Introduce Schedule.upTo operator

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -133,6 +133,12 @@ object ScheduleSpec extends ZIOBaseSpec {
         val expected  = Chunk((0L, 1.minute), (1L, 2.minute), (2L, 4.minute))
         assertM(scheduled)(equalTo(expected))
       },
+      testM("respect Schedule.upTo even if more input is provided than needed") {
+        val schedule  = Schedule.spaced(1.second).upTo(5.seconds)
+        val scheduled = clock.currentDateTime.orDie.flatMap(schedule.run(_, 1 to 10))
+        val expected  = Chunk(0L, 1L, 2L, 3L, 4L, 5L)
+        assertM(scheduled)(equalTo(expected))
+      },
       testM("free from stack overflow") {
         assertM(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(100000)).runCount)(
           equalTo(100000L)

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -307,6 +307,12 @@ sealed abstract class Schedule[-Env, -In, +Out] private (
   }
 
   /**
+   * A schedule that recurs during the given duration
+   */
+  def upTo(duration: Duration): Schedule[Env, In, Out] =
+    self <* Schedule.upTo(duration)
+
+  /**
    * Returns a new schedule with the specified effectfully computed delay added before the start
    * of each interval produced by this schedule.
    */
@@ -1039,6 +1045,12 @@ object Schedule {
 
     Schedule(loop(None, 0L))
   }
+
+  /**
+   * A schedule that recurs during the given duration
+   */
+  def upTo(duration: Duration): Schedule[Any, Any, Duration] =
+    elapsed.whileOutput(_ < duration)
 
   /**
    * A schedule that always recurs, producing a count of repeats: 0, 1, 2.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1759,7 +1759,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Runs this effect according to the specified schedule.
    *
    * See [[scheduleFrom]] for a variant that allows the schedule's decision to
-   * depend on the rsult of this effect.
+   * depend on the result of this effect.
    */
   final def schedule[R1 <: R, B](schedule: Schedule[R1, Any, B]): ZIO[R1 with Clock, E, B] =
     scheduleFrom(())(schedule)


### PR DESCRIPTION
This introduces an operator that allows a Schedule to recur for a given duration. As suggested here https://github.com/zio/zio/issues/4351