### PR TITLE
Replacing ☛ with `at` so tooling can auto-hyperlink stacktrace paths

### DIFF
--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -28,14 +28,14 @@ object MavenJunitSpec extends DefaultRunnableSpec {
             "should fail",
             s"""zio.test.junit.TestFailed:
                |11 did not satisfy equalTo(12)
-               |☛ ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10""".stripMargin
+               |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10""".stripMargin
           ) &&
             containsFailure(
               "should fail - isSome",
               s"""zio.test.junit.TestFailed:
                  |11 did not satisfy equalTo(12)
                  |Some(11) did not satisfy isSome(equalTo(12))
-                 |☛ ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13""".stripMargin
+                 |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13""".stripMargin
             ) &&
             containsSuccess("should succeed")
         )

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -218,7 +218,7 @@ object ZTestFrameworkSpec {
   }
 
   lazy val sourceFilePath: String = zio.test.sourcePath
-  lazy val assertLocation: String = s"☛ $sourceFilePath:XXX"
+  lazy val assertLocation: String = s"at $sourceFilePath:XXX"
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =
       output.replaceAll(Pattern.quote(sourceFilePath + ":") + "\\d+", sourceFilePath + ":XXX")

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -269,7 +269,7 @@ object ReportingTestUtils {
     """[\s║]*failed!"""
   )
 
-  def assertSourceLocation(): String = cyan(s"☛ $sourceFilePath:XXX")
+  def assertSourceLocation(): String = cyan(s"at $sourceFilePath:XXX")
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =
       output.replaceAll(Pattern.quote(sourceFilePath + ":") + "\\d+", sourceFilePath + ":XXX")

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -222,7 +222,7 @@ object DefaultTestReporter {
           .flatMap(renderFailureCase(_, offset, true))
           .map(_.withOffset(offset + 1)) ++
           Chunk.fromIterable(path.map { case (label, value) => dim(s"$label = ") + primary(value.toString) }) ++
-          Chunk(detail(s"☛ $location").toLine))
+          Chunk(detail(s"at $location").toLine))
     }
 
   private def renderAssertionFailureDetails(failureDetails: ::[AssertionValue], offset: Int): Message = {
@@ -242,7 +242,7 @@ object DefaultTestReporter {
   }
 
   private def renderAssertionLocation(av: AssertionValue, offset: Int) = av.sourceLocation.fold(Message()) { location =>
-    detail(s"☛ $location").toLine
+    detail(s"at $location").toLine
       .withOffset(offset + 1)
       .toMessage
   }

--- a/test/shared/src/main/scala/zio/test/Result.scala
+++ b/test/shared/src/main/scala/zio/test/Result.scala
@@ -139,7 +139,7 @@ object FailureCase {
 
         errorMessageLines ++ Chunk(codeString) ++ nested.flatMap(renderFailureCase(_, true)).map("  " + _) ++
           Chunk.fromIterable(path.map { case (label, value) => dim(s"$label = ") + blue(PrettyPrint(value)) }) ++
-          Chunk(cyan(s"☛ $location")) ++ Chunk("")
+          Chunk(cyan(s"at $location")) ++ Chunk("")
 
     }
 }


### PR DESCRIPTION
For series/2.0