### PR TITLE
Shared Layers

### DIFF
--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -35,7 +35,7 @@ abstract class ZIOSpec[R <: Has[_]: Tag] extends ZIOApp { self =>
     runSpec.provideSomeLayer[ZEnv with Has[ZIOAppArgs]](TestEnvironment.live ++ (TestEnvironment.live >>> layer))
 
   final def <>[R1 <: R: Tag](that: ZIOSpec[R1]): ZIOSpec[R with R1] =
-    new ZIOSpec[R with R1]{
+    new ZIOSpec[R with R1] {
       def layer: ZLayer[TestEnvironment, Any, R with R1] =
         self.layer ++ that.layer
       override def runSpec: ZIO[R with R1 with TestEnvironment with Has[ZIOAppArgs], Any, Any] =

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+import zio._
+import zio.test.environment.TestEnvironment
+import zio.test.render._
+
+@EnableReflectiveInstantiation
+abstract class ZIOSpec[R <: Has[_]: Tag](val layer: ZLayer[TestEnvironment, Any, R]) extends ZIOApp { self =>
+
+  def spec: ZSpec[R with TestEnvironment with Has[ZIOAppArgs], Any]
+
+  def aspects: Chunk[TestAspect[Nothing, R with TestEnvironment with Has[ZIOAppArgs], Nothing, Any]] =
+    Chunk.empty
+
+  final def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any] =
+    runSpec.provideSomeLayer[ZEnv with Has[ZIOAppArgs]](TestEnvironment.live ++ (TestEnvironment.live >>> layer))
+
+  final def <>[R1 <: R: Tag](that: ZIOSpec[R1]): ZIOSpec[R with R1] =
+    new ZIOSpec[R with R1](self.layer ++ that.layer) {
+      override def runSpec: ZIO[R with R1 with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
+        self.runSpec.zipPar(that.runSpec)
+      def spec: ZSpec[R with R1 with TestEnvironment with Has[ZIOAppArgs], Any] =
+        self.spec + that.spec
+    }
+
+  protected def runSpec: ZIO[R with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
+    for {
+      args     <- ZIO.service[ZIOAppArgs]
+      testArgs  = TestArgs.parse(args.args.toArray)
+      exitCode <- runSpec(spec, testArgs)
+      _        <- doExit(exitCode)
+    } yield ()
+
+  private def createTestReporter(rendererName: String): TestReporter[Any] = {
+    val renderer = rendererName match {
+      case "intellij" => IntelliJRenderer
+      case _          => TestRenderer.default
+    }
+    DefaultTestReporter(renderer, TestAnnotationRenderer.default)
+  }
+
+  private def doExit(exitCode: Int): UIO[Unit] =
+    exit(ExitCode(exitCode)).when(!isAmmonite).unit
+
+  private def isAmmonite: Boolean =
+    sys.env.exists { case (k, v) =>
+      k.contains("JAVA_MAIN_CLASS") && v == "ammonite.Main"
+    }
+
+  private def runSpec(
+    spec: ZSpec[R with TestEnvironment with Has[ZIOAppArgs], Any],
+    testArgs: TestArgs
+  ): URIO[R with TestEnvironment with Has[ZIOAppArgs], Int] = {
+    val filteredSpec = FilteredSpec(spec, testArgs)
+
+    for {
+      env <- ZIO.environment[R with TestEnvironment with Has[ZIOAppArgs]]
+      runner = TestRunner(
+                 TestExecutor.default[R with TestEnvironment with Has[ZIOAppArgs], Any](ZLayer.succeedMany(env))
+               )
+      testReporter = testArgs.testRenderer.fold(runner.reporter)(createTestReporter)
+      results <-
+        runner.withReporter(testReporter).run(aspects.foldLeft(filteredSpec)(_ @@ _)).provideLayer(runner.bootstrap)
+      hasFailures = results.exists {
+                      case ExecutedSpec.TestCase(test, _) => test.isLeft
+                      case _                              => false
+                    }
+      _ <- TestLogger
+             .logLine(SummaryBuilder.buildSummary(results).summary)
+             .when(testArgs.printSummary)
+             .provideLayer(runner.bootstrap)
+    } yield if (hasFailures) 1 else 0
+  }
+}

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+import zio._
+import zio.test.environment.TestEnvironment
+import zio.test.render._
+
+@EnableReflectiveInstantiation
+abstract class ZIOSpecAbstract extends ZIOApp { self =>
+
+  type Environment <: Has[_]
+
+  protected implicit def tag: Tag[Environment]
+
+  def layer: ZLayer[TestEnvironment, Any, Environment]
+
+  def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any]
+
+  def aspects: Chunk[TestAspect[Nothing, Environment with TestEnvironment with Has[ZIOAppArgs], Nothing, Any]] =
+    Chunk.empty
+
+  final def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any] =
+    runSpec.provideSomeLayer[ZEnv with Has[ZIOAppArgs]](TestEnvironment.live ++ (TestEnvironment.live >>> layer))
+
+  final def <>(that: ZIOSpecAbstract): ZIOSpecAbstract =
+    new ZIOSpecAbstract {
+      type Environment = self.Environment with that.Environment
+      def layer: ZLayer[TestEnvironment, Any, Environment] =
+        self.layer ++ that.layer
+      override def runSpec: ZIO[Environment with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
+        self.runSpec.zipPar(that.runSpec)
+      def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any] =
+        self.spec + that.spec
+      protected def tag: Tag[Environment] = {
+        implicit val selfTag: Tag[self.Environment] = self.tag
+        implicit val thatTag: Tag[that.Environment] = that.tag
+        val _                                       = (selfTag, thatTag)
+        Tag[Environment]
+      }
+    }
+
+  protected def runSpec: ZIO[Environment with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
+    for {
+      args     <- ZIO.service[ZIOAppArgs]
+      testArgs  = TestArgs.parse(args.args.toArray)
+      exitCode <- runSpec(spec, testArgs)
+      _        <- doExit(exitCode)
+    } yield ()
+
+  private def createTestReporter(rendererName: String): TestReporter[Any] = {
+    val renderer = rendererName match {
+      case "intellij" => IntelliJRenderer
+      case _          => TestRenderer.default
+    }
+    DefaultTestReporter(renderer, TestAnnotationRenderer.default)
+  }
+
+  private def doExit(exitCode: Int): UIO[Unit] =
+    exit(ExitCode(exitCode)).when(!isAmmonite).unit
+
+  private def isAmmonite: Boolean =
+    sys.env.exists { case (k, v) =>
+      k.contains("JAVA_MAIN_CLASS") && v == "ammonite.Main"
+    }
+
+  private def runSpec(
+    spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any],
+    testArgs: TestArgs
+  ): URIO[Environment with TestEnvironment with Has[ZIOAppArgs], Int] = {
+    val filteredSpec = FilteredSpec(spec, testArgs)
+
+    for {
+      env <- ZIO.environment[Environment with TestEnvironment with Has[ZIOAppArgs]]
+      runner =
+        TestRunner(
+          TestExecutor.default[Environment with TestEnvironment with Has[ZIOAppArgs], Any](ZLayer.succeedMany(env))
+        )
+      testReporter = testArgs.testRenderer.fold(runner.reporter)(createTestReporter)
+      results <-
+        runner.withReporter(testReporter).run(aspects.foldLeft(filteredSpec)(_ @@ _)).provideLayer(runner.bootstrap)
+      hasFailures = results.exists {
+                      case ExecutedSpec.TestCase(test, _) => test.isLeft
+                      case _                              => false
+                    }
+      _ <- TestLogger
+             .logLine(SummaryBuilder.buildSummary(results).summary)
+             .when(testArgs.printSummary)
+             .provideLayer(runner.bootstrap)
+    } yield if (hasFailures) 1 else 0
+  }
+}

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -1,0 +1,11 @@
+package zio.test
+
+import zio._
+import zio.test.environment._
+
+abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
+
+  final val layer: ZLayer[TestEnvironment, Any, TestEnvironment] = ZLayer.environment
+
+  def spec: ZSpec[TestEnvironment, Any]
+}


### PR DESCRIPTION
Resolves #4519. Resolves #5093. Resolves #5536.

Implements `ZIOSpec`, a spec that includes a layer that will be globally shared. Combining specs results in a new spec where running the spec will build the layers from all of the specs and then provide them to all the tests, so memoization of layers will automatically take care of making sure we don't build the same layer twice.

The next step, still to be done here, is to update the SBT test runner to reflectively instantiate all specs and then to combine them into a single spec to achieve global sharing of layers across tests.