### PR TITLE
Remove Extraneous Type Parameters

### DIFF
--- a/core/shared/src/main/scala-2/zio/ZIOVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOVersionSpecific.scala
@@ -63,15 +63,15 @@ private[zio] trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
 
 private final class ProvideSomePartiallyApplied[R0, -R, +E, +A](val self: ZIO[R, E, A]) extends AnyVal {
 
-  def provide[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R], trace: ZTraceElement): ZIO[R0, E1, A] =
+  def provide[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R], trace: ZTraceElement): ZIO[R0, E1, A] =
     self.provide(layer)
 
   @deprecated("use provide", "2.0.0")
-  def provideLayer[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R], trace: ZTraceElement): ZIO[R0, E1, A] =
+  def provideLayer[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R], trace: ZTraceElement): ZIO[R0, E1, A] =
     provide(layer)
 
   def provideSome[R0]: ZIO.ProvideSome[R0, R, E, A] =

--- a/core/shared/src/main/scala-2/zio/ZManagedVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZManagedVersionSpecific.scala
@@ -66,14 +66,14 @@ private final class ProvideSomeLayerManagedPartiallyApplied[R0, -R, +E, +A](
 ) extends AnyVal {
 
   def provide[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R], trace: ZTraceElement): ZManaged[R0, E1, A] =
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R], trace: ZTraceElement): ZManaged[R0, E1, A] =
     self.provide(layer)
 
   @deprecated("use provide", "2.0.0")
