### PR TITLE
Upstream Shared Layers To ZIOApp

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -47,7 +47,7 @@ object ZIOAppSpec extends ZIOBaseSpec {
         }
       }
 
-      val app1 = ZIOApp(ZIO.fail("Uh oh!"), RuntimeConfigAspect.addLogger(logger1))
+      val app1 = ZIOAppDefault(ZIO.fail("Uh oh!"), RuntimeConfigAspect.addLogger(logger1))
 
       for {
         c <- app1.invoke(Chunk.empty)

--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -4,28 +4,28 @@ import zio.test._
 
 object ZIOAppSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZIOAppSpec")(
-    test("fromEffect") {
+    test("fromZIO") {
       for {
         ref <- Ref.make(0)
-        _   <- ZIOApp.fromEffect(ref.update(_ + 1)).invoke(Chunk.empty)
+        _   <- ZIOApp.fromZIO(ref.update(_ + 1)).invoke(Chunk.empty)
         v   <- ref.get
       } yield assertTrue(v == 1)
     },
     test("failure translates into ExitCode.failure") {
       for {
-        code <- ZIOApp.fromEffect(ZIO.fail("Uh oh!")).invoke(Chunk.empty)
+        code <- ZIOApp.fromZIO(ZIO.fail("Uh oh!")).invoke(Chunk.empty)
       } yield assertTrue(code == ExitCode.failure)
     },
     test("success translates into ExitCode.success") {
       for {
-        code <- ZIOApp.fromEffect(ZIO.succeed("Hurray!")).invoke(Chunk.empty)
+        code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty)
       } yield assertTrue(code == ExitCode.success)
     },
     test("composed app logic runs component logic") {
       for {
         ref <- Ref.make(2)
-        app1 = ZIOApp.fromEffect(ref.update(_ + 3))
-        app2 = ZIOApp.fromEffect(ref.update(_ - 5))
+        app1 = ZIOApp.fromZIO(ref.update(_ + 3))
+        app2 = ZIOApp.fromZIO(ref.update(_ - 5))
         _   <- (app1 <> app2).invoke(Chunk.empty)
         v   <- ref.get
       } yield assertTrue(v == 0)

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -62,7 +62,7 @@ trait ZIOApp { self =>
   final def exit(code: ExitCode): UIO[Unit] =
     UIO {
       if (!shuttingDown) {
-        shuttingDownå = true
+        shuttingDown = true
         try Platform.exit(code.code)
         catch { case _: SecurityException => }
       }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -33,7 +33,7 @@ trait ZIOApp { self =>
    * A layer that manages the acquisition and release of services necessary for
    * the application to run.
    */
-  def layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, Environment]
+  def layer: ZLayer[Has[ZIOAppArgs], Any, Environment]
 
   /**
    * The main function of the application, which can access the command-line arguments through
@@ -131,7 +131,7 @@ object ZIOApp {
    */
   def apply[R <: Has[_]](
     run0: ZIO[R with ZEnv with Has[ZIOAppArgs], Any, Any],
-    layer0: ZLayer[ZEnv with Has[ZIOAppArgs], Any, R],
+    layer0: ZLayer[Has[ZIOAppArgs], Any, R],
     hook0: RuntimeConfigAspect
   )(implicit tagged: Tag[R]): ZIOApp =
     new ZIOApp {

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -84,8 +84,8 @@ trait ZIOApp { self =>
       val newRuntime = runtime.mapRuntimeConfig(hook)
 
       val newLayer =
-        ZLayer.environment[ZEnv] ++ ZLayer.succeed(ZIOAppArgs(args)) >>>
-          layer ++ ZLayer.environment[ZEnv with Has[ZIOAppArgs]]
+        ZLayer.environment[ZEnv] +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
+          layer +!+ ZLayer.environment[ZEnv with Has[ZIOAppArgs]]
 
       newRuntime.run(run.provideLayer(newLayer)).exitCode
     }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -18,31 +18,37 @@ package zio
 import zio.internal._
 
 /**
- * The entry point for a ZIO application.
- *
- * {{{
- * import zio.ZIOApp
- * import zio.Console._
- *
- * object MyApp extends ZIOApp {
- *
- *   def run =
- *     for {
- *       _ <- printLine("Hello! What is your name?")
- *       n <- readLine
- *       _ <- printLine("Hello, " + n + ", good to meet you!")
- *     } yield ()
- * }
- * }}}
+ * An entry point for a ZIO application that allows sharing layers between
+ * applications. For a simpler version that uses the default ZIO environment
+ * see `ZIOAppDefault`.
  */
 trait ZIOApp { self =>
   @volatile private var shuttingDown = false
+
+  implicit def tag: Tag[Environment]
+
+  type Environment <: Has[_]
+
+  /**
+   * A layer that manages the acquisition and release of services necessary for
+   * the application to run.
+   */
+  def layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, Environment]
+
+  /**
+   * The main function of the application, which can access the command-line arguments through
+   * the `args` helper method of this class. If the provided effect fails for any reason, the
+   * cause will be logged, and the exit code of the application will be non-zero. Otherwise,
+   * the exit code of the application will be zero.
+   */
+  def run: ZIO[Environment with ZEnv with Has[ZIOAppArgs], Any, Any]
 
   /**
    * Composes this [[ZIOApp]] with another [[ZIOApp]], to yield an application that
    * executes the logic of both applications.
    */
-  final def <>(that: ZIOApp): ZIOApp = ZIOApp(self.run.zipPar(that.run), self.hook >>> that.hook)
+  final def <>(that: ZIOApp): ZIOApp =
+    ZIOApp(self.run.zipPar(that.run), self.layer ++ that.layer, self.hook >>> that.hook)
 
   /**
    * A helper function to obtain access to the command-line arguments of the
@@ -56,7 +62,7 @@ trait ZIOApp { self =>
   final def exit(code: ExitCode): UIO[Unit] =
     UIO {
       if (!shuttingDown) {
-        shuttingDown = true
+        shuttingDownå = true
         try Platform.exit(code.code)
         catch { case _: SecurityException => }
       }
@@ -77,13 +83,20 @@ trait ZIOApp { self =>
     ZIO.runtime[ZEnv].flatMap { runtime =>
       val newRuntime = runtime.mapRuntimeConfig(hook)
 
-      newRuntime.run(run.provideCustomLayer(ZLayer.succeed(ZIOAppArgs(args)))).exitCode
+      newRuntime
+        .run(
+          run.provideCustomLayer(
+            (ZLayer.environment[ZEnv] ++ ZLayer.succeed(ZIOAppArgs(args))) >>> (layer ++ ZLayer
+              .environment[Has[ZIOAppArgs]])
+          )
+        )
+        .exitCode
     }
 
   /**
    * The Scala main function, intended to be called only by the Scala runtime.
    */
-  final def main(args0: Array[String]): Unit = {
+  final def main(args0: Array[String]): Unit =
     runtime.unsafeRun {
       (for {
         fiber <- invoke(Chunk.fromIterable(args0)).provide(runtime.environment).fork
@@ -111,35 +124,30 @@ trait ZIOApp { self =>
       } yield ())
     }
 
-    def runtime: Runtime[ZEnv] = Runtime.default
-  }
-
-  /**
-   * The main function of the application, which can access the command-line arguments through
-   * the `args` helper method of this class. If the provided effect fails for any reason, the
-   * cause will be logged, and the exit code of the application will be non-zero. Otherwise,
-   * the exit code of the application will be zero.
-   */
-  def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]
+  def runtime: Runtime[ZEnv] = Runtime.default
 }
 object ZIOApp {
-  class Proxy(app: ZIOApp) extends ZIOApp {
-    override final def hook = app.hook
-    override final def run  = app.run
-  }
 
   /**
    * Creates a [[ZIOApp]] from an effect, which can consume the arguments of the program, as well
    * as a hook into the ZIO runtime configuration.
    */
-  def apply(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any], hook0: RuntimeConfigAspect): ZIOApp =
+  def apply[R <: Has[_]](
+    run0: ZIO[R with ZEnv with Has[ZIOAppArgs], Any, Any],
+    layer0: ZLayer[ZEnv with Has[ZIOAppArgs], Any, R],
+    hook0: RuntimeConfigAspect
+  )(implicit tagged: Tag[R]): ZIOApp =
     new ZIOApp {
-      override def hook = hook0
-      def run           = run0
+      type Environment = R
+      def tag: Tag[Environment] = tagged
+      override def hook         = hook0
+      def layer                 = layer0
+      def run                   = run0
     }
 
   /**
    * Creates a [[ZIOApp]] from an effect, using the unmodified default runtime's configuration.
    */
-  def fromEffect(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOApp = ZIOApp(run0, RuntimeConfigAspect.identity)
+  def fromEffect(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOApp =
+    ZIOApp(run0, ZLayer.environment, RuntimeConfigAspect.identity)
 }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -145,6 +145,6 @@ object ZIOApp {
   /**
    * Creates a [[ZIOApp]] from an effect, using the unmodified default runtime's configuration.
    */
-  def fromEffect(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOApp =
+  def fromZIO(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOApp =
     ZIOApp(run0, ZLayer.environment, RuntimeConfigAspect.identity)
 }

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -63,6 +63,6 @@ object ZIOAppDefault {
    * Creates a [[ZIOAppDefault]] from an effect, using the unmodified default
    * runtime's configuration.
    */
-  def fromEffect(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOAppDefault =
+  def fromZIO(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOAppDefault =
     ZIOAppDefault(run0, RuntimeConfigAspect.identity)
 }

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -38,7 +38,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   type Environment = ZEnv
 
-  val layer = ZLayer.environment
+  val layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, ZEnv] = ZLayer.environment
 
   val tag: Tag[ZEnv] = Tag[ZEnv]
 }

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -38,7 +38,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   type Environment = ZEnv
 
-  val layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, ZEnv] = ZLayer.environment
+  val layer: ZLayer[Has[ZIOAppArgs], Any, ZEnv] = ZEnv.live
 
   val tag: Tag[ZEnv] = Tag[ZEnv]
 }

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+/**
+ * The entry point for a ZIO application.
+ *
+ * {{{
+ * import zio.ZIOApp
+ * import zio.Console._
+ *
+ * object MyApp extends ZIOAppDefault {
+ *
+ *   def run =
+ *     for {
+ *       _ <- printLine("Hello! What is your name?")
+ *       n <- readLine
+ *       _ <- printLine("Hello, " + n + ", good to meet you!")
+ *     } yield ()
+ * }
+ * }}}
+ */
+trait ZIOAppDefault extends ZIOApp {
+
+  type Environment = ZEnv
+
+  val layer = ZLayer.environment
+
+  val tag: Tag[ZEnv] = Tag[ZEnv]
+}
+
+object ZIOAppDefault {
+
+  /**
+   * Creates a [[ZIOAppDefault]] from an effect, which can consume the
+   * arguments of the program, as well as a hook into the ZIO runtime
+   * configuration.
+   */
+  def apply(
+    run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any],
+    hook0: RuntimeConfigAspect
+  ): ZIOAppDefault =
+    new ZIOAppDefault {
+      override def hook = hook0
+      def run           = run0
+    }
+
+  /**
+   * Creates a [[ZIOAppDefault]] from an effect, using the unmodified default
+   * runtime's configuration.
+   */
+  def fromEffect(run0: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any]): ZIOAppDefault =
+    ZIOAppDefault(run0, RuntimeConfigAspect.identity)
+}

--- a/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/LayerDefinitionExample.scala
@@ -1,7 +1,7 @@
 package zio.examples
 import zio._
 
-object LayerDefinitionExample extends ZIOApp {
+object LayerDefinitionExample extends ZIOAppDefault {
   trait Foo {
     def bar: UIO[Unit]
   }

--- a/examples/shared/src/main/scala/zio/examples/ZLayerInjectExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/ZLayerInjectExample.scala
@@ -3,7 +3,7 @@ package zio.examples
 import zio._
 import java.io.IOException
 
-object ZLayerInjectExample extends ZIOApp {
+object ZLayerInjectExample extends ZIOAppDefault {
   val program: ZIO[Has[OldLady] with Has[Console], IOException, Unit] =
     OldLady.contentsOfStomach.flatMap { contents =>
       Console.printLine(s"There was an old who lady swallowed:\n- ${contents.mkString("\n- ")}")

--- a/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/AbstractRunnableSpec.scala
@@ -20,7 +20,7 @@ import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
 import zio._
 
 @EnableReflectiveInstantiation
-abstract class AbstractRunnableSpec extends ZIOApp {
+abstract class AbstractRunnableSpec {
 
   type Environment
   type Failure
@@ -39,7 +39,7 @@ abstract class AbstractRunnableSpec extends ZIOApp {
   /**
    * Returns an effect that executes the spec, producing the results of the execution.
    */
-  def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any] =
+  final def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any] =
     runSpec(spec).provideCustomLayer(runner.bootstrap)
 
   /**

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -24,11 +24,6 @@ import zio.test.render._
 @EnableReflectiveInstantiation
 abstract class ZIOSpecAbstract extends ZIOApp { self =>
 
-  final def layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, Environment] =
-    (TestEnvironment.live ++ ZLayer.environment[Has[ZIOAppArgs]]) >>> testLayer
-
-  def testLayer: ZLayer[TestEnvironment with Has[ZIOAppArgs], Any, Environment]
-
   def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any]
 
   def aspects: Chunk[TestAspect[Nothing, Environment with TestEnvironment with Has[ZIOAppArgs], Nothing, Any]] =
@@ -40,8 +35,8 @@ abstract class ZIOSpecAbstract extends ZIOApp { self =>
   final def <>(that: ZIOSpecAbstract): ZIOSpecAbstract =
     new ZIOSpecAbstract {
       type Environment = self.Environment with that.Environment
-      def testLayer: ZLayer[TestEnvironment with Has[ZIOAppArgs], Any, Environment] =
-        self.testLayer ++ that.testLayer
+      def layer: ZLayer[Has[ZIOAppArgs], Any, Environment] =
+        self.layer +!+ that.layer
       override def runSpec: ZIO[Environment with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
         self.runSpec.zipPar(that.runSpec)
       def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any] =

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -24,11 +24,10 @@ import zio.test.render._
 @EnableReflectiveInstantiation
 abstract class ZIOSpecAbstract extends ZIOApp { self =>
 
-  type Environment <: Has[_]
+  final def layer: ZLayer[ZEnv with Has[ZIOAppArgs], Any, Environment] =
+    (TestEnvironment.live ++ ZLayer.environment[Has[ZIOAppArgs]]) >>> testLayer
 
-  protected implicit def tag: Tag[Environment]
-
-  def layer: ZLayer[TestEnvironment, Any, Environment]
+  def testLayer: ZLayer[TestEnvironment with Has[ZIOAppArgs], Any, Environment]
 
   def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any]
 
@@ -36,18 +35,18 @@ abstract class ZIOSpecAbstract extends ZIOApp { self =>
     Chunk.empty
 
   final def run: ZIO[ZEnv with Has[ZIOAppArgs], Any, Any] =
-    runSpec.provideSomeLayer[ZEnv with Has[ZIOAppArgs]](TestEnvironment.live ++ (TestEnvironment.live >>> layer))
+    runSpec.provideSomeLayer[ZEnv with Has[ZIOAppArgs]](TestEnvironment.live ++ layer)
 
   final def <>(that: ZIOSpecAbstract): ZIOSpecAbstract =
     new ZIOSpecAbstract {
       type Environment = self.Environment with that.Environment
-      def layer: ZLayer[TestEnvironment, Any, Environment] =
-        self.layer ++ that.layer
+      def testLayer: ZLayer[TestEnvironment with Has[ZIOAppArgs], Any, Environment] =
+        self.testLayer ++ that.testLayer
       override def runSpec: ZIO[Environment with TestEnvironment with Has[ZIOAppArgs], Any, Any] =
         self.runSpec.zipPar(that.runSpec)
       def spec: ZSpec[Environment with TestEnvironment with Has[ZIOAppArgs], Any] =
         self.spec + that.spec
-      protected def tag: Tag[Environment] = {
+      def tag: Tag[Environment] = {
         implicit val selfTag: Tag[self.Environment] = self.tag
         implicit val thatTag: Tag[that.Environment] = that.tag
         val _                                       = (selfTag, thatTag)

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -5,7 +5,7 @@ import zio.test.environment._
 
 abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
 
-  final val layer: ZLayer[TestEnvironment, Any, TestEnvironment] = ZLayer.environment
+  final val testLayer: ZLayer[TestEnvironment, Any, TestEnvironment] = ZLayer.environment
 
   def spec: ZSpec[TestEnvironment, Any]
 }


### PR DESCRIPTION
Upstreams the shared layers functionality previously implemented for `ZIOSpec` to `ZIOApp`. Given that this will be the first interaction users have with ZIO we need to spend some time to make sure the API is as nice as possible but I thought it would be helpful to have something to work off of.

Once we have this we can describe background processes as applications that can be composed with other applications and in particular reimplement #5582 in terms of layers.