### PR TITLE
Compositional Concurrency

### DIFF
--- a/benchmarks/src/main/scala/zio/CollectAllBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/CollectAllBenchmark.scala
@@ -63,7 +63,7 @@ class CollectAllBenchmark {
   @Benchmark
   def zioCollectAllParN(): Long = {
     val tasks  = (0 until count).map(_ => ZIO.succeed(1)).toList
-    val result = ZIO.collectAllParN(parallelism)(tasks).map(_.sum.toLong)
+    val result = ZIO.collectAllPar(tasks).map(_.sum.toLong).withParallelism(parallelism)
     unsafeRun(result)
   }
 

--- a/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/STMRetryBenchmark.scala
@@ -27,7 +27,7 @@ class STMRetryBenchmark {
     val n          = JRuntime.getRuntime().availableProcessors() - 1
     val updateHead = ref.update(list => 0 :: list.tail).commit.forever
 
-    short = UIO.collectAllParNDiscard(n)(List.fill(n)(updateHead))
+    short = UIO.collectAllParDiscard(List.fill(n)(updateHead)).withParallelism(n)
     long = ref.update(_.map(_ + 1)).commit
   }
 

--- a/core-tests/jvm/src/test/scala-2.12+/zio/StackTracesSpec.scala
+++ b/core-tests/jvm/src/test/scala-2.12+/zio/StackTracesSpec.scala
@@ -341,7 +341,7 @@ object StackTracesSpec extends DefaultRunnableSpec {
 
   def foreachParNFail: ZIO[Any, Nothing, Unit] =
     for {
-      _ <- ZIO.foreachParN(4)(1 to 10)(i => (if (i >= 7) UIO(i / 0) else UIO(i / 10)))
+      _ <- ZIO.foreachPar(1 to 10)(i => (if (i >= 7) UIO(i / 0) else UIO(i / 10))).withParallelism(4)
     } yield ()
 
   def leftAssociativeFold(n: Int): UIO[ZTrace] =

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -331,14 +331,14 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("collectAllParN")(
       test("returns results in the same order") {
         val list = List(1, 2, 3).map(IO.succeed[Int](_))
-        val res  = IO.collectAllParN(2)(list)
+        val res  = IO.collectAllPar(list).withParallelism(2)
         assertM(res)(equalTo(List(1, 2, 3)))
       }
     ),
     suite("collectAllParNDiscard")(
       test("preserves failures") {
         val tasks = List.fill(10)(ZIO.fail(new RuntimeException))
-        assertM(ZIO.collectAllParNDiscard(5)(tasks).flip)(anything)
+        assertM(ZIO.collectAllParDiscard(tasks).withParallelism(5).flip)(anything)
       }
     ),
     suite("collectFirst")(
@@ -920,26 +920,26 @@ object ZIOSpec extends ZIOBaseSpec {
     suite("foreachParN")(
       test("returns the list of results in the appropriate order") {
         val list = List(1, 2, 3)
-        val res  = IO.foreachParN(2)(list)(x => IO.succeed(x.toString))
+        val res  = IO.foreachPar(list)(x => IO.succeed(x.toString)).withParallelism(2)
         assertM(res)(equalTo(List("1", "2", "3")))
       },
       test("works on large lists") {
         val n   = 10
         val seq = List.range(0, 100000)
-        val res = IO.foreachParN(n)(seq)(UIO.succeed(_))
+        val res = IO.foreachPar(seq)(UIO.succeed(_)).withParallelism(n)
         assertM(res)(equalTo(seq))
       },
       test("runs effects in parallel") {
         val io = for {
           p <- Promise.make[Nothing, Unit]
-          _ <- UIO.foreachParN(2)(List(UIO.never, p.succeed(())))(identity).fork
+          _ <- UIO.foreachPar(List(UIO.never, p.succeed(())))(identity).withParallelism(2).fork
           _ <- p.await
         } yield true
         assertM(io)(isTrue)
       },
       test("propagates error") {
         val ints = List(1, 2, 3, 4, 5, 6)
-        val odds = ZIO.foreachParN(4)(ints)(n => if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd"))
+        val odds = ZIO.foreachPar(ints)(n => if (n % 2 != 0) ZIO.succeed(n) else ZIO.fail("not odd")).withParallelism(4)
         assertM(odds.either)(isLeft(equalTo("not odd")))
       } @@ zioTag(errors),
       test("interrupts effects on first failure") {
@@ -948,7 +948,7 @@ object ZIOSpec extends ZIOBaseSpec {
           ZIO.succeed(1),
           ZIO.fail("C")
         )
-        val io = ZIO.foreachParN(4)(actions)(a => a)
+        val io = ZIO.foreachPar(actions)(a => a).withParallelism(4)
         assertM(io.either)(isLeft(equalTo("C")))
       } @@ zioTag(errors, interruption)
     ),
@@ -957,7 +957,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val as = Seq(1, 2, 3, 4, 5)
         for {
           ref <- Ref.make(Seq.empty[Int])
-          _   <- ZIO.foreachParNDiscard(2)(as)(a => ref.update(_ :+ a))
+          _   <- ZIO.foreachParDiscard(as)(a => ref.update(_ :+ a)).withParallelism(2)
           rs  <- ref.get
         } yield assert(rs)(hasSize(equalTo(as.length))) &&
           assert(rs.toSet)(equalTo(as.toSet))
@@ -1807,19 +1807,19 @@ object ZIOSpec extends ZIOBaseSpec {
         implicit val canFail = CanFail
         val in               = List.range(0, 1000)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => ZIO.succeed(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.succeed(a)).withParallelism(3)
         } yield assert(res._1)(isEmpty) && assert(res._2)(equalTo(in))
       },
       test("collects failures") {
         val in = List.fill(10)(0)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => ZIO.fail(a))
+          res <- ZIO.partitionPar(in)(a => ZIO.fail(a)).withParallelism(3)
         } yield assert(res._1)(equalTo(in)) && assert(res._2)(isEmpty)
       } @@ zioTag(errors),
       test("collects failures and successes") {
         val in = List.range(0, 10)
         for {
-          res <- ZIO.partitionParN(3)(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a))
+          res <- ZIO.partitionPar(in)(a => if (a % 2 == 0) ZIO.fail(a) else ZIO.succeed(a)).withParallelism(3)
         } yield assert(res._1)(equalTo(List(0, 2, 4, 6, 8))) && assert(res._2)(equalTo(List(1, 3, 5, 7, 9)))
       } @@ zioTag(errors)
     ),

