### PR TITLE
#5849 Improve stack trace tests

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -70,9 +70,6 @@ object StackTracesSpec extends ZIOBaseSpec {
           assertHasStacktraceFor(trace)("spec.underlyingFailure") &&
           assertHasStacktraceFor(trace)("matchPrettyPrintCause") &&
           assert(trace)(containsString("Suppressed: java.lang.RuntimeException: deep failure")) &&
-          assert(trace)(
-            matchesRegex(s"""(?s).*at zio.StackTracesSpec.spec.deepUnderlyingFailure.*\\(.*:\\d*\\).*""")
-          ) &&
           assertTrue(numberOfOccurrences("Suppressed")(trace) == 1)
         }
       },
@@ -107,7 +104,7 @@ object StackTracesSpec extends ZIOBaseSpec {
     errorMessage => assert(trace)(matchesRegex(s"""(?s)^Exception in thread\\s"zio-fiber-\\d*"\\s$errorMessage.*"""))
 
   private def assertHasStacktraceFor(trace: String): String => TestResult = subject =>
-    assert(trace)(matchesRegex(s"""(?s).*at zio\\.StackTracesSpec\\.$subject.*\\(.*:\\d*\\).*"""))
+    assert(trace)(matchesRegex(s"""(?s).*at zio\\.StackTracesSpec.?\\.$subject.*\\(.*:\\d*\\).*"""))
 
   private def numberOfOccurrences(text: String): String => Int = stack =>
     (stack.length - stack.replace(text, "").length) / text.length


### PR DESCRIPTION
Added:
- checks for Fiber ID,
- checks for existence of stack trace (also for each failure point if embedded)

Overall we have now the following cases. If we miss something, please do not hesitate to let me know.

```
+ StackTracesSpec
  + captureSimpleCause
    + captures a simple failure
  + captureMultiMethod
    + captures a deep embedded failure
    + captures a deep embedded failure without suppressing the underlying cause
    + captures the embedded failure
Ran 4 tests in 595 ms: 4 succeeded, 0 ignored, 0 failed
```

resolves #5849