### PR TITLE
Remove Illegal Reflective Access

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -219,12 +219,8 @@ object CauseSpec extends ZIOBaseSpec {
           assert(squashed)(
             equalTo(e) &&
               hasMessage(equalTo(throwableMessage)) &&
-              hasThrowableCause(
-                isSubtype[IllegalArgumentException](
-                  hasMessage(equalTo(causeMessage)) &&
-                    hasThrowableCause(hasMessage(equalTo(renderedCause)))
-                )
-              )
+              hasThrowableCause(isSubtype[IllegalArgumentException](hasMessage(equalTo(causeMessage)))) &&
+              hasSuppressed(exists(hasMessage(equalTo(renderedCause))))
           )
         }
       }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3707,7 +3707,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           future <- ZIO.fail(new Throwable(new IllegalArgumentException)).toFuture
           result <- ZIO.fromFuture(_ => future).either
-        } yield assert(result)(isLeft(hasThrowableCause(hasThrowableCause(hasMessage(containsString("Fiber:Id("))))))
+        } yield assert(result)(isLeft(hasSuppressed(exists(hasMessage(containsString("Fiber:Id("))))))
       }
     ) @@ zioTag(future),
     suite("resurrect")(

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -128,7 +128,4 @@ private[internal] trait PlatformSpecific {
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
 
   final def newWeakReference[A](value: A): () => A = { () => value }
-
-  @silent("is never used")
-  final def forceThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,7 +16,6 @@
 
 package zio.internal
 
-import com.github.ghik.silencer.silent
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 import zio.{Cause, Supervisor}

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -146,18 +146,4 @@ private[internal] trait PlatformSpecific {
 
     () => ref.get()
   }
-
-  /**
-   * calling `initCause()` on [[java.lang.Throwable]] may fail on the JVM if `newCause != this`,
-   * which may happen if the cause is set to null.
-   * This works around this with reflection.
-   */
-  def forceThrowableCause(throwable: Throwable, newCause: Throwable): Unit = {
-    import scala.util.control.Exception._
-    ignoring(classOf[Throwable]) {
-      val causeField = classOf[Throwable].getDeclaredField("cause")
-      causeField.setAccessible(true)
-      causeField.set(throwable, newCause)
-    }
-  }
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -128,7 +128,4 @@ private[internal] trait PlatformSpecific {
   final def newWeakHashMap[A, B](): JMap[A, B] = new HashMap[A, B]()
 
   final def newWeakReference[A](value: A): () => A = { () => value }
-
-  @silent("is never used")
-  final def forceThrowableCause(throwable: => Throwable, newCause: => Throwable): Unit = ()
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -16,7 +16,6 @@
 
 package zio.internal
 
-import com.github.ghik.silencer.silent
 import zio.internal.stacktracer.Tracer
 import zio.internal.tracing.TracingConfig
 import zio.{Cause, Supervisor}

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -405,10 +405,10 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
       defects.headOption getOrElse (new InterruptedException)
 
   /**
-   * Squashes a `Cause` down to a single `Throwable`, chosen to be the
-   * "most important" `Throwable`.
-   * In addition, appends a new element the to `Throwable`s "caused by" chain,
-   * with this `Cause` "pretty printed" (in stackless mode) as the message.
+   * Squashes a `Cause` down to a single `Throwable`, chosen to be the "most
+   * important" `Throwable`. In addition, appends a new element to the
+   * suppressed exceptions of the `Throwable`, with this `Cause` "pretty
+   * printed" (in stackless mode) as the message.
    */
   final def squashTrace(implicit ev: E <:< Throwable): Throwable =
     squashTraceWith(ev)

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -60,11 +60,13 @@ trait Runtime[+R] {
   /**
    * Executes the Task/RIO effect synchronously, failing
    * with the original `Throwable` on both [[Cause.Fail]] and [[Cause.Die]].
-   * In addition, appends a new element to the `Throwable`s "caused by" chain,
-   * with this `Cause` "pretty printed" (in stackless mode) as the message.
-   * May fail on Scala.js if the effect cannot be entirely run synchronously.
+   * In addition, appends a new element to the suppressed exceptions of the
+   * `Throwable`, with this `Cause` "pretty printed" (in stackless mode) as the
+   * message. May fail on Scala.js if the effect cannot be entirely run
+   * synchronously.
    *
-   * This method is effectful and should only be done at the edges of your program.
+   * This method is effectful and should only be done at the edges of your
+   * program.
    */
   final def unsafeRunTask[A](task: => RIO[R, A]): A =
     unsafeRunSync(task).fold(cause => throw cause.squashTrace, identity)

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -211,6 +211,13 @@ object Assertion extends AssertionVariants {
     Assertion.assertionRec("hasMessage")(param(message))(message)(th => Some(th.getMessage))
 
   /**
+   * Makes a new assertion that requires an exception to have certain
+   * suppressed exceptions.
+   */
+  def hasSuppressed(cause: Assertion[Iterable[Throwable]]): Assertion[Throwable] =
+    Assertion.assertionRec("hasSuppressed")(param(cause))(cause)(th => Some(th.getSuppressed))
+
+  /**
    * Makes a new assertion that requires an exception to have a certain cause.
    */
   def hasThrowableCause(cause: Assertion[Throwable]): Assertion[Throwable] =


### PR DESCRIPTION
We are currently using reflective access when we squash a `Cause` down to a `Throwable` to attach the rendered `Cause` as the cause of the original `Throwable`. We do our best to do this in a principled way by finding the root cause of the `Throwable` and then adding to that. However, the expectation in Java is that the cause will be set at most once and never changed and even if the root cause is `null`, typical `Throwable` constructors set the cause to `null` permanently rather than leaving it unset so we can set it later. We work around this by using reflective access to set the field directly.

However, this reflective access has triggered warnings for a long time and is not going to be possible on JDK 17, which is being released later this year.

Given this, and that I think we really do want to return one of the original `Throwable` values rather than creating an entirely new cause, this PR changes the implementation to instead attach the rendered `Cause` as a suppressed exception. This is not as ideal as the "caused by" chain indicates a linear relationship that exists here where the `Cause` is the literal cause of the exception, but I think it is the best we can do within the constraints of the `Throwable` API.