### PR TITLE
Fix Flaky Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1384,7 +1384,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val thread = ZIO.succeed(Thread.currentThread())
 
         val global =
-          Executor.fromExecutionContext(RuntimeConfig.defaultYieldOpCount)(scala.concurrent.ExecutionContext.global)
+          Executor.fromExecutionContext(Int.MaxValue)(scala.concurrent.ExecutionContext.global)
         for {
           which   <- Ref.make[Option[Thread]](None)
           beforeL <- ZIO.descriptor.map(_.isLocked)

--- a/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZManagedSpec.scala
@@ -504,7 +504,7 @@ object ZManagedSpec extends ZIOBaseSpec {
         val thread = ZIO.succeed(Thread.currentThread())
 
         val global =
-          Executor.fromExecutionContext(RuntimeConfig.defaultYieldOpCount)(scala.concurrent.ExecutionContext.global)
+          Executor.fromExecutionContext(Int.MaxValue)(scala.concurrent.ExecutionContext.global)
         for {
           which   <- Ref.make[Option[Thread]](None)
           beforeL <- ZIO.descriptor.map(_.isLocked)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1984,7 +1984,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           test("shifts and does not shift back if there is no previous locked executor") {
             val thread = ZIO.succeed(Thread.currentThread())
-            val global = Executor.fromExecutionContext(100)(ExecutionContext.global)
+            val global = Executor.fromExecutionContext(Int.MaxValue)(ExecutionContext.global)
             for {
               default <- thread
               during  <- Ref.make[Thread](default)

--- a/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/experimental/ZStreamSpec.scala
@@ -2201,7 +2201,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           test("shifts and does not shift back if there is no previous locked executor") {
             val thread = ZIO.succeed(Thread.currentThread())
-            val global = Executor.fromExecutionContext(100)(ExecutionContext.global)
+            val global = Executor.fromExecutionContext(Int.MaxValue)(ExecutionContext.global)
             for {
               default <- thread
               during  <- Ref.make[Thread](default)


### PR DESCRIPTION
Since we are testing the actual thread we are running on we need to make make sure that we do not yield because that would potentially allow a different thread on the same executor to continue the computation, which is permissible but would cause the test to fail.