### PR TITLE
Back Port Zippable and Unzippable To ZIO 1.0

### DIFF
--- a/core/shared/src/main/scala/zio/Unzippable.scala
+++ b/core/shared/src/main/scala/zio/Unzippable.scala
@@ -1,0 +1,387 @@
+package zio
+
+trait Unzippable[A, B] {
+  type In
+  def unzip(in: In): (A, B)
+}
+
+object Unzippable extends UnzippableLowPriority1 {
+
+  type In[A, B, C] = Unzippable[A, B] { type In = C }
+
+  implicit def UnzippableLeftIdentity[A]: Unzippable.In[Unit, A, A] =
+    new Unzippable[Unit, A] {
+      type In = A
+      def unzip(in: A): (Unit, A) =
+        ((), in)
+    }
+}
+
+trait UnzippableLowPriority1 extends UnzippableLowPriority2 {
+
+  implicit def UnzippableRightIdentity[A]: Unzippable.In[A, Unit, A] =
+    new Unzippable[A, Unit] {
+      type In = A
+      def unzip(in: A): (A, Unit) =
+        (in, ())
+    }
+}
+
+trait UnzippableLowPriority2 extends UnzippableLowPriority3 {
+
+  implicit def Unzippable3[A, B, Z]: Unzippable.In[(A, B), Z, (A, B, Z)] =
+    new Unzippable[(A, B), Z] {
+      type In = (A, B, Z)
+      def unzip(in: (A, B, Z)): ((A, B), Z) =
+        ((in._1, in._2), in._3)
+    }
+
+  implicit def Unzippable4[A, B, C, Z]: Unzippable.In[(A, B, C), Z, (A, B, C, Z)] =
+    new Unzippable[(A, B, C), Z] {
+      type In = (A, B, C, Z)
+      def unzip(in: (A, B, C, Z)): ((A, B, C), Z) =
+        ((in._1, in._2, in._3), in._4)
+    }
+
+  implicit def Unzippable5[A, B, C, D, Z]: Unzippable.In[(A, B, C, D), Z, (A, B, C, D, Z)] =
+    new Unzippable[(A, B, C, D), Z] {
+      type In = (A, B, C, D, Z)
+      def unzip(in: (A, B, C, D, Z)): ((A, B, C, D), Z) =
+        ((in._1, in._2, in._3, in._4), in._5)
+    }
+
+  implicit def Unzippable6[A, B, C, D, E, Z]: Unzippable.In[(A, B, C, D, E), Z, (A, B, C, D, E, Z)] =
+    new Unzippable[(A, B, C, D, E), Z] {
+      type In = (A, B, C, D, E, Z)
+      def unzip(in: (A, B, C, D, E, Z)): ((A, B, C, D, E), Z) =
+        ((in._1, in._2, in._3, in._4, in._5), in._6)
+    }
+
+  implicit def Unzippable7[A, B, C, D, E, F, Z]: Unzippable.In[(A, B, C, D, E, F), Z, (A, B, C, D, E, F, Z)] =
+    new Unzippable[(A, B, C, D, E, F), Z] {
+      type In = (A, B, C, D, E, F, Z)
+      def unzip(in: (A, B, C, D, E, F, Z)): ((A, B, C, D, E, F), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6), in._7)
+    }
+
+  implicit def Unzippable8[A, B, C, D, E, F, G, Z]: Unzippable.In[(A, B, C, D, E, F, G), Z, (A, B, C, D, E, F, G, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G), Z] {
+      type In = (A, B, C, D, E, F, G, Z)
+      def unzip(in: (A, B, C, D, E, F, G, Z)): ((A, B, C, D, E, F, G), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7), in._8)
+    }
+
+  implicit def Unzippable9[A, B, C, D, E, F, G, H, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H), Z, (A, B, C, D, E, F, G, H, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H), Z] {
+      type In = (A, B, C, D, E, F, G, H, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, Z)): ((A, B, C, D, E, F, G, H), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8), in._9)
+    }
+
+  implicit def Unzippable10[A, B, C, D, E, F, G, H, I, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I), Z, (A, B, C, D, E, F, G, H, I, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, Z)): ((A, B, C, D, E, F, G, H, I), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9), in._10)
+    }
+
+  implicit def Unzippable11[A, B, C, D, E, F, G, H, I, J, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I, J), Z, (A, B, C, D, E, F, G, H, I, J, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, J, Z)): ((A, B, C, D, E, F, G, H, I, J), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9, in._10), in._11)
+    }
+
+  implicit def Unzippable12[A, B, C, D, E, F, G, H, I, J, K, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I, J, K), Z, (A, B, C, D, E, F, G, H, I, J, K, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, J, K, Z)): ((A, B, C, D, E, F, G, H, I, J, K), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9, in._10, in._11), in._12)
+    }
+
+  implicit def Unzippable13[A, B, C, D, E, F, G, H, I, J, K, L, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I, J, K, L), Z, (A, B, C, D, E, F, G, H, I, J, K, L, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, J, K, L, Z)): ((A, B, C, D, E, F, G, H, I, J, K, L), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9, in._10, in._11, in._12), in._13)
+    }
+
+  implicit def Unzippable14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)): ((A, B, C, D, E, F, G, H, I, J, K, L, M), Z) =
+        ((in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9, in._10, in._11, in._12, in._13), in._14)
+    }
+
+  implicit def Unzippable15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z]
+    : Unzippable.In[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)
+      def unzip(in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z) =
+        (
+          (in._1, in._2, in._3, in._4, in._5, in._6, in._7, in._8, in._9, in._10, in._11, in._12, in._13, in._14),
+          in._15
+        )
+    }
+
+  implicit def Unzippable16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15
+          ),
+          in._16
+        )
+    }
+
+  implicit def Unzippable17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16
+          ),
+          in._17
+        )
+    }
+
+  implicit def Unzippable18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16,
+            in._17
+          ),
+          in._18
+        )
+    }
+
+  implicit def Unzippable19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16,
+            in._17,
+            in._18
+          ),
+          in._19
+        )
+    }
+
+  implicit def Unzippable20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16,
+            in._17,
+            in._18,
+            in._19
+          ),
+          in._20
+        )
+    }
+
+  implicit def Unzippable21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16,
+            in._17,
+            in._18,
+            in._19,
+            in._20
+          ),
+          in._21
+        )
+    }
+
+  implicit def Unzippable22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z]: Unzippable.In[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+  ] =
+    new Unzippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U), Z] {
+      type In = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+      def unzip(
+        in: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+      ): ((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U), Z) =
+        (
+          (
+            in._1,
+            in._2,
+            in._3,
+            in._4,
+            in._5,
+            in._6,
+            in._7,
+            in._8,
+            in._9,
+            in._10,
+            in._11,
+            in._12,
+            in._13,
+            in._14,
+            in._15,
+            in._16,
+            in._17,
+            in._18,
+            in._19,
+            in._20,
+            in._21
+          ),
+          in._22
+        )
+    }
+}
+
+trait UnzippableLowPriority3 {
+
+  implicit def Unzippable2[A, B]: Unzippable.In[A, B, (A, B)] =
+    new Unzippable[A, B] {
+      type In = (A, B)
+      def unzip(in: (A, B)): (A, B) =
+        (in._1, in._2)
+    }
+}

