### PR TITLE
Additional ScalaFix rules from interop-cats migration

### DIFF
--- a/scalafix/input/src/main/scala/fix/BlockingUses.scala
+++ b/scalafix/input/src/main/scala/fix/BlockingUses.scala
@@ -1,0 +1,12 @@
+/*
+rule = Zio2Upgrade
+ */
+package fix
+
+import zio.blocking.effectBlockingIO
+import zio.blocking._
+import zio.blocking.Blocking
+
+object BlockingUses {
+  val x = Blocking.Service
+}

--- a/scalafix/input/src/main/scala/fix/ScheduleRenames.scala
+++ b/scalafix/input/src/main/scala/fix/ScheduleRenames.scala
@@ -1,0 +1,22 @@
+/*
+rule = Zio2Upgrade
+ */
+package fix
+
+import zio.Schedule.once
+
+object ScheduleRenames {
+  once.addDelayM _
+  once.checkM _
+  once.contramapM _
+  once.delayedM _
+  once.dimapM _
+  once.foldM _
+  once.mapM _
+  once.modifyDelayM _
+  once.reconsiderM _
+  once.untilInputM _
+  once.untilOutputM _
+  once.whileInputM _
+  once.whileOutputM _
+}

--- a/scalafix/input/src/main/scala/fix/ZSTMRenames.scala
+++ b/scalafix/input/src/main/scala/fix/ZSTMRenames.scala
@@ -1,0 +1,21 @@
+/*
+rule = Zio2Upgrade
+ */
+package fix
+
+import zio.stm.ZSTM
+
+object ZSTMRenames {
+  ZSTM.collectAll_ _
+  ZSTM.foreach_ _
+  ZSTM.fromFunction _
+  ZSTM.fromFunctionM _
+  ZSTM.ifM _
+  ZSTM.loop_ _
+  ZSTM.partial _
+  ZSTM.replicateM _
+  ZSTM.replicateM_ _
+  ZSTM.unlessM _
+  ZSTM.whenCaseM _
+  ZSTM.whenM _
+}

--- a/scalafix/input/src/main/scala/fix/Zio2Renames.scala
+++ b/scalafix/input/src/main/scala/fix/Zio2Renames.scala
@@ -6,9 +6,11 @@ package fix
 import zio._
 import zio.blocking.effectBlockingIO
 import zio.blocking._
+import zio.blocking.Blocking
 import zio.console._
 import zio.duration.Duration
 import zio.internal.Platform
+import zio.stream.ZStream
 import zio.test.Gen
 
 object Zio2Renames {
@@ -88,4 +90,12 @@ object Zio2Renames {
   
   zio.internal.Platform
     .fromExecutor(???)
+
+  Chunk.succeed(1).mapM(???)
+  ZStream.succeed("hi") >>= (x => ZStream.succeed(x))
+
+  ZIO.executor.map(_.asEC)
+  
+  ZManaged.fromFunction( (x: Int) => x)
+  ZManaged.fromFunctionM( (x: Int) => ZManaged.succeed(x))
 }

--- a/scalafix/output/src/main/scala/fix/BlockingUses.scala
+++ b/scalafix/output/src/main/scala/fix/BlockingUses.scala
@@ -1,0 +1,8 @@
+package fix
+
+
+
+
+object BlockingUses {
+  val x = Blocking.Service
+}

--- a/scalafix/output/src/main/scala/fix/ScheduleRenames.scala
+++ b/scalafix/output/src/main/scala/fix/ScheduleRenames.scala
@@ -1,0 +1,19 @@
+package fix
+
+import zio.Schedule.once
+
+object ScheduleRenames {
+  once.addDelayZIO _
+  once.checkZIO _
+  once.contramapZIO _
+  once.delayedZIO _
+  once.dimapZIO _
+  once.foldZIO _
+  once.mapZIO _
+  once.modifyDelayZIO _
+  once.reconsiderZIO _
+  once.untilInputZIO _
+  once.untilOutputZIO _
+  once.whileInputZIO _
+  once.whileOutputZIO _
+}

--- a/scalafix/output/src/main/scala/fix/ZSTMRenames.scala
+++ b/scalafix/output/src/main/scala/fix/ZSTMRenames.scala
@@ -1,0 +1,18 @@
+package fix
+
+import zio.stm.ZSTM
+
+object ZSTMRenames {
+  ZSTM.collectAllDiscard _
+  ZSTM.foreachDiscard _
+  ZSTM.access _
+  ZSTM.accessSTM _
+  ZSTM.ifSTM _
+  ZSTM.loopDiscard _
+  ZSTM.attempt _
+  ZSTM.replicateSTM _
+  ZSTM.replicateSTMDiscard _
+  ZSTM.unlessSTM _
+  ZSTM.whenCaseSTM _
+  ZSTM.whenSTM _
+}

--- a/scalafix/output/src/main/scala/fix/Zio2Renames.scala
+++ b/scalafix/output/src/main/scala/fix/Zio2Renames.scala
@@ -3,8 +3,10 @@ package fix
 import zio._
 
 
+
 import zio.Duration
 import zio.internal.Platform
+import zio.stream.ZStream
 import zio.test.Gen
 import zio.{ Console, FiberId, Has, Random }
 import zio.Console._
@@ -87,4 +89,12 @@ object Zio2Renames {
   
   zio.RuntimeConfig
     .fromExecutor(???)
+
+  Chunk.succeed(1).mapZIO(???)
+  ZStream.succeed("hi") flatMap (x => ZStream.succeed(x))
+
+  ZIO.executor.map(_.asExecutionContext)
+  
+  ZManaged.access( (x: Int) => x)
+  ZManaged.accessManaged( (x: Int) => ZManaged.succeed(x))
 }


### PR DESCRIPTION
- asEC to asExecutionContext
- fromFunction => access
- fromFunctionM => accessManaged
- Many ZSTM/STM renames
- Many Schedule renames
+zio.Chunk scope

rm more Blocking imports.