### PR TITLE
Fix race condition in fromOutputStreamWriter

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZStreamPlatformSpecificSpec.scala
@@ -2,9 +2,7 @@ package zio.stream
 
 import zio._
 import zio.blocking.{Blocking, effectBlockingIO}
-import zio.duration._
 import zio.test.Assertion._
-import zio.test.TestAspect._
 import zio.test._
 
 import java.io.{FileNotFoundException, FileReader, IOException, OutputStream, Reader}
@@ -371,7 +369,7 @@ object ZStreamPlatformSpecificSpec extends ZIOBaseSpec {
           val data  = Array.tabulate[Byte](ZStream.DefaultChunkSize * 5 / 2)(_.toByte)
           val write = (out: OutputStream) => { out.write(data); out.close() }
           ZStream.fromOutputStreamWriter(write).runCollect.map(assert(_)(equalTo(Chunk.fromArray(data))))
-        } @@ timeout(10.seconds) @@ flaky,
+        },
         testM("is interruptable") {
           val latch = new CountDownLatch(1)
           val write = (out: OutputStream) => { latch.await(); out.write(42); }


### PR DESCRIPTION
Because the input and output streams are piped together,
when the output stream is closed, the input stream completes.
Due to the semantics of `drainFork` that would sometimes cause
the output stream writer to be interrupted before completing
the error channel promise. But in fact we don't need a separate
error channel, we just need to make sure the input stream reader
waits for the output stream writer to complete.