### PR TITLE
Add ZIO.ifElse

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1105,6 +1105,16 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.fail("Fail").head.either)(isLeft(isSome(equalTo("Fail"))))
       } @@ zioTag(errors)
     ),
+    suite("ifElse")(
+      testM("runs `onTrue` if result of `b` is `true`") {
+        val zio = ZIO.ifElse(true)(ZIO.succeed(true), ZIO.succeed(false))
+        assertM(zio)(isTrue)
+      },
+      testM("runs `onFalse` if result of `b` is `false`") {
+        val zio = ZIO.ifElse(false)(ZIO.succeed(true), ZIO.succeed(false))
+        assertM(zio)(isFalse)
+      }
+    ),
     suite("ifM")(
       testM("runs `onTrue` if result of `b` is `true`") {
         val zio = ZIO.ifM(ZIO.succeed(true))(ZIO.succeed(true), ZIO.succeed(false))

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -457,6 +457,16 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(result)(equalTo(List("Closed")))
       }
     ),
+    suite("ifElse")(
+      testM("runs `onTrue` if result of `b` is `true`") {
+        val managed = ZManaged.ifElse(true)(ZManaged.succeed(true), ZManaged.succeed(false))
+        assertM(managed.use(ZIO.succeed(_)))(isTrue)
+      },
+      testM("runs `onFalse` if result of `b` is `false`") {
+        val managed = ZManaged.ifElse(false)(ZManaged.succeed(true), ZManaged.succeed(false))
+        assertM(managed.use(ZIO.succeed(_)))(isFalse)
+      }
+    ),
     suite("ifM")(
       testM("runs `onTrue` if result of `b` is `true`") {
         val managed = ZManaged.ifM(ZManaged.succeed(true))(ZManaged.succeed(true), ZManaged.succeed(false))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -272,6 +272,16 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertM(ZSTM.fromEither(ei).head.commit.run)(fails(isSome(equalTo("my error"))))
         } @@ zioTag(errors)
       ),
+      suite("ifElse")(
+        testM("runs `onTrue` if result of `b` is `true`") {
+          val transaction = ZSTM.ifElse(true)(ZSTM.succeed(true), ZSTM.succeed(false))
+          assertM(transaction.commit)(isTrue)
+        },
+        testM("runs `onFalse` if result of `b` is `false`") {
+          val transaction = ZSTM.ifElse(false)(ZSTM.succeed(true), ZSTM.succeed(false))
+          assertM(transaction.commit)(isFalse)
+        }
+      ),
       suite("ifM")(
         testM("runs `onTrue` if result of `b` is `true`") {
           val transaction = ZSTM.ifM(ZSTM.succeed(true))(ZSTM.succeed(true), ZSTM.succeed(false))

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -646,6 +646,12 @@ object IO {
   def identity: IO[Nothing, Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifElse]]
+   */
+  def ifElse[E, A](b: => Boolean)(onTrue: => IO[E, A], onFalse: => IO[E, A]): IO[E, A] =
+    ZIO.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see [[zio.ZIO.ifM]]
    */
   def ifM[E](b: IO[E, Boolean]): ZIO.IfM[Any, E] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -679,6 +679,12 @@ object RIO {
   def identity[R]: RIO[R, R] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifElse]]
+   */
+  def ifElse[R, A](b: => Boolean)(onTrue: => RIO[R, A], onFalse: => RIO[R, A]): RIO[R, A] =
+    ZIO.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see [[zio.ZIO.ifM]]
    */
   def ifM[R](b: RIO[R, Boolean]): ZIO.IfM[R, Throwable] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -647,6 +647,12 @@ object Task extends TaskPlatformSpecific {
   def identity: Task[Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifElse]]
+   */
+  def ifElse[A](b: => Boolean)(onTrue: => Task[A], onFalse: => Task[A]): Task[A] =
+    ZIO.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see [[zio.ZIO.ifM]]
    */
   def ifM(b: Task[Boolean]): ZIO.IfM[Any, Throwable] =

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -582,6 +582,12 @@ object UIO {
   def identity: UIO[Any] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifElse]]
