### PR TITLE
Run tests on 8 as the main Java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8']
         scala: ['2.11.12', '2.12.15', '2.13.6', '3.1.0']
         platform: ['JVM']
     steps:
@@ -79,8 +78,6 @@ jobs:
       uses: actions/checkout@v2.3.5
     - name: Setup Scala and Java
       uses: olafurpg/setup-scala@v13
-      with:
-        java-version: ${{ matrix.java }}
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
     - name: Mima Checks
@@ -122,15 +119,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8']
         platform: ['JS', 'Native']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.5
       - name: Setup Scala and Java
         uses: olafurpg/setup-scala@v13
-        with:
-          java-version: ${{ matrix.java }}
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Test on different Scala target platforms


### PR DESCRIPTION
Work around https://github.com/olafurpg/setup-scala/issues/45
We don't specify `java-version: ${{ matrix.java }}` for other steps (most importantly `publish`) and `olafurpg/setup-scala`/Jabba clearly defaults to 8.
