### PR TITLE
Fix Stack Traces

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -107,7 +107,7 @@ object StackTracesSpec extends ZIOBaseSpec {
   )
 
   // set to true to print traces
-  private val debug = true
+  private val debug = false
 
   private def show(trace: => Cause[Any]): Unit = if (debug) println(trace.prettyPrint)
 

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -107,7 +107,7 @@ object StackTracesSpec extends ZIOBaseSpec {
   )
 
   // set to true to print traces
-  private val debug = false
+  private val debug = true
 
   private def show(trace: => Cause[Any]): Unit = if (debug) println(trace.prettyPrint)
 


### PR DESCRIPTION
Resolves #5955.

Output of sample traces after this PR:

```
Exception in thread "zio-fiber-1635720897" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.value(StackTracesSpec.scala:12)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:125)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:13)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:9)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:27)
Exception in thread "zio-fiber-1635720897" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:26)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:26)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:26)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:32)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:32)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:125)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:38)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:22)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:27)
        Suppressed: java.lang.RuntimeException: deep failure

                Suppressed: java.lang.RuntimeException: other failure

Exception in thread "zio-fiber-1635720897" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:89)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:89)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:89)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:125)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:95)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:85)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:27)
        Suppressed: java.lang.RuntimeException: other failure

Exception in thread "zio-fiber-1635720897" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:58)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:58)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:58)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:64)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:125)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:70)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:54)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:27)
        Suppressed: java.lang.RuntimeException: deep failure
```