### PR TITLE
Optimize Metrics

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentHistogram.scala
+++ b/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentHistogram.scala
@@ -3,7 +3,7 @@ package zio.internal.metrics
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.atomic.{AtomicReferenceArray, DoubleAdder, LongAdder}
+import java.util.concurrent.atomic.{AtomicLongArray, DoubleAdder, LongAdder}
 
 private[zio] sealed abstract class ConcurrentHistogram {
 
@@ -24,7 +24,7 @@ private[zio] object ConcurrentHistogram {
 
   def manual(bounds: Chunk[Double]): ConcurrentHistogram =
     new ConcurrentHistogram {
-      private[this] val values     = new AtomicReferenceArray[Long](bounds.length + 1)
+      private[this] val values     = new AtomicLongArray(bounds.length + 1)
       private[this] val boundaries = Array.ofDim[Double](bounds.length)
       private[this] val count      = new LongAdder
       private[this] val sum        = new DoubleAdder
@@ -47,7 +47,7 @@ private[zio] object ConcurrentHistogram {
             if (value <= boundaries(from)) to = from else from = to
           }
         }
-        values.getAndUpdate(from, _ + 1L)
+        values.getAndIncrement(from)
         count.increment()
         sum.add(value)
         ()

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentState.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentState.scala
@@ -38,7 +38,7 @@ private[zio] class ConcurrentState {
         }
       }
 
-      override def unsafeHistogramChanged(key: MetricKey.Histogram, value: MetricState): Unit = {
+      override def unsafeHistogramChanged(key: MetricKey.Histogram, value: Double): Unit = {
         val iterator = listeners.iterator
         while (iterator.hasNext) {
           val listener = iterator.next()
@@ -46,7 +46,7 @@ private[zio] class ConcurrentState {
         }
       }
 
-      override def unsafeSummaryChanged(key: MetricKey.Summary, value: MetricState): Unit = {
+      override def unsafeSummaryChanged(key: MetricKey.Summary, value: Double): Unit = {
         val iterator = listeners.iterator
         while (iterator.hasNext) {
           val listener = iterator.next()
@@ -54,7 +54,7 @@ private[zio] class ConcurrentState {
         }
       }
 
-      override def unsafeSetChanged(key: MetricKey.SetCount, value: MetricState): Unit = {
+      override def unsafeSetChanged(key: MetricKey.SetCount, value: String): Unit = {
         val iterator = listeners.iterator
         while (iterator.hasNext) {
           val listener = iterator.next()
@@ -154,7 +154,7 @@ private[zio] class ConcurrentState {
 
       def unsafeObserve(value: Double): Unit = {
         histogram.observe(value)
-        listener.unsafeHistogramChanged(key, histogram.toMetricState)
+        listener.unsafeHistogramChanged(key, value)
       }
     }
   }
@@ -179,7 +179,7 @@ private[zio] class ConcurrentState {
       def observe(value: Double)(implicit trace: ZTraceElement): UIO[Unit] =
         ZIO.succeed {
           summary.observe(value, Instant.now)
-          listener.unsafeSummaryChanged(key, summary.toMetricState)
+          listener.unsafeSummaryChanged(key, value)
         }
       def quantileValues(implicit trace: ZTraceElement): zio.UIO[zio.Chunk[(Double, Option[Double])]] =
         ZIO.succeed(summary.summary.snapshot(Instant.now))
@@ -209,7 +209,7 @@ private[zio] class ConcurrentState {
 
       def unsafeObserve(word: String): Unit = {
         setCount.observe(word)
-        listener.unsafeSetChanged(key, setCount.toMetricState)
+        listener.unsafeSetChanged(key, word)
       }
     }
   }

--- a/core/shared/src/main/scala/zio/metrics/MetricListener.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricListener.scala
@@ -25,7 +25,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 trait MetricListener { self =>
   def unsafeGaugeChanged(key: MetricKey.Gauge, value: Double, delta: Double): Unit
   def unsafeCounterChanged(key: MetricKey.Counter, absValue: Double, delta: Double): Unit
-  def unsafeHistogramChanged(key: MetricKey.Histogram, value: MetricState): Unit
-  def unsafeSummaryChanged(key: MetricKey.Summary, value: MetricState): Unit
-  def unsafeSetChanged(key: MetricKey.SetCount, value: MetricState): Unit
+  def unsafeHistogramChanged(key: MetricKey.Histogram, value: Double): Unit
+  def unsafeSummaryChanged(key: MetricKey.Summary, value: Double): Unit
+  def unsafeSetChanged(key: MetricKey.SetCount, word: String): Unit
 }


### PR DESCRIPTION
When notifying listeners that a metric has changed we always need to only send the delta and never the entire metric state.