### PR TITLE
Implement ConcurrentMap

### DIFF
--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -9,7 +9,7 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("ConcurrentMap")(
       suite("compute")(
-        testM("returns a computed value") {
+        testM("computes a new value") {
           for {
             map      <- ConcurrentMap.make(1 -> 100)
             computed <- map.compute(1, _ + _)
@@ -38,6 +38,22 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
             computed <- map.computeIfAbsent("abc", _ => 10)
             stored   <- map.get("abc")
           } yield assert(computed)(equalTo(3)) && assert(stored)(isSome(equalTo(computed)))
+        }
+      ),
+      suite("computeIfPresent")(
+        testM("computes a value of an existing key") {
+          for {
+            map      <- ConcurrentMap.make(1 -> 100)
+            computed <- map.computeIfPresent(1, _ + _)
+            stored   <- map.get(1)
+          } yield assert(computed)(isSome(equalTo(101))) && assert(computed)(equalTo(stored))
+        },
+        testM("returns None if key doesn't exist") {
+          for {
+            map      <- ConcurrentMap.empty[Int, String]
+            computed <- map.computeIfPresent(1, (_, _) => "test")
+            stored   <- map.get(1)
+          } yield assert(computed)(isNone) && assert(computed)(equalTo(stored))
         }
       ),
       suite("constructors")(

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -24,6 +24,22 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
           } yield assert(computed)(isNone) && assert(computed)(equalTo(stored))
         }
       ),
+      suite("computeIfAbsent")(
+        testM("computes a value of a non-existing key") {
+          for {
+            map      <- ConcurrentMap.empty[String, Int]
+            computed <- map.computeIfAbsent("abc", _.length)
+            stored   <- map.get("abc")
+          } yield assert(computed)(equalTo(3)) && assert(stored)(isSome(equalTo(computed)))
+        },
+        testM("preserves the existing bindings") {
+          for {
+            map      <- ConcurrentMap.make("abc" -> 3)
+            computed <- map.computeIfAbsent("abc", _ => 10)
+            stored   <- map.get("abc")
+          } yield assert(computed)(equalTo(3)) && assert(stored)(isSome(equalTo(computed)))
+        }
+      ),
       suite("constructors")(
         testM("empty") {
           for {

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -44,6 +44,22 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
           } yield assert(res)(isNone)
         }
       ),
+      suite("put")(
+        testM("associates the non-existing key with a given value") {
+          for {
+            map    <- ConcurrentMap.empty[Int, String]
+            putRes <- map.put(1, "a")
+            getRes <- map.get(1)
+          } yield assert(putRes)(isNone) && assert(getRes)(isSome(equalTo("a")))
+        },
+        testM("overrides the existing mappings") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            putRes <- map.put(1, "b")
+            getRes <- map.get(1)
+          } yield assert(putRes)(isSome(equalTo("a"))) && assert(getRes)(isSome(equalTo("b")))
+        }
+      ),
       suite("putIfAbsent")(
         testM("associates the non-existing key with a given value") {
           for {

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -59,6 +59,36 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
             getRes <- map.get(1)
           } yield assert(putRes)(isSome(equalTo("a"))) && assert(getRes)(isSome(equalTo("a")))
         }
+      ),
+      suite("remove")(
+        testM("returns the value associated with removed key") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            remRes <- map.remove(1)
+            getRes <- map.get(1)
+          } yield assert(remRes)(isSome(equalTo("a"))) && assert(getRes)(isNone)
+        },
+        testM("returns None if map didn't contain the given key") {
+          for {
+            map    <- ConcurrentMap.empty[Int, String]
+            remRes <- map.remove(1)
+            getRes <- map.get(1)
+          } yield assert(remRes)(isNone) && assert(getRes)(isNone)
+        },
+        testM("succeeds if the key was mapped to the given value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            remRes <- map.remove(1, "a")
+            getRes <- map.get(1)
+          } yield assert(remRes)(isTrue) && assert(getRes)(isNone)
+        },
+        testM("fails if the key wasn't mapped to the given value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            remRes <- map.remove(1, "b")
+            getRes <- map.get(1)
+          } yield assert(remRes)(isFalse) && assert(getRes)(isSome(equalTo("a")))
+        }
       )
     )
 }

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -20,6 +20,22 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
             res <- map.get(1)
           } yield assert(res)(isNone)
         }
