### PR TITLE
Add Support For Checked Exceptions

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ExperimentalSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ExperimentalSpec.scala
@@ -1,0 +1,29 @@
+package zio
+
+import zio.Experimental._
+import zio.test._
+
+import scala.annotation.experimental
+import scala.language.experimental.saferExceptions
+
+@experimental
+object ExperimentalSpec extends ZIOBaseSpec {
+
+  val limit = 10e9
+  class LimitExceeded extends Exception
+  def f(x: Double): Double throws LimitExceeded =
+    if x < limit then x * x else throw LimitExceeded()
+
+  def spec = suite("ExperimentalSpec")(
+    test("fromThrows success case") {
+      for {
+        value <- ZIO.fromThrows(f(42))
+      } yield assertTrue(value == 1764.0)
+    },
+    test("fromThrows failure case") {
+      for {
+        value <- ZIO.fromThrows(f(limit + 1)).orElseSucceed("too large")
+      } yield assertTrue(value == "too large")
+    }
+  )
+}

--- a/core/shared/src/main/scala-3/zio/Experimental.scala
+++ b/core/shared/src/main/scala-3/zio/Experimental.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import scala.annotation.experimental
+import scala.language.experimental.saferExceptions
+
+@experimental
+object Experimental {
+
+  extension(zio: ZIO.type) {
+
+    /**
+     * Converts a value whose computation may throw exceptions into a `ZIO`
+     * value.
+     */
+    def fromThrows[E <: Exception, A](a: => A throws E): IO[E, A] =
+      ZIO.suspendSucceed {
+        try {
+          ZIO.succeedNow(a)
+        } catch {
+          case e: E => ZIO.fail(e)
+        }
+      }
+  }
+}


### PR DESCRIPTION
Implements a new `fromThrows` constructor on `ZIO` which allows lifting a value that may throw an exception using Scala 3's new support for checked exceptions into a ZIO value. This is currently under an `experimental` flag until the `experimental` flag on the underlying feature in Scala 3 is removed.