### PR TITLE
Complete Takers After On Queue Empty Space

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -1,8 +1,9 @@
 package zio
 
 import com.github.ghik.silencer.silent
-import zio.ZQueueSpecUtil.waitForSize
+import zio.ZQueueSpecUtil._
 import zio.duration._
+import zio.random._
 import zio.test.Assertion._
 import zio.test.TestAspect.{jvm, nonFlaky}
 import zio.test._
@@ -11,7 +12,6 @@ import zio.test.environment.Live
 import scala.collection.immutable.Range
 
 object ZQueueSpec extends ZIOBaseSpec {
-
   import ZIOTag._
 
   def spec: ZSpec[Environment, Failure] = suite("ZQueueSpec")(
@@ -854,7 +854,18 @@ object ZQueueSpec extends ZIOBaseSpec {
         _ <- q.shutdown
         _ <- f.await
       } yield assertCompletes
-    } @@ jvm(nonFlaky)
+    } @@ jvm(nonFlaky),
+    testM("many to many") {
+      checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        for {
+          queue    <- Queue.bounded[Int](n)
+          offerors <- ZIO.foreach(as)(a => queue.offer(a).fork)
+          takers   <- ZIO.foreach(as)(_ => queue.take.fork)
+          _        <- ZIO.foreach(offerors)(_.join)
+          _        <- ZIO.foreach(takers)(_.join)
+        } yield assertCompletes
+      }
+    }
   )
 }
 
@@ -864,4 +875,7 @@ object ZQueueSpecUtil {
 
   def waitForSize[RA, EA, RB, EB, A, B](queue: ZQueue[RA, EA, RB, EB, A, B], size: Int): URIO[Live, Int] =
     waitForValue(queue.size, size)
+
+  val smallInt: Gen[Random with Sized, Int] =
+    Gen.small(Gen.const(_), 1)
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -17,8 +17,7 @@ object MimaSettings {
         exclude[ReversedMissingMethodProblem](
           "zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="
         ),
-        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking"),
-
+        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking")
       ),
       mimaFailOnProblem := failOnProblem
     )

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -13,10 +13,12 @@ object MimaSettings {
       mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
       mimaBinaryIssueFilters ++= Seq(
         exclude[Problem]("zio.internal.*"),
+        exclude[Problem]("zio.ZQueue#internal#*"),
         exclude[ReversedMissingMethodProblem](
           "zio.ZManagedPlatformSpecific.zio$ZManagedPlatformSpecific$_setter_$blocking_="
         ),
-        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking")
+        exclude[ReversedMissingMethodProblem]("zio.ZManagedPlatformSpecific.blocking"),
+
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
After potentially adding a value to the queue in `unsafeOnQueueEmptySpace` we need to call `unsafeCompleteTakers` to complete any takers waiting for a value from the queue.