### PR TITLE
Review site publishing rule 

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,7 +20,7 @@ jobs:
       - run: |
           ./scripts/createSite.sh ${{ github.ref }}
       - name: Release to GitHub Pages
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/docs.') 
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages


### PR DESCRIPTION
Ensure site is only published when we push a tag `docs.<some info>`
Some info could be a date string indicating when the tag was created