### PR TITLE
Add accessor method for Clock.localDateTime

### DIFF
--- a/core/shared/src/main/scala/zio/clock/package.scala
+++ b/core/shared/src/main/scala/zio/clock/package.scala
@@ -103,6 +103,9 @@ package object clock {
   val instant: ZIO[Clock, Nothing, java.time.Instant] =
     ZIO.accessM(_.get.instant)
 
+  val localDateTime: ZIO[Clock, DateTimeException, java.time.LocalDateTime] =
+    ZIO.accessM(_.get.localDateTime)
+
   /**
    * Returns the system nano time, which is not relative to any date.
    */


### PR DESCRIPTION
Was surprised by absence of the accessor, it's convenient :-)