### PR TITLE
Return Option from ZIO.When

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -20,7 +20,7 @@ object BenchmarkUtil extends Runtime[ZEnv] {
     else zio *> repeat(n - 1)(zio)
 
   def verify(cond: Boolean)(message: => String): IO[AssertionError, Unit] =
-    ZIO.when(!cond)(IO.fail(new AssertionError(message)))
+    ZIO.when(!cond)(IO.fail(new AssertionError(message))).unit
 
   def catsForeach[A, B](as: List[A])(f: A => CIO[B]): CIO[List[B]] =
     Traverse[List].traverse(as)(f)

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -1229,7 +1229,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.unless]]
    */
-  def unless[E](b: => Boolean)(zio: => IO[E, Any]): IO[E, Unit] =
+  def unless[E, A](b: => Boolean)(zio: => IO[E, A]): IO[E, Option[A]] =
     ZIO.unless(b)(zio)
 
   /**
@@ -1334,26 +1334,26 @@ object IO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when[E](b: => Boolean)(io: => IO[E, Any]): IO[E, Unit] =
+  def when[E, A](b: => Boolean)(io: => IO[E, A]): IO[E, Option[A]] =
     ZIO.when(b)(io)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  def whenCase[E, A](a: => A)(pf: PartialFunction[A, IO[E, Any]]): IO[E, Unit] =
+  def whenCase[E, A, B](a: => A)(pf: PartialFunction[A, IO[E, B]]): IO[E, Option[B]] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
   @deprecated("use whenCaseZIO", "2.0.0")
-  def whenCaseM[E, A](a: => IO[E, A])(pf: PartialFunction[A, IO[E, Any]]): IO[E, Unit] =
+  def whenCaseM[E, A, B](a: => IO[E, A])(pf: PartialFunction[A, IO[E, B]]): IO[E, Option[B]] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseZIO]]
    */
-  def whenCaseZIO[E, A](a: => IO[E, A])(pf: PartialFunction[A, IO[E, Any]]): IO[E, Unit] =
+  def whenCaseZIO[E, A, B](a: => IO[E, A])(pf: PartialFunction[A, IO[E, B]]): IO[E, Option[B]] =
     ZIO.whenCaseZIO(a)(pf)
 
   /**

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -1330,7 +1330,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.unless]]
    */
-  def unless[R](b: => Boolean)(zio: => RIO[R, Any]): RIO[R, Unit] =
+  def unless[R, A](b: => Boolean)(zio: => RIO[R, A]): RIO[R, Option[A]] =
     ZIO.unless(b)(zio)
 
   /**
@@ -1367,26 +1367,26 @@ object RIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when[R](b: => Boolean)(rio: => RIO[R, Any]): RIO[R, Unit] =
+  def when[R, A](b: => Boolean)(rio: => RIO[R, A]): RIO[R, Option[A]] =
     ZIO.when(b)(rio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  def whenCase[R, A](a: => A)(pf: PartialFunction[A, RIO[R, Any]]): RIO[R, Unit] =
+  def whenCase[R, A, B](a: => A)(pf: PartialFunction[A, RIO[R, B]]): RIO[R, Option[B]] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
   @deprecated("use whenCaseZIO", "2.0.0")
-  def whenCaseM[R, A](a: => RIO[R, A])(pf: PartialFunction[A, RIO[R, Any]]): RIO[R, Unit] =
+  def whenCaseM[R, A, B](a: => RIO[R, A])(pf: PartialFunction[A, RIO[R, B]]): RIO[R, Option[B]] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseZIO]]
    */
-  def whenCaseZIO[R, A](a: => RIO[R, A])(pf: PartialFunction[A, RIO[R, Any]]): RIO[R, Unit] =
+  def whenCaseZIO[R, A, B](a: => RIO[R, A])(pf: PartialFunction[A, RIO[R, B]]): RIO[R, Option[B]] =
     ZIO.whenCaseZIO(a)(pf)
 
   /**

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -1212,7 +1212,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.unless]]
    */
-  def unless(b: => Boolean)(zio: => Task[Any]): Task[Unit] =
+  def unless[A](b: => Boolean)(zio: => Task[A]): Task[Option[A]] =
     ZIO.unless(b)(zio)
 
   /**
@@ -1243,26 +1243,26 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when(b: => Boolean)(task: => Task[Any]): Task[Unit] =
+  def when[A](b: => Boolean)(task: => Task[A]): Task[Option[A]] =
     ZIO.when(b)(task)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  def whenCase[A](a: => A)(pf: PartialFunction[A, Task[Any]]): Task[Unit] =
+  def whenCase[A, B](a: => A)(pf: PartialFunction[A, Task[B]]): Task[Option[B]] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
   @deprecated("use whenCaseZIO", "2.0.0")
-  def whenCaseM[A](a: => Task[A])(pf: PartialFunction[A, Task[Any]]): Task[Unit] =
+  def whenCaseM[A, B](a: => Task[A])(pf: PartialFunction[A, Task[B]]): Task[Option[B]] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseZIO]]
    */
