### PR TITLE
Expose ClockLive

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -143,7 +143,7 @@ object Clock extends ClockPlatformSpecific with Serializable {
   val live: Layer[Nothing, Has[Clock]] =
     ZLayer.succeed(ClockLive)
 
-  private[zio] object ClockLive extends Clock {
+  object ClockLive extends Clock {
     def currentTime(unit: TimeUnit): UIO[Long] =
       instant.map { inst =>
         // A nicer solution without loss of precision or range would be


### PR DESCRIPTION
Resolves #5342. It can occasionally be useful to access the live services in the default environment directly and these are not effectual resourceful so it is safe to do so. The other live implementations are already public, this one was just package private.