### PR TITLE
Update contributing.md

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -60,7 +60,7 @@ compile
 You can compile the test source code with the following sbt command:
 
 ```bash
-test:compile
+Test/compile
 ```
 
 [Learn more](https://www.scala-sbt.org) about sbt to understand how you can list projects, switch projects, and otherwise manage an sbt project.


### PR DESCRIPTION
If you say:

sbt:zio> test:compile

You get a warning:

[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead:

The syntax that doesn't produce the warning is:

Test/compile