### PR TITLE
Pass argument by name in `ZIO.debug`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2623,7 +2623,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Prints the specified message to the console for debugging purposes.
    */
-  def debug(value: Any): UIO[Unit] =
+  def debug(value: => Any): UIO[Unit] =
     ZIO.effectTotal(println(value))
 
   /**


### PR DESCRIPTION
Otherwise bad things happen like this — 

https://scastie.scala-lang.org/Y005JdE3RqOKkH2tBpjidw