### PR TITLE
Port Fix To ZStream#interruptWhen To Channel Encoding

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZChannel.scala
@@ -555,7 +555,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 
           exit match {
             case Exit.Success(Right(elem)) =>
-              pull.fork.map { leftFiber =>
+              pull.forkDaemon.map { leftFiber =>
                 ZChannel.write(elem) *> go(both(leftFiber, fiber))
               }
 
@@ -614,7 +614,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           }
 
         ZChannel
-          .fromZIO(ZIO.transplant(graft => graft(pullL).fork.zipWith(graft(pullR).fork)(BothRunning(_, _): MergeState)))
+          .fromZIO(pullL.forkDaemon.zipWith(pullR.forkDaemon)(BothRunning(_, _): MergeState))
           .flatMap(go)
           .embedInput(input)
       }


### PR DESCRIPTION
In `mergeWith` we are either joining or interrupting the fibers we are forking or explicitly giving the user the choice of how to handle the fibers through the `MergeDecision` returned by the continuation so we should not be using automatic supervision.