### PR TITLE
Implement `ZSink#raceBoth`

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/SinkUtils.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/SinkUtils.scala
@@ -1,0 +1,37 @@
+package zio.stream.experimental
+
+import zio.test.Assertion.equalTo
+import zio.test.{Assertion, TestResult, assert}
+import zio.{IO, UIO}
+
+object SinkUtils {
+
+  def findSink[A](a: A): ZSink[Any, Nothing, A, Unit, A, A] =
+    ZSink
+      .fold[Nothing, A, Option[A]](None)(_.isEmpty)((_, v) => if (a == v) Some(a) else None)
+      .mapZIO {
+        case Some(v) => IO.succeedNow(v)
+        case None    => IO.fail(())
+      }
+
+  def sinkRaceLaw[E, A, L](
+    stream: ZStream[Any, Nothing, A],
+    s1: ZSink[Any, Nothing, A, E, L, A],
+    s2: ZSink[Any, Nothing, A, E, L, A]
+  ): UIO[TestResult] =
+    for {
+      r1 <- stream.run(s1).either
+      r2 <- stream.run(s2).either
+      r  <- stream.run(s1.raceBoth(s2)).either
+    } yield {
+      r match {
+        case Left(_) => assert(r1)(Assertion.isLeft) || assert(r2)(Assertion.isLeft)
+        case Right(v) => {
+          v match {
+            case Left(w)  => assert(Right(w))(equalTo(r1))
+            case Right(w) => assert(Right(w))(equalTo(r2))
+          }
+        }
+      }
+    }
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZSinkSpec.scala
@@ -2,6 +2,7 @@ package zio.stream.experimental
 
 import zio._
 import zio.stream.internal.CharacterSet._
+import zio.stream.experimental.SinkUtils._
 import zio.test.Assertion._
 import zio.test.TestAspect.jvmOnly
 import zio.test._
@@ -656,12 +657,16 @@ object ZSinkSpec extends ZIOBaseSpec {
         }
       ),
       suite("Combinators")(
-        //      test("raceBoth") {
-        //        check(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
-        //          val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
-        //          sinkRaceLaw(ZStream.fromIterable(Random.shuffle(stream)), findSink(20), findSink(40))
-        //        }
-        //      },
+        test("raceBoth") {
+          check(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>
+            val stream = ints ++ (if (success1) List(20) else Nil) ++ (if (success2) List(40) else Nil)
+            sinkRaceLaw(
+              ZStream.fromIterableZIO(Random.shuffle(stream).provideLayer(Random.live)),
+              findSink(20),
+              findSink(40)
+            )
+          }
+        },
         //      suite("zipWithPar")(
         //        test("coherence") {
         //          check(Gen.listOf(Gen.int(0, 10)), Gen.boolean, Gen.boolean) { (ints, success1, success2) =>

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -1486,17 +1486,17 @@ object ZChannel {
     }
 
   def toHub[Err, Done, Elem](
-    hub: Hub[Exit[Either[Err, Done], Elem]]
+    hub: Hub[Either[Exit[Err, Done], Elem]]
   )(implicit trace: ZTraceElement): ZChannel[Any, Err, Elem, Done, Nothing, Nothing, Any] =
     toQueue(hub.toQueue)
 
   def toQueue[Err, Done, Elem](
-    queue: Enqueue[Exit[Either[Err, Done], Elem]]
+    queue: Enqueue[Either[Exit[Err, Done], Elem]]
   )(implicit trace: ZTraceElement): ZChannel[Any, Err, Elem, Done, Nothing, Nothing, Any] =
     ZChannel.readWithCause(
-      (in: Elem) => ZChannel.fromZIO(queue.offer(Exit.succeed(in))) *> toQueue(queue),
-      (cause: Cause[Err]) => ZChannel.fromZIO(queue.offer(Exit.failCause(cause.map(Left(_))))),
-      (done: Done) => ZChannel.fromZIO(queue.offer(Exit.fail(Right(done))))
+      (in: Elem) => ZChannel.fromZIO(queue.offer(Right(in))) *> toQueue(queue),
+      (cause: Cause[Err]) => ZChannel.fromZIO(queue.offer(Left(Exit.failCause(cause)))),
+      (done: Done) => ZChannel.fromZIO(queue.offer(Left(Exit.succeed(done))))
     )
 
   private[zio] sealed trait MergeState[Env, Err, Err1, Err2, Elem, Done, Done1, Done2]

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -342,7 +342,12 @@ class ZSink[-R, -InErr, -In, +OutErr, +L, +Z](val channel: ZChannel[R, InErr, Ch
   final def raceBoth[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
     that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
   )(implicit trace: ZTraceElement): ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]] =
-    ???
+    new ZSink(
+      self.channel.mergeWith(that.channel)(
+        selfDone => ZChannel.MergeDecision.done(ZIO.done(selfDone).map(Left(_))),
+        thatDone => ZChannel.MergeDecision.done(ZIO.done(thatDone).map(Right(_)))
+      )
+    )
 
   /**
    * Returns the sink that executes this one and times its execution.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -341,13 +341,24 @@ class ZSink[-R, -InErr, -In, +OutErr, +L, +Z](val channel: ZChannel[R, InErr, Ch
    */
   final def raceBoth[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
     that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
-  )(implicit trace: ZTraceElement): ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]] =
-    new ZSink(
-      self.channel.mergeWith(that.channel)(
-        selfDone => ZChannel.MergeDecision.done(ZIO.done(selfDone).map(Left(_))),
-        thatDone => ZChannel.MergeDecision.done(ZIO.done(thatDone).map(Right(_)))
-      )
-    )
+  )(implicit trace: ZTraceElement): ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]] = {
+    val managed =
+      for {
+        hub   <- ZHub.bounded[Either[Exit[InErr1, Any], Chunk[In1]]](1).toManaged
+        c1    <- ZChannel.fromHubManaged(hub)
+        c2    <- ZChannel.fromHubManaged(hub)
+        reader = ZChannel.toHub(hub)
+        writer = (c1 >>> self.channel).mergeWith(c2 >>> that.channel)(
+                   selfDone => ZChannel.MergeDecision.done(ZIO.done(selfDone).map(Left(_))),
+                   thatDone => ZChannel.MergeDecision.done(ZIO.done(thatDone).map(Right(_)))
+                 )
+        channel = reader.mergeWith(writer)(
+                    _ => ZChannel.MergeDecision.await(ZIO.done(_)),
+                    done => ZChannel.MergeDecision.done(ZIO.done(done))
+                  )
+      } yield new ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]](channel)
+    ZSink.unwrapManaged(managed)
+  }
 
   /**
    * Returns the sink that executes this one and times its execution.

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZSink.scala
@@ -340,11 +340,12 @@ class ZSink[-R, -InErr, -In, +OutErr, +L, +Z](val channel: ZChannel[R, InErr, Ch
    * one that finishes first.
    */
   final def raceBoth[R1 <: R, InErr1 <: InErr, OutErr1 >: OutErr, A0, In1 <: In, L1 >: L, Z1 >: Z](
-    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1]
+    that: ZSink[R1, InErr1, In1, OutErr1, L1, Z1],
+    capacity: Int = 16
   )(implicit trace: ZTraceElement): ZSink[R1, InErr1, In1, OutErr1, L1, Either[Z, Z1]] = {
     val managed =
       for {
-        hub   <- ZHub.bounded[Either[Exit[InErr1, Any], Chunk[In1]]](1).toManaged
+        hub   <- ZHub.bounded[Either[Exit[InErr1, Any], Chunk[In1]]](capacity).toManaged
         c1    <- ZChannel.fromHubManaged(hub)
         c2    <- ZChannel.fromHubManaged(hub)
         reader = ZChannel.toHub(hub)


### PR DESCRIPTION
This PR adds an implementation for `ZSink#raceBoth`.

Pretty new to `ZStream`, but to my understanding `ZChannel#mergeWith` does exactly what we need here.
For some reason the test is flaky in cases where both `success1` and `success2` are `true`.
Still trying to wrap my head around that, so any insight is welcome :slightly_smiling_face: 

Fixes #5864