### PR TITLE
Ignore Flaky Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -3457,7 +3457,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .take(3)
                 .runCollect
             )(equalTo(Chunk(1, 1, 1)))
-          } @@ TestAspect.jvmOnly
+          } @@ TestAspect.ignore
         ),
         suite("zipWithNext")(
           test("should zip with next element for a single chunk") {


### PR DESCRIPTION
This test creates a spin loop because both the left and right streams continue emitting values forever without yielding, causing flakiness in CI.