--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -282,6 +282,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectAllParN[E, A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[IO[E, A]])(implicit bf: BuildFrom[Collection[IO[E, A]], A, Collection[A]]): IO[E, Collection[A]] =
@@ -290,13 +291,14 @@ object IO {
   /**
    * @see See [[zio.ZIO.collectAllParN_]]
    */
-  @deprecated("use collectAllParNDiscard", "2.0.0")
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParN_[E, A](n: => Int)(as: => Iterable[IO[E, A]]): IO[E, Unit] =
     ZIO.collectAllParN_(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParNDiscard]]
    */
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParNDiscard[E, A](n: => Int)(as: => Iterable[IO[E, A]]): IO[E, Unit] =
     ZIO.collectAllParNDiscard(n)(as)
 
@@ -319,6 +321,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
+  @deprecated("use collectAllSuccessesPar", "2.0.0")
   def collectAllSuccessesParN[E, A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[IO[E, A]])(implicit bf: BuildFrom[Collection[IO[E, A]], A, Collection[A]]): UIO[Collection[A]] =
@@ -343,6 +346,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
+  @deprecated("use collectAllWithPar", "2.0.0")
   def collectAllWithParN[E, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[IO[E, A]]
   )(f: PartialFunction[A, B])(implicit bf: BuildFrom[Collection[IO[E, A]], B, Collection[B]]): IO[E, Collection[B]] =
@@ -373,6 +377,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.collectParN]]
    */
