### PR TITLE
Attempt to fix ZSink utfDecode

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZStreamPlatformSpecificSpec.scala
@@ -235,7 +235,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                 assertM(
                   ZStream
                     .fromFile(path, 24)
-                    .transduce(ZSink.utf8Decode)
+                    .transduce(ZSink.utf8Decode())
                     .runCollect
                     .map(_.collect { case Some(str) => str }.mkString)
                 )(
@@ -287,7 +287,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         test("returns the content of the resource") {
           ZStream
             .fromResource("zio/stream/bom/quickbrown-UTF-8-with-BOM.txt")
-            .transduce(ZSink.utf8Decode)
+            .transduce(ZSink.utf8Decode())
             .runCollect
             .map(b => assert(b.collect { case Some(str) => str }.mkString)(startsWithString("Sent")))
         },
@@ -306,7 +306,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                         .fromSocketServer(8896)
                         .foreach { c =>
                           c.read
-                            .transduce(ZSink.utf8Decode)
+                            .transduce(ZSink.utf8Decode())
                             .runCollect
                             .map(_.collect { case Some(str) => str }.mkString)
                             .flatMap(s => refOut.update(_ + s))

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZStreamPlatformSpecificSpec.scala
@@ -235,7 +235,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                 assertM(
                   ZStream
                     .fromFile(path, 24)
-                    .transduce(ZSink.utf8Decode())
+                    .transduce(ZSink.utf8Decode)
                     .runCollect
                     .map(_.collect { case Some(str) => str }.mkString)
                 )(
@@ -287,7 +287,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
         test("returns the content of the resource") {
           ZStream
             .fromResource("zio/stream/bom/quickbrown-UTF-8-with-BOM.txt")
-            .transduce(ZSink.utf8Decode())
+            .transduce(ZSink.utf8Decode)
             .runCollect
             .map(b => assert(b.collect { case Some(str) => str }.mkString)(startsWithString("Sent")))
         },
@@ -306,7 +306,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
                         .fromSocketServer(8896)
                         .foreach { c =>
                           c.read
-                            .transduce(ZSink.utf8Decode())
+                            .transduce(ZSink.utf8Decode)
                             .runCollect
                             .map(_.collect { case Some(str) => str }.mkString)
                             .flatMap(s => refOut.update(_ + s))

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -1,8 +1,7 @@
 package zio.stream.experimental
 
-import ZSink.{BOM, CharsetUtf32, CharsetUtf32BE, CharsetUtf32LE}
-
 import zio._
+import zio.stream.internal.CharacterSet._
 import zio.test.Assertion._
 import zio.test.TestAspect.jvmOnly
 import zio.test._
@@ -14,7 +13,7 @@ object ZSinkSpec extends ZIOBaseSpec {
 
   import ZIOTag._
 
-  private def stringToByteChunkOf(charset: Charset, source: String) =
+  private def stringToByteChunkOf(charset: Charset, source: String): Chunk[Byte] =
     Chunk.fromArray(source.getBytes(charset))
 
   private def testDecoderWithRandomStringUsing[Err](

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -27,7 +27,7 @@ object ZSinkSpec extends ZIOBaseSpec {
     ) { (originalBytes, chunkSize) =>
       ZStream
         .fromChunk(withBom(originalBytes))
-        .rechunk(chunkSize)
+//        .rechunk(chunkSize)
         .transduce(decoderUnderTest.map(_.getOrElse("")))
         .mkString
         .map { decodedString =>

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -1456,13 +1456,10 @@ object ZSink {
   def utf16Decode[Err](implicit trace: ZTraceElement): ZSink[Any, Err, Byte, Err, Byte, Option[String]] =
     ZSink.take[Err, Byte](2).flatMap {
       case BOM.Utf16BE =>
-        println(s">>> Utf16BE")
         utf16BEDecode
       case BOM.Utf16LE =>
-        println(s">>> Utf16LE")
         utf16LEDecode
       case bytes =>
-        println(s">>> No BOM: <$bytes>")
         new ZSink(ZChannel.write(bytes) >>> utf16BEDecode.channel)
     }
 

--- a/streams/shared/src/main/scala/zio/stream/internal/CharacterSet.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/CharacterSet.scala
@@ -1,0 +1,20 @@
+package zio.stream.internal
+
+import zio.Chunk
+
+import java.nio.charset.Charset
+
+object CharacterSet {
+
+  val CharsetUtf32: Charset   = Charset.forName("UTF-32")
+  val CharsetUtf32BE: Charset = Charset.forName("UTF-32BE")
+  val CharsetUtf32LE: Charset = Charset.forName("UTF-32LE")
+
+  object BOM {
+    val Utf8: Chunk[Byte]    = Chunk(-17, -69, -65)
+    val Utf16BE: Chunk[Byte] = Chunk(-2, -1)
+    val Utf16LE: Chunk[Byte] = Chunk(-1, -2)
+    val Utf32BE: Chunk[Byte] = Chunk(0, 0, -2, -1)
+    val Utf32LE: Chunk[Byte] = Chunk(-1, -2, 0, 0)
+  }
+}


### PR DESCRIPTION
The objective of this PR is to fix the `utfDecode` method in `ZSink`.

Before this PR, there's no unit tests for `utfDecode` so I added those. During the process, I discovered that the implementation of `utfDecode` wasn't able to pass the new unit tests.