### PR TITLE
Add JVM-specific ZSink.outputFromStream and ZSink.outputFromStreamManaged in experimental

### DIFF
--- a/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
@@ -5,6 +5,7 @@ import zio.test.Assertion._
 import zio.test._
 
 import java.nio.file.Files
+import java.io.ByteArrayOutputStream
 
 object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
   override def spec: Spec[Any, TestFailure[Throwable], TestSuccess] = suite("ZSink JVM")(
@@ -21,6 +22,18 @@ object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
             } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
           }
 
+      }
+    ),
+    suite("fromOutputStream")(
+      test("writes to byte array ouput stream") {
+        val data = (0 to 100).mkString
+
+        for {
+          bytes  <- Task(data.getBytes("UTF-8"))
+          os      = new ByteArrayOutputStream(data.length)
+          length <- ZStream.fromIterable(bytes).run(ZSink.fromOutputStream(os))
+          str    <- Task(os.toString())
+        } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
       }
     )
   )

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
@@ -32,7 +32,7 @@ object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
           bytes  <- Task(data.getBytes("UTF-8"))
           os      = new ByteArrayOutputStream(data.length)
           length <- ZStream.fromIterable(bytes).run(ZSink.fromOutputStream(os))
-          str    <- Task(os.toString())
+          str    <- Task(os.toString("UTF-8"))
         } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
       }
     )

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
@@ -1,0 +1,26 @@
+package zio.stream.experimental
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import java.io.ByteArrayOutputStream
+
+object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
+
+  override def spec: ZSpec[Any, Throwable] = suite("ZSink JVM experimental")(
+    suite("fromOutputStream")(
+      test("writes to byte array output stream") {
+        val data = (0 to 100).mkString
+
+        for {
+          bytes  <- Task(data.getBytes("UTF-8"))
+          os      = new ByteArrayOutputStream(data.length)
+          length <- ZStream.fromIterable(bytes).run(ZSink.fromOutputStream(os))
+          str    <- Task(os.toString())
+        } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
+      }
+
+    )
+  )
+
+}

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
@@ -19,7 +19,6 @@ object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
           str    <- Task(os.toString("UTF-8"))
         } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
       }
-
     )
   )
 

--- a/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/experimental/ZSinkPlatformSpecificSpec.scala
@@ -16,7 +16,7 @@ object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
           bytes  <- Task(data.getBytes("UTF-8"))
           os      = new ByteArrayOutputStream(data.length)
           length <- ZStream.fromIterable(bytes).run(ZSink.fromOutputStream(os))
-          str    <- Task(os.toString())
+          str    <- Task(os.toString("UTF-8"))
         } yield assert(data)(equalTo(str)) && assert(bytes.length.toLong)(equalTo(length))
       }
 

--- a/streams/js/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/experimental/platform.scala
@@ -200,3 +200,7 @@ trait ZStreamPlatformSpecificConstructors {
 
   trait ZStreamConstructorPlatformSpecific extends ZStreamConstructorLowPriority1
 }
+
+trait ZSinkPlatformSpecificConstructors {
+  self: ZSink.type =>
+}

--- a/streams/js/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/experimental/platform.scala
@@ -201,6 +201,4 @@ trait ZStreamPlatformSpecificConstructors {
   trait ZStreamConstructorPlatformSpecific extends ZStreamConstructorLowPriority1
 }
 
-trait ZSinkPlatformSpecificConstructors {
-  self: ZSink.type =>
-}
+trait ZSinkPlatformSpecificConstructors

--- a/streams/native/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/experimental/platform.scala
@@ -200,3 +200,7 @@ trait ZStreamPlatformSpecificConstructors {
 
   trait ZStreamConstructorPlatformSpecific extends ZStreamConstructorLowPriority1
 }
+
+trait ZSinkPlatformSpecificConstructors {
+  self: ZSink.type =>
+}

--- a/streams/native/src/main/scala/zio/stream/experimental/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/experimental/platform.scala
@@ -201,6 +201,4 @@ trait ZStreamPlatformSpecificConstructors {
   trait ZStreamConstructorPlatformSpecific extends ZStreamConstructorLowPriority1
 }
 
-trait ZSinkPlatformSpecificConstructors {
-  self: ZSink.type =>
-}
+trait ZSinkPlatformSpecificConstructors

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -499,7 +499,7 @@ class ZSink[-R, -InErr, -In, +OutErr, +L, +Z](val channel: ZChannel[R, InErr, Ch
     new ZSink(channel.provide(r))
 }
 
-object ZSink {
+object ZSink extends ZSinkPlatformSpecificConstructors {
 
   /**
    * Accesses the environment of the sink in the context of a sink.


### PR DESCRIPTION
Resolves #5867 

**Summary** 

- It is a copy&paste of non-experimental implementation
- In the first place, I added one successful test for the original `ZSink.fromOutputStream`, because there was no any.
- Added the same test for experimental implementation.