+  @deprecated("use collectPar", "2.0.0")
   def collectParN[E, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     in: Collection[A]
   )(f: A => IO[Option[E], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): IO[E, Collection[B]] =
@@ -732,6 +737,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
+  @deprecated("use foreachPar", "2.0.0")
   def foreachParN[E, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[A]
   )(fn: A => IO[E, B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): IO[E, Collection[B]] =
@@ -766,13 +772,14 @@ object IO {
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  @deprecated("use foreachParNDiscard", "2.0.0")
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParN_[E, A, B](n: => Int)(as: => Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParNDiscard]]
    */
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParNDiscard[E, A, B](n: => Int)(as: => Iterable[A])(f: A => IO[E, Any]): IO[E, Unit] =
     ZIO.foreachParNDiscard(n)(as)(f)
 
@@ -1068,6 +1075,7 @@ object IO {
   /**
    * @see See [[zio.ZIO.partitionParN]]
    */
+  @deprecated("use partitionPar", "2.0.0")
   def partitionParN[E, A, B](
     n: => Int
   )(in: => Iterable[A])(f: A => IO[E, B])(implicit ev: CanFail[E]): UIO[(Iterable[E], Iterable[B])] =

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -301,6 +301,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectAllParN[R, A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[RIO[R, A]])(implicit bf: BuildFrom[Collection[RIO[R, A]], A, Collection[A]]): RIO[R, Collection[A]] =
@@ -309,13 +310,14 @@ object RIO {
   /**
    * @see See [[zio.ZIO.collectAllParNDiscard]]
    */
-  @deprecated("use collectAllParNDiscard", "2.0.0")
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParN_[R, A](n: => Int)(as: => Iterable[RIO[R, A]]): RIO[R, Unit] =
     ZIO.collectAllParN_(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParN_]]
    */
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParNDiscard[R, A](n: => Int)(as: => Iterable[RIO[R, A]]): RIO[R, Unit] =
     ZIO.collectAllParNDiscard(n)(as)
 
@@ -338,6 +340,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
+  @deprecated("use collectAllSuccessesPar", "2.0.0")
   def collectAllSuccessesParN[R, A, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[RIO[R, A]]
   )(implicit bf: BuildFrom[Collection[RIO[R, A]], A, Collection[A]]): URIO[R, Collection[A]] =
@@ -362,6 +365,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
+  @deprecated("use collectAllWithPar", "2.0.0")
   def collectAllWithParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[RIO[R, A]]
   )(f: PartialFunction[A, B])(implicit bf: BuildFrom[Collection[RIO[R, A]], B, Collection[B]]): RIO[R, Collection[B]] =
@@ -392,6 +396,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.collectParN]]
    */
+  @deprecated("use collectPar", "2.0.0")
   def collectParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(in: Collection[A])(
     f: A => ZIO[R, Option[Throwable], B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): RIO[R, Collection[B]] =
@@ -752,6 +757,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
+  @deprecated("use foreachPar", "2.0.0")
   def foreachParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[A]
   )(fn: A => RIO[R, B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): RIO[R, Collection[B]] =
@@ -786,13 +792,14 @@ object RIO {
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  @deprecated("use foreachParNDiscard", "2.0.0")
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParN_[R, A, B](n: => Int)(as: => Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParNDiscard]]
    */
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParNDiscard[R, A, B](n: => Int)(as: => Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
     ZIO.foreachParNDiscard(n)(as)(f)
 
@@ -1112,6 +1119,7 @@ object RIO {
   /**
    * @see See [[zio.ZIO.partitionParN]]
    */
+  @deprecated("use partitionPar", "2.0.0")
   def partitionParN[R, A, B](n: => Int)(in: => Iterable[A])(
     f: A => RIO[R, B]
   ): RIO[R, (Iterable[Throwable], Iterable[B])] =

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -282,6 +282,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectAllParN[A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[Task[A]])(implicit bf: BuildFrom[Collection[Task[A]], A, Collection[A]]): Task[Collection[A]] =
@@ -290,13 +291,14 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.collectAllParN_]]
    */
-  @deprecated("use collectAllParNDiscard", "2.0.0")
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParN_[A](n: => Int)(as: => Iterable[Task[A]]): Task[Unit] =
     ZIO.collectAllParN_(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParNDiscard]]
    */
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParNDiscard[A](n: => Int)(as: => Iterable[Task[A]]): Task[Unit] =
     ZIO.collectAllParNDiscard(n)(as)
 
@@ -319,6 +321,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
+  @deprecated("use collectAllSuccessesPar", "2.0.0")
   def collectAllSuccessesParN[A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[Task[A]])(implicit bf: BuildFrom[Collection[Task[A]], A, Collection[A]]): UIO[Collection[A]] =
