### PR TITLE
Remove Scalafix

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,7 @@ pull_request_rules:
   - name: merge Scala Steward's PRs
     conditions:
       - author=scala-steward
-      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)"
+      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: test-library-update)"
       - "status-success=license/cla"
       - "status-success=ci"
     actions:

--- a/build.sbt
+++ b/build.sbt
@@ -24,20 +24,11 @@ inThisBuild(
 )
 
 addCommandAlias("build", "; prepare; testJVM")
-addCommandAlias("prepare", "; fix; fmt")
-addCommandAlias(
-  "fix",
-  "all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll"
-)
-addCommandAlias(
-  "fixCheck",
-  "; compile:scalafix --check ; test:scalafix --check"
-)
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
 addCommandAlias(
   "check",
-  "; scalafmtSbtCheck; scalafmtCheckAll; Test/compile; compile:scalafix --check; test:scalafix --check"
+  "; scalafmtSbtCheck; scalafmtCheckAll; Test/compile"
 )
 addCommandAlias(
   "compileJVM",

--- a/docs/about/coding_guidelines.md
+++ b/docs/about/coding_guidelines.md
@@ -7,7 +7,7 @@ These are coding guidelines strictly for ZIO contributors for ZIO projects and
 not general conventions to be applied by the Scala community at large.
 
 Additionally, bear in mind that, although we try to enforce these rules to the 
-best of our ability, both via automated rules (scalafix) and strict reviewing 
+best of our ability, both via automated rules (scalafmt) and strict reviewing 
 processes, it is both possible to find existing code that does not comply to 
 these rules. If that is the case, we would be extremely grateful if you could 
 make a contribution, by providing a fix to said issue.

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -4,7 +4,6 @@ import sbt._
 import sbtbuildinfo.BuildInfoKeys._
 import sbtbuildinfo._
 import sbtcrossproject.CrossPlugin.autoImport._
-import scalafix.sbt.ScalafixPlugin.autoImport._
 
 object BuildHelper {
   private val versions: Map[String, String] = {
@@ -35,7 +34,7 @@ object BuildHelper {
     if (sys.env.contains("CI")) {
       Seq("-Xfatal-warnings")
     } else {
-      Nil // to enable Scalafix locally
+      Nil
     }
   }
 
@@ -239,14 +238,6 @@ object BuildHelper {
           compilerPlugin("com.github.ghik" % "silencer-plugin" % SilencerVersion cross CrossVersion.full)
         )
     },
-    semanticdbEnabled := scalaVersion.value != ScalaDotty, // enable SemanticDB
-    semanticdbOptions += "-P:semanticdb:synthetics:on",
-    semanticdbVersion                      := scalafixSemanticdb.revision, // use Scalafix compatible version
-    ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
-    ThisBuild / scalafixDependencies ++= List(
-      "com.github.liancheng" %% "organize-imports" % "0.5.0",
-      "com.github.vovapolu"  %% "scaluzzi"         % "0.1.16"
-    ),
     Test / parallelExecution := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings := true,
@@ -303,8 +294,6 @@ object BuildHelper {
         |
         |Useful sbt tasks:
         |${item("build")} - Prepares sources, compiles and runs tests.
-        |${item("prepare")} - Prepares sources by applying both scalafix and scalafmt
-        |${item("fix")} - Fixes sources files using scalafix
         |${item("fmt")} - Formats source files using scalafmt
         |${item("~compileJVM")} - Compiles all JVM modules (file-watch enabled)
         |${item("testJVM")} - Runs all JVM tests

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                     % "1.4.9")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.9.31")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.10.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"                    % "0.4.3")
 addSbtPlugin("com.geirsson"                      % "sbt-ci-release"                % "1.5.7")


### PR DESCRIPTION
I don't feel like the cost / benefit is there in terms of developer productivity for using this on a regular basis. 

This takes a ton of memory which makes it very slow to make sure that a PR is ready to go and frequently causes SBT to crash.

At the same time the only thing we're getting is sorting of imports which is pretty easy to do as a matter of discipline and has no user facing impact.