### PR TITLE
BitChunk binary operations

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.random.Random
 import zio.test.Assertion._
+import zio.test.TestAspect.samples
 import zio.test._
 
 object BitChunkSpec extends ZIOBaseSpec {
@@ -198,7 +199,7 @@ object BitChunkSpec extends ZIOBaseSpec {
                 assert(actual)(equalTo(expected))
             }
         }
-      },
+      } @@ samples(20),
       testM("works the same when sliced") {
         val gen = for {
           operator      <- genBitwiseOperator
@@ -209,26 +210,20 @@ object BitChunkSpec extends ZIOBaseSpec {
           rightBitsTake <- Gen.int(0, rightBits.size)
           rightBitsDrop <- Gen.int(0, rightBits.size - rightBitsTake)
         } yield (operator, leftBits, leftBitsTake, leftBitsDrop, rightBits, rightBitsTake, rightBitsDrop)
-        checkM(gen) { case (bitwiseOp, leftBits, leftBitsTake, leftBitsDrop, rightBits, rightBitsTake, rightBitsDrop) =>
+        check(gen) { case (bitwiseOp, leftBits, leftBitsTake, leftBitsDrop, rightBits, rightBitsTake, rightBitsDrop) =>
           val expected = bitwiseOp(
             leftBits.take(leftBitsTake).drop(leftBitsDrop),
             rightBits.take(rightBitsTake).drop(rightBitsDrop)
           ).toBinaryString
-          check(
-            Gen.elements(
-              compressed(leftBits) -> rightBits,
-              leftBits             -> compressed(rightBits),
-              compressed(leftBits) -> compressed(rightBits)
-            )
-          ) { case (left, right) =>
-            val actual = bitwiseOp(
-              left.take(leftBitsTake).drop(leftBitsDrop),
-              right.take(rightBitsTake).drop(rightBitsDrop)
-            ).toBinaryString
-            assert(actual)(equalTo(expected))
-          }
+          val left  = compressed(leftBits)
+          val right = compressed(rightBits)
+          val actual = bitwiseOp(
+            left.take(leftBitsTake).drop(leftBitsDrop),
+            right.take(rightBitsTake).drop(rightBitsDrop)
+          ).toBinaryString
+          assert(actual)(equalTo(expected))
         }
-      }
+      } @@ samples(20)
     )
   )
 }

--- a/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
@@ -11,7 +11,8 @@ object BitChunkSpec extends ZIOBaseSpec {
       bytes <- Gen.listOf(Gen.anyByte)
     } yield Chunk.fromIterable(bytes)
 
-  def genInefficientBooleanChunk(multipleOf: Int = 1): Gen[Random with Sized, Chunk[Boolean]] = Gen.listOf(Gen.listOfN(multipleOf)(Gen.boolean)).map(bits => Chunk.fromIterable(bits.flatten))
+  def genInefficientBooleanChunk(multipleOf: Int = 1): Gen[Random with Sized, Chunk[Boolean]] =
+    Gen.listOf(Gen.listOfN(multipleOf)(Gen.boolean)).map(bits => Chunk.fromIterable(bits.flatten))
 
   val genInt: Gen[Random with Sized, Int] =
     Gen.small(Gen.const(_))