-  def whenCaseZIO[A](a: => Task[A])(pf: PartialFunction[A, Task[Any]]): Task[Unit] =
+  def whenCaseZIO[A, B](a: => Task[A])(pf: PartialFunction[A, Task[B]]): Task[Option[B]] =
     ZIO.whenCaseZIO(a)(pf)
 
   /**

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -1053,7 +1053,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.unless]]
    */
-  def unless(b: => Boolean)(zio: => UIO[Any]): UIO[Unit] =
+  def unless[A](b: => Boolean)(zio: => UIO[A]): UIO[Option[A]] =
     ZIO.unless(b)(zio)
 
   /**
@@ -1084,26 +1084,26 @@ object UIO {
   /**
    * @see See [[zio.ZIO.when]]
    */
-  def when(b: => Boolean)(uio: => UIO[Any]): UIO[Unit] =
+  def when[A](b: => Boolean)(uio: => UIO[A]): UIO[Option[A]] =
     ZIO.when(b)(uio)
 
   /**
    * @see See [[zio.ZIO.whenCase]]
    */
-  def whenCase[A](a: => A)(pf: PartialFunction[A, UIO[Any]]): UIO[Unit] =
+  def whenCase[A, B](a: => A)(pf: PartialFunction[A, UIO[B]]): UIO[Option[B]] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseM]]
    */
   @deprecated("use whenCaseZIO", "2.0.0")
-  def whenCaseM[A](a: => UIO[A])(pf: PartialFunction[A, UIO[Any]]): UIO[Unit] =
+  def whenCaseM[A, B](a: => UIO[A])(pf: PartialFunction[A, UIO[B]]): UIO[Option[B]] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.ZIO.whenCaseZIO]]
    */
-  def whenCaseZIO[A](a: => UIO[A])(pf: PartialFunction[A, UIO[Any]]): UIO[Unit] =
+  def whenCaseZIO[A, B](a: => UIO[A])(pf: PartialFunction[A, UIO[B]]): UIO[Option[B]] =
     ZIO.whenCaseZIO(a)(pf)
 
   /**

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -1183,7 +1183,7 @@ object URIO {
   /**
    * @see See [[zio.ZIO.unless]]
    */
-  def unless[R](b: => Boolean)(zio: => URIO[R, Any]): URIO[R, Unit] =
+  def unless[R, A](b: => Boolean)(zio: => URIO[R, A]): URIO[R, Option[A]] =
     ZIO.unless(b)(zio)
 
   /**
@@ -1220,26 +1220,26 @@ object URIO {
   /**
    * @see [[zio.ZIO.when]]
    */
-  def when[R](b: => Boolean)(rio: => URIO[R, Any]): URIO[R, Unit] =
+  def when[R, A](b: => Boolean)(rio: => URIO[R, A]): URIO[R, Option[A]] =
     ZIO.when(b)(rio)
 
   /**
    * @see [[zio.ZIO.whenCase]]
    */
-  def whenCase[R, A](a: => A)(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
+  def whenCase[R, A, B](a: => A)(pf: PartialFunction[A, URIO[R, B]]): URIO[R, Option[B]] =
     ZIO.whenCase(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenCaseM]]
    */
   @deprecated("use whenCaseZIO", "2.0.0")
