### PR TITLE
Structural logging

### DIFF
--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -25,7 +25,7 @@ object LoggingSpec extends ZIOBaseSpec {
 
   val clearOutput: UIO[Unit] = UIO(_logOutput.set(Vector.empty))
 
-  val stringLogger =
+  val stringLogger: ZLogger[String, Unit] =
     new ZLogger[String, Unit] {
       @tailrec
       def apply(
@@ -46,8 +46,10 @@ object LoggingSpec extends ZIOBaseSpec {
       }
     }
 
+  val causeLogger: ZLogger[Cause[Any], Unit] = stringLogger.contramap((cause: Cause[Any]) => cause.prettyPrint)
+
   val testLoggers: ZLogger.Set[String & Cause[Any], Unit] =
-    ZLogger.Set(stringLogger, stringLogger.contramap((cause: Cause[Any]) => cause.prettyPrint))
+    ZLogger.Set(stringLogger, causeLogger)
 
   override def runner: TestRunner[Environment, Any] = super.runner.withRuntimeConfig(_.copy(loggers = testLoggers))
 

--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 object LoggingSpec extends ZIOBaseSpec {
   final case class LogEntry(
     trace: ZTraceElement,
-    fiberId: FiberId.Runtime,
+    fiberId: FiberId,
     logLevel: LogLevel,
     message: () => String,
     context: Map[FiberRef.Runtime[_], AnyRef],
@@ -30,7 +30,7 @@ object LoggingSpec extends ZIOBaseSpec {
       @tailrec
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => String,
         context: Map[FiberRef.Runtime[_], AnyRef],

--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -33,12 +33,12 @@ object ZIOAppSpec extends ZIOBaseSpec {
     test("hook update platform") {
       val counter = new java.util.concurrent.atomic.AtomicInteger(0)
 
-      val logger1 = new ZLogger[String, Unit] {
+      val logger1 = new ZLogger[Any, Unit] {
         def apply(
           trace: ZTraceElement,
           fiberId: zio.FiberId,
           logLevel: zio.LogLevel,
-          message: () => String,
+          message: () => Any,
           context: Map[zio.FiberRef.Runtime[_], AnyRef],
           spans: List[zio.LogSpan]
         ): Unit = {

--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -36,7 +36,7 @@ object ZIOAppSpec extends ZIOBaseSpec {
       val logger1 = new ZLogger[String, Unit] {
         def apply(
           trace: ZTraceElement,
-          fiberId: zio.FiberId.Runtime,
+          fiberId: zio.FiberId,
           logLevel: zio.LogLevel,
           message: () => String,
           context: Map[zio.FiberRef.Runtime[_], AnyRef],

--- a/core-tests/shared/src/test/scala/zio/ZLoggerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLoggerSpec.scala
@@ -1,0 +1,59 @@
+package zio
+
+import zio.test._
+
+object ZLoggerSpec extends ZIOBaseSpec {
+  trait Animal
+  trait Dog     extends Animal
+  object Scotty extends Dog
+
+  def spec =
+    suite("ZLoggerSpec") {
+      suite("Set") {
+        test("simple lookup") {
+          val logger = ZLogger.simple[String, Unit](_ => ())
+
+          val set = ZLogger.Set(logger)
+
+          val loggers = set.getAll[String]
+
+          val test = loggers.exists(_ eq logger) // TODO: Fix assertTrue
+
+          assertTrue(test)
+        } +
+          test("supertype lookup 1") {
+            val logger = ZLogger.simple[Animal, Unit](_ => ())
+
+            val set = ZLogger.Set(logger)
+
+            val loggers = set.getAll[Scotty.type]
+
+            val test = loggers.exists(_ eq logger) // TODO: Fix assertTrue
+
+            assertTrue(test)
+          } +
+          test("supertype lookup 2") {
+            val logger = ZLogger.simple[Any, Unit](_ => ())
+
+            val set = ZLogger.Set(logger)
+
+            val loggers = set.getAll[Int]
+
+            val test = loggers.exists(_ eq logger) // TODO: Fix assertTrue
+
+            assertTrue(test)
+          } +
+          test("supertype lookup 3") {
+            val logger = ZLogger.simple[Cause[Any], Unit](_ => ())
+
+            val set = ZLogger.Set(logger)
+
+            val loggers = set.getAll[Cause[Dog]]
+
+            val test = loggers.exists(_ eq logger) // TODO: Fix assertTrue
+
+            assertTrue(test)
+          }
+      }
+    }
+}

--- a/core-tests/shared/src/test/scala/zio/ZLoggerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLoggerSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.test._
+import zio.test.TestAspect._
 
 object ZLoggerSpec extends ZIOBaseSpec {
   trait Animal
@@ -39,10 +40,12 @@ object ZLoggerSpec extends ZIOBaseSpec {
 
             val loggers = set.getAll[Int]
 
+            println(set)
+
             val test = loggers.exists(_ eq logger) // TODO: Fix assertTrue
 
             assertTrue(test)
-          } +
+          } @@ exceptDotty +
           test("supertype lookup 3") {
             val logger = ZLogger.simple[Cause[Any], Unit](_ => ())
 

--- a/core/js/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
@@ -57,10 +57,10 @@ private[zio] trait RuntimeConfigPlatformSpecific {
 
     val fatal = (_: Throwable) => false
 
-    val logger: ZLogger[String, Unit] =
+    val loggerString: ZLogger[String, Unit] =
       (
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         level: LogLevel,
         message: () => String,
         context: Map[FiberRef.Runtime[_], AnyRef],
@@ -81,6 +81,10 @@ private[zio] trait RuntimeConfigPlatformSpecific {
         }
       }
 
+    val loggerCause: ZLogger[Cause[Any], Unit] = loggerString.contramap(_.prettyPrint)
+
+    val loggers = ZLogger.Set(loggerString, loggerCause).filterLogLevel(_ >= LogLevel.Info)
+
     val reportFatal = (t: Throwable) => {
       t.printStackTrace()
       throw t
@@ -94,7 +98,7 @@ private[zio] trait RuntimeConfigPlatformSpecific {
       fatal,
       reportFatal,
       supervisor,
-      logger.filterLogLevel(_ >= LogLevel.Info),
+      loggers,
       RuntimeConfigFlags.empty
     )
   }

--- a/core/js/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
@@ -68,7 +68,7 @@ private[zio] trait RuntimeConfigPlatformSpecific {
       ) => {
         try {
           // TODO: Improve output & use console.group for spans, etc.
-          val line = ZLogger.defaultFormatter(trace, fiberId, level, message, context, spans)
+          val line = ZLogger.defaultString(trace, fiberId, level, message, context, spans)
 
           if (level == LogLevel.Fatal) jsglobal.console.error(line)
           else if (level == LogLevel.Error) jsglobal.console.error(line)

--- a/core/jvm/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
@@ -61,8 +61,8 @@ private[zio] trait RuntimeConfigPlatformSpecific {
 
     val fatal = (t: Throwable) => t.isInstanceOf[VirtualMachineError]
 
-    val logger: ZLogger[String, Any] =
-      ZLogger.defaultFormatter.map(println(_)).filterLogLevel(_ >= LogLevel.Info)
+    val loggers =
+      ZLogger.Set.default.map(println(_)).filterLogLevel(_ >= LogLevel.Info)
 
     val reportFatal = (t: Throwable) => {
       t.printStackTrace()
@@ -80,7 +80,7 @@ private[zio] trait RuntimeConfigPlatformSpecific {
       fatal,
       reportFatal,
       supervisor,
-      logger,
+      loggers,
       RuntimeConfigFlags.empty
     )
   }

--- a/core/native/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
@@ -59,7 +59,7 @@ private[zio] trait RuntimeConfigPlatformSpecific {
         throw t
       },
       supervisor = Supervisor.none,
-      logger = ZLogger.defaultString.map(println(_)).filterLogLevel(_ >= LogLevel.Info),
+      loggers = ZLogger.Set.default.map(println(_)).filterLogLevel(_ >= LogLevel.Info),
       runtimeConfigFlags = RuntimeConfigFlags.empty
     )
 

--- a/core/native/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/RuntimeConfigPlatformSpecific.scala
@@ -59,7 +59,7 @@ private[zio] trait RuntimeConfigPlatformSpecific {
         throw t
       },
       supervisor = Supervisor.none,
-      logger = ZLogger.defaultFormatter.map(println(_)).filterLogLevel(_ >= LogLevel.Info),
+      logger = ZLogger.defaultString.map(println(_)).filterLogLevel(_ >= LogLevel.Info),
       runtimeConfigFlags = RuntimeConfigFlags.empty
     )
 

--- a/core/shared/src/main/scala/zio/RuntimeConfig.scala
+++ b/core/shared/src/main/scala/zio/RuntimeConfig.scala
@@ -28,7 +28,7 @@ final case class RuntimeConfig(
   fatal: Throwable => Boolean,
   reportFatal: Throwable => Nothing,
   supervisor: Supervisor[Any],
-  logger: ZLogger[String, Any],
+  loggers: ZLogger.Set[String & Cause[Any], Any],
   runtimeConfigFlags: RuntimeConfigFlags
 ) { self =>
   def @@(aspect: RuntimeConfigAspect): RuntimeConfig = aspect(self)

--- a/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
+++ b/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
@@ -27,7 +27,7 @@ final case class RuntimeConfigAspect(customize: RuntimeConfig => RuntimeConfig)
 object RuntimeConfigAspect extends ((RuntimeConfig => RuntimeConfig) => RuntimeConfigAspect) {
 
   def addLogger(logger: ZLogger[String, Any]): RuntimeConfigAspect =
-    RuntimeConfigAspect(self => self.copy(logger = self.logger ++ logger))
+    RuntimeConfigAspect(self => self.copy(loggers = self.loggers + logger))
 
   def addReportFatal(f: Throwable => Nothing): RuntimeConfigAspect =
     RuntimeConfigAspect(self => self.copy(reportFatal = t => { self.reportFatal(t); f(t) }))

--- a/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
+++ b/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
@@ -26,7 +26,7 @@ final case class RuntimeConfigAspect(customize: RuntimeConfig => RuntimeConfig)
 }
 object RuntimeConfigAspect extends ((RuntimeConfig => RuntimeConfig) => RuntimeConfigAspect) {
 
-  def addLogger(logger: ZLogger[String, Any]): RuntimeConfigAspect =
+  def addLogger[A: Tag](logger: ZLogger[A, Any]): RuntimeConfigAspect =
     RuntimeConfigAspect(self => self.copy(loggers = self.loggers + logger))
 
   def addReportFatal(f: Throwable => Nothing): RuntimeConfigAspect =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -26,6 +26,7 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
+import izumi.reflect.macrortti.LightTypeTag
 
 /**
  * A `ZIO[R, E, A]` value is an immutable value that lazily describes a workflow
@@ -4661,37 +4662,38 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Logs the specified message at the current log level.
    */
-  def log(message: => String)(implicit trace: ZTraceElement): UIO[Unit] = new Logged(() => message, trace = trace)
+  def log(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
+    new Logged(ZLogger.stringTag, () => message, trace = trace)
 
   /**
    * Logs the specified message at the debug log level.
    */
   def logDebug(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => message, someDebug, trace = trace)
+    new Logged(ZLogger.stringTag, () => message, someDebug, trace = trace)
 
   /**
    * Logs the specified message at the error log level.
    */
   def logError(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => message, someError, trace = trace)
+    new Logged(ZLogger.stringTag, () => message, someError, trace = trace)
 
   /**
    * Logs the specified cause as an error.
    */
   def logErrorCause(cause: => Cause[Any])(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => cause.prettyPrint, someError, trace = trace)
+    new Logged(ZLogger.causeTag, () => cause, someError, trace = trace)
 
   /**
    * Logs the specified message at the fatal log level.
    */
   def logFatal(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => message, someFatal, trace = trace)
+    new Logged(ZLogger.stringTag, () => message, someFatal, trace = trace)
 
   /**
    * Logs the specified message at the informational log level.
    */
   def logInfo(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => message, someInfo, trace = trace)
+    new Logged(ZLogger.stringTag, () => message, someInfo, trace = trace)
 
   def logLevel(level: LogLevel): LogLevel = level
 
@@ -4707,7 +4709,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Logs the specified message at the warning log level.
    */
   def logWarning(message: => String)(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => message, someWarning, trace = trace)
+    new Logged[String](ZLogger.stringTag, () => message, someWarning, trace = trace)
 
   /**
    * Sequentially zips the specified effects using the specified combiner
@@ -6516,8 +6518,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     override def tag = Tags.Ensuring
   }
 
-  private[zio] final class Logged(
-    val message: () => String,
+  private[zio] final class Logged[A](
+    val typeTag: LightTypeTag,
+    val message: () => A,
     val overrideLogLevel: Option[LogLevel] = None,
     val overrideRef1: FiberRef.Runtime[_] = null,
     val overrideValue1: AnyRef = null,

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -75,7 +75,7 @@ object ZIOAspect {
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
         ZIO.runtimeConfig.flatMap { runtimeConfig =>
-          zio.withRuntimeConfig(runtimeConfig.copy(logger = ZLogger.none))
+          zio.withRuntimeConfig(runtimeConfig.copy(loggers = ZLogger.none.toSet))
         }
     }
 

--- a/core/shared/src/main/scala/zio/ZLogger.scala
+++ b/core/shared/src/main/scala/zio/ZLogger.scala
@@ -92,7 +92,7 @@ object ZLogger {
   private[zio] val stringTag: LightTypeTag = Tag[String].tag
   private[zio] val causeTag: LightTypeTag  = Tag[Cause[Any]].tag
 
-  import Predef.{Set => ScalaSet}
+  import Predef.{Set => ScalaSet, _}
 
   /**
    * Represents a set of loggers, which operate on different input types, but
@@ -111,7 +111,7 @@ object ZLogger {
     final def addAll[A2, B1 >: B](that: Set[A2, B1]): Set[A with A2, B1] = self.++[A2, B1](that)
 
     final def filterLogLevel(f: LogLevel => Boolean): Set[A, Option[B]] =
-      new Set(map.map { case (k, v) => k -> v.asInstanceOf[ZLogger[_, B]].filterLogLevel(f) }) {}
+      new Set[A, Option[B]](map.map { case (k, v) => k -> v.asInstanceOf[ZLogger[Any, B]].filterLogLevel(f) }) {}
 
     final def getAllDynamic(tag: LightTypeTag): ScalaSet[_ <: ZLogger[_, B]] = {
       val set = cache.get(tag)
@@ -134,7 +134,7 @@ object ZLogger {
       getAllDynamic(tag.tag).asInstanceOf[ScalaSet[ZLogger[C, B]]]
 
     final def map[C](f: B => C): Set[A, C] =
-      new Set(map.map { case (k, v) => k -> v.asInstanceOf[ZLogger[_, B]].map(f) }) {}
+      new Set[A, C](map.map { case (k, v) => k -> v.asInstanceOf[ZLogger[Any, B]].map(f) }) {}
 
     final def toLoggerWith[C, B1 >: B](b: B1)(f: (B1, B1) => B1)(implicit tag: Tag[C]): ZLogger[C, B1] =
       getAll[C].fold[ZLogger[C, B1]](ZLogger.succeed(b)) { case (acc, logger) =>

--- a/core/shared/src/main/scala/zio/ZLogger.scala
+++ b/core/shared/src/main/scala/zio/ZLogger.scala
@@ -149,8 +149,11 @@ object ZLogger {
 
     def apply[A, B](logger: ZLogger[A, B])(implicit tag: Tag[A]): Set[A, B] = empty[B].add[A, B](logger)
 
-    def apply[A, B](logger1: ZLogger[A, B], logger2: ZLogger[A, B])(implicit tag: Tag[A]): Set[A, B] =
-      empty[B].add[A, B](logger1).add[A, B](logger2)
+    def apply[A, B, Z](logger1: ZLogger[A, Z], logger2: ZLogger[B, Z])(implicit
+      tag1: Tag[A],
+      tag2: Tag[B]
+    ): Set[A & B, Z] =
+      empty[Z].add[A, Z](logger1).add[B, Z](logger2)
   }
 
   val defaultString: ZLogger[String, String] = (

--- a/core/shared/src/main/scala/zio/ZLogger.scala
+++ b/core/shared/src/main/scala/zio/ZLogger.scala
@@ -6,7 +6,7 @@ import izumi.reflect.macrortti.LightTypeTag
 trait ZLogger[-Message, +Output] { self =>
   def apply(
     trace: ZTraceElement,
-    fiberId: FiberId.Runtime,
+    fiberId: FiberId,
     logLevel: LogLevel,
     message: () => Message,
     context: Map[FiberRef.Runtime[_], AnyRef],
@@ -23,7 +23,7 @@ trait ZLogger[-Message, +Output] { self =>
     new ZLogger[M, zippable.Out] {
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => M,
         context: Map[FiberRef.Runtime[_], AnyRef],
@@ -43,7 +43,7 @@ trait ZLogger[-Message, +Output] { self =>
     new ZLogger[Message1, Output] {
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => Message1,
         context: Map[FiberRef.Runtime[_], AnyRef],
@@ -59,7 +59,7 @@ trait ZLogger[-Message, +Output] { self =>
     new ZLogger[Message, Option[Output]] {
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => Message,
         context: Map[FiberRef.Runtime[_], AnyRef],
@@ -74,7 +74,7 @@ trait ZLogger[-Message, +Output] { self =>
     new ZLogger[Message, B] {
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => Message,
         context: Map[FiberRef.Runtime[_], AnyRef],
@@ -83,7 +83,7 @@ trait ZLogger[-Message, +Output] { self =>
     }
 
   final def test(input: => Message): Output =
-    apply(ZTraceElement.empty, null, LogLevel.Info, () => input, Map(), Nil)
+    apply(ZTraceElement.empty, FiberId.None, LogLevel.Info, () => input, Map(), Nil)
 
   final def toSet[Message1 <: Message](implicit tag: Tag[Message1]): ZLogger.Set[Message1, Output] =
     ZLogger.Set(self: ZLogger[Message1, Output])
@@ -155,7 +155,7 @@ object ZLogger {
 
   val defaultString: ZLogger[String, String] = (
     trace: ZTraceElement,
-    fiberId: FiberId.Runtime,
+    fiberId: FiberId,
     logLevel: LogLevel,
     message0: () => String,
     context: Map[FiberRef.Runtime[_], AnyRef],
@@ -174,7 +174,7 @@ object ZLogger {
       .append(" level=")
       .append(logLevel.label)
       .append(" thread=#")
-      .append(fiberId.id.toString)
+      .append(fiberId.threadName)
       .append(" message=\"")
       .append(message0())
       .append("\"")
@@ -223,7 +223,7 @@ object ZLogger {
   val none: ZLogger[Any, Unit] = new ZLogger[Any, Unit] {
     def apply(
       trace: ZTraceElement,
-      fiberId: FiberId.Runtime,
+      fiberId: FiberId,
       logLevel: LogLevel,
       message: () => Any,
       context: Map[FiberRef.Runtime[_], AnyRef],
@@ -236,7 +236,7 @@ object ZLogger {
     new ZLogger[A, B] {
       def apply(
         trace: ZTraceElement,
-        fiberId: FiberId.Runtime,
+        fiberId: FiberId,
         logLevel: LogLevel,
         message: () => A,
         context: Map[FiberRef.Runtime[_], AnyRef],

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -11,7 +11,7 @@ object TestSpec extends ZIOBaseSpec {
 
   override val runner: TestRunner[TestEnvironment, Any] =
     defaultTestRunner.withRuntimeConfig { runtimeConfig =>
-      runtimeConfig.copy(logger = runtimeConfig.logger.filterLogLevel(_ >= LogLevel.Error))
+      runtimeConfig.copy(loggers = runtimeConfig.loggers.filterLogLevel(_ >= LogLevel.Error))
     }
 
   def spec: Spec[Environment, TestFailure[Any], TestSuccess] = suite("TestSpec")(


### PR DESCRIPTION
This is a revamp to the logging support in ZIO 2.0, which achieves the following goals:

1. It is possible to log values which are not strings. In particular, this enables _ZIO Logging_ to easily add support for structured logging, without any further modifications to ZIO 2.0 and without working around the core logging mechanism in ZIO 2.0.
2. Causes are not logged by converting them to string, but rather, they are logged directly. This is required because backends treat errors differently, particularly those that support structured logging.

In order to support these goals, three changes have been made:

1. The log primitive now accepts any value for logging, but requires a `LightTypeTag`, which can be serialized.
2. `RuntimeConfig` now stores a set of loggers, which is wrapped up into `ZLogger.Set`, a lightweight data type that holds a type-indexed set of loggers.
3. There are now two default loggers in ZIO, one for strings, and the other for `Cause`. These are the only types of loggers needed in order to support the `ZIO.log*` family of operations.

There is some pending work to do around optimizing lookups, because with this approach, every time a log operation happens, the target logger has to be looked up from a hash map. This work is deferred to later PRs since it is non-breaking.

Fixes #5930, #5856