### PR TITLE
Fixed #6049 - Misleading Example

### DIFF
--- a/docs/overview/basic_concurrency.md
+++ b/docs/overview/basic_concurrency.md
@@ -119,8 +119,8 @@ for {
   fiber1 <- IO.fail("Uh oh!").fork
   fiber2 <- IO.succeed("Hurray!").fork
   fiber   = fiber1.orElse(fiber2)
-  tuple  <- fiber.join
-} yield tuple
+  message  <- fiber.join
+} yield message
 ```
 
 ## Parallelism


### PR DESCRIPTION
Renamed "tuple" to "message" to be consistent with other code examples that wrap a String.

This change only affects the zio.dev overview of basic concurrency sample code illustrating Fiber#orElse.