### PR TITLE
Implement Specialized Version Of Register Function For ZStream.effectAsync

### DIFF
--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -49,7 +49,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -86,7 +86,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => ZIO[R, E, Any],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -118,7 +118,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Option[ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -49,7 +49,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -86,7 +86,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -118,7 +118,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -107,7 +107,7 @@ trait ZStreamPlatformSpecificConstructors {
    * by setting it to `None`.
    */
   def effectAsync[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Unit) => Unit,
+    register: ZStream.Register[R, E, A, Unit] => Unit,
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     effectAsyncMaybe(
@@ -125,7 +125,7 @@ trait ZStreamPlatformSpecificConstructors {
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Unit) => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Unit] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -162,7 +162,7 @@ trait ZStreamPlatformSpecificConstructors {
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Unit) => ZIO[R, E, Any],
+    register: ZStream.Register[R, E, A, Unit] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -194,7 +194,7 @@ trait ZStreamPlatformSpecificConstructors {
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Unit) => Option[ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Unit] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -107,7 +107,7 @@ trait ZStreamPlatformSpecificConstructors {
    * by setting it to `None`.
    */
   def effectAsync[R, E, A](
-    register: ZStream.Register[R, E, A, Unit] => Unit,
+    register: ZStream.Emit[R, E, A, Unit] => Unit,
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     effectAsyncMaybe(
@@ -125,7 +125,7 @@ trait ZStreamPlatformSpecificConstructors {
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: ZStream.Register[R, E, A, Unit] => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Unit] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -162,7 +162,7 @@ trait ZStreamPlatformSpecificConstructors {
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: ZStream.Register[R, E, A, Unit] => ZIO[R, E, Any],
+    register: ZStream.Emit[R, E, A, Unit] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -194,7 +194,7 @@ trait ZStreamPlatformSpecificConstructors {
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: ZStream.Register[R, E, A, Unit] => Option[ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Unit] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -31,7 +31,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsync[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => Unit,
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => Unit,
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     effectAsyncMaybe(
@@ -49,7 +49,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -86,7 +86,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -118,7 +118,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: ZStream.Register[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
+    register: ZStream.Emit[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -31,7 +31,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsync[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Unit,
+    register: ZStream.Register[R, E, A, Future[Boolean]] => Unit,
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     effectAsyncMaybe(
@@ -49,7 +49,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * setting it to `None`.
    */
   def effectAsyncInterrupt[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Either[Canceler[R], ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => Either[Canceler[R], ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {
@@ -86,7 +86,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * error type `E` can be used to signal the end of the stream, by setting it to `None`.
    */
   def effectAsyncM[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => ZIO[R, E, Any],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => ZIO[R, E, Any],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     managed {
@@ -118,7 +118,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
    * by setting it to `None`.
    */
   def effectAsyncMaybe[R, E, A](
-    register: (ZIO[R, Option[E], Chunk[A]] => Future[Boolean]) => Option[ZStream[R, E, A]],
+    register: ZStream.Register[R, E, A, Future[Boolean]] => Option[ZStream[R, E, A]],
     outputBuffer: Int = 16
   ): ZStream[R, E, A] =
     ZStream {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4499,14 +4499,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   }
 
   /**
-   * A `Register[R, E, A, B]` represents an asynchronous callback that can be
+   * An `Emit[R, E, A, B]` represents an asynchronous callback that can be
    * called multiple times. The callback can be called with a value of type
    * `ZIO[R, Option[E], Chunk[A]]`, where succeeding with a `Chunk[A]`
    * indicates to emit those elements, failing with `Some[E]` indicates to
    * terminate with that error, and failing with `None` indicates to terminate
    * with an end of stream signal.
    */
-  trait Register[+R, -E, -A, +B] extends (ZIO[R, Option[E], Chunk[A]] => B) {
+  trait Emit[+R, -E, -A, +B] extends (ZIO[R, Option[E], Chunk[A]] => B) {
 
     def apply(v1: ZIO[R, Option[E], Chunk[A]]): B
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4498,4 +4498,71 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       self.collect({ case o if tag.runtimeClass.isInstance(o) => o.asInstanceOf[O1] })
   }
 
+  /**
+   * A `Register[R, E, A, B]` represents an asynchronous callback that can be
+   * called multiple times. The callback can be called with a value of type
+   * `ZIO[R, Option[E], Chunk[A]]`, where succeeding with a `Chunk[A]`
+   * indicates to emit those elements, failing with `Some[E]` indicates to
+   * terminate with that error, and failing with `None` indicates to terminate
+   * with an end of stream signal.
+   */
+  trait Register[+R, -E, -A, +B] extends (ZIO[R, Option[E], Chunk[A]] => B) {
+
+    /**
+     * Emits a chunk containing the specified values.
+     */
+    def chunk(as: Chunk[A]): B =
+      apply(ZIO.succeedNow(as))
+
+    /**
+     * Terminates with a cause that dies with the specified `Throwable`.
+     */
+    def die(t: Throwable): B =
+      apply(ZIO.die(t))
+
+    /**
+     * Terminates with a cause that dies with a `Throwable` with the specified
+     * message.
+     */
+    def dieMessage(message: String): B =
+      apply(ZIO.dieMessage(message))
+
+    /**
+     * Either emits the specified value if this `Exit` is a `Success` or else
+     * terminates with the specified cause if this `Exit` is a `Failure`.
+     */
+    def done(exit: Exit[E, A]): B =
+      apply(ZIO.done(exit.mapBoth(e => Some(e), a => Chunk(a))))
+
+    /**
+     * Terminates with an end of stream signal.
+     */
+    val end: B =
+      apply(ZIO.fail(None))
+
+    /**
+     * Terminates with the specified error.
+     */
+    def fail(e: E): B =
+      apply(ZIO.fail(Some(e)))
+
+    /**
+     * Either emits the success value of this effect or terminates the stream
+     * with the failure value of this effect.
+     */
+    def fromEffect(zio: ZIO[R, E, A]): B =
+      apply(zio.mapBoth(e => Some(e), a => Chunk(a)))
+
+    /**
+     * Terminates the stream with the specified cause.
+     */
+    def halt(cause: Cause[E]): B =
+      apply(ZIO.halt(cause.map(e => Some(e))))
+
+    /**
+     * Emits a chunk containing the specified value.
+     */
+    def single(a: A): B =
+      apply(ZIO.succeedNow(Chunk(a)))
+  }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4508,6 +4508,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    */
   trait Register[+R, -E, -A, +B] extends (ZIO[R, Option[E], Chunk[A]] => B) {
 
+    def apply(v1: ZIO[R, Option[E], Chunk[A]]): B
+
     /**
      * Emits a chunk containing the specified values.
      */
@@ -4537,7 +4539,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     /**
      * Terminates with an end of stream signal.
      */
-    val end: B =
+    def end: B =
       apply(ZIO.fail(None))
 
     /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4556,6 +4556,13 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       apply(zio.mapBoth(e => Some(e), a => Chunk(a)))
 
     /**
+     * Either emits the success value of this effect or terminates the stream
+     * with the failure value of this effect.
+     */
+    def fromEffectChunk(zio: ZIO[R, E, Chunk[A]]): B =
+      apply(zio.mapError(e => Some(e)))
+
+    /**
      * Terminates the stream with the specified cause.
      */
     def halt(cause: Cause[E]): B =


### PR DESCRIPTION
Implements a specialized version of the register function in `ZStream.effectAsync`. This is compatible with all existing code since `Register` is just a more specific version of the previous register function.

This lets us implement some additional convenience methods on `Register` for emitting a single value or a chunk of values, failing, ending, and so on.

It does add an additional layer of indirection to the type signature of `effectAsync`, but the existing one is already relatively complicated so not sure this is a step back.

Copying @kitlangton.