+      ),
+      suite("putIfAbsent")(
+        testM("associates the non-existing key with a given value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            putRes <- map.putIfAbsent(2, "b")
+            getRes <- map.get(2)
+          } yield assert(putRes)(isNone) && assert(getRes)(isSome(equalTo("b")))
+        },
+        testM("preserves the existing mappings") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            putRes <- map.putIfAbsent(1, "b")
+            getRes <- map.get(1)
+          } yield assert(putRes)(isSome(equalTo("a"))) && assert(getRes)(isSome(equalTo("a")))
+        }
       )
     )
 }

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -3,10 +3,33 @@ package zio.concurrent
 import zio.ZIOBaseSpec
 import zio.test._
 import zio.test.Assertion._
+import zio.{Chunk, UIO}
 
 object ConcurrentMapSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("ConcurrentMap")(
+      suite("constructors")(
+        testM("empty") {
+          for {
+            map   <- ConcurrentMap.empty[Int, String]
+            items <- map.toChunk
+          } yield assert(items)(isEmpty)
+        },
+        testM("fromIterable") {
+          for {
+            data  <- UIO(Chunk(1 -> "a", 2 -> "b", 3 -> "c"))
+            map   <- ConcurrentMap.fromIterable(data)
+            items <- map.toChunk
+          } yield assert(items)(equalTo(data))
+        },
+        testM("make") {
+          for {
+            data  <- UIO(Chunk(1 -> "a", 2 -> "b", 3 -> "c"))
+            map   <- ConcurrentMap.make(data: _*)
+            items <- map.toChunk
+          } yield assert(items)(equalTo(data))
+        }
+      ),
       suite("get")(
         testM("retrieves an existing key") {
           for {

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -1,0 +1,25 @@
+package zio.concurrent
+
+import zio.ZIOBaseSpec
+import zio.test._
+import zio.test.Assertion._
+
+object ConcurrentMapSpec extends ZIOBaseSpec {
+  def spec: ZSpec[Environment, Failure] =
+    suite("ConcurrentMap")(
+      suite("get")(
+        testM("retrieves an existing key") {
+          for {
+            map <- ConcurrentMap.make(1 -> "a", 2 -> "b")
+            res <- map.get(1)
+          } yield assert(res)(isSome(equalTo("a")))
+        },
+        testM("returns None when retrieving a non-existing key") {
+          for {
+            map <- ConcurrentMap.empty[Int, String]
+            res <- map.get(1)
+          } yield assert(res)(isNone)
+        }
+      )
+    )
+}

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -89,6 +89,36 @@ object ConcurrentMapSpec extends ZIOBaseSpec {
             getRes <- map.get(1)
           } yield assert(remRes)(isFalse) && assert(getRes)(isSome(equalTo("a")))
         }
+      ),
+      suite("replace")(
+        testM("returns the replaced value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            repRes <- map.replace(1, "b")
+            getRes <- map.get(1)
+          } yield assert(repRes)(isSome(equalTo("a"))) && assert(getRes)(isSome(equalTo("b")))
+        },
+        testM("returns None if map didn't contain the given key") {
+          for {
+            map    <- ConcurrentMap.empty[Int, String]
+            repRes <- map.replace(1, "b")
+            getRes <- map.get(1)
+          } yield assert(repRes)(isNone) && assert(getRes)(isNone)
+        },
+        testM("succeeds if the key was mapped to the given value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            repRes <- map.replace(1, "a", "b")
+            getRes <- map.get(1)
+          } yield assert(repRes)(isTrue) && assert(getRes)(isSome(equalTo("b")))
+        },
+        testM("fails if the key wasn't mapped to the given value") {
+          for {
+            map    <- ConcurrentMap.make(1 -> "a")
+            repRes <- map.replace(1, "b", "c")
+            getRes <- map.get(1)
+          } yield assert(repRes)(isFalse) && assert(getRes)(isSome(equalTo("a")))
+        }
       )
     )
 }

