### PR TITLE
Fix *> and <* operators

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -16,6 +16,16 @@ object ZIOSpec extends ZIOBaseSpec {
   import ZIOTag._
 
   def spec: ZSpec[Environment, Failure] = suite("ZIOSpec")(
+    suite("heap")(
+      test("unit.forever is safe") {
+        for {
+          _     <- ZIO.debug("Press any line to stop...")
+          fiber <- ZIO.unit.forever.fork
+          _     <- ZIO.attempt(scala.io.StdIn.readLine())
+          _     <- fiber.interrupt
+        } yield assertCompletes
+      } @@ ignore
+    ),
     suite("&&")(
       test("true and true is true") {
         assertM(ZIO.succeed(true) && ZIO.succeed(true))(isTrue)


### PR DESCRIPTION
Previously, `ZIO.unit.forever` consumed all heap due to the way `zipRight` was implemented, possibly because of composable zips. 

It is not safe to implement `*>` in terms of `zip` + `map`, because that assumes the `zip` will terminate, but in the case of operators like `forever`, the zip will not terminate.

Note that `<&` and `&>` also have this problem but I did not fix them as the fix requires new parallelism operators.