### PR TITLE
ZIO Test Mock: Remove redundant `once` combinator for `Expectation[R]`

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedEffectMockSpec.scala
@@ -271,14 +271,6 @@ object AdvancedEffectMockSpec extends ZIOBaseSpec with MockSpecUtils[PureModule]
           )
         )
       }, {
-        val expectation = A.once
-
-        suite("A.once")(
-          testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
-          testValue("1xA passes")(expectation, a, equalTo("A")),
-          testDied("2xA fails")(expectation, a *> a, hasUnexpectedCall(PureModuleMock.SingleParam, 1))
-        )
-      }, {
         val expectation = A.twice
 
         suite("A.twice")(

--- a/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/AdvancedMethodMockSpec.scala
@@ -268,14 +268,6 @@ object AdvancedMethodMockSpec extends ZIOBaseSpec with MockSpecUtils[ImpureModul
             )
           )
         }, {
-          val expectation = A.once
-
-          suite("A.once")(
-            testDied("0xA fails")(expectation, ZIO.unit, hasUnsatisfiedExpectations),
-            testValue("1xA passes")(expectation, a, equalTo("A")),
-            testDied("2xA fails")(expectation, a *> a, hasUnexpectedCall(ImpureModuleMock.SingleParam, 1))
-          )
-        }, {
           val expectation = A.twice
 
           suite("A.twice")(

--- a/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpec.scala
@@ -63,7 +63,6 @@ object ExpectationSpec extends ZIOBaseSpec {
     ),
     suite("exactly and derived")(
       test("A exactly 5")(assert(A exactly 5)(equalTo(Exactly(A, 5)))),
-      test("A once")(assert(A.once)(equalTo(Exactly(A, 1)))),
       test("A twice")(assert(A.twice)(equalTo(Exactly(A, 2)))),
       test("A thrice")(assert(A.thrice)(equalTo(Exactly(A, 3))))
     )

--- a/test/shared/src/main/scala/zio/test/mock/Expectation.scala
+++ b/test/shared/src/main/scala/zio/test/mock/Expectation.scala
@@ -111,12 +111,6 @@ sealed abstract class Expectation[R <: Has[_]: Tag] { self =>
     Exactly(self, times)
 
   /**
-   * Alias for `exactly(1)`, produces a new expectation to satisfy itself exactly one time.
-   */
-  def once: Expectation[R] =
-    exactly(1)
-
-  /**
    * Alias for `exactly(2)`, produces a new expectation to satisfy itself exactly two times.
    */
   def twice: Expectation[R] =


### PR DESCRIPTION
@adamgfraser I'm really sorry for the noise 😳, but in #5834 I mistakenly added the `once` combinator, overlooking that this is exactly the default behavior when creating an `Expectation[R]`.

![Shame!](https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif)

It's not needed at all, so this PR removes it in order to avoid confusion for users.