-  def whenCaseM[R, A](a: => URIO[R, A])(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
+  def whenCaseM[R, A, B](a: => URIO[R, A])(pf: PartialFunction[A, URIO[R, B]]): URIO[R, Option[B]] =
     ZIO.whenCaseM(a)(pf)
 
   /**
    * @see [[zio.ZIO.whenCaseZIO]]
    */
-  def whenCaseZIO[R, A](a: => URIO[R, A])(pf: PartialFunction[A, URIO[R, Any]]): URIO[R, Unit] =
+  def whenCaseZIO[R, A, B](a: => URIO[R, A])(pf: PartialFunction[A, URIO[R, B]]): URIO[R, Option[B]] =
     ZIO.whenCaseZIO(a)(pf)
 
   /**

--- a/core/shared/src/main/scala/zio/ZHub.scala
+++ b/core/shared/src/main/scala/zio/ZHub.scala
@@ -368,9 +368,11 @@ object ZHub {
       val shutdown: UIO[Unit] =
         ZIO.suspendSucceedWith { (_, fiberId) =>
           shutdownFlag.set(true)
-          ZIO.whenZIO(shutdownHook.succeed(())) {
-            releaseMap.releaseAll(Exit.interrupt(fiberId), ExecutionStrategy.Parallel) *> strategy.shutdown
-          }
+          ZIO
+            .whenZIO(shutdownHook.succeed(())) {
+              releaseMap.releaseAll(Exit.interrupt(fiberId), ExecutionStrategy.Parallel) *> strategy.shutdown
+            }
+            .unit
         }.uninterruptible
       val size: UIO[Int] =
         ZIO.suspendSucceed {
@@ -431,10 +433,12 @@ object ZHub {
       val shutdown: UIO[Unit] =
         ZIO.suspendSucceedWith { (_, fiberId) =>
           shutdownFlag.set(true)
-          ZIO.whenZIO(shutdownHook.succeed(())) {
-            ZIO.foreachPar(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
-              ZIO.succeed(subscription.unsubscribe())
-          }
+          ZIO
+            .whenZIO(shutdownHook.succeed(())) {
+              ZIO.foreachPar(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
+                ZIO.succeed(subscription.unsubscribe())
+            }
+            .unit
         }.uninterruptible
       val size: UIO[Int] =
         ZIO.suspendSucceed {

--- a/core/shared/src/main/scala/zio/ZQueue.scala
+++ b/core/shared/src/main/scala/zio/ZQueue.scala
@@ -481,6 +481,7 @@ object ZQueue {
           .whenZIO(shutdownHook.succeed(()))(
             UIO.foreachParDiscard(unsafePollAll(takers))(_.interruptAs(fiberId)) *> strategy.shutdown
           )
+          .unit
       }.uninterruptible
 
     val isShutdown: UIO[Boolean] = UIO(shutdownFlag.get)

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -412,7 +412,7 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.unless]]
    */
-  def unless[E](b: => Boolean)(stm: => STM[E, Any]): STM[E, Unit] =
+  def unless[E, A](b: => Boolean)(stm: => STM[E, A]): STM[E, Option[A]] =
     ZSTM.unless(b)(stm)
 
   /**
@@ -455,25 +455,26 @@ object STM {
   /**
    * @see See [[zio.stm.ZSTM.when]]
    */
-  def when[E](b: => Boolean)(stm: => STM[E, Any]): STM[E, Unit] = ZSTM.when(b)(stm)
+  def when[E, A](b: => Boolean)(stm: => STM[E, A]): STM[E, Option[A]] =
+    ZSTM.when(b)(stm)
 
   /**
    * @see See [[zio.stm.ZSTM.whenCase]]
    */
-  def whenCase[E, A](a: => A)(pf: PartialFunction[A, STM[E, Any]]): STM[E, Unit] =
+  def whenCase[E, A, B](a: => A)(pf: PartialFunction[A, STM[E, B]]): STM[E, Option[B]] =
     ZSTM.whenCase(a)(pf)
 
   /**
    * @see See [[zio.stm.ZSTM.whenCaseM]]
    */
   @deprecated("use whenCaseSTM", "2.0.0")
-  def whenCaseM[E, A](a: STM[E, A])(pf: PartialFunction[A, STM[E, Any]]): STM[E, Unit] =
+  def whenCaseM[E, A, B](a: STM[E, A])(pf: PartialFunction[A, STM[E, B]]): STM[E, Option[B]] =
     ZSTM.whenCaseM(a)(pf)
 
   /**
    * @see See [[zio.stm.ZSTM.whenCaseSTM]]
    */
-  def whenCaseSTM[E, A](a: STM[E, A])(pf: PartialFunction[A, STM[E, Any]]): STM[E, Unit] =
+  def whenCaseSTM[E, A, B](a: STM[E, A])(pf: PartialFunction[A, STM[E, B]]): STM[E, Option[B]] =
     ZSTM.whenCaseSTM(a)(pf)
 
   /**

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -370,8 +370,8 @@ object MaybeConsoleSpec extends DefaultRunnableSpec {
       def maybeConsole(invokeConsole: Boolean) =
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
-      val maybeTest1 = maybeConsole(false).provideSomeLayer(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).provideSomeLayer(MockConsole.PrintLine(equalTo("foo"), unit))
+      val maybeTest1 = maybeConsole(false).unit.provideSomeLayer(MockConsole.empty)
+      val maybeTest2 = maybeConsole(true).unit.provideSomeLayer(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     }
   )

--- a/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/MockExampleSpec.scala
@@ -13,8 +13,8 @@ object MockExampleSpec extends DefaultRunnableSpec {
       def maybeConsole(invokeConsole: Boolean) =
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
-      val maybeTest1 = maybeConsole(false).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(true).inject(MockConsole.PrintLine(equalTo("foo"), unit))
+      val maybeTest1 = maybeConsole(false).unit.inject(MockConsole.empty)
+      val maybeTest2 = maybeConsole(true).unit.inject(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     test("expect no call on skipped branch") {
@@ -55,8 +55,8 @@ object MockExampleSpec extends DefaultRunnableSpec {
       def maybeConsole(invokeConsole: Boolean) =
         ZIO.when(invokeConsole)(Console.printLine("foo"))
 
-      val maybeTest1 = maybeConsole(true).inject(MockConsole.empty)
-      val maybeTest2 = maybeConsole(false).inject(MockConsole.PrintLine(equalTo("foo"), unit))
+      val maybeTest1 = maybeConsole(true).unit.inject(MockConsole.empty)
+      val maybeTest2 = maybeConsole(false).unit.inject(MockConsole.PrintLine(equalTo("foo"), unit))
       assertM(maybeTest1)(isUnit) *> assertM(maybeTest2)(isUnit)
     },
     test("expect call returning output") {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -294,7 +294,7 @@ trait ZStreamPlatformSpecificConstructors {
                 val blocking = ZIO.attemptBlocking(builder += iterator.next())
 
                 def go(i: Int): ZIO[Any, Throwable, Unit] =
-                  ZIO.when(i < maxChunkSize && iterator.hasNext)(blocking *> go(i + 1))
+                  ZIO.when(i < maxChunkSize && iterator.hasNext)(blocking *> go(i + 1)).unit
 
                 go(0).asSomeError.flatMap { _ =>
                   val chunk = builder.result()

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -266,9 +266,9 @@ abstract class ZSink[-R, +E, -I, +L, +Z] private (
                        openThatPush(nextSink.push).tap(thatPush.set).flatMap { p =>
                          switched.set(true) *> {
                            if (in.isDefined)
-                             p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty)
+                             p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty).unit
                            else
-                             p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty) *> p(None)
+                             p(Some(leftover).asInstanceOf[Some[Chunk[I2]]]).when(leftover.nonEmpty).unit *> p(None)
                          }
                        }
                      }

--- a/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/EmptyMockSpec.scala
@@ -15,7 +15,7 @@ object EmptyMockSpec extends ZIOBaseSpec with MockSpecUtils[Has[Console]] {
     suite("expect no calls on empty mocks")(
       testValue("should succeed when no call")(
         MockConsole.empty,
-        ZIO.when(false)(Console.printLine("foo")),
+        ZIO.when(false)(Console.printLine("foo")).unit,
         isUnit
       ), {
 

--- a/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/environment/TestConsole.scala
@@ -141,7 +141,7 @@ object TestConsole extends Serializable {
     override def print(line: => Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output :+ line.toString, data.errOutput)
-      } *> live.provide(Console.print(line)).whenZIO(debugState.get)
+      } *> live.provide(Console.print(line)).whenZIO(debugState.get).unit
 
     /**
      * Writes the specified string to the error buffer.
@@ -149,7 +149,7 @@ object TestConsole extends Serializable {
     override def printError(line: => Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output, data.errOutput :+ line.toString)
-      } *> live.provide(Console.printError(line)).whenZIO(debugState.get)
+      } *> live.provide(Console.printError(line)).whenZIO(debugState.get).unit
 
     /**
      * Writes the specified string to the output buffer followed by a newline
@@ -158,7 +158,7 @@ object TestConsole extends Serializable {
     override def printLine(line: => Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output :+ s"$line\n", data.errOutput)
-      } *> live.provide(Console.printLine(line)).whenZIO(debugState.get)
+      } *> live.provide(Console.printLine(line)).whenZIO(debugState.get).unit
 
     /**
      * Writes the specified string to the error buffer followed by a newline
@@ -167,7 +167,7 @@ object TestConsole extends Serializable {
     override def printLineError(line: => Any): IO[IOException, Unit] =
       consoleState.update { data =>
         Data(data.input, data.output, data.errOutput :+ s"$line\n")
-      } *> live.provide(Console.printLineError(line)).whenZIO(debugState.get)
+      } *> live.provide(Console.printLineError(line)).whenZIO(debugState.get).unit
 
     /**
      * Saves the `TestConsole`'s current state in an effect which, when run,


### PR DESCRIPTION
Resolves #5534.

One issues this raises a bit is whether we should be using `Any` more pervasively when an effect doesn't return a meaningful result.