### PR TITLE
Fix Signature Of ZStream.FromJavaStream

### DIFF
--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -247,7 +247,7 @@ val lines: ZStream[Any, Throwable, String] =
 For example, to convert the Java Stream to the ZIO Stream, `ZStream` has a `fromJavaStream` constructor which convert the Java Stream to the Java Iterator and then convert that to the ZIO Stream using `ZStream.fromJavaIterator` constructor:
 
 ```scala mdoc:silent:nest
-def fromJavaStream[R, A](stream: => java.util.stream.Stream[A]): ZStream[R, Throwable, A] =
+def fromJavaStream[A](stream: => java.util.stream.Stream[A]): ZStream[Any, Throwable, A] =
   ZStream.fromJavaIterator(stream.iterator())
 ```
 

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -428,7 +428,7 @@ trait ZStreamPlatformSpecificConstructors {
   /**
    * Creates a stream from a Java stream
    */
-  final def fromJavaStream[R, A](stream: => ju.stream.Stream[A]): ZStream[R, Throwable, A] =
+  final def fromJavaStream[A](stream: => ju.stream.Stream[A]): ZStream[Any, Throwable, A] =
     ZStream.fromJavaIterator(stream.iterator())
 
   /**


### PR DESCRIPTION
It currently includes an extraneous `R` type parameter. Since this type is completely unbounded it gets inferred as `Nothing`.