@@ -86,7 +87,7 @@ object BitChunkSpec extends ZIOBaseSpec {
       },
       testM("&") {
         check(genInefficientBooleanChunk(8), genInefficientBooleanChunk(8)) { case (leftBits, rightBits) =>
-          val actual = (compressed(leftBits) & compressed(rightBits)).toBinaryString
+          val actual   = (compressed(leftBits) & compressed(rightBits)).toBinaryString
           val expected = (leftBits & rightBits).toBinaryString
           assert(actual)(equalTo(expected))
         }
@@ -99,7 +100,7 @@ object BitChunkSpec extends ZIOBaseSpec {
       },
       testM("|") {
         check(genInefficientBooleanChunk(8), genInefficientBooleanChunk(8)) { case (leftBits, rightBits) =>
-          val actual = (compressed(leftBits) | compressed(rightBits)).toBinaryString
+          val actual   = (compressed(leftBits) | compressed(rightBits)).toBinaryString
           val expected = (leftBits | rightBits).toBinaryString
           assert(actual)(equalTo(expected))
         }
@@ -112,20 +113,20 @@ object BitChunkSpec extends ZIOBaseSpec {
       },
       testM("^") {
         check(genInefficientBooleanChunk(8), genInefficientBooleanChunk(8)) { case (leftBits, rightBits) =>
-          val actual = (compressed(leftBits) ^ compressed(rightBits)).toBinaryString
+          val actual   = (compressed(leftBits) ^ compressed(rightBits)).toBinaryString
           val expected = (leftBits ^ rightBits).toBinaryString
           assert(actual)(equalTo(expected))
         }
       },
       test("~ simple") {
         val bits = bytesFromBigEndianBits(true, false, true, false, true, true, true, false, true).asBits
-        val e = bytesFromBigEndianBits(true, true, true, true, true, true, true,
-          false, true, false, true, false, false, false, true, false).asBits
+        val e = bytesFromBigEndianBits(true, true, true, true, true, true, true, false, true, false, true, false, false,
+          false, true, false).asBits
         assert(~bits)(equalTo(e))
       },
       testM("~") {
         check(genByteChunk) { bytes =>
-          val actual = (~bytes.asBits).toBinaryString
+          val actual   = (~bytes.asBits).toBinaryString
           val expected = bytes.map(b => (~b).toByte).map(toBinaryString).mkString
           assert(actual)(equalTo(expected))
         }
@@ -134,14 +135,16 @@ object BitChunkSpec extends ZIOBaseSpec {
         val genOperator = Gen.elements(
           (left: Chunk[Boolean], right: Chunk[Boolean]) => left & right,
           (left: Chunk[Boolean], right: Chunk[Boolean]) => left | right,
-          (left: Chunk[Boolean], right: Chunk[Boolean]) => left ^ right,
+          (left: Chunk[Boolean], right: Chunk[Boolean]) => left ^ right
         )
-        checkM(genOperator, genInefficientBooleanChunk(8), genInefficientBooleanChunk(8)) { case (bitwiseOp, leftBits, rightBits) =>
-          val expected = bitwiseOp(leftBits, rightBits).toBinaryString
-          check(Gen.elements(compressed(leftBits) -> rightBits, leftBits -> compressed(rightBits))) { case (left, right) =>
-            val actual = bitwiseOp(left, right).toBinaryString
-            assert(actual)(equalTo(expected))
-          }
+        checkM(genOperator, genInefficientBooleanChunk(8), genInefficientBooleanChunk(8)) {
+          case (bitwiseOp, leftBits, rightBits) =>
+            val expected = bitwiseOp(leftBits, rightBits).toBinaryString
+            check(Gen.elements(compressed(leftBits) -> rightBits, leftBits -> compressed(rightBits))) {
+              case (left, right) =>
+                val actual = bitwiseOp(left, right).toBinaryString
+                assert(actual)(equalTo(expected))
+            }
         }
       }
     )

--- a/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkSpec.scala
@@ -13,12 +13,6 @@ object BitChunkSpec extends ZIOBaseSpec {
 
   def genInefficientBooleanChunk(multipleOf: Int = 1): Gen[Random with Sized, Chunk[Boolean]] = Gen.listOf(Gen.listOfN(multipleOf)(Gen.boolean)).map(bits => Chunk.fromIterable(bits.flatten))
 
-  val genByteSizedBitChunk: Gen[Random with Sized, Chunk[Boolean]] = {
-    val inefficientStorage = Gen.listOf(Gen.listOfN(8)(Gen.boolean)).map(bits => Chunk.fromIterable(bits.flatten))
-    val efficientStorage = genByteChunk.map(_.asBits)
-    Gen.oneOf(inefficientStorage, efficientStorage)
-  }
-
   val genInt: Gen[Random with Sized, Int] =
     Gen.small(Gen.const(_))
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1766,17 +1766,17 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override private[zio] def reverseArrayIterator[A1 >: Boolean]: Iterator[Array[A1]] =
       arrayIterator
 
-    def &(that: BitChunk): BitChunk = binaryOp(that)(_ => 0, _ => 0)((a: Byte, b: Byte) => (a & b).toByte)
+    def &(that: BitChunk): BitChunk = byteWiseOp(that)(_ => 0, _ => 0)((a: Byte, b: Byte) => (a & b).toByte)
 
-    def |(that: BitChunk): BitChunk = binaryOp(that)(identity, identity)((a: Byte, b: Byte) => (a | b).toByte)
+    def |(that: BitChunk): BitChunk = byteWiseOp(that)(identity, identity)((a: Byte, b: Byte) => (a | b).toByte)
 
-    def ^(that: BitChunk): BitChunk = binaryOp(that)(identity, identity)((a: Byte, b: Byte) => (a ^ b).toByte)
+    def ^(that: BitChunk): BitChunk = byteWiseOp(that)(identity, identity)((a: Byte, b: Byte) => (a ^ b).toByte)
 
     def unary_~ : BitChunk =
       BitChunk(bytes.mapChunk(b => (~b).toByte), minBitIndex, maxBitIndex)
 
-    private def binaryOp(that: BitChunk)(left: Byte => Byte, right: Byte => Byte)(both: (Byte, Byte) => Byte): BitChunk =
-      BitChunk(this.bytes.zipAllWith(that.bytes)(left, right)(both), this.minBitIndex.min(that.minBitIndex), this.maxBitIndex.max(that.maxBitIndex))
+    private def byteWiseOp(that: BitChunk)(left: Byte => Byte, right: Byte => Byte)(both: (Byte, Byte) => Byte): BitChunk =
+      BitChunk(this.bytes.zipAllWith(that.bytes)(left, right)(both), minBitIndex min that.minBitIndex, maxBitIndex max that.maxBitIndex)
   }
 
   private case object Empty extends Chunk[Nothing] { self =>

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1777,24 +1777,30 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
     override def &(that: Chunk[Boolean])(implicit ev: Boolean <:< Boolean): Chunk[Boolean] = that match {
       case thatBitChunk: BitChunk => byteWiseOp(thatBitChunk)(_ => 0, _ => 0)((a: Byte, b: Byte) => (a & b).toByte)
-      case that => super.&(that)
+      case that                   => super.&(that)
     }
 
     override def |(that: Chunk[Boolean])(implicit ev: Boolean <:< Boolean): Chunk[Boolean] = that match {
       case thatBitChunk: BitChunk => byteWiseOp(thatBitChunk)(identity, identity)((a: Byte, b: Byte) => (a | b).toByte)
-      case that => super.|(that)
+      case that                   => super.|(that)
     }
 
     override def ^(that: Chunk[Boolean])(implicit ev: Boolean <:< Boolean): Chunk[Boolean] = that match {
       case thatBitChunk: BitChunk => byteWiseOp(thatBitChunk)(identity, identity)((a: Byte, b: Byte) => (a ^ b).toByte)
-      case that => super.^(that)
+      case that                   => super.^(that)
     }
 
-    override def unary_~(implicit ev: Boolean <:< Boolean) : BitChunk =
+    override def unary_~(implicit ev: Boolean <:< Boolean): BitChunk =
       BitChunk(bytes.mapChunk(b => (~b).toByte), minBitIndex, maxBitIndex)
 
-    private def byteWiseOp(that: BitChunk)(left: Byte => Byte, right: Byte => Byte)(both: (Byte, Byte) => Byte): BitChunk =
-      BitChunk(this.bytes.zipAllWith(that.bytes)(left, right)(both), minBitIndex min that.minBitIndex, maxBitIndex max that.maxBitIndex)
+    private def byteWiseOp(
+      that: BitChunk
+    )(left: Byte => Byte, right: Byte => Byte)(both: (Byte, Byte) => Byte): BitChunk =
+      BitChunk(
+        this.bytes.zipAllWith(that.bytes)(left, right)(both),
+        minBitIndex min that.minBitIndex,
+        maxBitIndex max that.maxBitIndex
+      )
   }
 
   private case object Empty extends Chunk[Nothing] { self =>


### PR DESCRIPTION
Deals with requirement 5 of [#5050](https://github.com/zio/zio/issues/5050).
I see some problems with this solution that I would like help with.

1. Chunk.BitChunk is now exposed in `Chunk#asBits`, I'm not even sure if that will work since `BitChunk` is private.
**Update**: I added the bitwise operations to `Chunk[Boolean]` and override them in `Chunk.BitChunk`. `Chunk.BitChunk` is now hidden again.
2. I added a `Chunk.fromBits(bits: Boolean*): Chunk.BitChunk` constructor that assumes big endian bit-endianness. This constructor was mostly for tests, maybe it should be moved to `BitChunkSpec`?
**Update**:  I moved the `fromBits` constructor to `BitChunkSpec`.
