### PR TITLE
Improve Type Inference Of ZManaged Constructor

### DIFF
--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1608,16 +1608,16 @@ object ZManaged extends ZManagedPlatformSpecific {
   def acquireReleaseInterruptible[R, R1 <: R, E, A](
     acquire: ZIO[R, E, A]
   )(release: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =
-    acquireReleaseInterruptibleWith[R1, E, A](acquire)(_ => release)
+    acquireReleaseInterruptibleWith(acquire)(_ => release)
 
   /**
    * Lifts a ZIO[R, E, A] into ZManaged[R, E, A] with a release action.
    * The acquire action will be performed interruptibly, while release
    * will be performed uninterruptibly.
    */
-  def acquireReleaseInterruptibleWith[R, E, A](
+  def acquireReleaseInterruptibleWith[R, R1 <: R, E, A](
     acquire: ZIO[R, E, A]
-  )(release: A => URIO[R, Any]): ZManaged[R, E, A] =
+  )(release: A => URIO[R1, Any]): ZManaged[R1, E, A] =
     ZManaged.fromZIO(acquire).onExitFirst(_.foreach(release))
 
   /**
@@ -2433,6 +2433,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * does not need access to the resource but handles `Exit`. The acquire and
    * release actions will be performed uninterruptibly.
    */
+  @deprecated("use acquireReleaseExit", "2.0.0")
   def makeExit_[R, R1 <: R, E, A](acquire: ZIO[R, E, A])(
     release: Exit[Any, Any] => ZIO[R1, Nothing, Any]
   ): ZManaged[R1, E, A] =
@@ -2443,7 +2444,8 @@ object ZManaged extends ZManagedPlatformSpecific {
    * The acquire action will be performed interruptibly, while release
    * will be performed uninterruptibly.
    */
-  def makeInterruptible[R, E, A](
+  @deprecated("use acquireReleaseInterruptibleWith", "2.0.0")
+  def makeInterruptible[R, R1 <: R, E, A](
     acquire: ZIO[R, E, A]
   )(release: A => URIO[R, Any]): ZManaged[R, E, A] =
     acquireReleaseInterruptibleWith(acquire)(release)
@@ -2453,6 +2455,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * does not require access to the resource. The acquire action will be
    * performed interruptibly, while release will be performed uninterruptibly.
    */
+  @deprecated("use acquireReleaseInterruptible", "2.0.0")
   def makeInterruptible_[R, R1 <: R, E, A](
     acquire: ZIO[R, E, A]
   )(release: ZIO[R1, Nothing, Any]): ZManaged[R1, E, A] =


### PR DESCRIPTION
Most `fromAcquireRelease` variants take separate `R` and `R1` parameters to improve type inference when the `acquire` and `release` actions require different environments. Updates `fromAcquireReleaseInterruptibleWith` to conform to this pattern.