### PR TITLE
Adding helper methods to create histogram buckets

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOMetric.scala
+++ b/core/shared/src/main/scala/zio/ZIOMetric.scala
@@ -145,6 +145,23 @@ object ZIOMetric {
     }
 
   /**
+    * A helper method to create histogram bucket boundaries for a histogram with linear increasing values
+    */
+  def linearBuckets(start: Double, width: Double, count: Int): DoubleHistogramBuckets = {
+    val boundaries = Chunk.fromArray(0.until(count).map(i => start + i * width).toArray) ++ Chunk(Double.MaxValue)
+    DoubleHistogramBuckets(boundaries.map(boundary => (boundary, 0L)))
+  }
+
+  /**
+    * A helper method to create histogram bucket boundaries for a histogram with exponentially increasing values
+    */
+  def exponentialBuckets(start: Double, factor: Double, count: Int): DoubleHistogramBuckets = {
+    val boundaries =
+      Chunk.fromArray(0.until(count).map(i => start * Math.pow(factor, i.toDouble)).toArray) ++ Chunk(Double.MaxValue)
+    DoubleHistogramBuckets(boundaries.map(boundary => (boundary, 0L)))
+  }
+
+  /**
    * A metric aspect that adds a value to a summary each time the effect it is
    * applied to succeeds.
    */


### PR DESCRIPTION
This brings back the helper methods to create histogram buckets with linear or exponentially growing boundaries.