### PR TITLE
unify assertTrue with assertions

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -1,6 +1,7 @@
 package zio.test
 
 import zio.duration.durationInt
+import zio.test.Assertion.{isNonEmpty, isSome, not}
 import zio.test.SmartTestTypes._
 import zio.test.environment.TestClock
 import zio.{Chunk, NonEmptyChunk}
@@ -389,6 +390,29 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       test("reports source location of actual usage") {
         customAssertion("hello")
       } @@ failing
+    ),
+    suite("is")(
+      test("succeeds at root position") {
+        assert(Seq(1, 2, 3))(is(_.headOption.get == 1))
+      },
+      test("fails at root position") {
+        assert(Seq(1, 2, 3))(is(_.headOption.get == 4))
+      } @@ failing,
+      test("fails with negate") {
+        assert(Seq(1, 2, 3))(not(is(_.headOption.get == 1)))
+      } @@ failing,
+      test("succeeds with negate") {
+        assert(Seq(1, 2, 3))(not(is(_(3) == 4)))
+      },
+      test("fail with &&") {
+        assert(Option(Seq(1, 2, 3)))(isSome(isNonEmpty && is(_.head == 5)))
+      } @@ failing,
+      test("fail multiple with &&") {
+        assert(Option(Seq(1, 2, 3)))(isSome(is[Seq[Int]](_(3) == 4) && is(_.head == 5)))
+      } @@ failing,
+      test("succeeds multiple with &&") {
+        assert(Option(Seq(1, 2, 3)))(isSome(is[Seq[Int]](_(1) == 2) && is(_.head == 1)))
+      }
     )
   )
 

--- a/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2.x/zio/test/CompileVariants.scala
@@ -48,6 +48,8 @@ trait CompileVariants {
   def assertTrue(expr: Boolean, exprs: Boolean*): Assert = macro SmartAssertMacros.assert_impl
   def assertTrue(expr: Boolean): Assert = macro SmartAssertMacros.assertOne_impl
 
+  def is[T](f: T => Boolean): Assertion[T] = macro SmartAssertMacros.is_impl[T]
+
   /**
    * Checks the assertion holds for the given value.
    */

--- a/test/shared/src/main/scala/zio/test/AssertionResult.scala
+++ b/test/shared/src/main/scala/zio/test/AssertionResult.scala
@@ -9,22 +9,16 @@ sealed trait AssertionResult { self =>
     self match {
       case result: FailureDetailsResult =>
         result.copy(failureDetails = result.failureDetails.label(label))
-      case result: AssertionResult.TraceResult =>
-        result
     }
 
   def setGenFailureDetails(details: GenFailureDetails): AssertionResult =
     self match {
       case result: FailureDetailsResult =>
         result.copy(genFailureDetails = Some(details))
-      case result: TraceResult =>
-        result.copy(genFailureDetails = Some(details))
     }
 }
 
 object AssertionResult {
   case class FailureDetailsResult(failureDetails: FailureDetails, genFailureDetails: Option[GenFailureDetails] = None)
-      extends AssertionResult
-  case class TraceResult(trace: Trace[Boolean], genFailureDetails: Option[GenFailureDetails] = None)
       extends AssertionResult
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -73,11 +73,8 @@ package object test extends CompileVariants {
   type TestResult = BoolAlgebra[AssertionResult]
 
   object TestResult {
-    implicit def trace2TestResult(assert: Assert): TestResult = {
-      val trace = Arrow.run(assert.arrow, Right(()))
-      if (trace.isSuccess) BoolAlgebra.success(AssertionResult.TraceResult(trace))
-      else BoolAlgebra.failure(AssertionResult.TraceResult(trace))
-    }
+    implicit def trace2TestResult(assert: Assert): TestResult =
+      Assert.trace2TestResult(assert)
   }
 
   /**
@@ -156,7 +153,9 @@ package object test extends CompileVariants {
 
       loop(
         fragment,
-        FailureDetails(::(AssertionValue(assertion, value, assertResult, expression, sourceLocation), Nil))
+        FailureDetails(
+          ::(AssertionValue(assertion, value, assertResult, expression, sourceLocation, fragment.trace), Nil)
+        )
       )
     }
 


### PR DESCRIPTION
`assertTrue` should produce and run a regular `Assertion`.
Add `is` assertion macros to use with mocks and `AssertionM`:
```scala
val _: Assertion[User] = is(_.company.get.name == "abc")
```

TODO:

- [ ] fix assertion highlighting. Currently `is` assertion always highlights entire expression
- [ ] add functions support to dotty macros implementation