### PR TITLE
Add injectSome warning when not given a type

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacros.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacros.scala
@@ -1,6 +1,7 @@
 package zio.internal.macros
 
 import zio._
+import zio.internal.ansi.AnsiStringOps
 
 import scala.reflect.macros.blackbox
 
@@ -12,10 +13,12 @@ private[zio] class LayerMacros(val c: blackbox.Context) extends LayerMacroUtils 
   ): c.Expr[F[Any, E, A]] =
     injectBaseImpl[F, Any, R, E, A](layers, "provideLayer")
 
-  def injectSomeImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
+  def injectSomeImpl[F[_, _, _], R0 <: Has[_]: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layers: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[F[R0, E, A]] =
+  ): c.Expr[F[R0, E, A]] = {
+    assertEnvIsNotNothing[R0]()
     injectBaseImpl[F, R0, R, E, A](layers, "provideLayer")
+  }
 
   def debugGetRequirements[R: c.WeakTypeTag]: c.Expr[List[String]] =
     c.Expr[List[String]](q"${getRequirements[R]}")
@@ -24,6 +27,29 @@ private[zio] class LayerMacros(val c: blackbox.Context) extends LayerMacroUtils 
     val string = CleanCodePrinter.show(c)(any)
     c.Expr[String](q"$string")
   }
+
+  /**
+   * Ensures the macro has been annotated with the intended result type.
+   * The macro will not behave correctly otherwise.
+   */
+  private def assertEnvIsNotNothing[R <: Has[_]: c.WeakTypeTag](): Unit = {
+    val outType     = weakTypeOf[R]
+    val nothingType = weakTypeOf[Nothing]
+    val emptyHas    = weakTypeOf[Has[_]]
+    if (outType =:= nothingType || outType =:= emptyHas) {
+      val errorMessage =
+        s"""
+${"  ZLayer Wiring Error  ".red.bold.inverted}
+        
+You must provide a type to ${"injectSome".cyan.bold} (e.g. ${"foo.injectSome".cyan.bold}${"[Has[UserService] with Has[Config]".red.bold.underlined}${"(AnotherService.live)".cyan.bold})
+
+This type represents the services you are ${"not".underlined} currently injecting, leaving them in the environment until later.
+
+"""
+      c.abort(c.enclosingPosition, errorMessage)
+    }
+  }
+
 }
 
 private[zio] object MacroUnitTestUtils {


### PR DESCRIPTION
`.injectSome` needs a type ascription, denoting the remainder. Currently it does not give a useful error if this is forgotten. Now it will 😺 

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/7587245/139538454-ddd7ee9c-6262-40bd-840f-46bba6364389.png">
