### PR TITLE
fix: ZRef.unsafeMake on Scala 2.11

### DIFF
--- a/core/shared/src/main/scala/zio/ZRef.scala
+++ b/core/shared/src/main/scala/zio/ZRef.scala
@@ -1006,7 +1006,8 @@ object ZRef extends Serializable {
     }
   }
 
-  private[zio] final case class Atomic[A](value: AtomicReference[A]) extends Ref[A] { self =>
+  private[zio] final case class Atomic[A](value: AtomicReference[A]) extends ZRef[Any, Any, Nothing, Nothing, A, A] {
+    self =>
 
     def fold[EC, ED, C, D](
       ea: Nothing => EC,


### PR DESCRIPTION
On Scala 2.11, using `ZRef.unsafeMake` is not possible even from packages in zio.* and fails with an error like the following:

```scala
sbt:zio> coreJVM / compile
[info] compiling 1 Scala source to /home/zimon/zio/zio/core/jvm/target/scala-2.11/classes ...
[error] /home/zimon/zio/zio/core/shared/src/main/scala/zio/test/test.scala:6:13: Symbol 'type zio.Ref.Atomic' is missing from the classpath.
[error] This symbol is required by 'method zio.ZRef.unsafeMake'.
[error] Make sure that type Atomic is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'ZRef.class' was compiled against an incompatible version of zio.Ref.
[error] val ref = ZRef.unsafeMake(1)
[error] ^
[error] one error found
[error] (coreJVM / Compile / compileIncremental) Compilation failed
[error] Total time: 0 s, completed Nov 4, 2021, 7:43:01 PM
```

This appears to be due to the type alias `Ref ` in the return type.