### PR TITLE
HasMany Documentation

### DIFF
--- a/docs/datatypes/contextual/hasmany.md
+++ b/docs/datatypes/contextual/hasmany.md
@@ -1,0 +1,30 @@
+---
+id: hasmany
+title: "HasMany"
+---
+
+The `HasMany[K, A]` data type is used with the ZIO environment to express an effect's dependency on multiple services of type `A` which are keyed by type `A`.
+
+The `HasMany[K, A]` is a type alias for `Has[Map[K, A]]` data type:
+
+```scala
+type HasMany[K, A] = Has[Map[K, A]]
+```
+
+In ordinary `Has[A]` data type, when we want to express dependencies of type `Console`, `Logging` and `Random`, we use the `Has[Console] with Has[Logging] with Has[Random]` data type. This is convenient, where each type uniquely identifies one service.
+
+What about those cases where we need to express multiple services of type `Logging`? To deal with such cases we can use the `HasMany` data type. So in these cases the environment type would be something like `Has[Console] with HasMany[String, Logging] with Has[Random]`.
+
+To access the specified service correspond to a key, we can use the `ZIO.serviceAt[Service](key)` constructor. For example, to access a `Logging` service which is specified by the "ConsoleLogger" key, we can write:
+
+```scala mdoc:invisible
+import zio._
+trait Logging
+```
+
+```scala mdoc:silent:nest
+val logger: URIO[HasMany[String, Logging], Option[Logging]] =
+  ZIO.serviceAt[Logging]("ConsoleLogger")
+```
+
+A service can be updated at the specified key with the `ZIO#updateServiceAt` operator.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -38,6 +38,7 @@ module.exports = {
     "Contextual Types": [
         "datatypes/contextual/index",
         "datatypes/contextual/has",
+        "datatypes/contextual/hasmany",
         {
             type: "category",
             label: "ZIO Layers",


### PR DESCRIPTION
This PR documents the `HasMany` data type.

While I was trying to write an example of the `HasMany` use cases, I came across [a problem](https://discord.com/channels/629491597070827530/630498701860929559/894570165583351869) with that. To follow up on that, I will rephrase it here:

```
import zio._
work
object HasManyExample extends ZIOAppDefault {

  trait Logging {
    def log(line: Any): ZIO[Any, Throwable, Unit]
  }

  case class ConsoleLogging(console: Console) extends Logging {
    override def log(line: Any): ZIO[Any, Throwable, Unit] = console.printLine(s"console logger: $line")
  }

  object ConsoleLogging {
    def layer: URLayer[Has[Console], Has[Logging]] =
      (ConsoleLogging.apply _).toLayer[Logging]

    def indexedLayer: ZLayer[Has[Console], Nothing, HasMany[String, Logging]] =
      layer.map(x => Has(Map("console" -> x.get)))
  }

  case class RemoteLogging() extends Logging {
    override def log(line: Any): ZIO[Any, Throwable, Unit] = ZIO.succeedBlocking(println(s"remote logger: $line"))
  }

  object RemoteLogging {
    def layer: URLayer[Any, Has[Logging]] = (RemoteLogging.apply _).toLayer[Logging]

    def indexedLayer: ZLayer[Any, Nothing, HasMany[String, Logging]] =
      layer.map(x => Has(Map("remote" -> x.get)))
  }

  val myApp = for {
    c <- ZIO.serviceAt[Logging]("console")
    r <- ZIO.serviceAt[Logging]("remote")
    logger <- ZIO.fromOption(c).orElse(ZIO.fromOption(r))
    _ <- logger.log("Log something")
  } yield ()

  def run =
    myApp.provideCustomLayer(
      ConsoleLogging.indexedLayer ++ RemoteLogging.indexedLayer
    )

}
```

When running this program, the output is:

```
remote logger: Log something
```

This means that the first ‍‍‍‍‍`ZIO.serviceAt[Logging]("console")` returned `None`, while I expect it returns the console logger. Do you know what is the problem with composing layers?

Another thing is that I'm not sure my example reflects the exact goal of the `HasMany` data type. Please let me know is it a good example of its use cases or not? 