### PR TITLE
Preserve Scope of Forked Fibers in ZStream#interruptWhen

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/NamedThreadFactory.scala
+++ b/core/jvm/src/main/scala/zio/internal/NamedThreadFactory.scala
@@ -21,9 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 private[zio] final class NamedThreadFactory(name: String, daemon: Boolean) extends ThreadFactory {
 
-  private val parentGroup =
-    Option(System.getSecurityManager).fold(Thread.currentThread().getThreadGroup)(_.getThreadGroup)
-
+  private val parentGroup = Thread.currentThread().getThreadGroup
   private val threadGroup = new ThreadGroup(parentGroup, name)
   private val threadCount = new AtomicInteger(1)
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1909,7 +1909,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 s1      = ZStream.fromChunkQueue(queue1)
                 s2      = ZStream.fromChunkQueue(queue2)
                 s3      = s1.zipWithLatest(s2)((_, _)).interruptWhen(ZIO.never).take(3)
-                values <- s3.runDrain
+                _      <- s3.runDrain
               } yield assertCompletes
             } @@ nonFlaky
           ) @@ zioTag(interruption)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1874,7 +1874,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
       for {
         as    <- self.process
         runIO <- (io.asSomeError *> Pull.end).forkManaged
-      } yield runIO.join.disconnect.raceFirst(as)
+      } yield ZIO.transplant(graft => runIO.join.disconnect.raceFirst(graft(as)))
     }
 
   /**
@@ -1892,7 +1892,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
         pull = (done.get <*> p.isDone) flatMap {
                  case (true, _) => Pull.end
                  case (_, true) => asPull
-                 case _         => as.raceFirst(asPull)
+                 case _         => ZIO.transplant(graft => graft(as).raceFirst(asPull))
                }
       } yield pull
     }


### PR DESCRIPTION
When we use `raceFirst` in the implementation of `interruptWhen` the original stream may fork fibers in its implementation, either as part of user code or internal stream operators. We need to transplant these fibers to the current scope to make sure they don't get interrupted prematurely.