### PR TITLE
Enable fatal-warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,10 @@ addCommandAlias(
 )
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
-addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
+addCommandAlias(
+  "check",
+  "; scalafmtSbtCheck; scalafmtCheckAll; Test/compile; compile:scalafix --check; test:scalafix --check"
+)
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testMagnoliaTestsJVM/test:compile;testRefinedJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile;macrosTestsJVM/test:compile"


### PR DESCRIPTION
Scalafix, when run on its own, suppresses `fatal-warnings`, so that it can operate smoothly (and not get shot down because there is a warning in the codebase).

But in our case, we want to verify both that Scalafix is happy _and_ that the codebase doesn't contain any warnings.

related https://github.com/zio/zio-prelude/pull/727