### PR TITLE
is/as Smart Assertions

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -3,7 +3,7 @@ package zio.test
 import zio.duration.durationInt
 import zio.test.SmartTestTypes._
 import zio.test.environment.TestClock
-import zio.{Chunk, NonEmptyChunk}
+import zio.{Cause, Chunk, NonEmptyChunk}
 
 import java.time.LocalDateTime
 import scala.collection.immutable.SortedSet
@@ -355,6 +355,34 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       test("failure") {
         val res: Color = Blue("Hello")
         assertTrue(res.asInstanceOf[Red].foo > 10)
+      } @@ failing
+    ),
+    suite("is")(
+      test("success") {
+        val res = MyClass("coo")
+        assertTrue(res.is[MyClass])
+      },
+      test("failure") {
+        val res: Any = OtherClass("")
+        assertTrue(res.is[MyClass])
+      } @@ failing
+    ),
+    suite("as")(
+      test("success") {
+        val res: Color = Red(12)
+        assertTrue(res.as[Red].foo > 10)
+      },
+      test("failure") {
+        val res: Color = Blue("Hello")
+        assertTrue(res.as[Red].foo > 10)
+      } @@ failing,
+      test("success 2") {
+        val res: Either[Int, String] = Right("Hello")
+        assertTrue(res.as[Right[Int, String]].value == "Hello")
+      },
+      test("failure 2") {
+        val res: Either[Int, String] = Left(123)
+        assertTrue(res.as[Right[Int, String]].value == "Hello")
       } @@ failing
     ),
     suite("Map")(

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -263,13 +263,23 @@ $Assert($ast.withCode($codeString).withLocation)
     def unapply(method: AST.Method): Option[(AST, AssertAST, (Int, Int))] =
       all.reduce(_ orElse _).unapply(method)
 
-    val asInstance: ASTConverter =
+    val asInstanceOf: ASTConverter =
       ASTConverter.make { case AST.Method(_, lhsTpe, _, "asInstanceOf", List(tpe), _, _) =>
         AssertAST("as", List(lhsTpe, tpe))
       }
 
-    val isInstance: ASTConverter =
+    val isInstanceOf: ASTConverter =
       ASTConverter.make { case AST.Method(_, lhsTpe, _, "isInstanceOf", List(tpe), _, _) =>
+        AssertAST("is", List(lhsTpe, tpe))
+      }
+
+    val asInstance: ASTConverter =
+      ASTConverter.make { case AST.Method(_, lhsTpe, _, "as", List(tpe), _, _) =>
+        AssertAST("as", List(lhsTpe, tpe))
+      }
+
+    val isInstance: ASTConverter =
+      ASTConverter.make { case AST.Method(_, lhsTpe, _, "is", List(tpe), _, _) =>
         AssertAST("is", List(lhsTpe, tpe))
       }
 
@@ -469,7 +479,9 @@ $Assert($ast.withCode($codeString).withLocation)
       leftGet,
       asLeft,
       asInstance,
-      isInstance
+      isInstance,
+      asInstanceOf,
+      isInstanceOf
     )
   }
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -947,4 +947,15 @@ package object test extends CompileVariants {
   private def reassociate[A, B, C, D, E, F, G](fn: (A, B, C, D, E, F) => G): ((((((A, B), C), D), E), F)) => G = {
     case (((((a, b), c), d), e), f) => fn(a, b, c, d, e, f)
   }
+
+  implicit final class SmartAssertionOps[A](private val self: A) extends AnyVal {
+    def as[Subtype <: A]: Subtype = throw SmartAssertionExtensionError()
+
+    def is[Subtype <: A]: Boolean = throw SmartAssertionExtensionError()
+  }
+
+  private case class SmartAssertionExtensionError() extends Throwable {
+    override def getMessage: String =
+      s"This method can only be called inside of `assertTrue`"
+  }
 }


### PR DESCRIPTION
```scala
    suite("is")(
      test("success") {
        val res = MyClass("coo")
        assertTrue(res.is[MyClass])
      },
      test("failure") {
        val res: Any = OtherClass("")
        assertTrue(res.is[MyClass])
      } @@ failing
    ),
    suite("as")(
      test("success") {
        val res: Color = Red(12)
        assertTrue(res.as[Red].foo > 10)
      },
      test("failure") {
        val res: Color = Blue("Hello")
        assertTrue(res.as[Red].foo > 10)
      } @@ failing,
      test("success 2") {
        val res: Either[Int, String] = Right("Hello")
        assertTrue(res.as[Right[Int, String]].value == "Hello")
      },
      test("failure 2") {
        val res: Either[Int, String] = Left(123)
        assertTrue(res.as[Right[Int, String]].value == "Hello")
      } @@ failing
    ),

```