### PR TITLE
Adding foreachFlatten: ZIO.foreachFlatten(Col[A])(A => Col[B]): Col[B]

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -454,6 +454,14 @@ object IO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachFlatten[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[E, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => IO[E, Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): IO[E, Collection[B]] =
+    ZIO.foreachFlatten(in)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreach[R,E,A,B](in:Set*]]]
    */
   def foreach[E, A, B](in: Set[A])(f: A => IO[E, B]): IO[E, Set[B]] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -484,6 +484,14 @@ object RIO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachFlatten[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[R, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => RIO[R, Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): RIO[R, Collection[B]] =
+    ZIO.foreachFlatten(in)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreach[R,E,A,B](in:Set*]]]
    */
   def foreach[R, A, B](in: Set[A])(f: A => RIO[R, B]): RIO[R, Set[B]] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -460,6 +460,14 @@ object Task extends TaskPlatformSpecific {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreach[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => Task[Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): Task[Collection[B]] =
+    ZIO.foreachFlatten(in)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreach[R,E,A,B](in:Set*]]]
    */
   def foreach[A, B](in: Set[A])(f: A => Task[B]): Task[Set[B]] =

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -439,6 +439,14 @@ object UIO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachFlatten[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => UIO[Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): UIO[Collection[B]] =
+    ZIO.foreachFlatten(in)(f)
+
+  /**
    * @see See [[[zio.ZIO.foreach[R,E,A,B](in:Set*]]]
    */
   def foreach[A, B](in: Set[A])(f: A => UIO[B]): UIO[Set[B]] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -457,6 +457,14 @@ object URIO {
     ZIO.foreach(in)(f)
 
   /**
+   * @see See [[[zio.ZIO.foreachFlatten[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[R, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => URIO[R, Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): URIO[R, Collection[B]] =
+    ZIO.foreachFlatten(in)(f)
+
+  /**
    * @see [[[zio.ZIO.foreach[R,E,A,B](in:Set*]]]
    */
   final def foreach[R, A, B](in: Set[A])(f: A => URIO[R, B]): URIO[R, Set[B]] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2939,6 +2939,19 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ).map(_.result())
 
   /**
+   * Applies the function `f` to each element of the `Collection[A]`, then
+   * flattens the intermediate `Collection[B]`'s into a new `Collection[B]`.
+   */
+  def foreachFlatten[R, E, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(
+    f: A => ZIO[R, E, Collection[B]]
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZIO[R, E, Collection[B]] =
+    in.foldLeft[ZIO[R, E, Builder[B, Collection[B]]]](effectTotal(bf.newBuilder(in)))((io, a) =>
+      io.zipWith(f(a))(_ ++= _)
+    ).map(_.result())
+
+  /**
    * Determines whether all elements of the `Iterable[A]` satisfy the effectual
    * predicate `f`.
    */

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1720,6 +1720,19 @@ object ZManaged extends ZManagedPlatformSpecific {
     })
 
   /**
+   * Applies the function `f` to each element of the `Collection[A]`, then
+   * flattens the intermediate `Collection[B]`'s into a new `Collection[B]`.
+   */
+  def foreachFlatten[R, E, A1, A2, Collection[+Element] <: Iterable[Element]](in: Collection[A1])(
+    f: A1 => ZManaged[R, E, Collection[A2]]
+  )(implicit bf: BuildFrom[Collection[A1], A2, Collection[A2]]): ZManaged[R, E, Collection[A2]] =
+    ZManaged(ZIO.foreach(in.toList)(f(_).zio).map { result =>
+      val (fins, ass) = result.unzip
+      val as          = ass.flatten
+      (e => ZIO.foreach(fins.reverse)(_.apply(e)), bf.fromSpecific(in)(as))
+    })
+
+  /**
    * Applies the function `f` if the argument is non-empty and
    * returns the results in a new `Option[A2]`.
    */

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -168,6 +168,14 @@ object STM {
     ZSTM.foreach(in)(f)
 
   /**
+   * @see See [[[zio.stm.ZSTM.foreachFlatten[R,E,A,B,Collection[+Element]<:Iterable[Element]]*]]]
+   */
+  def foreachFlatten[E, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(f: A => STM[E, Collection[B]])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): STM[E, Collection[B]] =
+    ZSTM.foreachFlatten(in)(f)
+
+  /**
    * @see See [[[zio.stm.ZSTM.foreach[R,E,A,B](in:Set*]]]
    */
   def foreach[E, A, B](in: Set[A])(f: A => STM[E, B]): STM[E, Set[B]] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1194,6 +1194,20 @@ object ZSTM {
     }.map(_.result())
 
   /**
+   * Applies the function `f` to each element of the `Collection[A]`,
+   * flattens the intermediate `Collection[B]`'s, returning a transactional
+   * effect that produces a new `Collection[B]`.
+   */
+  def foreachFlatten[R, E, A, B, Collection[+Element] <: Iterable[Element]](
+    in: Collection[A]
+  )(
+    f: A => ZSTM[R, E, Collection[B]]
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZSTM[R, E, Collection[B]] =
+    in.foldLeft[ZSTM[R, E, Builder[B, Collection[B]]]](ZSTM.succeed(bf.newBuilder(in))) { (tx, a) =>
+      tx.zipWith(f(a))(_ ++= _)
+    }.map(_.result())
+
+  /**
    * Applies the function `f` to each element of the `Set[A]` and returns a
    * transactional effect that produces a new `Set[B]`.
    */

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -123,14 +123,27 @@ object BuildHelper {
     // One of -Ydelambdafy:inline or -Yrepl-class-based must be given to
     // avoid deadlocking on parallel operations, see
     //   https://issues.scala-lang.org/browse/SI-9076
-    Compile / console / scalacOptions := Seq(
-      "-Ypartial-unification",
-      "-language:higherKinds",
-      "-language:existentials",
-      "-Yno-adapted-args",
-      "-Xsource:2.13",
-      "-Yrepl-class-based"
-    ),
+    Compile / console / scalacOptions :=
+      (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) =>
+          Seq(
+            "-Ypartial-unification",
+            "-Yno-adapted-args"
+          )
+        case Some((2, 11)) =>
+          Seq(
+            "-Ypartial-unification",
+            "-Xexperimental",
+            "-Yno-adapted-args"
+          )
+        case _ =>
+          Seq.empty
+      }) ++ Seq(
+        "-language:higherKinds",
+        "-language:existentials",
+        "-Xsource:2.13",
+        "-Yrepl-class-based"
+      ),
     Compile / console / initialCommands := initialCommandsStr
   )
 


### PR DESCRIPTION
Mirrors expected functionality from `flatTraverse` in cats. Currently, the only way to do this is:

```scala
ZIO.foreach(List.empty[Int])(a => UIO(List(a.toString, a.toString))).map(_.flatten)
```

with this change, that can be simplified to
```scala
ZIO.flatForeach(List.empty[Int])(a => UIO(List(a.toString, a.toString)))
```

This has been asked about a few times on the ZIO Discord, @iravid gave a reason why it wouldn't be practical to do, though this was a while back so perhaps this can be revisited.

Initially, I was just going to add this change to `ZIO`/`UIO`/`IO`, but for completeness I branched out to the other objects that had `foreach` defined, though I don't have a use for that right now and can revert those if desired.

---

I have another change, but I don't know how to make the ergonomics correct without doing the type pivot trick used commonly in more functional codebases, so I'll leave it here as a comment. `ZIO.flatForeach` would be a welcome change without the instance function:

Example (note the required `(a: Int)`, which should be inferable considering `UIO[List[Int]]` has a concrete type):
```scala
scala> runSync(UIO(List(1,2,3,4)).flatForeach((a: Int) => putStrLn(s"Processing: ${a}").as(List(a.toString, a.toString))))
Processing: 1
Processing: 2
Processing: 3
Processing: 4
val res1: zio.Exit[java.io.IOException,List[String]] = Success(List(1, 1, 2, 2, 3, 3, 4, 4))
```

<details><summary>expand diff</summary>

### diff

```diff
diff --git a/core/shared/src/main/scala/zio/ZIO.scala b/core/shared/src/main/scala/zio/ZIO.scala
index a44d084bd..94a3e5a0f 100644
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -633,6 +633,11 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   def flatMap[R1 <: R, E1 >: E, B](k: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     new ZIO.FlatMap(self, k)
 
+  def flatForeach[R1 <: R, E1 >: E, Collection[+Element] <: Iterable[Element], AA, B](
+    k: AA => ZIO[R1, E1, Collection[B]]
+  )(implicit ev1: A <:< Collection[AA], bf: BuildFrom[Collection[AA], B, Collection[B]]): ZIO[R1, E1, Collection[B]] =
+   new ZIO.FlatMap(self.asInstanceOf[ZIO[R, E, Collection[AA]]], (as: Collection[AA]) => ZIO.flatForeach(as)(k))
+
   /**
    * Creates a composite effect that represents this effect followed by another
    * one that may depend on the error produced by this one.
```

</details>