### PR TITLE
Implement Zstream.execute

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3923,6 +3923,12 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     fromZIO(ZIO.environment[R])
 
   /**
+   * Creates a stream that executes the specified effect but emits no elements.
+   */
+  def execute[R, E](zio: ZIO[R, E, Any]): ZStream[R, E, Nothing] =
+    ZStream.fromZIO(zio).drain
+
+  /**
    * The stream that always fails with the `error`
    */
   def fail[E](error: => E): ZStream[Any, E, Nothing] =

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -3770,6 +3770,12 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     fromZIO(ZIO.environment[R])
 
   /**
+   * Creates a stream that executes the specified effect but emits no elements.
+   */
+  def execute[R, E](zio: ZIO[R, E, Any]): ZStream[R, E, Nothing] =
+    ZStream.fromZIO(zio).drain
+
+  /**
    * The stream that always fails with the `error`
    */
   def fail[E](error: => E): ZStream[Any, E, Nothing] =


### PR DESCRIPTION
Resolves #5623.

I wonder if the fact that it doesn't emit any elements is going to be confusing to people if they try to compose other streams after it with operators derived from `flatMap`.