### PR TITLE
Add Deprecated testM Operator

### DIFF
--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -52,7 +52,7 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
    */
   @deprecated("use suite", "2.0.0")
   def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Spec[R, E, T] =
-    zio.test.suiteM(label)(specs)
+    suite(label)(specs)
 
   /**
    * Builds a spec with a single test.
@@ -61,4 +61,11 @@ abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
     assertion: => In
   )(implicit testConstructor: TestConstructor[Nothing, In], sourceLocation: SourceLocation): testConstructor.Out =
     zio.test.test(label)(assertion)
+
+  /**
+   * Builds a spec with a single effectful test.
+   */
+  @deprecated("use test", "2.0.0")
+  def testM[R, E](label: String)(assertion: => ZIO[R, E, TestResult])(implicit loc: SourceLocation): ZSpec[R, E] =
+    test(label)(assertion)
 }

--- a/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/MutableRunnableSpec.scala
@@ -133,6 +133,15 @@ class MutableRunnableSpec[R <: Has[_]: Tag](
     builder
   }
 
+  /**
+   * Builds a spec with a single effectful test.
+   */
+  @deprecated("use test", "2.0.0")
+  final def testM(
+    label: String
+  )(assertion: => ZIO[R with TestEnvironment, Failure, TestResult])(implicit loc: SourceLocation): TestBuilder =
+    test(label)(assertion)
+
   final override def spec: ZSpec[Environment, Failure] = {
     specBuilt = true
     (stack.head @@ aspect).toSpec.provideCustomLayerShared(layer.mapError(TestFailure.fail))

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -733,7 +733,7 @@ package object test extends CompileVariants {
    */
   @deprecated("use suite", "2.0.0")
   def suiteM[R, E, T](label: String)(specs: ZIO[R, E, Iterable[Spec[R, E, T]]]): Spec[R, E, T] =
-    Spec.labeled(label, Spec.managed(specs.map(specs => Spec.multiple(Chunk.fromIterable(specs))).toManaged))
+    suite(label)(specs)
 
   /**
    * Builds a spec with a single test.
@@ -743,6 +743,13 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation
   ): testConstructor.Out =
     testConstructor(label)(assertion)
+
+  /**
+   * Builds a spec with a single effectful test.
+   */
+  @deprecated("use test", "2.0.0")
+  def testM[R, E](label: String)(assertion: => ZIO[R, E, TestResult])(implicit loc: SourceLocation): ZSpec[R, E] =
+    test(label)(assertion)
 
   /**
    * Passes version specific information to the specified function, which will


### PR DESCRIPTION
When we added smart constructors for tests we deleted `testM` but we can actually deprecate it so we can give users a more helpful warning when they migrate from ZIO 1.0 to ZIO 2.0