### PR TITLE
Align Return Values Of Schedule Constructors

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -346,9 +346,9 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
       val initial = self.initial
       def step(now: OffsetDateTime, in: In, state: State): ZIO[Env, Nothing, (State, Duration, Decision)] =
         self.step(now, in, state).flatMap {
-          case (state, out, Done) =>
+          case (state, _, Done) =>
             ZIO.succeedNow((state, Duration.Zero, Done))
-          case (state, out, Continue(interval)) =>
+          case (state, _, Continue(interval)) =>
             val delay = Duration(interval.toInstant.toEpochMilli - now.toInstant.toEpochMilli, TimeUnit.MILLISECONDS)
             ZIO.succeedNow((state, delay, Continue(interval)))
         }


### PR DESCRIPTION
Resolves #5462. Resolves #5463.

This PR makes a couple of changes to improve the usefulness of the return values of schedules.

First, it implements a new `delays` operator on `Schedule` analogous to the existing `repetitions` operator that returns a version of the schedule that outputs the delay between each step.

Second, it uses this to align the return values of the schedule constructors. Specifically, we implement the principle that constructors that return the number of repetitions must always return a value that is consistent with `Schedule#repetitions` and constructors that return the delay must return a value that is consistent with `Schedule#delays`.