### PR TITLE
#5917 Improve regex deconstructing trace

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -1,31 +1,35 @@
 package zio
 
-import zio.test.{ZSpec, assertTrue}
+import zio.test.{AssertionValue, BoolAlgebra, ZSpec, assertTrue}
 
 object StackTracesSpec extends ZIOBaseSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("StackTracesSpec")(
     suite("captureSimpleCause")(
       test("captures a simple failure") {
-        val failure =
-          for {
-            _ <- ZIO.succeed(15)
-            _ <- ZIO.fail("Oh no!")
-          } yield ()
-
-        val run = failure.catchAllCause(cause => ZIO(cause.prettyPrint))
-
+        val failureStackTraceContent: IO[String, Nothing] => ZIO[Any, Serializable, String] = {
+          case fail: ZIO[Any, String, Unit] =>
+            fail.catchAllCause {
+              case c: Cause[String] => ZIO(c.prettyPrint)
+              case _                => UnsupportedTestPath
+            }
+          case _ => UnsupportedTestPath
+        }
+        val checkExpectations: String => Boolean = {
+          case stack: String =>
+            stack.startsWith("Exception in thread") &&
+              stack.contains("zio-fiber") &&
+              stack.contains("java.lang.String: Oh no!")
+          case _ => false
+        }
         for {
-          stackTrace <- run
-          result = stackTrace match {
-                     case stack: String =>
-                       stack.startsWith("Exception in thread") &&
-                         stack.contains("zio-fiber") &&
-                         stack.contains("java.lang.String: Oh no!")
-                     case _ => false
-                   }
+          _          <- ZIO.succeed(15)
+          stackTrace <- failureStackTraceContent(ZIO.fail("Oh no!"))
+          result      = checkExpectations(stackTrace)
         } yield assertTrue(result)
       }
     )
   )
