### PR TITLE
Chunk.fromIterable should work with Iterables traversing only once

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -634,6 +634,17 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(Chunk.fromIterator(as.iterator))(equalTo(as))
       }
     },
+    test("fromIterable should works with Iterables traversing only once") {
+      val traversableOnceIterable = new Iterable[Int] {
+        val it = new Iterator[Int] {
+          var c: Int                    = 3
+          override def hasNext: Boolean = c > 0
+          override def next(): Int      = { c = c - 1; c }
+        }
+        override def iterator: Iterator[Int] = it
+      }
+      assert(Chunk.fromIterable(traversableOnceIterable))(equalTo(Chunk(2, 1, 0)))
+    },
     suite("unapplySeq")(
       test("matches a nonempty chunk") {
         val chunk = Chunk(1, 2, 3)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1219,7 +1219,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       case vector: Vector[A]            => VectorChunk(vector)
       case iterable =>
         val builder = ChunkBuilder.make[A]()
-        builder.sizeHint(iterable.size)
+        builder.sizeHint(iterable)
         builder ++= iterable
         builder.result()
     }


### PR DESCRIPTION
Also, eliminates traversing collection twice if iterable knownSize is -1