### PR TITLE
Backport ZIO#toManagedAuto

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4260,6 +4260,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
      * Converts this ZIO value to a ZManaged value. See [[ZManaged.fromAutoCloseable]].
      */
     def toManaged: ZManaged[R, E, A] = ZManaged.fromAutoCloseable(io)
+
+    /**
+     * Converts this ZIO value to a ZManaged value. See [[ZManaged.fromAutoCloseable]].
+     */
+    def toManagedAuto: ZManaged[R, E, A] =
+      ZManaged.fromAutoCloseable(io)
   }
 
   implicit final class ZioRefineToOrDieOps[R, E <: Throwable, A](private val self: ZIO[R, E, A]) extends AnyVal {


### PR DESCRIPTION
We previously renamed this extension method to avoid shadowing on the `series/2.x` branch in #4975. This back ports the new name to ZIO 1.0.