### PR TITLE
Fix ZStream#broadcast Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2288,7 +2288,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .exit
                 .map(_.isInterrupted)
             )(equalTo(false))
-          } @@ TestAspect.ignore,
+          } @@ ignore,
           test("interrupts pending tasks when one of the tasks fails") {
             for {
               interrupted <- Ref.make(0)


### PR DESCRIPTION
The test had not been updated to reflect the fact that the initial stream was chunked and for the improved semantics of the hub based implementation for back pressure.