### PR TITLE
Release M6-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  CI_RELEASE: "+internalMacrosJVM/publish;+internalMacrosJS/publish;+internalMacrosNative/publish"
   JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xmx3G # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
   JVM_OPTS: -XX:+PrintCommandLineFlags -Xmx3G # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,7 @@ inThisBuild(
         "john@degoes.net",
         url("http://degoes.net")
       )
-    ),
-    version := "2.0.0-M6"
+    )
   )
 )
 


### PR DESCRIPTION
After a brief discussion with @adamgfraser we decided it's better (as in more consistent with our past flow) to release M6-1 than do the backpublish internal macros (see #6067) 