### PR TITLE
Deprecated message in zio.App points to zio.ZIOAppDefault

### DIFF
--- a/core/js/src/main/scala/zio/App.scala
+++ b/core/js/src/main/scala/zio/App.scala
@@ -16,5 +16,5 @@
 
 package zio
 
-@deprecated("2.0.0", "Use zio.ZIOApp")
+@deprecated("2.0.0", "Use zio.ZIOAppDefault")
 trait App extends ZApp[ZEnv] with BootstrapRuntime

--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -37,5 +37,5 @@ package zio
  * }
  * }}}
  */
-@deprecated("2.0.0", "Use zio.ZIOApp")
+@deprecated("2.0.0", "Use zio.ZIOAppDefault")
 trait App extends ZApp[ZEnv] with BootstrapRuntime

--- a/core/native/src/main/scala/zio/App.scala
+++ b/core/native/src/main/scala/zio/App.scala
@@ -16,5 +16,5 @@
 
 package zio
 
-@deprecated("2.0.0", "Use zio.ZIOApp")
+@deprecated("2.0.0", "Use zio.ZIOAppDefault")
 trait App extends ZApp[ZEnv] with BootstrapRuntime


### PR DESCRIPTION
Deprecated message in zio.App now points to zio.ZIOAppDefault instead of zio.ZIOApp