### PR TITLE
Docs typo

### DIFF
--- a/docs/datatypes/misc/chunk.md
+++ b/docs/datatypes/misc/chunk.md
@@ -2,7 +2,7 @@
 id: chunk
 title: "Chunk"
 ---
-A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed are usually backed by arrays, but expose a purely functional, safe interface to the underlying elements, and they become lazy on operations that would be costly with arrays, such as repeated concatenation.
+A `Chunk[A]` represents a chunk of values of type `A`. Chunks are usually backed by arrays, but expose a purely functional, safe interface to the underlying elements, and they become lazy on operations that would be costly with arrays, such as repeated concatenation.
 
 ```scala mdoc:invisible
 import zio._


### PR DESCRIPTION
Think I found a couple extra words in the chunk documentation.