### PR TITLE
#4388 Adds execute method + test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -872,6 +872,13 @@ object ZStreamSpec extends ZIOBaseSpec {
               l   <- ref.get
             } yield assert(l.reverse)(equalTo(Range(0, 10).toList))
           ),
+          testM("execute")(
+            for {
+              ref <- Ref.make[Option[Int]](None)
+              _   <- ZStream.execute(ref.set(Some(1))).runDrain
+              l   <- ref.get
+            } yield assert(l)(equalTo(Some(1)))
+          ),
           testM("isn't too eager") {
             (ZStream(1) ++ ZStream.fail("fail")).drain.process.use(pull => assertM(pull.run)(succeeds(isEmpty)))
           }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -872,13 +872,6 @@ object ZStreamSpec extends ZIOBaseSpec {
               l   <- ref.get
             } yield assert(l.reverse)(equalTo(Range(0, 10).toList))
           ),
-          testM("execute")(
-            for {
-              ref <- Ref.make[Option[Int]](None)
-              _   <- ZStream.execute(ref.set(Some(1))).runDrain
-              l   <- ref.get
-            } yield assert(l)(equalTo(Some(1)))
-          ),
           testM("isn't too eager") {
             (ZStream(1) ++ ZStream.fail("fail")).drain.process.use(pull => assertM(pull.run)(succeeds(isEmpty)))
           }
@@ -987,6 +980,13 @@ object ZStreamSpec extends ZIOBaseSpec {
                  } yield ()).ensuringFirst(log.update("Ensuring" :: _)).runDrain
             execution <- log.get
           } yield assert(execution)(equalTo(List("Release", "Ensuring", "Use", "Acquire")))
+        },
+        testM("execute") {
+          for {
+            ref <- Ref.make(List[Int]())
+            _   <- ZStream.execute(ref.set(List(1))).runDrain
+            l   <- ref.get
+          } yield assert(l)(equalTo(List(1)))
         },
         testM("filter")(checkM(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
           for {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3722,6 +3722,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def environment[R]: ZStream[R, Nothing, R] =
     fromEffect(ZIO.environment[R])
 
+  /**
+   * Creates a [[zio.stream.ZStream]] from the given effect and drains it
+   */
   def execute[R, E, A](zio: ZIO[R, E, A]): ZStream[R, E, Nothing] =
     ZStream.fromEffect(zio).drain
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3722,6 +3722,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def environment[R]: ZStream[R, Nothing, R] =
     fromEffect(ZIO.environment[R])
 
+  def execute[R, E, A](zio: ZIO[R, E, A]): ZStream[R, E, Nothing] =
+    ZStream.fromEffect(zio).drain
+
   /**
    * The stream that always fails with the `error`
    */


### PR DESCRIPTION
This PR adds an `execute` method to `ZStream` and a corresponding unit test