### PR TITLE
Smart assert bug-fix and better array equality

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -321,6 +321,15 @@ object SmartAssertionSpec extends ZIOBaseSpec {
           assertTrue(map("zero") < 3)
         } @@ failing
       )
+    ),
+    suite("subtype option")(
+      test("success") {
+        trait Parent
+        case class Child(x: String) extends Parent
+        val someParent: Option[Parent] = Some(Child("hii"))
+        val someChild                  = Child("hii")
+        assertTrue(someParent.contains(someChild))
+      }
     )
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -19,7 +19,21 @@ object SmartAssertionSpec extends ZIOBaseSpec {
   private val company: Company = Company("Ziverge", List(User("Bobo", List.tabulate(2)(n => Post(s"Post #$n")))))
 
   def spec: ZSpec[Environment, Failure] = suite("SmartAssertionSpec")(
-    test("Head") {
+    suite("Array")(
+      suite("==")(
+        test("success") {
+          val a1 = Array(1, 2, 3)
+          val a2 = Array(1, 2, 3)
+          assertTrue(a1 == a2)
+        },
+        test("failure") {
+          val a1 = Array(1, 2, 3)
+          val a2 = Array(1, 3, 2)
+          assertTrue(a1 == a2)
+        } @@ failing
+      )
+    ),
+    test("multiple assertions") {
       val array = Array(1, 8, 2, 3, 888)
       assertTrue(
         !(array(0) == 1),
@@ -329,7 +343,14 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         val someParent: Option[Parent] = Some(Child("hii"))
         val someChild                  = Child("hii")
         assertTrue(someParent.contains(someChild))
-      }
+      },
+      test("failure") {
+        trait Parent
+        case class Child(x: String) extends Parent
+        val someParent: Option[Parent] = None
+        val someChild                  = Child("hii")
+        assertTrue(someParent.contains(someChild))
+      } @@ failing
     )
   )
 

--- a/test/shared/src/main/scala-2.x/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/SmartAssertMacros.scala
@@ -400,7 +400,7 @@ $Assert($ast.withCode($codeString).withLocation($locationString))
     val containsOption: ASTConverter =
       ASTConverter.make {
         case AST.Method(_, lhsTpe, _, "contains", _, Some(args), _) if lhsTpe <:< weakTypeOf[Option[_]] =>
-          AssertAST("containsOption", args = args)
+          AssertAST("containsOption", args = args, tpes = List(lhsTpe.dealias.typeArgs.head))
       }
 
     val containsString: ASTConverter =

--- a/test/shared/src/main/scala/zio/test/ErrorMessage.scala
+++ b/test/shared/src/main/scala/zio/test/ErrorMessage.scala
@@ -33,7 +33,7 @@ sealed trait ErrorMessage { self =>
       case ErrorMessage.Choice(success, failure) =>
         if (isSuccess) magenta(success) else red(failure)
 
-      case ErrorMessage.Value(value) => bold(blue(value.toString))
+      case ErrorMessage.Value(value) => bold(blue(PrettyPrint(value)))
 
       case ErrorMessage.Combine(lhs, rhs, spacing) =>
         lhs.render(isSuccess) + (" " * spacing) + rhs.render(isSuccess)
@@ -45,4 +45,12 @@ sealed trait ErrorMessage { self =>
             .mkString("\n")
 
     }
+
+}
+
+private[zio] object PrettyPrint {
+  def apply(any: Any): String = any match {
+    case array: Array[_] => array.mkString("Array(", ", ", ")")
+    case other           => other.toString
+  }
 }

--- a/test/shared/src/main/scala/zio/test/Result.scala
+++ b/test/shared/src/main/scala/zio/test/Result.scala
@@ -126,7 +126,7 @@ object FailureCase {
 
         errorMessageLines ++
           Chunk.fromIterable(path.drop(path.length - 1).map { case (label, value) =>
-            dim(s"$label = ") + blue(value.toString)
+            dim(s"$label = ") + blue(PrettyPrint(value))
           })
 
       case FailureCase(errorMessage, codeString, location, path, _, nested, _) =>
@@ -137,7 +137,7 @@ object FailureCase {
           }
 
         errorMessageLines ++ Chunk(codeString) ++ nested.flatMap(renderFailureCase(_, true)).map("  " + _) ++
-          Chunk.fromIterable(path.map { case (label, value) => dim(s"$label = ") + blue(value.toString) }) ++
+          Chunk.fromIterable(path.map { case (label, value) => dim(s"$label = ") + blue(PrettyPrint(value)) }) ++
           Chunk(cyan(s"☛ $location")) ++ Chunk("")
 
     }

--- a/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
+++ b/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
@@ -201,7 +201,11 @@ object SmartAssertions {
   def equalTo[A](that: A)(implicit diff: OptionalImplicit[Diff[A]]): Arrow[A, Boolean] =
     Arrow
       .make[A, Boolean] { a =>
-        val result = a == that
+        val result = (a, that) match {
+          case (a: Array[_], that: Array[_]) => a.sameElements[Any](that)
+          case _                             => a == that
+        }
+
         Trace.boolean(result) {
           diff.value match {
             case Some(diff) if !result =>


### PR DESCRIPTION
Fixed a bug received on Discord from `TimP`:

```scala
  trait Parent
  case class Child(x: String) extends Parent

  def testcontains = test("contains") {
    val someParent: Option[Parent] = None
    val someChild = Child("hi")
    assertTrue(someParent.contains(someChild))
  }
```

Also—from another feature request—I've made `==` on in a `assertTrue` for Arrays use `sameElements` under the hood, similar to the old `equalTo` assertion.