### PR TITLE
[Doc] FiberRef: fix the doc example which demonstrates inheritRefs and join

### DIFF
--- a/docs/datatypes/fiber/fiberref.md
+++ b/docs/datatypes/fiber/fiberref.md
@@ -146,7 +146,8 @@ val withJoin =
 val withoutJoin =
   for {
     fiberRef <- FiberRef.make[Int](0)
-    fiber    <- fiberRef.set(10)
+    fiber    <- fiberRef.set(10).fork
+    _        <- fiber.inheritRefs
     v        <- fiberRef.get
   } yield assert(v == 10)
 ```


### PR DESCRIPTION
There might be a typo in the `inheritRefs` example from the documentation https://zio.dev/docs/datatypes/fiber/fiberref#inheritrefs:

```scala
val withoutJoin =
  for {
    fiberRef <- FiberRef.make[Int](0)
    fiber    <- fiberRef.set(10)
    v        <- fiberRef.get
  } yield assert(v == 10)
```

in this example the fiber is not forked and the type of `fiber` is `Unit`, also `inheritRefs` is not called.

While the value of `v` will still be `10` and the example will pass, it might not demonstrate how to call `inheritRefs` manually.

Tried to fix the example by forking a fiber and using `inheritRefs` (as explained in the documentation I read before this example), tested the updated example locally and it passes as expected.