@@ -343,6 +346,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
+  @deprecated("use collectAllWithPar", "2.0.0")
   def collectAllWithParN[A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[Task[A]]
   )(f: PartialFunction[A, B])(implicit bf: BuildFrom[Collection[Task[A]], B, Collection[B]]): Task[Collection[B]] =
@@ -373,6 +377,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.collectParN]]
    */
+  @deprecated("use collectPar", "2.0.0")
   def collectParN[A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     in: Collection[A]
   )(f: A => IO[Option[Throwable], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): Task[Collection[B]] =
@@ -727,6 +732,7 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
+  @deprecated("use foreachPar", "2.0.0")
   def foreachParN[A, B, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[A])(fn: A => Task[B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): Task[Collection[B]] =
@@ -761,13 +767,14 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  @deprecated("use foreachParNDiscard", "2.0.0")
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParN_[A, B](n: => Int)(as: => Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParNDiscard]]
    */
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParNDiscard[A, B](n: => Int)(as: => Iterable[A])(f: A => Task[Any]): Task[Unit] =
     ZIO.foreachParNDiscard(n)(as)(f)
 
@@ -1053,8 +1060,9 @@ object Task extends TaskPlatformSpecific {
   /**
    * @see See [[zio.ZIO.partitionParN]]
    */
+  @deprecated("use partitionPar", "2.0.0")
   def partitionParN[A, B](n: => Int)(in: => Iterable[A])(f: A => Task[B]): Task[(Iterable[Throwable], Iterable[B])] =
-    ZIO.partitionParN(n)(in)(f)
+    ZIO.partitionPar(in)(f)
 
   /**
    * @see See [[zio.ZIO.raceAll]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -253,6 +253,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectAllParN[A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[UIO[A]])(implicit bf: BuildFrom[Collection[UIO[A]], A, Collection[A]]): UIO[Collection[A]] =
@@ -261,13 +262,14 @@ object UIO {
   /**
    * @see See [[zio.ZIO.collectAllParN_]]
    */
-  @deprecated("use collectAllParNDiscard", "2.0.0")
+  @deprecated("use collectAllDiscard", "2.0.0")
   def collectAllParN_[A](n: => Int)(as: => Iterable[UIO[A]]): UIO[Unit] =
     ZIO.collectAllParN_(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParNDiscard]]
    */
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParNDiscard[A](n: => Int)(as: => Iterable[UIO[A]]): UIO[Unit] =
     ZIO.collectAllParNDiscard(n)(as)
 
@@ -290,6 +292,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.collectAllSuccessesParN]]
    */
+  @deprecated("use collectAllSuccessesPar", "2.0.0")
   def collectAllSuccessesParN[A, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[UIO[A]])(implicit bf: BuildFrom[Collection[UIO[A]], A, Collection[A]]): UIO[Collection[A]] =
@@ -314,6 +317,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.collectAllWithParN]]
    */
+  @deprecated("use collectAllWithPar", "2.0.0")
   def collectAllWithParN[A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[UIO[A]]
   )(f: PartialFunction[A, B])(implicit bf: BuildFrom[Collection[UIO[A]], B, Collection[B]]): UIO[Collection[B]] =
