### PR TITLE
ZIO Test Mock: Fix `atLeast` and add exactly bounded expectations

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
@@ -270,6 +270,44 @@ object AdvancedEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule]
             hasUnexpectedCall(PureModuleMock.SingleParam, 1)
           )
         )
+      }, {
+        val expectation = A.once
+
+        suite("A.once")(
+          testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+          testValue("1xA passes")(expectation, a, equalTo("A")),
+          testDied("2xA fails")(expectation, a *> a, hasUnexpectedCall(PureModuleMock.SingleParam, 1))
+        )
+      }, {
+        val expectation = A.twice
+
+        suite("A.twice")(
+          testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+          testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+          testValue("2xA passes")(expectation, a *> a, equalTo("A")),
+          testDied("3xA fails")(expectation, a *> a *> a, hasUnexpectedCall(PureModuleMock.SingleParam, 1))
+        )
+      }, {
+        val expectation = A.thrice
+
+        suite("A.thrice")(
+          testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+          testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+          testDied("2xA fails")(expectation, a *> a, hasUnsatisfiedExpectations),
+          testValue("3xA passes")(expectation, a *> a *> a, equalTo("A")),
+          testDied("4xA fails")(expectation, a *> a *> a *> a, hasUnexpectedCall(PureModuleMock.SingleParam, 1))
+        )
+      }, {
+        val expectation = A.exactly(4)
+
+        suite("A.exactly(4)")(
+          testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+          testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+          testDied("2xA fails")(expectation, a *> a, hasUnsatisfiedExpectations),
+          testDied("3xA fails")(expectation, a *> a *> a, hasUnsatisfiedExpectations),
+          testValue("4xA passes")(expectation, a *> a *> a *> a, equalTo("A")),
+          testDied("5xA fails")(expectation, a *> a *> a *> a *> a, hasUnexpectedCall(PureModuleMock.SingleParam, 1))
+        )
       }
     )
   )

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
@@ -267,6 +267,48 @@ object AdvancedMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModul
               hasUnexpectedCall(ImpureModuleMock.SingleParam, 1)
             )
           )
+        }, {
+          val expectation = A.once
+
+          suite("A.once")(
+            testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+            testValue("1xA passes")(expectation, a, equalTo("A")),
+            testDied("2xA fails")(expectation, a *> a, hasUnexpectedCall(ImpureModuleMock.SingleParam, 1))
+          )
+        }, {
+          val expectation = A.twice
+
+          suite("A.twice")(
+            testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+            testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+            testValue("2xA passes")(expectation, a *> a, equalTo("A")),
+            testDied("3xA fails")(expectation, a *> a *> a, hasUnexpectedCall(ImpureModuleMock.SingleParam, 1))
+          )
+        }, {
+          val expectation = A.thrice
+
+          suite("A.thrice")(
+            testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+            testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+            testDied("2xA fails")(expectation, a *> a, hasUnsatisfiedExpectations),
+            testValue("3xA passes")(expectation, a *> a *> a, equalTo("A")),
+            testDied("4xA fails")(expectation, a *> a *> a *> a, hasUnexpectedCall(ImpureModuleMock.SingleParam, 1))
+          )
+        }, {
+          val expectation = A.exactly(4)
+
+          suite("A.exactly(4)")(
+            testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
+            testDied("1xA fails")(expectation, a, hasUnsatisfiedExpectations),
+            testDied("2xA fails")(expectation, a *> a, hasUnsatisfiedExpectations),
+            testDied("3xA fails")(expectation, a *> a *> a, hasUnsatisfiedExpectations),
+            testValue("4xA passes")(expectation, a *> a *> a *> a, equalTo("A")),
+            testDied("5xA fails")(
+              expectation,
+              a *> a *> a *> a *> a,
+              hasUnexpectedCall(ImpureModuleMock.SingleParam, 1)
+            )
+          )
         }
       )
     )

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -57,6 +57,15 @@ object ExpectationSpec extends ZIOBaseSpec {
     suite("repeats")(
       test("A repeats (2 to 5)")(assert(A repeats (2 to 5))(equalTo(Repeated(A, 2 to 5)))),
       test("nested repeats")(assert(A.repeats(2 to 3).repeats(1 to 2))(equalTo(Repeated(Repeated(A, 2 to 3), 1 to 2))))
+    ),
+    suite("optional")(
+      test("A optional")(assert(A.optional)(equalTo(Repeated(A, 0 to 1))))
+    ),
+    suite("exactly and derived")(
+      test("A exactly 5")(assert(A exactly 5)(equalTo(Exactly(A, 5)))),
+      test("A once")(assert(A.once)(equalTo(Exactly(A, 1)))),
+      test("A twice")(assert(A.twice)(equalTo(Exactly(A, 2)))),
+      test("A thrice")(assert(A.thrice)(equalTo(Exactly(A, 3))))
     )
   )
 }

--- a/test/shared/src/main/scala/zio/test/mock/internal/Debug.scala
+++ b/test/shared/src/main/scala/zio/test/mock/internal/Debug.scala
@@ -61,6 +61,10 @@ private[mock] object Debug {
         val progress = s"progress = $started out of $completed,"
         ("Repeated(" :: state :: s"range = $range," :: progress :: invoked :: prettify(child, 1) :: ")" :: Nil)
           .mkString(s"\n$ident")
+      case Expectation.Exactly(child, times, _, _, completed) =>
+        val progress = s"progress = completed $completed iterations,"
+        ("Exactly(" :: state :: s"times = $times," :: progress :: invoked :: prettify(child, 1) :: ")" :: Nil)
+          .mkString(s"\n$ident")
     }
   }
 


### PR DESCRIPTION
## Fixed `atLeast` buggy behavior when chained
Fixes #4058

## Exactly-bounded expectations
While using ZIO Test Mock, I find myself needing this pattern more and more, and I think it's handy to have these exactly-bounded expectations baked in the core. Other mocking frameworks out there have similar ones.