### PR TITLE
Fix `Assertion.isFailure` name

### DIFF
--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -469,7 +469,7 @@ object Assertion extends AssertionVariants {
    * assertion.
    */
   def isFailure(assertion: Assertion[Throwable]): Assertion[Try[Any]] =
-    Assertion.assertionRec("isSuccess")(param(assertion))(assertion) {
+    Assertion.assertionRec("isFailure")(param(assertion))(assertion) {
       case Failure(a) => Some(a)
       case Success(_) => None
     }


### PR DESCRIPTION
I was having this error message in my tests:

```scala
TestFailed: Try(...) = Success(...) did not satisfy isSuccess
```

😅