### PR TITLE
Standardize Names Of Operators Returning Boolean Values

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -82,7 +82,7 @@ object RTSSpec extends ZIOBaseSpec {
           acquireRelease = IO
                              .succeed(21)
                              .acquireReleaseExitWith((r: Int, exit: Exit[Any, Any]) =>
-                               if (exit.interrupted) exitLatch.succeed(r)
+                               if (exit.isInterrupted) exitLatch.succeed(r)
                                else IO.die(new Error("Unexpected case"))
                              )(a => startLatch.succeed(a) *> IO.never *> IO.succeed(1))
           fiber      <- acquireRelease.fork

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -47,7 +47,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
           f        = runtime.unsafeRunToFuture(UIO.never)
           _       <- UIO(f.cancel())
           r       <- ZIO.fromFuture(_ => f).exit
-        } yield assert(r.succeeded)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.
+        } yield assert(r.isSuccess)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.
       } @@ nonFlaky @@ zioTag(interruption),
       test("roundtrip preserves interruptibility") {
         for {
@@ -90,7 +90,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
           _  <- Fiber.fromFuture(f2).await
           e1 <- ZIO.fromFuture(_ => f1.cancel())
           e2 <- ZIO.fromFuture(_ => f2.cancel())
-        } yield assert(e1.succeeded)(isTrue) && assert(e2.succeeded)(isFalse)
+        } yield assert(e1.isSuccess)(isTrue) && assert(e2.isSuccess)(isFalse)
       } @@ nonFlaky,
       test("is a scala.concurrent.Future") {
         for {

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -11,7 +11,7 @@ object CauseSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("CauseSpec")(
     suite("Cause")(
       test("`Cause#died` and `Cause#stripFailures` are consistent") {
-        check(causes)(c => assert(c.keepDefects)(if (c.died) isSome(anything) else isNone))
+        check(causes)(c => assert(c.keepDefects)(if (c.isDie) isSome(anything) else isNone))
       },
       test("`Cause.equals` is symmetric") {
         check(causes, causes)((a, b) => assert(a == b)(equalTo(b == a)))

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1321,7 +1321,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       test("The canceler will run with an exit value indicating the effect was interrupted") {
         for {
           ref    <- Ref.make(false)
-          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.interrupted))
+          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.isInterrupted))
           _      <- managed.withEarlyRelease.use(_._1)
           result <- ref.get
         } yield assert(result)(isTrue)
@@ -1342,7 +1342,7 @@ object ZManagedSpec extends ZIOBaseSpec {
       test("Allows specifying an exit value") {
         for {
           ref    <- Ref.make(false)
-          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.succeeded))
+          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.isSuccess))
           _      <- managed.withEarlyReleaseExit(Exit.unit).use(_._1)
           result <- ref.get
         } yield assert(result)(isTrue)

--- a/core-tests/shared/src/test/scala/zio/ZScopeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZScopeSpec.scala
@@ -20,29 +20,29 @@ object ZScopeSpec extends ZIOBaseSpec {
     test("make returns an empty and open scope") {
       for {
         open  <- ZScope.make[Unit]
-        empty <- open.scope.empty
-        value <- open.scope.closed
+        empty <- open.scope.isEmpty
+        value <- open.scope.isClosed
       } yield assert(empty)(isTrue) && assert(value)(isFalse)
     },
     test("close makes the scope closed") {
       for {
         open  <- ZScope.make[Unit]
         _     <- open.close(())
-        value <- open.scope.closed
+        value <- open.scope.isClosed
       } yield assert(value)(isTrue)
     },
     test("close can be called multiple times") {
       for {
         open  <- ZScope.make[Unit]
         _     <- open.close(()).repeatN(10)
-        value <- open.scope.closed
+        value <- open.scope.isClosed
       } yield assert(value)(isTrue)
     },
     test("ensure makes the scope non-empty") {
       for {
         open  <- ZScope.make[Unit]
         value <- open.scope.ensure(_ => IO.unit)
-        empty <- open.scope.empty
+        empty <- open.scope.isEmpty
       } yield assert(empty)(isFalse) && assert(value)(isRight(anything))
     },
     test("ensure on closed scope returns false") {
@@ -50,7 +50,7 @@ object ZScopeSpec extends ZIOBaseSpec {
         open  <- ZScope.make[Unit]
         _     <- open.close(())
         value <- open.scope.ensure(_ => IO.unit)
-        empty <- open.scope.empty
+        empty <- open.scope.isEmpty
       } yield assert(empty)(isTrue) && assert(value)(isLeft(anything))
     },
     testScope("one finalizer", 0)((ref, scope) => scope.ensure(_ => ref.update(_ + 1)) as 1),
@@ -111,8 +111,8 @@ object ZScopeSpec extends ZIOBaseSpec {
           child    <- ZScope.make[Any]
           _        <- parent.scope.extend(child.scope)
           _        <- child.close(())
-          closed   <- child.scope.closed
-          released <- child.scope.released
+          closed   <- child.scope.isClosed
+          released <- child.scope.isReleased
         } yield assert(closed)(isTrue ?? "closed") && assert(released)(isFalse ?? "released")
       },
       test("single extension") {

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -79,7 +79,7 @@ private[internal] trait PlatformSpecific {
         throw t
       },
       reportFailure = (cause: Cause[Any]) =>
-        if (cause.died)
+        if (cause.isDie)
           println(cause.prettyPrint),
       tracing = Tracing(Tracer.Empty, TracingConfig.disabled),
       supervisor = Supervisor.none,

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -89,7 +89,7 @@ private[internal] trait PlatformSpecific {
           throw t
         } catch { case _: Throwable => throw t }
       },
