### PR TITLE
Generalize ZLayer#apply

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -356,6 +356,12 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   def apply[RIn, E, ROut](managed: ZManaged[RIn, E, ROut]): ZLayer[RIn, E, ROut] =
     Managed(managed)
 
+  /**
+   * Constructs a layer from an effectual resource.
+   */
+  def apply[RIn, E, ROut](zio: ZIO[RIn, E, ROut]): ZLayer[RIn, E, ROut] =
+    ZLayer(zio.toManaged)
+
   sealed trait Debug
 
   object Debug {


### PR DESCRIPTION
Adds a version of `ZLayer.apply` that accepts a `ZIO` effect, so you can use `ZLayer.apply` to convert both `ZIO` and `ZManaged` values into layers. This allows avoiding wrapping a for comprehension in parentheses and using `toLayer`, which can sometimes be a little akward.