### PR TITLE
Fix Signature of ZSTM#flip

### DIFF
--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -327,7 +327,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * allows you to use all methods on the error channel, possibly before
    * flipping back.
    */
-  def flip(implicit ev: CanFail[E]): ZSTM[R, A, E] =
+  def flip: ZSTM[R, A, E] =
     foldSTM(ZSTM.succeedNow, ZSTM.fail(_))
 
   /**


### PR DESCRIPTION
Resolves #5753.

Looks like this issue only impacted `ZSTM`. I looked at other uses of `CanFail` and didn't see any other issues.