### PR TITLE
Implement extensible ZLayer debugging

### DIFF
--- a/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
@@ -1,11 +1,11 @@
 package zio.autowire
 
-import zio.test.Assertion.{equalTo, isLeft}
-import zio.test.AssertionM.Render.param
-import zio.test.environment.TestConsole
-import zio.test._
 import zio._
 import zio.internal.macros.StringUtils.StringOps
+import zio.test.Assertion.{equalTo, isLeft}
+import zio.test.AssertionM.Render.param
+import zio.test._
+import zio.test.environment.TestConsole
 
 object AutoWireSpec extends ZIOBaseSpec {
 

--- a/core/shared/src/main/scala-2.x/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.x/zio/ZLayerCompanionVersionSpecific.scala
@@ -31,7 +31,7 @@ private[zio] trait ZLayerCompanionVersionSpecific {
     new WirePartiallyApplied[R]
 
   /**
-   * Automatically assembles a layer for the provided type `R`, leaving
+   * Automatically constructs a layer for the provided type `R`, leaving
    * a remainder `R0`.
    *
    * {{{
@@ -41,9 +41,24 @@ private[zio] trait ZLayerCompanionVersionSpecific {
    * val layer = ZLayer.wireSome[Engine, Car](carLayer, wheelsLayer)
    * }}}
    */
-
   def wireSome[R0 <: Has[_], R <: Has[_]]: WireSomePartiallyApplied[R0, R] =
     new WireSomePartiallyApplied[R0, R]
+
+  /**
+   * Automatically constructs a layer for the provided type `R`, leaving a
+   * remainder `ZEnv`. This will satisfy all transitive `ZEnv` requirements
+   * with `ZEnv.any`, allowing them to be provided later.
+   *
+   * {{{
+   * val oldLadyLayer: ZLayer[Fly, Nothing, OldLady] = ???
+   * val flyLayer: ZLayer[Blocking, Nothing, Fly] = ???
+   *
+   * // The ZEnv you use later will provide both Blocking to flyLayer and Console to zio
+   * val layer : ZLayer[ZEnv, Nothing, OldLady] = ZLayer.wireCustom[OldLady](oldLadyLayer, flyLayer)
+   * }}}
+   */
+  def wireCustom[R <: Has[_]]: WireSomePartiallyApplied[ZEnv, R] =
+    new WireSomePartiallyApplied[ZEnv, R]
 
 }
 

--- a/core/shared/src/main/scala-2.x/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2.x/zio/internal/macros/LayerMacroUtils.scala
@@ -3,6 +3,8 @@ package zio.internal.macros
 import zio._
 import zio.internal.ansi.AnsiStringOps
 
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 import scala.reflect.macros.blackbox
 
 private[zio] trait LayerMacroUtils {
@@ -68,30 +70,81 @@ private[zio] trait LayerMacroUtils {
   def isValidHasType(tpe: Type): Boolean =
     tpe.isHas || tpe.isAny
 
-  def injectBaseImpl[F[_, _, _], R: c.WeakTypeTag, E, A](
-    layers: Seq[c.Expr[ZLayer[_, E, _]]],
-    method: String
-  ): c.Expr[F[Any, E, A]] = {
-    assertProperVarArgs(layers)
-    val expr = buildMemoizedLayer(generateExprGraph(layers), getRequirements[R])
-    c.Expr[F[Any, E, A]](q"${c.prefix}.${TermName(method)}(${expr.tree})")
-  }
-
-  def injectSomeBaseImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
+  def injectBaseImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layers: Seq[c.Expr[ZLayer[_, E, _]]],
     method: String
   ): c.Expr[F[R0, E, A]] = {
-    assertProperVarArgs(layers)
-    val remainderRequirements = getRequirements[R0]
+    val expr = constructLayer[R0, R, E](layers)
+    c.Expr[F[R0, E, A]](q"${c.prefix}.${TermName(method)}(${expr.tree})")
+  }
+
+  def constructLayer[R0: c.WeakTypeTag, R: c.WeakTypeTag, E](
+    layers0: Seq[c.Expr[ZLayer[_, E, _]]]
+  ): c.Expr[ZLayer[Any, E, R]] = {
+    assertProperVarArgs(layers0)
+
+    val debug = layers0.collectFirst {
+      _.tree match {
+        case q"zio.ZLayer.Debug.tree"    => ZLayer.Debug.Tree
+        case q"zio.ZLayer.Debug.mermaid" => ZLayer.Debug.Mermaid
+      }
+    }
+    val layers = layers0.filter {
+      _.tree match {
+        case q"zio.ZLayer.Debug.tree" | q"zio.ZLayer.Debug.mermaid" => false
+        case _                                                      => true
+      }
+    }
+
     val remainderExpr =
       if (weakTypeOf[R0] =:= weakTypeOf[ZEnv]) reify(ZEnv.any)
       else reify(ZLayer.environment[R0])
+    val remainderNode =
+      if (weakTypeOf[R0] =:= weakTypeOf[Any]) List.empty
+      else List(Node(List.empty, getRequirements[R0], remainderExpr))
+    val nodes = remainderNode ++ layers.map(getNode)
 
-    val remainderNode = Node(List.empty, remainderRequirements, remainderExpr)
-    val nodes         = (remainderNode +: layers.map(getNode)).toList
+    val graph        = generateExprGraph(nodes)
+    val requirements = getRequirements[R]
+    val expr         = buildMemoizedLayer(graph, requirements)
+    debug.foreach { debug =>
+      debugLayers(debug, graph, requirements)
+    }
+    expr.asInstanceOf[c.Expr[ZLayer[Any, E, R]]]
+  }
 
-    val layerExpr = buildMemoizedLayer(generateExprGraph(nodes), getRequirements[R])
-    c.Expr[F[R0, E, A]](q"${c.prefix}.${TermName(method)}(${layerExpr.tree})")
+  private def debugLayers(
+    debug: ZLayer.Debug,
+    graph: ZLayerExprBuilder[c.Type, LayerExpr],
+    requirements: List[c.Type]
+  ): Unit = {
+    val graphString: String =
+      eitherToOption(
+        graph.graph
+          .map(layer => RenderedGraph(layer.showTree))
+          .buildComplete(requirements)
+      ).get
+        .fold[RenderedGraph](RenderedGraph.Row(List.empty), identity, _ ++ _, _ >>> _)
+        .render
+
+    val title   = "  ZLayer Wiring Graph  ".yellow.bold.inverted
+    val builder = new StringBuilder
+    builder ++= "\n" + title + "\n\n" + graphString + "\n\n"
+
+    if (debug == ZLayer.Debug.Mermaid) {
+      val mermaidLink: String = generateMermaidJsLink(requirements, graph)
+      builder ++= "Mermaid Live Editor Link".underlined + "\n" + mermaidLink.faint + "\n\n"
+    }
+
+    c.info(c.enclosingPosition, builder.result(), true)
+  }
+
+  /**
+   * Scala 2.11 doesn't have `Either.toOption`
+   */
+  private def eitherToOption[A](either: Either[_, A]): Option[A] = either match {
+    case Left(_)      => None
+    case Right(value) => Some(value)
   }
 
   def getRequirements(tpe: Type): List[c.Type] = {
@@ -143,6 +196,52 @@ private[zio] trait LayerMacroUtils {
   implicit class TreeOps(self: c.Expr[_]) {
     def showTree: String = CleanCodePrinter.show(c)(self.tree)
   }
+
+  /**
+   * Generates a link of the Layer graph for the Mermaid.js graph viz
+   * library's live-editor (https://mermaid-js.github.io/mermaid-live-editor)
+   */
+  private def generateMermaidJsLink[R <: Has[_]: c.WeakTypeTag, R0: c.WeakTypeTag, E](
+    requirements: List[c.Type],
+    graph: ZLayerExprBuilder[c.Type, LayerExpr]
+  ): String = {
+    val cool = eitherToOption(
+      graph.graph
+        .map(layer => layer.showTree)
+        .buildComplete(requirements)
+    ).get
+
+    val map = cool.fold[Map[String, Chunk[String]]](
+      z = Map.empty,
+      value = str => Map(str -> Chunk.empty),
+      composeH = _ ++ _,
+      composeV = (m1, m2) =>
+        m2.map { case (key, values) =>
+          val result = m1.keys.toSet -- m1.values.flatten.toSet
+          key -> (values ++ Chunk.fromIterable(result))
+        } ++ m1
+    )
+
+    val mermaidGraphString = map.flatMap {
+      case (key, children) if children.isEmpty =>
+        List(s"    $key")
+      case (key, children) =>
+        children.map { child =>
+          s"    $key --> $child"
+        }
+    }
+      .mkString("\\n")
+
+    val mermaidGraph =
+      s"""{"code":"graph\\n$mermaidGraphString\\n    ","mermaid": "{\\n  \\"theme\\": \\"default\\"\\n}", "updateEditor": true, "autoSync": true, "updateDiagram": true}"""
+
+    val encodedMermaidGraph: String =
+      new String(Base64.getEncoder.encode(mermaidGraph.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)
+
+    val mermaidLink = s"https://mermaid-js.github.io/mermaid-live-editor/edit/#$encodedMermaidGraph"
+    mermaidLink
+  }
+
 }
 
 trait ExprGraphCompileVariants {}

--- a/core/shared/src/main/scala-2.x/zio/internal/macros/LayerMacros.scala
+++ b/core/shared/src/main/scala-2.x/zio/internal/macros/LayerMacros.scala
@@ -10,11 +10,12 @@ private[zio] class LayerMacros(val c: blackbox.Context) extends LayerMacroUtils 
   def injectImpl[F[_, _, _], R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
   ): c.Expr[F[Any, E, A]] =
-    injectBaseImpl[F, R, E, A](layers, "provideLayer")
+    injectBaseImpl[F, Any, R, E, A](layers, "provideLayer")
 
   def injectSomeImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[F[R0, E, A]] = injectSomeBaseImpl[F, R0, R, E, A](layers, "provideLayer")
+  ): c.Expr[F[R0, E, A]] =
+    injectBaseImpl[F, R0, R, E, A](layers, "provideLayer")
 
   def debugGetRequirements[R: c.WeakTypeTag]: c.Expr[List[String]] =
     c.Expr[List[String]](q"${getRequirements[R]}")

--- a/core/shared/src/main/scala-2.x/zio/internal/macros/WireMacros.scala
+++ b/core/shared/src/main/scala-2.x/zio/internal/macros/WireMacros.scala
@@ -1,7 +1,6 @@
 package zio.internal.macros
 
 import zio.internal.ansi.AnsiStringOps
-import zio.internal.macros.StringUtils.StringOps
 import zio.{Has, ZLayer}
 
 import scala.reflect.macros.blackbox
@@ -19,76 +18,15 @@ final class WireMacros(val c: blackbox.Context) extends LayerMacroUtils {
   ): c.Expr[ZLayer[R0, E, R]] = {
     val _ = (dummyK, dummyKRemainder)
     assertEnvIsNotNothing[R]()
-    assertProperVarArgs(layers)
-
-    val deferredRequirements = getRequirements[R0]
-    val requirements         = getRequirements[R] diff deferredRequirements
-
-    val deferredLayer =
-      if (deferredRequirements.nonEmpty) Seq(Node(List.empty, deferredRequirements, reify(ZLayer.environment[R0])))
-      else Nil
-
-    val nodes = (deferredLayer ++ layers.map(getNode)).toList
-
-    buildMemoizedLayer(generateExprGraph(nodes), deferredRequirements ++ requirements)
-      .asInstanceOf[c.Expr[ZLayer[R0, E, R]]]
-  }
-
-  def wireDebugImpl[
-    E,
-    R0: c.WeakTypeTag,
-    R <: Has[_]: c.WeakTypeTag
-  ](layers: c.Expr[ZLayer[_, E, _]]*)(
-    dummyKRemainder: c.Expr[DummyK[R0]],
-    dummyK: c.Expr[DummyK[R]]
-  ): c.Expr[ZLayer[R0, E, R]] = {
-    val _ = (dummyK, dummyKRemainder)
-    assertEnvIsNotNothing[R]()
-    assertProperVarArgs(layers)
-
-    val deferredRequirements = getRequirements[R0]
-    val requirements         = getRequirements[R] diff deferredRequirements
-
-    val deferredLayer =
-      if (deferredRequirements.isEmpty) List.empty
-      else List(Node(List.empty, deferredRequirements, reify(ZLayer.environment[R0])))
-    val nodes = deferredLayer ++ layers.map(getNode)
-
-    val graph = generateExprGraph(nodes)
-    graph.buildLayerFor(requirements)
-
-    val graphString: String = {
-      eitherToOption(
-        graph.graph
-          .map(layer => RenderedGraph(layer.showTree))
-          .buildComplete(requirements)
-      ).get
-        .fold[RenderedGraph](RenderedGraph.Row(List.empty), identity, _ ++ _, _ >>> _)
-        .render
-    }
-
-    val maxWidth = graphString.maxLineWidth
-    val title    = "  ZLayer Wiring Graph  ".yellow.bold.inverted
-    val adjust   = (maxWidth - title.length) / 2
-    val rendered = "\n" + (" " * adjust) + title + "\n\n" + graphString + "\n\n"
-
-    c.abort(c.enclosingPosition, rendered)
-  }
-
-  /**
-   * Scala 2.11 doesn't have `Either.toOption`
-   */
-  private def eitherToOption[A](either: Either[_, A]): Option[A] = either match {
-    case Left(_)      => None
-    case Right(value) => Some(value)
+    constructLayer[R0, R, E](layers)
   }
 
   /**
    * Ensures the macro has been annotated with the intended result type.
    * The macro will not behave correctly otherwise.
    */
-  private def assertEnvIsNotNothing[Out <: Has[_]: c.WeakTypeTag](): Unit = {
-    val outType     = weakTypeOf[Out]
+  private def assertEnvIsNotNothing[R <: Has[_]: c.WeakTypeTag](): Unit = {
+    val outType     = weakTypeOf[R]
     val nothingType = weakTypeOf[Nothing]
     if (outType == nothingType) {
       val errorMessage =

--- a/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
@@ -16,12 +16,16 @@ object LayerDefinitionExample extends App {
   }
 
   override def run(args: List[String]): URIO[ZEnv, ExitCode] = {
-    val liveLayer: ULayer[Has[Foo]] =
-      (Console.live ++ ZLayer.succeed("Hello") ++ ZLayer.succeed(3)) >>> Foo.live
 
-    ZIO
-      .accessZIO[Has[Foo]](_.get.bar)
-      .inject(liveLayer)
+    val program: ZIO[Has[Foo], Nothing, Unit] = ZIO.serviceWith[Foo](_.bar)
+
+    program
+      .inject(
+        Console.live,
+        ZLayer.succeed("Hello"),
+        ZLayer.succeed(3),
+        Foo.live
+      )
       .exitCode
   }
 

--- a/examples/shared/src/main/scala/zio/examples/ZLayerInjectExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/ZLayerInjectExample.scala
@@ -2,7 +2,7 @@ package zio.examples
 
 import zio._
 
-object ProvideLayerAutoExample extends App {
+object ZLayerInjectExample extends App {
   val program =
     OldLady.contentsOfStomach.flatMap { contents =>
       Console.printLine(s"There was an old who lady swallowed:\n- ${contents.mkString("\n- ")}")
@@ -19,7 +19,7 @@ object ProvideLayerAutoExample extends App {
 
   def run(args: List[String]): URIO[ZEnv, ExitCode] =
     program
-      .inject(OldLady.live, Spider.live, Fly.live, Bear.live, Console.live)
+      .inject(OldLady.live, Spider.live, Fly.live, Bear.live, Console.live, ZLayer.Debug.tree)
       .exitCode
 
   trait OldLady {
@@ -33,7 +33,7 @@ object ProvideLayerAutoExample extends App {
       (for {
         spiderGuts <- Spider.contentsOfStomach
       } yield new OldLady {
-        def contentsOfStomach: UIO[List[String]] = UIO("a Spider" :: spiderGuts)
+        def contentsOfStomach: UIO[List[String]] = UIO("a Spdder" :: spiderGuts)
       }).toLayer
   }
 

--- a/examples/shared/src/test/scala/zio/examples/test/ZLayerInjectExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ZLayerInjectExampleSpec.scala
@@ -1,11 +1,11 @@
 package zio.examples.test
 
 import zio._
-import zio.examples.ProvideLayerAutoExample.{Bear, Fly, OldLady, Spider}
+import zio.examples.ZLayerInjectExample.{Bear, Fly, OldLady, Spider}
 import zio.test.Assertion.anything
 import zio.test._
 
-object ProvideLayerAutoExampleSpec extends DefaultRunnableSpec {
+object ZLayerInjectExampleSpec extends DefaultRunnableSpec {
 
   private val exampleZio: ZIO[Has[Console] with Has[OldLady], Nothing, Unit] =
     OldLady.contentsOfStomach.flatMap { contents =>

--- a/streams/shared/src/main/scala-2.x/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-2.x/zio.stream/ZStreamVersionSpecific.scala
@@ -1,9 +1,9 @@
 package zio.stream
 
 import zio.internal.macros.LayerMacros
-import zio.{ZEnv, ZLayer}
+import zio.{Has, NeedsEnv, ZEnv, ZLayer}
 
-private[zio] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>
+private[stream] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>
 
   /**
    * Automatically constructs the part of the environment that is not part of the `ZEnv`,
@@ -23,9 +23,35 @@ private[zio] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =
     macro LayerMacros.injectSomeImpl[ZStream, ZEnv, R, E1, O]
 
   /**
+   * Splits the environment into two parts, assembling one part using the
+   * specified layers and leaving the remainder `R0`.
+   *
+   * {{{
+   * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
+   *
+   * val managed: ZStream[Clock with Random, Nothing, Unit] = ???
+   *
+   * val managed2 = managed.injectSome[Random](clockLayer)
+   * }}}
+   */
+  def injectSome[R0 <: Has[_]]: ProvideSomeLayerStreamPartiallyApplied[R0, R, E, O] =
+    new ProvideSomeLayerStreamPartiallyApplied[R0, R, E, O](self)
+
+  /**
    * Automatically assembles a layer for the ZStream effect.
    */
   def inject[E1 >: E](layers: ZLayer[_, E1, _]*): ZStream[Any, E1, O] =
     macro LayerMacros.injectImpl[ZStream, R, E1, O]
 
+}
+
+private final class ProvideSomeLayerStreamPartiallyApplied[R0 <: Has[_], -R, +E, +O](val self: ZStream[R, E, O])
+    extends AnyVal {
+  def provideLayer[E1 >: E, R1](
+    layer: ZLayer[R0, E1, R1]
+  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZStream[R0, E1, O] =
+    self.provideLayer(layer)
+
+  def apply[E1 >: E](layers: ZLayer[_, E1, _]*): ZStream[R0, E1, O] =
+    macro LayerMacros.injectSomeImpl[ZStream, R0, R, E1, O]
 }

--- a/test-tests/shared/src/test/scala/zio/test/AutoWireSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AutoWireSpec.scala
@@ -21,9 +21,9 @@ object AutoWireSpec extends ZIOBaseSpec {
               double <- ZIO.service[Double]
             } yield str.length + double.toInt).toLayer
           test("automatically constructs a layer from its dependencies") {
-            val program = ZIO.service[Int]
+            val program = ZIO.environment[ZEnv] *> ZIO.service[Int]
             assertM(program)(equalTo(128))
-          }.inject(doubleLayer, stringLayer, intLayer)
+          }.injectCustom(doubleLayer, stringLayer, intLayer)
         },
         test("reports missing top-level layers") {
           val program: URIO[Has[String] with Has[Int], String] = UIO("test")

--- a/test/shared/src/main/scala-2.x/zio/test/SpecLayerMacros.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/SpecLayerMacros.scala
@@ -10,15 +10,15 @@ class SpecLayerMacros(val c: blackbox.Context) extends LayerMacroUtils {
   def injectSharedImpl[R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
   ): c.Expr[Spec[Any, E, A]] =
-    injectBaseImpl[Spec, R, E, A](layers, "provideLayerShared")
+    injectBaseImpl[Spec, Any, R, E, A](layers, "provideLayerShared")
 
   def injectCustomSharedImpl[R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
   ): c.Expr[Spec[TestEnvironment, E, A]] =
-    injectSomeBaseImpl[Spec, TestEnvironment, R, E, A](layers, "provideLayerShared")
+    injectBaseImpl[Spec, TestEnvironment, R, E, A](layers, "provideLayerShared")
 
   def injectSomeSharedImpl[R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
   ): c.Expr[Spec[R0, E, A]] =
-    injectSomeBaseImpl[Spec, R0, R, E, A](layers, "provideLayerShared")
+    injectBaseImpl[Spec, R0, R, E, A](layers, "provideLayerShared")
 }


### PR DESCRIPTION
Implemented `ZLayer.Debug.tree` and `ZLayer.Debug.mermaid`:
Also, I've simplified the Layer generation code a bit, so all these different methods hit the same code paths.

```scala

        val layer =
          ZLayer.wire[Has[OldLady]](
            OldLady.live,
            Spider.live,
            Fly.live,
            Bear.live,
            Console.live,
            ZLayer.Debug.mermaid
          )
      // Including `ZLayer.Debug.mermaid` will generate the following compilation error:
      //
      // ◉ OldLady.live
      // ├─◑ Spider.live
      // │ ╰─◑ Fly.live
      // │   ╰─◑ Console.live
      // ╰─◑ Bear.live
      //   ╰─◑ Fly.live
      //     ╰─◑ Console.live
      // 
      // Mermaid Live Editor Link
      // https://mermaid-js.github.io/mermaid-live-editor/edit/#eyJjb2RlIjoiZ3JhcGhcbiAgICBDb25zb2xlLmxpdmVcbiAgICBTcGlkZXIubGl2ZSAtLT4gRmx5LmxpdmVcbiAgICBGbHkubGl2ZSAtLT4gQ29uc29sZS5saXZlXG4gICAgT2xkTGFkeS5saXZlIC0tPiBTcGlkZXIubGl2ZVxuICAgIE9sZExhZHkubGl2ZSAtLT4gQmVhci5saXZlXG4gICAgQmVhci5saXZlIC0tPiBGbHkubGl2ZVxuICAgICIsIm1lcm1haWQiOiAie1xuICBcInRoZW1lXCI6IFwiZGVmYXVsdFwiXG59IiwgInVwZGF0ZUVkaXRvciI6IHRydWUsICJhdXRvU3luYyI6IHRydWUsICJ1cGRhdGVEaWFncmFtIjogdHJ1ZX0=
```