-  def provideLayer[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R], trace: ZTraceElement): ZManaged[R0, E1, A] =
+  def provideLayer[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R], trace: ZTraceElement): ZManaged[R0, E1, A] =
     provide(layer)
 
   def provideSome[R0]: ZManaged.ProvideSome[R0, R, E, A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1462,10 +1462,10 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Provides a layer to the ZIO effect, which translates it to another level.
    */
-  final def provide[E1 >: E, R0, R1](
-    layer: => ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZIO[R0, E1, A] =
-    ZIO.suspendSucceed(layer.build.map(_.upcast(ev)).use(r => self.provideEnvironment(r)))
+  final def provide[E1 >: E, R0](
+    layer: => ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZIO[R0, E1, A] =
+    ZIO.suspendSucceed(layer.build.use(r => self.provideEnvironment(r)))
 
   /**
    * Provides the part of the environment that is not part of the `ZEnv`,
@@ -1521,9 +1521,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Provides a layer to the ZIO effect, which translates it to another level.
    */
   @deprecated("use provide", "2.0.0")
-  final def provideLayer[E1 >: E, R0, R1](
-    layer: => ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZIO[R0, E1, A] =
+  final def provideLayer[E1 >: E, R0](
+    layer: => ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZIO[R0, E1, A] =
     provide(layer)
 
   /**
@@ -5665,7 +5665,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     def apply[E1 >: E, R1](
       layer: => ZLayer[R0, E1, R1]
     )(implicit ev: R0 with R1 <:< R, tagged: Tag[R1], trace: ZTraceElement): ZIO[R0, E1, A] =
-      self.provide[E1, R0, R0 with R1](ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZIO[R0 with R1, E, A]].provide(ZLayer.environment[R0] ++ layer)
   }
 
   final class UpdateService[-R, +E, +A, M](private val self: ZIO[R, E, A]) extends AnyVal {

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -811,10 +811,10 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
   /**
    * Provides a layer to the `ZManaged`, which translates it to another level.
    */
-  final def provide[E1 >: E, R0, R1](
-    layer: => ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZManaged[R0, E1, A] =
-    ZManaged.suspend(layer.build.map(_.upcast(ev)).flatMap(r => self.provideEnvironment(r)))
+  final def provide[E1 >: E, R0](
+    layer: => ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZManaged[R0, E1, A] =
+    ZManaged.suspend(layer.build.flatMap(r => self.provideEnvironment(r)))
 
   /**
    * Provides the part of the environment that is not part of the `ZEnv`,
@@ -870,9 +870,9 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * Provides a layer to the `ZManaged`, which translates it to another level.
    */
   @deprecated("use provide", "2.0.0")
-  final def provideLayer[E1 >: E, R0, R1](
-    layer: => ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZManaged[R0, E1, A] =
+  final def provideLayer[E1 >: E, R0](
+    layer: => ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZManaged[R0, E1, A] =
     provide(layer)
 
   /**
@@ -1575,7 +1575,7 @@ object ZManaged extends ZManagedPlatformSpecific {
       tagged: Tag[R1],
       trace: ZTraceElement
     ): ZManaged[R0, E1, A] =
-      self.provide[E1, R0, R0 with R1](ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZManaged[R0 with R1, E, A]].provide(ZLayer.environment[R0] ++ layer)
   }
 
   final class UnlessManaged[R, E](private val b: () => ZManaged[R, E, Boolean]) extends AnyVal {

--- a/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
@@ -49,9 +49,9 @@ private[stream] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O
 private final class ProvideSomeStreamPartiallyApplied[R0, -R, +E, +O](
   val self: ZStream[R, E, O]
 ) extends AnyVal {
-  def provide[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): ZStream[R0, E1, O] =
+  def provide[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): ZStream[R0, E1, O] =
     self.provide(layer)
 
   def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZStream[R0, E1, O] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2821,11 +2821,11 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   /**
    * Provides a layer to the stream, which translates it to another level.
    */
-  final def provide[E1 >: E, R0, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZStream[R0, E1, A] =
+  final def provide[E1 >: E, R0](
+    layer: ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZStream[R0, E1, A] =
     new ZStream(ZChannel.managed(layer.build) { r =>
-      self.channel.provideEnvironment(r.upcast(ev))
+      self.channel.provideEnvironment(r)
     })
 
   /**
@@ -2882,9 +2882,9 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    * Provides a layer to the stream, which translates it to another level.
    */
   @deprecated("use provide", "2.0.0")
-  final def provideLayer[E1 >: E, R0, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev: R1 <:< R, trace: ZTraceElement): ZStream[R0, E1, A] =
+  final def provideLayer[E1 >: E, R0](
+    layer: ZLayer[R0, E1, R]
+  )(implicit trace: ZTraceElement): ZStream[R0, E1, A] =
     provide(layer)
 
   /**
@@ -5739,7 +5739,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       tagged: Tag[R1],
       trace: ZTraceElement
     ): ZStream[R0, E1, A] =
-      self.provide[E1, R0, R0 with R1](ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZStream[R0 with R1, E, A]].provide(ZLayer.environment[R0] ++ layer)
   }
 
   final class UpdateService[-R, +E, +A, M](private val self: ZStream[R, E, A]) extends AnyVal {

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -65,7 +65,7 @@ object GenUtils {
     }
 
   def provideSize[A](zio: ZIO[Random with Sized, Nothing, A])(n: Int): URIO[Random, A] =
-    zio.provide[Nothing, Random, Random with Sized](Random.any ++ Sized.live(n))
+    zio.provide(Random.any ++ Sized.live(n))
 
   val random: Gen[Any, Gen[Random, Int]] =
     Gen.const(Gen.int(-10, 10))

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion.equalTo
 import zio.test.ReportingTestUtils._
 import zio.test.TestAspect.silent
 import zio.test.render.IntelliJRenderer
-import zio.{Clock, Layer, ZIO, ZTraceElement}
+import zio.{Layer, ZIO, ZTraceElement}
 
 object IntellijRendererSpec extends ZIOBaseSpec {
   import IntelliJRenderUtils._
@@ -259,7 +259,7 @@ object IntelliJRenderUtils {
     for {
       _ <- IntelliJTestRunner(testEnvironment)
              .run(spec)
-             .provide[Nothing, TestEnvironment, TestLogger with Clock](
+             .provide[Nothing, TestEnvironment](
                TestLogger.fromConsole ++ TestClock.default
              )
       output <- TestConsole.output

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -6,7 +6,7 @@ import zio.test.mock.internal.InvalidCall._
 import zio.test.mock.internal.MockException._
 import zio.test.mock.module.{PureModule, PureModuleMock}
 import zio.test.render.TestRenderer
-import zio.{Cause, Clock, Layer, Promise, ZIO, ZTraceElement}
+import zio.{Cause, Layer, Promise, ZIO, ZTraceElement}
 
 import scala.{Console => SConsole}
 
@@ -52,7 +52,7 @@ object ReportingTestUtils {
     for {
       _ <- TestTestRunner(testEnvironment)
              .run(spec)
-             .provide[Nothing, TestEnvironment, TestLogger with Clock](
+             .provide(
                TestLogger.fromConsole ++ TestClock.default
              )
       output <- TestConsole.output
@@ -62,7 +62,7 @@ object ReportingTestUtils {
     for {
       results <- TestTestRunner(testEnvironment)
                    .run(spec)
-                   .provide[Nothing, TestEnvironment, TestLogger with Clock](
+                   .provide(
                      TestLogger.fromConsole ++ TestClock.default
                    )
       actualSummary = SummaryBuilder.buildSummary(results)

--- a/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
@@ -93,15 +93,15 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
 
 private final class InjectSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
 
-  def provide[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): Spec[R0, E1, T] =
+  def provide[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     self.provide(layer)
 
   @deprecated("use provide", "2.0.0")
-  def provideLayer[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): Spec[R0, E1, T] =
+  def provideLayer[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     provide(layer)
 
   def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
@@ -110,15 +110,15 @@ private final class InjectSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R,
 
 private final class InjectSomeSharedPartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
 
-  def provideShared[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): Spec[R0, E1, T] =
+  def provideShared[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     self.provideShared(layer)
 
   @deprecated("use provideShared", "2.0.0")
-  def provideLayerShared[E1 >: E, R1](
-    layer: ZLayer[R0, E1, R1]
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R]): Spec[R0, E1, T] =
+  def provideLayerShared[E1 >: E](
+    layer: ZLayer[R0, E1, R]
+  )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     provideShared(layer)
 
   def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1844,7 +1844,7 @@ object TestAspect extends TestAspectCompanionVersionSpecific with TimeoutVariant
         def apply[R >: R0 with R1, E >: E1](
           spec: Spec[R, TestFailure[E], TestSuccess]
         )(implicit trace: ZTraceElement): Spec[R0, TestFailure[E], TestSuccess] =
-          spec.provide(ZLayer.environment[R0] ++ layer)
+          spec.asInstanceOf[Spec[R0 with R1, TestFailure[E], TestSuccess]].provide(ZLayer.environment[R0] ++ layer)
       }
   }
 
@@ -1868,7 +1868,7 @@ object TestAspect extends TestAspectCompanionVersionSpecific with TimeoutVariant
         def apply[R >: R0 with R1, E >: E1](
           spec: Spec[R, TestFailure[E], TestSuccess]
         )(implicit trace: ZTraceElement): Spec[R0, TestFailure[E], TestSuccess] =
-          spec.provideShared(ZLayer.environment[R0] ++ layer)
+          spec.asInstanceOf[Spec[R0 with R1, TestFailure[E], TestSuccess]].provideShared(ZLayer.environment[R0] ++ layer)
       }
   }
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1868,7 +1868,9 @@ object TestAspect extends TestAspectCompanionVersionSpecific with TimeoutVariant
         def apply[R >: R0 with R1, E >: E1](
           spec: Spec[R, TestFailure[E], TestSuccess]
         )(implicit trace: ZTraceElement): Spec[R0, TestFailure[E], TestSuccess] =
-          spec.asInstanceOf[Spec[R0 with R1, TestFailure[E], TestSuccess]].provideShared(ZLayer.environment[R0] ++ layer)
+          spec
+            .asInstanceOf[Spec[R0 with R1, TestFailure[E], TestSuccess]]
+            .provideShared(ZLayer.environment[R0] ++ layer)
       }
   }
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1844,7 +1844,7 @@ object TestAspect extends TestAspectCompanionVersionSpecific with TimeoutVariant
         def apply[R >: R0 with R1, E >: E1](
           spec: Spec[R, TestFailure[E], TestSuccess]
         )(implicit trace: ZTraceElement): Spec[R0, TestFailure[E], TestSuccess] =
-          spec.provide[TestFailure[E], R0, R0 with R1](ZLayer.environment[R0] ++ layer)
+          spec.provide(ZLayer.environment[R0] ++ layer)
       }
   }
 
@@ -1868,7 +1868,7 @@ object TestAspect extends TestAspectCompanionVersionSpecific with TimeoutVariant
         def apply[R >: R0 with R1, E >: E1](
           spec: Spec[R, TestFailure[E], TestSuccess]
         )(implicit trace: ZTraceElement): Spec[R0, TestFailure[E], TestSuccess] =
-          spec.provideShared[TestFailure[E], R0, R0 with R1](ZLayer.environment[R0] ++ layer)
+          spec.provideShared(ZLayer.environment[R0] ++ layer)
       }
   }
 }


### PR DESCRIPTION
Now that `Has` has been deleted we can remove some type parameters.