### PR TITLE
Fix Bug In ZStream#flatMapPar

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2122,6 +2122,13 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(count)(equalTo(2)) && assert(result)(fails(equalTo("Boom")))
           } @@ nonFlaky
         ),
+        suite("mapMParUnordered")(
+          testM("mapping with failure is failure") {
+            val stream =
+              ZStream.fromIterable(0 to 3).mapMParUnordered(10)(_ => ZIO.fail("fail"))
+            assertM(stream.runDrain.run)(fails(equalTo("fail")))
+          } @@ nonFlaky
+        ),
         suite("mergeTerminateLeft")(
           testM("terminates as soon as the first stream terminates") {
             for {


### PR DESCRIPTION
Currently it is possible for `flatMapPar` to signal the end of the stream even though a failure has occurred.

This is possible because the following line assumes that if acquiring the permits wins the race against awaiting the inner failure then all streams have completed successfully and we can signal stream completion.

```scala
innerFailure.await.interruptible.raceWith(permits.withPermits(n.toLong)(ZIO.unit).interruptible)(???)
```

However, this is not necessarily the case because even if the left side is already complete the right side could still win the race.

To address this, we change the logic of the inner stream acquiring the permit so that it only releases the permit in the event of success. The main purpose of the permits is to control parallelism. If one inner stream has failed then all inner streams are in the process of being shut down so there is no point in releasing a permit to allow a new stream to be created. In the event of failure the inner stream completes the inner failure promise to signal to the outer stream, ensuring that it is always the case that either the permit is released or failure is signaled.