### PR TITLE
Clean tracing

### DIFF
--- a/core/shared/src/main/scala/zio/IO.scala
+++ b/core/shared/src/main/scala/zio/IO.scala
@@ -576,12 +576,6 @@ object IO {
     ZIO.failCause(cause)
 
   /**
-   * @see See [[zio.ZIO.failCauseWith]]
-   */
-  def failCauseWith[E](function: (() => ZTrace) => Cause[E])(implicit trace: ZTraceElement): IO[E, Nothing] =
-    ZIO.failCauseWith(function)
-
-  /**
    * @see [[zio.ZIO.fiberId]]
    */
   def fiberId(implicit trace: ZTraceElement): UIO[FiberId] =
@@ -928,13 +922,6 @@ object IO {
   @deprecated("use failCause", "2.0.0")
   def halt[E](cause: => Cause[E])(implicit trace: ZTraceElement): IO[E, Nothing] =
     ZIO.halt(cause)
-
-  /**
-   * @see See [[zio.ZIO.haltWith]]
-   */
-  @deprecated("use failCauseWith", "2.0.0")
-  def haltWith[E](function: (() => ZTrace) => Cause[E])(implicit trace: ZTraceElement): IO[E, Nothing] =
-    ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/RIO.scala
+++ b/core/shared/src/main/scala/zio/RIO.scala
@@ -586,12 +586,6 @@ object RIO {
     ZIO.failCause(cause)
 
   /**
-   * @see See [[zio.ZIO.failCauseWith]]
-   */
-  def failCauseWith[R](function: (() => ZTrace) => Cause[Throwable])(implicit trace: ZTraceElement): RIO[R, Nothing] =
-    ZIO.failCauseWith(function)
-
-  /**
    * @see [[zio.ZIO.fiberId]]
    */
   def fiberId(implicit trace: ZTraceElement): UIO[FiberId] =
@@ -960,13 +954,6 @@ object RIO {
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Throwable])(implicit trace: ZTraceElement): Task[Nothing] =
     ZIO.halt(cause)
-
-  /**
-   * @see See [[zio.ZIO.haltWith]]
-   */
-  @deprecated("use failCauseWith", "2.0.0")
-  def haltWith[R](function: (() => ZTrace) => Cause[Throwable])(implicit trace: ZTraceElement): RIO[R, Nothing] =
-    ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -169,7 +169,7 @@ trait Runtime[+R] {
             case ZIO.Tags.Fail =>
               val zio = curZio.asInstanceOf[ZIO.Fail[E]]
 
-              done = Exit.failCause(zio.fill(() => null))
+              done = Exit.failCause(zio.cause())
 
             case ZIO.Tags.Succeed =>
               val zio = curZio.asInstanceOf[ZIO.Succeed[A]]

--- a/core/shared/src/main/scala/zio/Task.scala
+++ b/core/shared/src/main/scala/zio/Task.scala
@@ -566,14 +566,6 @@ object Task extends TaskPlatformSpecific {
     ZIO.failCause(cause)
 
   /**
-   * @see See [[zio.ZIO.failCauseWith]]
-   */
-  def failCauseWith[E <: Throwable](function: (() => ZTrace) => Cause[E])(implicit
-    trace: ZTraceElement
-  ): Task[Nothing] =
-    ZIO.failCauseWith(function)
-
-  /**
    * @see [[zio.ZIO.fiberId]]
    */
   def fiberId(implicit trace: ZTraceElement): UIO[FiberId] =
@@ -907,13 +899,6 @@ object Task extends TaskPlatformSpecific {
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Throwable])(implicit trace: ZTraceElement): Task[Nothing] =
     ZIO.halt(cause)
-
-  /**
-   * @see See [[zio.ZIO.haltWith]]
-   */
-  @deprecated("use failCauseWith", "2.0.0")
-  def haltWith[E <: Throwable](function: (() => ZTrace) => Cause[E])(implicit trace: ZTraceElement): Task[Nothing] =
-    ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/UIO.scala
+++ b/core/shared/src/main/scala/zio/UIO.scala
@@ -485,12 +485,6 @@ object UIO {
     ZIO.failCause(cause)
 
   /**
-   * @see [[zio.ZIO.failCauseWith]]
-   */
-  def failCauseWith(function: (() => ZTrace) => Cause[Nothing])(implicit trace: ZTraceElement): UIO[Nothing] =
-    ZIO.failCauseWith(function)
-
-  /**
    * @see [[zio.ZIO.fiberId]]
    */
   def fiberId(implicit trace: ZTraceElement): UIO[FiberId] =
@@ -789,13 +783,6 @@ object UIO {
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Nothing])(implicit trace: ZTraceElement): UIO[Nothing] =
     ZIO.halt(cause)
-
-  /**
-   * @see [[zio.ZIO.haltWith]]
-   */
-  @deprecated("use failCauseWith", "2.0.0")
-  def haltWith(function: (() => ZTrace) => Cause[Nothing])(implicit trace: ZTraceElement): UIO[Nothing] =
-    ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/URIO.scala
+++ b/core/shared/src/main/scala/zio/URIO.scala
@@ -505,12 +505,6 @@ object URIO {
     ZIO.failCause(cause)
 
   /**
-   * @see [[zio.ZIO.failCauseWith]]
-   */
-  def failCauseWith[R](function: (() => ZTrace) => Cause[Nothing])(implicit trace: ZTraceElement): URIO[R, Nothing] =
-    ZIO.failCauseWith(function)
-
-  /**
    * @see [[zio.ZIO.fiberId]]
    */
   def fiberId(implicit trace: ZTraceElement): UIO[FiberId] =
@@ -860,13 +854,6 @@ object URIO {
   @deprecated("use failCause", "2.0.0")
   def halt(cause: => Cause[Nothing])(implicit trace: ZTraceElement): UIO[Nothing] =
     ZIO.halt(cause)
-
-  /**
-   * @see [[zio.ZIO.haltWith]]
-   */
-  @deprecated("use failCauseWith", "2.0.0")
-  def haltWith[R](function: (() => ZTrace) => Cause[Nothing])(implicit trace: ZTraceElement): URIO[R, Nothing] =
-    ZIO.haltWith(function)
 
   /**
    * @see [[zio.ZIO.ifM]]

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -350,7 +350,10 @@ private[zio] final class FiberContext[E, A](
                       else fastPathFlatMapContinuationTrace :: Nil
                     fastPathFlatMapContinuationTrace = null.asInstanceOf[ZTraceElement]
 
-                    val tracedCause = zio.fill(() => captureTrace(zio.trace :: fastPathTrace))
+                    val cause = zio.cause()
+                    val tracedCause = 
+                      if (cause.isTraced) cause 
+                      else cause.traced(captureTrace(zio.trace :: fastPathTrace))
 
                     val discardedFolds = unwindStack()
                     val fullCause =


### PR DESCRIPTION
Previously, user-defined code captured over a function that mutably generates stack traces. This has been eliminated with new logic that fills in traces if they are missing in the causes.