### PR TITLE
Rename ZIO#unoption to ZIO#unsome

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1634,17 +1634,17 @@ object ZIOSpec extends ZIOBaseSpec {
         assertM(ZIO.die(ExampleError).sandbox.option)(equalTo(None))
       } @@ zioTag(errors)
     ),
-    suite("optional")(
+    suite("unsome")(
       test("fails when given Some error") {
-        val task: IO[String, Option[Int]] = IO.fail(Some("Error")).unoption
+        val task: IO[String, Option[Int]] = IO.fail(Some("Error")).unsome
         assertM(task.exit)(fails(equalTo("Error")))
       } @@ zioTag(errors),
       test("succeeds with None given None error") {
-        val task: IO[String, Option[Int]] = IO.fail(None).unoption
+        val task: IO[String, Option[Int]] = IO.fail(None).unsome
         assertM(task)(isNone)
       } @@ zioTag(errors),
       test("succeeds with Some given a value") {
-        val task: IO[String, Option[Int]] = IO.succeed(1).unoption
+        val task: IO[String, Option[Int]] = IO.succeed(1).unsome
         assertM(task)(isSome(equalTo(1)))
       }
     ),

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -619,15 +619,15 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("optional")(
       test("fails when given Some error") {
-        val managed: UManaged[Exit[String, Option[Int]]] = Managed.fail(Some("Error")).unoption.exit
+        val managed: UManaged[Exit[String, Option[Int]]] = Managed.fail(Some("Error")).unsome.exit
         managed.use(res => ZIO.succeed(assert(res)(fails(equalTo("Error")))))
       } @@ zioTag(errors),
       test("succeeds with None given None error") {
-        val managed: Managed[String, Option[Int]] = Managed.fail(None).unoption
+        val managed: Managed[String, Option[Int]] = Managed.fail(None).unsome
         managed.use(res => ZIO.succeed(assert(res)(isNone)))
       } @@ zioTag(errors),
       test("succeeds with Some given a value") {
-        val managed: Managed[String, Option[Int]] = Managed.succeed(1).unoption
+        val managed: Managed[String, Option[Int]] = Managed.succeed(1).unsome
         assertM(managed.useNow)(isSome(equalTo(1)))
       }
     ),

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -318,15 +318,15 @@ object ZSTMSpec extends ZIOBaseSpec {
       suite("optional to convert:")(
         test("A Some(e) in E to a e in E") {
           val ei: Either[Option[String], Int] = Left(Some("my Error"))
-          assertM(ZSTM.fromEither(ei).unoption.commit.exit)(fails(equalTo("my Error")))
+          assertM(ZSTM.fromEither(ei).unsome.commit.exit)(fails(equalTo("my Error")))
         },
         test("a None in E into None in A") {
           val ei: Either[Option[String], Int] = Left(None)
-          assertM(ZSTM.fromEither(ei).unoption.commit)(isNone)
+          assertM(ZSTM.fromEither(ei).unsome.commit)(isNone)
         },
         test("no error") {
           val ei: Either[Option[String], Int] = Right(42)
-          assertM(ZSTM.fromEither(ei).unoption.commit)(isSome(equalTo(42)))
+          assertM(ZSTM.fromEither(ei).unsome.commit)(isSome(equalTo(42)))
         }
       ),
       suite("orDie")(

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -650,9 +650,9 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
   /**
    * Converts an option on errors into an option on values.
    */
-  @deprecated("use unoption", "2.0.0")
+  @deprecated("use unsome", "2.0.0")
   final def optional[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
-    unoption
+    unsome
 
   /**
    * Translates effect failure into death of the fiber, making all failures unchecked and
@@ -1122,17 +1122,24 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
   /**
    * Converts an option on errors into an option on values.
    */
+  @deprecated("use unsome", "2.0.0")
   final def unoption[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
-    self.foldManaged(
-      e => ev(e).fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
-      a => ZManaged.succeedNow(Some(a))
-    )
+    unsome
 
   /**
    * The inverse operation `ZManaged.sandboxed`
    */
   def unsandbox[E1](implicit ev: E IsSubtypeOfError Cause[E1]): ZManaged[R, E1, A] =
     ZManaged.unsandbox(mapError(ev))
+
+      /**
+     * Converts an option on errors into an option on values.
+     */
+    final def unsome[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
+      self.foldManaged(
+        e => ev(e).fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
+        a => ZManaged.succeedNow(Some(a))
+      )
 
   /**
    * Updates a service in the environment of this effect.
@@ -1741,7 +1748,7 @@ object ZManaged extends ZManagedPlatformSpecific {
   def collect[R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
     f: A => ZManaged[R, Option[E], B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZManaged[R, E, Collection[B]] =
-    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
+    foreach[R, E, A, Option[B], Iterable](in)(a => f(a).unsome).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Evaluate each effect in the structure from left to right, and collect the
@@ -1840,7 +1847,7 @@ object ZManaged extends ZManagedPlatformSpecific {
   def collectPar[R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
     f: A => ZManaged[R, Option[E], B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZManaged[R, E, Collection[B]] =
-    foreachPar[R, E, A, Option[B], Iterable](in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
+    foreachPar[R, E, A, Option[B], Iterable](in)(a => f(a).unsome).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Evaluate each effect in the structure in parallel, collecting the
@@ -1851,7 +1858,7 @@ object ZManaged extends ZManagedPlatformSpecific {
   def collectParN[R, E, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(in: Collection[A])(
     f: A => ZManaged[R, Option[E], B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZManaged[R, E, Collection[B]] =
-    foreachParN[R, E, A, Option[B], Iterable](n)(in)(a => f(a).unoption).map(_.flatten).map(bf.fromSpecific(in))
+    foreachParN[R, E, A, Option[B], Iterable](n)(in)(a => f(a).unsome).map(_.flatten).map(bf.fromSpecific(in))
 
   /**
    * Similar to Either.cond, evaluate the predicate,

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -1132,14 +1132,14 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
   def unsandbox[E1](implicit ev: E IsSubtypeOfError Cause[E1]): ZManaged[R, E1, A] =
     ZManaged.unsandbox(mapError(ev))
 
-      /**
-     * Converts an option on errors into an option on values.
-     */
-    final def unsome[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
-      self.foldManaged(
-        e => ev(e).fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
-        a => ZManaged.succeedNow(Some(a))
-      )
+  /**
+   * Converts an option on errors into an option on values.
+   */
+  final def unsome[E1](implicit ev: E IsSubtypeOfError Option[E1]): ZManaged[R, E1, Option[A]] =
+    self.foldManaged(
+      e => ev(e).fold[ZManaged[R, E1, Option[A]]](ZManaged.succeedNow(Option.empty[A]))(ZManaged.fail(_)),
+      a => ZManaged.succeedNow(Some(a))
+    )
 
   /**
    * Updates a service in the environment of this effect.

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -756,14 +756,14 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
       a => ZSTM.succeedNow(Right(a))
     )
 
-      /**
-     * Converts an option on errors into an option on values.
-     */
-    def unsome[E1](implicit ev: E <:< Option[E1]): ZSTM[R, E1, Option[A]] =
-      foldSTM(
-        _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.fail(_)),
-        a => ZSTM.succeedNow(Some(a))
-      )
+  /**
+   * Converts an option on errors into an option on values.
+   */
+  def unsome[E1](implicit ev: E <:< Option[E1]): ZSTM[R, E1, Option[A]] =
+    foldSTM(
+      _.fold[ZSTM[R, E1, Option[A]]](ZSTM.succeedNow(Option.empty[A]))(ZSTM.fail(_)),
+      a => ZSTM.succeedNow(Some(a))
+    )
 
   /**
    * Updates a service in the environment of this effect.

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -164,7 +164,7 @@ val result: IO[Throwable, Option[(User, Team)]] = (for {
   id   <- maybeId
   user <- getUser(id).some
   team <- getTeam(user.teamId).asSomeError 
-} yield (user, team)).unoption 
+} yield (user, team)).unsome 
 ```
 
 #### Either

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -77,7 +77,7 @@ val result: IO[Throwable, Option[(User, Team)]] = (for {
   id   <- maybeId
   user <- getUser(id).some
   team <- getTeam(user.teamId).asSomeError 
-} yield (user, team)).unoption 
+} yield (user, team)).unsome 
 ```
 
 ### Either

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3526,11 +3526,11 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
         exec match {
           case ExecutionStrategy.Sequential =>
             pullL.unsome
-                          .zipWith(pullR.unsome)(handleSuccess(_, _, excess))
+              .zipWith(pullR.unsome)(handleSuccess(_, _, excess))
               .catchAllCause(e => UIO.succeedNow(Exit.failCause(e.map(Some(_)))))
           case _ =>
             pullL.unsome
-                          .zipWithPar(pullR.unsome)(handleSuccess(_, _, excess))
+              .zipWithPar(pullR.unsome)(handleSuccess(_, _, excess))
               .catchAllCause(e => UIO.succeedNow(Exit.failCause(e.map(Some(_)))))
         }
       case ((LeftDone, excess), _, pullR) =>

--- a/test/shared/src/main/scala/zio/test/FunctionVariants.scala
+++ b/test/shared/src/main/scala/zio/test/FunctionVariants.scala
@@ -64,7 +64,7 @@ trait FunctionVariants {
         for {
           lock    <- Semaphore.make(1)
           bufPull <- BufferedPull.make[R, Nothing, Sample[R, B]](pull)
-          fun     <- Fun.makeHash((_: A) => lock.withPermit(bufPull.pullElement).unoption.map(_.get.value))(hash)
+          fun     <- Fun.makeHash((_: A) => lock.withPermit(bufPull.pullElement).unsome.map(_.get.value))(hash)
         } yield fun
       }
     }


### PR DESCRIPTION
`unoption` is the inverse operation of `some` which is a little confusing and not consistent with our `left` and `unfelt` naming convention. I think if we are going to go with the `unXYZ` naming convention it needs to be `unsome`.