### PR TITLE
Cause Cleanup

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -79,14 +79,14 @@ object CauseSpec extends ZIOBaseSpec {
         }
       }
     ),
-    suite("Meta")(
-      test("`Meta` is excluded from equals") {
+    suite("Stackless")(
+      test("`Stackless` is excluded from equals") {
         check(causes) { c =>
           assert(Cause.stackless(c))(equalTo(c)) &&
           assert(c)(equalTo(Cause.stackless(c)))
         }
       },
-      test("`Meta` is excluded from hashCode") {
+      test("`Stackless` is excluded from hashCode") {
         check(causes)(c => assert(Cause.stackless(c).hashCode)(equalTo(c.hashCode)))
       }
     ),
@@ -101,6 +101,19 @@ object CauseSpec extends ZIOBaseSpec {
         check(causes) { c =>
           assert(c && empty)(equalTo(c)) &&
           assert(empty && c)(equalTo(c))
+        }
+      }
+    ),
+    suite("Monad Laws:")(
+      test("Left identity") {
+        check(causes)(c => assert(c.flatMap(Cause.fail(_)))(equalTo(c)))
+      },
+      test("Right identity") {
+        check(errors, errorCauseFunctions)((e, f) => assert(Cause.fail(e).flatMap(f))(equalTo(f(e))))
+      },
+      test("Associativity") {
+        check(causes, errorCauseFunctions, errorCauseFunctions) { (c, f, g) =>
+          assert(c.flatMap(f).flatMap(g))(equalTo(c.flatMap(e => f(e).flatMap(g))))
         }
       }
     ),

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5221,7 +5221,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * exists. Otherwise extracts the contained `IO[E, A]`
    */
   def unsandbox[R, E, A](v: => ZIO[R, Cause[E], A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
-    ZIO.suspendSucceed(v.catchAll(ZIO.failCause(_)))
+    ZIO.suspendSucceed(v.mapErrorCause(_.flatten))
 
   /**
    * Returns an effect indicating that execution is no longer required to be

--- a/core/shared/src/main/scala/zio/ZTrace.scala
+++ b/core/shared/src/main/scala/zio/ZTrace.scala
@@ -23,7 +23,11 @@ import scala.annotation.tailrec
 final case class ZTrace(
   fiberId: FiberId,
   stackTrace: Chunk[ZTraceElement]
-) {
+) { self =>
+
+  def ++(that: ZTrace): ZTrace =
+    ZTrace(self.fiberId combine that.fiberId, self.stackTrace ++ that.stackTrace)
+
   def prettyPrint: String =
     stackTrace.collect {
       case s if s.toString.length > 0 => s"\tat ${s} on ${fiberId}"

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1004,7 +1004,7 @@ private[zio] final class FiberContext[E, A](
                   (fiberId, _) => {
                     fiberFailureCauses.observe(classOf[InterruptedException].getName)
                   }
-                )(combineUnit, combineUnit)
+                )(combineUnit, combineUnit, leftUnit)
             }
 
             null
@@ -1249,4 +1249,5 @@ private[zio] object FiberContext {
   lazy val fiberLifetimeBoundaries = ZIOMetric.Histogram.Boundaries.exponential(1.0, 2.0, 100)
 
   val combineUnit = (a: Unit, b: Unit) => ()
+  val leftUnit    = (a: Unit, b: Any) => a
 }

--- a/core/shared/src/main/scala/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/zio/internal/Stack.scala
@@ -39,7 +39,7 @@ private[zio] final class Stack[A <: AnyRef]() extends Iterable[A] { self =>
       var currentIndex = findNonNull(currentArray)
       var _next        = computeNext()
 
-      private def isMoreChunks(): Boolean = (currentArray ne null) && currentArray(0).isInstanceOf[Array[_]]
+      private def hasMoreChunks(): Boolean = (currentArray ne null) && currentArray(0).isInstanceOf[Array[_]]
 
       def hasNext: Boolean = _next ne null
 
@@ -62,7 +62,7 @@ private[zio] final class Stack[A <: AnyRef]() extends Iterable[A] { self =>
       private def computeNext(): A =
         if (currentIndex < 0) null.asInstanceOf[A]
         else {
-          if (currentIndex == 0 && isMoreChunks()) {
+          if (currentIndex == 0 && hasMoreChunks()) {
             currentArray = currentArray(0).asInstanceOf[Array[AnyRef]]
             currentIndex = 12
           }


### PR DESCRIPTION
Cleans up a couple of outstanding items from recent work on tracing and related refactoring to `Cause`:

* Generalizes `fold` to be able to fold over all cases of `Cause` and refactors implementation to be stack safe
* Reimplements `linearize`, `traced` and `untrued` in terms of `fold`
* Implements associative composition of `ZTrace` values
* Reimplements `flatMap` on `Cause`