### PR TITLE
ZIO 2.0: Allow type annotation for empty Chunk & Cause

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -540,7 +540,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
 }
 
 object Cause extends Serializable {
-  val empty: Cause[Nothing]                               = Internal.Empty
+  def empty[A]: Cause[A]                                  = Internal.Empty
   def die(defect: Throwable): Cause[Nothing]              = Internal.Die(defect)
   def fail[E](error: E): Cause[E]                         = Internal.Fail(error)
   def interrupt(fiberId: Fiber.Id): Cause[Nothing]        = Internal.Interrupt(fiberId)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1211,7 +1211,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
   /**
    * Returns the empty chunk.
    */
-  val empty: Chunk[Nothing] =
+  override def empty[A]: Chunk[A] =
     Empty
 
   /**


### PR DESCRIPTION
Most `empty` methods allow you to specify the type. If you leave this off, it is inferred as `Nothing` as before. 

This is mostly useful in `foldLeft`, so you can write `foldLeft(Chunk.empty[String])`.