+   */
+  def ifElse[A](b: => Boolean)(onTrue: => UIO[A], onFalse: => UIO[A]): UIO[A] =
+    ZIO.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see [[zio.ZIO.ifM]]
    */
   def ifM(b: UIO[Boolean]): ZIO.IfM[Any, Nothing] =

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -617,6 +617,12 @@ object URIO {
   def identity[R]: URIO[R, R] = ZIO.identity
 
   /**
+   * @see [[zio.ZIO.ifElse]]
+   */
+  def ifElse[R, A](b: => Boolean)(onTrue: => URIO[R, A], onFalse: => URIO[R, A]): URIO[R, A] =
+    ZIO.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see [[zio.ZIO.ifM]]
    */
   def ifM[R](b: URIO[R, Boolean]): ZIO.IfM[R, Nothing] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3461,6 +3461,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def identity[R]: URIO[R, R] = fromFunction[R, R](ZIO.identityFn[R])
 
   /**
+   * The moral equivalent of `if (p) onTrue else onFalse`
+   */
+  def ifElse[R, E, A](b: => Boolean)(onTrue: => ZIO[R, E, A], onFalse: => ZIO[R, E, A]): ZIO[R, E, A] =
+    effectSuspendTotal(if (b) onTrue else onFalse)
+
+  /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
   def ifM[R, E](b: ZIO[R, E, Boolean]): ZIO.IfM[R, E] =

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1919,6 +1919,12 @@ object ZManaged extends ZManagedPlatformSpecific {
   def identity[R]: ZManaged[R, Nothing, R] = fromFunction(scala.Predef.identity)
 
   /**
+   * The moral equivalent of `if (p) onTrue else onFalse`
+   */
+  def ifElse[R, E, A](b: => Boolean)(onTrue: => ZManaged[R, E, A], onFalse: => ZManaged[R, E, A]): ZManaged[R, E, A] =
+    ZManaged.suspend(if (b) onTrue else onFalse)
+
+  /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
   def ifM[R, E](b: ZManaged[R, E, Boolean]): ZManaged.IfM[R, E] =

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -215,6 +215,12 @@ object STM {
   def identity: USTM[Any] = ZSTM.identity
 
   /**
+   * @see See [[zio.stm.ZSTM.ifElse]]
+   */
+  def ifElse[E, A](b: => Boolean)(onTrue: => STM[E, A], onFalse: => STM[E, A]): STM[E, A] =
+    ZSTM.ifElse(b)(onTrue, onFalse)
+
+  /**
    * @see See [[zio.stm.ZSTM.ifM]]
    */
   def ifM[E](b: STM[E, Boolean]): ZSTM.IfM[Any, E] =

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1270,6 +1270,12 @@ object ZSTM {
   def identity[R]: URSTM[R, R] = fromFunction[R, R](ZIO.identityFn)
 
   /**
+   * The moral equivalent of `if (p) onTrue else onFalse`
+   */
+  def ifElse[R, E, A](b: => Boolean)(onTrue: => ZSTM[R, E, A], onFalse: => ZSTM[R, E, A]): ZSTM[R, E, A] =
+    suspend(if (b) onTrue else onFalse)
+
+  /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
    */
   def ifM[R, E](b: ZSTM[R, E, Boolean]): ZSTM.IfM[R, E] =


### PR DESCRIPTION
Currently, to achieve logic like: `if (b) onTrue else onFalse` i'll do:
```
ZIO.ifM(ZIO.succeed(b))(onTrue, onFalse)
```
and that is ok, but there is already `when` combinator which operates on a pure boolean and i think that something like `ifElse` also could be useful:

```
ZIO.ifElse(b)(onTrue, onFalse)
```
