### PR TITLE
Deprecate ZIO#forkInternal

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -912,10 +912,10 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * }}}
    */
   final def fork: URIO[R, Fiber.Runtime[E, A]] =
-    new ZIO.Fork(self, () => None, None)
+    new ZIO.Fork(self, () => None)
 
   final def forkIn(scope: => ZScope[Exit[Any, Any]]): URIO[R, Fiber.Runtime[E, A]] =
-    new ZIO.Fork(self, () => Some(scope), None)
+    new ZIO.Fork(self, () => Some(scope))
 
   /**
    * Forks the effect into a new independent fiber, with the specified name.
@@ -936,8 +936,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * reported. This is useful for implementing combinators that handle failures
    * themselves.
    */
+  @deprecated("use fork", "2.0.0")
   final def forkInternal: ZIO[R, Nothing, Fiber.Runtime[E, A]] =
-    new ZIO.Fork(self, () => None, Some(_ => ZIO.unit))
+    new ZIO.Fork(self, () => None)
 
   /**
    * Forks the fiber in a [[ZManaged]]. Using the [[ZManaged]] value will
@@ -5981,8 +5982,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
 
   private[zio] final class Fork[R, E, A](
     val value: ZIO[R, E, A],
-    val scope: () => Option[ZScope[Exit[Any, Any]]],
-    val reportFailure: Option[Cause[Any] => UIO[Any]]
+    val scope: () => Option[ZScope[Exit[Any, Any]]]
   ) extends URIO[R, Fiber.Runtime[E, A]] {
     override def tag = Tags.Fork
   }


### PR DESCRIPTION
This operator no longer makes sense based on the recent changes to `reportFailure`.