### PR TITLE
Implement ZChannel.fromHubManaged

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -1457,7 +1457,7 @@ object ZChannel {
   def fromHubManaged[Err, Done, Elem](
     hub: Hub[Either[Exit[Err, Done], Elem]]
   )(implicit trace: ZTraceElement): ZManaged[Any, Nothing, ZChannel[Any, Any, Any, Any, Err, Elem, Done]] =
-    hub.subscribe.map(queue => fromQueue(queue)
+    hub.subscribe.map(fromQueue)
 
   def fromInput[Err, Elem, Done](
     input: AsyncInputConsumer[Err, Elem, Done]

--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -1454,6 +1454,11 @@ object ZChannel {
   )(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Err, Elem, Done] =
     ZChannel.managed(hub.subscribe)(fromQueue)
 
+  def fromHubManaged[Err, Done, Elem](
+    hub: Hub[Either[Exit[Err, Done], Elem]]
+  )(implicit trace: ZTraceElement): ZManaged[Any, Nothing, ZChannel[Any, Any, Any, Any, Err, Elem, Done]] =
+    hub.subscribe.map(queue => fromQueue(queue)
+
   def fromInput[Err, Elem, Done](
     input: AsyncInputConsumer[Err, Elem, Done]
   )(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Err, Elem, Done] =


### PR DESCRIPTION
Like `ZStream.fromHubManaged` allows separating the acquisition of the subscription from taking messages from the subscription to facilitate composition with other resource acquisition logic, such as signaling to an upstream that a downstream has subscribed to the broadcast and is ready for publishing to begin.