### PR TITLE
Rename ZStream#repeatZIOWith to ZStream#repeatZIOWithSchedule

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4156,12 +4156,12 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(result)(equalTo(1))
           }
         ),
-        suite("repeatEffectWith")(
+        suite("repeatZIOWithSchedule")(
           test("succeed")(
             for {
               ref <- Ref.make[List[Int]](Nil)
               fiber <- ZStream
-                         .repeatZIOWith(ref.update(1 :: _), Schedule.spaced(10.millis))
+                         .repeatZIOWithSchedule(ref.update(1 :: _), Schedule.spaced(10.millis))
                          .take(2)
                          .runDrain
                          .fork
@@ -4175,16 +4175,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               ref     <- Ref.make(0)
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())
               schedule = Schedule.identity[Int].whileOutput(_ < length)
-              result  <- ZStream.repeatZIOWith(effect, schedule).runCollect
+              result  <- ZStream.repeatZIOWithSchedule(effect, schedule).runCollect
             } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
           }),
           test("should perform repetitions in addition to the first execution (one repetition)") {
-            assertM(ZStream.repeatZIOWith(UIO(1), Schedule.once).runCollect)(
+            assertM(ZStream.repeatZIOWithSchedule(UIO(1), Schedule.once).runCollect)(
               equalTo(Chunk(1, 1))
             )
           },
           test("should perform repetitions in addition to the first execution (zero repetitions)") {
-            assertM(ZStream.repeatZIOWith(UIO(1), Schedule.stop).runCollect)(
+            assertM(ZStream.repeatZIOWithSchedule(UIO(1), Schedule.stop).runCollect)(
               equalTo(Chunk(1))
             )
           },
@@ -4196,7 +4196,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               effect     = ZIO.unit
               schedule   = Schedule.spaced(interval)
               streamFiber <- ZStream
-                               .repeatZIOWith(effect, schedule)
+                               .repeatZIOWithSchedule(effect, schedule)
                                .tap(_ => collected.update(_ + 1))
                                .runDrain
                                .fork

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -4128,12 +4128,12 @@ object ZStreamSpec extends ZIOBaseSpec {
 //             } yield assert(result)(equalTo(1))
 //           }
         ),
-        suite("repeatEffectWith")(
+        suite("repeatZIOWithSchedule")(
           test("succeed")(
             for {
               ref <- Ref.make[List[Int]](Nil)
               fiber <- ZStream
-                         .repeatZIOWith(ref.update(1 :: _), Schedule.spaced(10.millis))
+                         .repeatZIOWithSchedule(ref.update(1 :: _), Schedule.spaced(10.millis))
                          .take(2)
                          .runDrain
                          .fork
@@ -4147,16 +4147,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               ref     <- Ref.make(0)
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())
               schedule = Schedule.identity[Int].whileOutput(_ < length)
-              result  <- ZStream.repeatZIOWith(effect, schedule).runCollect
+              result  <- ZStream.repeatZIOWithSchedule(effect, schedule).runCollect
             } yield assert(result)(equalTo(Chunk.fromIterable(0 to length)))
           }),
           test("should perform repetitions in addition to the first execution (one repetition)") {
-            assertM(ZStream.repeatZIOWith(UIO(1), Schedule.once).runCollect)(
+            assertM(ZStream.repeatZIOWithSchedule(UIO(1), Schedule.once).runCollect)(
               equalTo(Chunk(1, 1))
             )
           },
           test("should perform repetitions in addition to the first execution (zero repetitions)") {
-            assertM(ZStream.repeatZIOWith(UIO(1), Schedule.stop).runCollect)(
+            assertM(ZStream.repeatZIOWithSchedule(UIO(1), Schedule.stop).runCollect)(
               equalTo(Chunk(1))
             )
           },
@@ -4168,7 +4168,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               effect     = ZIO.unit
               schedule   = Schedule.spaced(interval)
               streamFiber <- ZStream
-                               .repeatZIOWith(effect, schedule)
+                               .repeatZIOWithSchedule(effect, schedule)
                                .tap(_ => collected.update(_ + 1))
                                .runDrain
                                .fork

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4410,15 +4410,22 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an effect producing a value of type `A`, which is repeated using the
    * specified schedule.
    */
-  @deprecated("use repeatZIOWith", "2.0.0")
+  @deprecated("use repeatZIOWithSchedule", "2.0.0")
   def repeatEffectWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, Any]): ZStream[R with Has[Clock], E, A] =
-    repeatZIOWith(effect, schedule)
+    repeatZIOWithSchedule(effect, schedule)
 
   /**
    * Repeats the value using the provided schedule.
    */
+  @deprecated("use repeatWithSchedule", "2.0.0")
   def repeatWith[R, A](a: => A, schedule: Schedule[R, A, _]): ZStream[R with Has[Clock], Nothing, A] =
-    repeatZIOWith(UIO.succeed(a), schedule)
+    repeatWithSchedule(a, schedule)
+
+  /**
+   * Repeats the value using the provided schedule.
+   */
+  def repeatWithSchedule[R, A](a: => A, schedule: Schedule[R, A, _]): ZStream[R with Has[Clock], Nothing, A] =
+    repeatZIOWithSchedule(UIO.succeed(a), schedule)
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats forever.
@@ -4460,7 +4467,10 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an effect producing a value of type `A`, which is repeated using the
    * specified schedule.
    */
-  def repeatZIOWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, Any]): ZStream[R with Has[Clock], E, A] =
+  def repeatZIOWithSchedule[R, E, A](
+    effect: ZIO[R, E, A],
+    schedule: Schedule[R, A, Any]
+  ): ZStream[R with Has[Clock], E, A] =
     ZStream.fromZIO(effect zip schedule.driver).flatMap { case (a, driver) =>
       ZStream.succeed(a) ++
         ZStream.unfoldZIO(a)(driver.next(_).foldZIO(ZIO.succeed(_), _ => effect.map(nextA => Some(nextA -> nextA))))
@@ -4510,7 +4520,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * A stream that emits Unit values spaced by the specified duration.
    */
   def tick(interval: Duration): ZStream[Has[Clock], Nothing, Unit] =
-    repeatWith((), Schedule.spaced(interval))
+    repeatWithSchedule((), Schedule.spaced(interval))
 
   /**
    * A stream that contains a single `Unit` value.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -4239,13 +4239,20 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    */
   @deprecated("use repeatZIOWith", "2.0.0")
   def repeatEffectWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, Any]): ZStream[R with Has[Clock], E, A] =