+
+  private val UnsupportedTestPath = ZIO.fail("not considered scenario")
 }

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -7,7 +7,7 @@ object StackTracesSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("StackTracesSpec")(
     suite("captureSimpleCause")(
       test("captures a simple failure") {
-        val checkExpectations: String => Boolean = {
+        val meetsExpectations: String => Boolean = {
           case stack: String =>
             stack.startsWith("Exception in thread") && includesAll(Seq("zio-fiber", "java.lang.String: Oh no!"))(stack)
           case _ => false
@@ -22,8 +22,7 @@ object StackTracesSpec extends ZIOBaseSpec {
                             }
                           case _ => UnsupportedTestPath
                         }
-          result = checkExpectations(stackTrace)
-        } yield assertTrue(result)
+        } yield assertTrue(meetsExpectations(stackTrace))
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -17,9 +17,7 @@ object StackTracesSpec extends ZIOBaseSpec {
         }
         val checkExpectations: String => Boolean = {
           case stack: String =>
-            stack.startsWith("Exception in thread") &&
-              stack.contains("zio-fiber") &&
-              stack.contains("java.lang.String: Oh no!")
+            stack.startsWith("Exception in thread") && includesAll(Seq("zio-fiber", "java.lang.String: Oh no!"))(stack)
           case _ => false
         }
         for {
@@ -30,6 +28,8 @@ object StackTracesSpec extends ZIOBaseSpec {
       }
     )
   )
+
+  private def includesAll(texts: Seq[String]): String => Boolean = stack => texts.map(stack.contains).forall(r => r)
 
   private val UnsupportedTestPath = ZIO.fail("not considered scenario")
 }

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -7,22 +7,20 @@ object StackTracesSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("StackTracesSpec")(
     suite("captureSimpleCause")(
       test("captures a simple failure") {
-        val meetsExpectations: String => Boolean = {
-          case stack: String =>
-            stack.startsWith("Exception in thread") && includesAll(Seq("zio-fiber", "java.lang.String: Oh no!"))(stack)
-          case _ => false
-        }
         for {
           _ <- ZIO.succeed(15)
           stackTrace <- ZIO.fail("Oh no!") match {
-                          case fail: ZIO[Any, Serializable, String] =>
+                          case fail: ZIO[Any, String, Nothing] =>
                             fail.catchAllCause {
                               case c: Cause[String] => ZIO(c.prettyPrint)
                               case _                => UnsupportedTestPath
                             }
                           case _ => UnsupportedTestPath
                         }
-        } yield assertTrue(meetsExpectations(stackTrace))
+        } yield {
+          assertTrue(stackTrace.startsWith("Exception in thread")) &&
+          assertTrue(includesAll(Seq("zio-fiber", "java.lang.String: Oh no!"))(stackTrace))
+        }
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -1,6 +1,6 @@
 package zio
 
-import zio.test.{AssertionValue, BoolAlgebra, ZSpec, assertTrue}
+import zio.test.{ZSpec, assertTrue}
 
 object StackTracesSpec extends ZIOBaseSpec {
 

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -1,0 +1,31 @@
+package zio
+
+import zio.test.{ZSpec, assertTrue}
+
+object StackTracesSpec extends ZIOBaseSpec {
+
+  def spec: ZSpec[Environment, Failure] = suite("StackTracesSpec")(
+    suite("captureSimpleCause")(
+      test("captures a simple failure") {
+        val failure =
+          for {
+            _ <- ZIO.succeed(15)
+            _ <- ZIO.fail("Oh no!")
+          } yield ()
+
+        val run = failure.catchAllCause(cause => ZIO(cause.prettyPrint))
+
+        for {
+          stackTrace <- run
+          result = stackTrace match {
+                     case stack: String =>
+                       stack.startsWith("Exception in thread") &&
+                         stack.contains("zio-fiber") &&
+                         stack.contains("java.lang.String: Oh no!")
+                     case _ => false
+                   }
+        } yield assertTrue(result)
+      }
+    )
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -7,23 +7,22 @@ object StackTracesSpec extends ZIOBaseSpec {
   def spec: ZSpec[Environment, Failure] = suite("StackTracesSpec")(
     suite("captureSimpleCause")(
       test("captures a simple failure") {
-        val failureStackTraceContent: IO[String, Nothing] => ZIO[Any, Serializable, String] = {
-          case fail: ZIO[Any, String, Unit] =>
-            fail.catchAllCause {
-              case c: Cause[String] => ZIO(c.prettyPrint)
-              case _                => UnsupportedTestPath
-            }
-          case _ => UnsupportedTestPath
-        }
         val checkExpectations: String => Boolean = {
           case stack: String =>
             stack.startsWith("Exception in thread") && includesAll(Seq("zio-fiber", "java.lang.String: Oh no!"))(stack)
           case _ => false
         }
         for {
-          _          <- ZIO.succeed(15)
-          stackTrace <- failureStackTraceContent(ZIO.fail("Oh no!"))
-          result      = checkExpectations(stackTrace)
+          _ <- ZIO.succeed(15)
+          stackTrace <- ZIO.fail("Oh no!") match {
+                          case fail: ZIO[Any, Serializable, String] =>
+                            fail.catchAllCause {
+                              case c: Cause[String] => ZIO(c.prettyPrint)
+                              case _                => UnsupportedTestPath
+                            }
+                          case _ => UnsupportedTestPath
+                        }
+          result = checkExpectations(stackTrace)
         } yield assertTrue(result)
       }
     )
@@ -31,5 +30,5 @@ object StackTracesSpec extends ZIOBaseSpec {
 
   private def includesAll(texts: Seq[String]): String => Boolean = stack => texts.map(stack.contains).forall(r => r)
 
-  private val UnsupportedTestPath = ZIO.fail("not considered scenario")
+  private val UnsupportedTestPath: Task[String] = ZIO("not considered scenario")
 }

--- a/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Tracer.scala
+++ b/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Tracer.scala
@@ -26,7 +26,7 @@ object Tracer {
   private[internal] def createTrace(location: String, file: String, line: Int, column: Int): String =
     s"$location($file:$line:$column)".intern
 
-  private val regex = """(.*?)\((.*?):(.*?):(.*?)\)""".r
+  private val regex = """(.*?)\((.*?):([^:]*?):([^:]*?)\)""".r
 }
 
 sealed trait Tracer {

--- a/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Tracer.scala
+++ b/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Tracer.scala
@@ -8,7 +8,7 @@ object Tracer {
    * implicitly required (or the method is explicitly called)
    *
    * This can be disabled by importing
-   * `import zio.stacktracer.TracingImplicits.disableAutoTrace``
+   * `import zio.stacktracer.TracingImplicits.disableAutoTrace`
    */
   inline given autoTrace: Tracer.instance.Type =
     ${Macros.autoTraceImpl}
@@ -36,12 +36,12 @@ object Tracer {
   private[internal] def createTrace(location: String, file: String, line: Int, column: Int): String =
     s"$location($file:$line:$column)".intern
 
-  private val regex = """(.*?)\((.*?):(.*?):(.*?)\)""".r
+  private val regex = """(.*?)\((.*?):([^:]*?):([^:]*?)\)""".r
 }
 
 sealed trait Tracer {
   type Type <: AnyRef
   val empty: Type
   def unapply(trace: Type): Option[(String, String, Int, Int)]
-  def apply(location: String, file: String, line: Int, column: Int): Type with Tracer.Traced 
+  def apply(location: String, file: String, line: Int, column: Int): Type with Tracer.Traced
 }


### PR DESCRIPTION
Here is a fixed regular expression for deconstructing ZTraceElement. It's tested on Windows platform. 
A test runs fine from IntelliJ. Additional tests introduced here: https://github.com/zio/zio/pull/5949.

Fixes #5917
Fixes #5914