### PR TITLE
Do Not Read Ahead In ZChannel#mergeWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
@@ -770,12 +770,12 @@ private[zio] object SingleProducerAsyncInput {
       .flatMap(p => Ref.make[State[Err, Elem, Done]](State.Empty(p)))
       .map(new SingleProducerAsyncInput(_))
 
-  sealed trait State[+Err, +Elem, +Done]
+  sealed trait State[Err, Elem, Done]
   object State {
-    case class Empty(notifyProducer: Promise[Nothing, Unit]) extends State[Nothing, Nothing, Nothing]
+    case class Empty[Err, Elem, Done](notifyProducer: Promise[Nothing, Unit]) extends State[Err, Elem, Done]
     case class Emit[Err, Elem, Done](notifyConsumers: Queue[Promise[Err, Either[Done, Elem]]])
         extends State[Err, Elem, Done]
-    case class Error[+Err](a: Cause[Err]) extends State[Err, Nothing, Nothing]
-    case class Done[+A](a: A)             extends State[Nothing, Nothing, A]
+    case class Error[Err, Elem, Done](cause: Cause[Err]) extends State[Err, Elem, Done]
+    case class Done[Err, Elem, Done](done: Done)         extends State[Err, Elem, Done]
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
@@ -677,7 +677,7 @@ private[zio] trait AsyncInputProducer[-Err, -Elem, -Done] {
   def emit(el: Elem)(implicit trace: ZTraceElement): UIO[Any]
   def done(a: Done)(implicit trace: ZTraceElement): UIO[Any]
   def error(cause: Cause[Err])(implicit trace: ZTraceElement): UIO[Any]
-  def await(implicit trace: ZTraceElement): UIO[Any]
+  def awaitRead(implicit trace: ZTraceElement): UIO[Any]
 }
 
 /**

--- a/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/internal/ChannelExecutor.scala
@@ -4,6 +4,8 @@ import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.experimental.ZChannel
 
+import scala.collection.immutable.Queue
+
 class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
   initialChannel: () => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
   @volatile private var providedEnv: Any,
@@ -133,7 +135,7 @@ class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
               input = null
 
               lazy val drainer: URIO[Env, Any] =
-                ZIO.suspendSucceed {
+                bridgeInput.awaitRead *> ZIO.suspendSucceed {
                   val state = inputExecutor.run()
 
                   state match {
@@ -675,6 +677,7 @@ private[zio] trait AsyncInputProducer[-Err, -Elem, -Done] {
   def emit(el: Elem)(implicit trace: ZTraceElement): UIO[Any]
   def done(a: Done)(implicit trace: ZTraceElement): UIO[Any]
   def error(cause: Cause[Err])(implicit trace: ZTraceElement): UIO[Any]
+  def await(implicit trace: ZTraceElement): UIO[Any]
 }
 
 /**
@@ -702,30 +705,33 @@ private[zio] class SingleProducerAsyncInput[Err, Elem, Done](
   def emit(el: Elem)(implicit trace: ZTraceElement): UIO[Any] =
     Promise.make[Nothing, Unit].flatMap { p =>
       ref.modify {
-        case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> emit(el), s)
-        case s @ State.Error(_)                => (ZIO.interrupt, s)
-        case s @ State.Done(_)                 => (ZIO.interrupt, s)
-        case State.Empty(notifyConsumer) =>
-          (notifyConsumer.succeed(()) *> p.await, State.Emit(el, p))
+        case s @ State.Emit(notifyConsumers) =>
+          val (notifyConsumer, notifyConsumers) = s.notifyConsumers.dequeue
+          (
+            notifyConsumer.succeed(Right(el)),
+            if (notifyConsumers.isEmpty) State.Empty(p)
+            else State.Emit(notifyConsumers)
+          )
+        case s @ State.Error(_)              => (ZIO.interrupt, s)
+        case s @ State.Done(_)               => (ZIO.interrupt, s)
+        case s @ State.Empty(notifyProducer) => (notifyProducer.await, s)
       }.flatten
     }
 
   def done(a: Done)(implicit trace: ZTraceElement): UIO[Any] =
     ref.modify {
-      case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> done(a), s)
-      case s @ State.Error(_)                => (ZIO.interrupt, s)
-      case s @ State.Done(_)                 => (ZIO.interrupt, s)
-      case State.Empty(notifyConsumer) =>
-        (notifyConsumer.succeed(()), State.Done(a))
+      case State.Emit(notifyConsumers)     => (ZIO.foreachDiscard(notifyConsumers)(_.succeed(Left(a))), State.Done(a))
+      case s @ State.Error(_)              => (ZIO.interrupt, s)
+      case s @ State.Done(_)               => (ZIO.interrupt, s)
+      case s @ State.Empty(notifyProducer) => (notifyProducer.await, s)
     }.flatten
 
   def error(cause: Cause[Err])(implicit trace: ZTraceElement): UIO[Any] =
     ref.modify {
-      case s @ State.Emit(_, notifyProducer) => (notifyProducer.await *> error(cause), s)
-      case s @ State.Error(_)                => (ZIO.interrupt, s)
-      case s @ State.Done(_)                 => (ZIO.interrupt, s)
-      case State.Empty(notifyConsumer) =>
-        (notifyConsumer.succeed(()), SingleProducerAsyncInput.State.Error(cause))
+      case State.Emit(notifyConsumers)     => (ZIO.foreachDiscard(notifyConsumers)(_.failCause(cause)), State.Error(cause))
+      case s @ State.Error(_)              => (ZIO.interrupt, s)
+      case s @ State.Done(_)               => (ZIO.interrupt, s)
+      case s @ State.Empty(notifyProducer) => (notifyProducer.await, s)
     }.flatten
 
   def takeWith[A](
@@ -733,14 +739,14 @@ private[zio] class SingleProducerAsyncInput[Err, Elem, Done](
     onElement: Elem => A,
     onDone: Done => A
   )(implicit trace: ZTraceElement): UIO[A] =
-    Promise.make[Nothing, Unit].flatMap { p =>
+    Promise.make[Err, Either[Done, Elem]].flatMap { p =>
       ref.modify {
-        case State.Emit(a, notifyProducer) =>
-          (notifyProducer.succeed(()).as(onElement(a)), State.Empty(p))
+        case State.Emit(notifyConsumers) =>
+          (p.await.foldCause(onError, _.fold(onDone, onElement)), State.Emit(notifyConsumers.enqueue(p)))
         case s @ State.Error(a) => (UIO.succeed(onError(a)), s)
         case s @ State.Done(a)  => (UIO.succeed(onDone(a)), s)
-        case s @ State.Empty(notifyConsumer) =>
-          (notifyConsumer.await *> takeWith(onError, onElement, onDone), s)
+        case s @ State.Empty(notifyProducer) =>
+          (notifyProducer.succeed(()) *> p.await.foldCause(onError, _.fold(onDone, onElement)), State.Emit(Queue(p)))
       }.flatten
     }
 
@@ -749,6 +755,12 @@ private[zio] class SingleProducerAsyncInput[Err, Elem, Done](
 
   def close(implicit trace: ZTraceElement): UIO[Any] =
     ZIO.fiberId.flatMap(id => error(Cause.interrupt(id)))
+
+  def awaitRead(implicit trace: ZTraceElement): UIO[Any] =
+    ref.modify {
+      case s @ State.Empty(notifyProducer) => (notifyProducer.await, s)
+      case s                               => (ZIO.unit, s)
+    }.flatten
 }
 
 private[zio] object SingleProducerAsyncInput {
@@ -760,9 +772,10 @@ private[zio] object SingleProducerAsyncInput {
 
   sealed trait State[+Err, +Elem, +Done]
   object State {
-    case class Empty(notifyConsumer: Promise[Nothing, Unit])                extends State[Nothing, Nothing, Nothing]
-    case class Emit[+Elem](a: Elem, notifyProducer: Promise[Nothing, Unit]) extends State[Nothing, Elem, Nothing]
-    case class Error[+Err](a: Cause[Err])                                   extends State[Err, Nothing, Nothing]
-    case class Done[+A](a: A)                                               extends State[Nothing, Nothing, A]
+    case class Empty(notifyProducer: Promise[Nothing, Unit]) extends State[Nothing, Nothing, Nothing]
+    case class Emit[Err, Elem, Done](notifyConsumers: Queue[Promise[Err, Either[Done, Elem]]])
+        extends State[Err, Elem, Done]
+    case class Error[+Err](a: Cause[Err]) extends State[Err, Nothing, Nothing]
+    case class Done[+A](a: A)             extends State[Nothing, Nothing, A]
   }
 }


### PR DESCRIPTION
Addresses the remaining issue in the implementation of `ZChannel.mergeWith` to allow #5922 and #5954 to be merged.

The key insight here is that it is not safe in general for a channel operator to read from its upstream if it does not have a request to do so from its downstream. The reason is that the downstream may never want to read at all and if the channel operator reads from the upstream it may "steal" an element that someone else wants to consume.

This comes up in `mergeWith` because `mergeWith` is currently implemented in terms of `Bridge` and `SingleProducerAsyncInput`, which basically creates a single element queue and forks a fiber to read from the upstream while the merged channels read from the queue. This results in a situation where the `mergeWith` operator "reads ahead" by one element.

This becomes particularly problematic in cases where you have nested merges. For example, consider:

```scala
readFromUpstreamAndOfferToHub.mergeWith(
  readFromLeftHubSubscriptionAndWriteToDownstream.mergeWith(
    readFromRightHubSubscriptionAndOfferToDownStream
  )
)
```

This seems correct because `readFromUpstreamAndOfferToHub` is the only channel that reads from upstream, so we would expect it to read all the upstream elements, publish them to the hub, and then the two other merged channels to read from the hub subscriptions, process, and write to downstream.

However, what actually happens is that the inner `mergeWith` "reads ahead" by a single element and thus can take one of the elements from the upstream that is supposed to be read by the outer channel. The inner merge doesn't do anything with this element so it just gets lost.

With this change the fiber that is forked in the execution of `Bridge` waits for the downstream to read before executing the upstream channel.