### PR TITLE
Fast path interpreter

### DIFF
--- a/benchmarks/src/main/scala/zio/UnsafeRunBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/UnsafeRunBenchmark.scala
@@ -7,15 +7,29 @@ import java.util.concurrent.TimeUnit
 
 /**
  * {{{
- * [info] Benchmark                    (depth)   Mode  Cnt        Score       Error  Units
- * [info] UnsafeRunBenchmark.zioLeft         1  thrpt    5  2527835.063 ∩┐╜ 20547.193  ops/s
- * [info] UnsafeRunBenchmark.zioLeft         2  thrpt    5  2192859.126 ∩┐╜ 21557.848  ops/s
- * [info] UnsafeRunBenchmark.zioLeft         4  thrpt    5  1861759.677 ∩┐╜ 21811.809  ops/s
- * [info] UnsafeRunBenchmark.zioLeft         8  thrpt    5  1478009.404 ∩┐╜ 13764.737  ops/s
- * [info] UnsafeRunBenchmark.zioRight        1  thrpt    5  2434178.854 ∩┐╜ 23297.673  ops/s
- * [info] UnsafeRunBenchmark.zioRight        2  thrpt    5  2197319.901 ∩┐╜ 13466.396  ops/s
- * [info] UnsafeRunBenchmark.zioRight        4  thrpt    5  1981274.470 ∩┐╜ 15435.194  ops/s
- * [info] UnsafeRunBenchmark.zioRight        8  thrpt    5  1561479.601 ∩┐╜ 42674.608  ops/s
+ * [info] UnsafeRunBenchmark.zioLeft          1  thrpt   10    2924072.908 ∩┐╜   207535.037  ops/s
+ * [info] UnsafeRunBenchmark.zioLeft'         1  thrpt   10  264234984.929 ∩┐╜ 27407427.777  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioLeft          2  thrpt   10    2619085.083 ∩┐╜   181905.105  ops/s
+ * [info] UnsafeRunBenchmark.zioLeft'         2  thrpt   10  109613072.462 ∩┐╜   526748.448  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioLeft          4  thrpt   10    2252902.513 ∩┐╜    71522.781  ops/s
+ * [info] UnsafeRunBenchmark.zioLeft'         4  thrpt   10   44569924.478 ∩┐╜  1060326.379  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioLeft          8  thrpt   10    1782754.491 ∩┐╜    59228.031  ops/s
+ * [info] UnsafeRunBenchmark.zioLeft'         8  thrpt   10   15689424.820 ∩┐╜  1487690.562  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioRight         1  thrpt   10    2673482.726 ∩┐╜    24960.009  ops/s
+ * [info] UnsafeRunBenchmark.zioRight'        1  thrpt   10  270720926.073 ∩┐╜   537049.199  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioRight         2  thrpt   10    2644805.378 ∩┐╜    58712.959  ops/s
+ * [info] UnsafeRunBenchmark.zioRight'        2  thrpt   10   98828477.442 ∩┐╜   493812.270  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioRight         4  thrpt   10    2434308.062 ∩┐╜    22470.067  ops/s
+ * [info] UnsafeRunBenchmark.zioRight'        4  thrpt   10   35925377.327 ∩┐╜  1732444.668  ops/s
+ *
+ * [info] UnsafeRunBenchmark.zioRight         8  thrpt   10    2035601.943 ∩┐╜    69795.749  ops/s
+ * [info] UnsafeRunBenchmark.zioRight'        8  thrpt   10   15740140.258 ∩┐╜   672817.959  ops/s
  * }}}
  */
 @State(Scope.Thread)

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -3,9 +3,63 @@ package zio
 import zio.test._
 
 object RuntimeSpec extends ZIOBaseSpec {
+  val r = Runtime.default 
+
+  def foo = 
+    for {
+      _ <- ZIO.succeed(42)
+      _ <- ZIO.fail("Uh oh!")
+    } yield ()
+
+  def bar = 
+    for {
+      _ <- ZIO.succeed(92)
+      a <- foo 
+    } yield a
+
+  def buz = 
+    for {
+      _ <- UIO.async[Int](k => k(ZIO.succeed(42)))
+      a <- bar 
+    } yield a
+
+  def traceOf(exit: Exit[Any, Any]): Chunk[String] = 
+    exit.fold[ZTrace](_.trace, _ => ZTrace.none).stackTrace.map(_.toString)
+
+  def fastPath[E, A](zio: ZIO[ZEnv, E, A], maxStack: Int = 50): Exit[E, A] = 
+    r.tryFastUnsafeRunSync(zio, 0, maxStack)
+
+   def slowPath[E, A](zio: ZIO[ZEnv, E, A]): Exit[E, A] = 
+    r.defaultUnsafeRunSync(zio)
+
   def spec = suite("RuntimeSpec") {
-    test("example") {
-      assertTrue(true)
+    suite("primitives") {
+      test("ZIO.succeed") {
+        assertTrue(fastPath(ZIO.succeed(42)) == Exit.succeed(42))
+      } 
+    } +
+    suite("fallback") {
+      test("defaultUnsafeRunSync on async") {
+        val answer = slowPath(UIO.async[Int](k => k(ZIO.succeed(42))))
+
+        assertTrue(answer == Exit.succeed(42))
+      } + 
+      test("merged traces") {
+        val exit = slowPath(buz)
+
+        val trace = traceOf(exit)
+
+        assertTrue(trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")))
+      }
+    } + 
+    suite("traces") {
+      test("depth of 2") {
+        val exit = fastPath(bar)
+
+        val trace = traceOf(exit)
+
+        assertTrue(trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")))
+      }
     }
   }
 }

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.test._
+import zio.test.TestAspect._
 
 object RuntimeSpec extends ZIOBaseSpec {
   val r = Runtime.default
@@ -47,7 +48,7 @@ object RuntimeSpec extends ZIOBaseSpec {
           } yield assertTrue(
             trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")) && trace.exists(_.contains("buz"))
           )
-        }
+        } @@ jvmOnly
       } +
       suite("traces") {
         test("depth of 2") {

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -1,0 +1,8 @@
+package zio
+
+import zio.test.Assertion._
+import zio.test._
+
+object RuntimeSpec extends ZIOBaseSpec {
+  def spec = suite("RuntimeSpec")()
+}

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -3,63 +3,60 @@ package zio
 import zio.test._
 
 object RuntimeSpec extends ZIOBaseSpec {
-  val r = Runtime.default 
+  val r = Runtime.default
 
-  def foo = 
+  def foo =
     for {
       _ <- ZIO.succeed(42)
       _ <- ZIO.fail("Uh oh!")
     } yield ()
 
-  def bar = 
+  def bar =
     for {
       _ <- ZIO.succeed(92)
-      a <- foo 
+      a <- foo
     } yield a
 
-  def buz = 
+  def buz =
     for {
       _ <- UIO.async[Int](k => k(ZIO.succeed(42)))
-      a <- bar 
+      a <- bar
     } yield a
 
-  def traceOf(exit: Exit[Any, Any]): Chunk[String] = 
+  def traceOf(exit: Exit[Any, Any]): Chunk[String] =
     exit.fold[ZTrace](_.trace, _ => ZTrace.none).stackTrace.map(_.toString)
 
-  def fastPath[E, A](zio: ZIO[ZEnv, E, A], maxStack: Int = 50): Exit[E, A] = 
-    r.tryFastUnsafeRunSync(zio, 0, maxStack)
+  def fastPath[E, A](zio: ZIO[ZEnv, E, A], maxStack: Int = 50): Exit[E, A] =
+    r.unsafeRunSyncFast(zio, maxStack)
 
-   def slowPath[E, A](zio: ZIO[ZEnv, E, A]): Exit[E, A] = 
-    r.defaultUnsafeRunSync(zio)
+  def slowPath[E, A](zio: ZIO[ZEnv, E, A]): Task[Exit[E, A]] =
+    Task.attemptBlocking(r.defaultUnsafeRunSync(zio))
 
   def spec = suite("RuntimeSpec") {
     suite("primitives") {
       test("ZIO.succeed") {
         assertTrue(fastPath(ZIO.succeed(42)) == Exit.succeed(42))
-      } 
+      }
     } +
-    suite("fallback") {
-      test("defaultUnsafeRunSync on async") {
-        val answer = slowPath(UIO.async[Int](k => k(ZIO.succeed(42))))
+      suite("fallback") {
+        test("merged traces") {
 
-        assertTrue(answer == Exit.succeed(42))
-      } + 
-      test("merged traces") {
-        val exit = slowPath(buz)
+          for {
+            exit <- slowPath(buz)
+            trace = traceOf(exit)
+          } yield assertTrue(
+            trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")) && trace.exists(_.contains("buz"))
+          )
+        }
+      } +
+      suite("traces") {
+        test("depth of 2") {
+          val exit = fastPath(bar)
 
-        val trace = traceOf(exit)
+          val trace = traceOf(exit)
 
-        assertTrue(trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")))
+          assertTrue(trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")))
+        }
       }
-    } + 
-    suite("traces") {
-      test("depth of 2") {
-        val exit = fastPath(bar)
-
-        val trace = traceOf(exit)
-
-        assertTrue(trace.exists(_.contains("foo")) && trace.exists(_.contains("bar")))
-      }
-    }
   }
 }

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -1,8 +1,11 @@
 package zio
 
-import zio.test.Assertion._
 import zio.test._
 
 object RuntimeSpec extends ZIOBaseSpec {
-  def spec = suite("RuntimeSpec")()
+  def spec = suite("RuntimeSpec") {
+    test("example") {
+      assertTrue(true)
+    }
+  }
 }

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.test._
-import zio.test.TestAspect._
+import zio.test.TestAspect.jvmOnly
 
 object RuntimeSpec extends ZIOBaseSpec {
   val r = Runtime.default

--- a/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeSpec.scala
@@ -26,8 +26,8 @@ object RuntimeSpec extends ZIOBaseSpec {
   def traceOf(exit: Exit[Any, Any]): Chunk[String] =
     exit.fold[ZTrace](_.trace, _ => ZTrace.none).stackTrace.map(_.toString)
 
-  def fastPath[E, A](zio: ZIO[ZEnv, E, A], maxStack: Int = 50): Exit[E, A] =
-    r.unsafeRunSyncFast(zio, maxStack)
+  def fastPath[E, A](zio: ZIO[ZEnv, E, A]): Exit[E, A] =
+    r.unsafeRunSyncFast(zio)
 
   def slowPath[E, A](zio: ZIO[ZEnv, E, A]): Task[Exit[E, A]] =
     Task.attemptBlocking(r.defaultUnsafeRunSync(zio))

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -492,8 +492,9 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
     mapTrace(_ ++ trace)
 
   /**
-   * Returns a homogenized list of failures for the cause. This homogenization process throws
-   * away key information, but it is useful for interop with traditional stack traces.
+   * Returns a homogenized list of failures for the cause. This homogenization
+   * process throws away key information, but it is useful for interop with
+   * traditional stack traces.
    */
   final def unified: List[Unified] = {
     @tailrec

--- a/core/shared/src/main/scala/zio/Exit.scala
+++ b/core/shared/src/main/scala/zio/Exit.scala
@@ -236,6 +236,15 @@ sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
   }
 
   /**
+    * Converts the `Exit` to a `ZIO` effect.
+    */
+  final def toZIO(implicit trace: ZTraceElement): IO[E, A] = 
+    self match {
+      case Exit.Failure(cause) => ZIO.failCause(cause)
+      case Exit.Success(value) => ZIO.succeedNow(value)
+    }
+
+  /**
    * Discards the value.
    */
   final def unit: Exit[E, Unit] = as(())

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -913,11 +913,6 @@ object Fiber extends FiberPlatformSpecific {
   def unsafeCurrentFiber(): Option[Fiber[Any, Any]] =
     Option(_currentFiber.get)
 
-  private[zio] def newFiberId(): FiberId.Runtime =
-    FiberId.Runtime((java.lang.System.currentTimeMillis / 1000).toInt, _fiberCounter.getAndIncrement())
-
   private[zio] val _currentFiber: ThreadLocal[internal.FiberContext[_, _]] =
     new ThreadLocal[internal.FiberContext[_, _]]()
-
-  private[zio] val _fiberCounter = new java.util.concurrent.atomic.AtomicInteger(0)
 }

--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -27,5 +27,13 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * better integrate with Scala exception handling.
  */
 final case class FiberFailure(cause: Cause[Any]) extends Throwable(null, null, true, false) {
-  override def getMessage: String = cause.prettyPrint
+  override def getMessage: String = cause.unified.headOption.fold("<unknown>")(_.message)
+
+  override def getStackTrace(): Array[StackTraceElement] =
+    cause.unified.headOption.fold[Chunk[StackTraceElement]](Chunk.empty)(_.trace).toArray
+
+  def unsafeInitSuppressed(): Unit =
+    if (getSuppressed().length == 0) {
+      cause.unified.iterator.drop(1).foreach(unified => addSuppressed(unified.toThrowable))
+    }
 }

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -27,7 +27,7 @@ import scala.annotation.tailrec
 sealed trait FiberId extends Serializable { self =>
   import FiberId._
 
-  def combine(that: FiberId): FiberId =
+  final def combine(that: FiberId): FiberId =
     (self, that) match {
       case (None, that)                                 => that
       case (that, None)                                 => that
@@ -37,7 +37,9 @@ sealed trait FiberId extends Serializable { self =>
       case (self @ Runtime(_, _), that @ Runtime(_, _)) => Composite(Set(self, that))
     }
 
-  def ids: Set[Int] =
+  final def getOrElse(that: => FiberId): FiberId = if (isNone) that else self
+
+  final def ids: Set[Int] =
     self match {
       case None                => Set.empty
       case Runtime(id, _)      => Set(id)

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -53,6 +53,11 @@ object FiberId {
   def combineAll(fiberIds: Set[FiberId]): FiberId =
     fiberIds.foldLeft[FiberId](FiberId.None)(_ combine _)
 
+  private[zio] def unsafeMake(): FiberId.Runtime =
+    FiberId.Runtime((java.lang.System.currentTimeMillis / 1000).toInt, _fiberCounter.getAndIncrement())
+
+  private[zio] val _fiberCounter = new java.util.concurrent.atomic.AtomicInteger(0)
+
   case object None                                           extends FiberId
   final case class Runtime(id: Int, startTimeSeconds: Int)   extends FiberId
   final case class Composite(fiberIds: Set[FiberId.Runtime]) extends FiberId

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -43,6 +43,22 @@ sealed trait FiberId extends Serializable { self =>
       case Runtime(id, _)      => Set(id)
       case Composite(fiberIds) => fiberIds.map(_.id)
     }
+
+  final def isNone: Boolean =
+    self match {
+      case None           => true
+      case Composite(set) => set.forall(_.isNone)
+      case _              => false
+    }
+
+  final def threadName: String = s"zio-fiber-${self.ids.mkString(",")}"
+
+  final def toOption: Option[FiberId] =
+    self match {
+      case None           => Option.empty[FiberId]
+      case Composite(set) => set.map(_.toOption).collect { case Some(fiberId) => fiberId }.reduceOption(_.combine(_))
+      case other          => Some(other)
+    }
 }
 
 object FiberId {

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -87,7 +87,6 @@ trait Runtime[+R] {
    * program.
    */
   final def unsafeRun[E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): A =
-    //defaultUnsafeRunSync(zio).fold(cause => throw FiberFailure(cause), identity(_))
     try unsafeRunFast(zio, 50)
     catch {
       case failure: ZIO.ZioError[_] => throw FiberFailure(failure.cause)

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -233,6 +233,8 @@ trait Runtime[+R] {
             case t: Throwable =>
               val builder = stackTraceBuilder.value
 
+              chunkBuilder += zio.trace 
+
               if (x1 ne null) {
                 builder += x1.trace
                 if (x2 ne null) {

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -233,7 +233,7 @@ trait Runtime[+R] {
             case t: Throwable =>
               val builder = stackTraceBuilder.value
 
-              chunkBuilder += zio.trace
+              builder += zio.trace
 
               if (x1 ne null) {
                 builder += x1.trace

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -90,7 +90,7 @@ trait Runtime[+R] {
     //defaultUnsafeRunSync(zio).fold(cause => throw FiberFailure(cause), identity(_))
     try unsafeRunFast(zio, 50)
     catch {
-      case failure : ZIO.ZioError[_] => throw FiberFailure(failure.cause)
+      case failure: ZIO.ZioError[_] => throw FiberFailure(failure.cause)
     }
 
   /**
@@ -125,7 +125,7 @@ trait Runtime[+R] {
     try {
       Exit.Success(unsafeRunFast(zio, 50))
     } catch {
-      case failure : ZIO.ZioError[_] => Exit.Failure(failure.cause.asInstanceOf[Cause[E]])
+      case failure: ZIO.ZioError[_] => Exit.Failure(failure.cause.asInstanceOf[Cause[E]])
     }
 
   private[zio] def unsafeRunFast[E, A](zio: ZIO[R, E, A], maxStack: Int)(implicit
@@ -199,7 +199,7 @@ trait Runtime[+R] {
 
                 // Give up, the mini-interpreter can't handle it:
                 defaultUnsafeRunSync(zio) match {
-                  case Exit.Success(value) => 
+                  case Exit.Success(value) =>
                     if (x1 ne null) {
                       val k = x1
                       x1 = x2; x2 = x3; x3 = x4; x4 = nullK
@@ -212,7 +212,7 @@ trait Runtime[+R] {
                 }
             }
           } catch {
-            case failure : ZIO.ZioError[_] =>
+            case failure: ZIO.ZioError[_] =>
               val builder = stackTraceBuilder.value
 
               builder += failure.trace

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -233,7 +233,7 @@ trait Runtime[+R] {
             case t: Throwable =>
               val builder = stackTraceBuilder.value
 
-              chunkBuilder += zio.trace 
+              chunkBuilder += zio.trace
 
               if (x1 ne null) {
                 builder += x1.trace

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2995,7 +2995,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     succeedWith { (runtimeConfig, _) =>
       try effect
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t))
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
       }
     }
 
@@ -5248,7 +5248,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     suspendSucceedWith { (runtimeConfig, _) =>
       try rio
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t))
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
       }
     }
 
@@ -5283,7 +5283,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     suspendSucceedWith((runtimeConfig, fiberId) =>
       try f(runtimeConfig, fiberId)
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t))
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
       }
     )
 
@@ -6236,7 +6236,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     final val SetRuntimeConfig       = 29
   }
 
-  private[zio] final case class ZioError[E, A](exit: Exit[E, A]) extends Throwable with NoStackTrace
+  private[zio] final case class ZioError[E](cause: Cause[E], trace: ZTraceElement) extends Throwable with NoStackTrace
 
   private[zio] trait TracedCont[-A0, -R, +E, +A] extends (A0 => ZIO[R, E, A]) {
     val trace: ZTraceElement

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -476,16 +476,8 @@ private[zio] final class FiberContext[E, A](
             // Prevent interruption of interruption:
             unsafeSetInterrupting(true)
 
-          case ZIO.ZioError(exit) =>
-            exit match {
-              case Exit.Success(value) =>
-                curZio = unsafeNextEffect(value)
-
-              case Exit.Failure(cause) =>
-                val trace = curZio.trace
-
-                curZio = ZIO.failCause(cause)(trace)
-            }
+          case ZIO.ZioError(cause, trace) =>
+            curZio = ZIO.failCause(cause)(trace)
 
           // Catastrophic error handler. Any error thrown inside the interpreter is
           // either a bug in the interpreter or a bug in the user's code. Let the

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -651,7 +651,7 @@ private[zio] final class FiberContext[E, A](
 
     val parentScope = (forkScope orElse unsafeGetRef(forkScopeOverride)).getOrElse(scope)
 
-    val childId    = Fiber.newFiberId()
+    val childId    = FiberId.unsafeMake()
     val childScope = ZScope.unsafeMake[Exit[E, A]]()
 
     val childContext = new FiberContext[E, A](

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -552,18 +552,10 @@ private[zio] final class FiberContext[E, A](
     }
 
   private def unsafeCaptureTrace(prefix: List[ZTraceElement]): ZTrace = {
-    val builder = ChunkBuilder.make[ZTraceElement]()
-    val empty   = ZTraceElement.empty
-    var last    = empty
+    val builder = StackTraceBuilder.unsafeMake()
 
-    def addToTrace(trace: ZTraceElement): Unit =
-      if ((trace ne null) && (trace ne empty) && (trace ne last)) {
-        last = trace
-        builder += trace
-      }
-
-    prefix.foreach(addToTrace(_))
-    stack.foreach(k => addToTrace(k.trace))
+    prefix.foreach(builder += _)
+    stack.foreach(k => builder += k.trace)
 
     ZTrace(fiberId, builder.result())
   }

--- a/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio._
+
+class StackTraceBuilder private () { self =>
+  private var last: ZTraceElement                  = null.asInstanceOf[ZTraceElement]
+  private val builder: ChunkBuilder[ZTraceElement] = ChunkBuilder.make()
+
+  def +=(trace: ZTraceElement): Unit =
+    if ((trace ne last) && (trace ne null) && (trace ne ZTraceElement.empty)) {
+      builder += trace
+      last = trace
+    }
+
+  def result(): Chunk[ZTraceElement] = builder.result()
+}
+object StackTraceBuilder {
+  def unsafeMake(): StackTraceBuilder = new StackTraceBuilder()
+}

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -973,12 +973,12 @@ object ZSTM {
     ZIO.environmentWithZIO[R] { r =>
       ZIO.suspendSucceedWith { (runtimeConfig, fiberId) =>
         tryCommitSync(runtimeConfig, fiberId, stm, r) match {
-          case TryCommit.Done(exit) => 
+          case TryCommit.Done(exit) =>
             exit match {
               case Exit.Success(value) => ZIO.succeedNow(value)
               case Exit.Failure(cause) => throw new ZIO.ZioError(cause, trace)
             }
-            
+
           case TryCommit.Suspend(journal) =>
             val txnId = makeTxnId()
             val state = new AtomicReference[State[E, A]](State.Running)


### PR DESCRIPTION
This is the completion of work begun prior to the last ZIO World on adding a fast-path interpreter for `unsafeRun`, to improve the performance of interop code that heavily relies on `unsafeRun`. 

In the happy path, the new fast-path interpreter achieves one allocation.