--- a/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -8,6 +8,22 @@ import zio.{Chunk, UIO}
 object ConcurrentMapSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("ConcurrentMap")(
+      suite("compute")(
+        testM("returns a computed value") {
+          for {
+            map      <- ConcurrentMap.make(1 -> 100)
+            computed <- map.compute(1, _ + _)
+            stored   <- map.get(1)
+          } yield assert(computed)(isSome(equalTo(101))) && assert(computed)(equalTo(stored))
+        },
+        testM("returns None if remap produced null (e.g. missing key)") {
+          for {
+            map      <- ConcurrentMap.empty[Int, String]
+            computed <- map.compute(1, (_, v) => v)
+            stored   <- map.get(1)
+          } yield assert(computed)(isNone) && assert(computed)(equalTo(stored))
+        }
+      ),
       suite("constructors")(
         testM("empty") {
           for {

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -288,7 +288,7 @@ sealed abstract class Fiber[+E, +A] { self =>
    */
   final def toFutureWith(f: E => Throwable): UIO[CancelableFuture[A]] =
     UIO.effectSuspendTotal {
-      val p: concurrent.Promise[A] = scala.concurrent.Promise[A]()
+      val p: scala.concurrent.Promise[A] = scala.concurrent.Promise[A]()
 
       def failure(cause: Cause[E]): UIO[p.type] = UIO(p.failure(cause.squashTraceWith(f)))
       def success(value: A): UIO[p.type]        = UIO(p.success(value))

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -127,13 +127,13 @@ trait Runtime[+R] {
    * This method is effectful and should only be used at the edges of your program.
    */
   final def unsafeRunToFuture[E <: Throwable, A](zio: ZIO[R, E, A]): CancelableFuture[A] = {
-    val p: concurrent.Promise[A] = scala.concurrent.Promise[A]()
+    val p: scala.concurrent.Promise[A] = scala.concurrent.Promise[A]()
 
     val canceler = unsafeRunWith(zio)(_.fold(cause => p.failure(cause.squashTraceWith(identity)), p.success))
 
     new CancelableFuture[A](p.future) {
       def cancel(): Future[Exit[Throwable, A]] = {
-        val p: concurrent.Promise[Exit[Throwable, A]] = scala.concurrent.Promise[Exit[Throwable, A]]()
+        val p: scala.concurrent.Promise[Exit[Throwable, A]] = scala.concurrent.Promise[Exit[Throwable, A]]()
         canceler(Fiber.Id.None)(p.success)
         p.future
       }

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -1,7 +1,8 @@
 package zio.concurrent
 
-import java.util.concurrent.ConcurrentHashMap
 import zio.{Chunk, ChunkBuilder, UIO}
+
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -4,7 +4,12 @@ import java.util.concurrent.ConcurrentHashMap
 import zio.UIO
 
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
-  def get(key: K): UIO[Option[V]]                             = ???
+  /**
+   * Retrieves the value associated with the given key.
+   */
+  def get(key: K): UIO[Option[V]] =
+    UIO(Option(underlying.get(key)))
+
   def putIfAbsent(key: K, value: V): UIO[Option[V]]           = ???
   def remove(key: K): UIO[Option[V]]                          = ???
   def replace(key: K, value: V): UIO[Option[V]]               = ???

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -8,11 +8,18 @@ import java.util.concurrent.ConcurrentHashMap
  * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].
  */
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
+
   /**
    * Attempts to compute a mapping for the given key and its current mapped value.
    */
   def compute(key: K, remap: (K, V) => V): UIO[Option[V]] =
     UIO(Option(underlying.compute(key, remap(_, _))))
+
+  /**
+   * Computes a value of a non-existing key.
+   */
+  def computeIfAbsent(key: K, map: K => V): UIO[V] = 
+    UIO(underlying.computeIfAbsent(key, map(_)))
 
   /**
    * Retrieves the value associated with the given key.

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -3,6 +3,9 @@ package zio.concurrent
 import java.util.concurrent.ConcurrentHashMap
 import zio.UIO
 
+/**
+ * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].
+ */
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
 
   /**

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -22,7 +22,19 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
   def putIfAbsent(key: K, value: V): UIO[Option[V]] =
     UIO(Option(underlying.putIfAbsent(key, value)))
 
-  def remove(key: K): UIO[Option[V]]                          = ???
+  /**
+   * Removes binding for the given key, optionally returning value associated
+   * with it.
+   */
+  def remove(key: K): UIO[Option[V]] = 
+    UIO(Option(underlying.remove(key)))
+
+  /**
+   * Removes binding for the given key if it is mapped to a given value.
+   */
+  def remove(key: K, value: V): UIO[Boolean] =
+    UIO(underlying.remove(key, value))
+
   def replace(key: K, value: V): UIO[Option[V]]               = ???
   def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???
   def update(key: K, value: V): UIO[Any]                      = ???

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -5,7 +5,7 @@ import zio.{Chunk, ChunkBuilder, UIO}
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].
+ * Wrapper over `java.util.concurrent.ConcurrentHashMap`.
  */
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
 

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -13,12 +13,12 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
    * Attempts to compute a mapping for the given key and its current mapped value.
    */
   def compute(key: K, remap: (K, V) => V): UIO[Option[V]] =
-    UIO(Option(underlying.compute(key, remap(_, _))))
+    UIO(Option(underlying.compute(key, (k, v) => if (v == null) null.asInstanceOf[V] else remap(k, v))))
 
   /**
    * Computes a value of a non-existing key.
    */
-  def computeIfAbsent(key: K, map: K => V): UIO[V] = 
+  def computeIfAbsent(key: K, map: K => V): UIO[V] =
     UIO(underlying.computeIfAbsent(key, map(_)))
 
   /**

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -37,7 +37,6 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
 
   def replace(key: K, value: V): UIO[Option[V]]               = ???
   def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???
-  def update(key: K, value: V): UIO[Any]                      = ???
 
   /**
    * Collects all bindings into a chunk.

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -8,6 +8,11 @@ import java.util.concurrent.ConcurrentHashMap
  * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].
  */
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
+  /**
+   * Attempts to compute a mapping for the given key and its current mapped value.
+   */
+  def compute(key: K, remap: (K, V) => V): UIO[Option[V]] =
+    UIO(Option(underlying.compute(key, remap(_, _))))
 
   /**
    * Retrieves the value associated with the given key.

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -1,0 +1,19 @@
+package zio.concurrent
+
+import java.util.concurrent.ConcurrentHashMap
+import zio.UIO
+
+final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
+  def get(key: K): UIO[Option[V]]                             = ???
+  def putIfAbsent(key: K, value: V): UIO[Option[V]]           = ???
+  def remove(key: K): UIO[Option[V]]                          = ???
+  def replace(key: K, value: V): UIO[Option[V]]               = ???
+  def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???
+  def update(key: K, value: V): UIO[Any]                      = ???
+}
+
+object ConcurrentMap {
+  def empty[K, V]: UIO[ConcurrentMap[K, V]] = ???
+
+  def make[K, V](pairs: (K, V)*): UIO[ConcurrentMap[K, V]] = ???
+}

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -23,23 +23,33 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
     UIO(Option(underlying.putIfAbsent(key, value)))
 
   /**
-   * Removes binding for the given key, optionally returning value associated
+   * Removes the entry for the given key, optionally returning value associated
    * with it.
    */
-  def remove(key: K): UIO[Option[V]] = 
+  def remove(key: K): UIO[Option[V]] =
     UIO(Option(underlying.remove(key)))
 
   /**
-   * Removes binding for the given key if it is mapped to a given value.
+   * Removes the entry for the given key if it is mapped to a given value.
    */
   def remove(key: K, value: V): UIO[Boolean] =
     UIO(underlying.remove(key, value))
 
-  def replace(key: K, value: V): UIO[Option[V]]               = ???
-  def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???
+  /**
+   * Replaces the entry for the given key only if it is mapped to some value.
+   */
+  def replace(key: K, value: V): UIO[Option[V]] =
+    UIO(Option(underlying.replace(key, value)))
 
   /**
-   * Collects all bindings into a chunk.
+   * Replaces the entry for the given key only if it was previously mapped
+   * to a given value.
+   */
+  def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] =
+    UIO(underlying.replace(key, oldValue, newValue))
+
+  /**
+   * Collects all entries into a chunk.
    */
   def toChunk: UIO[Chunk[(K, V)]] =
     UIO {
@@ -55,7 +65,7 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
     }
 
   /**
-   * Collects all bindings into a list.
+   * Collects all entries into a list.
    */
   def toList: UIO[List[(K, V)]] =
     toChunk.map(_.toList)
@@ -70,7 +80,8 @@ object ConcurrentMap {
     UIO(new ConcurrentMap(new ConcurrentHashMap()))
 
   /**
-   * Makes a new `ConcurrentMap` initialized with provided collection of key-value pairs.
+   * Makes a new `ConcurrentMap` initialized with provided collection of
+   * key-value pairs.
    */
   def fromIterable[K, V](pairs: Iterable[(K, V)]): UIO[ConcurrentMap[K, V]] =
     UIO {

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -1,7 +1,7 @@
 package zio.concurrent
 
 import java.util.concurrent.ConcurrentHashMap
-import zio.UIO
+import zio.{Chunk, ChunkBuilder, UIO}
 
 /**
  * Wrapper over [[java.util.concurrent.ConcurrentHashMap]].
@@ -25,6 +25,28 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
   def replace(key: K, value: V): UIO[Option[V]]               = ???
   def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???
   def update(key: K, value: V): UIO[Any]                      = ???
+
+  /**
+   * Collects all bindings into a chunk.
+   */
+  def toChunk: UIO[Chunk[(K, V)]] =
+    UIO {
+      val builder = ChunkBuilder.make[(K, V)]()
+
+      val it = underlying.entrySet().iterator()
+      while (it.hasNext()) {
+        val entry = it.next()
+        builder += entry.getKey() -> entry.getValue()
+      }
+
+      builder.result()
+    }
+
+  /**
+   * Collects all bindings into a list.
+   */
+  def toList: UIO[List[(K, V)]] =
+    toChunk.map(_.toList)
 }
 
 object ConcurrentMap {

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -13,7 +13,34 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
 }
 
 object ConcurrentMap {
-  def empty[K, V]: UIO[ConcurrentMap[K, V]] = ???
 
-  def make[K, V](pairs: (K, V)*): UIO[ConcurrentMap[K, V]] = ???
+  /**
+   * Makes an empty `ConcurrentMap`.
+   */
+  def empty[K, V]: UIO[ConcurrentMap[K, V]] =
+    UIO(new ConcurrentMap(new ConcurrentHashMap()))
+
+  /**
+   * Makes a new `ConcurrentMap` initialized with provided collection of key-value pairs.
+   */
+  def fromIterable[K, V](pairs: Iterable[(K, V)]): UIO[ConcurrentMap[K, V]] =
+    UIO {
+      val underlying = new ConcurrentHashMap[K, V]()
+
+      pairs.foreach(kv => underlying.put(kv._1, kv._2))
+
+      new ConcurrentMap(underlying)
+    }
+
+  /**
+   * Makes a new `ConcurrentMap` initialized with provided key-value pairs.
+   */
+  def make[K, V](pairs: (K, V)*): UIO[ConcurrentMap[K, V]] =
+    UIO {
+      val underlying = new ConcurrentHashMap[K, V]()
+
+      pairs.foreach(kv => underlying.put(kv._1, kv._2))
+
+      new ConcurrentMap(underlying)
+    }
 }

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -4,13 +4,20 @@ import java.util.concurrent.ConcurrentHashMap
 import zio.UIO
 
 final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashMap[K, V]) extends AnyVal {
+
   /**
    * Retrieves the value associated with the given key.
    */
   def get(key: K): UIO[Option[V]] =
     UIO(Option(underlying.get(key)))
 
-  def putIfAbsent(key: K, value: V): UIO[Option[V]]           = ???
+  /**
+   * Associates the given key with a given value, unless the key was already
+   * associated with some other value.
+   */
+  def putIfAbsent(key: K, value: V): UIO[Option[V]] =
+    UIO(Option(underlying.putIfAbsent(key, value)))
+
   def remove(key: K): UIO[Option[V]]                          = ???
   def replace(key: K, value: V): UIO[Option[V]]               = ???
   def replace(key: K, oldValue: V, newValue: V): UIO[Boolean] = ???

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -13,13 +13,19 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
    * Attempts to compute a mapping for the given key and its current mapped value.
    */
   def compute(key: K, remap: (K, V) => V): UIO[Option[V]] =
-    UIO(Option(underlying.compute(key, (k, v) => if (v == null) null.asInstanceOf[V] else remap(k, v))))
+    UIO(Option(underlying.compute(key, (k, v) => if (v == null) v else remap(k, v))))
 
   /**
    * Computes a value of a non-existing key.
    */
   def computeIfAbsent(key: K, map: K => V): UIO[V] =
     UIO(underlying.computeIfAbsent(key, map(_)))
+
+  /**
+   * Attempts to compuate a new mapping of an existing key.
+   */
+  def computeIfPresent(key: K, remap: (K, V) => V): UIO[Option[V]] =
+    UIO(Option(underlying.computeIfPresent(key, (k, v) => if (v == null) v else remap(k, v))))
 
   /**
    * Retrieves the value associated with the given key.

--- a/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/core/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -16,8 +16,13 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
     UIO(Option(underlying.get(key)))
 
   /**
-   * Associates the given key with a given value, unless the key was already
-   * associated with some other value.
+   * Adds a new key-value pair and optionally returns previously bound value.
+   */
+  def put(key: K, value: V): UIO[Option[V]] =
+    UIO(Option(underlying.put(key, value)))
+
+  /**
+   * Adds a new key-value pair, unless the key is already bound to some other value.
    */
   def putIfAbsent(key: K, value: V): UIO[Option[V]] =
     UIO(Option(underlying.putIfAbsent(key, value)))


### PR DESCRIPTION
Resolves #5808.

### Summary

- Verified that `java.util.concurrent.ConcurrentHashMap` is the most suited for the "backend" job.
- Exposed the "core" functionality from `scala.collection.concurrent.Map` "lifted" in ZIO. Other combinators will be added as part of #5889.

### Issue

What to do with `compute*` combinators? They're coming from Java world, but I can't think of a way to provide them in a "pure" way, i.e. even if we change their signatures to accept ZIO values, we'd have to `unsafeRun` at one point, which is unfortunate.