### PR TITLE
Improve Ergonomics Of ZStream#via

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/experimental/ZStream.scala
@@ -3797,14 +3797,6 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
     new ZStream.UpdateServiceAt[R, E, A, Service](self)
 
   /**
-   * Threads the stream through the transformation function `f`.
-   */
-  final def via[R2, E2, A2](f: ZStream[R, E, A] => ZStream[R2, E2, A2])(implicit
-    trace: ZTraceElement
-  ): ZStream[R2, E2, A2] =
-    f(self)
-
-  /**
    * Returns this stream if the specified condition is satisfied, otherwise returns an empty stream.
    */
   def when(b: => Boolean)(implicit trace: ZTraceElement): ZStream[R, E, A] =
@@ -6180,7 +6172,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   /**
    * Provides syntax for applying pipelines to streams.
    */
-  implicit class PipelineSyntax[Env, Err, Elem](private val self: ZStream[Env, Err, Elem]) extends AnyVal {
+  implicit final class PipelineSyntax[Env, Err, Elem](private val self: ZStream[Env, Err, Elem]) extends AnyVal {
 
     /**
      * Symbolic alias for [[ZStream#via]].
@@ -6267,6 +6259,13 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
 
       new ZStream(self.channel >>> collecting(Chunk.empty))
     }
+
+    /**
+     * Threads the stream through the transformation function `f`.
+     */
+    def via[OutEnv, OutErr, OutElem](f: ZStream[Env, Err, Elem] => ZStream[OutEnv, OutErr, OutElem])(implicit
+      trace: ZTraceElement
+    ): ZStream[OutEnv, OutErr, OutElem] = f(self)
 
     /**
      * Threads the stream through a transformation pipeline.


### PR DESCRIPTION
We moved the variant of `via` that takes a `ZPipeline` to an extension method for variance reasons but that caused an issue because the variant of `via` that takes a function from stream to stream shadows it. We move that variant to implicit syntax as well to allow both versions to be used.