### PR TITLE
Generalize Accessible

### DIFF
--- a/core/shared/src/main/scala/zio/Accessible.scala
+++ b/core/shared/src/main/scala/zio/Accessible.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.Accessible.IsAny
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.implicitNotFound
@@ -44,16 +43,8 @@ import scala.annotation.implicitNotFound
  * }}}
  */
 trait Accessible[R] {
-  def apply[R0, E, A](
-    f: R => ZIO[R0, E, A]
-  )(implicit tag: Tag[R], isAny: IsAny[R0], trace: ZTraceElement): ZIO[R, E, A] =
-    ZIO.serviceWithZIO[R](f.asInstanceOf[R => ZIO[Any, E, A]])
-}
-
-object Accessible {
-  @implicitNotFound(
-    "The methods of your service definition should not use the environment, because this leaks implementation details to clients of the service, and these implementation details should be hidden and free to change based on the specific nature of the implementation. In order to use this accessor, please consider refactoring your service methods so they no longer use ZIO environment."
-  )
-  sealed trait IsAny[R]
-  implicit val anyIsAny: IsAny[Any] = new IsAny[Any] {}
+  def apply[R1 <: R, E, A](
+    f: R => ZIO[R1, E, A]
+  )(implicit tag: Tag[R], trace: ZTraceElement): ZIO[R1, E, A] =
+    ZIO.serviceWithZIO[R](f)
 }


### PR DESCRIPTION
While having methods defined on services not use the environment is idiomatic, I think we have seen there are some situations where this is not possible (e.g. transactions) so it is nice to be able to use `Accessible` in these situations since we pushing it as part of the standard way to use the environment.