### PR TITLE
Prevent Fibers From Being Terminated Prematurely In ZChannel#mergeWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -613,7 +613,10 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               }
           }
 
-        ZChannel.fromZIO(pullL.fork.zipWith(pullR.fork)(BothRunning(_, _): MergeState)).flatMap(go).embedInput(input)
+        ZChannel
+          .fromZIO(ZIO.transplant(graft => graft(pullL).fork.zipWith(graft(pullR).fork)(BothRunning(_, _): MergeState)))
+          .flatMap(go)
+          .embedInput(input)
       }
 
     ZChannel.unwrapManaged(m)


### PR DESCRIPTION
With this change tests in #5922 and #5954 should pass.