### PR TITLE
2.0 Renaming & Deprecation Bike-Shed Party 💃🕺 

### DIFF
--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -20,7 +20,7 @@ class GenBenchmarks {
   var elementSize: Int = _
   @Benchmark
   def zioDouble: List[Double] =
-    unsafeRun(Gen.listOfN(listSize)(Gen.uniform).sample.map(_.value).runHead.get.provideLayer(ZEnv.live))
+    unsafeRun(Gen.listOfN(listSize)(Gen.uniform).sample.map(_.value).runHead.some.provideLayer(ZEnv.live))
 
   @Benchmark
   def zioIntListsOfSizeN: List[List[Int]] =
@@ -30,7 +30,7 @@ class GenBenchmarks {
         .sample
         .map(_.value)
         .runHead
-        .get
+        .some
         .provideLayer(ZEnv.live)
     )
 
@@ -42,7 +42,7 @@ class GenBenchmarks {
         .sample
         .map(_.value)
         .runHead
-        .get
+        .some
         .provideLayer(ZEnv.live)
     )
 

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -70,7 +70,7 @@ object SerializableSpec extends ZIOBaseSpec {
       } yield assert(result)(equalTo(list))
     },
     test("ZIO is serializable") {
-      val v = ZIO.fromFunction[Int, Int](_ + 1)
+      val v = ZIO.access[Int](_ + 1)
       for {
         returnZIO <- serializeAndBack(v)
         computeV  <- returnZIO.provide(9)

--- a/core-tests/shared/src/test/scala/zio/LatchOps.scala
+++ b/core-tests/shared/src/test/scala/zio/LatchOps.scala
@@ -2,7 +2,7 @@ package zio
 
 trait LatchOps {
   def withLatch[R, E, A](f: UIO[Unit] => ZIO[R, E, A]): ZIO[R, E, A] =
-    Promise.make[Nothing, Unit] >>= (latch => f(latch.succeed(()).unit) <* latch.await)
+    Promise.make[Nothing, Unit] flatMap (latch => f(latch.succeed(()).unit) <* latch.await)
 
   def withLatch[R, E, A](f: (UIO[Unit], UIO[Unit]) => ZIO[R, E, A]): ZIO[R, E, A] =
     for {

--- a/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
@@ -25,7 +25,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("interruptAs")(assertLazy(IO.interruptAs)),
       test("left")(assertLazy(IO.left)),
       test("lock")(assertLazy(IO.lock)),
-      test("require")(assertLazy(ZIO.require)),
       test("right")(assertLazy(IO.right)),
       test("some")(assertLazy(IO.some)),
       test("succeed")(assertLazy(IO.succeed))
@@ -54,7 +53,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("left")(assertLazy(RIO.left)),
       test("lock")(assertLazy(RIO.lock)),
       test("provide")(assertLazy(RIO.provide)),
-      test("require")(assertLazy(RIO.require)),
       test("right")(assertLazy(RIO.right)),
       test("sleep")(assertLazy(RIO.sleep)),
       test("some")(assertLazy(RIO.some)),
@@ -72,7 +70,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("interruptAs")(assertLazy(Task.interruptAs)),
       test("left")(assertLazy(Task.left)),
       test("lock")(assertLazy(Task.lock)),
-      test("require")(assertLazy(Task.require)),
       test("right")(assertLazy(Task.right)),
       test("some")(assertLazy(Task.some)),
       test("succeed")(assertLazy(Task.succeed))
@@ -133,7 +130,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("left")(assertLazy(ZIO.left)),
       test("lock")(assertLazy(ZIO.lock)),
       test("provide")(assertLazy(ZIO.provide)),
-      test("require")(assertLazy(ZIO.require)),
       test("right")(assertLazy(ZIO.right)),
       test("sleep")(assertLazy(ZIO.sleep)),
       test("some")(assertLazy(ZIO.some)),

--- a/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
@@ -36,7 +36,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("fail")(assertLazy(Managed.fail)),
       test("failCause")(assertLazy(Managed.failCause)),
       test("fromEither")(assertLazy(Managed.fromEither)),
-      test("require")(assertLazy(Managed.require)),
       test("succeed")(assertLazy(Managed.succeed))
     ),
     suite("RIO")(
@@ -112,7 +111,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
       test("failCause")(assertLazy(ZManaged.failCause)),
       test("fromEither")(assertLazy(ZManaged.fromEither)),
       test("interruptAs")(assertLazy(ZManaged.interruptAs)),
-      test("require")(assertLazy(ZManaged.require)),
       test("succeed")(assertLazy(ZManaged.succeed))
     ),
     suite("ZIO")(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -33,14 +33,6 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.succeed(false) && ZIO.fail("fail"))(isFalse)
       }
     ),
-    suite("***")(
-      test("splits the environment") {
-        val zio1 = ZIO.fromFunction((n: Int) => n + 2)
-        val zio2 = ZIO.fromFunction((n: Int) => n * 3)
-        val zio3 = zio1 *** zio2
-        assertM(zio3.provide((4, 5)))(equalTo((6, 15)))
-      }
-    ),
     suite("unary_!")(
       test("not true is false") {
         assertM(!ZIO.succeed(true))(isFalse)
@@ -890,7 +882,7 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("foreachParDiscard")(
       test("accumulates errors") {
         def task(started: Ref[Int], trigger: Promise[Nothing, Unit])(i: Int): IO[Int, Unit] =
-          started.updateAndGet(_ + 1) >>= { count =>
+          started.updateAndGet(_ + 1) flatMap { count =>
             IO.when(count == 3)(trigger.succeed(())) *> trigger.await *> IO.fail(i)
           }
 

--- a/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/ExecutorSpec.scala
@@ -47,7 +47,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     suite("Create the default unyielding executor and check that:")(
       test("When converted to an EC, it reports Throwables to stdout") {
         val t = new CheckPrintThrowable
-        TestExecutor.failing.asEC.reportFailure(t)
+        TestExecutor.failing.asExecutionContext.reportFailure(t)
         assert(t.printed)(isTrue)
       }
     ),
@@ -64,7 +64,7 @@ object ExecutorSpec extends ZIOBaseSpec {
         assert(TestExecutor.y.submitOrThrow(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When converted to an ExecutionContext, it accepts Runnables") {
-        assert(TestExecutor.y.asEC.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.y.asExecutionContext.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When created from an EC, must not throw when fed an effect ") {
         assert(Executor.fromExecutionContext(1)(TestExecutor.ec).submit(TestExecutor.runnable))(
@@ -80,7 +80,7 @@ object ExecutorSpec extends ZIOBaseSpec {
         assert(TestExecutor.u.submitOrThrow(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When converted to an ExecutionContext, it accepts Runnables") {
-        assert(TestExecutor.u.asEC.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
+        assert(TestExecutor.u.asExecutionContext.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))
       },
       test("When converted to Java, it accepts Runnables") {
         assert(TestExecutor.u.asJava.execute(TestExecutor.runnable))(not(throwsA[RejectedExecutionException]))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -1054,18 +1054,6 @@ object ZSTMSpec extends ZIOBaseSpec {
         assertM(tx.commit.exit)(fails(equalTo(List(2, 4, 6, 3, 5, 6))))
       } @@ zioTag(errors)
     ),
-    suite("ZSTM require")(
-      test("require successful") {
-        val opt = ZSTM.fromEither[Throwable, Option[Int]](Right(Some(1)))
-        val tx  = ZSTM.require[Any, Throwable, Int](ExampleError)
-        assertM(tx(opt).commit)(equalTo(1))
-      },
-      test("reduceAll on None") {
-        val opt = ZSTM.fromEither[Throwable, Option[Int]](Right(None))
-        val tx  = ZSTM.require[Any, Throwable, Int](ExampleError)
-        assertM(tx(opt).commit.exit)(fails(equalTo(ExampleError)))
-      }
-    ),
     suite("when combinators")(
       test("when true") {
         for {

--- a/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
@@ -27,13 +27,13 @@ trait ExecutorPlatformSpecific { this: Executor =>
    */
   lazy val asECES: ExecutionContextExecutorService =
     new AbstractExecutorService with ExecutionContextExecutorService {
-      override val prepare: ExecutionContext                               = asEC
+      override val prepare: ExecutionContext                               = asExecutionContext
       override val isShutdown: Boolean                                     = false
       override val isTerminated: Boolean                                   = false
       override val shutdown: Unit                                          = ()
       override val shutdownNow: ju.List[Runnable]                          = ju.Collections.emptyList[Runnable]
-      override def execute(runnable: Runnable): Unit                       = asEC execute runnable
-      override def reportFailure(t: Throwable): Unit                       = asEC reportFailure t
+      override def execute(runnable: Runnable): Unit                       = asExecutionContext execute runnable
+      override def reportFailure(t: Throwable): Unit                       = asExecutionContext reportFailure t
       override def awaitTermination(length: Long, unit: TimeUnit): Boolean = false
     }
 

--- a/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/ExecutorPlatformSpecific.scala
@@ -25,7 +25,7 @@ trait ExecutorPlatformSpecific { this: Executor =>
   /**
    * Views this `Executor` as a Scala `ExecutionContextExecutorService`.
    */
-  lazy val asECES: ExecutionContextExecutorService =
+  lazy val asExecutionContextExecutorService: ExecutionContextExecutorService =
     new AbstractExecutorService with ExecutionContextExecutorService {
       override val prepare: ExecutionContext                               = asExecutionContext
       override val isShutdown: Boolean                                     = false

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -802,28 +802,11 @@ object IO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunction]]
-   */
-  def fromFunction[A](f: Any => A): IO[Nothing, A] = ZIO.fromFunction(f)
-
-  /**
-   * @see [[zio.ZIO.fromFunctionFuture]]
-   */
-  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
-    ZIO.fromFunctionFuture(f)
-
-  /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  @deprecated("use fromFunctionZIO", "2.0.0")
+  @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[E, A](f: Any => IO[E, A]): IO[E, A] =
     ZIO.fromFunctionM(f)
-
-  /**
-   * @see [[zio.ZIO.fromFunctionZIO]]
-   */
-  def fromFunctionZIO[E, A](f: Any => IO[E, A]): IO[E, A] =
-    ZIO.fromFunctionZIO(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
@@ -866,11 +849,6 @@ object IO {
   @deprecated("use failCauseWith", "2.0.0")
   def haltWith[E](function: (() => ZTrace) => Cause[E]): IO[E, Nothing] =
     ZIO.haltWith(function)
-
-  /**
-   * @see [[zio.ZIO.identity]]
-   */
-  def identity: IO[Nothing, Any] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.ifM]]
@@ -1103,6 +1081,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.require]]
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[E, A](error: => E): IO[E, Option[A]] => IO[E, A] =
     ZIO.require[Any, E, A](error)
 

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -810,13 +810,6 @@ object IO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunctionM]]
-   */
-  @deprecated("use accessZIO", "2.0.0")
-  def fromFunctionM[E, A](f: Any => IO[E, A]): IO[E, A] =
-    ZIO.fromFunctionM(f)
-
-  /**
    * @see See [[zio.ZIO.fromFuture]]
    */
   def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -94,7 +94,7 @@ final class Promise[E, A] private (
    * that if you do not need to memoize the result of the specified effect.
    */
   def complete(io: IO[E, A]): UIO[Boolean] =
-    io.to(this)
+    io.intoPromise(this)
 
   /**
    * Completes the promise with the specified effect. If the promise has

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -612,12 +612,6 @@ object RIO {
     ZIO.filterNotPar(as)(f)
 
   /**
-   * @see See [[zio.ZIO.first]]
-   */
-  def first[A]: RIO[(A, Any), A] =
-    ZIO.first
-
-  /**
    * @see See [[zio.ZIO.firstSuccessOf]]
    */
   def firstSuccessOf[R, A](
@@ -825,29 +819,11 @@ object RIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see See [[zio.ZIO.fromFunction]]
-   */
-  def fromFunction[R, A](f: R => A): URIO[R, A] =
-    ZIO.fromFunction(f)
-
-  /**
-   * @see See [[zio.ZIO.fromFunctionFuture]]
-   */
-  def fromFunctionFuture[R, A](f: R => scala.concurrent.Future[A]): RIO[R, A] =
-    ZIO.fromFunctionFuture(f)
-
-  /**
    * @see See [[zio.ZIO.fromFunctionM]]
    */
-  @deprecated("use fromFunctionZIO", "2.0.0")
+  @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[R, A](f: R => Task[A]): RIO[R, A] =
     ZIO.fromFunctionM(f)
-
-  /**
-   * @see See [[zio.ZIO.fromFunctionZIO]]
-   */
-  def fromFunctionZIO[R, A](f: R => Task[A]): RIO[R, A] =
-    ZIO.fromFunctionZIO(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
@@ -897,11 +873,6 @@ object RIO {
   @deprecated("use failCauseWith", "2.0.0")
   def haltWith[R](function: (() => ZTrace) => Cause[Throwable]): RIO[R, Nothing] =
     ZIO.haltWith(function)
-
-  /**
-   * @see See [[zio.ZIO.identity]]
-   */
-  def identity[R]: RIO[R, R] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.ifM]]
@@ -1142,8 +1113,9 @@ object RIO {
     ZIO.replicateZIODiscard(n)(effect)
 
   /**
-   * @see See [[zio.ZIO.require]]
+   * @see See [[zio.ZIO.someOrFail]]
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[A](error: => Throwable): IO[Throwable, Option[A]] => IO[Throwable, A] =
     ZIO.require[Any, Throwable, A](error)
 
@@ -1162,12 +1134,6 @@ object RIO {
    * @see See [[zio.ZIO.runtime]]
    */
   def runtime[R]: ZIO[R, Nothing, Runtime[R]] = ZIO.runtime
-
-  /**
-   * @see See [[zio.ZIO.second]]
-   */
-  def second[A]: RIO[(Any, A), A] =
-    ZIO.second
 
   /**
    * @see See [[zio.ZIO.setState]]
@@ -1250,12 +1216,6 @@ object RIO {
    */
   def suspendWith[R, A](p: (Platform, Fiber.Id) => RIO[R, A]): RIO[R, A] =
     ZIO.suspendWith(p)
-
-  /**
-   * @see See [[zio.ZIO.swap]]
-   */
-  def swap[A, B]: RIO[(A, B), (B, A)] =
-    ZIO.swap
 
   /**
    * @see See [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -827,6 +827,13 @@ object RIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
+   * @see See [[zio.ZIO.fromFunction]]
+   */
+  @deprecated("use access", "2.0.0")
+  def fromFunction[R, A](f: R => A): URIO[R, A] =
+    ZIO.fromFunction(f)
+
+  /**
    * @see See [[zio.ZIO.fromFunctionM]]
    */
   @deprecated("use accessZIO", "2.0.0")
@@ -1121,7 +1128,7 @@ object RIO {
     ZIO.replicateZIODiscard(n)(effect)
 
   /**
-   * @see See [[zio.ZIO.someOrFail]]
+   * @see See [[zio.ZIO.require]]
    */
   @deprecated("use someOrFail", "2.0.0")
   def require[A](error: => Throwable): IO[Throwable, Option[A]] => IO[Throwable, A] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -803,13 +803,6 @@ object Task extends TaskPlatformSpecific {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunctionM]]
-   */
-  @deprecated("use accessZIO", "2.0.0")
-  def fromFunctionM[A](f: Any => Task[A]): Task[A] =
-    ZIO.fromFunctionM(f)
-
-  /**
    * @see See [[zio.ZIO.fromFuture]]
    */
   def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -795,34 +795,19 @@ object Task extends TaskPlatformSpecific {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunction]]
-   */
-  def fromFunction[A](f: Any => A): Task[A] = ZIO.fromFunction(f)
-
-  /**
    * @see See [[zio.ZIO.fromFutureInterrupt]]
    */
   def fromFutureInterrupt[A](make: ExecutionContext => scala.concurrent.Future[A]): Task[A] =
     ZIO.fromFutureInterrupt(make)
 
-  /**
-   * @see [[zio.ZIO.fromFunctionFuture]]
-   */
-  def fromFunctionFuture[A](f: Any => scala.concurrent.Future[A]): Task[A] =
-    ZIO.fromFunctionFuture(f)
 
   /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  @deprecated("use fromFunctionZIO", "2.0.0")
+  @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[A](f: Any => Task[A]): Task[A] =
     ZIO.fromFunctionM(f)
 
-  /**
-   * @see [[zio.ZIO.fromFunctionZIO]]
-   */
-  def fromFunctionZIO[A](f: Any => Task[A]): Task[A] =
-    ZIO.fromFunctionZIO(f)
 
   /**
    * @see See [[zio.ZIO.fromFuture]]
@@ -854,11 +839,6 @@ object Task extends TaskPlatformSpecific {
   @deprecated("use failCauseWith", "2.0.0")
   def haltWith[E <: Throwable](function: (() => ZTrace) => Cause[E]): Task[Nothing] =
     ZIO.haltWith(function)
-
-  /**
-   * @see [[zio.ZIO.identity]]
-   */
-  def identity: Task[Any] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.ifM]]
@@ -1088,6 +1068,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.require]]
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[A](error: => Throwable): Task[Option[A]] => Task[A] =
     ZIO.require[Any, Throwable, A](error)
 

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -710,29 +710,18 @@ object UIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunction]]
-   */
-  def fromFunction[A](f: Any => A): UIO[A] = ZIO.fromFunction(f)
-
-  /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  @deprecated("use fromFunctionZIO", "2.0.0")
+  @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[A](f: Any => UIO[A]): UIO[A] =
-    ZIO.fromFunctionM(f)
-
-  /**
-   * @see [[zio.ZIO.fromFunctionZIO]]
-   */
-  def fromFunctionZIO[A](f: Any => UIO[A]): UIO[A] =
-    ZIO.fromFunctionZIO(f)
+    ZIO.accessZIO(f)
 
   /**
    * @see See [[zio.ZIO.halt]]
    */
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Nothing]): UIO[Nothing] =
-    ZIO.halt(cause)
+    ZIO.failCause(cause)
 
   /**
    * @see [[zio.ZIO.haltWith]]
@@ -740,11 +729,6 @@ object UIO {
   @deprecated("use failCauseWith", "2.0.0")
   def haltWith(function: (() => ZTrace) => Cause[Nothing]): UIO[Nothing] =
     ZIO.haltWith(function)
-
-  /**
-   * @see [[zio.ZIO.identity]]
-   */
-  def identity: UIO[Any] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -718,18 +718,11 @@ object UIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunctionM]]
-   */
-  @deprecated("use accessZIO", "2.0.0")
-  def fromFunctionM[A](f: Any => UIO[A]): UIO[A] =
-    ZIO.accessZIO(f)
-
-  /**
    * @see See [[zio.ZIO.halt]]
    */
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Nothing]): UIO[Nothing] =
-    ZIO.failCause(cause)
+    ZIO.halt(cause)
 
   /**
    * @see [[zio.ZIO.haltWith]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -537,12 +537,6 @@ object URIO {
     ZIO.filterNotPar(as)(f)
 
   /**
-   * @see [[zio.ZIO.first]]
-   */
-  def first[A]: URIO[(A, Any), A] =
-    ZIO.first
-
-  /**
    * @see [[zio.ZIO.firstSuccessOf]]
    */
   def firstSuccessOf[R, A](
@@ -750,23 +744,11 @@ object URIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
-   * @see [[zio.ZIO.fromFunction]]
-   */
-  def fromFunction[R, A](f: R => A): URIO[R, A] =
-    ZIO.fromFunction(f)
-
-  /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
-  @deprecated("use fromFunctionZIO", "2.0.0")
+  @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[R, A](f: R => UIO[A]): URIO[R, A] =
-    ZIO.fromFunctionM(f)
-
-  /**
-   * @see [[zio.ZIO.fromFunctionZIO]]
-   */
-  def fromFunctionZIO[R, A](f: R => UIO[A]): URIO[R, A] =
-    ZIO.fromFunctionZIO(f)
+    ZIO.accessZIO(f)
 
   /**
    * @see [[zio.ZIO.getState]]
@@ -793,11 +775,6 @@ object URIO {
   @deprecated("use failCauseWith", "2.0.0")
   def haltWith[R](function: (() => ZTrace) => Cause[Nothing]): URIO[R, Nothing] =
     ZIO.haltWith(function)
-
-  /**
-   * @see [[zio.ZIO.identity]]
-   */
-  def identity[R]: URIO[R, R] = ZIO.identity
 
   /**
    * @see [[zio.ZIO.ifM]]
@@ -1026,12 +1003,6 @@ object URIO {
   def runtime[R]: URIO[R, Runtime[R]] = ZIO.runtime
 
   /**
-   * @see [[zio.ZIO.second]]
-   */
-  def second[A]: URIO[(Any, A), A] =
-    ZIO.second
-
-  /**
    * @see [[zio.ZIO.setState]]
    */
   def setState[S: Tag](s: S): ZIO[Has[ZState[S]], Nothing, Unit] =
@@ -1100,11 +1071,6 @@ object URIO {
    */
   def succeedBlocking[A](a: => A): UIO[A] =
     ZIO.succeedBlocking(a)
-
-  /**
-   * @see [[zio.ZIO.swap]]
-   */
-  def swap[A, B]: URIO[(A, B), (B, A)] = ZIO.swap
 
   /**
    * @see [[zio.ZIO.trace]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -752,11 +752,18 @@ object URIO {
     ZIO.fromFiberZIO(fiber)
 
   /**
+   * @see [[zio.ZIO.fromFunction]]
+   */
+  @deprecated("use access", "2.0.0")
+  def fromFunction[R, A](f: R => A): URIO[R, A] =
+    ZIO.fromFunction(f)
+
+  /**
    * @see [[zio.ZIO.fromFunctionM]]
    */
   @deprecated("use accessZIO", "2.0.0")
   def fromFunctionM[R, A](f: R => UIO[A]): URIO[R, A] =
-    ZIO.accessZIO(f)
+    ZIO.fromFunctionM(f)
 
   /**
    * @see [[zio.ZIO.getState]]

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -62,10 +62,10 @@ object ZIOAspect {
   /**
    * As aspect that runs effects on the specified `ExecutionContext`.
    */
-  def on(ec: ExecutionContext): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+  def lockExecutionContext(ec: ExecutionContext): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
-        zio.on(ec)
+        zio.lockExecutionContext(ec)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -395,7 +395,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * resourceful function.
    */
   def fromFunctionManaged[A, E, B: Tag](f: A => ZManaged[Any, E, B]): ZLayer[A, E, Has[B]] =
-    fromManaged(ZManaged.fromFunctionManaged(f))
+    fromManaged(ZManaged.accessManaged(f))
 
   /**
    * Constructs a layer from the environment using the specified function,
@@ -417,7 +417,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * resourceful function, which must return one or more services.
    */
   def fromFunctionManyManaged[A, E, B](f: A => ZManaged[Any, E, B]): ZLayer[A, E, B] =
-    ZLayer(ZManaged.fromFunctionManaged(f))
+    ZLayer(ZManaged.accessManaged(f))
 
   /**
    * Constructs a layer from the environment using the specified effectful
@@ -4233,7 +4233,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * Constructs a layer from a managed resource.
    */
   def fromManaged[R, E, A: Tag](m: ZManaged[R, E, A]): ZLayer[R, E, Has[A]] =
-    ZLayer(m.asService)
+    ZLayer(m.map(Has(_)))
 
   /**
    * Constructs a layer from a managed resource, which must return one or more

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -4246,7 +4246,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * Constructs a layer from the specified effect.
    */
   def fromZIO[R, E, A: Tag](zio: ZIO[R, E, A]): ZLayer[R, E, Has[A]] =
-    fromZIOMany(zio.asService)
+    fromZIOMany(zio.map(Has(_)))
 
   /**
    * Constructs a layer from the specified effect, which must return one or

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -70,6 +70,15 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
     self.orDie
 
   /**
+   * Symbolic alias for zip.
+   */
+  @deprecated("use zip", "2.0.0")
+  def &&&[R1 <: R, E1 >: E, B](that: ZManaged[R1, E1, B])(implicit
+    zippable: Zippable[A, B]
+  ): ZManaged[R1, E1, zippable.Out] =
+    self <*> that
+
+  /**
    * Symbolic alias for zipParRight
    */
   def &>[R1 <: R, E1 >: E, A1](that: ZManaged[R1, E1, A1]): ZManaged[R1, E1, A1] =
@@ -2147,6 +2156,13 @@ object ZManaged extends ZManagedPlatformSpecific {
     succeed(v).flatMap(_.fold(fail(_), succeedNow))
 
   /**
+   * Lifts a function `R => A` into a `ZManaged[R, Nothing, A]`.
+   */
+  @deprecated("use access", "2.0.0")
+  def fromFunction[R, A](f: R => A): ZManaged[R, Nothing, A] =
+    ZManaged.fromZIO(ZIO.environment[R]).map(f)
+
+  /**
    * Lifts an effectful function whose effect requires no environment into
    * an effect that requires the input to the function.
    */
@@ -2648,6 +2664,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * Requires that the given `ZManaged[E, Option[A]]` contain a value. If there is no
    * value, then the specified error will be raised.
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[R, E, A](error: => E): ZManaged[R, E, Option[A]] => ZManaged[R, E, A] =
     (zManaged: ZManaged[R, E, Option[A]]) => zManaged.flatMap(_.fold[ZManaged[R, E, A]](fail(error))(succeedNow))
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -596,7 +596,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
                         self.zio
                           .provide((r, finalizers))
                           .map(_._2)
-                          .to(promise)
+                          .intoPromise(promise)
                       }
                       .once
       } yield (complete *> promise.await).toManaged

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -49,7 +49,14 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   /**
    * Views this `Executor` as a Scala `ExecutionContext`.
    */
+  @deprecated("use asExecutionContext", "2.0.0")
   lazy val asEC: ExecutionContext =
+    asExecutionContext
+
+  /**
+   * Views this `Executor` as a Scala `ExecutionContext`.
+   */
+  lazy val asExecutionContext: ExecutionContext =
     new ExecutionContext {
       override def execute(r: Runnable): Unit =
         if (!submit(r)) throw new RejectedExecutionException("Rejected: " + r.toString)

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -366,6 +366,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.require]]
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[E, A](error: => E): STM[E, Option[A]] => STM[E, A] =
     ZSTM.require[Any, E, A](error)
 

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -208,21 +208,16 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.fromFunction]]
    */
+  @deprecated("use access", "2.0.0")
   def fromFunction[A](f: Any => A): USTM[A] =
     ZSTM.fromFunction(f)
 
   /**
    * @see See [[zio.stm.ZSTM.fromFunctionM]]
    */
-  @deprecated("use fromFunctionSTM", "2.0.0")
+  @deprecated("use accessSTM", "2.0.0")
   def fromFunctionM[E, A](f: Any => STM[E, A]): STM[E, A] =
     ZSTM.fromFunctionM(f)
-
-  /**
-   * @see See [[zio.stm.ZSTM.fromFunctionSTM]]
-   */
-  def fromFunctionSTM[E, A](f: Any => STM[E, A]): STM[E, A] =
-    ZSTM.fromFunctionSTM(f)
 
   /**
    * @see See [[zio.stm.ZSTM.fromOption]]
@@ -235,11 +230,6 @@ object STM {
    */
   def fromTry[A](a: => Try[A]): TaskSTM[A] =
     ZSTM.fromTry(a)
-
-  /**
-   * @see See [[zio.stm.ZSTM.identity]]
-   */
-  def identity: USTM[Any] = ZSTM.identity
 
   /**
    * @see See [[zio.stm.ZSTM.ifM]]

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -363,7 +363,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Unwraps the optional success of this effect, but can fail with None value.
    */
-  @deprecated("use someOrFail", "2.0.0")
+  @deprecated("use some", "2.0.0")
   def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZSTM[R, Option[Nothing], B] =
     foldSTM(
       ev1,

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -128,6 +128,14 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     orTry(that)
 
   /**
+   * Feeds the value produced by this effect to the specified function,
+   * and then runs the returned effect as well to produce its results.
+   */
+  @deprecated("use flatMap", "2.0.0")
+  def >>=[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
+    self flatMap f
+
+  /**
    * Returns an effect that submerges the error case of an `Either` into the
    * `STM`. The inverse operation of `STM.either`.
    */
@@ -1438,6 +1446,7 @@ object ZSTM {
    * Requires that the given `ZSTM[R, E, Option[A]]` contain a value. If there is no
    * value, then the specified error will be raised.
    */
+  @deprecated("use someOrFail", "2.0.0")
   def require[R, E, A](error: => E): ZSTM[R, E, Option[A]] => ZSTM[R, E, A] =
     _.flatMap(_.fold[ZSTM[R, E, A]](fail(error))(succeedNow))
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -82,15 +82,9 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Alias for `<*>` and `zip`.
    */
+  @deprecated("use zip", "2.0.0")
   def &&&[R1 <: R, E1 >: E, B](that: ZSTM[R1, E1, B])(implicit zippable: Zippable[A, B]): ZSTM[R1, E1, zippable.Out] =
     self <*> that
-
-  /**
-   * Splits the environment, providing the first part to this effect and the
-   * second part to that effect.
-   */
-  def ***[R1, E1 >: E, B](that: ZSTM[R1, E1, B]): ZSTM[(R, R1), E1, (A, B)] =
-    (ZSTM.first >>> self) &&& (ZSTM.second >>> that)
 
   /**
    * Sequentially zips this value with the specified one, discarding the
@@ -98,13 +92,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    */
   def *>[R1 <: R, E1 >: E, B](that: => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
     self zipRight that
-
-  /**
-   * Depending on provided environment, returns either this one or the other
-   * effect lifted in `Left` or `Right`, respectively.
-   */
-  def +++[R1, B, E1 >: E](that: ZSTM[R1, E1, B]): ZSTM[Either[R, R1], E1, Either[A, B]] =
-    ZSTM.accessSTM[Either[R, R1]](_.fold(self.provide(_).map(Left(_)), that.provide(_).map(Right(_))))
 
   /**
    * Sequentially zips this value with the specified one, discarding the
@@ -128,12 +115,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     self.orElseEither(that)
 
   /**
-   * Propagates self environment to that.
-   */
-  def <<<[R1, E1 >: E](that: ZSTM[R1, E1, R]): ZSTM[R1, E1, A] =
-    that >>> self
-
-  /**
    * Tries this effect first, and if it fails or retries, tries the other effect.
    */
   def <>[R1 <: R, E1, A1 >: A](that: => ZSTM[R1, E1, A1]): ZSTM[R1, E1, A1] =
@@ -147,36 +128,11 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     orTry(that)
 
   /**
-   * Feeds the value produced by this effect to the specified function,
-   * and then runs the returned effect as well to produce its results.
-   */
-  def >>=[R1 <: R, E1 >: E, B](f: A => ZSTM[R1, E1, B]): ZSTM[R1, E1, B] =
-    self flatMap f
-
-  /**
-   * Propagates the given environment to self.
-   */
-  def >>>[E1 >: E, B](that: ZSTM[A, E1, B]): ZSTM[R, E1, B] =
-    flatMap(that.provide)
-
-  /**
-   * Depending on provided environment returns either this one or the other effect.
-   */
-  def |||[R1, E1 >: E, A1 >: A](that: ZSTM[R1, E1, A1]): ZSTM[Either[R, R1], E1, A1] =
-    ZSTM.accessSTM[Either[R, R1]](_.fold(self.provide, that.provide))
-
-  /**
    * Returns an effect that submerges the error case of an `Either` into the
    * `STM`. The inverse operation of `STM.either`.
    */
   def absolve[E1 >: E, B](implicit ev: A <:< Either[E1, B]): ZSTM[R, E1, B] =
     ZSTM.absolve(self.map(ev))
-
-  /**
-   * Named alias for `>>>`.
-   */
-  def andThen[E1 >: E, B](that: ZSTM[A, E1, B]): ZSTM[R, E1, B] =
-    self >>> that
 
   /**
    * Maps the success value of this effect to the specified constant value.
@@ -237,12 +193,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    */
   def collectSTM[R1 <: R, E1 >: E, B](pf: PartialFunction[A, ZSTM[R1, E1, B]]): ZSTM[R1, E1, B] =
     foldSTM(ZSTM.fail(_), (a: A) => if (pf.isDefinedAt(a)) pf(a) else ZSTM.retry)
-
-  /**
-   * Named alias for `<<<`.
-   */
-  def compose[R1, E1 >: E](that: ZSTM[R1, E1, R]): ZSTM[R1, E1, A] =
-    self <<< that
 
   /**
    * Commits this transaction atomically.
@@ -413,6 +363,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Unwraps the optional success of this effect, but can fail with None value.
    */
+  @deprecated("use someOrFail", "2.0.0")
   def get[B](implicit ev1: E <:< Nothing, ev2: A <:< Option[B]): ZSTM[R, Option[Nothing], B] =
     foldSTM(
       ev1,
@@ -506,38 +457,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
       e => ZSTM.fail(Some(e)),
       _.fold[ZSTM[R, Option[E], Unit]](ZSTM.unit)(_ => ZSTM.fail(None))
     )
-
-  /**
-   * Propagates the success value to the first element of a tuple, but
-   * passes the effect input `R` along unmodified as the second element
-   * of the tuple.
-   */
-  def onFirst[R1 <: R]: ZSTM[R1, E, (A, R1)] =
-    self <*> ZSTM.identity[R1]
-
-  /**
-   * Returns this effect if environment is on the left, otherwise returns
-   * whatever is on the right unmodified. Note that the result is lifted
-   * in either.
-   */
-  def onLeft[C]: ZSTM[Either[R, C], E, Either[A, C]] =
-    self +++ ZSTM.identity[C]
-
-  /**
-   * Returns this effect if environment is on the right, otherwise returns
-   * whatever is on the left unmodified. Note that the result is lifted
-   * in either.
-   */
-  def onRight[C]: ZSTM[Either[C, R], E, Either[C, A]] =
-    ZSTM.identity[C] +++ self
-
-  /**
-   * Propagates the success value to the second element of a tuple, but
-   * passes the effect input `R` along unmodified as the first element
-   * of the tuple.
-   */
-  def onSecond[R1 <: R]: ZSTM[R1, E, (R1, A)] =
-    ZSTM.identity[R1] <*> self
 
   /**
    * Converts the failure channel into an `Option`.
@@ -1190,13 +1109,6 @@ object ZSTM {
     filterNot[R, E, A, Iterable](as)(f).map(_.toSet)
 
   /**
-   * Returns an effectful function that extracts out the first element of a
-   * tuple.
-   */
-  def first[A]: ZSTM[(A, Any), Nothing, A] =
-    fromFunction(_._1)
-
-  /**
    * Returns an effect that first executes the outer effect, and then executes
    * the inner effect, returning the value from the inner effect, and effectively
    * flattening a nested effect.
@@ -1290,6 +1202,7 @@ object ZSTM {
   /**
    * Lifts a function `R => A` into a `URSTM[R, A]`.
    */
+  @deprecated("use access", "2.0.0")
   def fromFunction[R, A](f: R => A): URSTM[R, A] =
     access(f)
 
@@ -1297,15 +1210,8 @@ object ZSTM {
    * Lifts an effectful function whose effect requires no environment into
    * an effect that requires the input to the function.
    */
-  @deprecated("use fromFunctionSTM", "2.0.0")
+  @deprecated("use accessSTM", "2.0.0")
   def fromFunctionM[R, E, A](f: R => STM[E, A]): ZSTM[R, E, A] =
-    fromFunctionSTM(f)
-
-  /**
-   * Lifts an effectful function whose effect requires no environment into
-   * an effect that requires the input to the function.
-   */
-  def fromFunctionSTM[R, E, A](f: R => STM[E, A]): ZSTM[R, E, A] =
     accessSTM(f)
 
   /**
@@ -1324,11 +1230,6 @@ object ZSTM {
         case Success(a) => STM.succeedNow(a)
       }
     }
-
-  /**
-   * Returns the identity effectful function, which performs no effects
-   */
-  def identity[R]: URSTM[R, R] = fromFunction[R, R](ZIO.identityFn)
 
   /**
    * Runs `onTrue` if the result of `b` is `true` and `onFalse` otherwise.
@@ -1553,13 +1454,6 @@ object ZSTM {
     succeed(Right(a))
 
   /**
-   * Returns an effectful function that extracts out the second element of a
-   * tuple.
-   */
-  def second[A]: URSTM[(Any, A), A] =
-    fromFunction(_._2)
-
-  /**
    * Accesses the specified service in the environment of the effect.
    */
   def service[A: Tag]: ZSTM[Has[A], Nothing, A] =
@@ -1606,12 +1500,6 @@ object ZSTM {
    */
   def suspend[R, E, A](stm: => ZSTM[R, E, A]): ZSTM[R, E, A] =
     STM.succeed(stm).flatten
-
-  /**
-   * Returns an effectful function that merely swaps the elements in a `Tuple2`.
-   */
-  def swap[A, B]: URSTM[(A, B), (B, A)] =
-    fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Returns an `STM` effect that succeeds with `Unit`.

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -200,22 +200,6 @@ val ztry = ZIO.fromTry(Try(42 / 0))
 
 The error type of the resulting effect will always be `Throwable`, because `Try` can only fail with values of type `Throwable`.
 
-#### Function
-
-| Function          | Input Type      | Output Type    |
-|-------------------|-----------------|----------------|
-| `fromFunction`    | `R => A`        | `URIO[R, A]`   |
-| `fromFunctionZIO` | `R => IO[E, A]` | `ZIO[R, E, A]` |
-
-A function `A => B` can be converted into a ZIO effect with `ZIO.fromFunction`:
-
-```scala mdoc:silent
-val zfun: URIO[Int, Int] =
-  ZIO.fromFunction((i: Int) => i * i)
-```
-
-The environment type of the effect is `A` (the input type of the function), because in order to run the effect, it must be supplied with a value of this type.
-
 #### Future
 
 | Function              | Input Type                                       | Output Type        |

--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -145,7 +145,7 @@ val s2 = ZStream.fromChunks(Chunk(1, 2, 3), Chunk(4, 5, 6))
 
 ### From Effect
 
-**ZStream.fromEffect** — We can create a stream from an effect by using `ZStream.fromEffect` constructor. For example, the following stream is a stream that reads a line from a user:
+**ZStream.fromZIO** — We can create a stream from an effect by using `ZStream.fromZIO` constructor. For example, the following stream is a stream that reads a line from a user:
 
 ```scala mdoc:silent:nest
 val readline: ZStream[Has[Console], IOException, String] = 
@@ -159,11 +159,11 @@ val randomInt: ZStream[Has[Random], Nothing, Int] =
   ZStream.fromZIO(Random.nextInt)
 ```
 
-**ZStream.fromEffectOption** — In some cases, depending on the result of the effect, we should decide to emit an element or return an empty stream. In these cases, we can use `fromEffectOption` constructor:
+**ZStream.fromZIOOption** — In some cases, depending on the result of the effect, we should decide to emit an element or return an empty stream. In these cases, we can use `fromZIOOption` constructor:
 
 ```scala 
 object ZStream {
-  def fromEffectOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] = ???
+  def fromZIOOption[R, E, A](fa: ZIO[R, Option[E], A]): ZStream[R, E, A] = ???
 }
 ```
 
@@ -304,7 +304,7 @@ val repeatZeroEverySecond: ZStream[Has[Clock], Nothing, Int] =
   ZStream.repeatWith(0, Schedule.spaced(1.seconds))
 ```
 
-**ZStream.repeatEffect** — Assume we have an effectful API, and we need to call that API and create a stream from the result of that. We can create a stream from that effect that repeats forever.
+**ZStream.repeatZIO** — Assume we have an effectful API, and we need to call that API and create a stream from the result of that. We can create a stream from that effect that repeats forever.
 
 Let's see an example of creating a stream of random numbers:
 
@@ -313,7 +313,7 @@ val randomInts: ZStream[Has[Random], Nothing, Int] =
   ZStream.repeatZIO(Random.nextInt)
 ```
 
-**ZStream.repeatEffectOption** — We can repeatedly evaluate the given effect and terminate the stream based on some conditions. 
+**ZStream.repeatZIOOption** — We can repeatedly evaluate the given effect and terminate the stream based on some conditions. 
 
 Let's create a stream repeatedly from user inputs until user enter "EOF" string:
 
@@ -327,7 +327,7 @@ val userInputs: ZStream[Has[Console], IOException, String] =
   )
 ```
 
-Here is another interesting example of using `repeatEffectOption`; In this example, we are draining an `Iterator` to create a stream of that iterator:
+Here is another interesting example of using `repeatZIOOption`; In this example, we are draining an `Iterator` to create a stream of that iterator:
 
 ```scala mdoc:silent:nest
 def drainIterator[A](it: Iterator[A]): ZStream[Any, Throwable, A] =
@@ -346,7 +346,7 @@ val stream: ZStream[Has[Clock], Nothing, Unit] =
   ZStream.tick(1.seconds)
 ```
 
-There are some other variant of repetition API like `repeatEffectWith`, `repeatEffectOption`, `repeatEffectChunk` and `repeatEffectChunkOption`.
+There are some other variant of repetition API like `repeatZIOWith`, `repeatZIOOption`, `repeatZIOChunk` and `repeatZIOChunkOption`.
 
 ### From Unfolding/Pagination
 
@@ -500,13 +500,13 @@ val stream: ZStream[Any, IOException, Byte] =
   ZStream.fromInputStream(new FileInputStream("file.txt"))
 ```
 
-Note that the InputStream will not be explicitly closed after it is exhausted. Use `ZStream.fromInputStreamEffect`, or `ZStream.fromInputStreamManaged` instead.
+Note that the InputStream will not be explicitly closed after it is exhausted. Use `ZStream.fromInputStreamZIO`, or `ZStream.fromInputStreamManaged` instead.
 
-**ZStream.fromInputStreamEffect** — Creates a stream from a `java.io.InputStream`. Ensures that the InputStream is closed after it is exhausted:
+**ZStream.fromInputStreamZIO** — Creates a stream from a `java.io.InputStream`. Ensures that the InputStream is closed after it is exhausted:
 
 ```scala mdoc:silent:nest
 val stream: ZStream[Any, IOException, Byte] = 
-  ZStream.fromInputStreamEffect(
+  ZStream.fromInputStreamZIO(
     ZIO.attempt(new FileInputStream("file.txt"))
       .refineToOrDie[IOException]
   )
@@ -537,7 +537,7 @@ val stream: ZStream[Any, IOException, Char] =
    ZStream.fromReader(new FileReader("file.txt"))
 ```
 
-ZIO Stream also has `ZStream.fromReaderEffect` and `ZStream.fromReaderManaged` variants.
+ZIO Stream also has `ZStream.fromReaderZIO` and `ZStream.fromReaderManaged` variants.
 
 ### From Java Stream
 
@@ -548,7 +548,7 @@ val stream: ZStream[Any, Throwable, Int] =
   ZStream.fromJavaStream(java.util.stream.Stream.of(1, 2, 3))
 ```
 
-ZIO Stream also has `ZStream.fromJavaStream`, `ZStream.fromJavaStreamEffect` and `ZStream.fromJavaStreamManaged` variants.
+ZIO Stream also has `ZStream.fromJavaStream`, `ZStream.fromJavaStreamZIO` and `ZStream.fromJavaStreamManaged` variants.
 
 ### From Queue and Hub
 

--- a/docs/howto/interop/with-cats-effect.md
+++ b/docs/howto/interop/with-cats-effect.md
@@ -575,15 +575,15 @@ import zio.interop.catz._
 def transactor: ZManaged[Any, Throwable, HikariTransactor[Task]] =
   for {
     rt <- ZIO.runtime[Any].toManaged
-    be <- ZIO.blockingExecutor.toManaged            // our blocking EC
+    be <- ZIO.blockingExecutor.toManaged                          // our blocking EC
     xa <- HikariTransactor
             .newHikariTransactor[Task](
-              "org.h2.Driver",                      // driver classname
-              "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", // connect URL
-              "sa",                                 // username
-              "",                                   // password
-              rt.platform.executor.asEC,            // await connection here
-              Blocker.liftExecutionContext(be.asEC) // execute JDBC operations here
+              "org.h2.Driver",                                    // driver classname
+              "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",               // connect URL
+              "sa",                                               // username
+              "",                                                 // password
+              rt.platform.executor.asExecutionContext,            // await connection here
+              Blocker.liftExecutionContext(be.asExecutionContext) // execute JDBC operations here
             )
             .toManagedZIO
   } yield xa
@@ -625,11 +625,11 @@ def transactor: ZManaged[Any, Throwable, HikariTransactor[Task]] =
     xa <-
       HikariTransactor
         .newHikariTransactor[Task](
-          "org.h2.Driver",                      // driver classname
-          "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", // connect URL
-          "sa",                                 // username
-          "",                                   // password
-          rt.platform.executor.asEC             // await connection here
+          "org.h2.Driver",                        // driver classname
+          "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",   // connect URL
+          "sa",                                   // username
+          "",                                     // password
+          rt.platform.executor.asExecutionContext // await connection here
         )
         .toManaged
   } yield xa

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -102,17 +102,6 @@ val ztry = ZIO.fromTry(Try(42 / 0))
 
 The error type of the resulting effect will always be `Throwable`, because `Try` can only fail with values of type `Throwable`.
 
-### Function
-
-A function `A => B` can be converted into a ZIO effect with `ZIO.fromFunction`:
-
-```scala mdoc:silent
-val zfun: URIO[Int, Int] =
-  ZIO.fromFunction((i: Int) => i * i)
-```
-
-The environment type of the effect is `A` (the input type of the function), because in order to run the effect, it must be supplied with a value of this type.
-
 ### Future
 
 A `Future` can be converted into a ZIO effect using `ZIO.fromFuture`:

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -51,14 +51,14 @@ object ZStreamSpec extends ZIOBaseSpec {
         ) @@ TestAspect.jvmOnly, // This is horrendously slow on Scala.js for some reason
         test("access") {
           for {
-            result <- ZStream.access[String](identity).provide("test").runHead.get
+            result <- ZStream.access[String](identity).provide("test").runHead.some
 
           } yield assert(result)(equalTo("test"))
         },
         suite("accessZIO")(
           test("accessZIO") {
             for {
-              result <- ZStream.accessZIO[String](ZIO.succeed(_)).provide("test").runHead.get
+              result <- ZStream.accessZIO[String](ZIO.succeed(_)).provide("test").runHead.some
             } yield assert(result)(equalTo("test"))
           },
           test("accessZIO fails") {
@@ -70,7 +70,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("accessStream")(
           test("accessStream") {
             for {
-              result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.get
+              result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.some
             } yield assert(result)(equalTo("test"))
           },
           test("accessStream fails") {
@@ -3351,7 +3351,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               left   <- Queue.unbounded[Chunk[Int]]
               right  <- Queue.unbounded[Chunk[Int]]
               out    <- Queue.bounded[Take[Nothing, (Int, Int)]](1)
-              _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).into(out).fork
+              _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).intoQueue(out).fork
               _      <- left.offer(Chunk(0))
               _      <- right.offerAll(List(Chunk(0), Chunk(1)))
               chunk1 <- ZIO.replicateZIO(2)(out.take.flatMap(_.done)).map(_.flatten)

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -3417,10 +3417,11 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("zipWithLatest")(
           test("succeed") {
             for {
-              left   <- Queue.unbounded[Chunk[Int]]
-              right  <- Queue.unbounded[Chunk[Int]]
-              out    <- Queue.bounded[Take[Nothing, (Int, Int)]](1)
-              _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).runIntoQueue(out).fork
+              left  <- Queue.unbounded[Chunk[Int]]
+              right <- Queue.unbounded[Chunk[Int]]
+              out   <- Queue.bounded[Take[Nothing, (Int, Int)]](1)
+              _ <-
+                ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).runIntoQueue(out).fork
               _      <- left.offer(Chunk(0))
               _      <- right.offerAll(List(Chunk(0), Chunk(1)))
               chunk1 <- ZIO.collectAll(ZIO.replicate(2)(out.take.flatMap(_.done))).map(_.flatten)

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -3420,7 +3420,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               left   <- Queue.unbounded[Chunk[Int]]
               right  <- Queue.unbounded[Chunk[Int]]
               out    <- Queue.bounded[Take[Nothing, (Int, Int)]](1)
-              _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).runInto(out).fork
+              _      <- ZStream.fromChunkQueue(left).zipWithLatest(ZStream.fromChunkQueue(right))((_, _)).runIntoQueue(out).fork
               _      <- left.offer(Chunk(0))
               _      <- right.offerAll(List(Chunk(0), Chunk(1)))
               chunk1 <- ZIO.collectAll(ZIO.replicate(2)(out.take.flatMap(_.done))).map(_.flatten)

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -50,13 +50,13 @@ object ZStreamSpec extends ZIOBaseSpec {
         ) @@ TestAspect.jvmOnly, // This is horrendously slow on Scala.js for some reason
         test("access") {
           for {
-            result <- ZStream.access[String](identity).provide("test").runHead.get
+            result <- ZStream.access[String](identity).provide("test").runHead.some
           } yield assert(result)(equalTo("test"))
         },
         suite("accessZIO")(
           test("accessZIO") {
             for {
-              result <- ZStream.accessZIO[String](ZIO.succeed(_)).provide("test").runHead.get
+              result <- ZStream.accessZIO[String](ZIO.succeed(_)).provide("test").runHead.some
             } yield assert(result)(equalTo("test"))
           },
           test("accessZIO fails") {
@@ -68,7 +68,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("accessStream")(
           test("accessStream") {
             for {
-              result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.get
+              result <- ZStream.accessStream[String](ZStream.succeed(_)).provide("test").runHead.some
             } yield assert(result)(equalTo("test"))
           },
           test("accessStream fails") {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -116,11 +116,6 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     self zipRight that
 
   /**
-   * Symbolic alias for [[ZStream#flatMap]].
-   */
-  def >>=[R1 <: R, E1 >: E, O2](f0: O => ZStream[R1, E1, O2]): ZStream[R1, E1, O2] = flatMap(f0)
-
-  /**
    * Symbolic alias for [[ZStream#transduce]].
    */
   def >>>[R1 <: R, E1 >: E, O2 >: O, O3](transducer: ZTransducer[R1, E1, O2, O3]) =
@@ -1957,8 +1952,8 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     interruptWhen(Clock.sleep(duration))
 
   /**
-   * Enqueues elements of this stream into a queue. Stream failure and ending will also be
-   * signalled.
+   * Enqueues elements of this stream into a queue. Stream failure and ending
+   * will also be signalled.
    */
   @deprecated("use intoQueue", "2.0.0")
   final def into[R1 <: R, E1 >: E](
@@ -1985,8 +1980,8 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     intoQueueManaged(hub.toQueue)
 
   /**
-   * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow for scope
-   * composition.
+   * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow
+   * for scope composition.
    */
   @deprecated("use intoQueueManaged", "2.0.0")
   final def intoManaged[R1 <: R, E1 >: E](
@@ -1995,8 +1990,17 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     intoQueueManaged(queue)
 
   /**
-   * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow for scope
-   * composition.
+   * Enqueues elements of this stream into a queue. Stream failure and ending
+   * will also be signalled.
+   */
+  final def intoQueue[R1 <: R, E1 >: E](
+    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
+  ): ZIO[R1, E1, Unit] =
+    intoQueueManaged(queue).useDiscard(UIO.unit)
+
+  /**
+   * Like [[ZStream#intoQueue]], but provides the result as a [[ZManaged]] to
+   * allow for scope composition.
    */
   final def intoQueueManaged[R1 <: R, E1 >: E](
     queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
@@ -2016,15 +2020,6 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
       }
       _ <- pull.toManaged
     } yield ()
-
-  /**
-   * Enqueues elements of this stream into a queue. Stream failure and ending will also be
-   * signalled.
-   */
-  final def intoQueue[R1 <: R, E1 >: E](
-    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
-  ): ZIO[R1, E1, Unit] =
-    intoQueueManaged(queue).useDiscard(UIO.unit)
 
   /**
    * Locks the execution of this stream to the specified executor. Any streams

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -116,6 +116,13 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     self zipRight that
 
   /**
+   * Symbolic alias for [[ZStream#flatMap]].
+   */
+  @deprecated("use flatMap", "2.0.0")
+  def >>=[R1 <: R, E1 >: E, O2](f0: O => ZStream[R1, E1, O2]): ZStream[R1, E1, O2] =
+    flatMap(f0)
+
+  /**
    * Symbolic alias for [[ZStream#transduce]].
    */
   def >>>[R1 <: R, E1 >: E, O2 >: O, O3](transducer: ZTransducer[R1, E1, O2, O3]) =
@@ -3001,8 +3008,6 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   final def tap[R1 <: R, E1 >: E](f0: O => ZIO[R1, E1, Any]): ZStream[R1, E1, O] =
     mapZIO(o => f0(o).as(o))
 
-  // TODO: add tapError and tapCause and tapBoth
-
   /**
    * Throttles the chunks of this stream according to the given bandwidth parameters using the token bucket
    * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
@@ -3190,9 +3195,9 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
                 Some(ZScope.global)
               )
             case Current(fiber) =>
-              fiber.join flatMap store
+              fiber.join.flatMap(store)
             case NotStarted =>
-              chunks flatMap store
+              chunks.flatMap(store)
             case Done =>
               Pull.end
           }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1947,10 +1947,11 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    * Enqueues elements of this stream into a queue. Stream failure and ending will also be
    * signalled.
    */
+  @deprecated("use intoQueue", "2.0.0")
   final def into[R1 <: R, E1 >: E](
     queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
   ): ZIO[R1, E1, Unit] =
-    intoManaged(queue).useDiscard(UIO.unit)
+    intoQueue(queue)
 
   /**
    * Publishes elements of this stream to a hub. Stream failure and ending will
@@ -1959,7 +1960,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   final def intoHub[R1 <: R, E1 >: E](
     hub: ZHub[R1, Nothing, Nothing, Any, Take[E1, O], Any]
   ): ZIO[R1, E1, Unit] =
-    into(hub.toQueue)
+    intoQueue(hub.toQueue)
 
   /**
    * Like [[ZStream#intoHub]], but provides the result as a [[ZManaged]] to
@@ -1968,13 +1969,23 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
   final def intoHubManaged[R1 <: R, E1 >: E](
     hub: ZHub[R1, Nothing, Nothing, Any, Take[E1, O], Any]
   ): ZManaged[R1, E1, Unit] =
-    intoManaged(hub.toQueue)
+    intoQueueManaged(hub.toQueue)
 
   /**
    * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow for scope
    * composition.
    */
+  @deprecated("use intoQueueManaged", "2.0.0")
   final def intoManaged[R1 <: R, E1 >: E](
+    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
+  ): ZManaged[R1, E1, Unit] =
+    intoQueueManaged(queue)
+
+  /**
+   * Like [[ZStream#into]], but provides the result as a [[ZManaged]] to allow for scope
+   * composition.
+   */
+  final def intoQueueManaged[R1 <: R, E1 >: E](
     queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
   ): ZManaged[R1, E1, Unit] =
     for {
@@ -1992,6 +2003,15 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
       }
       _ <- pull.toManaged
     } yield ()
+
+  /**
+   * Enqueues elements of this stream into a queue. Stream failure and ending will also be
+   * signalled.
+   */
+  final def intoQueue[R1 <: R, E1 >: E](
+    queue: ZQueue[R1, Nothing, Nothing, Any, Take[E1, O], Any]
+  ): ZIO[R1, E1, Unit] =
+    intoQueueManaged(queue).useDiscard(UIO.unit)
 
   /**
    * Locks the execution of this stream to the specified executor. Any streams

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -649,7 +649,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                               latch.succeed(()) *>
                                 (errorSignal.await raceFirst f(outElem))
                                   .tapCause(errorSignal.failCause)
-                                  .to(p)
+                                  .intoPromise(p)
                             }.fork
                        _ <- latch.await
                      } yield ()

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -66,7 +66,8 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * Symbolic alias for [[ZStream#flatMap]].
    */
   @deprecated("use flatMap", "2.0.0")
-  def >>=[R1 <: R, E1 >: E, A2](f0: A => ZStream[R1, E1, A2]): ZStream[R1, E1, A2] = flatMap(f0)
+  def >>=[R1 <: R, E1 >: E, A2](f0: A => ZStream[R1, E1, A2]): ZStream[R1, E1, A2] =
+    flatMap(f0)
 
   // /**
   //  * Symbolic alias for [[ZStream#transduce]].
@@ -2064,7 +2065,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * Maps over elements of the stream with the specified effectful function.
    */
   def mapZIO[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1]): ZStream[R1, E1, A1] =
-    loopOnPartialChunksElements((a, emit) => f(a) flatMap emit)
+    loopOnPartialChunksElements((a, emit) => f(a).flatMap(emit))
 
   /**
    * Maps over elements of the stream with the specified effectful function,

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -2033,7 +2033,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * Maps over elements of the stream with the specified effectful function.
    */
   def mapZIO[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1]): ZStream[R1, E1, A1] =
-    loopOnPartialChunksElements((a, emit) => f(a) >>= emit)
+    loopOnPartialChunksElements((a, emit) => f(a) flatMap emit)
 
   /**
    * Maps over elements of the stream with the specified effectful function,

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -86,10 +86,12 @@ final class ZTestTask(
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
     Runtime((), specInstance.platform)
-      .unsafeRunAsyncWith((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged).useDiscard(ZIO.unit)) { exit =>
+      .unsafeRunAsyncWith {
+          run(eventHandler).toManaged.provideLayer(sbtTestLayer(loggers)).useDiscard(ZIO.unit)
+      } { exit =>
         exit match {
           case Exit.Failure(cause) => Console.err.println(s"$runnerType failed: " + cause.prettyPrint)
-          case _                   =>
+          case _ =>
         }
         continuation(Array())
       }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -155,7 +155,7 @@ object ZTestFrameworkSpec {
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
-          zTestTask.sendSummary.provide(Summary(1, 0, 0, "foo")),
+          zTestTask.sendSummary.provide(Summary(0, 0, 0, "foo")),
           TestArgs.empty
         )
       }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -134,7 +134,7 @@ object ZTestFrameworkSpec {
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
-          UIO.succeed(Summary(1, 0, 0, "foo")) >>> zTestTask.sendSummary,
+          zTestTask.sendSummary.provide(Summary(1, 0, 0, "foo")),
           TestArgs.empty
         )
       }
@@ -155,7 +155,7 @@ object ZTestFrameworkSpec {
         new ZTestTask(
           zTestTask.taskDef,
           zTestTask.testClassLoader,
-          UIO.succeed(Summary(0, 0, 0, "foo")) >>> zTestTask.sendSummary,
+          zTestTask.sendSummary.provide(Summary(1, 0, 0, "foo")),
           TestArgs.empty
         )
       }

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunner.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunner.scala
@@ -86,7 +86,9 @@ final class ZTestTask(
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
     Runtime((), specInstance.platform)
-      .unsafeRunAsyncWith((sbtTestLayer(loggers).build >>> run(eventHandler).toManaged).useDiscard(ZIO.unit)) { exit =>
+      .unsafeRunAsyncWith {
+         run(eventHandler).toManaged.provideLayer(sbtTestLayer(loggers)).useDiscard(ZIO.unit)
+      } { exit =>
         exit match {
           case Exit.Failure(cause) => Console.err.println(s"$runnerType failed: " + cause.prettyPrint)
           case _                   =>

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/package.scala
@@ -10,10 +10,10 @@ package object sbt {
 
   object SendSummary {
     def fromSend(send: Summary => Unit): SendSummary =
-      URIO.fromFunctionZIO(summary => URIO.succeed(send(summary)))
+      URIO.accessZIO(summary => URIO.succeed(send(summary)))
 
     def fromSendM(send: Summary => UIO[Unit]): SendSummary =
-      URIO.fromFunctionZIO(send)
+      URIO.accessZIO(send)
 
     def noop: SendSummary =
       UIO.unit

--- a/test/shared/src/main/scala/zio/test/mock/Mock.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Mock.scala
@@ -38,7 +38,7 @@ abstract class Mock[R <: Has[_]: Tag] { self =>
       if (!TestPlatform.isJS) runtime
       else
         runtime.withExecutor {
-          val ec = runtime.platform.executor.asEC
+          val ec = runtime.platform.executor.asExecutionContext
           Executor.fromExecutionContext(Int.MaxValue)(ec)
         }
     }


### PR DESCRIPTION
Starting a PR to discuss further `2.0` name changes and deprecations. 

The goal would be to help with API discovery by deprecating duplicated and/or non-idiomatic methods as well as rarely used symbolic aliases. Arrow combinator methods such as `andThen` show up in autocomplete, and will not (99% of the time) be what the user is actually seeking. Furthermore, we can continue to solidify naming patterns, ensuring each common prefix or suffix has a consistent, shared meaning across the codebase.

ZIO's API is already one of the best I've ever used, with a incredible focus on consistency and discoverability. As a ZIO user, I've often had the experience of hoping that some potential method existed, and after typing a few letters, having autocomplete suggest precisely what I was looking for. There's no better _DX_ than sensing an API is pre-anticipating your needs. I believe this is achieved through consistent and thoughtful API design, where the user subconsciously observes patterns of naming/meaning as they use the library, allowing them to anticipate and _reach out_ for similar methods they've never seen before.

So yeah, ZIO 2.0 presents the opportunity to achieve even more consistency, to step back and observe new patterns, and to codify these new patterns with shared pre/postfixes and APIs. Much work has already been done on this front (#5226 and #5221), but there's always more.

What I've done in this PR:

1. Remove the Arrow combinators (`&&&`, `+++`, `|||`, `onSecond`, `onFirst`, `second`, `first`, `andThen`, `>>>`, `compose`, `<<<`).
    - While lawful and interesting, these methods do not reflect how the environment is idiomatically used in the vast majority of applications. Users exploring the codebase (a great way to learn) might be misled by their existence, they also consume precious auto-complete real estate.
  
2. Remove duplicate methods.
    - `get` was essentially a more constrained version of `some`
    - `require` was essentially an awkward variant of `someOrFail`

3. Nix `>>=`.
    - We should probably cut ties with the rest of the Haskellisms, now that `putStrLn` and `getStr` have gone away. Using `flatMap` is only a few extra characters, and won't frighten non-Haskellers.

4. Some v. Partial
    - I haven't made this change yet, but I'd like to discuss it. `Some` is mostly used for combinators involving `Option` (`someOrFail`, `some`, `someOrFailException`, 'asSome', 'asSomeError'), yet methods `tapSome`, `catchSomeCause`, 'catchSome` also use the same modifier and deal with PartialFunctions.
    - It would be great to give the pattern of PartialFunction-accepting variants its own discrete suffix. I think `catchPartial`, `tapPartial`, whilst slightly more verbose, would remove the ambiguity.
    
5. `as`, `to`, `into` prefixes
    - `as` is used when transforming the `A` inside of a ZIO, generally as shortcuts for `map(aToFoo(_))`. `asSome`, `asRight`, etcetera.
    - `to` is when the ZIO is transformed into something else, `.toLayer`, `.toManaged`. `.toFuture` is slightly more interesting, as you get back a `URIO[R, Future]`, but that's mostly to maintain purity.
    - Currently there's a `ZIO.to` method that doesn't follow either of the above patterns. It instead accepts a `Promise`, completing that promise with the result of the ZIO. This pattern of accepting some secondary data-type, modifying it with the result of the current effect, already exists in ZStream as `intoHub`, `intoQueue`. So I've renamed `to` -> `intoPromise`. 
    
6. `collect` v. `collectAll`
    - `collect` is a very common Scala collections method, accepting a partial function. A variant exists on the `ZIO` trait that performs the expected combination of map/filter using a partial function. However, we also have `collectAll`, which is the `ZIO` equivalent of Haskell's `sequence`. `sequence` is truly a horrible name, as there's often a `sequencePar` variant (and even `sequenceParUnordered` in some libraries), which is oxymoronic. So, while `collectAll` is a much better name than `sequence`, it has this unfortunate ambiguity with Scala's famous `collect` operator. Can we think of a better name here and vanquish this ambiguity? 😆 
  
Okay, that was a lot. Hoping to iterate a lot on this PR and consolidate all the naming bike-sheddery. 