### PR TITLE
Debug Tracing

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.test.Assertion.{containsString, matchesRegex}
 import zio.test.{TestResult, assert, assertTrue}
+import zio.test.TestAspect.sequential
 
 object StackTracesSpec extends ZIOBaseSpec {
 
@@ -93,12 +94,16 @@ object StackTracesSpec extends ZIOBaseSpec {
         }
       }
     )
-  )
+  ) @@ sequential
 
   // set to true to print traces
   private val debug = false
 
-  private def show(trace: => Cause[Any]): Unit = if (debug) println(trace.prettyPrint)
+  private def show(trace: => Cause[Any]): Unit =
+    if (debug) {
+      println("*****")
+      println(trace.prettyPrint)
+    }
 
   private def assertHasExceptionInThreadZioFiber(trace: String): String => TestResult =
     errorMessage => assert(trace)(matchesRegex(s"""(?s)^Exception in thread\\s"zio-fiber-\\d*"\\s$errorMessage.*"""))
@@ -114,7 +119,7 @@ object StackTracesSpec extends ZIOBaseSpec {
   private val matchPrettyPrintCause: ZIO[Any, String, Nothing] => ZIO[Any, Throwable, String] = {
     case fail: IO[String, Nothing] =>
       fail.catchAllCause {
-        case c: Cause[String] => show(c); ZIO(c.prettyPrint)
+        case c: Cause[String] => ZIO.succeed(show(c)) *> ZIO(c.prettyPrint)
         case _                => UnsupportedTestPath
       }
     case _ => UnsupportedTestPath

--- a/core/shared/src/main/scala/zio/ZTrace.scala
+++ b/core/shared/src/main/scala/zio/ZTrace.scala
@@ -32,20 +32,29 @@ final case class ZTrace(
    * Converts the ZIO trace into a Java stack trace, by converting each trace
    * element into a Java stack trace element.
    */
-  def toJava: Chunk[StackTraceElement] =
-    stackTrace.collect { case ZTraceElement.SourceLocation(location, file, line, _) =>
-      val last = location.lastIndexOf(".")
-
-      val (before, after) = if (last < 0) ("", "." + location) else location.splitAt(last)
-
-      def stripSlash(file: String): String = {
-        val last = file.lastIndexOf("/")
-
-        if (last < 0) file else file.drop(last + 1)
+  def toJava: Chunk[StackTraceElement] = {
+    val chunkBuilder  = ChunkBuilder.make[StackTraceElement](stackTrace.size)
+    val chunkIterator = stackTrace.chunkIterator
+    var index         = 0
+    var previous      = -1
+    while (chunkIterator.hasNextAt(index)) {
+      chunkIterator.nextAt(index) match {
+        case ZTraceElement.SourceLocation(location, file, line, _) if line != previous =>
+          previous = line
+          val last            = location.lastIndexOf(".")
+          val (before, after) = if (last < 0) ("", "." + location) else location.splitAt(last)
+          def stripSlash(file: String): String = {
+            val last = file.lastIndexOf("/")
+            if (last < 0) file else file.drop(last + 1)
+          }
+          val stackTraceElement = new StackTraceElement(before, after.drop(1), stripSlash(file), line)
+          chunkBuilder += stackTraceElement
+        case _ =>
       }
-
-      new StackTraceElement(before, after.drop(1), stripSlash(file), line)
+      index += 1
     }
+    chunkBuilder.result()
+  }
 }
 
 object ZTrace {


### PR DESCRIPTION
@baldram I tried running `StackTracesSpec` in debug mode. I think there may have been some issue because tests are by default run in parallel so the order the debug traces is printed in is nondeterministic and could lead to spurious differences.

I used `TestAspect.sequential` to run the tests sequentially and added a separator between the debug statements to make it easier to visualize the traces for each test. With these changes, the traces generated on both platforms are identical (with the exception of the Scala 3 version having an additional `.macros` at the end of the trace that could potentially be cleaned up) and are as shown below.

This appears to be correct with the first test having a simple trace, the second trace having two suppressed exceptions, and the third and fourth having one suppressed exception. But I could be missing something. Please let me know what you think.

```
*****
Exception in thread "zio-fiber-1636671703" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.value(StackTracesSpec.scala:14)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:15)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:11)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
*****
Exception in thread "zio-fiber-1636671703" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:28)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:28)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:28)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:40)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:24)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
        Suppressed: java.lang.RuntimeException: deep failure
                at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:28)
                at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:28)
                at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
                at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
                at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:40)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:24)
                at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
                Suppressed: java.lang.RuntimeException: other failure
                        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
                        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:34)
                        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
                        at zio.StackTracesSpec.spec(StackTracesSpec.scala:40)
                        at zio.StackTracesSpec.spec(StackTracesSpec.scala:24)
                        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
*****
Exception in thread "zio-fiber-1636671703" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:55)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:55)
        at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:55)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:61)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:67)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:51)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
        Suppressed: java.lang.RuntimeException: deep failure
                at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:55)
                at zio.StackTracesSpec.spec.deepUnderlyingFailure(StackTracesSpec.scala:55)
                at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:61)
                at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:67)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:51)
                at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
*****
Exception in thread "zio-fiber-1636671703" java.lang.String: Oh no!
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:81)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:81)
        at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:81)
        at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:87)
        at zio.StackTracesSpec.spec(StackTracesSpec.scala:77)
        at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
        Suppressed: java.lang.RuntimeException: other failure
                at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:81)
                at zio.StackTracesSpec.spec.underlyingFailure(StackTracesSpec.scala:81)
                at zio.StackTracesSpec.matchPrettyPrintCause(StackTracesSpec.scala:121)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:87)
                at zio.StackTracesSpec.spec(StackTracesSpec.scala:77)
                at zio.test.sbt.BaseTestTask.run(BaseTestTask.scala:28)
```