### PR TITLE
Update Runtime.scala

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -102,8 +102,7 @@ trait Runtime[+R] {
    * This method is effectful and should only be invoked at the edges of your program.
    */
   final def unsafeRunAsyncCancelable[E, A](zio: => ZIO[R, E, A])(k: Exit[E, A] => Any): Fiber.Id => Exit[E, A] = {
-    lazy val curZio = if (Platform.isJVM) ZIO.yieldNow *> zio else zio
-    val canceler    = unsafeRunWith(curZio)(k)
+    val canceler    = unsafeRunWith(zio)(k)
     fiberId => {
       val result = internal.OneShot.make[Exit[E, A]]
       canceler(fiberId)(result.set)

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -102,7 +102,7 @@ trait Runtime[+R] {
    * This method is effectful and should only be invoked at the edges of your program.
    */
   final def unsafeRunAsyncCancelable[E, A](zio: => ZIO[R, E, A])(k: Exit[E, A] => Any): Fiber.Id => Exit[E, A] = {
-    val canceler    = unsafeRunWith(zio)(k)
+    val canceler = unsafeRunWith(zio)(k)
     fiberId => {
       val result = internal.OneShot.make[Exit[E, A]]
       canceler(fiberId)(result.set)


### PR DESCRIPTION
The idea behind this change is to optimize evaluation for very small ZIO programs eg: `UIO(1)`.

By default, the current thread should be used (better performance). In case the developer want's to ensure the execution happens in the ZIO thread pool, they are free to use `yieldNow` in their program.

This optimization also works much better with single-threaded frameworks such as netty and nio.