@@ -344,6 +348,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.collectParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectParN[A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     in: Collection[A]
   )(f: A => IO[Option[Nothing], B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): UIO[Collection[B]] =
@@ -688,6 +693,7 @@ object UIO {
   /**
    * @see See [[zio.ZIO.foreachParN]]
    */
+  @deprecated("use foreachPar", "2.0.0")
   def foreachParN[A, B, Collection[+Element] <: Iterable[Element]](
     n: => Int
   )(as: Collection[A])(fn: A => UIO[B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): UIO[Collection[B]] =
@@ -696,13 +702,14 @@ object UIO {
   /**
    * @see See [[zio.ZIO.foreachParN_]]
    */
-  @deprecated("use foreachParNDiscard", "2.0.0")
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParN_[A](n: => Int)(as: => Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see See [[zio.ZIO.foreachParNDiscard]]
    */
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParNDiscard[A](n: => Int)(as: => Iterable[A])(f: A => UIO[Any]): UIO[Unit] =
     ZIO.foreachParNDiscard(n)(as)(f)
 

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -281,6 +281,7 @@ object URIO {
   /**
    * @see See [[zio.ZIO.collectAllParN]]
    */
+  @deprecated("use collectAllPar", "2.0.0")
   def collectAllParN[R, A, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[URIO[R, A]]
   )(implicit bf: BuildFrom[Collection[URIO[R, A]], A, Collection[A]]): URIO[R, Collection[A]] =
@@ -289,13 +290,14 @@ object URIO {
   /**
    * @see See [[zio.ZIO.collectAllParN_]]
    */
-  @deprecated("use collectAllParNDiscard", "2.0.0")
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParN_[R, A](n: => Int)(as: => Iterable[URIO[R, A]]): URIO[R, Unit] =
     ZIO.collectAllParN_(n)(as)
 
   /**
    * @see See [[zio.ZIO.collectAllParNDiscard]]
    */
+  @deprecated("use collectAllParDiscard", "2.0.0")
   def collectAllParNDiscard[R, A](n: => Int)(as: => Iterable[URIO[R, A]]): URIO[R, Unit] =
     ZIO.collectAllParNDiscard(n)(as)
 
@@ -318,6 +320,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.collectAllSuccessesParN]]
    */
+  @deprecated("use collectAllSuccessesPar", "2.0.0")
   def collectAllSuccessesParN[R, A, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[URIO[R, A]]
   )(implicit bf: BuildFrom[Collection[URIO[R, A]], A, Collection[A]]): URIO[R, Collection[A]] =
@@ -342,6 +345,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.collectAllWithParN]]
    */
+  @deprecated("use collectAllWithPar", "2.0.0")
   def collectAllWithParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(as: Collection[URIO[R, A]])(
     f: PartialFunction[A, B]
   )(implicit bf: BuildFrom[Collection[URIO[R, A]], B, Collection[B]]): URIO[R, Collection[B]] =
@@ -372,6 +376,7 @@ object URIO {
   /**
    * @see See [[zio.ZIO.collectParN]]
    */
+  @deprecated("use collectPar", "2.0.0")
   def collectParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(in: Collection[A])(
     f: A => ZIO[R, Option[Nothing], B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): URIO[R, Collection[B]] =
@@ -678,6 +683,7 @@ object URIO {
   /**
    * @see [[zio.ZIO.foreachParN]]
    */
+  @deprecated("use foreachPar", "2.0.0")
   def foreachParN[R, A, B, Collection[+Element] <: Iterable[Element]](n: => Int)(
     as: Collection[A]
   )(fn: A => URIO[R, B])(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): URIO[R, Collection[B]] =
@@ -712,13 +718,14 @@ object URIO {
   /**
    * @see [[zio.ZIO.foreachParN_]]
    */
-  @deprecated("use foreachParNDiscard", "2.0.0")
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParN_[R, A, B](n: => Int)(as: => Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachParN_(n)(as)(f)
 
   /**
    * @see [[zio.ZIO.foreachParNDiscard]]
    */
+  @deprecated("use foreachParDiscard", "2.0.0")
   def foreachParNDiscard[R, A, B](n: => Int)(as: => Iterable[A])(f: A => URIO[R, Any]): URIO[R, Unit] =
     ZIO.foreachParNDiscard(n)(as)(f)
 

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -126,6 +126,26 @@ object ZIOAspect {
     }
 
   /**
+   * As aspect that runs effects with the specified maximum number of fibers
+   * for parallel operators.
+   */
+  def parallel(n: Int): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
+        zio.withParallelism(n)
+    }
+
+  /**
+   * As aspect that runs effects with an unbounded maximum number of fibers for
+   * parallel operators.
+   */
+  def parallelUnbounded: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
+        zio.withParallelismUnbounded
+    }
+
+  /**
    * An aspect that retries effects according to the specified schedule.
    */
   def retry[R1 <: Has[Clock], E1](schedule: Schedule[R1, E1, Any]): ZIOAspect[Nothing, R1, Nothing, E1, Nothing, Any] =

--- a/docs/about/coding_guidelines.md
+++ b/docs/about/coding_guidelines.md
@@ -105,7 +105,7 @@ This section will attempt to provide some guidelines and examples to document, g
 5. Constructors for a data type `X` that are based on another data type `Y` should be placed in the companion object `X` and named `fromY`. 
    For example, `ZIO.fromOption`, `ZStream.fromEffect`;
    
-6. Parallel versions of methods should be named the same, but with a `Par` suffix. Parallel versions with a bound on parallelism should use a `ParN` suffix;
+6. Parallel versions of methods should be named the same, but with a `Par` suffix.
 
 7. `foreach` should be used for operators that effectually iterate over a collection. For example, `ZIO.foreach`.
 

--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -34,11 +34,10 @@ Code | Rewrite
 `uio.retryOrElseEither(s, f)` | `uio`*
 `uio.tapBoth(f, g)` | `uio.tap(g)`
 `uio.tapError(f)` | `uio`
-`ZIO.partitionM(in)(f)` | `ZIO.foreach(in)(f)`*
-`ZIO.partitionMPar(in)(f)` | `ZIO.foreachPar(in)(f)`*
-`ZIO.partitionMParN(n)(in)(f)` | `ZIO.foreachParN(n)(in)(f)`*
-`ZIO.validateM(in)(f)` | `ZIO.foreach(in)(f)`*
-`ZIO.validateFirstM(in)(f)` | `ZIO.foreach(in)(f)`*
+`ZIO.partitionZIO(in)(f)` | `ZIO.foreach(in)(f)`*
+`ZIO.partitionZIOPar(in)(f)` | `ZIO.foreachPar(in)(f)`*
+`ZIO.validateZIO(in)(f)` | `ZIO.foreach(in)(f)`*
+`ZIO.validateFirstZIO(in)(f)` | `ZIO.foreach(in)(f)`*
 
 **ZManaged**
 
@@ -86,4 +85,4 @@ Code | Rewrite
 
 - `either`, `option`, `orElseEither`, and `retryOrElseEither` wrap their results in `Some` or `Right` so after rewriting, code calling these methods can be simplified to accept an `A` rather than an `Option[A]` or `Either[E, A]`. 
 
-- `partitionM`, `partitionMPar`, `partitionMParN`, `validateM` and `validateFirstM` have error accumulating semantics on either error channel or success channel. After rewrite the error type can be simplified to `E` rather than `List[E]` or the success type `List[B]` instead of `(List[E], List[B])`.
+- `partitionZIO`, `partitionZIOPar`, `validateZIO` and `validateFirstZIO` have error accumulating semantics on either error channel or success channel. After rewrite the error type can be simplified to `E` rather than `List[E]` or the success type `List[B]` instead of `(List[E], List[B])`.

--- a/docs/datatypes/stream/index.md
+++ b/docs/datatypes/stream/index.md
@@ -36,9 +36,11 @@ So streams are everywhere. We can see all of these different things as being str
 
 ## Motivation
 
-Assume, we would like to take a list of numbers and grab all the prime numbers and then do some more hard work on each of these prime numbers. We can do it using `ZIO.foreachParN` and `ZIO.filterPar` operators like this:
+Assume, we would like to take a list of numbers and grab all the prime numbers and then do some more hard work on each of these prime numbers. We can do it using `ZIO.foreachPar` and `ZIO.filterPar` operators like this:
 
 ```scala mdoc:silent
+import zio.ZIOAspect._
+
 def isPrime(number: Int): Task[Boolean] = Task.succeed(???)
 def moreHardWork(i: Int): Task[Boolean] = Task.succeed(???)
 
@@ -46,7 +48,7 @@ val numbers = 1 to 1000
 
 for {
   primes <- ZIO.filterPar(numbers)(isPrime)
-  _      <- ZIO.foreachParN(20)(primes)(moreHardWork)
+  _      <- ZIO.foreachPar(primes)(moreHardWork) @@ parallel(20)
 } yield ()
 ```
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2101,7 +2101,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 
               for {
                 l <- s.mapZIOPar(8)(f).runCollect
-                r <- IO.foreachParN(8)(data)(f)
+                r <- IO.foreachPar(data)(f).withParallelism(8)
               } yield assert(l.toList)(equalTo(r))
             }
           },

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2248,7 +2248,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 
               for {
                 l <- s.mapZIOPar(8)(f).runCollect
-                r <- IO.foreachParN(8)(data)(f)
+                r <- IO.foreachPar(data)(f).withParallelism(8)
               } yield assert(l.toList)(equalTo(r))
             }
           },


### PR DESCRIPTION
Makes the maximum number of fibers for parallel operators a regional setting. Deprecates all bounded parallelism operators.