### PR TITLE
Clarify Semantics of Cause#stripSomeDefects

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -488,7 +488,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    */
   final def stripSomeDefects(pf: PartialFunction[Throwable, Any]): Option[Cause[E]] =
     fold[Option[Cause[E]]](
-      None,
+      Some(Empty),
       (e, trace) => Some(Fail(e, trace)),
       (t, trace) => if (pf.isDefinedAt(t)) None else Some(Die(t, trace)),
       (fiberId, trace) => Some(Interrupt(fiberId, trace))


### PR DESCRIPTION
We have a couple of operators that return an option of a cause, which creates some ambiguity of when `None` should be used versus `Some(Empty)`. I think the correct interpretation is generally that `Empty` denotes an error occurred but no information is available about it, whereas `None` indicates no error occurred or no error occurred matching the specified predicate.

I audited existing operators and they are consistent with this with the exception of `stripSomeDefects`, where we convert an `Empty` cause to `None` which seems incorrect as we should only remove defects matching the specified predicate and otherwise leave the cause unchanged.