### PR TITLE
Start documenting migration from cats effect to ZIO

### DIFF
--- a/docs/howto/migrate/from-cats-efect.md
+++ b/docs/howto/migrate/from-cats-efect.md
@@ -1,0 +1,23 @@
+---
+id: from-cats-efect
+title:  "How to Migrate from Cats Effect to ZIO?"
+---
+
+Cats `IO[A]` can be easily replaced with ZIO's `Task[A]` (an alias for `ZIO[Any, Throwable, A]`).
+Translation should be relatively straightfoward. Below, you'll find tables showing the ZIO equivalents of
+various `cats.*`'s methods.
+
+### Methods on cats.FlatMap.Ops
+
+| cats | ZIO |
+|-------|-----|
+|`flatMap`|`flatMap`|
+|`flatten`|`flatten`|
+|`productREval`|`zipRight`|
+|`productLEval`|`zipLeft`|
+|`mproduct`|`zipPar`|
+|`flatTap`|`tap`|
+
+### TODO
+
+TODO

--- a/docs/howto/migrate/from-monix.md
+++ b/docs/howto/migrate/from-monix.md
@@ -11,6 +11,9 @@ Once you've completed the initial translation, you'll find that ZIO is outfitted
 methods which have no Monix equivalents, so have fun exploring the API and see if you can rewrite some
 of your logic at a higher level of abstraction, with more powerful combinators and fewer lines code.
 
+If you are using operators from from Cats Effect extension methods see also 
+[here](https://zio.dev/docs/howto/migrate/from-cats-effect).
+
 ### Methods on Trait
 
 | Monix | ZIO |


### PR DESCRIPTION
While migrating something from Monix to ZIO I have found that there was `flatTap` from Cats which were nowhere to be found in Monix migration guide. So I have started with documentation of it at least like this.