### PR TITLE
Fixes - zio/zio#5875

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ project/secrets.tar.xz
 target
 test-output/
 .sbtopts
+.jvmopts
 project/.sbt
 test-output/
 .bloop

--- a/core-tests/shared/src/test/scala/zio/FiberContextSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberContextSpec.scala
@@ -1,0 +1,19 @@
+package zio
+
+import zio.test.ZSpec
+import zio.test._
+import zio.test.Assertion._
+
+object FiberContextSpec extends ZIOBaseSpec {
+  override def spec: ZSpec[Environment, Failure] =
+    suite("FiberContextSpec")(
+      testM("Get fiber and print fiber context info")(
+        for {
+          fiber <- ZIO.succeed(()).fork
+          info  <- ZIO.succeed({ println(fiber.toString()); fiber.toString() })
+          _     <- fiber.join
+        } yield assert(info)(containsString("FiberContext") && containsString("fiberId"))
+      )
+    )
+
+}

--- a/core/shared/src/main/scala/zio/internal/ExecutionMetrics.scala
+++ b/core/shared/src/main/scala/zio/internal/ExecutionMetrics.scala
@@ -47,4 +47,7 @@ abstract class ExecutionMetrics {
    * The number of current live worker threads.
    */
   def workersCount: Int
+
+  override def toString: String =
+    s"""ExecutionMetrics(concurrency=$concurrency, capacity=$capacity, size=$size, enqueuedCount=$enqueuedCount, dequeuedCount=$dequeuedCount, workersCount=$workersCount)""".stripMargin
 }

--- a/core/shared/src/main/scala/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/zio/internal/Executor.scala
@@ -66,6 +66,8 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
       if (submit(command)) ()
       else throw new java.util.concurrent.RejectedExecutionException
 
+  override def toString: String =
+    s"Executor(yieldOpCount=$yieldOpCount, metrics=${metrics.mkString})"
 }
 
 object Executor extends DefaultExecutors with Serializable {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1077,6 +1077,19 @@ private[zio] final class FiberContext[E, A](
     // For improved fairness, we resume in order of submission:
     observers.reverse.foreach(k => k(result))
   }
+
+  override def toString(): String =
+    s"""${super.toString()}
+       |  fiberId:         $fiberId
+       |  platform:        
+       |    executor:
+       |      yieldOpCount:   ${platform.executor.yieldOpCount}
+       |      metrics:        ${platform.executor.metrics.getOrElse("not tracked")}
+       |    tracing:       ${platform.tracing}
+       |  state:           $state
+       |  interruptStatus: ${InterruptStatus.fromBoolean(interruptStatus.peekOrElse(true))}
+       |  scopeKey:        ${scopeKey}
+    """.stripMargin
 }
 private[zio] object FiberContext {
   sealed abstract class FiberState[+E, +A] extends Serializable with Product {

--- a/core/shared/src/main/scala/zio/internal/Platform.scala
+++ b/core/shared/src/main/scala/zio/internal/Platform.scala
@@ -109,6 +109,9 @@ abstract class Platform { self =>
     new Platform.Proxy(self) {
       override def supervisor: Supervisor[Any] = s0
     }
+
+  override def toString: String =
+    s"Platform(executor=$executor, tracing=$tracing)"
 }
 object Platform extends PlatformSpecific {
   abstract class Proxy(self: Platform) extends Platform {


### PR DESCRIPTION
- Adds `.toString()` for a `FiberContext`,`ExecutionMetrics`, `Executor`, `Platform`

```
FiberContext(identityHashCode=521960438)
  fiberId:         Id(1635628369111,0)
  platform:        
    executor:
      yieldOpCount:   2048
      metrics:        ExecutionMetrics(concurrency=16, capacity=2147483647, size=0, enqueuedCount=0, dequeuedCount=0, workersCount=0)
    tracing:       Tracing(zio.internal.stacktracer.Tracer$$anon$1@212bf671,TracingConfig(true,true,true,100,100,10,10,10))
  state:           Executing(Running(false),List(),Empty)
  interruptStatus: Interruptible
  scopeKey:        null
```

Fixes - zio/zio#5875