### PR TITLE
Deprecate ZIO#forkOn

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -950,6 +950,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Forks an effect that will be executed on the specified `ExecutionContext`.
    */
+  @deprecated("use onExecutionContext(ec).fork", "2.0.0")
   final def forkOn(ec: => ExecutionContext): ZIO[R, E, Fiber.Runtime[E, A]] =
     self.onExecutionContext(ec).fork
 


### PR DESCRIPTION
While we have been adding new operators over time this seems like one we can maybe cut out. It can already be implemented extremely compositionally as `zio.onExecutionContext(ec).fork` which still provides a fluent API. There are a variety of ways one might want to customize a forked effect and I don't think this one is sufficiently common to warrant its own variant. It also seems odd that this takes an `ExecutionContext` and not an `Executor` when `Executor` is supposed to be our first class representation of a thread pool.