### PR TITLE
Include the JVM stack up to Runtime.unsafeRun* in the fiber trace

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RuntimeSpec.scala
@@ -33,7 +33,7 @@ object RuntimeSpec extends ZIOBaseSpec {
             )
           )
         }
-      } @@ TestAspect.jvmOnly,
+      },
       test("in unsafeRunToFuture") {
         for {
           res <- ZIO.fromFuture(_ => CallSite.failingUnsafeRunToFuture(runtime)).exit
@@ -74,7 +74,7 @@ object RuntimeSpec extends ZIOBaseSpec {
             )
           )
         }
-      } @@ TestAspect.jvmOnly,
+      },
       test("in unsafeRunToFuture") {
         for {
           res <- ZIO

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -42,7 +42,7 @@ object RuntimeSpec extends ZIOBaseSpec {
       },
       test("in unsafeRunToFuture") {
         for {
-          res <- ZIO.fromFuture(_ => CallSite.failingUnsafeRunToFuture(runtime)).run
+          res <- ZIO.fromFuture(_ => CallSite.failingUnsafeRunToFuture(runtime)).exit
         } yield {
           assert(res)(
             fails(
@@ -112,14 +112,14 @@ object RuntimeSpec extends ZIOBaseSpec {
   private def stackTraceSanitized(e: Throwable) = {
     val writer = new StringWriter()
     e.printStackTrace(new PrintWriter(writer))
-    writer.toString.linesIterator
+    writer.toString.split("\n")
       .map(_.replaceAll("\\(.*\\)$", "(XXX)").trim)
       .mkString("\n")
   }
 
   private def containsLinesInOrder(lines: String*): Assertion[String] =
     Assertion.assertion("containsLinesInOrder")(RenderParam.Value(lines)) { text =>
-      val filtered = text.linesIterator.toSeq.filter(l => lines.contains(l.trim))
+      val filtered = text.split("\n").toSeq.filter(l => lines.contains(l.trim))
       filtered.containsSlice(lines)
     }
 

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -23,8 +23,6 @@ object RuntimeSpec extends ZIOBaseSpec {
                 containsLinesInOrder(
                   // the exception
                   "java.lang.RuntimeException: kaboom!",
-                  // fiber trace of the effect
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   // parent stack trace - the stack up to unsafe run
                   "Fiber:FiberId(0,0) execution trace:",
                   "at zio.Runtime$$anon$3.unsafeRunTask(XXX)",
@@ -47,8 +45,6 @@ object RuntimeSpec extends ZIOBaseSpec {
                 stackTraceSanitized,
                 containsLinesInOrder(
                   "java.lang.RuntimeException: kaboom!",
-                  // fiber trace of the effect
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   // parent stack trace - the stack up to unsafe run
                   "Fiber:FiberId(0,0) execution trace:",
                   "at zio.Runtime$$anon$3.unsafeRunToFuture(XXX)",

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -23,11 +23,7 @@ object RuntimeSpec extends ZIOBaseSpec {
                 containsLinesInOrder(
                   // the exception
                   "java.lang.RuntimeException: kaboom!",
-                  "at zio.RuntimeSpec$EffectSite$.$anonfun$failing$3(XXX)",
-                  "java.lang.RuntimeException: kaboom!",
                   // fiber trace of the effect
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   // parent stack trace - the stack up to unsafe run
                   "Fiber:FiberId(0,0) execution trace:",
@@ -39,7 +35,7 @@ object RuntimeSpec extends ZIOBaseSpec {
             )
           )
         }
-      },
+      } @@ TestAspect.jvmOnly,
       test("in unsafeRunToFuture") {
         for {
           res <- ZIO.fromFuture(_ => CallSite.failingUnsafeRunToFuture(runtime)).exit
@@ -51,11 +47,7 @@ object RuntimeSpec extends ZIOBaseSpec {
                 stackTraceSanitized,
                 containsLinesInOrder(
                   "java.lang.RuntimeException: kaboom!",
-                  "at zio.RuntimeSpec$EffectSite$.$anonfun$failing$3(XXX)",
-                  "java.lang.RuntimeException: kaboom!",
                   // fiber trace of the effect
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
-                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   "at zio.RuntimeSpec.EffectSite.failing(XXX)",
                   // parent stack trace - the stack up to unsafe run
                   "Fiber:FiberId(0,0) execution trace:",
@@ -86,7 +78,7 @@ object RuntimeSpec extends ZIOBaseSpec {
             )
           )
         }
-      },
+      } @@ TestAspect.jvmOnly,
       test("in unsafeRunToFuture") {
         for {
           res <- ZIO
@@ -120,7 +112,7 @@ object RuntimeSpec extends ZIOBaseSpec {
 
   private def containsLinesInOrder(lines: String*): Assertion[String] =
     Assertion.assertion("containsLinesInOrder")(RenderParam.Value(lines)) { text =>
-      val filtered = text.split("\n").toSeq.filter(l => lines.contains(l.trim))
+      val filtered = text.split("\n").toSeq.filter(l => lines.contains(l.trim)).distinct
       filtered.containsSlice(lines)
     }
 

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -1,0 +1,141 @@
+package zio
+
+import zio.ZIO.attemptBlocking
+import zio.test.Assertion._
+import zio.test.AssertionM.RenderParam
+import zio.test._
+
+import java.io.{PrintWriter, StringWriter}
+
+object RuntimeSpec extends ZIOBaseSpec {
+  private val runtime = Runtime.default
+  override def spec: ZSpec[Environment, Failure] = suite("RuntimeSpec")(
+    suite("By default include stack trace up to unsafeRun* in Fiber Trace")(
+      test("in unsafeRunTask") {
+        for {
+          res <- attemptBlocking(CallSite.failingUnsafeRunTask(runtime)).exit
+        } yield {
+          assert(res)(
+            fails(
+              hasField(
+                "stackTrace",
+                stackTraceSanitized,
+                containsLinesInOrder(
+                  // the exception
+                  "java.lang.RuntimeException: kaboom!",
+                  "at zio.RuntimeSpec$EffectSite$.$anonfun$failing$3(XXX)",
+                  "java.lang.RuntimeException: kaboom!",
+                  // fiber trace of the effect
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  // parent stack trace - the stack up to unsafe run
+                  "Fiber:FiberId(0,0) execution trace:",
+                  "at zio.Runtime$$anon$3.unsafeRunTask(XXX)",
+                  "at zio.RuntimeSpec$CallSite$.run(XXX)",
+                  "at zio.RuntimeSpec$CallSite$.failingUnsafeRunTask(XXX)"
+                )
+              )
+            )
+          )
+        }
+      },
+      test("in unsafeRunToFuture") {
+        for {
+          res <- ZIO.fromFuture(_ => CallSite.failingUnsafeRunToFuture(runtime)).run
+        } yield {
+          assert(res)(
+            fails(
+              hasField(
+                "stackTrace",
+                stackTraceSanitized,
+                containsLinesInOrder(
+                  "java.lang.RuntimeException: kaboom!",
+                  "at zio.RuntimeSpec$EffectSite$.$anonfun$failing$3(XXX)",
+                  "java.lang.RuntimeException: kaboom!",
+                  // fiber trace of the effect
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  "at zio.RuntimeSpec.EffectSite.failing(XXX)",
+                  // parent stack trace - the stack up to unsafe run
+                  "Fiber:FiberId(0,0) execution trace:",
+                  "at zio.Runtime$$anon$3.unsafeRunToFuture(XXX)",
+                  "at zio.RuntimeSpec$CallSite$.run(XXX)",
+                  "at zio.RuntimeSpec$CallSite$.failingUnsafeRunToFuture(XXX)"
+                )
+              )
+            )
+          )
+        }
+      }
+    ),
+    suite("when captureUnsafeRunStack = false, don't capture stack")(
+      test("in unsafeRunTask") {
+        for {
+          res <- attemptBlocking(
+                   CallSite.failingUnsafeRunTask(runtime.withTracingConfig(_.withCaptureUnsafeRunStack(false)))
+                 ).exit
+        } yield {
+          assert(res)(
+            fails(
+              hasField(
+                "stackTrace",
+                stackTraceSanitized,
+                not(containsString("at zio.RuntimeSpec$CallSite$.run(XXX)"))
+              )
+            )
+          )
+        }
+      },
+      test("in unsafeRunToFuture") {
+        for {
+          res <- ZIO
+                   .fromFuture(_ =>
+                     CallSite.failingUnsafeRunToFuture(runtime.withTracingConfig(_.withCaptureUnsafeRunStack(false)))
+                   )
+                   .exit
+        } yield {
+          assert(res)(
+            fails(
+              hasField(
+                "stackTrace",
+                stackTraceSanitized,
+                not(containsString("at zio.RuntimeSpec$CallSite$.run(XXX)"))
+              )
+            )
+          )
+        }
+      }
+    )
+  )
+
+  private def stackTraceSanitized(e: Throwable) = {
+    val writer = new StringWriter()
+    e.printStackTrace(new PrintWriter(writer))
+    writer.toString.linesIterator
+      .map(_.replaceAll("\\(.*\\)$", "(XXX)").trim)
+      .mkString("\n")
+  }
+
+  private def containsLinesInOrder(lines: String*): Assertion[String] =
+    Assertion.assertion("containsLinesInOrder")(RenderParam.Value(lines)) { text =>
+      val filtered = text.linesIterator.toSeq.filter(l => lines.contains(l.trim))
+      filtered.containsSlice(lines)
+    }
+
+  private object CallSite {
+
+    private def run[T](t: => T): T = t
+
+    def failingUnsafeRunTask(rt: Runtime[Has[Clock]]) =
+      run(rt.unsafeRunTask(EffectSite.failing))
+
+    def failingUnsafeRunToFuture(rt: Runtime[Has[Clock]]) =
+      run(rt.unsafeRunToFuture(EffectSite.failing))
+  }
+
+  private object EffectSite {
+    val failing = ZIO.sleep(10.millis) *>
+      ZIO.fail(new RuntimeException("kaboom!")).unit
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -112,7 +112,8 @@ object RuntimeSpec extends ZIOBaseSpec {
   private def stackTraceSanitized(e: Throwable) = {
     val writer = new StringWriter()
     e.printStackTrace(new PrintWriter(writer))
-    writer.toString.split("\n")
+    writer.toString
+      .split("\n")
       .map(_.replaceAll("\\(.*\\)$", "(XXX)").trim)
       .mkString("\n")
   }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -345,10 +345,9 @@ trait Runtime[+R] {
       Some(
         ZTrace(
           FiberId.None,
-          Thread.currentThread.getStackTrace
+          Thread.currentThread.getStackTrace.toList
             .drop(2)
-            .map(_.toString.asInstanceOf[ZTraceElement])
-            .toList,
+            .map(s => ZTraceElement.fromString(s.toString)),
           Nil,
           None
         )

--- a/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
+++ b/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
@@ -54,4 +54,9 @@ object RuntimeConfigAspect extends ((RuntimeConfig => RuntimeConfig) => RuntimeC
    */
   def track(weak: Boolean): RuntimeConfigAspect =
     addSupervisor(Supervisor.unsafeTrack(weak))
+
+  def captureUnsafeRunStack: RuntimeConfigAspect =
+    RuntimeConfigAspect(self =>
+      self.copy(tracing = self.tracing.copy(tracingConfig = self.tracing.tracingConfig.withCaptureUnsafeRunStack(true)))
+    )
 }

--- a/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
+++ b/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
@@ -57,13 +57,13 @@ final case class TracingConfig(
   ancestryLength: Int,
   ancestorExecutionTraceLength: Int,
   ancestorStackTraceLength: Int,
-  captureUnsafeRunStack: Boolean
+  captureUnsafeRunStack: Boolean = false
 ) {
   def withCaptureUnsafeRunStack(capture: Boolean) = copy(captureUnsafeRunStack = capture)
 }
 
 object TracingConfig {
-  def enabled: TracingConfig   = TracingConfig(true, true, true, 100, 100, 10, 10, 10, true)
-  def stackOnly: TracingConfig = TracingConfig(false, false, true, 100, 100, 10, 10, 10, true)
-  def disabled: TracingConfig  = TracingConfig(false, false, false, 0, 0, 0, 0, 10, false)
+  def enabled: TracingConfig   = TracingConfig(true, true, true, 100, 100, 10, 10, 10)
+  def stackOnly: TracingConfig = TracingConfig(false, false, true, 100, 100, 10, 10, 10)
+  def disabled: TracingConfig  = TracingConfig(false, false, false, 0, 0, 0, 0, 10)
 }

--- a/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
+++ b/core/shared/src/main/scala/zio/internal/tracing/TracingConfig.scala
@@ -45,6 +45,8 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * @param ancestorStackTraceLength How many lines of stack trace to include in the
  *                                 trace of last lines before .fork in the parent fiber
  *                                 that spawned the current fiber
+ * @param captureUnsafeRunStack if this is true, `Runtime.unsafeRun*` will capture the call stack up to this method and
+ *                              it will be included in the traces as the root parent trace (as Fiber(0,0))
  */
 final case class TracingConfig(
   traceExecution: Boolean,
@@ -54,11 +56,14 @@ final case class TracingConfig(
   stackTraceLength: Int,
   ancestryLength: Int,
   ancestorExecutionTraceLength: Int,
-  ancestorStackTraceLength: Int
-)
+  ancestorStackTraceLength: Int,
+  captureUnsafeRunStack: Boolean
+) {
+  def withCaptureUnsafeRunStack(capture: Boolean) = copy(captureUnsafeRunStack = capture)
+}
 
 object TracingConfig {
-  def enabled: TracingConfig   = TracingConfig(true, true, true, 100, 100, 10, 10, 10)
-  def stackOnly: TracingConfig = TracingConfig(false, false, true, 100, 100, 10, 10, 10)
-  def disabled: TracingConfig  = TracingConfig(false, false, false, 0, 0, 0, 0, 10)
+  def enabled: TracingConfig   = TracingConfig(true, true, true, 100, 100, 10, 10, 10, true)
+  def stackOnly: TracingConfig = TracingConfig(false, false, true, 100, 100, 10, 10, 10, true)
+  def disabled: TracingConfig  = TracingConfig(false, false, false, 0, 0, 0, 0, 10, false)
 }

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -93,5 +93,6 @@ package object zio
       def unapply(trace: ZTraceElement): Option[(String, String, Int, Int)] =
         Tracer.instance.unapply(trace)
     }
+    def fromString(s: String) = Tracer.instance.fromString(s)
   }
 }

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -227,7 +227,8 @@ val config = TracingConfig(
   stackTraceLength = 100,
   ancestryLength = 10,
   ancestorExecutionTraceLength = 10,
-  ancestorStackTraceLength = 10
+  ancestorStackTraceLength = 10,
+  captureUnsafeRunStack = true
 )
 val rt3 = Runtime.default.mapRuntimeConfig(runtimeConfig => runtimeConfig.copy(tracing = runtimeConfig.tracing.copy(tracingConfig = config)))
 ```

--- a/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Tracer.scala
+++ b/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Tracer.scala
@@ -12,12 +12,13 @@ object Tracer {
 
   val instance: Tracer = new Tracer {
     type Type = String
-    val empty: Type with Traced = "".asInstanceOf[Type with Traced]
+    val empty: Type with Traced = fromString("")
     def unapply(trace: Type): Option[(String, String, Int, Int)] =
       trace match {
         case regex(location, file, line, column) => Some((location, file, line.toInt, column.toInt))
         case _                                   => None
       }
+    def fromString(s: String) = s.asInstanceOf[Type with Traced]
   }
 
   private[internal] def createTrace(location: String, file: String, line: Int, column: Int): String =
@@ -30,4 +31,5 @@ sealed trait Tracer {
   type Type <: AnyRef
   val empty: Type with Tracer.Traced
   def unapply(trace: Type): Option[(String, String, Int, Int)]
+  def fromString(trace: String): Type with Tracer.Traced
 }

--- a/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Tracer.scala
+++ b/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Tracer.scala
@@ -28,6 +28,7 @@ object Tracer {
         case _                                   => None
       }
     }
+    def fromString(trace: String): Type = trace
   }
 
   private[internal] def createTrace(location: String, file: String, line: Int, column: Int): String =
@@ -40,4 +41,5 @@ sealed trait Tracer {
   type Type <: AnyRef
   val empty: Type
   def unapply(trace: Type): Option[(String, String, Int, Int)]
+  def fromString(trace: String): Type
 }


### PR DESCRIPTION
Issue #5785