### PR TITLE
Deprecate CheckM

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -80,7 +80,7 @@ object ChunkSpec extends ZIOBaseSpec {
         }
       },
       test("buffer used") {
-        checkM(Gen.chunkOf(Gen.int), Gen.chunkOf(Gen.int)) { (as, bs) =>
+        check(Gen.chunkOf(Gen.int), Gen.chunkOf(Gen.int)) { (as, bs) =>
           val effect   = ZIO.succeed(bs.foldLeft(as)(_ :+ _))
           val actual   = ZIO.collectAllPar(ZIO.replicate(100)(effect))
           val expected = as ++ bs
@@ -136,7 +136,7 @@ object ChunkSpec extends ZIOBaseSpec {
         }
       },
       test("buffer used") {
-        checkM(Gen.chunkOf(Gen.int), Gen.chunkOf(Gen.int)) { (as, bs) =>
+        check(Gen.chunkOf(Gen.int), Gen.chunkOf(Gen.int)) { (as, bs) =>
           val effect   = ZIO.succeed(as.foldRight(bs)(_ +: _))
           val actual   = ZIO.collectAllPar(ZIO.replicate(100)(effect))
           val expected = as ++ bs
@@ -266,7 +266,7 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("mapAccumZIO")(
       test("mapAccumZIO happy path") {
-        checkM(smallChunks(Gen.int), smallChunks(Gen.int), Gen.int, Gen.function2(Gen.int <*> Gen.int)) {
+        check(smallChunks(Gen.int), smallChunks(Gen.int), Gen.int, Gen.function2(Gen.int <*> Gen.int)) {
           (left, right, s, f) =>
             val actual = (left ++ right).mapAccumZIO[Any, Nothing, Int, Int](s)((s, a) => UIO.succeed(f(s, a)))
             val expected = (left ++ right).foldLeft[(Int, Chunk[Int])]((s, Chunk.empty)) { case ((s0, bs), a) =>
@@ -285,7 +285,7 @@ object ChunkSpec extends ZIOBaseSpec {
       check(smallChunks(intGen), fn)((c, f) => assert(c.map(f).toList)(equalTo(c.toList.map(f))))
     },
     suite("mapZIO")(
-      test("mapZIO happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, f) =>
+      test("mapZIO happy path")(check(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, f) =>
         chunk.mapZIO(s => UIO.succeed(f(s))).map(assert(_)(equalTo(chunk.map(f))))
       }),
       test("mapZIO error") {
@@ -325,7 +325,7 @@ object ChunkSpec extends ZIOBaseSpec {
       check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.find(p))(equalTo(chunk.toList.find(p))))
     },
     suite("findZIO")(
-      test("findZIO happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
+      test("findZIO happy path")(check(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
         chunk.findZIO(s => UIO.succeed(p(s))).map(assert(_)(equalTo(chunk.find(p))))
       }),
       test("findZIO error") {
@@ -337,7 +337,7 @@ object ChunkSpec extends ZIOBaseSpec {
       check(mediumChunks(intGen), fn)((chunk, p) => assert(chunk.filter(p).toList)(equalTo(chunk.toList.filter(p))))
     },
     suite("filterZIO")(
-      test("filterZIO happy path")(checkM(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
+      test("filterZIO happy path")(check(mediumChunks(intGen), Gen.function(Gen.boolean)) { (chunk, p) =>
         chunk.filterZIO(s => UIO.succeed(p(s))).map(assert(_)(equalTo(chunk.filter(p))))
       }),
       test("filterZIO error") {
@@ -420,7 +420,7 @@ object ChunkSpec extends ZIOBaseSpec {
       },
       test("collectZIO chunk") {
         val pfGen = Gen.partialFunction[Has[Random] with Has[Sized], Int, UIO[Int]](Gen.successes(intGen))
-        checkM(mediumChunks(intGen), pfGen) { (c, pf) =>
+        check(mediumChunks(intGen), pfGen) { (c, pf) =>
           for {
             result   <- c.collectZIO(pf).map(_.toList)
             expected <- UIO.collectAll(c.toList.collect(pf))
@@ -448,7 +448,7 @@ object ChunkSpec extends ZIOBaseSpec {
       },
       test("collectWhileZIO chunk") {
         val pfGen = Gen.partialFunction[Has[Random] with Has[Sized], Int, UIO[Int]](Gen.successes(intGen))
-        checkM(mediumChunks(intGen), pfGen) { (c, pf) =>
+        check(mediumChunks(intGen), pfGen) { (c, pf) =>
           for {
             result   <- c.collectWhileZIO(pf).map(_.toList)
             expected <- UIO.foreach(c.toList.takeWhile(pf.isDefinedAt))(pf.apply)

--- a/core-tests/shared/src/test/scala/zio/RandomSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RandomSpec.scala
@@ -14,7 +14,7 @@ object RandomSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("RandomSpec")(
     test("nextDoubleBetween generates doubles in specified range") {
-      checkM(genDoubles) { case (min, max) =>
+      check(genDoubles) { case (min, max) =>
         for {
           n <- Live.live(Random.nextDoubleBetween(min, max))
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -22,7 +22,7 @@ object RandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextFloatBetween generates floats in specified range") {
-      checkM(genFloats) { case (min, max) =>
+      check(genFloats) { case (min, max) =>
         for {
           n <- Live.live(Random.nextFloatBetween(min, max))
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -30,7 +30,7 @@ object RandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextIntBetween generates integers in specified range") {
-      checkM(genInts) { case (min, max) =>
+      check(genInts) { case (min, max) =>
         for {
           n <- Live.live(Random.nextIntBetween(min, max))
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -38,7 +38,7 @@ object RandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextLongBetween generates longs in specified range") {
-      checkM(genLongs) { case (min, max) =>
+      check(genLongs) { case (min, max) =>
         for {
           n <- Live.live(Random.nextLongBetween(min, max))
         } yield assert(n)(isGreaterThanEqualTo(min)) &&

--- a/core-tests/shared/src/test/scala/zio/ZHubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZHubSpec.scala
@@ -10,7 +10,7 @@ object ZHubSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZHubSpec")(
     suite("sequential publishers and subscribers")(
       test("with one publisher and one subscriber") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -26,7 +26,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("with one publisher and two subscribers") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -57,7 +57,7 @@ object ZHubSpec extends ZIOBaseSpec {
     ),
     suite("concurrent publishers and subscribers")(
       test("one to one") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise <- Promise.make[Nothing, Unit]
             hub     <- Hub.bounded[Int](n)
@@ -72,7 +72,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("one to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -95,7 +95,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("many to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -123,7 +123,7 @@ object ZHubSpec extends ZIOBaseSpec {
     ),
     suite("back pressure")(
       test("one to one") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise <- Promise.make[Nothing, Unit]
             hub     <- Hub.bounded[Int](n)
@@ -138,7 +138,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("one to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -161,7 +161,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("many to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -189,7 +189,7 @@ object ZHubSpec extends ZIOBaseSpec {
     ),
     suite("dropping")(
       test("one to one") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise <- Promise.make[Nothing, Unit]
             hub     <- Hub.dropping[Int](n)
@@ -204,7 +204,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("one to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -227,7 +227,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("many to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -255,7 +255,7 @@ object ZHubSpec extends ZIOBaseSpec {
     ),
     suite("sliding")(
       test("one to one") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise <- Promise.make[Nothing, Unit]
             hub     <- Hub.sliding[Int](n)
@@ -271,7 +271,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("one to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -294,7 +294,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("many to many") {
-        checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -322,7 +322,7 @@ object ZHubSpec extends ZIOBaseSpec {
     ),
     suite("unbounded")(
       test("one to one") {
-        checkM(Gen.listOf(smallInt)) { as =>
+        check(Gen.listOf(smallInt)) { as =>
           for {
             promise <- Promise.make[Nothing, Unit]
             hub     <- Hub.unbounded[Int]
@@ -337,7 +337,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("one to many") {
-        checkM(Gen.listOf(smallInt)) { as =>
+        check(Gen.listOf(smallInt)) { as =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]
@@ -360,7 +360,7 @@ object ZHubSpec extends ZIOBaseSpec {
         }
       },
       test("many to many") {
-        checkM(Gen.listOf(smallInt)) { as =>
+        check(Gen.listOf(smallInt)) { as =>
           for {
             promise1 <- Promise.make[Nothing, Unit]
             promise2 <- Promise.make[Nothing, Unit]

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -343,7 +343,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("collectFirst")(
       test("collects the first value for which the effectual functions returns Some") {
-        checkM(Gen.listOf(Gen.int), Gen.partialFunction(Gen.int)) { (as, pf) =>
+        check(Gen.listOf(Gen.int), Gen.partialFunction(Gen.int)) { (as, pf) =>
           def f(n: Int): UIO[Option[Int]] = UIO.succeed(pf.lift(n))
           assertM(ZIO.collectFirst(as)(f))(equalTo(as.collectFirst(pf)))
         }
@@ -371,7 +371,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("companion object method consistency")(
       test("absolve") {
-        checkM(Gen.alphaNumericString) { str =>
+        check(Gen.alphaNumericString) { str =>
           val ioEither: UIO[Either[Nothing, String]] = IO.succeed(Right(str))
           for {
             abs1 <- ioEither.absolve
@@ -388,7 +388,7 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(race1)(equalTo(race2))
       },
       test("flatten") {
-        checkM(Gen.alphaNumericString) { str =>
+        check(Gen.alphaNumericString) { str =>
           for {
             flatten1 <- IO.succeed(IO.succeed(str)).flatten
             flatten2 <- IO.flatten(IO.succeed(IO.succeed(str)))
@@ -537,7 +537,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("exists")(
       test("determines whether any element satisfies the effectual predicate") {
-        checkM(Gen.listOf(Gen.int), Gen.function(Gen.boolean)) { (as, f) =>
+        check(Gen.listOf(Gen.int), Gen.function(Gen.boolean)) { (as, f) =>
           val actual   = IO.exists(as)(a => IO.succeed(f(a)))
           val expected = as.exists(f)
           assertM(actual)(equalTo(expected))
@@ -660,19 +660,19 @@ object ZIOSpec extends ZIOBaseSpec {
     ) @@ zioTag(errors),
     suite("foldLeft")(
       test("with a successful step function sums the list properly") {
-        checkM(Gen.listOf(Gen.int)) { l =>
+        check(Gen.listOf(Gen.int)) { l =>
           val res = IO.foldLeft(l)(0)((acc, el) => IO.succeed(acc + el))
           assertM(res)(equalTo(l.sum))
         }
       },
       test("`with a failing step function returns a failed IO") {
-        checkM(Gen.listOf1(Gen.int)) { l =>
+        check(Gen.listOf1(Gen.int)) { l =>
           val res = IO.foldLeft(l)(0)((_, _) => IO.fail("fail"))
           assertM(res.exit)(fails(equalTo("fail")))
         }
       } @@ zioTag(errors),
       test("run sequentially from left to right") {
-        checkM(Gen.listOf1(Gen.int)) { l =>
+        check(Gen.listOf1(Gen.int)) { l =>
           val res = IO.foldLeft(l)(List.empty[Int])((acc, el) => IO.succeed(el :: acc))
           assertM(res)(equalTo(l.reverse))
         }
@@ -680,19 +680,19 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("foldRight")(
       test("with a successful step function sums the list properly") {
-        checkM(Gen.listOf(Gen.int)) { l =>
+        check(Gen.listOf(Gen.int)) { l =>
           val res = IO.foldRight(l)(0)((el, acc) => IO.succeed(acc + el))
           assertM(res)(equalTo(l.sum))
         }
       },
       test("`with a failing step function returns a failed IO") {
-        checkM(Gen.listOf1(Gen.int)) { l =>
+        check(Gen.listOf1(Gen.int)) { l =>
           val res = IO.foldRight(l)(0)((_, _) => IO.fail("fail"))
           assertM(res.exit)(fails(equalTo("fail")))
         }
       } @@ zioTag(errors),
       test("run sequentially from right to left") {
-        checkM(Gen.listOf1(Gen.int)) { l =>
+        check(Gen.listOf1(Gen.int)) { l =>
           val res = IO.foldRight(l)(List.empty[Int])((el, acc) => IO.succeed(el :: acc))
           assertM(res)(equalTo(l))
         }
@@ -700,7 +700,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("forall")(
       test("determines whether all elements satisfy the effectual predicate") {
-        checkM(Gen.listOf(Gen.int), Gen.function(Gen.boolean)) { (as, f) =>
+        check(Gen.listOf(Gen.int), Gen.function(Gen.boolean)) { (as, f) =>
           val actual   = IO.forall(as)(a => IO.succeed(f(a)))
           val expected = as.forall(f)
           assertM(actual)(equalTo(expected))
@@ -709,7 +709,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("foreach")(
       test("returns the list of results") {
-        checkAllM(functionIOGen, listGen) { (f, list) =>
+        checkAll(functionIOGen, listGen) { (f, list) =>
           val res = IO.foreach(list)(f)
           assertM(res)(isSubtype[List[Int]](anything) && hasSize(equalTo(100)))
         }
@@ -1408,7 +1408,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("mapBoth")(
       test("maps over both error and value channels") {
-        checkM(Gen.int) { i =>
+        check(Gen.int) { i =>
           val res = IO.fail(i).mapBoth(_.toString, identity).either
           assertM(res)(isLeft(equalTo(i.toString)))
         }
@@ -1686,7 +1686,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val causes    = Gen.causes(smallInts, Gen.throwable)
         val successes = Gen.successes(smallInts)
         val exits     = Gen.either(causes, successes).map(_.fold(Exit.failCause, Exit.succeed))
-        checkM(exits, exits, exits) { (exit1, exit2, exit3) =>
+        check(exits, exits, exits) { (exit1, exit2, exit3) =>
           val zio1  = ZIO.done(exit1)
           val zio2  = ZIO.done(exit2)
           val zio3  = ZIO.done(exit3)
@@ -3448,7 +3448,7 @@ object ZIOSpec extends ZIOBaseSpec {
       }
     ),
     test("unleft") {
-      checkM(Gen.oneOf(Gen.failures(Gen.int), Gen.successes(Gen.either(Gen.int, Gen.int)))) { zio =>
+      check(Gen.oneOf(Gen.failures(Gen.int), Gen.successes(Gen.either(Gen.int, Gen.int)))) { zio =>
         for {
           actual   <- zio.left.unleft.exit
           expected <- zio.exit
@@ -3557,7 +3557,7 @@ object ZIOSpec extends ZIOBaseSpec {
       }
     ) @@ zioTag(errors),
     test("right") {
-      checkM(Gen.oneOf(Gen.failures(Gen.int), Gen.successes(Gen.either(Gen.int, Gen.int)))) { zio =>
+      check(Gen.oneOf(Gen.failures(Gen.int), Gen.successes(Gen.either(Gen.int, Gen.int)))) { zio =>
         for {
           actual   <- zio.right.unright.exit
           expected <- zio.exit
@@ -3577,7 +3577,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val causes = Gen.causes(Gen.string, Gen.throwable)
         def cause[R, E](zio: ZIO[R, E, Nothing]): ZIO[R, Nothing, Cause[E]] =
           zio.foldCauseZIO(ZIO.succeed(_), ZIO.fail)
-        checkM(causes) { c =>
+        check(causes) { c =>
           for {
             result <- cause(ZIO.failCause(c).sandbox.mapErrorCause(e => e.untraced).unsandbox)
           } yield assert(result)(equalTo(c)) &&

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -355,7 +355,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         testAcquirePar(4, res => ZManaged.foreachPar(List(1, 2, 3, 4))(_ => res))
       },
       test("Maintains finalizer ordering in inner ZManaged values") {
-        checkM(Gen.int(5, 100))(l => testParallelNestedFinalizerOrdering(l, ZManaged.foreachPar(_)(identity)))
+        check(Gen.int(5, 100))(l => testParallelNestedFinalizerOrdering(l, ZManaged.foreachPar(_)(identity)))
       }
     ),
     suite("foreachParN")(
@@ -376,7 +376,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         testAcquirePar(2, res => ZManaged.foreachParN(2)(List(1, 2, 3, 4))(_ => res))
       },
       test("Maintains finalizer ordering in inner ZManaged values") {
-        checkM(Gen.int(4, 10), Gen.int(5, 100)) { (n, l) =>
+        check(Gen.int(4, 10), Gen.int(5, 100)) { (n, l) =>
           testParallelNestedFinalizerOrdering(l, ZManaged.foreachParN(n)(_)(identity))
         }
       }
@@ -1426,7 +1426,7 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("flatten")(
       test("Returns the same as ZManaged.flatten") {
-        checkM(Gen.string(Gen.alphaNumericChar)) { str =>
+        check(Gen.string(Gen.alphaNumericChar)) { str =>
           val test = for {
             flatten1 <- ZManaged.succeed(ZManaged.succeed(str)).flatten
             flatten2 <- ZManaged.flatten(ZManaged.succeed(ZManaged.succeed(str)))
@@ -1437,7 +1437,7 @@ object ZManagedSpec extends ZIOBaseSpec {
     ),
     suite("absolve")(
       test("Returns the same as ZManaged.absolve") {
-        checkM(Gen.string(Gen.alphaNumericChar)) { str =>
+        check(Gen.string(Gen.alphaNumericChar)) { str =>
           val managedEither: ZManaged[Any, Nothing, Either[Nothing, String]] = ZManaged.succeed(Right(str))
           val test = for {
             abs1 <- managedEither.absolve

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -276,7 +276,7 @@ object ZQueueSpec extends ZIOBaseSpec {
         } yield assert(res)(hasSize(isGreaterThanEqualTo(5)))
       },
       test("returns elements in the correct order") {
-        checkM(Gen.chunkOf(Gen.int(-10, 10))) { as =>
+        check(Gen.chunkOf(Gen.int(-10, 10))) { as =>
           for {
             queue <- Queue.bounded[Int](100)
             f     <- ZIO.foreach(as)(queue.offer).fork
@@ -844,7 +844,7 @@ object ZQueueSpec extends ZIOBaseSpec {
       } yield assertCompletes
     } @@ jvm(nonFlaky),
     test("many to many") {
-      checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+      check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
         for {
           queue    <- Queue.bounded[Int](n)
           offerors <- ZIO.foreach(as)(a => queue.offer(a).fork)

--- a/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
@@ -255,7 +255,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
         val subscription = hub.subscribe()
         for {
@@ -274,7 +274,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and two subscribers") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -299,7 +299,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length * 2)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -328,7 +328,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def isEmpty(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("isEmpty always returns false on a subscription that is not empty") {
-      checkM(Gen.listOf(smallInt)) { as =>
+      check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(1000)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -355,7 +355,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def isFull(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("isFull always returns false on a hub that is not full") {
-      checkM(Gen.listOf(smallInt)) { as =>
+      check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(10000)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -379,7 +379,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishNonFull(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("publishing to a hub that is not full always succeeds") {
-      checkM(Gen.listOf(smallInt)) { as =>
+      check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(10000)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -401,7 +401,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def pollNonEmpty(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("polling from a hub that is not empty always succeeds") {
-      checkM(Gen.listOf(smallInt)) { as =>
+      check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(1000)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -424,7 +424,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishAllPollUpTo1To1(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
-      checkM(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
+      check(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
         val hub          = makeHub(1000)
         val subscription = hub.subscribe()
         for {
@@ -437,7 +437,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def publishAllPollUpToNToN(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
-      checkM(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
+      check(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
         val hub           = makeHub(1000)
         val subscription1 = hub.subscribe()
         val subscription2 = hub.subscribe()
@@ -457,7 +457,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def poll(label: String)(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test(label) {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
         val subscription = hub.subscribe()
         for {
@@ -475,7 +475,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def slidingPublishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
         val n            = math.min(hub.capacity, as.length)
         val subscription = hub.subscribe()
@@ -492,7 +492,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def slidingPublishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and two subscribers") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length)
         val n             = math.min(hub.capacity, as.length)
         val subscription1 = hub.subscribe()
@@ -513,7 +513,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def slidingPublishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
-      checkM(Gen.listOf1(smallInt)) { as =>
+      check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length * 2)
         val n             = math.min(hub.capacity, as.length)
         val subscription1 = hub.subscribe()
@@ -538,7 +538,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def slidingPublishAllPollUpTo1To1(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
-      checkM(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
+      check(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
         val chunks       = as.sorted.grouped(chunkSize).map(Chunk.fromIterable).toList
         val hub          = makeHub(2)
         val n            = math.min(hub.capacity, chunks.flatten.length)
@@ -553,7 +553,7 @@ object HubSpec extends ZIOBaseSpec {
 
   def slidingPublishAllPollUpToNToN(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
-      checkM(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
+      check(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
         val leftChunks    = as.sorted.grouped(chunkSize).map(Chunk.fromIterable).toList
         val rightChunks   = as.map(-_).sorted.grouped(chunkSize).map(Chunk.fromIterable).toList
         val hub           = makeHub(2)

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/ConcurrentSummarySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/ConcurrentSummarySpec.scala
@@ -25,7 +25,7 @@ object ConcurrentSummarySpec extends ZIOBaseSpec {
         )
       },
       test("single observe works with arbitrary maxSize") {
-        checkM(Gen.int(0, 100000)) { maxSize =>
+        check(Gen.int(0, 100000)) { maxSize =>
           val summary = ConcurrentSummary.manual(maxSize, maxAge = 10.seconds, err = 0.0, quantiles = Chunk.empty)
           val observe = Clock.instant.flatMap(now => ZIO.attempt(summary.observe(11.0, now)))
 

--- a/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TArraySpec.scala
@@ -861,7 +861,7 @@ object TArraySpec extends ZIOBaseSpec {
     ),
     suite("size") {
       test("returns the size of the array") {
-        checkM(Gen.listOf(Gen.int)) { as =>
+        check(Gen.listOf(Gen.int)) { as =>
           val size = TArray.fromIterable(as).map(_.size)
           assertM(size.commit)(equalTo(as.size))
         }

--- a/core-tests/shared/src/test/scala/zio/stm/THubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/THubSpec.scala
@@ -13,7 +13,7 @@ object THubSpec extends ZIOBaseSpec {
     suite("THubSpec")(
       suite("sequential publishers and subscribers")(
         test("with one publisher and one subscriber") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -31,7 +31,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("with one publisher and two subscribers") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -62,7 +62,7 @@ object THubSpec extends ZIOBaseSpec {
       ),
       suite("concurrent publishers and subscribers")(
         test("one to one") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise <- Promise.make[Nothing, Unit]
               hub     <- THub.bounded[Int](n).commit
@@ -77,7 +77,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("one to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -100,7 +100,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("many to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -128,7 +128,7 @@ object THubSpec extends ZIOBaseSpec {
       ),
       suite("back pressure")(
         test("one to one") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise <- Promise.make[Nothing, Unit]
               hub     <- THub.bounded[Int](n).commit
@@ -143,7 +143,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("one to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -166,7 +166,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("many to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -194,7 +194,7 @@ object THubSpec extends ZIOBaseSpec {
       ),
       suite("dropping")(
         test("one to one") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise <- Promise.make[Nothing, Unit]
               hub     <- THub.dropping[Int](n).commit
@@ -209,7 +209,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("one to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -232,7 +232,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("many to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -260,7 +260,7 @@ object THubSpec extends ZIOBaseSpec {
       ),
       suite("sliding")(
         test("one to one") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise <- Promise.make[Nothing, Unit]
               hub     <- THub.sliding[Int](n).commit
@@ -276,7 +276,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("one to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -299,7 +299,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("many to many") {
-          checkM(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+          check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -327,7 +327,7 @@ object THubSpec extends ZIOBaseSpec {
       ),
       suite("unbounded")(
         test("one to one") {
-          checkM(Gen.listOf(smallInt)) { as =>
+          check(Gen.listOf(smallInt)) { as =>
             for {
               promise <- Promise.make[Nothing, Unit]
               hub     <- THub.unbounded[Int].commit
@@ -342,7 +342,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("one to many") {
-          checkM(Gen.listOf(smallInt)) { as =>
+          check(Gen.listOf(smallInt)) { as =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]
@@ -365,7 +365,7 @@ object THubSpec extends ZIOBaseSpec {
           }
         },
         test("many to many") {
-          checkM(Gen.listOf(smallInt)) { as =>
+          check(Gen.listOf(smallInt)) { as =>
             for {
               promise1 <- Promise.make[Nothing, Unit]
               promise2 <- Promise.make[Nothing, Unit]

--- a/core-tests/shared/src/test/scala/zio/stm/TPriorityQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TPriorityQueueSpec.scala
@@ -25,7 +25,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("TPriorityQueueSpec")(
     test("isEmpty") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue <- TPriorityQueue.empty[Event]
           _     <- queue.offerAll(as)
@@ -35,7 +35,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("nonEmpty") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue    <- TPriorityQueue.empty[Event]
           _        <- queue.offerAll(as)
@@ -45,7 +45,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("offerAll and takeAll") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue  <- TPriorityQueue.empty[Event]
           _      <- queue.offerAll(as)
@@ -55,7 +55,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("removeIf") {
-      checkM(genEvents, genPredicate) { (as, f) =>
+      check(genEvents, genPredicate) { (as, f) =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           _     <- queue.removeIf(f)
@@ -65,7 +65,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("retainIf") {
-      checkM(Gen.listOf(genEvent), genPredicate) { (as, f) =>
+      check(Gen.listOf(genEvent), genPredicate) { (as, f) =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           _     <- queue.retainIf(f)
@@ -75,7 +75,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("take") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           takes <- STM.collectAll(STM.replicate(as.length)(queue.take))
@@ -88,7 +88,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
         as <- genEvents
         n  <- Gen.int(0, as.length)
       } yield (as, n)
-      checkM(gen) { case (as, n) =>
+      check(gen) { case (as, n) =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           left  <- queue.takeUpTo(n)
@@ -98,7 +98,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("toChunk") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           list  <- queue.toChunk
@@ -107,7 +107,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("toList") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           list  <- queue.toList
@@ -116,7 +116,7 @@ object TPriorityQueueSpec extends ZIOBaseSpec {
       }
     },
     test("toVector") {
-      checkM(genEvents) { as =>
+      check(genEvents) { as =>
         val transaction = for {
           queue <- TPriorityQueue.fromIterable(as)
           list  <- queue.toVector

--- a/core-tests/shared/src/test/scala/zio/stm/TRandomSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TRandomSpec.scala
@@ -2,7 +2,7 @@ package zio.stm
 
 import zio.stm.TRandom._
 import zio.test.Assertion.{isGreaterThanEqualTo, isLessThan}
-import zio.test.{Gen, ZSpec, assert, checkM}
+import zio.test.{Gen, ZSpec, assert, check}
 import zio.{Has, Random, ZIOBaseSpec}
 
 object TRandomSpec extends ZIOBaseSpec {
@@ -15,7 +15,7 @@ object TRandomSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("TRandomSpec")(
     test("nextDoubleBetween generates doubles in specified range") {
-      checkM(genDoubles) { case (min, max) =>
+      check(genDoubles) { case (min, max) =>
         for {
           n <- nextDoubleBetween(min, max).commit
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -23,7 +23,7 @@ object TRandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextFloatBetween generates floats in specified range") {
-      checkM(genFloats) { case (min, max) =>
+      check(genFloats) { case (min, max) =>
         for {
           n <- nextFloatBetween(min, max).commit
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -31,7 +31,7 @@ object TRandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextIntBetween generates integers in specified range") {
-      checkM(genInts) { case (min, max) =>
+      check(genInts) { case (min, max) =>
         for {
           n <- nextIntBetween(min, max).commit
         } yield assert(n)(isGreaterThanEqualTo(min)) &&
@@ -39,7 +39,7 @@ object TRandomSpec extends ZIOBaseSpec {
       }
     },
     test("nextLongBetween generates longs in specified range") {
-      checkM(genLongs) { case (min, max) =>
+      check(genLongs) { case (min, max) =>
         for {
           n <- nextLongBetween(min, max).commit
         } yield assert(n)(isGreaterThanEqualTo(min)) &&

--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -9,7 +9,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
   override def spec: ZSpec[Environment, Failure] = suite("TSemaphore")(
     suite("factories")(
       test("make") {
-        checkM(Gen.long(1L, Int.MaxValue)) { expected =>
+        check(Gen.long(1L, Int.MaxValue)) { expected =>
           val actual = for {
             sem <- TSemaphore.make(expected)
             cap <- sem.available
@@ -21,7 +21,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
     ),
     suite("acquire and release")(
       test("acquiring and releasing a permit should not change the availability") {
-        checkM(Gen.long(1L, Int.MaxValue)) { expected =>
+        check(Gen.long(1L, Int.MaxValue)) { expected =>
           val actual = for {
             sem <- TSemaphore.make(expected)
             _   <- sem.acquire *> sem.release
@@ -31,7 +31,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
         }
       },
       test("used capacity must be equal to the # of acquires minus # of releases") {
-        checkM(usedCapacityGen) { case (capacity, acquire, release) =>
+        check(usedCapacityGen) { case (capacity, acquire, release) =>
           val actual = for {
             sem <- TSemaphore.make(capacity)
             _   <- repeat(sem.acquire)(acquire) *> repeat(sem.release)(release)
@@ -43,7 +43,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
         }
       },
       test("acquireN/releaseN(n) is acquire/release repeated N times") {
-        checkM(Gen.long(1, 100)) { capacity =>
+        check(Gen.long(1, 100)) { capacity =>
           def acquireRelease(
             sem: TSemaphore
           )(acq: Long => STM[Nothing, Unit])(rel: Long => STM[Nothing, Unit]): STM[Nothing, (Long, Long)] =

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -150,7 +150,7 @@ object ZSTMSpec extends ZIOBaseSpec {
         assertM(STM.fail(-1).flatMapError(s => STM.succeed(s"log: $s")).commit.exit)(fails(equalTo("log: -1")))
       } @@ zioTag(errors),
       test("flatten") {
-        checkM(Gen.alphaNumericString) { str =>
+        check(Gen.alphaNumericString) { str =>
           val tx =
             for {
               flatten1 <- STM.succeed(STM.succeed(str)).flatten
@@ -186,19 +186,19 @@ object ZSTMSpec extends ZIOBaseSpec {
       } @@ zioTag(errors),
       suite("foldLeft")(
         test("with a successful step function sums the list properly") {
-          checkM(Gen.listOf(Gen.int)) { l =>
+          check(Gen.listOf(Gen.int)) { l =>
             val tx = STM.foldLeft(l)(0)((acc, el) => STM.succeed(acc + el))
             assertM(tx.commit)(equalTo(l.sum))
           }
         },
         test("with a failing step function returns a failed transaction") {
-          checkM(Gen.listOf1(Gen.int)) { l =>
+          check(Gen.listOf1(Gen.int)) { l =>
             val tx = STM.foldLeft(l)(0)((_, _) => STM.fail("fail"))
             assertM(tx.commit.exit)(fails(equalTo("fail")))
           }
         },
         test("run sequentially from left to right") {
-          checkM(Gen.listOf1(Gen.int)) { l =>
+          check(Gen.listOf1(Gen.int)) { l =>
             val tx = STM.foldLeft(l)(List.empty[Int])((acc, el) => STM.succeed(el :: acc))
             assertM(tx.commit)(equalTo(l.reverse))
           }
@@ -206,19 +206,19 @@ object ZSTMSpec extends ZIOBaseSpec {
       ),
       suite("foldRight")(
         test("with a successful step function sums the list properly") {
-          checkM(Gen.listOf(Gen.int)) { l =>
+          check(Gen.listOf(Gen.int)) { l =>
             val tx = STM.foldRight(l)(0)((el, acc) => STM.succeed(acc + el))
             assertM(tx.commit)(equalTo(l.sum))
           }
         },
         test("with a failing step function returns a failed transaction") {
-          checkM(Gen.listOf1(Gen.int)) { l =>
+          check(Gen.listOf1(Gen.int)) { l =>
             val tx = STM.foldRight(l)(0)((_, _) => STM.fail("fail"))
             assertM(tx.commit.exit)(fails(equalTo("fail")))
           }
         },
         test("run sequentially from right to left") {
-          checkM(Gen.listOf1(Gen.int)) { l =>
+          check(Gen.listOf1(Gen.int)) { l =>
             val tx = STM.foldRight(l)(List.empty[Int])((el, acc) => STM.succeed(el :: acc))
             assertM(tx.commit)(equalTo(l))
           }

--- a/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/js/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 
 object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("ZStream JS")(
-    test("async")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+    test("async")(check(Gen.chunkOf(Gen.int)) { chunk =>
       val s = ZStream.async[Any, Throwable, Int](k => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
 
       assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))
@@ -26,12 +26,12 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                       .runCollect
         } yield assert(result)(equalTo(Chunk.empty))
       },
-      test("asyncMaybe Some")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+      test("asyncMaybe Some")(check(Gen.chunkOf(Gen.int)) { chunk =>
         val s = ZStream.asyncMaybe[Any, Throwable, Int](_ => Some(ZStream.fromIterable(chunk)))
 
         assertM(s.runCollect.map(_.take(chunk.size)))(equalTo(chunk))
       }),
-      test("asyncMaybe None")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+      test("asyncMaybe None")(check(Gen.chunkOf(Gen.int)) { chunk =>
         val s = ZStream.asyncMaybe[Any, Throwable, Int] { k =>
           chunk.foreach(a => k(Task.succeed(Chunk.single(a))))
           None
@@ -62,7 +62,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
       }
     ),
     suite("asyncZIO")(
-      test("asyncZIO")(checkM(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
+      test("asyncZIO")(check(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
         for {
           latch <- Promise.make[Nothing, Unit]
           fiber <- ZStream
@@ -111,7 +111,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
       }
     ),
     suite("asyncManaged")(
-      test("asyncManaged")(checkM(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
+      test("asyncManaged")(check(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
         for {
           latch <- Promise.make[Nothing, Unit]
           fiber <- ZStream
@@ -177,7 +177,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
           result <- cancelled.get
         } yield assert(result)(isTrue)
       },
-      test("asyncInterrupt Right")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+      test("asyncInterrupt Right")(check(Gen.chunkOf(Gen.int)) { chunk =>
         val s = ZStream.asyncInterrupt[Any, Throwable, Int](_ => Right(ZStream.fromIterable(chunk)))
 
         assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -24,7 +24,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("ZStream JVM")(
     suite("Constructors")(
-      test("async")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+      test("async")(check(Gen.chunkOf(Gen.int)) { chunk =>
         val s = ZStream.async[Any, Throwable, Int] { k =>
           global.execute(() => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
         }
@@ -42,12 +42,12 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                         .runCollect
           } yield assert(result)(equalTo(Chunk.empty))
         },
-        test("asyncMaybe Some")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+        test("asyncMaybe Some")(check(Gen.chunkOf(Gen.int)) { chunk =>
           val s = ZStream.asyncMaybe[Any, Throwable, Int](_ => Some(ZStream.fromIterable(chunk)))
 
           assertM(s.runCollect.map(_.take(chunk.size)))(equalTo(chunk))
         }),
-        test("asyncMaybe None")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+        test("asyncMaybe None")(check(Gen.chunkOf(Gen.int)) { chunk =>
           val s = ZStream.asyncMaybe[Any, Throwable, Int] { k =>
             global.execute(() => chunk.foreach(a => k(Task.succeed(Chunk.single(a)))))
             None
@@ -78,7 +78,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         }
       ),
       suite("asyncZIO")(
-        test("asyncZIO")(checkM(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
+        test("asyncZIO")(check(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
           for {
             latch <- Promise.make[Nothing, Unit]
             fiber <- ZStream
@@ -127,7 +127,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         }
       ),
       suite("asyncManaged")(
-        test("asyncManaged")(checkM(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
+        test("asyncManaged")(check(Gen.chunkOf(Gen.int).filter(_.nonEmpty)) { chunk =>
           for {
             latch <- Promise.make[Nothing, Unit]
             fiber <- ZStream
@@ -193,7 +193,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
             result <- cancelled.get
           } yield assert(result)(isTrue)
         },
-        test("asyncInterrupt Right")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+        test("asyncInterrupt Right")(check(Gen.chunkOf(Gen.int)) { chunk =>
           val s = ZStream.asyncInterrupt[Any, Throwable, Int](_ => Right(ZStream.fromIterable(chunk)))
 
           assertM(s.take(chunk.size.toLong).runCollect)(equalTo(chunk))
@@ -322,7 +322,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         }
       ),
       test("fromBlockingIterator") {
-        checkM(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
+        check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
           assertM(ZStream.fromBlockingIterator(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))
         }
       },
@@ -393,7 +393,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         }
       ),
       suite("fromSocketServer")(
-        test("read data")(checkM(Gen.string.filter(_.nonEmpty)) { message =>
+        test("read data")(check(Gen.string.filter(_.nonEmpty)) { message =>
           for {
             refOut <- Ref.make("")
 
@@ -417,7 +417,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
             _ <- server.interrupt
           } yield assert(receive)(equalTo(message))
         }),
-        test("write data")(checkM(Gen.string.filter(_.nonEmpty)) { message =>
+        test("write data")(check(Gen.string.filter(_.nonEmpty)) { message =>
           (for {
             refOut <- Ref.make("")
 
@@ -446,7 +446,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
       ),
       suite("fromOutputStreamWriter")(
         test("reads what is written") {
-          checkM(Gen.listOf(Gen.chunkOf(Gen.byte)), Gen.int(1, 10)) { (bytess, chunkSize) =>
+          check(Gen.listOf(Gen.chunkOf(Gen.byte)), Gen.int(1, 10)) { (bytess, chunkSize) =>
             val write    = (out: OutputStream) => for (bytes <- bytess) out.write(bytes.toArray)
             val expected = bytess.foldLeft[Chunk[Byte]](Chunk.empty)(_ ++ _)
             ZStream.fromOutputStreamWriter(write, chunkSize).runCollect.map(assert(_)(equalTo(expected)))

--- a/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/compression/CompressionSpec.scala
@@ -66,7 +66,7 @@ object CompressionSpec extends DefaultRunnableSpec {
           )(fails(anything))
         ),
         test("inflate what JDK deflated")(
-          checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
             case (chunk, n, bufferSize) =>
               assertM(for {
                 deflated <- ZIO.succeed(deflatedStream(chunk.toArray))
@@ -75,7 +75,7 @@ object CompressionSpec extends DefaultRunnableSpec {
           }
         ),
         test("inflate what JDK deflated, nowrap")(
-          checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
             case (chunk, n, bufferSize) =>
               assertM(for {
                 deflated <- ZIO.succeed(noWrapDeflatedStream(chunk.toArray))
@@ -147,7 +147,7 @@ object CompressionSpec extends DefaultRunnableSpec {
           )(fails(anything))
         ),
         test("gunzip what JDK gzipped, nowrap")(
-          checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
             case (chunk, n, bufferSize) =>
               assertM(for {
                 deflated <- ZIO.succeed(jdkGzippedStream(chunk.toArray))
@@ -183,7 +183,7 @@ object CompressionSpec extends DefaultRunnableSpec {
       ),
       suite("deflate")(
         test("JDK inflates what was deflated")(
-          checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
             case (input, n, bufferSize) =>
               assertM(for {
                 deflated <- Stream.fromIterable(input).rechunk(n).transduce(deflate(bufferSize, false)).runCollect
@@ -219,7 +219,7 @@ object CompressionSpec extends DefaultRunnableSpec {
       ),
       suite("gzip")(
         test("JDK gunzips what was gzipped")(
-          checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+          check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
             case (input, n, bufferSize) =>
               assertM(for {
                 gzipped  <- Stream.fromIterable(input).rechunk(n).transduce(gzip(bufferSize)).runCollect

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/DeflateSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/DeflateSpec.scala
@@ -11,7 +11,7 @@ object DeflateSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[Environment, Failure] =
     suite("DeflateSpec")(
       test("JDK inflates what was deflated")(
-        checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+        check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case (input, n, bufferSize) =>
             assertM(for {
               (deflated, _) <-

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/GunzipSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/GunzipSpec.scala
@@ -62,7 +62,7 @@ object GunzipSpec extends DefaultRunnableSpec {
         )(fails(anything))
       ),
       test("gunzip what JDK gzipped, nowrap")(
-        checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+        check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case (chunk, n, bufferSize) =>
             assertM(for {
               deflated <- ZIO.succeed(jdkGzippedStream(chunk.toArray))

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/GzipSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/GzipSpec.scala
@@ -8,7 +8,7 @@ object GzipSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[Environment, Failure] =
     suite("GzipSpec")(
       test("JDK gunzips what was gzipped")(
-        checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+        check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case (input, n, bufferSize) =>
             assertM(for {
               gzipped <- (ZStream.fromIterable(input).rechunk(n).channel >>> Gzip.makeGzipper(bufferSize)).runCollect

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/InflateSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/InflateSpec.scala
@@ -56,7 +56,7 @@ object InflateSpec extends DefaultRunnableSpec {
         )(fails(anything))
       ),
       test("inflate what JDK deflated")(
-        checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+        check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case (chunk, n, bufferSize) =>
             assertM(for {
               deflated <- ZIO.succeed(deflatedStream(chunk.toArray))
@@ -65,7 +65,7 @@ object InflateSpec extends DefaultRunnableSpec {
         }
       ),
       test("inflate what JDK deflated, nowrap")(
-        checkM(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
+        check(Gen.listOfBounded(0, `1K`)(Gen.byte).zip(Gen.int(1, `1K`)).zip(Gen.int(1, `1K`))) {
           case (chunk, n, bufferSize) =>
             assertM(for {
               deflated <- ZIO.succeed(noWrapDeflatedStream(chunk.toArray))

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -28,15 +28,15 @@ object ZStreamSpec extends ZIOBaseSpec {
     suite("ZStreamSpec")(
       suite("Combinators")(
         suite("absolve")(
-          test("happy path")(checkM(tinyChunkOf(Gen.int)) { xs =>
+          test("happy path")(check(tinyChunkOf(Gen.int)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_)))
             assertM(stream.absolve.runCollect)(equalTo(xs))
           }),
-          test("failure")(checkM(tinyChunkOf(Gen.int)) { xs =>
+          test("failure")(check(tinyChunkOf(Gen.int)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
             assertM(stream.absolve.runCollect.exit)(fails(equalTo("Ouch")))
           }),
-          test("round-trip #1")(checkM(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
+          test("round-trip #1")(check(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs.map(Right(_)))
             val stream = xss ++ ZStream(Left(s)) ++ xss
             for {
@@ -44,7 +44,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               res2 <- stream.absolve.either.runCollect
             } yield assert(res1)(startsWith(res2))
           }),
-          test("round-trip #2")(checkM(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
+          test("round-trip #2")(check(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs)
             val stream = xss ++ ZStream.fail(s)
             for {
@@ -465,7 +465,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("buffer")(
-          test("maintains elements and ordering")(checkM(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
+          test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
             assertM(
               ZStream
                 .fromChunks(chunk: _*)
@@ -621,7 +621,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("bufferUnbounded")(
-          test("buffer the Stream")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+          test("buffer the Stream")(check(Gen.chunkOf(Gen.int)) { chunk =>
             assertM(
               ZStream
                 .fromIterable(chunk)
@@ -729,7 +729,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("changes") {
-          checkM(pureStreamOfInts) { stream =>
+          check(pureStreamOfInts) { stream =>
             for {
               actual <- stream.changes.runCollect.map(_.toList)
               expected <- stream.runCollect.map { as =>
@@ -741,7 +741,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("changesWithZIO") {
-          checkM(pureStreamOfInts) { stream =>
+          check(pureStreamOfInts) { stream =>
             for {
               actual <- stream.changesWithZIO((l, r) => ZIO.succeed(l == r)).runCollect.map(_.toList)
               expected <- stream.runCollect.map { as =>
@@ -781,7 +781,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        test("collectSome")(checkM(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.int), _))) { s =>
+        test("collectSome")(check(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.int), _))) { s =>
           for {
             res1 <- (s.collectSome.runCollect)
             res2 <- (s.runCollect.map(_.collect { case Some(x) => x }))
@@ -839,7 +839,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("concat")(
-          test("concat")(checkM(streamOfInts, streamOfInts) { (s1, s2) =>
+          test("concat")(check(streamOfInts, streamOfInts) { (s1, s2) =>
             for {
               chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).exit
               streamConcat <- (s1 ++ s2).runCollect.exit
@@ -920,7 +920,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } @@ zioTag(errors)
         ),
         suite("drop")(
-          test("drop")(checkM(streamOfInts, Gen.int) { (s, n) =>
+          test("drop")(check(streamOfInts, Gen.int) { (s, n) =>
             for {
               dropStreamResult <- s.drop(n.toLong).runCollect.exit
               dropListResult   <- s.runCollect.map(_.drop(n)).exit
@@ -939,7 +939,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("dropUntil") {
-          checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.dropUntil(p).runCollect
               res2 <- s.runCollect.map(_.dropWhile(!p(_)).drop(1))
@@ -948,7 +948,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("dropWhile")(
           test("dropWhile")(
-            checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+            check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
               for {
                 res1 <- s.dropWhile(p).runCollect
                 res2 <- s.runCollect.map(_.dropWhile(p))
@@ -990,14 +990,14 @@ object ZStreamSpec extends ZIOBaseSpec {
             execution <- log.get
           } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
         },
-        test("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+        test("filter")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             res1 <- s.filter(p).runCollect
             res2 <- s.runCollect.map(_.filter(p))
           } yield assert(res1)(equalTo(res2))
         }),
         suite("filterZIO")(
-          test("filterZIO")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          test("filterZIO")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.filterZIO(s => IO.succeed(p(s))).runCollect
               res2 <- s.runCollect.map(_.filter(p))
@@ -1024,14 +1024,14 @@ object ZStreamSpec extends ZIOBaseSpec {
 
             assertM(stream.runCollect)(equalTo(Chunk(expected)))
           } @@ TestAspect.jvmOnly, // Too slow on Scala.js
-          test("left identity")(checkM(Gen.int, Gen.function(pureStreamOfInts)) { (x, f) =>
+          test("left identity")(check(Gen.int, Gen.function(pureStreamOfInts)) { (x, f) =>
             for {
               res1 <- ZStream(x).flatMap(f).runCollect
               res2 <- f(x).runCollect
             } yield assert(res1)(equalTo(res2))
           }),
           test("right identity")(
-            checkM(pureStreamOfInts)(m =>
+            check(pureStreamOfInts)(m =>
               for {
                 res1 <- m.flatMap(i => ZStream(i)).runCollect
                 res2 <- m.runCollect
@@ -1041,7 +1041,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           test("associativity") {
             val tinyStream = Gen.int(0, 2).flatMap(pureStreamGen(Gen.int, _))
             val fnGen      = Gen.function(tinyStream)
-            checkM(tinyStream, fnGen, fnGen) { (m, f, g) =>
+            check(tinyStream, fnGen, fnGen) { (m, f, g) =>
               for {
                 leftStream  <- m.flatMap(f).flatMap(g).runCollect
                 rightStream <- m.flatMap(x => f(x).flatMap(g)).runCollect
@@ -1142,14 +1142,14 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("flatMapPar")(
-          test("guarantee ordering")(checkM(tinyListOf(Gen.int)) { (m: List[Int]) =>
+          test("guarantee ordering")(check(tinyListOf(Gen.int)) { (m: List[Int]) =>
             for {
               flatMap    <- ZStream.fromIterable(m).flatMap(i => ZStream(i, i)).runCollect
               flatMapPar <- ZStream.fromIterable(m).flatMapPar(1)(i => ZStream(i, i)).runCollect
             } yield assert(flatMap)(equalTo(flatMapPar))
           }),
           test("consistent with flatMap")(
-            checkM(Gen.int(1, Int.MaxValue), tinyListOf(Gen.int)) { (n, m) =>
+            check(Gen.int(1, Int.MaxValue), tinyListOf(Gen.int)) { (n, m) =>
               for {
                 flatMap <- ZStream
                              .fromIterable(m)
@@ -1428,11 +1428,11 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(fails(equalTo(e)))
           } @@ zioTag(errors)
         ),
-        test("flattenIterables")(checkM(tinyListOf(tinyListOf(Gen.int))) { lists =>
+        test("flattenIterables")(check(tinyListOf(tinyListOf(Gen.int))) { lists =>
           assertM(ZStream.fromIterable(lists).flattenIterables.runCollect)(equalTo(Chunk.fromIterable(lists.flatten)))
         }),
         suite("flattenTake")(
-          test("happy path")(checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+          test("happy path")(check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
             assertM(
               ZStream
                 .fromChunks(chunks: _*)
@@ -1748,7 +1748,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 
           val int = Gen.int(0, 5)
 
-          checkM(
+          check(
             int.flatMap(pureStreamGen(Gen.boolean, _)),
             int.flatMap(pureStreamGen(Gen.int, _)),
             int.flatMap(pureStreamGen(Gen.int, _))
@@ -1792,7 +1792,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               .map(result => assert(result)(equalTo(Chunk("[", "1", "]"))))
           },
           test("mkString(Sep) equivalence") {
-            checkM(
+            check(
               Gen
                 .int(0, 10)
                 .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.int))))
@@ -1806,7 +1806,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("mkString(Before, Sep, After) equivalence") {
-            checkM(
+            check(
               Gen
                 .int(0, 10)
                 .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.int))))
@@ -1974,7 +1974,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(uninterruptible)(isSome(equalTo(InterruptStatus.Uninterruptible)))
           }
         ),
-        test("map")(checkM(pureStreamOfInts, Gen.function(Gen.int)) { (s, f) =>
+        test("map")(check(pureStreamOfInts, Gen.function(Gen.int)) { (s, f) =>
           for {
             res1 <- s.map(f).runCollect
             res2 <- s.runCollect.map(_.map(f))
@@ -2012,13 +2012,13 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        test("mapConcat")(checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
+        test("mapConcat")(check(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
           for {
             res1 <- s.mapConcat(f).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
           } yield assert(res1)(equalTo(res2))
         }),
-        test("mapConcatChunk")(checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
+        test("mapConcatChunk")(check(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
           for {
             res1 <- s.mapConcatChunk(f).runCollect
             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2026,7 +2026,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         }),
         suite("mapConcatChunkM")(
           test("mapConcatChunkM happy path") {
-            checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
+            check(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
               for {
                 res1 <- s.mapConcatChunkZIO(b => UIO.succeedNow(f(b))).runCollect
                 res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2043,7 +2043,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("mapConcatM")(
           test("mapConcatM happy path") {
-            checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
+            check(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
               for {
                 res1 <- s.mapConcatZIO(b => UIO.succeedNow(f(b))).runCollect
                 res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2076,7 +2076,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("mapZIO")(
           test("ZIO#foreach equivalence") {
-            checkM(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
+            check(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
               val s = ZStream.fromIterable(data)
 
               for {
@@ -2096,7 +2096,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("mapZIOPar")(
           test("foreachParN equivalence") {
-            checkNM(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
+            checkN(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
               val s = ZStream.fromIterable(data)
 
               for {
@@ -2125,7 +2125,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- interrupted.get
             } yield assert(result)(isTrue)
           },
-          test("guarantee ordering")(checkM(Gen.int(1, 4096), Gen.listOf(Gen.int)) { (n: Int, m: List[Int]) =>
+          test("guarantee ordering")(check(Gen.int(1, 4096), Gen.listOf(Gen.int)) { (n: Int, m: List[Int]) =>
             for {
               mapZIO    <- ZStream.fromIterable(m).mapZIO(UIO.succeedNow).runCollect
               mapZIOPar <- ZStream.fromIterable(m).mapZIOPar(n)(UIO.succeedNow).runCollect
@@ -2219,7 +2219,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("mergeWith")(
-          test("equivalence with set union")(checkM(streamOfInts, streamOfInts) {
+          test("equivalence with set union")(check(streamOfInts, streamOfInts) {
             (s1: ZStream[Any, String, Int], s2: ZStream[Any, String, Int]) =>
               for {
                 mergedStream <- (s1 merge s2).runCollect.map(_.toSet).exit
@@ -2495,7 +2495,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         ),
         suite("scan")(
-          test("scan")(checkM(pureStreamOfInts) { s =>
+          test("scan")(check(pureStreamOfInts) { s =>
             for {
               streamResult <- s.scan(0)(_ + _).runCollect
               chunkResult  <- s.runCollect.map(_.scan(0)(_ + _))
@@ -2503,7 +2503,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           })
         ),
         suite("scanReduce")(
-          test("scanReduce")(checkM(pureStreamOfInts) { s =>
+          test("scanReduce")(check(pureStreamOfInts) { s =>
             for {
               streamResult <- s.scanReduce(_ + _).runCollect
               chunkResult  <- s.runCollect.map(_.scan(0)(_ + _).tail)
@@ -2645,7 +2645,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           s1.someOrFail(-1).runCollect.either.map(assert(_)(isLeft(equalTo(-1))))
         },
         suite("take")(
-          test("take")(checkM(streamOfInts, Gen.int) { (s, n) =>
+          test("take")(check(streamOfInts, Gen.int) { (s, n) =>
             for {
               takeStreamResult <- s.take(n.toLong).runCollect.exit
               takeListResult   <- s.runCollect.map(_.take(n)).exit
@@ -2673,7 +2673,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         ),
         test("takeRight") {
-          checkM(pureStreamOfInts, Gen.int(1, 4)) { (s, n) =>
+          check(pureStreamOfInts, Gen.int(1, 4)) { (s, n) =>
             for {
               streamTake <- s.takeRight(n).runCollect
               chunkTake  <- s.runCollect.map(_.takeRight(n))
@@ -2681,7 +2681,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("takeUntil") {
-          checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          check(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeUntil <- s.takeUntil(p).runCollect.exit
               chunkTakeUntil <- s.runCollect
@@ -2693,7 +2693,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("takeUntilM") {
-          checkM(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
+          check(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
             for {
               streamTakeUntilM <- s.takeUntilZIO(p).runCollect.exit
               chunkTakeUntilM <- s.runCollect
@@ -2708,7 +2708,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         suite("takeWhile")(
-          test("takeWhile")(checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          test("takeWhile")(check(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.exit
               chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).exit
@@ -3051,7 +3051,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("toInputStream")(
           test("read one-by-one") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
                 ZIO.succeedNow(
@@ -3063,7 +3063,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("read in batches") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
                 val batches: List[(Array[Byte], Int)] = Iterator.continually {
@@ -3168,7 +3168,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assert(out)(equalTo(Chunk.fromIterable(1 to n)))).use(ZIO.succeed(_))
         } @@ TestAspect.jvmOnly, // Until #3360 is solved
         suite("toQueue")(
-          test("toQueue")(checkM(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
+          test("toQueue")(check(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
             val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
             assertM(
               s.toQueue(1000)
@@ -3177,7 +3177,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               equalTo(c.map(Take.single) :+ Take.end)
             )
           }),
-          test("toQueueUnbounded")(checkM(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
+          test("toQueueUnbounded")(check(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
             val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
             assertM(
               s.toQueueUnbounded.use(queue => queue.size.repeatWhile(_ != c.size + 1) *> queue.takeAll)
@@ -3188,7 +3188,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("toReader")(
           test("read one-by-one") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
                 ZIO.succeedNow(
@@ -3200,7 +3200,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("read in batches") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
                 val batches: List[(Array[Char], Int)] = Iterator.continually {
@@ -3334,7 +3334,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(l.zip(r).runCollect)(equalTo(Chunk((1, "a"), (2, "b"), (3, "c"))))
           },
           test("zip equivalence with Chunk#zipWith") {
-            checkM(
+            check(
               tinyListOf(Gen.chunkOf(Gen.int)),
               tinyListOf(Gen.chunkOf(Gen.int))
             ) { (l, r) =>
@@ -3355,7 +3355,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("zipAllWith")(
           test("zipAllWith") {
-            checkM(
+            check(
               // We're using ZStream.fromChunks in the test, and that discards empty
               // chunks; so we're only testing for non-empty chunks here.
               tinyListOf(Gen.chunkOf(Gen.int).filter(_.size > 0)),
@@ -3395,7 +3395,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             chunk   = Chunk.fromIterable(map).sorted
             chunks <- splitChunks(Chunk(chunk))
           } yield chunks
-          checkM(genSortedByKey, genSortedByKey, genExecutionStrategy) { (as, bs, exec) =>
+          check(genSortedByKey, genSortedByKey, genExecutionStrategy) { (as, bs, exec) =>
             val left   = ZStream.fromChunks(as: _*)
             val right  = ZStream.fromChunks(bs: _*)
             val actual = left.zipAllSortedByKeyWithExec(right)(exec)(identity, identity)(_ + _)
@@ -3407,7 +3407,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(actual.runCollect)(equalTo(expected))
           }
         },
-        test("zipWithIndex")(checkM(pureStreamOfInts) { s =>
+        test("zipWithIndex")(check(pureStreamOfInts) { s =>
           for {
             res1 <- (s.zipWithIndex.runCollect)
             res2 <- (s.runCollect.map(_.zipWithIndex.map(t => (t._1, t._2.toLong))))
@@ -3454,7 +3454,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(ZStream.empty.zipWithNext.runCollect)(isEmpty)
           },
           test("should output same values as zipping with tail plus last element") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithNext.runCollect
@@ -3478,7 +3478,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(ZStream.empty.zipWithPrevious.runCollect)(isEmpty)
           },
           test("should output same values as first element plus zipping with init") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithPrevious.runCollect
@@ -3496,7 +3496,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )
           },
           test("should output same values as zipping with both previous and next element") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithPreviousAndNext.runCollect
@@ -3536,7 +3536,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("when")(
           test("returns the stream if the condition is satisfied") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               for {
                 result1  <- stream.when(true).runCollect
                 result2  <- ZStream.when(true)(stream).runCollect
@@ -3545,7 +3545,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("returns an empty stream if the condition is not satisfied") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               for {
                 result1 <- stream.when(false).runCollect
                 result2 <- ZStream.when(false)(stream).runCollect
@@ -3554,7 +3554,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("dies if the condition throws an exception") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               val exception     = new Exception
               def cond: Boolean = throw exception
               assertM(stream.when(cond).runDrain.exit)(dies(equalTo(exception)))
@@ -3563,7 +3563,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("whenCase")(
           test("returns the resulting stream if the given partial function is defined for the given value") {
-            checkM(Gen.int) { o =>
+            check(Gen.int) { o =>
               for {
                 result  <- ZStream.whenCase(Some(o)) { case Some(v) => ZStream(v) }.runCollect
                 expected = Chunk(o)
@@ -3588,7 +3588,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("whenCaseZIO")(
           test("returns the resulting stream if the given partial function is defined for the given effectful value") {
-            checkM(Gen.int) { o =>
+            check(Gen.int) { o =>
               for {
                 result  <- ZStream.whenCaseZIO(ZIO.succeed(Some(o))) { case Some(v) => ZStream(v) }.runCollect
                 expected = Chunk(o)
@@ -3626,7 +3626,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("whenZIO")(
           test("returns the stream if the effectful condition is satisfied") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               for {
                 result1  <- stream.whenZIO(ZIO.succeed(true)).runCollect
                 result2  <- ZStream.whenZIO(ZIO.succeed(true))(stream).runCollect
@@ -3635,7 +3635,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("returns an empty stream if the effectful condition is not satisfied") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               for {
                 result1 <- stream.whenZIO(ZIO.succeed(false)).runCollect
                 result2 <- ZStream.whenZIO(ZIO.succeed(false))(stream).runCollect
@@ -3644,7 +3644,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("fails if the effectful condition fails") {
-            checkM(pureStreamOfInts) { stream =>
+            check(pureStreamOfInts) { stream =>
               val exception = new Exception
               assertM(stream.whenZIO(ZIO.fail(exception)).runDrain.exit)(fails(equalTo(exception)))
             }
@@ -3707,7 +3707,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("rechunk") {
-          checkM(tinyChunkOf(Gen.chunkOf(Gen.int)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
+          check(tinyChunkOf(Gen.chunkOf(Gen.int)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
             val expected = Chunk.fromIterable(chunk.flatten.grouped(n).toList)
             assertM(
               ZStream
@@ -3719,7 +3719,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("concatAll") {
-          checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+          check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
             assertM(
               ZStream.concatAll(Chunk.fromIterable(chunks.map(ZStream.fromChunk(_)))).runCollect
             )(
@@ -3937,11 +3937,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("fromChunk") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.int)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
+          check(Gen.small(Gen.chunkOfN(_)(Gen.int)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
         },
         suite("fromChunks")(
           test("fromChunks") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { cs =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { cs =>
               assertM(ZStream.fromChunks(cs: _*).runCollect)(
                 equalTo(Chunk.fromIterable(cs).flatten)
               )
@@ -3975,26 +3975,26 @@ object ZStreamSpec extends ZIOBaseSpec {
             ZStream.fromInputStream(is, chunkSize).runCollect map { bytes => assert(bytes.toArray)(equalTo(data)) }
           },
           test("example 2") {
-            checkM(Gen.small(Gen.chunkOfN(_)(Gen.byte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
+            check(Gen.small(Gen.chunkOfN(_)(Gen.byte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
               val is = new ByteArrayInputStream(bytes.toArray)
               ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
             }
           }
         ),
-        test("fromIterable")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        test("fromIterable")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           def lazyL = l
           assertM(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))
         }),
-        test("fromIterableZIO")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        test("fromIterableZIO")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           assertM(ZStream.fromIterableZIO(UIO.succeed(l)).runCollect)(equalTo(l))
         }),
         test("fromIterator") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
+          check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
             assertM(ZStream.fromIterator(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))
           }
         },
         test("fromIteratorSucceed") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
+          check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
             assertM(ZStream.fromIteratorSucceed(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))
           }
         },
@@ -4231,7 +4231,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- ref.get
             } yield assert(result)(equalTo(List(1, 1)))
           ),
-          test("allow schedule rely on effect value")(checkNM(10)(Gen.int(1, 100)) { (length: Int) =>
+          test("allow schedule rely on effect value")(checkN(10)(Gen.int(1, 100)) { (length: Int) =>
             for {
               ref     <- Ref.make(0)
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())

--- a/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZTransducerSpec.scala
@@ -103,7 +103,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("IterableLike#grouped equivalence") {
-          checkM(
+          check(
             Gen
               .int(0, 10)
               .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.int)))),
@@ -373,7 +373,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("splitLines")(
         test("preserves data")(
-          checkM(weirdStringGenForSplitLines) { lines =>
+          check(weirdStringGenForSplitLines) { lines =>
             val data = lines.mkString("\n")
 
             ZTransducer.splitLines.push.use { push =>
@@ -386,7 +386,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         ),
         test("preserves data in chunks") {
-          checkM(weirdStringGenForSplitLines) { xs =>
+          check(weirdStringGenForSplitLines) { xs =>
             val data = Chunk.fromIterable(xs.sliding(2, 2).toList.map(_.mkString("\n")))
             testSplitLines(Seq(data))
           }
@@ -411,7 +411,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
         }
       ),
       suite("splitOn")(
-        test("preserves data")(checkM(Gen.chunkOf(Gen.string.filter(!_.contains("|")).filter(_.nonEmpty))) { lines =>
+        test("preserves data")(check(Gen.chunkOf(Gen.string.filter(!_.contains("|")).filter(_.nonEmpty))) { lines =>
           val data   = lines.mkString("|")
           val parser = ZTransducer.splitOn("|")
           assertM(run(parser, List(Chunk.single(data))))(equalTo(lines))
@@ -457,7 +457,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
             equalTo(Chunk(0, 0, 0, 1, 0))
           )
         },
-        test("preserves data")(checkM(Gen.chunkOf(Gen.byte.filter(_ != 0.toByte))) { bytes =>
+        test("preserves data")(check(Gen.chunkOf(Gen.byte.filter(_ != 0.toByte))) { bytes =>
           val splitSequence = Chunk[Byte](0, 1)
           val data          = bytes.flatMap(_ +: splitSequence)
           val parser        = ZTransducer.splitOnChunk(splitSequence)
@@ -510,7 +510,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
         }
       ),
       suite("utf8DecodeChunk")(
-        test("regular strings")(checkM(Gen.string) { s =>
+        test("regular strings")(check(Gen.string) { s =>
           ZTransducer.utf8Decode.push.use { push =>
             for {
               part1 <- push(Some(Chunk.fromArray(s.getBytes("UTF-8"))))
@@ -562,7 +562,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("handle byte order mark") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf8Decode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk[Byte](-17, -69, -65) ++ Chunk.fromArray(s.getBytes("UTF-8"))))
@@ -573,7 +573,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
         }
       ),
       suite("iso_8859_1")(
-        test("ISO-8859-1 strings")(checkM(Gen.iso_8859_1) { s =>
+        test("ISO-8859-1 strings")(check(Gen.iso_8859_1) { s =>
           ZTransducer.iso_8859_1Decode.push.use { push =>
             for {
               part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.ISO_8859_1))))
@@ -584,7 +584,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("branchAfter")(
         test("switches transducers") {
-          checkM(Gen.chunkOf(Gen.int)) { data =>
+          check(Gen.chunkOf(Gen.int)) { data =>
             val test =
               ZStream
                 .fromChunk(0 +: data)
@@ -601,7 +601,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("finalizes transducers") {
-          checkM(Gen.chunkOf(Gen.int)) { data =>
+          check(Gen.chunkOf(Gen.int)) { data =>
             val test =
               Ref.make(0).flatMap { ref =>
                 ZStream
@@ -629,7 +629,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("finalizes transducers - inner transducer fails") {
-          checkM(Gen.chunkOf(Gen.int)) { data =>
+          check(Gen.chunkOf(Gen.int)) { data =>
             val test =
               Ref.make(0).flatMap { ref =>
                 ZStream
@@ -663,7 +663,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
               n    <- Gen.int.filter(_ > data.length)
             } yield (data, n)
 
-          checkM(gen) { case (data, n) =>
+          check(gen) { case (data, n) =>
             val test =
               ZStream
                 .fromChunk(data)
@@ -677,7 +677,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("utf16BEDecode")(
         test("regular strings") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf16BEDecode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16BE))))
@@ -689,7 +689,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("utf16FEDecode")(
         test("regular strings") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf16LEDecode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16LE))))
@@ -701,7 +701,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("utf16Decode")(
         test("regular strings") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf16Decode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16))))
@@ -711,7 +711,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("no magic sequence - parse as big endian") {
-          checkM(Gen.string.filter(_.nonEmpty)) { s =>
+          check(Gen.string.filter(_.nonEmpty)) { s =>
             ZTransducer.utf16Decode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16BE))))
@@ -721,7 +721,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("big endian") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf16Decode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk[Byte](-2, -1) ++ Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16BE))))
@@ -731,7 +731,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
           }
         },
         test("little endian") {
-          checkM(Gen.string) { s =>
+          check(Gen.string) { s =>
             ZTransducer.utf16Decode.push.use { push =>
               for {
                 part1 <- push(Some(Chunk[Byte](-1, -2) ++ Chunk.fromArray(s.getBytes(StandardCharsets.UTF_16LE))))
@@ -743,7 +743,7 @@ object ZTransducerSpec extends ZIOBaseSpec {
       ),
       suite("usASCII")(
         test("US-ASCII strings") {
-          checkM(Gen.chunkOf(Gen.asciiString)) { chunk =>
+          check(Gen.chunkOf(Gen.asciiString)) { chunk =>
             val s = chunk.mkString("")
             ZTransducer.usASCIIDecode.push.use { push =>
               for {

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZChannelSimulatedChecks.scala
@@ -9,7 +9,7 @@ object ZChannelSimulatedChecks extends ZIOBaseSpec {
   override def spec: ZSpec[Environment, Failure] =
     suite("ZChannel simulated checks")(
       test("done channel")(
-        checkM(gen) { sim =>
+        check(gen) { sim =>
           for {
             channelResult <- sim.asDoneChannel.run.exit
             effectResult  <- sim.asEffect.exit
@@ -17,7 +17,7 @@ object ZChannelSimulatedChecks extends ZIOBaseSpec {
         }
       ),
       test("out channel")(
-        checkM(gen) { sim =>
+        check(gen) { sim =>
           for {
             channelResult <- sim.asOutChannel.runCollect.map(_._1).exit
             effectResult  <- sim.asEffect.exit.map(_.map(Chunk.single))

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -23,15 +23,15 @@ object ZStreamSpec extends ZIOBaseSpec {
     suite("ZStreamSpec")(
       suite("Combinators")(
         suite("absolve")(
-          test("happy path")(checkM(tinyChunkOf(Gen.int)) { xs =>
+          test("happy path")(check(tinyChunkOf(Gen.int)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_)))
             assertM(stream.absolve.runCollect)(equalTo(xs))
           }),
-          test("failure")(checkM(tinyChunkOf(Gen.int)) { xs =>
+          test("failure")(check(tinyChunkOf(Gen.int)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
             assertM(stream.absolve.runCollect.exit)(fails(equalTo("Ouch")))
           }),
-          test("round-trip #1")(checkM(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
+          test("round-trip #1")(check(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs.map(Right(_)))
             val stream = xss ++ ZStream(Left(s)) ++ xss
             for {
@@ -39,7 +39,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               res2 <- stream.absolve.either.runCollect
             } yield assert(res1)(startsWith(res2))
           }),
-          test("round-trip #2")(checkM(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
+          test("round-trip #2")(check(tinyChunkOf(Gen.int), Gen.string) { (xs, s) =>
             val xss    = ZStream.fromIterable(xs)
             val stream = xss ++ ZStream.fail(s)
             for {
@@ -436,7 +436,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //       }
         //     ),
         suite("buffer")(
-          test("maintains elements and ordering")(checkM(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
+          test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
             assertM(
               ZStream
                 .fromChunks(chunk: _*)
@@ -468,7 +468,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("bufferChunks")(
-          test("maintains elements and ordering")(checkM(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
+          test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
             assertM(
               ZStream
                 .fromChunks(chunk: _*)
@@ -710,7 +710,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("bufferUnbounded")(
-          test("buffer the Stream")(checkM(Gen.chunkOf(Gen.int)) { chunk =>
+          test("buffer the Stream")(check(Gen.chunkOf(Gen.int)) { chunk =>
             assertM(
               ZStream
                 .fromIterable(chunk)
@@ -819,7 +819,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //       }.runCollect)(equalTo(Chunk(2)))
         //     },
         test("changes") {
-          checkM(pureStreamOfInts) { stream =>
+          check(pureStreamOfInts) { stream =>
             for {
               actual <- stream.changes.runCollect.map(_.toList)
               expected <- stream.runCollect.map { as =>
@@ -831,7 +831,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("changesWithZIO") {
-          checkM(pureStreamOfInts) { stream =>
+          check(pureStreamOfInts) { stream =>
             for {
               actual <- stream.changesWithZIO((l, r) => ZIO.succeed(l == r)).runCollect.map(_.toList)
               expected <- stream.runCollect.map { as =>
@@ -876,7 +876,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        //     test("collectSome")(checkM(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.int), _))) { s =>
+        //     test("collectSome")(check(Gen.bounded(0, 5)(pureStreamGen(Gen.option(Gen.int), _))) { s =>
         //       for {
         //         res1 <- (s.collectSome.runCollect)
         //         res2 <- (s.runCollect.map(_.collect { case Some(x) => x }))
@@ -934,7 +934,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         //     suite("concat")(
-        //       test("concat")(checkM(streamOfInts, streamOfInts) { (s1, s2) =>
+        //       test("concat")(check(streamOfInts, streamOfInts) { (s1, s2) =>
         //         for {
         //           chunkConcat  <- s1.runCollect.zipWith(s2.runCollect)(_ ++ _).run
         //           streamConcat <- (s1 ++ s2).runCollect.run
@@ -1033,7 +1033,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 //               } @@ zioTag(errors)
 //             ),
         suite("drop")(
-          test("drop")(checkM(streamOfInts, Gen.int) { (s, n) =>
+          test("drop")(check(streamOfInts, Gen.int) { (s, n) =>
             for {
               dropStreamResult <- s.drop(n).runCollect.exit
               dropListResult   <- s.runCollect.map(_.drop(n)).exit
@@ -1051,7 +1051,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         ),
         suite("dropRight")(
-          test("dropRight")(checkM(streamOfInts, Gen.int(0, 1000)) { (s, n) =>
+          test("dropRight")(check(streamOfInts, Gen.int(0, 1000)) { (s, n) =>
             for {
               dropStreamResult <- s.dropRight(n).runCollect.exit
               dropListResult   <- s.runCollect.map(_.dropRight(n)).exit
@@ -1069,7 +1069,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         ),
         test("dropUntil") {
-          checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.dropUntil(p).runCollect
               res2 <- s.runCollect.map(_.dropWhile(!p(_)).drop(1))
@@ -1078,7 +1078,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("dropWhile")(
           test("dropWhile")(
-            checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+            check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
               for {
                 res1 <- s.dropWhile(p).runCollect
                 res2 <- s.runCollect.map(_.dropWhile(p))
@@ -1120,14 +1120,14 @@ object ZStreamSpec extends ZIOBaseSpec {
         //         execution <- log.get
         //       } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
         //     },
-        test("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+        test("filter")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             res1 <- s.filter(p).runCollect
             res2 <- s.runCollect.map(_.filter(p))
           } yield assert(res1)(equalTo(res2))
         }),
         suite("filterZIO")(
-          test("filterZIO")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          test("filterZIO")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.filterZIO(s => IO.succeed(p(s))).runCollect
               res2 <- s.runCollect.map(_.filter(p))
@@ -1142,14 +1142,14 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        test("find")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+        test("find")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {
             res1 <- s.find(p).runHead
             res2 <- s.runCollect.map(_.find(p))
           } yield assert(res1)(equalTo(res2))
         }),
         suite("findZIO")(
-          test("findZIO")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          test("findZIO")(check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               res1 <- s.findZIO(s => IO.succeed(p(s))).runHead
               res2 <- s.runCollect.map(_.find(p))
@@ -1176,14 +1176,14 @@ object ZStreamSpec extends ZIOBaseSpec {
 
             assertM(stream.runCollect)(equalTo(Chunk(expected)))
           } @@ TestAspect.jvmOnly, // Too slow on Scala.js
-          test("left identity")(checkM(Gen.int, Gen.function(pureStreamOfInts)) { (x, f) =>
+          test("left identity")(check(Gen.int, Gen.function(pureStreamOfInts)) { (x, f) =>
             for {
               res1 <- ZStream(x).flatMap(f).runCollect
               res2 <- f(x).runCollect
             } yield assert(res1)(equalTo(res2))
           }),
           test("right identity")(
-            checkM(pureStreamOfInts)(m =>
+            check(pureStreamOfInts)(m =>
               for {
                 res1 <- m.flatMap(i => ZStream(i)).runCollect
                 res2 <- m.runCollect
@@ -1193,7 +1193,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           test("associativity") {
             val tinyStream = Gen.int(0, 2).flatMap(pureStreamGen(Gen.int, _))
             val fnGen      = Gen.function(tinyStream)
-            checkM(tinyStream, fnGen, fnGen) { (m, f, g) =>
+            check(tinyStream, fnGen, fnGen) { (m, f, g) =>
               for {
                 leftStream  <- m.flatMap(f).flatMap(g).runCollect
                 rightStream <- m.flatMap(x => f(x).flatMap(g)).runCollect
@@ -1294,14 +1294,14 @@ object ZStreamSpec extends ZIOBaseSpec {
           //       }
         ),
         suite("flatMapPar")(
-          test("guarantee ordering")(checkM(tinyListOf(Gen.int)) { (m: List[Int]) =>
+          test("guarantee ordering")(check(tinyListOf(Gen.int)) { (m: List[Int]) =>
             for {
               flatMap    <- ZStream.fromIterable(m).flatMap(i => ZStream(i, i)).runCollect
               flatMapPar <- ZStream.fromIterable(m).flatMapPar(1)(i => ZStream(i, i)).runCollect
             } yield assert(flatMap)(equalTo(flatMapPar))
           }),
           test("consistent with flatMap")(
-            checkM(Gen.int(1, 10000), tinyListOf(Gen.int)) { (n, m) =>
+            check(Gen.int(1, 10000), tinyListOf(Gen.int)) { (n, m) =>
               for {
                 flatMap <- ZStream
                              .fromIterable(m)
@@ -1580,11 +1580,11 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(fails(equalTo(e)))
           } @@ zioTag(errors)
         ),
-        //     test("flattenIterables")(checkM(tinyListOf(tinyListOf(Gen.int))) { lists =>
+        //     test("flattenIterables")(check(tinyListOf(tinyListOf(Gen.int))) { lists =>
         //       assertM(ZStream.fromIterable(lists).flattenIterables.runCollect)(equalTo(Chunk.fromIterable(lists.flatten)))
         //     }),
         //     suite("flattenTake")(
-        //       test("happy path")(checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+        //       test("happy path")(check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
         //         assertM(
         //           ZStream
         //             .fromChunks(chunks: _*)
@@ -1900,7 +1900,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 
           val int = Gen.int(0, 5)
 
-          checkM(
+          check(
             int.flatMap(pureStreamGen(Gen.boolean, _)),
             int.flatMap(pureStreamGen(Gen.int, _)),
             int.flatMap(pureStreamGen(Gen.int, _))
@@ -1944,7 +1944,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               .map(result => assert(result)(equalTo(Chunk("[", "1", "]"))))
           },
           test("mkString(Sep) equivalence") {
-            checkM(
+            check(
               Gen
                 .int(0, 10)
                 .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.int))))
@@ -1958,7 +1958,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("mkString(Before, Sep, After) equivalence") {
-            checkM(
+            check(
               Gen
                 .int(0, 10)
                 .flatMap(Gen.listOfN(_)(Gen.small(Gen.chunkOfN(_)(Gen.int))))
@@ -2131,7 +2131,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(uninterruptible)(isSome(equalTo(InterruptStatus.Uninterruptible)))
           }
         ),
-        test("map")(checkM(pureStreamOfInts, Gen.function(Gen.int)) { (s, f) =>
+        test("map")(check(pureStreamOfInts, Gen.function(Gen.int)) { (s, f) =>
           for {
             res1 <- s.map(f).runCollect
             res2 <- s.runCollect.map(_.map(f))
@@ -2169,13 +2169,13 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
-        //     test("mapConcat")(checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
+        //     test("mapConcat")(check(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
         //       for {
         //         res1 <- s.mapConcat(f).runCollect
         //         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
         //       } yield assert(res1)(equalTo(res2))
         //     }),
-        //     test("mapConcatChunk")(checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
+        //     test("mapConcatChunk")(check(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
         //       for {
         //         res1 <- s.mapConcatChunk(f).runCollect
         //         res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2183,7 +2183,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //     }),
         //     suite("mapConcatChunkM")(
         //       test("mapConcatChunkM happy path") {
-        //         checkM(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
+        //         check(pureStreamOfInts, Gen.function(Gen.chunkOf(Gen.int))) { (s, f) =>
         //           for {
         //             res1 <- s.mapConcatChunkM(b => UIO.succeedNow(f(b))).runCollect
         //             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2200,7 +2200,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //     ),
         //     suite("mapConcatM")(
         //       test("mapConcatM happy path") {
-        //         checkM(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
+        //         check(pureStreamOfInts, Gen.function(Gen.listOf(Gen.int))) { (s, f) =>
         //           for {
         //             res1 <- s.mapConcatM(b => UIO.succeedNow(f(b))).runCollect
         //             res2 <- s.runCollect.map(_.flatMap(v => f(v).toSeq))
@@ -2233,7 +2233,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         },
         suite("mapZIO")(
           test("ZIO#foreach equivalence") {
-            checkM(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
+            check(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
               val s = ZStream.fromIterable(data)
 
               for {
@@ -2253,7 +2253,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("mapZIOPar")(
           test("foreachParN equivalence") {
-            checkNM(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
+            checkN(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
               val s = ZStream.fromIterable(data)
 
               for {
@@ -2282,7 +2282,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- interrupted.get
             } yield assert(result)(isTrue)
           },
-          test("guarantee ordering")(checkM(Gen.int(1, 4096), Gen.listOf(Gen.int)) { (n: Int, m: List[Int]) =>
+          test("guarantee ordering")(check(Gen.int(1, 4096), Gen.listOf(Gen.int)) { (n: Int, m: List[Int]) =>
             for {
               mapZIO    <- ZStream.fromIterable(m).mapZIO(UIO.succeedNow).runCollect
               mapZIOPar <- ZStream.fromIterable(m).mapZIOPar(n)(UIO.succeedNow).runCollect
@@ -2379,7 +2379,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //       }
         //     ),
         suite("mergeWith")(
-          test("equivalence with set union")(checkM(streamOfInts, streamOfInts) {
+          test("equivalence with set union")(check(streamOfInts, streamOfInts) {
             (s1: ZStream[Any, String, Int], s2: ZStream[Any, String, Int]) =>
               for {
                 mergedStream <- (s1 merge s2).runCollect.map(_.toSet).exit
@@ -2635,7 +2635,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //       )
         //     ),
         suite("scan")(
-          test("scan")(checkM(pureStreamOfInts) { s =>
+          test("scan")(check(pureStreamOfInts) { s =>
             for {
               streamResult <- s.scan(0)(_ + _).runCollect
               chunkResult  <- s.runCollect.map(_.scan(0)(_ + _))
@@ -2643,7 +2643,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           })
         ),
         suite("scanReduce")(
-          test("scanReduce")(checkM(pureStreamOfInts) { s =>
+          test("scanReduce")(check(pureStreamOfInts) { s =>
             for {
               streamResult <- s.scanReduce(_ + _).runCollect
               chunkResult  <- s.runCollect.map(_.scan(0)(_ + _).tail)
@@ -2724,7 +2724,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           s1.someOrFail(-1).runCollect.either.map(assert(_)(isLeft(equalTo(-1))))
         },
         suite("take")(
-          test("take")(checkM(streamOfInts, Gen.int) { (s, n) =>
+          test("take")(check(streamOfInts, Gen.int) { (s, n) =>
             for {
               takeStreamResult <- s.take(n.toLong).runCollect.exit
               takeListResult   <- s.runCollect.map(_.take(n)).exit
@@ -2752,7 +2752,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )
         ),
         test("takeRight") {
-          checkM(pureStreamOfInts, Gen.int(1, 4)) { (s, n) =>
+          check(pureStreamOfInts, Gen.int(1, 4)) { (s, n) =>
             for {
               streamTake <- s.takeRight(n).runCollect
               chunkTake  <- s.runCollect.map(_.takeRight(n))
@@ -2760,7 +2760,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("takeUntil") {
-          checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          check(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeUntil <- s.takeUntil(p).runCollect.exit
               chunkTakeUntil <- s.runCollect
@@ -2772,7 +2772,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("takeUntilM") {
-          checkM(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
+          check(streamOfInts, Gen.function(Gen.successes(Gen.boolean))) { (s, p) =>
             for {
               streamTakeUntilM <- s.takeUntilZIO(p).runCollect.exit
               chunkTakeUntilM <- s.runCollect
@@ -2795,7 +2795,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
         },
         suite("takeWhile")(
-          test("takeWhile")(checkM(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+          test("takeWhile")(check(streamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
             for {
               streamTakeWhile <- s.takeWhile(p).runCollect.exit
               chunkTakeWhile  <- s.runCollect.map(_.takeWhile(p)).exit
@@ -3136,7 +3136,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("toInputStream")(
           test("read one-by-one") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
                 ZIO.succeedNow(
@@ -3148,7 +3148,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("read in batches") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.byte))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toInputStream.use[Any, Throwable, TestResult] { is =>
                 val batches: List[(Array[Byte], Int)] = Iterator.continually {
@@ -3253,7 +3253,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assert(out)(equalTo(Chunk.fromIterable(1 to n)))).use(ZIO.succeed(_))
         } @@ TestAspect.jvmOnly, // Until #3360 is solved
         //     suite("toQueue")(
-        //       test("toQueue")(checkM(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
+        //       test("toQueue")(check(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
         //         val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
         //         assertM(
         //           s.toQueue(1000)
@@ -3262,7 +3262,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //           equalTo(c.toSeq.toList.map(Take.single) :+ Take.end)
         //         )
         //       }),
-        //       test("toQueueUnbounded")(checkM(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
+        //       test("toQueueUnbounded")(check(Gen.chunkOfBounded(0, 3)(Gen.int)) { (c: Chunk[Int]) =>
         //         val s = ZStream.fromChunk(c).flatMap(ZStream.succeed(_))
         //         assertM(
         //           s.toQueueUnbounded.use(queue => queue.size.repeatWhile(_ != c.size + 1) *> queue.takeAll)
@@ -3273,7 +3273,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         //     ),
         suite("toReader")(
           test("read one-by-one") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
                 ZIO.succeedNow(
@@ -3285,7 +3285,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           },
           test("read in batches") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.char))) { chunks =>
               val content = chunks.flatMap(_.toList)
               ZStream.fromChunks(chunks: _*).toReader.use[Any, Throwable, TestResult] { reader =>
                 val batches: List[(Array[Char], Int)] = Iterator.continually {
@@ -3402,7 +3402,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             chunk   = Chunk.fromIterable(map).sorted
             chunks <- splitChunks(Chunk(chunk))
           } yield chunks
-          checkM(genSortedByKey, genSortedByKey, genExecutionStrategy) { (as, bs, exec) =>
+          check(genSortedByKey, genSortedByKey, genExecutionStrategy) { (as, bs, exec) =>
             val left   = ZStream.fromChunks(as: _*)
             val right  = ZStream.fromChunks(bs: _*)
             val actual = left.zipAllSortedByKeyWithExec(right)(exec)(identity, identity)(_ + _)
@@ -3423,7 +3423,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(l.zip(r).runCollect)(equalTo(Chunk((1, "a"), (2, "b"), (3, "c"))))
           },
           test("zip equivalence with Chunk#zipWith") {
-            checkM(
+            check(
               tinyListOf(Gen.chunkOf(Gen.int)),
               tinyListOf(Gen.chunkOf(Gen.int))
             ) { (l, r) =>
@@ -3444,7 +3444,7 @@ object ZStreamSpec extends ZIOBaseSpec {
         ),
         suite("zipAllWith")(
           test("zipAllWith") {
-            checkM(
+            check(
               // We're using ZStream.fromChunks in the test, and that discards empty
               // chunks; so we're only testing for non-empty chunks here.
               tinyListOf(Gen.chunkOf(Gen.int).filter(_.size > 0)),
@@ -3476,7 +3476,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(isLeft(equalTo("Ouch")))
           }
         ),
-        test("zipWithIndex")(checkM(pureStreamOfInts) { s =>
+        test("zipWithIndex")(check(pureStreamOfInts) { s =>
           for {
             res1 <- (s.zipWithIndex.runCollect)
             res2 <- (s.runCollect.map(_.zipWithIndex.map(t => (t._1, t._2.toLong))))
@@ -3543,7 +3543,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(ZStream.empty.zipWithNext.runCollect)(isEmpty)
           },
           test("should output same values as zipping with tail plus last element") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithNext.runCollect
@@ -3567,7 +3567,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             assertM(ZStream.empty.zipWithPrevious.runCollect)(isEmpty)
           },
           test("should output same values as first element plus zipping with init") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithPrevious.runCollect
@@ -3585,7 +3585,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             )
           },
           test("should output same values as zipping with both previous and next element") {
-            checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+            check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
               val stream = ZStream.fromChunks(chunks: _*)
               for {
                 result0 <- stream.zipWithPreviousAndNext.runCollect
@@ -3657,7 +3657,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("rechunk") {
-          checkM(tinyChunkOf(Gen.chunkOf(Gen.int)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
+          check(tinyChunkOf(Gen.chunkOf(Gen.int)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
             val expected = Chunk.fromIterable(chunk.flatten.grouped(n).toList)
             assertM(
               ZStream
@@ -3669,7 +3669,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         },
         test("concatAll") {
-          checkM(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
+          check(tinyListOf(Gen.chunkOf(Gen.int))) { chunks =>
             assertM(
               ZStream.concatAll(Chunk.fromIterable(chunks.map(ZStream.fromChunk(_)))).runCollect
             )(
@@ -3887,11 +3887,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         test("fromChunk") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.int)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
+          check(Gen.small(Gen.chunkOfN(_)(Gen.int)))(c => assertM(ZStream.fromChunk(c).runCollect)(equalTo(c)))
         },
         // suite("fromChunks")(
         //   test("fromChunks") {
-        //     checkM(tinyListOf(Gen.chunkOf(Gen.int))) { cs =>
+        //     check(tinyListOf(Gen.chunkOf(Gen.int))) { cs =>
         //       assertM(ZStream.fromChunks(cs: _*).runCollect)(
         //         equalTo(Chunk.fromIterable(cs).flatten)
         //       )
@@ -3930,29 +3930,29 @@ object ZStreamSpec extends ZIOBaseSpec {
         //     ZStream.fromInputStream(is, chunkSize).runCollect map { bytes => assert(bytes.toArray)(equalTo(data)) }
         //   },
         //   test("example 2") {
-        //     checkM(Gen.small(Gen.chunkOfN(_)(Gen.byte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
+        //     check(Gen.small(Gen.chunkOfN(_)(Gen.byte)), Gen.int(1, 10)) { (bytes, chunkSize) =>
         //       val is = new ByteArrayInputStream(bytes.toArray)
         //       ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
         //     }
         //   }
         // ),
-        // test("fromIterable")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        // test("fromIterable")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
         //   def lazyL = l
         //   assertM(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))
         // }),
-        // test("fromIterableZIO")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        // test("fromIterableZIO")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
         //   assertM(ZStream.fromIterableZIO(UIO.effectTotal(l)).runCollect)(equalTo(l))
         // }),
-        // test("fromIterator")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        // test("fromIterator")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
         //   def lazyIt = l.iterator
         //   assertM(ZStream.fromIterator(lazyIt).runCollect)(equalTo(l))
         // }),
-        test("fromIteratorSucceed")(checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
+        test("fromIteratorSucceed")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           def lazyIt = l.iterator
           assertM(ZStream.fromIteratorSucceed(lazyIt).runCollect)(equalTo(l))
         }),
         test("fromBlockingIterator") {
-          checkM(Gen.small(Gen.chunkOfN(_)(Gen.int))) { chunk =>
+          check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { chunk =>
             assertM(ZStream.blocking(ZStream.fromIterator(chunk.iterator)).runCollect)(equalTo(chunk))
           }
         },
@@ -4197,7 +4197,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- ref.get
             } yield assert(result)(equalTo(List(1, 1)))
           ),
-          test("allow schedule rely on effect value")(checkNM(10)(Gen.int(1, 100)) { (length: Int) =>
+          test("allow schedule rely on effect value")(checkN(10)(Gen.int(1, 100)) { (length: Int) =>
             for {
               ref     <- Ref.make(0)
               effect   = ref.getAndUpdate(_ + 1).filterOrFail(_ <= length + 1)(())

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -7,8 +7,8 @@ import zio.{Chunk, Random, Ref, ZIO}
 object CheckSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("CheckSpec")(
-    test("checkM is polymorphic in error type") {
-      checkM(Gen.int(1, 100)) { n =>
+    test("check is polymorphic in error type") {
+      check(Gen.int(1, 100)) { n =>
         for {
           _ <- ZIO.attempt(())
           r <- Random.nextIntBounded(n)
@@ -16,14 +16,14 @@ object CheckSpec extends ZIOBaseSpec {
       }
     },
     test("effectual properties can be tested") {
-      checkM(Gen.int(1, 100)) { n =>
+      check(Gen.int(1, 100)) { n =>
         for {
           r <- Random.nextIntBounded(n)
         } yield assert(r)(isLessThan(n))
       }
     },
-    test("error in checkM is test failure") {
-      checkM(Gen.int(1, 100)) { n =>
+    test("error in check is test failure") {
+      check(Gen.int(1, 100)) { n =>
         for {
           _ <- ZIO.fail("fail")
           r <- Random.nextIntBounded(n)
@@ -37,7 +37,7 @@ object CheckSpec extends ZIOBaseSpec {
       val gen = Gen.listOfN(10)(Gen.int(-10, 10))
       for {
         ref <- Ref.make(0)
-        _ <- checkM(gen <*> gen) { _ =>
+        _ <- check(gen <*> gen) { _ =>
                for {
                  _ <- ref.update(_ + 1)
                  p <- Random.nextIntBounded(10).map(_ != 0)
@@ -77,8 +77,8 @@ object CheckSpec extends ZIOBaseSpec {
         nonEmpty ==> sorted
       }
     },
-    test("checkM effect type is correctly inferred") {
-      checkM(Gen.unit) { _ =>
+    test("check effect type is correctly inferred") {
+      check(Gen.unit) { _ =>
         for {
           _ <- Random.nextInt
         } yield assertCompletes

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -633,7 +633,7 @@ object GenSpec extends ZIOBaseSpec {
     ),
     suite("zipWith")(
       test("left preservation") {
-        checkM(deterministic, deterministic) { (a, b) =>
+        check(deterministic, deterministic) { (a, b) =>
           for {
             left  <- sample(a.zip(b).map(_._1))
             right <- sample(a)
@@ -641,7 +641,7 @@ object GenSpec extends ZIOBaseSpec {
         }
       } @@ scala2Only,
       test("right preservation") {
-        checkM(deterministic, deterministic) { (a, b) =>
+        check(deterministic, deterministic) { (a, b) =>
           for {
             left  <- sample(a.zip(b).map(_._2))
             right <- sample(b)
@@ -649,7 +649,7 @@ object GenSpec extends ZIOBaseSpec {
         }
       } @@ scala2Only,
       test("shrinking") {
-        checkM(random, random) { (a, b) =>
+        check(random, random) { (a, b) =>
           for {
             left  <- shrink(a.zip(b))
             right <- shrink(a.cross(b))
@@ -659,7 +659,7 @@ object GenSpec extends ZIOBaseSpec {
       test("shrink search") {
         val gen      = shrinkable.zip(shrinkable)
         val smallInt = Gen.int(0, 9)
-        checkM(smallInt, smallInt) { (m, n) =>
+        check(smallInt, smallInt) { (m, n) =>
           for {
             result <- shrinkWith(gen) { case (x, y) => x < m && y < n }
           } yield assert(result.reverse.headOption)(isSome(equalTo((m, 0)) || equalTo((0, n))))

--- a/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/StreamSpec.scala
@@ -36,7 +36,7 @@ object StreamSpec extends ZIOBaseSpec {
           } yield assert(actual.take(4))(equalTo(expected))
         },
         test("is consistent with ZStream#flatMap") {
-          checkM(genStream, genIntStreamFunction) { (stream, f) =>
+          check(genStream, genIntStreamFunction) { (stream, f) =>
             val left  = flatMapStream(stream.filter(_.isDefined))(a => f(a).filter(_.isDefined))
             val right = stream.collectSome.flatMap(a => f(a).collectSome).map(Some(_))
             assertEqualStream(left, right)
@@ -44,21 +44,21 @@ object StreamSpec extends ZIOBaseSpec {
         },
         suite("laws")(
           test("left identity") {
-            checkM(genStream) { stream =>
+            check(genStream) { stream =>
               val left  = flatMapStream(stream)(a => ZStream(Some(a)))
               val right = stream
               assertEqualStream(left, right)
             }
           },
           test("right identity") {
-            checkM(Gen.int, genIntStreamFunction) { (a, f) =>
+            check(Gen.int, genIntStreamFunction) { (a, f) =>
               val left  = flatMapStream(ZStream(Some(a)))(f)
               val right = f(a)
               assertEqualStream(left, right)
             }
           },
           test("associativity") {
-            checkM(Gen.int, genIntStreamFunction, genIntStreamFunction) { (a, f, g) =>
+            check(Gen.int, genIntStreamFunction, genIntStreamFunction) { (a, f, g) =>
               val left  = flatMapStream(flatMapStream(ZStream(Some(a)))(f))(g)
               val right = flatMapStream(ZStream(Some(a)))(a => flatMapStream(f(a))(g))
               assertEqualStream(left, right)

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -249,7 +249,7 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("samples sets the number of sufficient samples to the specified value") {
       for {
         ref   <- Ref.make(0)
-        _     <- checkM(Gen.int.noShrink)(_ => assertM(ref.update(_ + 1))(anything))
+        _     <- check(Gen.int.noShrink)(_ => assertM(ref.update(_ + 1))(anything))
         value <- ref.get
       } yield assert(value)(equalTo(42))
     } @@ samples(42),
@@ -272,7 +272,7 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("shrinks sets the maximum number of shrinkings to the specified value") {
       for {
         ref   <- Ref.make(0)
-        _     <- checkM(Gen.int)(_ => assertM(ref.update(_ + 1))(nothing))
+        _     <- check(Gen.int)(_ => assertM(ref.update(_ + 1))(nothing))
         value <- ref.get
       } yield assert(value)(equalTo(1))
     } @@ shrinks(0),

--- a/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/environment/RandomSpec.scala
@@ -69,7 +69,7 @@ object RandomSpec extends ZIOBaseSpec {
       } yield assert(value)(equalTo(-1157408321)) && assert(value2)(equalTo(758500184))
     } @@ nonFlaky,
     test("getting the seed and setting the seed is an identity") {
-      checkM(Gen.long) { seed =>
+      check(Gen.long) { seed =>
         for {
           _        <- TestRandom.setSeed(seed)
           newSeed  <- TestRandom.getSeed
@@ -85,7 +85,7 @@ object RandomSpec extends ZIOBaseSpec {
   def checkClear[A, B <: Has[Random]](generate: SRandom => A)(feed: (ZRandom, List[A]) => UIO[Unit])(
     clear: ZRandom => UIO[Unit]
   )(extract: ZRandom => UIO[A]): URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long) { seed =>
+    check(Gen.long) { seed =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -101,7 +101,7 @@ object RandomSpec extends ZIOBaseSpec {
   def checkFeed[A, B >: Has[Random]](generate: SRandom => A)(
     feed: (ZRandom, List[A]) => UIO[Unit]
   )(extract: ZRandom => UIO[A]): URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long) { seed =>
+    check(Gen.long) { seed =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -126,7 +126,7 @@ object RandomSpec extends ZIOBaseSpec {
   def forAllEqual[A](
     f: ZRandom => UIO[A]
   )(g: SRandom => A): URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long) { seed =>
+    check(Gen.long) { seed =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -137,7 +137,7 @@ object RandomSpec extends ZIOBaseSpec {
     }
 
   def forAllEqualBytes: URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long) { seed =>
+    check(Gen.long) { seed =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -151,7 +151,7 @@ object RandomSpec extends ZIOBaseSpec {
     }
 
   def forAllEqualGaussian: URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long) { seed =>
+    check(Gen.long) { seed =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -164,7 +164,7 @@ object RandomSpec extends ZIOBaseSpec {
   def forAllEqualN[A](
     f: (ZRandom, Int) => UIO[A]
   )(g: (SRandom, Int) => A): URIO[Has[Random] with Has[TestConfig], TestResult] =
-    checkM(Gen.long, Gen.int(1, 100)) { (seed, size) =>
+    check(Gen.long, Gen.int(1, 100)) { (seed, size) =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -177,7 +177,7 @@ object RandomSpec extends ZIOBaseSpec {
   def forAllEqualShuffle(
     f: (ZRandom, List[Int]) => UIO[List[Int]]
   )(g: (SRandom, List[Int]) => List[Int]): ZIO[Has[Random] with Has[Sized] with Has[TestConfig], Nothing, TestResult] =
-    checkM(Gen.long, Gen.listOf(Gen.int)) { (seed, testList) =>
+    check(Gen.long, Gen.listOf(Gen.int)) { (seed, testList) =>
       for {
         sRandom    <- ZIO.succeed(new SRandom(seed))
         testRandom <- TestRandom.makeTest(DefaultData)
@@ -192,7 +192,7 @@ object RandomSpec extends ZIOBaseSpec {
   ): URIO[Has[Random] with Has[TestConfig], TestResult] = {
     val num = implicitly[Numeric[A]]
     import num._
-    checkM(gen.map(num.abs(_))) { upper =>
+    check(gen.map(num.abs(_))) { upper =>
       for {
         testRandom <- ZIO.environment[Has[Random]].map(_.get[Random])
         nextRandom <- next(testRandom, upper)
@@ -209,7 +209,7 @@ object RandomSpec extends ZIOBaseSpec {
       value1 <- gen
       value2 <- gen if (value1 != value2)
     } yield if (value2 > value1) (value1, value2) else (value2, value1)
-    checkM(genMinMax) { case (min, max) =>
+    check(genMinMax) { case (min, max) =>
       for {
         testRandom <- ZIO.environment[Has[Random]].map(_.get[Random])
         nextRandom <- between(testRandom, min, max)

--- a/test/shared/src/main/scala/zio/test/CheckConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/CheckConstructor.scala
@@ -1,0 +1,108 @@
+package zio.test
+
+import zio.{ZIO, ZManaged}
+import zio.stm.ZSTM
+
+trait CheckConstructor[Environment, In] {
+  type OutEnvironment <: Environment
+  type OutError
+  def apply(input: => In): ZIO[OutEnvironment, OutError, TestResult]
+}
+
+object CheckConstructor extends CheckConstructorLowPriority1 {
+
+  type WithOut[Environment, In, OutEnvironment0, OutError0] =
+    CheckConstructor[Environment, In] {
+      type OutEnvironment = OutEnvironment0
+      type OutError       = OutError0
+    }
+
+  implicit def TestResultConstructor[R, A <: TestResult]: CheckConstructor.WithOut[R, A, R, Nothing] =
+    new CheckConstructor[R, A] {
+      type OutEnvironment = R
+      type OutError       = Nothing
+      def apply(input: => A): ZIO[OutEnvironment, OutError, TestResult] =
+        ZIO.succeedNow(input)
+    }
+}
+
+trait CheckConstructorLowPriority1 extends CheckConstructorLowPriority2 {
+
+  implicit def TestResultZIOConstructor[R, R1, E, A <: TestResult]
+    : CheckConstructor.WithOut[R, ZIO[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZIO[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZIO[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input
+    }
+}
+
+trait CheckConstructorLowPriority2 extends CheckConstructorLowPriority3 {
+
+  implicit def TestResultZManagedConstructor[R, R1, E, A <: TestResult]
+    : CheckConstructor.WithOut[R, ZManaged[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZManaged[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZManaged[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input.useNow
+    }
+}
+
+trait CheckConstructorLowPriority3 extends CheckConstructorLowPriority4 {
+
+  implicit def TestResultZSTMConstructor[R, R1, E, A <: TestResult]
+    : CheckConstructor.WithOut[R, ZSTM[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZSTM[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZSTM[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input.commit
+    }
+}
+
+trait CheckConstructorLowPriority4 extends CheckConstructorLowPriority5 {
+
+  implicit def AssertConstructor[R, A <: Assert]: CheckConstructor.WithOut[R, A, R, Nothing] =
+    new CheckConstructor[R, A] {
+      type OutEnvironment = R
+      type OutError       = Nothing
+      def apply(input: => A): ZIO[OutEnvironment, OutError, TestResult] =
+        ZIO.succeedNow(input)
+    }
+}
+
+trait CheckConstructorLowPriority5 extends CheckConstructorLowPriority6 {
+
+  implicit def AssertZIOConstructor[R, R1, E, A <: Assert]: CheckConstructor.WithOut[R, ZIO[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZIO[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZIO[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input
+    }
+}
+
+trait CheckConstructorLowPriority6 extends CheckConstructorLowPriority7 {
+
+  implicit def AssertZManagedConstructor[R, R1, E, A <: Assert]
+    : CheckConstructor.WithOut[R, ZManaged[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZManaged[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZManaged[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input.useNow
+    }
+}
+
+trait CheckConstructorLowPriority7 {
+
+  implicit def AssertZSTMConstructor[R, R1, E, A <: Assert]: CheckConstructor.WithOut[R, ZSTM[R1, E, A], R with R1, E] =
+    new CheckConstructor[R, ZSTM[R1, E, A]] {
+      type OutEnvironment = R with R1
+      type OutError       = E
+      def apply(input: => ZSTM[R1, E, A]): ZIO[OutEnvironment, OutError, TestResult] =
+        input.commit
+    }
+}

--- a/test/shared/src/main/scala/zio/test/laws/ZLaws.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLaws.scala
@@ -16,7 +16,7 @@
 
 package zio.test.laws
 
-import zio.test.{Gen, TestConfig, TestResult, check, checkM}
+import zio.test.{Gen, TestConfig, TestResult, check}
 import zio.{Has, URIO, ZIO}
 
 /**
@@ -64,7 +64,7 @@ object ZLaws {
   abstract class Law1M[-Caps[_], -R](label: String) extends ZLaws[Caps, R] { self =>
     def apply[A: Caps](a1: A): URIO[R, TestResult]
     final def run[R1 <: R with Has[TestConfig], A: Caps](gen: Gen[R1, A]): ZIO[R1, Nothing, TestResult] =
-      checkM(gen)(apply(_).map(_.map(_.label(label))))
+      check(gen)(apply(_).map(_.map(_.label(label))))
   }
 
   /**
@@ -82,7 +82,7 @@ object ZLaws {
   abstract class Law2M[-Caps[_], -R](label: String) extends ZLaws[Caps, R] { self =>
     def apply[A: Caps](a1: A, a2: A): URIO[R, TestResult]
     final def run[R1 <: R with Has[TestConfig], A: Caps](gen: Gen[R1, A]): ZIO[R1, Nothing, TestResult] =
-      checkM(gen, gen)(apply(_, _).map(_.map(_.label(label))))
+      check(gen, gen)(apply(_, _).map(_.map(_.label(label))))
   }
 
   /**
@@ -100,6 +100,6 @@ object ZLaws {
   abstract class Law3M[-Caps[_], -R](label: String) extends ZLaws[Caps, R] { self =>
     def apply[A: Caps](a1: A, a2: A, a3: A): URIO[R, TestResult]
     final def run[R1 <: R with Has[TestConfig], A: Caps](gen: Gen[R1, A]): ZIO[R1, Nothing, TestResult] =
-      checkM(gen, gen, gen)(apply(_, _, _).map(_.map(_.label(label))))
+      check(gen, gen, gen)(apply(_, _, _).map(_.map(_.label(label))))
   }
 }

--- a/test/shared/src/main/scala/zio/test/laws/ZLawsF.scala
+++ b/test/shared/src/main/scala/zio/test/laws/ZLawsF.scala
@@ -16,7 +16,7 @@
 
 package zio.test.laws
 
-import zio.test.{Gen, TestConfig, TestResult, check, checkM}
+import zio.test.{Gen, TestConfig, TestResult, check}
 import zio.{Has, URIO, ZIO}
 
 /**
@@ -115,7 +115,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen))(apply(_).map(_.map(_.label(label))))
+        check(genF(gen))(apply(_).map(_.map(_.label(label))))
     }
 
     /**
@@ -139,7 +139,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
     }
 
     /**
@@ -163,7 +163,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
     }
   }
 
@@ -240,7 +240,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen))(apply(_).map(_.map(_.label(label))))
+        check(genF(gen))(apply(_).map(_.map(_.label(label))))
     }
 
     /**
@@ -264,7 +264,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
     }
 
     /**
@@ -288,7 +288,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
     }
   }
 
@@ -348,7 +348,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen))(apply(_).map(_.map(_.label(label))))
+        check(genF(gen))(apply(_).map(_.map(_.label(label))))
     }
 
     /**
@@ -369,7 +369,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen))(apply(_, _).map(_.map(_.label(label))))
     }
 
     /**
@@ -390,7 +390,7 @@ object ZLawsF {
         genF: GenF[R1, F],
         gen: Gen[R1, A]
       ): ZIO[R1, Nothing, TestResult] =
-        checkM(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
+        check(genF(gen), genF(gen), genF(gen))(apply(_, _, _).map(_.map(_.label(label))))
     }
   }
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -211,37 +211,45 @@ package object test extends CompileVariants {
    * Checks the test passes for "sufficient" numbers of samples from the
    * given random variable.
    */
-  def check[R <: Has[TestConfig], A](rv: Gen[R, A])(test: A => TestResult): URIO[R, TestResult] =
-    TestConfig.samples.flatMap(checkN(_)(rv)(test))
+  def check[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
    */
-  def check[R <: Has[TestConfig], A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (A, B) => TestResult
-  ): URIO[R, TestResult] =
+  def check[R <: Has[TestConfig], A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (A, B) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `check` that accepts three random variables.
    */
-  def check[R <: Has[TestConfig], A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (A, B, C) => TestResult
-  ): URIO[R, TestResult] =
+  def check[R <: Has[TestConfig], A, B, C, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (A, B, C) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3)(test.tupled)
 
   /**
    * A version of `check` that accepts four random variables.
    */
-  def check[R <: Has[TestConfig], A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (A, B, C, D) => TestResult
-  ): URIO[R, TestResult] =
+  def check[R <: Has[TestConfig], A, B, C, D, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (A, B, C, D) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
 
   /**
    * A version of `check` that accepts five random variables.
    */
-  def check[R <: Has[TestConfig], A, B, C, D, F](
+  def check[R <: Has[TestConfig], A, B, C, D, F, In](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
     rv3: Gen[R, C],
@@ -249,13 +257,15 @@ package object test extends CompileVariants {
     rv5: Gen[R, F]
   )(
     test: (A, B, C, D, F) => TestResult
-  ): URIO[R, TestResult] =
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
 
   /**
    * A version of `check` that accepts six random variables.
    */
-  def check[R <: Has[TestConfig], A, B, C, D, F, G](
+  def check[R <: Has[TestConfig], A, B, C, D, F, G, In](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
     rv3: Gen[R, C],
@@ -264,13 +274,16 @@ package object test extends CompileVariants {
     rv6: Gen[R, G]
   )(
     test: (A, B, C, D, F, G) => TestResult
-  ): URIO[R, TestResult] =
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6)(test.tupled)
 
   /**
    * Checks the effectual test passes for "sufficient" numbers of samples from
    * the given random variable.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A](rv: Gen[R, A])(
     test: A => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -279,6 +292,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkM` that accepts two random variables.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -287,6 +301,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkM` that accepts three random variables.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -295,6 +310,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkM` that accepts four random variables.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -308,6 +324,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkM` that accepts five random variables.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -322,6 +339,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkM` that accepts six random variables.
    */
+  @deprecated("use check", "2.0.0")
   def checkM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, G](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -339,51 +357,61 @@ package object test extends CompileVariants {
    * is useful for deterministic `Gen` that comprehensively explore all
    * possibilities in a given domain.
    */
-  def checkAll[R <: Has[TestConfig], A](rv: Gen[R, A])(test: A => TestResult): URIO[R, TestResult] =
-    checkAllM(rv)(test andThen ZIO.succeedNow)
+  def checkAll[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkStream(rv.sample)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
    */
-  def checkAll[R <: Has[TestConfig], A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-    test: (A, B) => TestResult
-  ): URIO[R, TestResult] =
+  def checkAll[R <: Has[TestConfig], A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
+    test: (A, B) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2)(test.tupled)
 
   /**
    * A version of `checkAll` that accepts three random variables.
    */
-  def checkAll[R <: Has[TestConfig], A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-    test: (A, B, C) => TestResult
-  ): URIO[R, TestResult] =
+  def checkAll[R <: Has[TestConfig], A, B, C, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+    test: (A, B, C) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3)(test.tupled)
 
   /**
    * A version of `checkAll` that accepts four random variables.
    */
-  def checkAll[R <: Has[TestConfig], A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-    test: (A, B, C, D) => TestResult
-  ): URIO[R, TestResult] =
+  def checkAll[R <: Has[TestConfig], A, B, C, D, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+    test: (A, B, C, D) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
 
   /**
    * A version of `checkAll` that accepts five random variables.
    */
-  def checkAll[R <: Has[TestConfig], A, B, C, D, F](
+  def checkAll[R <: Has[TestConfig], A, B, C, D, F, In](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
     rv3: Gen[R, C],
     rv4: Gen[R, D],
     rv5: Gen[R, F]
   )(
-    test: (A, B, C, D, F) => TestResult
-  ): URIO[R, TestResult] =
+    test: (A, B, C, D, F) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
 
   /**
    * A version of `checkAll` that accepts six random variables.
    */
-  def checkAll[R <: Has[TestConfig], A, B, C, D, F, G](
+  def checkAll[R <: Has[TestConfig], A, B, C, D, F, G, In](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
     rv3: Gen[R, C],
@@ -391,8 +419,10 @@ package object test extends CompileVariants {
     rv5: Gen[R, F],
     rv6: Gen[R, G]
   )(
-    test: (A, B, C, D, F, G) => TestResult
-  ): URIO[R, TestResult] =
+    test: (A, B, C, D, F, G) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6)(test.tupled)
 
   /**
@@ -400,6 +430,7 @@ package object test extends CompileVariants {
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A](
     rv: Gen[R, A]
   )(test: A => ZIO[R1, E, TestResult]): ZIO[R1, E, TestResult] =
@@ -408,6 +439,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllM` that accepts two random variables.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -416,6 +448,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllM` that accepts three random variables.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -424,6 +457,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllM` that accepts four random variables.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -437,6 +471,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllM` that accepts five random variables.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -451,6 +486,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllM` that accepts six random variables.
    */
+  @deprecated("use checkAll", "2.0.0")
   def checkAllM[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, G](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -468,6 +504,7 @@ package object test extends CompileVariants {
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A](rv: Gen[R, A], parallelism: Int)(
     test: A => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -476,6 +513,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllMPar` that accepts two random variables.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B], parallelism: Int)(
     test: (A, B) => ZIO[R1, E, TestResult]
   ): ZIO[R1, E, TestResult] =
@@ -484,6 +522,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllMPar` that accepts three random variables.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A, B, C](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -497,6 +536,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllMPar` that accepts four random variables.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -511,6 +551,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllMPar` that accepts five random variables.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -526,6 +567,7 @@ package object test extends CompileVariants {
   /**
    * A version of `checkAllMPar` that accepts six random variables.
    */
+  @deprecated("use checkPar", "2.0.0")
   def checkAllMPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, G](
     rv1: Gen[R, A],
     rv2: Gen[R, B],
@@ -540,6 +582,94 @@ package object test extends CompileVariants {
     checkAllMPar(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6, parallelism)(test.tupled)
 
   /**
+   * Checks in parallel the effectual test passes for all values from the given random
+   * variable. This is useful for deterministic `Gen` that comprehensively
+   * explore all possibilities in a given domain.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, In](rv: Gen[R, A], parallelism: Int)(
+    test: A => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+
+  /**
+   * A version of `checkAllMPar` that accepts two random variables.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B], parallelism: Int)(
+    test: (A, B) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkAllPar(rv1 <*> rv2, parallelism)(test.tupled)
+
+  /**
+   * A version of `checkAllMPar` that accepts three random variables.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, In](
+    rv1: Gen[R, A],
+    rv2: Gen[R, B],
+    rv3: Gen[R, C],
+    parallelism: Int
+  )(
+    test: (A, B, C) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkAllPar(rv1 <*> rv2 <*> rv3, parallelism)(test.tupled)
+
+  /**
+   * A version of `checkAllMPar` that accepts four random variables.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, In](
+    rv1: Gen[R, A],
+    rv2: Gen[R, B],
+    rv3: Gen[R, C],
+    rv4: Gen[R, D],
+    parallelism: Int
+  )(
+    test: (A, B, C, D) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4, parallelism)(test.tupled)
+
+  /**
+   * A version of `checkAllMPar` that accepts five random variables.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, In](
+    rv1: Gen[R, A],
+    rv2: Gen[R, B],
+    rv3: Gen[R, C],
+    rv4: Gen[R, D],
+    rv5: Gen[R, F],
+    parallelism: Int
+  )(
+    test: (A, B, C, D, F) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5, parallelism)(test.tupled)
+
+  /**
+   * A version of `checkAllMPar` that accepts six random variables.
+   */
+  def checkAllPar[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, G, In](
+    rv1: Gen[R, A],
+    rv2: Gen[R, B],
+    rv3: Gen[R, C],
+    rv4: Gen[R, D],
+    rv5: Gen[R, F],
+    rv6: Gen[R, G],
+    parallelism: Int
+  )(
+    test: (A, B, C, D, F, G) => In
+  )(implicit
+    checkConstructor: CheckConstructor[R, In]
+  ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+    checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6, parallelism)(test.tupled)
+
+  /**
    * Checks the test passes for the specified number of samples from the given
    * random variable.
    */
@@ -550,6 +680,7 @@ package object test extends CompileVariants {
    * Checks the effectual test passes for the specified number of samples from
    * the given random variable.
    */
+  @deprecated("use checkN", "2.0.0")
   def checkNM(n: Int): CheckVariants.CheckNM =
     new CheckVariants.CheckNM(n)
 
@@ -615,31 +746,41 @@ package object test extends CompileVariants {
   object CheckVariants {
 
     final class CheckN(private val n: Int) extends AnyVal {
-      def apply[R <: Has[TestConfig], A](rv: Gen[R, A])(test: A => TestResult): URIO[R, TestResult] =
-        checkNM(n)(rv)(test andThen ZIO.succeedNow)
-      def apply[R <: Has[TestConfig], A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
-        test: (A, B) => TestResult
-      ): URIO[R, TestResult] =
+      def apply[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
+        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+      def apply[R <: Has[TestConfig], A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
+        test: (A, B) => In
+      )(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
         checkN(n)(rv1 <*> rv2)(test.tupled)
-      def apply[R <: Has[TestConfig], A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
-        test: (A, B, C) => TestResult
-      ): URIO[R, TestResult] =
+      def apply[R <: Has[TestConfig], A, B, C, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
+        test: (A, B, C) => In
+      )(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
         checkN(n)(rv1 <*> rv2 <*> rv3)(test.tupled)
-      def apply[R <: Has[TestConfig], A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
-        test: (A, B, C, D) => TestResult
-      ): URIO[R, TestResult] =
+      def apply[R <: Has[TestConfig], A, B, C, D, In](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
+        test: (A, B, C, D) => In
+      )(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
         checkN(n)(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
-      def apply[R <: Has[TestConfig], A, B, C, D, F](
+      def apply[R <: Has[TestConfig], A, B, C, D, F, In](
         rv1: Gen[R, A],
         rv2: Gen[R, B],
         rv3: Gen[R, C],
         rv4: Gen[R, D],
         rv5: Gen[R, F]
       )(
-        test: (A, B, C, D, F) => TestResult
-      ): URIO[R, TestResult] =
+        test: (A, B, C, D, F) => In
+      )(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
         checkN(n)(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
-      def apply[R <: Has[TestConfig], A, B, C, D, F, G](
+      def apply[R <: Has[TestConfig], A, B, C, D, F, G, In](
         rv1: Gen[R, A],
         rv2: Gen[R, B],
         rv3: Gen[R, C],
@@ -647,23 +788,29 @@ package object test extends CompileVariants {
         rv5: Gen[R, F],
         rv6: Gen[R, G]
       )(
-        test: (A, B, C, D, F, G) => TestResult
-      ): URIO[R, TestResult] =
+        test: (A, B, C, D, F, G) => In
+      )(implicit
+        checkConstructor: CheckConstructor[R, In]
+      ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
         checkN(n)(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6)(test.tupled)
     }
 
     final class CheckNM(private val n: Int) extends AnyVal {
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A](rv: Gen[R, A])(
         test: A => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] = checkStream(rv.sample.forever.take(n.toLong))(test)
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =
         checkNM(n)(rv1 <*> rv2)(test.tupled)
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
         test: (A, B, C) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =
         checkNM(n)(rv1 <*> rv2 <*> rv3)(test.tupled)
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B, C, D](
         rv1: Gen[R, A],
         rv2: Gen[R, B],
@@ -673,6 +820,7 @@ package object test extends CompileVariants {
         test: (A, B, C, D) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =
         checkNM(n)(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F](
         rv1: Gen[R, A],
         rv2: Gen[R, B],
@@ -683,6 +831,7 @@ package object test extends CompileVariants {
         test: (A, B, C, D, F) => ZIO[R1, E, TestResult]
       ): ZIO[R1, E, TestResult] =
         checkNM(n)(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
+      @deprecated("use checkN", "2.0.0")
       def apply[R <: Has[TestConfig], R1 <: R, E, A, B, C, D, F, G](
         rv1: Gen[R, A],
         rv2: Gen[R, B],

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -215,7 +215,9 @@ package object test extends CompileVariants {
   def check[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In]
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n =>
+      checkStream(rv.sample.forever.collectSome.take(n.toLong))(a => checkConstructor(test(a)))
+    )
 
   /**
    * A version of `check` that accepts two random variables.
@@ -361,7 +363,7 @@ package object test extends CompileVariants {
   def checkAll[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In]
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStream(rv.sample)(a => checkConstructor(test(a)))
+    checkStream(rv.sample.collectSome)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
@@ -592,7 +594,7 @@ package object test extends CompileVariants {
   )(implicit
     checkConstructor: CheckConstructor[R, In]
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+    checkStreamPar(rv.sample.collectSome, parallelism)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAllMPar` that accepts two random variables.
@@ -758,7 +760,7 @@ package object test extends CompileVariants {
       def apply[R <: Has[TestConfig], A, In](rv: Gen[R, A])(test: A => In)(implicit
         checkConstructor: CheckConstructor[R, In]
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.sample.forever.collectSome.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: Has[TestConfig], A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
The `check` operator is now able to handle test results as well as effects returning effect results.