### PR TITLE
Rename ZIO#tapCause to ZIO#tapErrorCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3353,11 +3353,11 @@ object ZIOSpec extends ZIOBaseSpec {
         }
       }
     ),
-    suite("tapCause")(
+    suite("tapErrorCause")(
       test("effectually peeks at the cause of the failure of this effect") {
         for {
           ref    <- Ref.make(false)
-          result <- ZIO.dieMessage("die").tapCause(_ => ref.set(true)).exit
+          result <- ZIO.dieMessage("die").tapErrorCause(_ => ref.set(true)).exit
           effect <- ref.get
         } yield assert(result)(dies(hasMessage(equalTo("die")))) &&
           assert(effect)(isTrue)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -1173,11 +1173,11 @@ object ZManagedSpec extends ZIOBaseSpec {
         ).useNow
       }
     ),
-    suite("tapCause")(
+    suite("tapErrorCause")(
       test("effectually peeks at the cause of the failure of the acquired resource") {
         (for {
           ref    <- Ref.make(false).toManaged
-          result <- ZManaged.dieMessage("die").tapCause(_ => ref.set(true).toManaged).exit
+          result <- ZManaged.dieMessage("die").tapErrorCause(_ => ref.set(true).toManaged).exit
           effect <- ref.get.toManaged
         } yield assert(result)(dies(hasMessage(equalTo("die")))) &&
           assert(effect)(isTrue)).useNow

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -974,8 +974,9 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * Returns an effect that effectually peeks at the cause of the failure of
    * the acquired resource.
    */
+  @deprecated("use tapErrorCause", "2.0.0")
   final def tapCause[R1 <: R, E1 >: E](f: Cause[E] => ZManaged[R1, E1, Any]): ZManaged[R1, E1, A] =
-    catchAllCause(c => f(c) *> ZManaged.failCause(c))
+    tapErrorCause(f)
 
   /**
    * Returns an effect that effectually "peeks" at the defect of the acquired
@@ -989,6 +990,13 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    */
   def tapError[R1 <: R, E1 >: E](f: E => ZManaged[R1, E1, Any])(implicit ev: CanFail[E]): ZManaged[R1, E1, A] =
     tapBoth(f, ZManaged.succeedNow)
+
+  /**
+   * Returns an effect that effectually peeks at the cause of the failure of
+   * the acquired resource.
+   */
+  final def tapErrorCause[R1 <: R, E1 >: E](f: Cause[E] => ZManaged[R1, E1, Any]): ZManaged[R1, E1, A] =
+    catchAllCause(c => f(c) *> ZManaged.failCause(c))
 
   /**
    * Like [[ZManaged#tap]], but uses a function that returns a ZIO value rather than a

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2233,10 +2233,10 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
                  latch <- Promise.make[Nothing, Unit]
                  _     <- out.offer(p.await.mapError(Some(_)))
                  _ <- permits.withPermit {
-                        latch.succeed(()) *>                 // Make sure we start evaluation before moving on to the next element
-                          (errorSignal.await raceFirst f(a)) // Interrupt evaluation if another task fails
+                        latch.succeed(()) *>                      // Make sure we start evaluation before moving on to the next element
+                          (errorSignal.await raceFirst f(a))      // Interrupt evaluation if another task fails
                             .tapErrorCause(errorSignal.failCause) // Notify other tasks of a failure
-                            .intoPromise(p)                  // Transfer the result to the consuming stream
+                            .intoPromise(p)                       // Transfer the result to the consuming stream
                       }.fork
                  _ <- latch.await
                } yield ()

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2235,7 +2235,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
                  _ <- permits.withPermit {
                         latch.succeed(()) *>                 // Make sure we start evaluation before moving on to the next element
                           (errorSignal.await raceFirst f(a)) // Interrupt evaluation if another task fails
-                            .tapCause(errorSignal.failCause) // Notify other tasks of a failure
+                            .tapErrorCause(errorSignal.failCause) // Notify other tasks of a failure
                             .intoPromise(p)                  // Transfer the result to the consuming stream
                       }.fork
                  _ <- latch.await

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -648,7 +648,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                        _ <- permits.withPermit {
                               latch.succeed(()) *>
                                 (errorSignal.await raceFirst f(outElem))
-                                  .tapCause(errorSignal.failCause)
+                                  .tapErrorCause(errorSignal.failCause)
                                   .intoPromise(p)
                             }.fork
                        _ <- latch.await


### PR DESCRIPTION
Resolves #5483. In my review it seemed like the most common pattern was for the `Cause` variant to be identical to the normal one except have `Cause` at the end (with slight variations if there is another postfix (e.g. `foldCauseZIO`). This seems to be logical and many operators don't read well otherwise (e.g. `failCause` doesn't really make sense as `cause`). Renames `tapCause` to `tapErrorCause` to conform to this.