### PR TITLE
Preserve Partial Ordering Of Stream Elements In ZStream#zipWithLatest

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3392,29 +3392,25 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
                     (rightDone, leftFiber) => ZIO.done(rightDone).zipWith(leftFiber.join)((r, l) => (l, r, false))
                   )
                 }.flatMap { case (l, r, leftFirst) =>
-                  ZStream.fromEffect(Ref.make(l(l.size - 1)) <*> Ref.make(r(r.size - 1))).flatMap {
-                    case (latestLeft, latestRight) =>
-                      ZStream.fromChunk(
-                        if (leftFirst) r.map(f(l(l.size - 1), _))
-                        else l.map(f(_, r(r.size - 1)))
-                      ) ++
-                        ZStream
-                          .repeatEffectOption(
-                            left.tap(chunk => latestLeft.set(chunk(chunk.size - 1))) <*> latestRight.get
-                          )
-                          .mergeWith(
-                            ZStream.repeatEffectOption(
-                              right.tap(chunk => latestRight.set(chunk(chunk.size - 1))) <*> latestLeft.get
-                            )
-                          )(
-                            { case (leftChunk, rightLatest) =>
-                              leftChunk.map(f(_, rightLatest))
-                            },
-                            { case (rightChunk, leftLatest) =>
-                              rightChunk.map(f(leftLatest, _))
+                  ZStream.fromEffect(Ref.make(l(l.size - 1) -> r(r.size - 1))).flatMap { latest =>
+                    ZStream.fromChunk(
+                      if (leftFirst) r.map(f(l(l.size - 1), _))
+                      else l.map(f(_, r(r.size - 1)))
+                    ) ++
+                      ZStream
+                        .repeatEffectOption(left)
+                        .mergeEither(ZStream.repeatEffectOption(right))
+                        .mapM {
+                          case Left(leftChunk) =>
+                            latest.modify { case (_, rightLatest) =>
+                              (leftChunk.map(f(_, rightLatest)), (leftChunk(leftChunk.size - 1), rightLatest))
                             }
-                          )
-                          .flatMap(ZStream.fromChunk(_))
+                          case Right(rightChunk) =>
+                            latest.modify { case (leftLatest, _) =>
+                              (rightChunk.map(f(leftLatest, _)), (leftLatest, rightChunk(rightChunk.size - 1)))
+                            }
+                        }
+                        .flatMap(ZStream.fromChunk(_))
                   }
                 }).process
 


### PR DESCRIPTION
Resolves #5679.

As observed in that issue, `zipWithLatest` can currently emit stream elements in an order that is inconsistent with the order of the original stream elements. For example, if we have a left stream with `A` and `B` and a right stream with `1` and `2`, we can observe outputs such as `A1, B2, B1` and `A1, B2, B2`.

This occurs because of two issues. First, two different `Ref` values are used so updated are not performed atomically, resulting in situations such as where both upstreams update the "latest" values and then get them. Second, we currently perform the effect of reading and updating the `Ref` before merging so we have no guarantee that the order of effects matches the order of stream elements.

This PR fixes these issues so that we have the guarantee that a combination of values that appear at the same point or later in the input streams will appear in an order that is consistent with the order of the original stream elements.