### PR TITLE
Add "tapError" operator to ZStream

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2719,6 +2719,15 @@ object ZStreamSpec extends ZIOBaseSpec {
             )
           }
         ),
+        suite("tapError")(
+          testM("tapError") {
+            for {
+              ref <- Ref.make("")
+              res <- (ZStream(1, 1) ++ ZStream.fail("Ouch")).tapError(err => ref.update(_ + err)).runCollect.either
+              err <- ref.get
+            } yield assert(res)(isLeft(equalTo("Ouch"))) && assert(err)(equalTo("Ouch"))
+          }
+        ),
         suite("throttleEnforce")(
           testM("free elements") {
             assertM(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2837,6 +2837,15 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
     mapM(o => f0(o).as(o))
 
   /**
+   * Returns a stream that effectfully "peeks" at the failure of the stream.
+   */
+  final def tapError[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any])(implicit ev: CanFail[E]): ZStream[R1, E1, O] =
+    ZStream(self.process.map(_.tapError {
+      case None      => ZIO.fail(None)
+      case Some(err) => f(err).mapError(Some(_))
+    }))
+
+  /**
    * Throttles the chunks of this stream according to the given bandwidth parameters using the token bucket
    * algorithm. Allows for burst in the processing of elements by allowing the token bucket to accumulate
    * tokens up to a `units + burst` threshold. Chunks that do not meet the bandwidth constraints are dropped.


### PR DESCRIPTION
This commits adds a tapError operator to ZStream, with the same
signature as the one on plain ZIO. The use of a "None" error to signal
end-of-stream is kept internal, as it's not a semantic error as such.