### PR TITLE
Propagate Failure In ZIOApp

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -13,12 +13,12 @@ object ZIOAppSpec extends ZIOBaseSpec {
     },
     test("failure translates into ExitCode.failure") {
       for {
-        code <- ZIOApp.fromZIO(ZIO.fail("Uh oh!")).invoke(Chunk.empty)
+        code <- ZIOApp.fromZIO(ZIO.fail("Uh oh!")).invoke(Chunk.empty).exitCode
       } yield assertTrue(code == ExitCode.failure)
     },
     test("success translates into ExitCode.success") {
       for {
-        code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty)
+        code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty).exitCode
       } yield assertTrue(code == ExitCode.success)
     },
     test("composed app logic runs component logic") {
@@ -50,7 +50,7 @@ object ZIOAppSpec extends ZIOBaseSpec {
       val app1 = ZIOAppDefault(ZIO.fail("Uh oh!"), RuntimeConfigAspect.addLogger(logger1))
 
       for {
-        c <- app1.invoke(Chunk.empty)
+        c <- app1.invoke(Chunk.empty).exitCode
         v <- ZIO.succeed(counter.get())
       } yield assertTrue(c == ExitCode.failure) && assertTrue(v == 1)
     }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -79,7 +79,7 @@ trait ZIOApp { self =>
   /**
    * Invokes the main app. Designed primarily for testing.
    */
-  final def invoke(args: Chunk[String]): ZIO[ZEnv, Nothing, ExitCode] =
+  final def invoke(args: Chunk[String]): ZIO[ZEnv, Any, Any] =
     ZIO.runtime[ZEnv].flatMap { runtime =>
       val newRuntime = runtime.mapRuntimeConfig(hook)
 
@@ -87,7 +87,7 @@ trait ZIOApp { self =>
         ZLayer.environment[ZEnv] +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
           layer +!+ ZLayer.environment[ZEnv with Has[ZIOAppArgs]]
 
-      newRuntime.run(run.provideLayer(newLayer)).exitCode
+      newRuntime.run(run.provideLayer(newLayer))
     }
 
   /**


### PR DESCRIPTION
Resolves #5678.

We need to not use `exitCode` internally in `invoke` so we can preserve the error to properly log it and exit based on it in `main`.