### PR TITLE
Use SourceLocation for assertTrue

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -217,7 +217,7 @@ object SmartAssertionSpec extends ZIOBaseSpec {
     test("exists must fail when all elements of iterable do not satisfy specified assertion") {
       val value = Seq(1, 42, 5)
       assertTrue(value.exists(_ == 423))
-    } @@ TestAspect.tag("IMPORTANT") @@ failing,
+    } @@ failing,
     test("forall must succeed when all elements of iterable satisfy specified assertion") {
       assertTrue(Seq("a", "bb", "ccc").forall(l => l.nonEmpty && l.length <= 3))
     },
@@ -252,11 +252,11 @@ object SmartAssertionSpec extends ZIOBaseSpec {
     test("hasIntersection must succeed when intersection satisfies specified assertion") {
       val seq = Seq(1, 2, 3, 4, 5)
       assertTrue((seq intersect Seq(4, 5, 6, 7, 8)).length == 105)
-    } @@ TestAspect.tag("IMPORTANT") @@ failing,
+    } @@ failing,
     test("hasIntersection must succeed when intersection satisfies specified assertion") {
       val seq = Seq(1, 2, 3, 4, 5)
       assertTrue(seq.intersect(Seq(4, 5, 6, 7, 8)).length == 108)
-    } @@ TestAspect.tag("IMPORTANT") @@ failing,
+    } @@ failing,
     test("hasIntersection must succeed when empty intersection satisfies specified assertion") {
       assertTrue((Seq(1, 2, 3, 4) intersect Seq(5, 6, 7)).isEmpty)
     },
@@ -379,8 +379,18 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         val someChild                  = Child("hii")
         assertTrue(someParent.contains(someChild))
       } @@ failing
+    ),
+    suite("custom assertions")(
+      test("reports source location of actual usage") {
+        customAssertion("hello")
+      } @@ failing
     )
   )
+
+  // The implicit SourceLocation will be used by assertTrue to report the
+  // actual location.
+  def customAssertion(string: String)(implicit sourceLocation: SourceLocation): Assert =
+    assertTrue(string == "coool")
 
   // Test Types
   private sealed trait Color

--- a/test/shared/src/main/scala-2.x/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/SmartAssertMacros.scala
@@ -12,12 +12,6 @@ class SmartAssertMacros(val c: blackbox.Context) {
   private val Arrow  = q"_root_.zio.test.Arrow"
   private val Assert = q"_root_.zio.test.Assert"
 
-  private[test] def location(c: blackbox.Context): (String, Int) = {
-    val path = c.enclosingPosition.source.path
-    val line = c.enclosingPosition.line
-    (path, line)
-  }
-
   def assert_impl(expr: c.Expr[Boolean], exprs: c.Expr[Boolean]*): c.Tree =
     exprs.map(assertOne_impl).foldLeft(assertOne_impl(expr)) { (acc, assert) =>
       q"$acc && $assert"
@@ -159,16 +153,13 @@ class SmartAssertMacros(val c: blackbox.Context) {
     val (_, start, codeString) = text(tree)
     implicit val pos           = PositionContext(start, codeString)
 
-    val (file, line)   = location(c)
-    val locationString = s"$file:$line"
-
     val parsed = parseExpr(tree)
     val ast    = astToAssertion(parsed)
 
     val block =
       q"""
 ..$stmts
-$Assert($ast.withCode($codeString).withLocation($locationString))
+$Assert($ast.withCode($codeString).withLocation)
         """
 
     block

--- a/test/shared/src/main/scala-dotty/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-dotty/zio/test/Macros.scala
@@ -137,7 +137,7 @@ class SmartAssertMacros(ctx: Quotes)  {
     val ast = transform(value)
 
     val arrow = ast.asExprOf[Arrow[Any, Boolean]]
-    '{Assert($arrow.withCode(${Expr(code)}).withLocation(${Expr(srcLocation)}))}
+    '{Assert($arrow.withCode(${Expr(code)}).withLocation)}
   }
 
   def smartAssert_impl(values: Expr[Seq[Boolean]]): Expr[Assert] = {

--- a/test/shared/src/main/scala/zio/test/Arrow.scala
+++ b/test/shared/src/main/scala/zio/test/Arrow.scala
@@ -55,8 +55,8 @@ sealed trait Arrow[-A, +B] { self =>
   def withCode(code: String): Arrow[A, B] =
     meta(code = Some(code))
 
-  def withLocation(location: String): Arrow[A, B] =
-    meta(location = Some(location))
+  def withLocation(implicit location: SourceLocation): Arrow[A, B] =
+    meta(location = Some(s"${location.path}:${location.line}"))
 
   def withParentSpan(span: (Int, Int)): Arrow[A, B] =
     meta(parentSpan = Some(Span(span._1, span._2)))


### PR DESCRIPTION
Besides a simplification, this will allow users to use `SourceLocation` in custom assertions, and get the location of each invocation of the custom assertion, rather than the source location of where the custom assertion uses `assertTrue`.