### PR TITLE
Fix Flaky Stream Tests

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1190,7 +1190,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         ).flatMapPar(2)(identity).runDrain.either
               cancelled <- substreamCancelled.get
             } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
-          },
+          } @@ nonFlaky,
           testM("outer errors interrupt all fibers") {
             for {
               substreamCancelled <- Ref.make[Boolean](false)
@@ -1220,7 +1220,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         ).flatMapPar(2)(identity).runDrain.run
               cancelled <- substreamCancelled.get
             } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
-          },
+          } @@ nonFlaky,
           testM("outer defects interrupt all fibers") {
             val ex = new RuntimeException()
 
@@ -1324,7 +1324,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         ).flatMapParSwitch(2)(identity).runDrain.either
               cancelled <- substreamCancelled.get
             } yield assert(cancelled)(isTrue) && assert(result)(isLeft(equalTo("Ouch")))
-          } @@ flaky,
+          } @@ nonFlaky,
           testM("outer errors interrupt all fibers") {
             for {
               substreamCancelled <- Ref.make[Boolean](false)
@@ -1354,7 +1354,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                         ).flatMapParSwitch(2)(identity).runDrain.run
               cancelled <- substreamCancelled.get
             } yield assert(cancelled)(isTrue) && assert(result)(dies(equalTo(ex)))
-          },
+          } @@ nonFlaky,
           testM("outer defects interrupt all fibers") {
             val ex = new RuntimeException()
 


### PR DESCRIPTION
In `flatMapPar`, the managed permit is currently constructed in the context of the stream, which means then when we run the stream the permit can be released and the outer can interrupt the inner fibers before we can offer the error from running the inner stream. We run the stream in the `use` action of the managed permit to ensure that the inner error is signaled.