--- a/core/shared/src/main/scala/zio/Zippable.scala
+++ b/core/shared/src/main/scala/zio/Zippable.scala
@@ -1,0 +1,421 @@
+package zio
+
+trait Zippable[-A, -B] {
+  type Out
+  def zip(left: A, right: B): Out
+}
+
+object Zippable extends ZippableLowPriority1 {
+
+  type Out[-A, -B, C] = Zippable[A, B] { type Out = C }
+
+  implicit def ZippableLeftIdentity[A]: Zippable.Out[Unit, A, A] =
+    new Zippable[Unit, A] {
+      type Out = A
+      def zip(left: Unit, right: A) =
+        right
+    }
+}
+
+trait ZippableLowPriority1 extends ZippableLowPriority2 {
+
+  implicit def ZippableRightIdentity[A]: Zippable.Out[A, Unit, A] =
+    new Zippable[A, Unit] {
+      type Out = A
+      def zip(left: A, right: Unit) =
+        left
+    }
+}
+
+trait ZippableLowPriority2 extends ZippableLowPriority3 {
+
+  implicit def Zippable3[A, B, Z]: Zippable.Out[(A, B), Z, (A, B, Z)] =
+    new Zippable[(A, B), Z] {
+      type Out = (A, B, Z)
+      def zip(left: (A, B), right: Z): (A, B, Z) =
+        (left._1, left._2, right)
+    }
+
+  implicit def Zippable4[A, B, C, Z]: Zippable.Out[(A, B, C), Z, (A, B, C, Z)] =
+    new Zippable[(A, B, C), Z] {
+      type Out = (A, B, C, Z)
+      def zip(left: (A, B, C), right: Z): (A, B, C, Z) =
+        (left._1, left._2, left._3, right)
+    }
+
+  implicit def Zippable5[A, B, C, D, Z]: Zippable.Out[(A, B, C, D), Z, (A, B, C, D, Z)] =
+    new Zippable[(A, B, C, D), Z] {
+      type Out = (A, B, C, D, Z)
+      def zip(left: (A, B, C, D), right: Z): (A, B, C, D, Z) =
+        (left._1, left._2, left._3, left._4, right)
+    }
+
+  implicit def Zippable6[A, B, C, D, E, Z]: Zippable.Out[(A, B, C, D, E), Z, (A, B, C, D, E, Z)] =
+    new Zippable[(A, B, C, D, E), Z] {
+      type Out = (A, B, C, D, E, Z)
+      def zip(left: (A, B, C, D, E), right: Z): (A, B, C, D, E, Z) =
+        (left._1, left._2, left._3, left._4, left._5, right)
+    }
+
+  implicit def Zippable7[A, B, C, D, E, F, Z]: Zippable.Out[(A, B, C, D, E, F), Z, (A, B, C, D, E, F, Z)] =
+    new Zippable[(A, B, C, D, E, F), Z] {
+      type Out = (A, B, C, D, E, F, Z)
+      def zip(left: (A, B, C, D, E, F), right: Z): (A, B, C, D, E, F, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, right)
+    }
+
+  implicit def Zippable8[A, B, C, D, E, F, G, Z]: Zippable.Out[(A, B, C, D, E, F, G), Z, (A, B, C, D, E, F, G, Z)] =
+    new Zippable[(A, B, C, D, E, F, G), Z] {
+      type Out = (A, B, C, D, E, F, G, Z)
+      def zip(left: (A, B, C, D, E, F, G), right: Z): (A, B, C, D, E, F, G, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, right)
+    }
+
+  implicit def Zippable9[A, B, C, D, E, F, G, H, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H), Z, (A, B, C, D, E, F, G, H, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H), Z] {
+      type Out = (A, B, C, D, E, F, G, H, Z)
+      def zip(left: (A, B, C, D, E, F, G, H), right: Z): (A, B, C, D, E, F, G, H, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, right)
+    }
+
+  implicit def Zippable10[A, B, C, D, E, F, G, H, I, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I), Z, (A, B, C, D, E, F, G, H, I, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I), right: Z): (A, B, C, D, E, F, G, H, I, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, right)
+    }
+
+  implicit def Zippable11[A, B, C, D, E, F, G, H, I, J, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J), Z, (A, B, C, D, E, F, G, H, I, J, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J), right: Z): (A, B, C, D, E, F, G, H, I, J, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, right)
+    }
+
+  implicit def Zippable12[A, B, C, D, E, F, G, H, I, J, K, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K), Z, (A, B, C, D, E, F, G, H, I, J, K, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K), right: Z): (A, B, C, D, E, F, G, H, I, J, K, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, left._11, right)
+    }
+
+  implicit def Zippable13[A, B, C, D, E, F, G, H, I, J, K, L, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L), Z, (A, B, C, D, E, F, G, H, I, J, K, L, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          right
+        )
+    }
+
+  implicit def Zippable14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L, M), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, M, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          right
+        )
+    }
+
+  implicit def Zippable15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          right
+        )
+    }
+
+  implicit def Zippable16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          right
+        )
+    }
+
+  implicit def Zippable17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          right
+        )
+    }
+
+  implicit def Zippable18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          right
+        )
+    }
+
+  implicit def Zippable19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          right
+        )
+    }
+
+  implicit def Zippable20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          right
+        )
+    }
+
+  implicit def Zippable21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          left._20,
+          right
+        )
+    }
+
+  implicit def Zippable22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          left._20,
+          left._21,
+          right
+        )
+    }
+}
+
+trait ZippableLowPriority3 {
+
+  implicit def Zippable2[A, B]: Zippable.Out[A, B, (A, B)] =
+    new Zippable[A, B] {
+      type Out = (A, B)
+      def zip(left: A, right: B): Out = (left, right)
+    }
+}


### PR DESCRIPTION
Some ZIO ecosystem libraries would like to start using `Zippable` to construct tuples without nesting. We can't actually change the signatures of operators in ZIO 1.0 to use `Zippable` but we can make it available so that other ecosystem libraries can depend on it.