### PR TITLE
Breadth First Search Generators

### DIFF
--- a/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
+++ b/benchmarks/src/main/scala-2.12/zio/GenBenchmarks.scala
@@ -20,7 +20,7 @@ class GenBenchmarks {
   var elementSize: Int = _
   @Benchmark
   def zioDouble: List[Double] =
-    unsafeRun(Gen.listOfN(listSize)(Gen.uniform).sample.map(_.value).runHead.some.provideLayer(ZEnv.live))
+    unsafeRun(Gen.listOfN(listSize)(Gen.uniform).sample.collectSome.map(_.value).runHead.some.provideLayer(ZEnv.live))
 
   @Benchmark
   def zioIntListsOfSizeN: List[List[Int]] =
@@ -28,6 +28,7 @@ class GenBenchmarks {
       Gen
         .listOfN(listSize)(Gen.listOfN(elementSize)(Gen.int))
         .sample
+        .collectSome
         .map(_.value)
         .runHead
         .some
@@ -40,6 +41,7 @@ class GenBenchmarks {
       Gen
         .listOfN(listSize)(Gen.stringN(elementSize)(Gen.char))
         .sample
+        .collectSome
         .map(_.value)
         .runHead
         .some

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -212,7 +212,7 @@ object DeriveGen {
   type Typeclass[T] = DeriveGen[T]
 
   def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
-    instance(Gen.suspend(Gen.zipAll(caseClass.parameters.map(_.typeclass.derive)).map(caseClass.rawConstruct)))
+    instance(Gen.suspend(Gen.collectAll(caseClass.parameters.map(_.typeclass.derive)).map(caseClass.rawConstruct)))
 
   def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
     instance(Gen.suspend(Gen.oneOf(sealedTrait.subtypes.map(_.typeclass.derive): _*)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -87,23 +87,23 @@ object GenSpec extends ZIOBaseSpec {
     ),
     suite("monad laws")(
       test("monad left identity") {
-        assertM(equal(Gen.fromIterable(-10 to 10).flatMap(a => Gen.const(a)), Gen.fromIterable(-10 to 10)))(isTrue)
+        assertM(equal(smallInt.flatMap(a => Gen.const(a)), smallInt))(isTrue)
       },
       test("monad right identity") {
         val n = 10
 
-        def f(n: Int): Gen[Has[Random], Int] = Gen.fromIterable(-n to n)
+        def f(n: Int): Gen[Has[Random], Int] = Gen.int(-n, n)
 
         assertM(equal(Gen.const(n).flatMap(f), f(n)))(isTrue)
       },
       test("monad associativity") {
-        val fa = Gen.fromIterable(List(0, 1, 2))
+        val fa = Gen.int(0, 2)
 
         def f(p: Int): Gen[Has[Random], (Int, Int)] =
-          Gen.const(p) <*> Gen.fromIterable(List(0, 1, 2, 3))
+          Gen.const(p) <*> Gen.int(0, 3)
 
         def g(p: (Int, Int)): Gen[Has[Random], (Int, Int, Int)] =
-          Gen.const(p).zipWith(Gen.fromIterable(List(0, 1, 2, 3, 4, 5))) { case ((x, y), z) => (x, y, z) }
+          Gen.const(p).zipWith(Gen.int(0, 5)) { case ((x, y), z) => (x, y, z) }
 
         assertM(equal(fa.flatMap(f).flatMap(g), fa.flatMap(a => f(a).flatMap(g))))(isTrue)
       }

--- a/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
@@ -6,7 +6,7 @@ import zio.test.Assertion._
 
 object StreamSpec extends ZIOBaseSpec {
 
-  def spec: ZSpec[Environment,Failure] =
+  def spec: ZSpec[Environment, Failure] =
     suite("StreamSpec")(
       suite("flatMapStream")(
         test("implements breadth first search") {

--- a/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
@@ -1,0 +1,161 @@
+package zio.test
+
+import zio._
+import zio.stream._
+import zio.test.Assertion._
+
+object StreamSpec extends ZIOBaseSpec {
+
+  def spec: ZSpec[Environment,Failure] =
+    suite("StreamSpec")(
+      suite("flatMapStream")(
+        test("implements breadth first search") {
+          val expected = List(
+            Map(
+              (0, 0) -> 1
+            ),
+            Map(
+              (0, 1) -> 1,
+              (1, 0) -> 1
+            ),
+            Map(
+              (0, 2) -> 1,
+              (1, 1) -> 1,
+              (2, 0) -> 1
+            ),
+            Map(
+              (0, 3) -> 1,
+              (1, 2) -> 1,
+              (2, 1) -> 1,
+              (3, 0) -> 1
+            )
+          )
+          val stream = flatMapStream(nats)(a => flatMapStream(nats)(b => ZStream.succeed(Some((a, b)))))
+          for {
+            actual <- runCollectUnordered(100)(stream)
+          } yield assert(actual.take(4))(equalTo(expected))
+        },
+        test("is consistent with ZStream#flatMap") {
+          checkM(genStream, genIntStreamFunction) { (stream, f) =>
+            val left  = flatMapStream(stream.filter(_.isDefined))(a => f(a).filter(_.isDefined))
+            val right = stream.collectSome.flatMap(a => f(a).collectSome).map(Some(_))
+            assertEqualStream(left, right)
+          }
+        },
+        suite("laws")(
+          test("left identity") {
+            checkM(genStream) { stream =>
+              val left  = flatMapStream(stream)(a => ZStream(Some(a)))
+              val right = stream
+              assertEqualStream(left, right)
+            }
+          },
+          test("right identity") {
+            checkM(Gen.int, genIntStreamFunction) { (a, f) =>
+              val left  = flatMapStream(ZStream(Some(a)))(f)
+              val right = f(a)
+              assertEqualStream(left, right)
+            }
+          },
+          test("associativity") {
+            checkM(Gen.int, genIntStreamFunction, genIntStreamFunction) { (a, f, g) =>
+              val left  = flatMapStream(flatMapStream(ZStream(Some(a)))(f))(g)
+              val right = flatMapStream(ZStream(Some(a)))(a => flatMapStream(f(a))(g))
+              assertEqualStream(left, right)
+            }
+          }
+        ),
+        suite("resource safety")(
+          test("releases inner streams when they are done") {
+            val expected = List(
+              "outer acquire",
+              "inner1 acquire",
+              "inner2 acquire",
+              "inner2 release",
+              "inner1 release",
+              "outer release"
+            )
+            for {
+              ref <- Ref.make[List[String]](List.empty)
+              resource = (label: String) =>
+                           ZStream.acquireReleaseWith(
+                             ref.update(s"$label acquire" :: _)
+                           )(_ => ref.update(s"$label release" :: _))
+              stream = resource("outer") *>
+                         ZStream(
+                           Some(resource("inner1") *> ZStream(Some(1), None, Some(2))),
+                           Some(resource("inner2") *> ZStream(Some(3)))
+                         )
+              _      <- flatMapStream(stream)(identity).runDrain
+              actual <- ref.get.map(_.reverse)
+            } yield assert(actual)(equalTo(expected))
+          },
+          test("releases inner streams when interrupted") {
+            val expected = List(
+              "outer acquire",
+              "inner1 acquire",
+              "inner1 release",
+              "outer release"
+            )
+            for {
+              promise <- Promise.make[Nothing, Unit]
+              ref     <- Ref.make[List[String]](List.empty)
+              resource = (label: String) =>
+                           ZStream.acquireReleaseWith(
+                             ref.update(s"$label acquire" :: _)
+                           )(_ => ref.update(s"$label release" :: _))
+              stream = resource("outer") *>
+                         ZStream(
+                           Some(resource("inner1") *> ZStream(Some(1), None, Some(2))),
+                           Some(ZStream.fromZIO(promise.succeed(()).asSome)),
+                           Some(ZStream.never),
+                           Some(resource("inner2") *> ZStream(Some(3)))
+                         )
+              fiber  <- flatMapStream(stream)(identity).runDrain.fork
+              _      <- promise.await
+              _      <- fiber.interrupt
+              actual <- ref.get.map(_.reverse)
+            } yield assert(actual)(equalTo(expected))
+          }
+        )
+      )
+    )
+
+  def collectUnordered[A](as: Iterable[Option[A]]): List[Map[A, Int]] =
+    as
+      .foldLeft(::(Map.empty[A, Int], Nil)) {
+        case (list, None) =>
+          ::(Map.empty[A, Int], list)
+        case (head :: tail, Some(a)) =>
+          head.get(a) match {
+            case None    => ::(head + (a -> 1), tail)
+            case Some(n) => ::(head + (a -> (n + 1)), tail)
+          }
+      }
+      .tail
+      .reverse
+
+  def assertEqualStream[R, E, A](
+    left: ZStream[R, E, Option[A]],
+    right: ZStream[R, E, Option[A]]
+  ): ZIO[R, E, TestResult] =
+    for {
+      actual   <- runCollectUnordered(100)(left)
+      expected <- runCollectUnordered(100)(right)
+    } yield assert(actual)(equalTo(expected))
+
+  lazy val genIntStreamFunction: Gen[Has[Random] with Has[Sized], Int => ZStream[Any, Nothing, Option[Int]]] =
+    Gen.function(genStream)
+
+  lazy val genStream: Gen[Has[Random] with Has[Sized], ZStream[Any, Nothing, Option[Int]]] =
+    for {
+      as <- Gen.listOf(Gen.option(Gen.int))
+      n  <- Gen.small(n => Gen.int(1, n), 1)
+    } yield ZStream.fromIterable(as).rechunk(n)
+
+  lazy val nats: ZStream[Any, Nothing, Option[Int]] =
+    ZStream.iterate(0)(_ + 1).map(Some(_)).intersperse(None)
+
+  def runCollectUnordered[R, E, A](n: Int)(stream: ZStream[R, E, Option[A]]): ZIO[R, E, List[Map[A, Int]]] =
+    stream.take(n.toLong).runCollect.map(collectUnordered)
+}

--- a/test/shared/src/main/scala/zio/test/FunctionVariants.scala
+++ b/test/shared/src/main/scala/zio/test/FunctionVariants.scala
@@ -60,7 +60,7 @@ trait FunctionVariants {
    */
   final def functionWith[R, A, B](gen: Gen[R, B])(hash: A => Int): Gen[R, A => B] =
     Gen.fromZIO {
-      gen.sample.forever.process.use { pull =>
+      gen.sample.forever.collectSome.process.use { pull =>
         for {
           lock    <- Semaphore.make(1)
           bufPull <- BufferedPull.make[R, Nothing, Sample[R, B]](pull)

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.Random._
 import zio.stream.{Stream, ZStream}
-import zio.{Chunk, ExecutionStrategy, Has, NonEmptyChunk, Random, UIO, URIO, ZIO, Zippable}
+import zio.{Chunk, Has, NonEmptyChunk, Random, UIO, URIO, ZIO, Zippable}
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -29,19 +29,20 @@ import scala.math.Numeric.DoubleIsFractional
  * A `Gen[R, A]` represents a generator of values of type `A`, which requires
  * an environment `R`. Generators may be random or deterministic.
  */
-final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
+final case class Gen[-R, +A](sample: ZStream[R, Nothing, Option[Sample[R, A]]]) { self =>
 
   /**
    * A symbolic alias for `zip`.
    */
+  @deprecated("use <*>", "2.0.0")
   def <&>[R1 <: R, B](that: Gen[R1, B])(implicit zippable: Zippable[A, B]): Gen[R1, zippable.Out] =
-    self.zip(that)
+    self <*> that
 
   /**
-   * A symbolic alias for `cross`.
+   * A symbolic alias for `zip`.
    */
   def <*>[R1 <: R, B](that: Gen[R1, B])(implicit zippable: Zippable[A, B]): Gen[R1, zippable.Out] =
-    self.cross(that)
+    self.zip(that)
 
   /**
    * Maps the values produced by this generator with the specified partial
@@ -56,15 +57,17 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Composes this generator with the specified generator to create a cartesian
    * product of elements.
    */
+  @deprecated("use zip", "2.0.0")
   def cross[R1 <: R, B](that: Gen[R1, B])(implicit zippable: Zippable[A, B]): Gen[R1, zippable.Out] =
-    self.crossWith(that)(zippable.zip(_, _))
+    self.zip(that)
 
   /**
    * Composes this generator with the specified generator to create a cartesian
    * product of elements with the specified function.
    */
+  @deprecated("use zipWith", "2.0.0")
   def crossWith[R1 <: R, B, C](that: Gen[R1, B])(f: (A, B) => C): Gen[R1, C] =
-    self.flatMap(a => that.map(b => f(a, b)))
+    self.zipWith(that)(f)
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -77,9 +80,8 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * val evens: Gen[Has[Random], Int] = Gen.int.map(_ * 2)
    * }}}
    */
-  def filter(f: A => Boolean): Gen[R, A] = Gen {
-    sample.flatMap(sample => if (f(sample.value)) sample.filter(f) else ZStream.empty)
-  }
+  def filter(f: A => Boolean): Gen[R, A] =
+    self.flatMap(a => if (f(a)) Gen.const(a) else Gen.empty)
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -90,19 +92,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 
   def withFilter(f: A => Boolean): Gen[R, A] = filter(f)
 
-  def flatMap[R1 <: R, B](f: A => Gen[R1, B]): Gen[R1, B] = Gen {
-    self.sample.flatMap { sample =>
-      val values  = f(sample.value).sample
-      val shrinks = Gen(sample.shrink).flatMap(f).sample
-      values.map(_.flatMap(Sample(_, shrinks)))
+  def flatMap[R1 <: R, B](f: A => Gen[R1, B]): Gen[R1, B] =
+    Gen {
+      flatMapStream(self.sample) { sample =>
+        val values  = f(sample.value).sample
+        val shrinks = Gen(sample.shrink).flatMap(f).sample
+        values.map(_.map(_.flatMap(Sample(_, shrinks))))
+      }
     }
-  }
 
   def flatten[R1 <: R, B](implicit ev: A <:< Gen[R1, B]): Gen[R1, B] =
     flatMap(ev)
 
   def map[B](f: A => B): Gen[R, B] =
-    Gen(sample.map(_.map(f)))
+    Gen(sample.map(_.map(_.map(f))))
 
   /**
    * Maps an effectual function over a generator.
@@ -115,7 +118,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Maps an effectual function over a generator.
    */
   def mapZIO[R1 <: R, B](f: A => ZIO[R1, Nothing, B]): Gen[R1, B] =
-    Gen(sample.mapZIO(_.foreach(f)))
+    Gen(sample.mapZIO(ZIO.foreach(_)(_.foreach(f))))
 
   /**
    * Discards the shrinker for this generator.
@@ -130,54 +133,40 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * to generate it.
    */
   def reshrink[R1 <: R, B](f: A => Sample[R1, B]): Gen[R1, B] =
-    Gen(sample.map(sample => f(sample.value)))
+    Gen(sample.map(_.map(sample => f(sample.value))))
 
   /**
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect: ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect.map(_.toList)
+    sample.collectSome.map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    sample.collectSome.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.
    */
   def runHead: ZIO[R, Nothing, Option[A]] =
-    sample.map(_.value).runHead
+    sample.collectSome.map(_.value).runHead
 
   /**
-   * Zips two generators together pairwise. The new generator will generate
-   * elements as long as either generator is generating elements, running the
-   * other generator multiple times if necessary.
+   * Composes this generator with the specified generator to create a cartesian
+   * product of elements.
    */
   def zip[R1 <: R, B](that: Gen[R1, B])(implicit zippable: Zippable[A, B]): Gen[R1, zippable.Out] =
     self.zipWith(that)(zippable.zip(_, _))
 
   /**
-   * Zips two generators together pairwise with the specified function. The new
-   * generator will generate elements as long as either generator is generating
-   * elements, running the other generator multiple times if necessary.
+   * Composes this generator with the specified generator to create a cartesian
+   * product of elements with the specified function.
    */
-  def zipWith[R1 <: R, B, C](that: Gen[R1, B])(f: (A, B) => C): Gen[R1, C] = Gen {
-    val left  = self.sample.map(Right(_)) ++ self.sample.map(Left(_)).forever
-    val right = that.sample.map(Right(_)) ++ that.sample.map(Left(_)).forever
-    left
-      .zipAllWithExec(right)(ExecutionStrategy.Sequential)(
-        l => (Some(l), None),
-        r => (None, Some(r))
-      )((l, r) => (Some(l), Some(r)))
-      .collectWhile {
-        case (Some(Right(l)), Some(Right(r))) => l.zipWith(r)(f)
-        case (Some(Right(l)), Some(Left(r)))  => l.zipWith(r)(f)
-        case (Some(Left(l)), Some(Right(r)))  => l.zipWith(r)(f)
-      }
-  }
+  def zipWith[R1 <: R, B, C](that: Gen[R1, B])(f: (A, B) => C): Gen[R1, C] =
+    self.flatMap(a => that.map(b => f(a, b)))
 }
 
 object Gen extends GenZIO with FunctionVariants with TimeVariants {
@@ -434,6 +423,13 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     listOfN(n)(g).map(Chunk.fromIterable)
 
   /**
+   * Composes the specified generators to create a cartesian product of
+   * elements with the specified function.
+   */
+  def collectAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]] =
+    gens.foldRight[Gen[R, List[A]]](Gen.const(List.empty))(_.zipWith(_)(_ :: _))
+
+  /**
    * Combines the specified deterministic generators to return a new
    * deterministic generator that generates all of the values generated by
    * the specified generators.
@@ -445,7 +441,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A constant generator of the specified value.
    */
   def const[A](a: => A): Gen[Any, A] =
-    Gen(ZStream.succeed(Sample.noShrink(a)))
+    Gen(ZStream.succeed(Some(Sample.noShrink(a))))
 
   /**
    * A constant generator of the specified sample.
@@ -457,8 +453,9 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * Composes the specified generators to create a cartesian product of
    * elements with the specified function.
    */
+  @deprecated("use collectAll", "2.0.0")
   def crossAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]] =
-    gens.foldRight[Gen[R, List[A]]](Gen.const(List.empty))(_.crossWith(_)(_ :: _))
+    collectAll(gens)
 
   /**
    * Composes the specified generators to create a cartesian product of
@@ -551,33 +548,33 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
   ): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))).map(Some(_)).intersperse(None))
 
   /**
    * Constructs a generator from a function that uses randomness. The returned
    * generator will not have any shrinking.
    */
   final def fromRandom[A](f: Random => UIO[A]): Gen[Has[Random], A] =
-    Gen(ZStream.fromZIO(ZIO.accessZIO[Has[Random]](r => f(r.get)).map(Sample.noShrink)))
+    fromRandomSample(f(_).map(Sample.noShrink))
 
   /**
    * Constructs a generator from a function that uses randomness to produce a
    * sample.
    */
   final def fromRandomSample[R <: Has[Random], A](f: Random => UIO[Sample[R, A]]): Gen[R, A] =
-    Gen(ZStream.fromZIO(ZIO.accessZIO[Has[Random]](r => f(r.get))))
+    fromZIOSample(ZIO.serviceWith(f))
 
   /**
    * Constructs a generator from an effect that constructs a value.
    */
   def fromZIO[R, A](effect: URIO[R, A]): Gen[R, A] =
-    Gen(ZStream.fromZIO(effect.map(Sample.noShrink)))
+    fromZIOSample(effect.map(Sample.noShrink))
 
   /**
    * Constructs a generator from an effect that constructs a sample.
    */
   def fromZIOSample[R, A](effect: ZIO[R, Nothing, Sample[R, A]]): Gen[R, A] =
-    Gen(ZStream.fromZIO(effect))
+    Gen(ZStream.fromZIO(effect.asSome))
 
   /**
    * A generator of floats. Shrinks toward '0'.
@@ -663,7 +660,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     bounded(min, max)(listOfN(_)(g))
 
   def listOfN[R <: Has[Random], A](n: Int)(g: Gen[R, A]): Gen[R, List[A]] =
-    List.fill(n)(g).foldRight[Gen[R, List[A]]](const(Nil))((a, gen) => a.crossWith(gen)(_ :: _))
+    collectAll(List.fill(n)(g))
 
   /**
    * A generator of longs. Shrinks toward '0'.
@@ -703,7 +700,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of maps of the specified size.
    */
   def mapOfN[R <: Has[Random], A, B](n: Int)(key: Gen[R, A], value: Gen[R, B]): Gen[R, Map[A, B]] =
-    setOfN(n)(key).crossWith(listOfN(n)(value))(_.zip(_).toMap)
+    setOfN(n)(key).zipWith(listOfN(n)(value))(_.zip(_).toMap)
 
   /**
    * A generator of maps whose size falls within the specified bounds.
@@ -963,8 +960,9 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * generate elements as long as any generator is generating elements, running
    * the other generators multiple times if necessary.
    */
+  @deprecated("use collectAll", "2.0.0")
   def zipAll[R, A](gens: Iterable[Gen[R, A]]): Gen[R, List[A]] =
-    gens.foldRight[Gen[R, List[A]]](Gen.const(List.empty))(_.zipWith(_)(_ :: _))
+    collectAll(gens)
 
   /**
    * Zips the specified generators together pairwise. The new generator will

--- a/test/shared/src/main/scala/zio/test/GenZIO.scala
+++ b/test/shared/src/main/scala/zio/test/GenZIO.scala
@@ -27,7 +27,7 @@ trait GenZIO {
     val failure        = e.map(Cause.fail)
     val die            = t.map(Cause.die)
     val empty          = Gen.const(Cause.empty)
-    val interrupt      = Gen.long.crossWith(Gen.long)((l, r) => Cause.interrupt(FiberId(l, r)))
+    val interrupt      = Gen.long.zipWith(Gen.long)((l, r) => Cause.interrupt(FiberId(l, r)))
     def traced(n: Int) = Gen.suspend(causesN(n - 1).map(Cause.Traced(_, ZTrace(FiberId(0L, 0L), Nil, Nil, None))))
     def meta(n: Int)   = Gen.suspend(causesN(n - 1).flatMap(c => Gen.elements(Cause.stack(c), Cause.stackless(c))))
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -20,7 +20,7 @@ import zio.stream.{ZSink, ZStream}
 import zio.test.AssertionResult.FailureDetailsResult
 import zio.test.environment._
 
-import scala.collection.immutable.Queue
+import scala.collection.immutable.{Queue => ScalaQueue}
 import scala.language.implicitConversions
 import scala.util.Try
 
@@ -781,7 +781,7 @@ package object test extends CompileVariants {
       outerStream: ZIO[R, Option[Nothing], Chunk[Option[A]]],
       currentOuterChunk: Ref[(Chunk[Option[A]], Int)],
       currentInnerStream: Ref[Option[PullInner]],
-      currentStreams: Ref[Queue[State]],
+      currentStreams: Ref[ScalaQueue[State]],
       innerFinalizers: ZManaged.ReleaseMap
     ): ZIO[R1, Option[Nothing], Chunk[Option[B]]] = {
 
@@ -899,7 +899,7 @@ package object test extends CompileVariants {
         outerStream        <- stream.process
         currentOuterChunk  <- Ref.make[(Chunk[Option[A]], Int)]((Chunk.empty, 0)).toManaged
         currentInnerStream <- Ref.make[Option[PullInner]](None).toManaged
-        currentStreams     <- Ref.make[Queue[State]](Queue(PullOuter)).toManaged
+        currentStreams     <- Ref.make[ScalaQueue[State]](ScalaQueue(PullOuter)).toManaged
         innerFinalizers    <- ZManaged.ReleaseMap.makeManaged(ExecutionStrategy.Sequential)
       } yield pull(outerDone, outerStream, currentOuterChunk, currentInnerStream, currentStreams, innerFinalizers)
     }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -20,6 +20,7 @@ import zio.stream.{ZSink, ZStream}
 import zio.test.AssertionResult.FailureDetailsResult
 import zio.test.environment._
 
+import scala.collection.immutable.Queue
 import scala.language.implicitConversions
 import scala.util.Try
 
@@ -403,7 +404,7 @@ package object test extends CompileVariants {
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A](
     rv: Gen[R, A]
   )(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
-    checkStream(rv.sample)(test)
+    checkStream(rv.sample.collectSome)(test)
 
   /**
    * A version of `checkAllM` that accepts two random variables.
@@ -471,7 +472,7 @@ package object test extends CompileVariants {
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A](rv: Gen[R, A], parallelism: Int)(
     test: A => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(test)
+    checkStreamPar(rv.sample.collectSome, parallelism)(test)
 
   /**
    * A version of `checkAllMPar` that accepts two random variables.
@@ -655,7 +656,7 @@ package object test extends CompileVariants {
     final class CheckNM(private val n: Int) extends AnyVal {
       def apply[R <: Has[TestConfig], R1 <: R, E, A](rv: Gen[R, A])(
         test: A => ZIO[R1, E, TestResult]
-      ): ZIO[R1, E, TestResult] = checkStream(rv.sample.forever.take(n.toLong))(test)
+      ): ZIO[R1, E, TestResult] = checkStream(rv.sample.forever.collectSome.take(n.toLong))(test)
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =
@@ -757,4 +758,159 @@ package object test extends CompileVariants {
           .catchAll(ZStream.succeed(_))
       }
     }
+
+  /**
+   * An implementation of `ZStream#flatMap` that supports breadth first search.
+   */
+  private[test] def flatMapStream[R, R1 <: R, A, B](
+    stream: ZStream[R, Nothing, Option[A]]
+  )(f: A => ZStream[R1, Nothing, Option[B]]): ZStream[R1, Nothing, Option[B]] = {
+
+    sealed trait State
+
+    case object PullOuter extends State
+    case class PullInner(
+      stream: ZIO[R1, Option[Nothing], Chunk[Option[B]]],
+      chunk: Chunk[Option[B]],
+      index: Int,
+      finalizer: ZManaged.Finalizer
+    ) extends State
+
+    def pull(
+      outerDone: Ref[Boolean],
+      outerStream: ZIO[R, Option[Nothing], Chunk[Option[A]]],
+      currentOuterChunk: Ref[(Chunk[Option[A]], Int)],
+      currentInnerStream: Ref[Option[PullInner]],
+      currentStreams: Ref[Queue[State]],
+      innerFinalizers: ZManaged.ReleaseMap
+    ): ZIO[R1, Option[Nothing], Chunk[Option[B]]] = {
+
+      def pullNonEmpty[R, E, A](pull: ZIO[R, Option[E], Chunk[A]]): ZIO[R, Option[E], Chunk[A]] =
+        pull.flatMap(as => if (as.nonEmpty) ZIO.succeed(as) else pullNonEmpty(pull))
+
+      def pullOuter(
+        outerStream: ZIO[R, Option[Nothing], Chunk[Option[A]]],
+        outerChunk: Chunk[Option[A]],
+        outerChunkIndex: Int
+      ): ZIO[R1, Option[Nothing], (Option[A], Chunk[Option[A]], Int)] =
+        if (outerChunkIndex < outerChunk.size)
+          ZIO.succeedNow((outerChunk(outerChunkIndex), outerChunk, outerChunkIndex + 1))
+        else
+          pullNonEmpty(outerStream).map(chunk => (chunk(0), chunk, 1))
+
+      def openInner(a: A): ZIO[R1, Nothing, (ZIO[R1, Option[Nothing], Chunk[Option[B]]], ZManaged.Finalizer)] =
+        ZIO.uninterruptibleMask { restore =>
+          for {
+            releaseMap <- ZManaged.ReleaseMap.make
+            pull       <- restore(f(a).process.zio.provideSome[R1]((_, releaseMap)).map(_._2))
+            finalizer  <- innerFinalizers.add(releaseMap.releaseAll(_, ExecutionStrategy.Sequential))
+          } yield (pull, finalizer)
+        }
+
+      def pullInner(
+        innerStream: ZIO[R1, Option[Nothing], Chunk[Option[B]]],
+        innerChunk: Chunk[Option[B]],
+        innerChunkIndex: Int
+      ): ZIO[R1, Option[Nothing], (Option[B], Chunk[Option[B]], Int)] =
+        if (innerChunkIndex < innerChunk.size)
+          ZIO.succeedNow((innerChunk(innerChunkIndex), innerChunk, innerChunkIndex + 1))
+        else
+          pullNonEmpty(innerStream).map(chunk => (chunk(0), chunk, 1))
+
+      currentInnerStream.get.flatMap {
+        case None =>
+          currentStreams.get.map(_.headOption).flatMap {
+            case None =>
+              ZIO.fail(None)
+            case Some(PullInner(innerStream, chunk, index, innerFinalizer)) =>
+              currentInnerStream.set(Some(PullInner(innerStream, chunk, index, innerFinalizer))) *>
+                currentStreams.update(_.tail) *>
+                pull(outerDone, outerStream, currentOuterChunk, currentInnerStream, currentStreams, innerFinalizers)
+            case Some(PullOuter) =>
+              outerDone.get.flatMap { done =>
+                if (done)
+                  currentStreams.get.flatMap { queue =>
+                    if (queue.size == 1) ZIO.fail(None)
+                    else {
+                      currentStreams.update(_.tail.enqueue(PullOuter)) *>
+                        ZIO.succeedNow(Chunk(None))
+                    }
+                  }
+                else
+                  currentOuterChunk.get.flatMap { case (outerChunk, outerChunkIndex) =>
+                    pullOuter(outerStream, outerChunk, outerChunkIndex).foldZIO(
+                      _ =>
+                        outerDone.set(true) *>
+                          pull(
+                            outerDone,
+                            outerStream,
+                            currentOuterChunk,
+                            currentInnerStream,
+                            currentStreams,
+                            innerFinalizers
+                          ),
+                      {
+                        case (Some(a), outerChunk, outerChunkIndex) =>
+                          openInner(a).flatMap { case (innerStream, innerFinalizer) =>
+                            currentOuterChunk.set((outerChunk, outerChunkIndex)) *>
+                              currentInnerStream.set(Some(PullInner(innerStream, Chunk.empty, 0, innerFinalizer))) *>
+                              pull(
+                                outerDone,
+                                outerStream,
+                                currentOuterChunk,
+                                currentInnerStream,
+                                currentStreams,
+                                innerFinalizers
+                              )
+                          }
+                        case (None, outerChunk, outerChunkIndex) =>
+                          currentOuterChunk.set((outerChunk, outerChunkIndex)) *>
+                            currentStreams.update(_.tail.enqueue(PullOuter)) *>
+                            ZIO.succeedNow(Chunk(None))
+                      }
+                    )
+                  }
+              }
+          }
+        case Some(PullInner(innerStream, innerChunk, innerChunkIndex, innerFinalizer)) =>
+          pullInner(innerStream, innerChunk, innerChunkIndex).foldZIO(
+            _ =>
+              innerFinalizer(Exit.unit) *>
+                currentInnerStream.set(None) *>
+                pull(outerDone, outerStream, currentOuterChunk, currentInnerStream, currentStreams, innerFinalizers),
+            {
+              case (None, innerChunk, innerChunkIndex) =>
+                currentInnerStream.set(None) *>
+                  currentStreams.update(
+                    _.enqueue(PullInner(innerStream, innerChunk, innerChunkIndex, innerFinalizer))
+                  ) *>
+                  pull(outerDone, outerStream, currentOuterChunk, currentInnerStream, currentStreams, innerFinalizers)
+              case (Some(b), innerChunk, innerChunkIndex) =>
+                currentInnerStream.set(Some(PullInner(innerStream, innerChunk, innerChunkIndex, innerFinalizer))) *>
+                  ZIO.succeedNow(Chunk(Some(b)))
+            }
+          )
+      }
+    }
+
+    ZStream {
+      for {
+        outerDone          <- Ref.make(false).toManaged
+        outerStream        <- stream.process
+        currentOuterChunk  <- Ref.make[(Chunk[Option[A]], Int)]((Chunk.empty, 0)).toManaged
+        currentInnerStream <- Ref.make[Option[PullInner]](None).toManaged
+        currentStreams     <- Ref.make[Queue[State]](Queue(PullOuter)).toManaged
+        innerFinalizers    <- ZManaged.ReleaseMap.makeManaged(ExecutionStrategy.Sequential)
+      } yield pull(outerDone, outerStream, currentOuterChunk, currentInnerStream, currentStreams, innerFinalizers)
+    }
+  }
+
+  /**
+   * An implementation of `ZStream#merge` that supports breadth first search.
+   */
+  private[test] def mergeStream[R, A](
+    left: ZStream[R, Nothing, Option[A]],
+    right: ZStream[R, Nothing, Option[A]]
+  ): ZStream[R, Nothing, Option[A]] =
+    flatMapStream(ZStream(Some(left), Some(right)))(identity)
 }


### PR DESCRIPTION
Refactors `Gen#flatMap` to use breadth first search. This will not impact random generators but will significantly increase the utility of deterministic generators.