### PR TITLE
Ignore Build Metadata on ZIO Versions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,8 +7,6 @@ Include ZIO in your project by adding the following to your `build.sbt` file:
 
 ```scala mdoc:passthrough
 println(s"""```""")
-if (zio.BuildInfo.isSnapshot)
-  println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "dev.zio" %% "zio" % "${zio.BuildInfo.version.split('+').head}"""")
 println(s"""```""")
 ```
@@ -17,8 +15,6 @@ If you want to use ZIO streams, you should also include the following dependency
 
 ```scala mdoc:passthrough
 println(s"""```""")
-if (zio.BuildInfo.isSnapshot)
-  println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "dev.zio" %% "zio-streams" % "${zio.BuildInfo.version.split('+').head}"""")
 println(s"""```""")
 ```


### PR DESCRIPTION
This PR ignores build metadata to reflect the latest published ZIO artifacts.

To address the #5786 issue, we also need a process to merge `series/2.x` branch to the `documentation` branch after each release.