### PR TITLE
Implement Gen#resize

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -715,6 +715,11 @@ object GenSpec extends ZIOBaseSpec {
         }
         assertCompletes
       }
+    },
+    test("resize") {
+      for {
+        size <- Gen.size.resize(42).runHead.some
+      } yield assertTrue(size == 42)
     }
   )
 }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -143,6 +143,12 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Option[Sample[R, A]]]) 
     Gen(sample.map(_.map(sample => f(sample.value))))
 
   /**
+   * Sets the size parameter for this generator to the specified value.
+   */
+  def resize(size: Int)(implicit trace: ZTraceElement): Gen[R with Has[Sized], A] =
+    Sized.withSizeGen(size)(self)
+
+  /**
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect(implicit trace: ZTraceElement): ZIO[R, Nothing, List[A]] =

--- a/test/shared/src/main/scala/zio/test/Sized.scala
+++ b/test/shared/src/main/scala/zio/test/Sized.scala
@@ -1,11 +1,13 @@
 package zio.test
 
 import zio.{FiberRef, Has, Layer, UIO, URIO, ZIO, ZLayer, ZTraceElement}
+import zio.stream.ZStream
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait Sized extends Serializable {
   def size(implicit trace: ZTraceElement): UIO[Int]
   def withSize[R, E, A](size: Int)(zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A]
+  def withSizeGen[R, A](size: Int)(gen: Gen[R, A])(implicit trace: ZTraceElement): Gen[R, A]
 }
 
 object Sized {
@@ -17,6 +19,14 @@ object Sized {
           fiberRef.get
         def withSize[R, E, A](size: Int)(zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
           fiberRef.locally(size)(zio)
+        def withSizeGen[R, A](size: Int)(gen: Gen[R, A])(implicit trace: ZTraceElement): Gen[R, A] =
+          Gen {
+            ZStream
+              .fromZIO(fiberRef.get)
+              .flatMap { oldSize =>
+                ZStream.managed(fiberRef.locallyManaged(size)) *> gen.sample.mapZIO(a => fiberRef.set(oldSize).as(a))
+              }
+          }
       }
     })
 
@@ -25,4 +35,7 @@ object Sized {
 
   def withSize[R <: Has[Sized], E, A](size: Int)(zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
     ZIO.accessZIO[R](_.get.withSize(size)(zio))
+
+  def withSizeGen[R <: Has[Sized], A](size: Int)(gen: Gen[R, A])(implicit trace: ZTraceElement): Gen[R, A] =
+    Gen.fromZIO(ZIO.service[Sized]).flatMap(_.withSizeGen(size)(gen))
 }


### PR DESCRIPTION
Allows locally modifying the size parameter, for example to construct recursive generators.