### PR TITLE
Fixed #4593 - Removed "invisible" tag from docs

### DIFF
--- a/docs/datatypes/concurrency/hub.md
+++ b/docs/datatypes/concurrency/hub.md
@@ -153,7 +153,7 @@ trait ZStream[-R, +E, +O] {
 
 We would now like to have multiple downstream consumers process each of these transactions, for example to persist them and log them in addition to applying our business logic to them. With `Hub` this is easy because we can just use the `toQueue` operator to view any `Hub` as a `Queue` that can only be written to.
 
-```scala mdoc:invisible
+```scala mdoc
 type ??? = Nothing
 ```
 
@@ -203,7 +203,7 @@ The `map` operator allows us to transform the type of messages received from the
 
 The `mapM` operator works the same way except it allows us to perform an effect each time a value is taken from the hub. We could use this for example to log each time a message is taken from the hub.
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio._
 import zio.console._
 ```
@@ -244,7 +244,7 @@ The `contramapM` operator works the same way except it allows us to perform an e
 
 Using these operators, we could describe a hub that validates its inputs, allowing publishers to publish raw data and subscribers to receive validated data while signaling to publishers when data they attempt to publish is not valid.
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio._
 import zio.console._
 ```
@@ -345,7 +345,7 @@ The managed effect here describes subscribing to receive messages from the hub w
 
 Here is an example of using it:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio._
 import zio.stream._
 ```

--- a/docs/datatypes/concurrency/index.md
+++ b/docs/datatypes/concurrency/index.md
@@ -39,7 +39,7 @@ As the lock-oriented programming does not compose and has lots of drawbacks, ZIO
 
 Let's see how the `modify` function of `Ref` is implemented without any locking mechanism:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.util.concurrent.atomic.AtomicReference
 import zio.UIO
 ```

--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -26,7 +26,7 @@ The `Ref` has lots of operations. Here we are going to introduce the most import
 ### make
 `Ref` is never empty and it always contains something. We can create `Ref` by providing the initial value to the `make`,  which is a constructor of the `Ref` data type. We should pass an **immutable value** of type `A` to the constructor, and it returns an `UIO[Ref[A]]` value:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 ```

--- a/docs/datatypes/concurrency/refm.md
+++ b/docs/datatypes/concurrency/refm.md
@@ -28,7 +28,7 @@ We can pass in an effectful program into every single update. All of them will b
 
 In the following example, we are going to send `getAge` request to usersApi for each user and updating the state respectively:
 
-```scala mdoc:invisible
+```scala mdoc
 import scala.collection.mutable.HashMap
 
 val users: List[String] = List("a", "b")

--- a/docs/datatypes/contextual/has.md
+++ b/docs/datatypes/contextual/has.md
@@ -16,7 +16,7 @@ ZIO Wrap services with `Has` data type to:
 ### Combining Services
 Two or more `Has[_]` elements can be combined _horizontally_ using their `++` operator:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 
 trait Logging 
@@ -55,7 +55,7 @@ ZIO environment has a `ZIO#provide` which takes an `R` and returns a `ZIO` effec
 
 Assume we have two `Logging` and `RandomInt` services:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 ```
 
@@ -206,7 +206,7 @@ case class RandomIntLive() extends RandomInt {
 
 Now, we can lift these two implementations into the `ZLayer`. The `ZLayer` will wrap our services into the `Has[_]` data type:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 trait Logging {
   def log(line: String): UIO[Unit]

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -12,7 +12,7 @@ The input type is also known as _environment type_. This type-parameter indicate
 `R` represents dependencies; whatever services, config, or wiring a part of a ZIO program depends upon to work. We will explore what we can do with `R`, as it plays a crucial role in `ZIO`.
 
 For example, when we have `ZIO[Console, Nothing, Unit]`, this shows that to run this effect we need to provide an implementation of the `Console` service:
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 import zio.console._
 ```
@@ -203,12 +203,12 @@ Let's start learning this pattern by writing a `Logging` service:
 
 Accessor methods allow us to utilize all the features inside the service through the ZIO Environment. That means, if we call `log`, we don't need to pull out the `log` function from the ZIO Environment. The `accessM` method helps us to access the environment of effect and reduce the redundant operation, every time.
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.console._
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{Has, UIO, Layer, ZLayer, ZIO, URIO}
 ```
 
@@ -238,7 +238,7 @@ object logging {
 
 We might need `Console` and `Clock` services to implement the `Logging` service. In this case, we use `ZLayer.fromServices` constructor:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.clock.Clock
 ```
 
@@ -296,7 +296,7 @@ _Module Pattern 2.0_ has more similarity with object-oriented way of defining se
 
 1. **Service Definition** — Defining service in this version has changed slightly compared to the previous version. We would take the service definition and pull it out into the top-level:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 ```
 
@@ -317,7 +317,7 @@ case class LoggingLive() extends Logging {
 
 3. **Define Service Dependencies** — We might need `Console` and `Clock` services to implement the `Logging` service. In this case, we put its dependencies into its constructor. All the dependencies are just interfaces, not implementation. Just like what we did in object-oriented style:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import java.time._
 import zio._
 
@@ -412,7 +412,7 @@ trait ZIO[-R, +E, +A] {
 
 This is similar to dependency injection, and the `provide` function can be thought of as `inject`.
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 ```
 
@@ -502,7 +502,7 @@ Sometimes we have written a program that contains ZIO built-in services and some
 
 Let's write an effect that has some built-in services and also has a `Logging` service:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.console._
 import zio.clock._

--- a/docs/datatypes/contextual/zlayer.md
+++ b/docs/datatypes/contextual/zlayer.md
@@ -62,7 +62,7 @@ def succeed[A: Tag](a: A): ULayer[Has[A]]
 
 In the following example, we are going to create a `nameLayer` that provides us the name of `Adam`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 
@@ -110,7 +110,7 @@ Fortunately, the construction of ZIO layers can be effectful and resourceful, th
 
 We can lift any `ZManaged` to `ZLayer` by providing a managed resource to the `ZIO.fromManaged` constructor:
 
-```scala mdoc:invisible
+```scala mdoc
 import scala.io.BufferedSource
 ```
 
@@ -130,7 +130,7 @@ val fileLayer: ZLayer[Any, Throwable, Has[BufferedSource]] = managedFile.toLayer
 
 Let's see another real-world example of creating a layer from managed resources. Assume we have written a managed `UserRepository`:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.blocking._
 import zio.console._
@@ -185,7 +185,7 @@ val layer_ = ZIO.succeed("Hello, World!").toLayer
 
 Assume we have a `ZIO` effect that read the application config from a file, we can create a layer from that:
 
-```scala mdoc:invisible
+```scala mdoc
 trait AppConfig
 ```
 
@@ -220,7 +220,7 @@ object logging {
 
 We can create that by using `ZLayer.fromService` constructor, which depends on `Console` service:
 
-```scala mdoc:invisible
+```scala mdoc
 import logging.Logging
 import logging.Logging._
 ```
@@ -245,7 +245,7 @@ We said that we can think of the `ZLayer` as a more powerful _constructor_. Cons
 
 Let's get into an example, assume we have these services with their implementations:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio.blocking.Blocking
 import zio.console.Console
 import zio._
@@ -304,7 +304,7 @@ If we don't want to share a module, we should create a fresh, non-shared version
 
 ## Updating Local Dependencies
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio.{ Has, IO, Layer, UIO, URIO, ZEnv, ZIO, ZLayer }
 import zio.clock.Clock
 import zio.console.Console
@@ -472,7 +472,7 @@ val layer: ZLayer[Any, Nothing, Has[Connection] with UserRepo] = connection >+> 
 
 Here, the `Connection` dependency has been passed through, and is available to all downstream services. This allows a style of composition where the `>+>` operator is used to build a progressively larger set of services, with each new service able to depend on all the services before it.
 
-```scala mdoc:invisible
+```scala mdoc
 type Baker = Has[Baker.Service]
 type Ingredients = Has[Ingredients.Service]
 type Oven = Has[Oven.Service]

--- a/docs/datatypes/core/io.md
+++ b/docs/datatypes/core/io.md
@@ -11,7 +11,7 @@ title: "IO"
 
 Let's see how the `IO` type alias is defined:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 ```
 

--- a/docs/datatypes/core/rio.md
+++ b/docs/datatypes/core/rio.md
@@ -10,7 +10,7 @@ title: "RIO"
 > In Scala, the _type alias_ is a way to give a name to another type, to avoid having to repeat the original type again and again. It doesn't affect the type-checking process. It just helps us to have an expressive API design.
 
 Let's see how `RIO` is defined:
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 ```
 

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -2,7 +2,7 @@
 id: runtime
 title: "Runtime"
 ---
-```scala mdoc:invisible
+```scala mdoc
 import zio.{Runtime, ZIO, UIO, URIO, Has, Task}
 import zio.internal.Platform
 ```

--- a/docs/datatypes/core/task.md
+++ b/docs/datatypes/core/task.md
@@ -7,7 +7,7 @@ title: "Task"
 
 Let's see how the `Task` type alias is defined:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 ```
 

--- a/docs/datatypes/core/uio.md
+++ b/docs/datatypes/core/uio.md
@@ -11,7 +11,7 @@ title: "UIO"
 
 Let's see how the `UIO` type alias is defined:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 ```
 

--- a/docs/datatypes/core/urio.md
+++ b/docs/datatypes/core/urio.md
@@ -11,7 +11,7 @@ title: "URIO"
 
 Let's see how the `URIO` type alias is defined:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZIO
 ```
 
@@ -23,7 +23,7 @@ So the `URIO` just equal to `ZIO` which requires `R` and cannot fail because in 
 
 In following example, the type of `putStrLn` is `URIO[Console, Unit]` which means, it requires `Console` service as an environment, and it succeeds with `Unit` value:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.console._
 

--- a/docs/datatypes/core/zio.md
+++ b/docs/datatypes/core/zio.md
@@ -26,7 +26,7 @@ The `ZIO[R, E, A]` data type has three type parameters:
 
 In the following example, the `getStrLn` function requires the `Console` service, it may fail with value of type `IOException`, or may succeed with a value of type `String`:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ZIO, IO, URIO, UIO, Task, RIO, Schedule}
 import zio.console._
 import java.io.IOException
@@ -162,7 +162,7 @@ val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
 
 We can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
 
-```scala mdoc:invisible
+```scala mdoc
 trait Team
 ```
 
@@ -260,7 +260,7 @@ The error type of the resulting effect will always be `Throwable`, because `Futu
 
 A `Promise` can be converted into a ZIO effect using `ZIO.fromPromiseScala`:
 
-```scala mdoc:invisible
+```scala mdoc
 import scala.util.{Success, Failure}
 import zio.Fiber
 ```
@@ -400,7 +400,7 @@ def safeDownload(url: String) =
 
 An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.effectAsync`:
 
-```scala mdoc:invisible
+```scala mdoc
 trait User { 
   def teamId: String
 }
@@ -621,7 +621,7 @@ def sqrt(io: UIO[Double]): IO[String, Double] =
 #### Catching All Errors 
 If we want to catch and recover from all types of errors and effectfully attempt recovery, we can use the `catchAll` method:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ FileNotFoundException, IOException }
 def readFile(s: String): IO[IOException, Array[Byte]] = 
   ZIO.effect(???).refineToOrDie[IOException]
@@ -701,7 +701,7 @@ Nearly all error handling methods are defined in terms of `foldM`, because it is
 
 In the following example, `foldM` is used to handle both failure and success of the `readUrls` method:
 
-```scala mdoc:invisible
+```scala mdoc
 sealed trait Content
 case class NoContent(t: Throwable) extends Content
 case class OkContent(s: String) extends Content
@@ -844,7 +844,7 @@ Brackets consist of an *acquire* action, a *utilize* action (which uses the acqu
 import zio.{ UIO, IO }
 ```
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -7,10 +7,10 @@ To perform an effect without blocking the current process, we can use fibers, wh
 
 We can `fork` any `IO[E, A]` to immediately yield an `UIO[Fiber[E, A]]`. The provided `Fiber` can be used to `join` the fiber, which will resume on production of the fiber's value, or to `interrupt` the fiber, which immediately terminates the fiber and safely releases all resources acquired by the fiber.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
-```scala mdoc:invisible
+```scala mdoc
 sealed trait Analysis
 case object Analyzed extends Analysis
 
@@ -110,7 +110,7 @@ The `await` is similar to join but lower level than join. When we call join if t
 ### Parallelism
 To execute actions in parallel, the `zipPar` method can be used:
 
-```scala mdoc:invisible
+```scala mdoc
 case class Matrix()
 def computeInverse(m: Matrix): UIO[Matrix] = IO.succeed(m)
 def applyMatrices(m1: Matrix, m2: Matrix, m3: Matrix): UIO[Matrix] = IO.succeed(m1)

--- a/docs/datatypes/misc/chunk.md
+++ b/docs/datatypes/misc/chunk.md
@@ -4,7 +4,7 @@ title: "Chunk"
 ---
 A `Chunk[A]` represents a chunk of values of type `A`. Chunks are usually backed by arrays, but expose a purely functional, safe interface to the underlying elements, and they become lazy on operations that would be costly with arrays, such as repeated concatenation.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 

--- a/docs/datatypes/misc/schedule.md
+++ b/docs/datatypes/misc/schedule.md
@@ -3,7 +3,7 @@ id: schedule
 title: "Schedule"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.duration._
 import zio.console._

--- a/docs/datatypes/misc/supervisor.md
+++ b/docs/datatypes/misc/supervisor.md
@@ -11,7 +11,7 @@ A `Supervisor[A]` is allowed to supervise the launching and termination of fiber
 The `track` creates a new supervisor that tracks children in a set. It takes a boolean `weak` parameter as input, which indicates whether track children in a `Weakset` or not.
 
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.Supervisor
 ```
 
@@ -26,7 +26,7 @@ The `fibersIn` creates a new supervisor with an initial sorted set of fibers.
 
 In the following example we are creating a new supervisor from an initial set of fibers:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{Ref, Fiber}
 import scala.collection.immutable.SortedSet
 def fibers: Seq[Fiber.Runtime[Any, Any]] = ???
@@ -43,7 +43,7 @@ def fiberListSupervisor = for {
 
 Whenever we need to supervise a ZIO effect, we can call `ZIO#supervised` function, `supervised` takes a supervisor and return another effect. The behavior of children fibers is reported to the provided supervisor:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 import zio.clock._

--- a/docs/datatypes/resource/index.md
+++ b/docs/datatypes/resource/index.md
@@ -16,7 +16,7 @@ Scala has a `try` / `finally` construct which helps us to make sure we don't lea
 
 Assume we want to read a file and return the number of its lines:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io._
 import zio.{Task, UIO, ZIO, ZManaged}
 ```
@@ -77,7 +77,7 @@ Every bracket requires three actions:
 2. **Using Resource**— An effect describing the actual process to produce a result. For example, counting the number of lines in a file.
 3. **Releasing Resource**— An effect describing the final step of releasing or cleaning up the resource. For example, closing a file.
 
-```scala mdoc:invisible
+```scala mdoc
 trait Resource
 ```
 

--- a/docs/datatypes/resource/managed.md
+++ b/docs/datatypes/resource/managed.md
@@ -5,7 +5,7 @@ title: "Managed"
 
 `Managed[E, A]` is a type alias for `ZManaged[Any, E, A]`, which represents a managed resource that has no requirements, and may fail with an `E`, or succeed with an `A`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZManaged
 ```
 
@@ -67,7 +67,7 @@ It is possible to combine multiple `Managed` using `flatMap` to obtain a single 
 import zio._
 ```
 
-```scala mdoc:invisible:nest
+```scala mdoc:nest
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.effect(???).refineToOrDie[IOException]

--- a/docs/datatypes/resource/rmanaged.md
+++ b/docs/datatypes/resource/rmanaged.md
@@ -5,7 +5,7 @@ title: "RManaged"
 
 `RManaged[R, A]` is a type alias for `ZManaged[R, Throwable, A]`, which represents a managed resource that requires an `R`, and may fail with a `Throwable` value, or succeed with an `A`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZManaged
 ```
 

--- a/docs/datatypes/resource/task-managed.md
+++ b/docs/datatypes/resource/task-managed.md
@@ -5,7 +5,7 @@ title: "TaskManaged"
 
 `TaskManaged[A]` is a type alias for `ZManaged[Any, Throwable, A]`, which represents a managed resource that has no requirements, and may fail with a `Throwable` value, or succeed with an `A`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZManaged
 ```
 

--- a/docs/datatypes/resource/umanaged.md
+++ b/docs/datatypes/resource/umanaged.md
@@ -5,7 +5,7 @@ title: "UManaged"
 
 `UManaged[A]` is a type alias for `ZManaged[Any, Nothing, A]`, which represents an **unexceptional** managed resource that doesn't require any specific environment, and cannot fail, but can succeed with an `A`.
  
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZManaged
 ```
 

--- a/docs/datatypes/resource/urmanaged.md
+++ b/docs/datatypes/resource/urmanaged.md
@@ -5,7 +5,7 @@ title: "URManaged"
 
 `URManaged[R, A]` is a type alias for `ZManaged[R, Nothing, A]`, which represents a managed resource that requires an `R`, and cannot fail, but can succeed with an `A`.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.ZManaged
 ```
 

--- a/docs/datatypes/resource/zmanaged.md
+++ b/docs/datatypes/resource/zmanaged.md
@@ -17,7 +17,7 @@ In this section, we explore some common ways to create managed resources.
 
 `ZManaged` has a `make` constructor which requires `acquire` and `release` actions:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io._
 import zio.blocking._
 import zio.console._
@@ -79,7 +79,7 @@ val managedHello_ = putStrLn("Hello, World!").toManaged_
 
 This is useful when we want to combine `ZManaged` effects with `ZIO` effects. Assume during creation of managed resource, we need to log some information, we can lift a `ZIO` effect to `ZManaged` world:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.blocking._
 import zio.console._
@@ -144,7 +144,7 @@ trait ZManaged[-R, +E, +A] {
 
 `Reservation` data type is defined as follows:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import java.io.{FileInputStream, FileOutputStream, Closeable}
 import zio.console._

--- a/docs/datatypes/stm/index.md
+++ b/docs/datatypes/stm/index.md
@@ -25,7 +25,7 @@ The ZIO STM API is inspired by Haskell's [STM library](http://hackage.haskell.or
 
 Let's start from a simple `inc` function, which takes a mutable reference of `Int` and increase it by `amount`:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{Ref, ZIO}
 import zio.stm.{TRef, STM}
 ```
@@ -67,7 +67,7 @@ The `modify` function takes these three steps:
 
 Let's see how the `modify` function of `Ref` is implemented without any locking mechanism:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.util.concurrent.atomic.AtomicReference
 import zio.UIO
 ```
@@ -92,7 +92,7 @@ As we see, the `modify` operation is implemented in terms of the `compare-and-sw
 
 Let's rename the `inc` function to the `deposit` as follows to try the classic problem of transferring money from one account to another:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio.{Ref, ZIO, IO}
 import zio.stm.{TRef, STM}
 ```

--- a/docs/datatypes/stream/index.md
+++ b/docs/datatypes/stream/index.md
@@ -3,7 +3,7 @@ id: index
 title: "Introduction"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ZIO, Task}
 import zio.Queue
 import zio.stream.{ZStream, ZTransducer}

--- a/docs/datatypes/stream/subscriptionref.md
+++ b/docs/datatypes/stream/subscriptionref.md
@@ -32,7 +32,7 @@ A `SubscriptionRef` can be extremely useful to model some shared state where one
 
 To see how this works, let's create a simple example where a "server" repeatedly updates a value that is observed by multiple "clients".
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio._
 import zio.stream._
 ```

--- a/docs/datatypes/stream/zsink.md
+++ b/docs/datatypes/stream/zsink.md
@@ -2,7 +2,7 @@
 id: zsink
 title: "ZSink"
 ---
-```scala mdoc:invisible
+```scala mdoc
 import zio.clock.Clock
 import zio.console.Console
 import zio.blocking.Blocking
@@ -383,7 +383,7 @@ val sum: ZIO[Any, Nothing, String] =
 
 Like `ZStream`, two `ZSink` can be zipped together. Both of them will be run in parallel, and their results will be combined in a tuple:
 
-```scala mdoc:invisible
+```scala mdoc
 case class Record()
 ```
 

--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -9,7 +9,7 @@ A `ZStream[R, E, O]` is a description of a program that, when evaluated, may emi
 
 One way to think of `ZStream` is as a `ZIO` program that could emit multiple values. As we know, a `ZIO[R, E, A]` data type, is a functional effect which is a description of a program that needs an environment of type `R`, it may end with an error of type `E`, and in case of success, it returns a value of type `A`. The important note about `ZIO` effects is that in the case of success they always end with exactly one value. There is no optionality here, no multiple infinite values, we always get exact value:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ZIO, Task, ZManaged, Chunk}
 import zio.stm.{STM, TQueue}
 import zio.blocking.Blocking
@@ -265,7 +265,7 @@ val list = ZStream.fromIterable(List(1, 2, 3))
 
 Assume we have a database that returns a list of users using `Task`:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 case class User(name: String)
 ```
@@ -422,7 +422,7 @@ One might ask what is the difference between `unfold` and `paginate` combinators
 
 Assume we have a paginated API that returns an enormous amount of data in a paginated fashion. When we call that API, it returns a data type `ResultPage` which contains the first-page result and, it also contains a flag indicating whether that result is the last one, or we have more data on the next page:
 
-```scala mdoc:invisible
+```scala mdoc
 case class RowData()
 ```
 
@@ -1257,7 +1257,7 @@ val c2 = a concat b
 
 Also, we can use `ZStream.concatAll` constructor to concatenate given streams together:
 
-```scala mdoc:invisible
+```scala mdoc
 val a = ZStream(1, 2, 3)
 val b = ZStream(4, 5)
 ```
@@ -1276,7 +1276,7 @@ val stream = ZStream(1, 2, 3).flatMap(x => ZStream.repeat(x).take(4))
 
 Assume we have an API that takes an author name and returns all its book:
 
-```scala mdoc:invisible
+```scala mdoc
 case class Book()
 ```
 
@@ -1361,7 +1361,7 @@ We can launch the Kafka consumer, the HTTP server, and our job runner and fork t
 
 So another idea is to watch background components. The `ZIO#forkManaged` enables us to race all forked fibers in a `ZManaged` context. By using `ZIO.raceAll` as soon as one of those fibers terminates with either success or failure, it will interrupt all the rest components as the part of the release action of `ZManaged`:
 
-```scala mdoc:invisible
+```scala mdoc
 val kafkaConsumer     : ZStream[Any, Nothing, Int] = ZStream.fromEffect(ZIO.succeed(???))
 val httpServer        : ZIO[Any, Nothing, Nothing] = ZIO.never
 val scheduledJobRunner: ZIO[Any, Nothing, Nothing] = ZIO.never
@@ -1662,7 +1662,7 @@ abstract class ZStream[-R, +E, +O] {
 
 When we are doing I/O, batching is very important. With ZIO streams, we can create user-defined batches. It is pretty easy to do that with the `ZStream#aggregateAsyncWithin` operator. Let's see the below snippet code:
 
-```scala mdoc:invisible
+```scala mdoc
 case class Record()
 val dataStream: ZStream[Any, Nothing, Record] = ZStream.repeat(Record())
 ```

--- a/docs/datatypes/stream/ztransducer.md
+++ b/docs/datatypes/stream/ztransducer.md
@@ -3,7 +3,7 @@ id: ztransducer
 title: "ZTransducer"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.stream.{UStream, ZStream, ZTransducer, ZSink}
 import zio.{Schedule, Chunk, IO, ZIO}
 import zio.console._

--- a/docs/howto/interop/with-cats-effect.md
+++ b/docs/howto/interop/with-cats-effect.md
@@ -3,7 +3,7 @@ id: with-cats-effect
 title: "How to Interop with Cats Effect?"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 // Contributor Note:
 // This page has some unchecked markdown documentation. They are related
 // to the zio-interop-cats module compatible with the Cats Effect 2.x
@@ -41,7 +41,7 @@ Due to the limitations of the Cats Effect, ZIO cannot provide instances for arbi
 
 For convenience, ZIO includes the `Task` and `RIO` type aliases, which fix the error type to `Throwable`, and may be useful for interop with Cats Effect:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ZIO, Task, RIO}
 ```
 
@@ -73,7 +73,7 @@ object ZioCatsEffectInterop extends scala.App {
 
 If we are working with Cats Effect 3.x, the `catsEffectApp[Task]` will be expanded as if we called the following code explicitly:
 
-```scala mdoc:invisible
+```scala mdoc
 import ZioCatsEffectInterop.catsEffectApp
 ```
 

--- a/docs/howto/mock-services.md
+++ b/docs/howto/mock-services.md
@@ -20,7 +20,7 @@ If the job of the _capability_ is to call on another _capability_, how should we
 A pure function is such a function which operates only on its inputs and produces only its output. Command-like methods, by definition are impure, as
 their job is to change state of the collaborating object (performing a _side effect_). For example:
 
-```scala mdoc:invisible
+```scala mdoc
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait Event
@@ -40,7 +40,7 @@ not the one you expected.
 
 Inside the future there may be happening any side effects. It may open a file, print to console, connect to databases. We simply don't know. Let's have a look how this problem would be solved using ZIO's effect system:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 trait Event
 ```
 
@@ -148,7 +148,7 @@ For overloaded methods we nest a list of numbered objects, each representing sub
 Finally we need to define a _compose layer_ that can create our environment from a `Proxy`.
 A `Proxy` holds the mock state and serves predefined responses to calls.
 
-```scala mdoc:invisible
+```scala mdoc
 def withRuntime[R]: URIO[R, Runtime[R]] = ???
 ```
 
@@ -185,7 +185,7 @@ multiple services.
 
 ## Complete example
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 trait AccountEvent
 ```
 
@@ -259,7 +259,7 @@ For each built-in ZIO service you will find their mockable counterparts in `zio.
 
 To create expectations we use the previously defined _capability tags_:
 
-```scala mdoc:invisible
+```scala mdoc
 object Example {
   trait Service {
     def zeroArgs: UIO[Int]

--- a/docs/howto/use-test-assertions.md
+++ b/docs/howto/use-test-assertions.md
@@ -23,7 +23,7 @@ Assertion.hasAt[A](pos: Int)(assertion: Assertion[A]): Assertion[Seq[A]]
 
 I could start by writing:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 
@@ -42,7 +42,7 @@ of the return type `Assertion[A]`.
 I could select `equalTo`, as it accepts an `A` as a parameter, allowing me to
 supply `5`:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 
@@ -67,7 +67,7 @@ Assertion.approximatelyEquals[A: Numeric](reference: A, tolerance: A): Assertion
 
 Changing out `equalTo` with `approximatelyEquals` leaves us with:
 
-```scala mdoc:reset:invisible
+```scala mdoc:reset
 import zio.test._, zio.test.Assertion._
 ```
 

--- a/docs/overview/basic_concurrency.md
+++ b/docs/overview/basic_concurrency.md
@@ -30,7 +30,7 @@ The `Fiber[E, A]` data type in ZIO has two type parameters:
 
 Fibers do not have an `R` type parameter, because they model effects that are already running, and which already had their required environment provided to them.
 
-```scala mdoc:invisible
+```scala mdoc
 
 import zio._
 ```

--- a/docs/overview/basic_operations.md
+++ b/docs/overview/basic_operations.md
@@ -3,7 +3,7 @@ id: overview_basic_operations
 title:  "Basic Operations"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 ```

--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -5,7 +5,7 @@ title:  "Creating Effects"
 
 This section explores some of the common ways to create ZIO effects from values, from common Scala types, and from both synchronous and asynchronous side-effects.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.{ ZIO, Task, UIO, URIO, IO }
 ```
 
@@ -69,7 +69,7 @@ val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
 
 You can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
 
-```scala mdoc:invisible
+```scala mdoc
 trait Team
 ```
 
@@ -179,7 +179,7 @@ val getStrLn2: IO[IOException, String] =
 
 An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.effectAsync`:
 
-```scala mdoc:invisible
+```scala mdoc
 trait User { 
   def teamId: String
 }

--- a/docs/overview/handling_errors.md
+++ b/docs/overview/handling_errors.md
@@ -5,7 +5,7 @@ title:  "Handling Errors"
 
 This section looks at some of the common ways to detect and respond to failure.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 
@@ -34,7 +34,7 @@ def sqrt(io: UIO[Double]): IO[String, Double] =
 
 If you want to catch and recover from all types of errors and effectfully attempt recovery, you can use the `catchAll` method:
 
-```scala mdoc:invisible
+```scala mdoc
 import java.io.{ FileNotFoundException, IOException }
 
 def openFile(s: String): IO[IOException, Array[Byte]] = 
@@ -100,7 +100,7 @@ Nearly all error handling methods are defined in terms of `foldM`, because it is
 
 In the following example, `foldM` is used to handle both failure and success of the `readUrls` method:
 
-```scala mdoc:invisible
+```scala mdoc
 sealed trait Content
 case class NoContent(t: Throwable) extends Content
 case class OkContent(s: String) extends Content

--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -7,7 +7,7 @@ This section looks at some of the common ways to safely handle resources using Z
 
 ZIO's resource management features work across synchronous, asynchronous, concurrent, and other effect types, and provide strong guarantees even in the presence of failure, interruption, or defects in the application.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 ```
 
@@ -47,7 +47,7 @@ ZIO encapsulates this common pattern with `ZIO#bracket`, which allows you to spe
 
 The release effect is guaranteed to be executed by the runtime system, even in the presence of errors or interruption.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import java.io.{ File, IOException }
 

--- a/docs/overview/testing_effects.md
+++ b/docs/overview/testing_effects.md
@@ -7,7 +7,7 @@ There are many approaches to testing functional effects, including using free mo
 
 This section introduces environmental effects and shows you how to write testable functional code using them.
 
-```scala mdoc:invisible
+```scala mdoc
 import zio._
 import zio.console._
 ```
@@ -89,7 +89,7 @@ In this section, we'll explore how to use environmental effects by developing a 
 
 We will define the database service with the help of a module, which is an interface that contains only a single field, which provides access to the service.
 
-```scala mdoc:invisible
+```scala mdoc
 trait UserID
 trait UserProfile
 val userId = new UserID { }

--- a/docs/resources/ecosystem/community.md
+++ b/docs/resources/ecosystem/community.md
@@ -1333,7 +1333,7 @@ libraryDependencies += "com.vladkopanev" %% "zio-saga-core" % "0.4.0"
 
 In the following example, all API requests have a compensating action. We compose all them together and then run the whole as one transaction:
 
-```scala mdoc:invisible:reset
+```scala mdoc:reset
 import zio.{IO, UIO, URIO, ZIO}
 def bookHotel: UIO[Unit] = IO.unit
 def cancelHotel: UIO[Unit] = IO.unit

--- a/docs/services/blocking.md
+++ b/docs/services/blocking.md
@@ -3,7 +3,7 @@ id: blocking
 title: "Blocking"
 ---
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.duration._
 import zio.{Schedule, RIO, UIO}
 ```
@@ -37,7 +37,7 @@ and continuously create new threads as necessary.
 
 The `blocking` operator takes a ZIO effect and return another effect that is going to run on a blocking thread pool:
 
-```scala mdoc:invisible:nest
+```scala mdoc:nest
 val program = ZIO.foreachPar((1 to 100).toArray)(t => zio.blocking.blocking(blockingTask(t)))
 ```
 

--- a/docs/services/clock.md
+++ b/docs/services/clock.md
@@ -7,7 +7,7 @@ Clock service contains some functionality related to time and scheduling.
 
 To get the current time in a specific time unit, the `currentTime` function takes a unit as `TimeUnit` and returns `UIO[Long]`:
 
-```scala mdoc:invisible
+```scala mdoc
 import zio.clock._
 import zio.console._
 import zio.duration._


### PR DESCRIPTION
Original issue:

> We should ensure that all code snippets in the documentation are checked with mdoc to ensure that they compile as written.
> 
> Can I also ask that for all examples we NOT use hidden or invisible code? I know sometimes people do this because they want to omit things they see as boilerplate like imports or type definitions. However, a lot of people are going to copy and paste and compile these examples as written so if there are things missing it makes it harder for them to get started.