### PR TITLE
Feature/5882

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1381,8 +1381,7 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("onExecutor")(
       test("effects continue on current executor if no executor is specified") {
-        val getExecutor = ZIO.descriptor.map(_.executor)
-        val thread      = ZIO.succeed(Thread.currentThread())
+        val thread = ZIO.succeed(Thread.currentThread())
 
         val global =
           Executor.fromExecutionContext(RuntimeConfig.defaultYieldOpCount)(scala.concurrent.ExecutionContext.global)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1381,12 +1381,19 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("onExecutor")(
       test("effects continue on current executor if no executor is specified") {
+        val getExecutor = ZIO.descriptor.map(_.executor)
+        val thread      = ZIO.succeed(Thread.currentThread())
+
         val global =
           Executor.fromExecutionContext(RuntimeConfig.defaultYieldOpCount)(scala.concurrent.ExecutionContext.global)
         for {
-          _        <- ZIO.unit.onExecutor(global)
-          executor <- ZIO.descriptor.map(_.executor)
-        } yield assert(executor)(equalTo(global))
+          which   <- Ref.make[Option[Thread]](None)
+          beforeL <- ZIO.descriptor.map(_.isLocked)
+          _       <- thread.flatMap(t => which.set(Some(t))).onExecutor(global)
+          after   <- thread
+          during  <- which.get.some
+          afterL  <- ZIO.descriptor.map(_.isLocked)
+        } yield assert(beforeL)(isFalse) && assert(afterL)(isFalse) && assert(during)(equalTo(after))
       },
       test("effects are shifted back if executor is specified") {
         val default = RuntimeConfig.default.executor

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -501,23 +501,18 @@ object ZManagedSpec extends ZIOBaseSpec {
           assert(after)(equalTo(default))
       },
       test("does not shift back to original executor if it was not locked") {
-        val executor: UIO[Executor] = ZIO.descriptorWith(descriptor => ZIO.succeedNow(descriptor.executor))
-        val global                  = Executor.fromExecutionContext(100)(ExecutionContext.global)
+        val thread = ZIO.succeed(Thread.currentThread())
+
+        val global =
+          Executor.fromExecutionContext(RuntimeConfig.defaultYieldOpCount)(scala.concurrent.ExecutionContext.global)
         for {
-          default <- executor
-          ref1    <- Ref.make[Executor](default)
-          ref2    <- Ref.make[Executor](default)
-          managed  = ZManaged.acquireRelease(executor.flatMap(ref1.set))(executor.flatMap(ref2.set)).onExecutor(global)
-          before  <- executor
-          use     <- managed.useDiscard(executor)
-          acquire <- ref1.get
-          release <- ref2.get
-          after   <- executor
-        } yield assert(before)(equalTo(default)) &&
-          assert(acquire)(equalTo(global)) &&
-          assert(use)(equalTo(global)) &&
-          assert(release)(equalTo(global)) &&
-          assert(after)(equalTo(global))
+          which   <- Ref.make[Option[Thread]](None)
+          beforeL <- ZIO.descriptor.map(_.isLocked)
+          _       <- thread.flatMap(t => which.set(Some(t))).toManaged.onExecutor(global).useDiscard(ZIO.unit)
+          after   <- thread
+          during  <- which.get.some
+          afterL  <- ZIO.descriptor.map(_.isLocked)
+        } yield assert(beforeL)(isFalse) && assert(afterL)(isFalse) && assert(during)(equalTo(after))
       }
     ),
     suite("mergeAll")(

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.{FiberContext, Platform}
+import zio.internal.{FiberContext, Platform, StackBool}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.concurrent.Future
@@ -302,7 +302,7 @@ trait Runtime[+R] {
     lazy val context: FiberContext[E, A] = new FiberContext[E, A](
       fiberId,
       runtimeConfig,
-      InterruptStatus.Interruptible,
+      StackBool(InterruptStatus.Interruptible.toBoolean),
       new java.util.concurrent.atomic.AtomicReference(
         Map(FiberContext.currentEnvironment -> environment.asInstanceOf[AnyRef])
       ),

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -303,7 +303,6 @@ trait Runtime[+R] {
       fiberId,
       runtimeConfig,
       environment.asInstanceOf[AnyRef],
-      false,
       InterruptStatus.Interruptible,
       new java.util.concurrent.atomic.AtomicReference(Map.empty),
       scope

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -302,9 +302,10 @@ trait Runtime[+R] {
     lazy val context: FiberContext[E, A] = new FiberContext[E, A](
       fiberId,
       runtimeConfig,
-      environment.asInstanceOf[AnyRef],
       InterruptStatus.Interruptible,
-      new java.util.concurrent.atomic.AtomicReference(Map.empty),
+      new java.util.concurrent.atomic.AtomicReference(
+        Map(FiberContext.currentEnvironment -> environment.asInstanceOf[AnyRef])
+      ),
       scope
     )
 

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -303,7 +303,6 @@ trait Runtime[+R] {
       fiberId,
       runtimeConfig,
       environment.asInstanceOf[AnyRef],
-      runtimeConfig.executor,
       false,
       InterruptStatus.Interruptible,
       new java.util.concurrent.atomic.AtomicReference(Map.empty),

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -121,7 +121,6 @@ private[zio] final class FiberContext[E, A](
     while (unwinding && !stack.isEmpty) {
       stack.pop() match {
         case _: InterruptExit =>
-          // do not remove InterruptExit from stack trace as it was not added
           interruptStatus.popDrop(())
 
         case finalizer: Finalizer =>

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -30,9 +30,9 @@ import scala.annotation.{switch, tailrec}
  * An implementation of Fiber that maintains context necessary for evaluation.
  */
 private[zio] final class FiberContext[E, A](
-  protected val fiberId: FiberId.Runtime,
+  val fiberId: FiberId.Runtime,
   var runtimeConfig: RuntimeConfig,
-  startIStatus: InterruptStatus,
+  val interruptStatus: StackBool,
   val fiberRefLocals: FiberRefLocals,
   openScope: ZScope.Open[Exit[E, A]]
 ) extends Fiber.Runtime.Internal[E, A]
@@ -53,8 +53,6 @@ private[zio] final class FiberContext[E, A](
   private[this] var asyncEpoch: Long = 0L
 
   private[this] val stack = Stack[ErasedTracedCont]()
-
-  private[this] val interruptStatus = StackBool(startIStatus.toBoolean)
 
   var scopeKey: ZScope.Key = null
 
@@ -677,7 +675,7 @@ private[zio] final class FiberContext[E, A](
     val childContext = new FiberContext[E, A](
       childId,
       runtimeConfig,
-      InterruptStatus.fromBoolean(interruptStatus.peekOrElse(true)),
+      StackBool(interruptStatus.peekOrElse(true)),
       new AtomicReference(childFiberRefLocals),
       childScope
     )

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -458,7 +458,7 @@ private[zio] final class FiberContext[E, A](
                         case None =>
                           setFiberRefValue(currentExecutor, Some(executor))
 
-                          ZIO.unit
+                          shift(executor)(curZio.trace)
 
                         case Some(currentExecutor) =>
                           if (executor eq currentExecutor) ZIO.unit

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -516,8 +516,7 @@ private[zio] final class FiberContext[E, A](
 
                     setFiberRefValue(fiberRef, zio.localValue)
 
-                    curZio =
-                      zio.zio.ensuring(ZIO.succeed(setFiberRefValue(fiberRef, oldValue))(curZio.trace))(curZio.trace)
+                    curZio = zio.zio.ensuring(ZIO.succeed(setFiberRefValue(fiberRef, oldValue))(zio.trace))(zio.trace)
 
                   case ZIO.Tags.FiberRefDelete =>
                     val zio = curZio.asInstanceOf[ZIO.FiberRefDelete]

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1983,18 +1983,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(executor2)(equalTo(default))
           },
           test("shifts and does not shift back if there is no previous locked executor") {
+            val thread = ZIO.succeed(Thread.currentThread())
             val global = Executor.fromExecutionContext(100)(ExecutionContext.global)
             for {
-              default   <- ZIO.executor
-              ref1      <- Ref.make[Executor](default)
-              ref2      <- Ref.make[Executor](default)
-              stream1    = ZStream.fromZIO(ZIO.executor.flatMap(ref1.set)).onExecutor(global)
-              stream2    = ZStream.fromZIO(ZIO.executor.flatMap(ref2.set))
-              _         <- (stream1 *> stream2).runDrain
-              executor1 <- ref1.get
-              executor2 <- ref2.get
-            } yield assert(executor1)(equalTo(global)) &&
-              assert(executor2)(equalTo(global))
+              default <- thread
+              during  <- Ref.make[Thread](default)
+              after   <- Ref.make[Thread](default)
+              stream1  = ZStream.fromZIO(thread.flatMap(during.set)).onExecutor(global)
+              stream2  = ZStream.fromZIO(thread.flatMap(after.set))
+              _       <- (stream1 *> stream2).runDrain
+              thread1 <- during.get
+              thread2 <- after.get
+            } yield assert(thread1)(equalTo(thread2))
           }
         ),
         suite("managed")(

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2115,18 +2115,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(executor2)(equalTo(default))
           },
           test("shifts and does not shift back if there is no previous locked executor") {
+            val thread = ZIO.succeed(Thread.currentThread())
             val global = Executor.fromExecutionContext(100)(ExecutionContext.global)
             for {
-              default   <- ZIO.executor
-              ref1      <- Ref.make[Executor](default)
-              ref2      <- Ref.make[Executor](default)
-              stream1    = ZStream.fromZIO(ZIO.executor.flatMap(ref1.set)).onExecutor(global)
-              stream2    = ZStream.fromZIO(ZIO.executor.flatMap(ref2.set))
-              _         <- (stream1 *> stream2).runDrain
-              executor1 <- ref1.get
-              executor2 <- ref2.get
-            } yield assert(executor1)(equalTo(global)) &&
-              assert(executor2)(equalTo(global))
+              default <- thread
+              during  <- Ref.make[Thread](default)
+              after   <- Ref.make[Thread](default)
+              stream1  = ZStream.fromZIO(thread.flatMap(during.set)).onExecutor(global)
+              stream2  = ZStream.fromZIO(thread.flatMap(after.set))
+              _       <- (stream1 *> stream2).runDrain
+              thread1 <- during.get
+              thread2 <- after.get
+            } yield assert(thread1)(equalTo(thread2))
           }
         ),
         suite("managed")(

--- a/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -110,5 +110,5 @@ object TestClockSpecJVM extends ZIOBaseSpec {
           } yield assert(values.reverse)(equalTo(List(5L)))
         }
       )
-    ) @@ TestAspect.nonFlaky
+    ) @@ TestAspect.nonFlaky(10)
 }


### PR DESCRIPTION
Partial fix for #5882 

  - move current fork scope override into fiber refs
  - move current executor into fiber refs
  - move environment to fiber refs
  - reduce size of Stack by int packing

There is more that can be done to minimize the size of each fiber but this is a good start.