-      reportFailure = (cause: Cause[Any]) => if (cause.died) System.err.println(cause.prettyPrint),
+      reportFailure = (cause: Cause[Any]) => if (cause.isDie) System.err.println(cause.prettyPrint),
       supervisor = Supervisor.none,
       enableCurrentFiber = false
     )

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -79,7 +79,7 @@ private[internal] trait PlatformSpecific {
         throw t
       },
       reportFailure = (cause: Cause[Any]) =>
-        if (cause.died)
+        if (cause.isDie)
           println(cause.prettyPrint),
       tracing = Tracing(Tracer.Empty, TracingConfig.disabled),
       supervisor = Supervisor.none,

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -141,9 +141,24 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Determines if the result is interrupted.
    */
-  final def interrupted: Boolean = self match {
+  @deprecated("use isInterrupted", "2.0.0")
+  final def interrupted: Boolean =
+    isInterrupted
+
+  /**
+   * Determines if the result is interrupted.
+   */
+  final def isInterrupted: Boolean = self match {
     case Success(_) => false
-    case Failure(c) => c.interrupted
+    case Failure(c) => c.isInterrupted
+  }
+
+  /**
+   * Determines if the result is a success.
+   */
+  final def isSuccess: Boolean = self match {
+    case Success(_) => true
+    case _          => false
   }
 
   /**
@@ -188,10 +203,9 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
   /**
    * Determines if the result is a success.
    */
-  final def succeeded: Boolean = self match {
-    case Success(_) => true
-    case _          => false
-  }
+  @deprecated("use isSuccess", "2.0.0")
+  final def succeeded: Boolean =
+    isSuccess
 
   /**
    * Converts the `Exit` to an `Either[Throwable, A]`, by wrapping the

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -461,7 +461,7 @@ object Fiber extends FiberPlatformSpecific {
     def interrupters: Set[Fiber.Id]
     def interruptStatus: InterruptStatus
     def executor: Executor
-    def locked: Boolean
+    def isLocked: Boolean
     def scope: ZScope[Exit[Any, Any]]
   }
 
@@ -490,7 +490,7 @@ object Fiber extends FiberPlatformSpecific {
         def interrupters: Set[Fiber.Id]      = interrupters0
         def interruptStatus: InterruptStatus = interruptStatus0
         def executor: Executor               = executor0
-        def locked: Boolean                  = locked0
+        def isLocked: Boolean                = locked0
         def scope: ZScope[Exit[Any, Any]]    = scope0
       }
   }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1201,7 +1201,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   final def onInterrupt[R1 <: R](cleanup: Set[Fiber.Id] => URIO[R1, Any]): ZIO[R1, E, A] =
     ZIO.uninterruptibleMask { restore =>
       restore(self).foldCauseZIO(
-        cause => if (cause.interrupted) cleanup(cause.interruptors) *> ZIO.failCause(cause) else ZIO.failCause(cause),
+        cause => if (cause.isInterrupted) cleanup(cause.interruptors) *> ZIO.failCause(cause) else ZIO.failCause(cause),
         a => ZIO.succeedNow(a)
       )
     }
@@ -4161,7 +4161,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   def lock[R, E, A](executor: => Executor)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     ZIO.descriptorWith { descriptor =>
-      if (descriptor.locked) ZIO.shift(executor).acquireRelease(ZIO.shift(descriptor.executor), zio)
+      if (descriptor.isLocked) ZIO.shift(executor).acquireRelease(ZIO.shift(descriptor.executor), zio)
       else ZIO.shift(executor).acquireRelease(ZIO.unshift, zio)
     }
 

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -2302,7 +2302,7 @@ object ZManaged extends ZManagedPlatformSpecific {
   def lock(executor: => Executor): ZManaged[Any, Nothing, Unit] =
     ZManaged.acquireReleaseWith {
       ZIO.descriptorWith { descriptor =>
-        if (descriptor.locked) ZIO.shift(executor).as(Some(descriptor.executor))
+        if (descriptor.isLocked) ZIO.shift(executor).as(Some(descriptor.executor))
         else ZIO.shift(executor).as(None)
       }
     } {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -956,7 +956,7 @@ private[zio] final class FiberContext[E, A](
   private[this] def isInterruptible(): Boolean = interruptStatus.peekOrElse(true)
 
   @inline
-  private[this] def isInterrupting(): Boolean = state.get().interrupting
+  private[this] def isInterrupting(): Boolean = state.get().isInterrupting
 
   @inline
   private[this] final def shouldInterrupt(): Boolean =
@@ -1052,7 +1052,7 @@ private[zio] final class FiberContext[E, A](
             _
           ) => // TODO: Dotty doesn't infer this properly
 
-        if (openScope.scope.unsafeClosed()) {
+        if (openScope.scope.unsafeIsClosed()) {
           val interruptorsCause = oldState.interruptorsCause
 
           val newExit =
@@ -1226,7 +1226,7 @@ private[zio] object FiberContext {
   sealed abstract class FiberState[+E, +A] extends Serializable with Product {
     def suppressed: Cause[Nothing]
     def status: Fiber.Status
-    def interrupting: Boolean = status.isInterrupting
+    def isInterrupting: Boolean = status.isInterrupting
     def interruptors: Set[Fiber.Id]
     def interruptorsCause: Cause[Nothing] =
       interruptors.foldLeft[Cause[Nothing]](Cause.empty) { case (acc, interruptor) =>

--- a/core/shared/src/main/scala/zio/internal/FiberState.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberState.scala
@@ -23,7 +23,7 @@ private[zio] final class FiberState[E, A](executing0: FiberState.Executing[E, A]
 
   def getStatus: Fiber.Status = executing.status
 
-  def interrupting: Boolean = {
+  def isInterrupting: Boolean = {
     @tailrec
     def loop(status0: Fiber.Status): Boolean =
       status0 match {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -138,7 +138,7 @@ object ZSinkSpec extends ZIOBaseSpec {
                               .map(_.reverse)
                               .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
                               .exit
-            } yield assert(foldResult.succeeded)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
+            } yield assert(foldResult.isSuccess)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
           }
         }
       ),

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -827,7 +827,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).exit
               streamConcat <- (s1 ++ s2).runCollect.exit
-            } yield assert(streamConcat.succeeded && chunkConcat.succeeded)(isTrue) implies assert(
+            } yield assert(streamConcat.isSuccess && chunkConcat.isSuccess)(isTrue) implies assert(
               streamConcat
             )(
               equalTo(chunkConcat)
@@ -908,7 +908,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               dropStreamResult <- s.drop(n.toLong).runCollect.exit
               dropListResult   <- s.runCollect.map(_.drop(n)).exit
-            } yield assert(dropListResult.succeeded)(isTrue) implies assert(dropStreamResult)(
+            } yield assert(dropListResult.isSuccess)(isTrue) implies assert(dropStreamResult)(
               equalTo(dropListResult)
             )
           }),
@@ -2123,7 +2123,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .mapZIOPar(8)(_ => ZIO(1).repeatN(2000))
                 .runDrain
                 .exit
-                .map(_.interrupted)
+                .map(_.isInterrupted)
             )(equalTo(false))
           } @@ TestAspect.jvmOnly,
           test("interrupts pending tasks when one of the tasks fails") {
@@ -2211,14 +2211,14 @@ object ZStreamSpec extends ZIOBaseSpec {
                                  .zipWith(s2.runCollect)((left, right) => left ++ right)
                                  .map(_.toSet)
                                  .exit
-              } yield assert(!mergedStream.succeeded && !mergedLists.succeeded)(isTrue) || assert(
+              } yield assert(!mergedStream.isSuccess && !mergedLists.isSuccess)(isTrue) || assert(
                 mergedStream
               )(
                 equalTo(mergedLists)
               )
           }),
           test("fail as soon as one stream fails") {
-            assertM(ZStream(1, 2, 3).merge(ZStream.fail(())).runCollect.exit.map(_.succeeded))(
+            assertM(ZStream(1, 2, 3).merge(ZStream.fail(())).runCollect.exit.map(_.isSuccess))(
               equalTo(false)
             )
           } @@ nonFlaky(20),
@@ -2633,7 +2633,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               takeStreamResult <- s.take(n.toLong).runCollect.exit
               takeListResult   <- s.runCollect.map(_.take(n)).exit
-            } yield assert(takeListResult.succeeded)(isTrue) implies assert(takeStreamResult)(
+            } yield assert(takeListResult.isSuccess)(isTrue) implies assert(takeStreamResult)(
               equalTo(takeListResult)
             )
           }),
@@ -2671,7 +2671,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               chunkTakeUntil <- s.runCollect
                                   .map(as => as.takeWhile(!p(_)) ++ as.dropWhile(!p(_)).take(1))
                                   .exit
-            } yield assert(chunkTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(
+            } yield assert(chunkTakeUntil.isSuccess)(isTrue) implies assert(streamTakeUntil)(
               equalTo(chunkTakeUntil)
             )
           }
@@ -2686,7 +2686,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                                        .zipWith(as.dropWhileZIO(p(_).map(!_)).map(_.take(1)))(_ ++ _)
                                    )
                                    .exit
-            } yield assert(chunkTakeUntilM.succeeded)(isTrue) implies assert(streamTakeUntilM)(
+            } yield assert(chunkTakeUntilM.isSuccess)(isTrue) implies assert(streamTakeUntilM)(
               equalTo(chunkTakeUntilM)
             )
           }
@@ -2696,7 +2696,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.exit
               chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).exit
-            } yield assert(chunkTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
+            } yield assert(chunkTakeWhile.isSuccess)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
           }),
           test("takeWhile doesn't stop when hitting an empty chunk (#4272)") {
             ZStream

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -322,7 +322,7 @@ object ZSinkSpec extends ZIOBaseSpec {
                               .map(_.reverse)
                               .flatMap(_.foldLeft(z)((acc, el) => acc.flatMap(f(_, el))))
                               .exit
-            } yield assert(foldResult.succeeded)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
+            } yield assert(foldResult.isSuccess)(isTrue) implies assert(foldResult)(succeeds(equalTo(sinkResult)))
           }
         }
       ),

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -1023,7 +1023,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               dropStreamResult <- s.drop(n).runCollect.exit
               dropListResult   <- s.runCollect.map(_.drop(n)).exit
-            } yield assert(dropListResult.succeeded)(isTrue) implies assert(dropStreamResult)(
+            } yield assert(dropListResult.isSuccess)(isTrue) implies assert(dropStreamResult)(
               equalTo(dropListResult)
             )
           }),
@@ -1041,7 +1041,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               dropStreamResult <- s.dropRight(n).runCollect.exit
               dropListResult   <- s.runCollect.map(_.dropRight(n)).exit
-            } yield assert(dropListResult.succeeded)(isTrue) implies assert(dropStreamResult)(
+            } yield assert(dropListResult.isSuccess)(isTrue) implies assert(dropStreamResult)(
               equalTo(dropListResult)
             )
           }),
@@ -2275,7 +2275,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .mapZIOPar(8)(_ => ZIO(1).repeatN(2000))
                 .runDrain
                 .exit
-                .map(_.interrupted)
+                .map(_.isInterrupted)
             )(equalTo(false))
           } @@ TestAspect.jvmOnly,
           test("interrupts pending tasks when one of the tasks fails") {
@@ -2366,14 +2366,14 @@ object ZStreamSpec extends ZIOBaseSpec {
                                  .zipWith(s2.runCollect)((left, right) => left ++ right)
                                  .map(_.toSet)
                                  .exit
-              } yield assert(!mergedStream.succeeded && !mergedLists.succeeded)(isTrue) || assert(
+              } yield assert(!mergedStream.isSuccess && !mergedLists.isSuccess)(isTrue) || assert(
                 mergedStream
               )(
                 equalTo(mergedLists)
               )
           }),
           test("fail as soon as one stream fails") {
-            assertM(ZStream(1, 2, 3).merge(ZStream.fail(())).runCollect.exit.map(_.succeeded))(
+            assertM(ZStream(1, 2, 3).merge(ZStream.fail(())).runCollect.exit.map(_.isSuccess))(
               equalTo(false)
             )
           } @@ nonFlaky(20),
@@ -2707,7 +2707,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               takeStreamResult <- s.take(n.toLong).runCollect.exit
               takeListResult   <- s.runCollect.map(_.take(n)).exit
-            } yield assert(takeListResult.succeeded)(isTrue) implies assert(takeStreamResult)(
+            } yield assert(takeListResult.isSuccess)(isTrue) implies assert(takeStreamResult)(
               equalTo(takeListResult)
             )
           }),
@@ -2745,7 +2745,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               chunkTakeUntil <- s.runCollect
                                   .map(as => as.takeWhile(!p(_)) ++ as.dropWhile(!p(_)).take(1))
                                   .exit
-            } yield assert(chunkTakeUntil.succeeded)(isTrue) implies assert(streamTakeUntil)(
+            } yield assert(chunkTakeUntil.isSuccess)(isTrue) implies assert(streamTakeUntil)(
               equalTo(chunkTakeUntil)
             )
           }
@@ -2760,7 +2760,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                                        .zipWith(as.dropWhileZIO(p(_).map(!_)).map(_.take(1)))(_ ++ _)
                                    )
                                    .exit
-            } yield assert(chunkTakeUntilM.succeeded)(isTrue) implies assert(streamTakeUntilM)(
+            } yield assert(chunkTakeUntilM.isSuccess)(isTrue) implies assert(streamTakeUntilM)(
               equalTo(chunkTakeUntilM)
             )
           }
@@ -2778,7 +2778,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.exit
               chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).exit
-            } yield assert(chunkTakeWhile.succeeded)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
+            } yield assert(chunkTakeWhile.isSuccess)(isTrue) implies assert(streamTakeWhile)(equalTo(chunkTakeWhile))
           }),
           test("takeWhile doesn't stop when hitting an empty chunk (#4272)") {
             ZStream

--- a/streams/js/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/experimental/platform.scala
@@ -42,7 +42,7 @@ trait ZStreamPlatformSpecificConstructors {
                           try {
                             runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                           } catch {
-                            case FiberFailure(c) if c.interrupted =>
+                            case FiberFailure(c) if c.isInterrupted =>
                               Future.successful(false)
                           }
                         }
@@ -84,7 +84,7 @@ trait ZStreamPlatformSpecificConstructors {
              try {
                runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
              } catch {
-               case FiberFailure(c) if c.interrupted =>
+               case FiberFailure(c) if c.isInterrupted =>
                  Future.successful(false)
              }
            }.toManaged

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -61,7 +61,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                             try {
                               runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             } catch {
-                              case FiberFailure(c) if c.interrupted =>
+                              case FiberFailure(c) if c.isInterrupted =>
                                 Future.successful(false)
                             }
                           )
@@ -97,7 +97,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                try {
                  runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                } catch {
-                 case FiberFailure(c) if c.interrupted =>
+                 case FiberFailure(c) if c.isInterrupted =>
                    Future.successful(false)
                }
              }.toManaged
@@ -130,7 +130,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                            try {
                              runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                            } catch {
-                             case FiberFailure(c) if c.interrupted =>
+                             case FiberFailure(c) if c.isInterrupted =>
                                Future.successful(false)
                            }
                          }

--- a/streams/jvm/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/experimental/platform.scala
@@ -41,7 +41,7 @@ trait ZStreamPlatformSpecificConstructors {
                             runtime.unsafeRun(stream.Take.fromPull(k).flatMap(output.offer))
                             ()
                           } catch {
-                            case FiberFailure(c) if c.interrupted =>
+                            case FiberFailure(c) if c.isInterrupted =>
                           }
                         }
                       }
@@ -83,7 +83,7 @@ trait ZStreamPlatformSpecificConstructors {
                runtime.unsafeRun(stream.Take.fromPull(k).flatMap(output.offer))
                ()
              } catch {
-               case FiberFailure(c) if c.interrupted =>
+               case FiberFailure(c) if c.isInterrupted =>
              }
            }.toManaged
     } yield {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -137,7 +137,7 @@ trait ZStreamPlatformSpecificConstructors {
                               runtime.unsafeRun(stream.Take.fromPull(k).flatMap(output.offer))
                               ()
                             } catch {
-                              case FiberFailure(c) if c.interrupted =>
+                              case FiberFailure(c) if c.isInterrupted =>
                             }
                           )
                         }
@@ -173,7 +173,7 @@ trait ZStreamPlatformSpecificConstructors {
                  runtime.unsafeRun(stream.Take.fromPull(k).flatMap(output.offer))
                  ()
                } catch {
-                 case FiberFailure(c) if c.interrupted =>
+                 case FiberFailure(c) if c.isInterrupted =>
                }
              }.toManaged
         done <- ZRef.makeManaged(false)
@@ -206,7 +206,7 @@ trait ZStreamPlatformSpecificConstructors {
                              runtime.unsafeRun(stream.Take.fromPull(k).flatMap(output.offer))
                              ()
                            } catch {
-                             case FiberFailure(c) if c.interrupted =>
+                             case FiberFailure(c) if c.isInterrupted =>
                            }
                          }
                        }

--- a/streams/native/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/experimental/platform.scala
@@ -42,7 +42,7 @@ trait ZStreamPlatformSpecificConstructors {
                           try {
                             runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                           } catch {
-                            case FiberFailure(c) if c.interrupted =>
+                            case FiberFailure(c) if c.isInterrupted =>
                               Future.successful(false)
                           }
                         }
@@ -84,7 +84,7 @@ trait ZStreamPlatformSpecificConstructors {
              try {
                runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
              } catch {
-               case FiberFailure(c) if c.interrupted =>
+               case FiberFailure(c) if c.isInterrupted =>
                  Future.successful(false)
              }
            }.toManaged

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -61,7 +61,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                             try {
                               runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             } catch {
-                              case FiberFailure(c) if c.interrupted =>
+                              case FiberFailure(c) if c.isInterrupted =>
                                 Future.successful(false)
                             }
                           )
@@ -97,7 +97,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                try {
                  runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                } catch {
-                 case FiberFailure(c) if c.interrupted =>
+                 case FiberFailure(c) if c.isInterrupted =>
                    Future.successful(false)
                }
              }.toManaged
@@ -130,7 +130,7 @@ trait ZStreamPlatformSpecificConstructors { self: ZStream.type =>
                            try {
                              runtime.unsafeRunToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                            } catch {
-                             case FiberFailure(c) if c.interrupted =>
+                             case FiberFailure(c) if c.isInterrupted =>
                                Future.successful(false)
                            }
                          }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -506,7 +506,7 @@ object Assertion extends AssertionVariants {
    */
   def isInterrupted: Assertion[Exit[Any, Any]] =
     Assertion.assertion("isInterrupted")() {
-      case Exit.Failure(cause) => cause.interrupted
+      case Exit.Failure(cause) => cause.isInterrupted
       case _                   => false
     }
 

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -208,7 +208,7 @@ object TestAspect extends TimeoutVariants {
         ): ZIO[R, TestFailure[E], TestSuccess] =
           test.fork.flatMap { fiber =>
             fiber.join.raceWith[R, TestFailure[E], TestFailure[E], Unit, TestSuccess](Live.live(ZIO.sleep(duration)))(
-              (exit, sleepFiber) => dump(label).when(!exit.succeeded) *> sleepFiber.interrupt *> ZIO.done(exit),
+              (exit, sleepFiber) => dump(label).when(!exit.isSuccess) *> sleepFiber.interrupt *> ZIO.done(exit),
               (_, _) => dump(label) *> fiber.join
             )
           }


### PR DESCRIPTION
I went through all the operators in ZIO that return `Boolean` values based on the principle that they should have the form `isXYZ`. I excluded methods that take an argument (e.g. `exists`) or change state in some way and return a value based on that (e.g. `offer`).

We are generally already following this rule pretty well. The main exception is in some of the operators on `Cause` and `Exit` where we use past tense terms like `died` or `interrupted` instead of `isDie` or `isInterrupted`. There were also some places in `ZScope` we were not following this, though those were mostly internally facing. This standardizes all of those.