### PR TITLE
Removing erroneous newlines from diff renderer for assertTrue

### DIFF
--- a/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
+++ b/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
@@ -210,8 +210,8 @@ object SmartAssertions {
         Trace.boolean(result) {
           diff.value match {
             case Some(diff) if !diff.isLowPriority && !result =>
-              M.custom(ConsoleUtils.underlined("Expected")) + "\n" +/ M.value(PrettyPrint(that)) + "\n" +/
-                M.custom(ConsoleUtils.underlined("Diff")) + "\n" +/
+              M.custom(ConsoleUtils.underlined("Expected")) +/ M.value(PrettyPrint(that)) +/
+                M.custom(ConsoleUtils.underlined("Diff")) +/
                 M.custom(ConsoleUtils.red(diff.diff(that, a).render))
             case _ =>
               M.value(a) + M.equals + M.value(that)


### PR DESCRIPTION
This fixes a small rendering bug with Smart Asserts in ZIO 2.0.

for 

```scala
assertTrue("a" == "b")
```

Before:
![image](https://user-images.githubusercontent.com/601206/130232102-879b3513-8e7d-4906-b541-3a1e2e45aa2e.png)

After:
![image](https://user-images.githubusercontent.com/601206/130232149-f0deeac5-a995-4444-b868-acd237f54052.png)