-    repeatZIOWith(effect, schedule)
+    repeatZIOWithSchedule(effect, schedule)
 
   /**
    * Repeats the value using the provided schedule.
    */
+  @deprecated("use repeatWithSchedule", "2.0.0")
   def repeatWith[R, A](a: => A, schedule: Schedule[R, A, _]): ZStream[R with Has[Clock], Nothing, A] =
-    repeatZIOWith(UIO.succeed(a), schedule)
+    repeatWithSchedule(a, schedule)
+
+  /**
+   * Repeats the value using the provided schedule.
+   */
+  def repeatWithSchedule[R, A](a: => A, schedule: Schedule[R, A, _]): ZStream[R with Has[Clock], Nothing, A] =
+    repeatZIOWithSchedule(UIO.succeed(a), schedule)
 
   /**
    * Creates a stream from an effect producing a value of type `A` which repeats forever.
@@ -4280,7 +4287,10 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an effect producing a value of type `A`, which is repeated using the
    * specified schedule.
    */
-  def repeatZIOWith[R, E, A](effect: ZIO[R, E, A], schedule: Schedule[R, A, Any]): ZStream[R with Has[Clock], E, A] =
+  def repeatZIOWithSchedule[R, E, A](
+    effect: ZIO[R, E, A],
+    schedule: Schedule[R, A, Any]
+  ): ZStream[R with Has[Clock], E, A] =
     ZStream.fromZIO(effect zip schedule.driver).flatMap { case (a, driver) =>
       ZStream.succeed(a) ++
         ZStream.unfoldZIO(a)(driver.next(_).foldZIO(ZIO.succeed(_), _ => effect.map(nextA => Some(nextA -> nextA))))
@@ -4324,7 +4334,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * A stream that emits Unit values spaced by the specified duration.
    */
   def tick(interval: Duration): ZStream[Has[Clock], Nothing, Unit] =
-    repeatWith((), Schedule.spaced(interval))
+    repeatWithSchedule((), Schedule.spaced(interval))
 
   /**
    * A stream that contains a single `Unit` value.


### PR DESCRIPTION
The current name feels a little odd in that you would normally expect a `With` operator to be take a function or possibly a value but not necessarily a schedule.