### PR TITLE
Add tests and better null handling for isThrowableCause

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -570,17 +570,17 @@ object AssertionSpec extends ZIOBaseSpec {
       assert(assertion.equals(assertionM))(isFalse ?? "assertion != assertionM") &&
       assert(assertionM.equals(assertion))(isFalse ?? "assertionM != assertion")
     },
-    test("isThrowableCause must succeed when supplied value has matching cause") {
+    test("hasThrowableCause must succeed when supplied value has matching cause") {
       val cause = new Exception("cause")
       val t = new Exception("result", cause)
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
     },
-    test("isThrowableCause must fail when supplied value has non-matching cause") {
+    test("hasThrowableCause must fail when supplied value has non-matching cause") {
       val cause = new Exception("something different")
       val t = new Exception("result", cause)
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
     } @@ failing,
-    test("isThrowableCause must fail when supplied value does not have a cause") {
+    test("hasThrowableCause must fail when supplied value does not have a cause") {
       val t = new Exception("result")
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
     } @@ failing,

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -572,18 +572,18 @@ object AssertionSpec extends ZIOBaseSpec {
     },
     test("hasThrowableCause must succeed when supplied value has matching cause") {
       val cause = new Exception("cause")
-      val t = new Exception("result", cause)
+      val t     = new Exception("result", cause)
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
     },
     test("hasThrowableCause must fail when supplied value has non-matching cause") {
       val cause = new Exception("something different")
-      val t = new Exception("result", cause)
+      val t     = new Exception("result", cause)
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
     } @@ failing,
     test("hasThrowableCause must fail when supplied value does not have a cause") {
       val t = new Exception("result")
       assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
-    } @@ failing,
+    } @@ failing
   )
 
   case class SampleUser(name: String, age: Int)

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -569,7 +569,21 @@ object AssertionSpec extends ZIOBaseSpec {
       val assertionM = AssertionM.assertionDirect[Unit]("sameName")()(_ => ???)
       assert(assertion.equals(assertionM))(isFalse ?? "assertion != assertionM") &&
       assert(assertionM.equals(assertion))(isFalse ?? "assertionM != assertion")
-    }
+    },
+    test("isThrowableCause must succeed when supplied value has matching cause") {
+      val cause = new Exception("cause")
+      val t = new Exception("result", cause)
+      assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
+    },
+    test("isThrowableCause must fail when supplied value has non-matching cause") {
+      val cause = new Exception("something different")
+      val t = new Exception("result", cause)
+      assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
+    } @@ failing,
+    test("isThrowableCause must fail when supplied value does not have a cause") {
+      val t = new Exception("result")
+      assert(t)(hasThrowableCause(hasMessage(equalTo("cause"))))
+    } @@ failing,
   )
 
   case class SampleUser(name: String, age: Int)

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -221,7 +221,7 @@ object Assertion extends AssertionVariants {
    * Makes a new assertion that requires an exception to have a certain cause.
    */
   def hasThrowableCause(cause: Assertion[Throwable]): Assertion[Throwable] =
-    Assertion.assertionRec("hasThrowableCause")(param(cause))(cause)(th => Some(th.getCause))
+    Assertion.assertionRec("hasThrowableCause")(param(cause))(cause)(th => Option(th.getCause))
 
   /**
    * Makes a new assertion that requires a given string to end with the specified suffix.


### PR DESCRIPTION
This PR changes the behavior of `isThrowableCause` to better handle exceptions with `null` as their cause (all exceptions not created with an explicit cause). Instead of producing a null pointer exception, it will produce an appropriate "does not match" message.

Tests  are also added for `isThrowableCause`.