### PR TITLE
More Migrations, mostly drawn from working on interop-cats upgrade

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1248,7 +1248,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Executes the effect on the specified `ExecutionContext` and then shifts back
    * to the default one.
    */
-  @deprecated("use lockExecutionContext", "2.0.0")
+  @deprecated("use onExecutionContext", "2.0.0")
   final def on(ec: => ExecutionContext)(implicit trace: ZTraceElement): ZIO[R, E, A] =
     self.onExecutionContext(ec)
 

--- a/scalafix/input/src/main/scala/fix/ZStreamSpec.scala
+++ b/scalafix/input/src/main/scala/fix/ZStreamSpec.scala
@@ -31,6 +31,10 @@ object ZStreamSpec extends DefaultRunnableSpec {
             val stream = ZStream.fromIterable(xs.map(Right(_)))
             assertM(stream.absolve.runCollect)(equalTo(xs))
           }),
+          testM("happy path all")(checkAllM(tinyChunkOf(Gen.anyInt)) { xs =>
+            val stream = ZStream.fromIterable(xs.map(Right(_)))
+            assertM(stream.absolve.runCollect)(equalTo(xs))
+          }),
           testM("failure")(checkM(tinyChunkOf(Gen.anyInt)) { xs =>
             val stream = ZStream.fromIterable(xs.map(Right(_))) ++ ZStream.succeed(Left("Ouch"))
             assertM(stream.absolve.runCollect.run)(fails(equalTo("Ouch")))

--- a/scalafix/input/src/main/scala/fix/Zio2Renames.scala
+++ b/scalafix/input/src/main/scala/fix/Zio2Renames.scala
@@ -7,6 +7,8 @@ import zio._
 import zio.blocking.effectBlockingIO
 import zio.blocking._
 import zio.console._
+import zio.duration.Duration
+import zio.internal.Platform
 import zio.test.Gen
 
 object Zio2Renames {
@@ -68,4 +70,22 @@ object Zio2Renames {
 
   // Blocking
   effectBlockingIO(1)
+
+  ZIO.succeed(1).on _
+
+  Cause.fail("Die").interrupted
+
+  Fiber.Id
+
+  zio.duration.Duration
+  
+  val x: Layer[Nothing, zio.random.Random] = zio.random.Random.live
+
+  zio.internal.Executor
+
+  Platform
+    .fromExecutor(???)
+  
+  zio.internal.Platform
+    .fromExecutor(???)
 }

--- a/scalafix/output/src/main/scala/fix/ZManagedSpec.scala
+++ b/scalafix/output/src/main/scala/fix/ZManagedSpec.scala
@@ -8,7 +8,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{nonFlaky, scala2Only}
 import zio.test._
 import zio.test.environment._
-import zio.{ Clock, Has, _ }
+import zio.{ Clock, FiberId, Has, _ }
 import zio.test.environment.Live
 
 object ZManagedSpec extends DefaultRunnableSpec {
@@ -1271,7 +1271,7 @@ object ZManagedSpec extends DefaultRunnableSpec {
       test("The canceler will run with an exit value indicating the effect was interrupted") {
         for {
           ref    <- Ref.make(false)
-          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.interrupted))
+          managed = ZManaged.acquireReleaseExitWith(ZIO.unit)((_, e) => ref.set(e.isInterrupted))
           _      <- managed.withEarlyRelease.use(_._1)
           result <- ref.get
         } yield assert(result)(isTrue)
@@ -1606,7 +1606,7 @@ object ZManagedSpec extends DefaultRunnableSpec {
 
   def doInterrupt(
     managed: IO[Nothing, Unit] => ZManaged[Any, Nothing, Unit],
-    expected: Fiber.Id => Option[Exit[Nothing, Unit]]
+    expected: FiberId => Option[Exit[Nothing, Unit]]
   ): ZIO[Has[Live], Nothing, TestResult] =
     for {
       fiberId            <- ZIO.fiberId

--- a/scalafix/output/src/main/scala/fix/Zio2Renames.scala
+++ b/scalafix/output/src/main/scala/fix/Zio2Renames.scala
@@ -3,8 +3,10 @@ package fix
 import zio._
 
 
+import zio.Duration
+import zio.internal.Platform
 import zio.test.Gen
-import zio.Console
+import zio.{ Console, FiberId, Has, Random }
 import zio.Console._
 import zio.ZIO.attemptBlockingIO
 import zio.test.Gen
@@ -68,4 +70,21 @@ object Zio2Renames {
 
   // Blocking
   attemptBlockingIO(1)
+
+  ZIO.succeed(1).onExecutionContext _
+
+  Cause.fail("Die").isInterrupted
+
+  FiberId
+
+  zio.Duration
+  
+  val x: Layer[Nothing, Has[Random]] = zio.Random.live
+
+  zio.Executor
+
+  RuntimeConfig.fromExecutor(???)
+  
+  zio.RuntimeConfig
+    .fromExecutor(???)
 }

--- a/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
@@ -19,6 +19,8 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
       "bracket_"               -> "acquireRelease",
       "bracket_"               -> "acquireRelease",
       "checkM"                 -> "check",
+      "checkNM"                -> "checkN",
+      "checkAllM"              -> "checkAll",
       "collectAllPar_"         -> "collectAllParDiscard",
       "collectAll_"            -> "collectAllDiscard",
       "collectM"               -> "collectZIO",
@@ -53,6 +55,8 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
       "halt"                   -> "failCause",
       "haltWith"               -> "failCauseWith",
       "ifM"                    -> "ifZIO",
+      "interrupted"            -> "isInterrupted",
+      "lockExecutionContext"   -> "onExecutionContext", // Hard to test, because this only existed in a non-deprecated state in an earlier milestone
       "loop_"                  -> "loopDiscard",
       "makeReserve"            -> "fromReservationZIO",
       "mapConcatM"             -> "mapConcatZIO",
@@ -60,7 +64,9 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
       "mapM"                   -> "mapZIO",
       "mapMPar"                -> "mapZIOPar",
       "mapMParUnordered"       -> "mapZIOParUnordered",
+      "on"                     -> "onExecutionContext",
       "optional"               -> "unsome",
+      "unoption"               -> "unsome",
       "paginateChunkM"         -> "paginateChunkZIO",
       "paginateM"              -> "paginateZIO",
       "partitionPar_"          -> "partitionParDiscard",
@@ -99,6 +105,7 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
     "zio.test.DefaultRunnableSpec",
     "zio.Exit",
     "zio.ZIO",
+    "zio.Cause",
     "zio.IO",
     "zio.Managed",
     "zio.RIO",
@@ -147,23 +154,6 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
     }
   }
   
-  case class AppRecognizer() {
-    object Matcher {
-      def unapply(tree: Tree)(implicit sdoc: SemanticDocument): Option[Patch] =
-        tree match {
-          case t@ q"..$mods class $tname[..$tparams] ..$ctorMods (...$paramss) extends $template"  =>
-            template.tokens.foreach(println)
-            Some(Patch.replaceTree(t, s"${mods.mkString(" ")} class $tname[${tparams.mkString(",")}] ${ctorMods.mkString(" ")} (${paramss.mkString(",")} extends Foo$template"))
-          case t @ q"..$mods trait $tname[..$tparams] extends $template" =>
-            template.tokens.foreach(println)
-            Some(Patch.replaceTree(t, s"${mods.mkString(" ")} class $tname[${tparams.mkString(",")}]  extends Foo$template"))
-          case _ => None
-        }
-    }
-  }
-  
-  val AppRecognizerStable = AppRecognizer()
-
   val UniversalRenames = Renames(scopes, renames)
 
   val ZIORenames = Renames(
@@ -217,6 +207,7 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
   val TestConsoleService_Old      = SymbolMatcher.normalized("zio/test/environment/package.TestConsole.Service#")
   val TestRandom_Old      = SymbolMatcher.normalized("zio/test/environment/package.TestRandom#")
   val TestRandomService_Old      = SymbolMatcher.normalized("zio/test/environment/package.TestRandom.Service#")
+  val FiberId_Old      = SymbolMatcher.normalized("zio/Fiber.Id#")
 
   val Blocking_Old_Exact   = SymbolMatcher.exact("zio/blocking/package.Blocking#")
   val Random_Old_Exact     = SymbolMatcher.exact("zio/random/package.Random#")
@@ -240,6 +231,8 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
   val TestConsoleService_Old_Exact      = SymbolMatcher.exact("zio/test/environment/package.TestConsole.Service#")
   val TestRandom_Old_Exact      = SymbolMatcher.exact("zio/test/environment/package.TestRandom#")
   val TestRandomService_Old_Exact      = SymbolMatcher.exact("zio/test/environment/package.TestRandom.Service#")
+  
+  val FiberId_Old_Exact      = SymbolMatcher.exact("zio/Fiber.Id#")
 
   val hasImport    = Symbol("zio/Has#")
   val newRandom    = Symbol("zio/Random#")
@@ -255,6 +248,8 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
   val newTestSystem      = Symbol("zio/test/environment/TestSystem#")
   val newTestConsole      = Symbol("zio/test/environment/TestConsole#")
   val newTestRandom      = Symbol("zio/test/environment/TestRandom#")
+
+  val newFiberId      = Symbol("zio/FiberId#")
 
   val Clock_Old_Package   = SymbolMatcher.normalized("zio.clock")
   val Random_Old_Package  = SymbolMatcher.normalized("zio.random")
@@ -291,8 +286,6 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
     "zio.clock.localDateTime"   -> "zio.Clock.localDateTime",
     "zio.clock.currentTime"     -> "zio.Clock.currentTime",
     "zio.clock.currentDateTime" -> "zio.Clock.currentDateTime",
-    // Intentionally removed. It breaks because of the different depth. It was not forgotten
-    //    "zio.duration.Duration"     -> "zio.Duration",
     // Random
     "zio.random.nextString"        -> "zio.Random.nextString",
     "zio.random.nextBoolean"       -> "zio.Random.nextBoolean",
@@ -352,7 +345,7 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
     "zio.test.TimeVariants.anyZoneOffset" -> "zio.test.Gen.zoneOffset",
     "zio.test.TimeVariants.anyZoneId" -> "zio.test.Gen.zoneId",
     // App
-    "zio.App" -> "zio.ZIOAppDefault"
+    "zio.App" -> "zio.ZIOAppDefault",
   )
 
   val foreachParN             = ParNRenamer("foreachPar", 3)
@@ -368,7 +361,6 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
       case ZIORenames.Matcher(patch)       => patch
       case ZManagedRenames.Matcher(patch)  => patch
       case UniversalRenames.Matcher(patch) => patch
-//      case AppRecognizerStable.Matcher(patch) => patch // TODO Decide if this is worth pursuing
 
       // Replace >>= with flatMap. For some reason, this doesn't work with the
       // technique used above.
@@ -462,8 +454,11 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
           Patch.addGlobalImport(newConsole)
 
       case t @ Blocking_Old_Exact(Name(_)) =>
-        Patch.addGlobalImport(newRandom) +
           Patch.replaceTree(unwindSelect(t), s"Any")
+
+      case t @ FiberId_Old_Exact(Name(_)) =>
+        Patch.replaceTree(unwindSelect(t), "FiberId") +
+          Patch.addGlobalImport(newFiberId)
 
       case t @ Random_Old_Exact(Name(_)) =>
         Patch.addGlobalImport(hasImport) +
@@ -539,12 +534,42 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
         Random_Old(_) | Clock_Old(_) | Console_Old(_) | System_Old(_) | Sized_Old(_) | SizedService_Old(_) | 
         Live_Old(_) | TestConfig_Old(_) | TestConfigService_Old(_) | TestSystem_Old(_) | TestSystemService_Old(_) | 
         TestConsole_Old(_) | TestConsoleService_Old(_) | TestRandom_Old(_) | TestRandomService_Old(_) | 
-        TestAnnotations_Old(_) | TestAnnotationsService_Old(_) | TestLogger_Old(_) | TestLoggerService_Old(_)) =>
+        TestAnnotations_Old(_) | TestAnnotationsService_Old(_) | TestLogger_Old(_) | TestLoggerService_Old(_) | FiberId_Old(_)) =>
         Patch.removeImportee(t)
 
       case t @ q"import zio.console._" =>
         Patch.replaceTree(t, "") +
           Patch.addGlobalImport(wildcardImport(q"zio.Console"))
+
+      case t @ q"Fiber.Id" =>
+        Patch.replaceTree(t, "FiberId") +
+          Patch.addGlobalImport(Symbol("zio/FiberId#"))
+
+      // TODO Safe to do for many similar types?
+      case t @ q"import zio.duration.Duration" =>
+        Patch.replaceTree(t, "import zio.Duration")
+
+      case t @ q"zio.duration.Duration" =>
+        Patch.replaceTree(t, "zio.Duration")
+        
+      case t @ q"zio.random.Random" =>
+        Patch.replaceTree(t, "zio.Random")
+
+      case t @ q"zio.internal.Executor" =>
+        Patch.replaceTree(t, "zio.Executor")
+
+      case t @ q"Platform.fromExecutor" =>
+        Patch.replaceTree(t, "RuntimeConfig.fromExecutor")
+        
+      case t @ q"zio.internal.Platform" =>
+        Patch.replaceTree(t, "zio.RuntimeConfig")
+
+      case t @ q"zio.internal.Tracing" =>
+        Patch.replaceTree(t, "zio.internal.tracing.Tracing")
+        
+      case t @ q"import zio.internal.Tracing" =>
+        Patch.replaceTree(t, "import zio.internal.tracing.Tracing")
+
     }.asPatch + replaceSymbols
 
   private def wildcardImport(ref: Term.Ref): Importer =


### PR DESCRIPTION
- checkNM => checkN
- checkAllM -> checkAll
- interrupted -> isInterrupted
- Fiber.Id -> FiberId
- unoption -> unsome
- lockExecutionContext -> onExecutionContext
- on -> onExecutionContext
- Executor
- RuntimeConfig

Add zio.Cause scope