### PR TITLE
Restoring having `NeedsEnv[R]` on the provide overloads

### DIFF
--- a/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
@@ -65,8 +65,9 @@ object TagCorrectnessSpec extends ZIOSpecDefault {
             environment.get
           }
 
-        val layer = testBaseLayer[Any, String] >>> testSecondLayer[String]
-        ZIO.unit.provideCustomLayer(layer).as(assertTrue(true))
+        val layer                                  = testBaseLayer[Any, String] >>> testSecondLayer[String]
+        val zio: ZIO[Svc[String], Nothing, String] = ZIO.succeed("a")
+        zio.provideCustomLayer(layer).as(assertCompletes)
       },
       // https://github.com/zio/zio/issues/3816
       test("Issue #3816") {

--- a/core/shared/src/main/scala-2/zio/ZIOVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOVersionSpecific.scala
@@ -35,7 +35,7 @@ private[zio] trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
    * val zio2 : ZIO[ZEnv, Nothing, Unit] = zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): ZIO[ZEnv, E1, A] =
+  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZIO[ZEnv, E1, A] =
     macro LayerMacros.provideCustomImpl[ZIO, ZEnv, R, E1, A]
 
   /**
@@ -56,7 +56,7 @@ private[zio] trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   /**
    * Automatically assembles a layer for the ZIO effect.
    */
-  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): ZIO[Any, E1, A] =
+  def provide[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZIO[Any, E1, A] =
     macro LayerMacros.provideImpl[ZIO, R, E1, A]
 
 }
@@ -71,6 +71,6 @@ private final class ProvideSomeLayerPartiallyApplied[R0, -R, +E, +A](val self: Z
   def provideSomeLayer[R0]: ZIO.ProvideSomeLayer[R0, R, E, A] =
     new ZIO.ProvideSomeLayer[R0, R, E, A](self)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZIO[R0, E1, A] =
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZIO[R0, E1, A] =
     macro LayerMacros.provideSomeImpl[ZIO, R0, R, E1, A]
 }

--- a/core/shared/src/main/scala-2/zio/ZManagedVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZManagedVersionSpecific.scala
@@ -35,7 +35,7 @@ private[zio] trait ZManagedVersionSpecific[-R, +E, +A] { self: ZManaged[R, E, A]
    * val managed2 : ZManaged[ZEnv, Nothing, Unit] = managed.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): ZManaged[ZEnv, E1, A] =
+  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZManaged[ZEnv, E1, A] =
     macro LayerMacros.provideCustomImpl[ZManaged, ZEnv, R, E1, A]
 
   /**
@@ -56,7 +56,7 @@ private[zio] trait ZManagedVersionSpecific[-R, +E, +A] { self: ZManaged[R, E, A]
   /**
    * Automatically assembles a layer for the ZManaged effect.
    */
-  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): ZManaged[Any, E1, A] =
+  def provide[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZManaged[Any, E1, A] =
     macro LayerMacros.provideImpl[ZManaged, R, E1, A]
 
 }
@@ -73,6 +73,6 @@ private final class ProvideSomeLayerManagedPartiallyApplied[R0, -R, +E, +A](
   def provideSomeLayer[R0]: ZManaged.ProvideSomeLayer[R0, R, E, A] =
     new ZManaged.ProvideSomeLayer[R0, R, E, A](self)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZManaged[R0, E1, A] =
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZManaged[R0, E1, A] =
     macro LayerMacros.provideSomeImpl[ZManaged, R0, R, E1, A]
 }

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -47,7 +47,7 @@ private[zio] trait LayerMacroUtils {
     layers: Seq[c.Expr[ZLayer[_, E, _]]],
     method: String,
     provideMethod: ProvideMethod
-  ): c.Expr[F[R0, E, A]] = {
+  )(ev: c.Tree): c.Expr[F[R0, E, A]] = {
     val expr = constructLayer[R0, R, E](layers, provideMethod)
     c.Expr[F[R0, E, A]](q"${c.prefix}.${TermName(method)}(${expr.tree})")
   }

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacros.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacros.scala
@@ -27,18 +27,18 @@ private[zio] class LayerMacros(val c: blackbox.Context) extends LayerMacroUtils 
 
   def provideImpl[F[_, _, _], R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[F[Any, E, A]] =
-    provideBaseImpl[F, Any, R, E, A](layer, "provideLayer", ProvideMethod.Provide)
+  )(ev: c.Tree): c.Expr[F[Any, E, A]] =
+    provideBaseImpl[F, Any, R, E, A](layer, "provideLayer", ProvideMethod.Provide)(ev)
 
   def provideSomeImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[F[R0, E, A]] =
-    provideBaseImpl[F, R0, R, E, A](layer, "provideLayer", ProvideMethod.ProvideSome)
+  )(ev: c.Tree): c.Expr[F[R0, E, A]] =
+    provideBaseImpl[F, R0, R, E, A](layer, "provideLayer", ProvideMethod.ProvideSome)(ev)
 
   def provideCustomImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[F[R0, E, A]] =
-    provideBaseImpl[F, R0, R, E, A](layer, "provideLayer", ProvideMethod.ProvideCustom)
+  )(ev: c.Tree): c.Expr[F[R0, E, A]] =
+    provideBaseImpl[F, R0, R, E, A](layer, "provideLayer", ProvideMethod.ProvideCustom)(ev)
 
   def debugGetRequirements[R: c.WeakTypeTag]: c.Expr[List[String]] =
     c.Expr[List[String]](q"${getRequirements[R]}")

--- a/core/shared/src/main/scala-3/zio/ZIOVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOVersionSpecific.scala
@@ -17,7 +17,7 @@ trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
    * val zio2 : ZIO[ZEnv, Nothing, Unit] = zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZIO[ZEnv, E1, A] =
+  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZIO[ZEnv, E1, A] =
     ${LayerMacros.provideImpl[ZEnv, R, E1,A]('self, 'layer)}
 
   /**
@@ -39,12 +39,12 @@ trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
    * Automatically assembles a layer for the ZIO effect, which
    * translates it to another level.
    */
-  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZIO[Any, E1, A] =
+  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZIO[Any, E1, A] =
     ${LayerMacros.provideImpl[Any,R,E1, A]('self, 'layer)}
 
 }
 
 private final class provideSomePartiallyApplied[R0, -R, +E, +A](val self: ZIO[R, E, A]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): ZIO[R0, E1, A] =
-  ${LayerMacros.provideImpl[R0, R, E1, A]('self, 'layer)}
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): ZIO[R0, E1, A] =
+    ${LayerMacros.provideImpl[R0, R, E1, A]('self, 'layer)}
 }

--- a/core/shared/src/main/scala-3/zio/ZManagedVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZManagedVersionSpecific.scala
@@ -17,8 +17,8 @@ trait ZManagedVersionSpecific[-R, +E, +A] { self: ZManaged[R, E, A] =>
    * val managed2 : ZManaged[ZEnv, Nothing, Unit] = managed.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZManaged[ZEnv, E1, A] =
-  ${ZManagedMacros.provideImpl[ZEnv, R, E1, A]('self, 'layer)}
+  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZManaged[ZEnv, E1, A] =
+    ${ZManagedMacros.provideImpl[ZEnv, R, E1, A]('self, 'layer)}
 
 
   /**
@@ -40,12 +40,12 @@ trait ZManagedVersionSpecific[-R, +E, +A] { self: ZManaged[R, E, A] =>
    * Automatically assembles a layer for the ZManaged effect,
    * which translates it to another level.
    */
-  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZManaged[Any, E1, A] =
+  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZManaged[Any, E1, A] =
     ${ZManagedMacros.provideImpl[Any, R, E1, A]('self, 'layer)}
 }
 
 private final class provideSomeZManagedPartiallyApplied[R0, -R, +E, +A](val self: ZManaged[R, E, A]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): ZManaged[R0, E1, A] =
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): ZManaged[R0, E1, A] =
     ${ZManagedMacros.provideImpl[R0, R, E1, A]('self, 'layer)}
 }
 

--- a/docs/datatypes/test/index.md
+++ b/docs/datatypes/test/index.md
@@ -23,7 +23,11 @@ What about functional effects? Can we assert two effects using ordinary scala as
 
 Let's say we have a random generator effect, and we want to ensure that the output is bigger than zero, so we should `unsafeRun` the effect and assert the result:
 
-```scala mcoc:compile-only
+```scala mdoc:invisible
+import zio._
+```
+
+```scala mdoc:compile-only
 import scala.Predef.assert
 
 val random = Runtime.default.unsafeRun(
@@ -152,9 +156,9 @@ import zio.test.{test, _}
 import zio.test.Assertion._
 
 val kafkaLayer: ZLayer[Any, Nothing, Int] = ZLayer.succeed(1)
-val test1 = test("kafkatest")(assertTrue(true))
-val test2 = test("kafkatest")(assertTrue(true))
-val test3 = test("kafkatest")(assertTrue(true))
+val test1: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
+val test2: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
+val test3: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
 ```
 
 ```scala mdoc:compile-only
@@ -175,6 +179,7 @@ Support for property based testing is included out-of-the-box through the `check
 
 ```scala mdoc:compile-only
 import zio.test._
+
 val associativity =
   check(Gen.int, Gen.int, Gen.int) { (x, y, z) =>
     assertTrue(((x + y) + z) == (x + (y + z)))
@@ -187,7 +192,7 @@ ZIO Test also supports automatic derivation of generators using the ZIO Test Mag
 
 ```scala mdoc:compile-only
 import zio._
-import zio.Random
+import zio.test._
 import zio.test.magnolia._
 
 case class Point(x: Double, y: Double)

--- a/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
@@ -20,7 +20,7 @@ private[stream] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O
    * val stream2 : ZStream[ZEnv, Nothing, Unit] = stream.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): ZStream[ZEnv, E1, O] =
+  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZStream[ZEnv, E1, O] =
     macro LayerMacros.provideCustomImpl[ZStream, ZEnv, R, E1, O]
 
   /**
@@ -41,7 +41,7 @@ private[stream] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O
   /**
    * Automatically assembles a layer for the ZStream effect.
    */
-  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): ZStream[Any, E1, O] =
+  def provide[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZStream[Any, E1, O] =
     macro LayerMacros.provideImpl[ZStream, R, E1, O]
 
 }
@@ -54,6 +54,6 @@ private final class ProvideSomeLayerStreamPartiallyApplied[R0, -R, +E, +O](
   )(implicit ev: NeedsEnv[R]): ZStream[R0, E1, O] =
     self.provideLayer(layer)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZStream[R0, E1, O] =
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): ZStream[R0, E1, O] =
     macro LayerMacros.provideSomeImpl[ZStream, R0, R, E1, O]
 }

--- a/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
@@ -1,6 +1,6 @@
 package zio.stream
 
-import zio.{ZLayer, ZEnv}
+import zio.{ZLayer, ZEnv, NeedsEnv}
 import zio.internal.macros.LayerMacros
 
 trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>
@@ -18,14 +18,14 @@ trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>
    * val stream2 : ZStream[ZEnv, Nothing, Unit] = stream.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZStream[ZEnv, E1, O] =
+  inline def provideCustom[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZStream[ZEnv, E1, O] =
     ${ZStreamProvideMacro.provideImpl[ZEnv, R, E1, O]('self, 'layer)}
 
   /**
    * Automatically assembles a layer for the ZStream effect,
    * which translates it to another level.
    */
-  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*): ZStream[Any, E1, O] =
+  inline def provide[E1 >: E](inline layer: ZLayer[_,E1,_]*)(using ev: NeedsEnv[R]): ZStream[Any, E1, O] =
     ${ZStreamProvideMacro.provideImpl[Any, R, E1, O]('self, 'layer)}
 
 }

--- a/test/shared/src/main/scala-2/zio/test/SpecLayerMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SpecLayerMacros.scala
@@ -9,16 +9,16 @@ import scala.reflect.macros.blackbox
 class SpecLayerMacros(val c: blackbox.Context) extends LayerMacroUtils {
   def provideSharedImpl[R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[Any, E, A]] =
-    provideBaseImpl[Spec, Any, R, E, A](layer, "provideLayerShared", ProvideMethod.Provide)
+  )(ev: c.Tree): c.Expr[Spec[Any, E, A]] =
+    provideBaseImpl[Spec, Any, R, E, A](layer, "provideLayerShared", ProvideMethod.Provide)(ev)
 
   def provideCustomSharedImpl[R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[TestEnvironment, E, A]] =
-    provideBaseImpl[Spec, TestEnvironment, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideCustom)
+  )(ev: c.Tree): c.Expr[Spec[TestEnvironment, E, A]] =
+    provideBaseImpl[Spec, TestEnvironment, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideCustom)(ev)
 
   def provideSomeSharedImpl[R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[R0, E, A]] =
-    provideBaseImpl[Spec, R0, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideSome)
+  )(ev: c.Tree): c.Expr[Spec[R0, E, A]] =
+    provideBaseImpl[Spec, R0, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideSome)(ev)
 }

--- a/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
@@ -1,6 +1,6 @@
 package zio.test
 
-import zio.{NeedsEnv, ZLayer}
+import zio.{ZLayer, NeedsEnv}
 import zio.internal.macros.LayerMacros
 
 private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
@@ -8,7 +8,7 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
   /**
    * Automatically assembles a layer for the spec, translating it up a level.
    */
-  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
+  def provide[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
     macro LayerMacros.provideImpl[Spec, R, E1, T]
 
   /**
@@ -29,7 +29,7 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   spec.provideCustom(userRepoLayer, databaseLayer)
    * }}}
    */
-  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
+  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[TestEnvironment, E1, T] =
     macro LayerMacros.provideCustomImpl[Spec, TestEnvironment, R, E1, T]
 
   /**
@@ -50,7 +50,7 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    * Automatically assembles a layer for the spec, sharing services between all
    * tests.
    */
-  def provideShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
+  def provideShared[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[Any, E1, T] =
     macro SpecLayerMacros.provideSharedImpl[R, E1, T]
 
   /**
@@ -72,7 +72,7 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   spec.provideCustomShared(userRepoLayer, databaseLayer)
    * }}}
    */
-  def provideCustomShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
+  def provideCustomShared[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[TestEnvironment, E1, T] =
     macro SpecLayerMacros.provideCustomSharedImpl[R, E1, T]
 
   /**
@@ -98,7 +98,7 @@ private final class provideSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R
   )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     self.provideLayer(layer)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     macro LayerMacros.provideSomeImpl[Spec, R0, R, E1, T]
 }
 
@@ -109,6 +109,6 @@ private final class provideSomeSharedPartiallyApplied[R0, -R, +E, +T](val self: 
   )(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     self.provideLayerShared(layer)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*)(implicit ev: NeedsEnv[R]): Spec[R0, E1, T] =
     macro SpecLayerMacros.provideSomeSharedImpl[R0, R, E1, T]
 }

--- a/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
@@ -1,6 +1,6 @@
 package zio.test
 
-import zio.{ZIO, ZLayer}
+import zio.{ZIO, ZLayer, NeedsEnv}
 
 trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
 
@@ -8,13 +8,13 @@ trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    * Automatically assembles a layer for the spec, translating it
    * up a level.
    */
-  inline def provide[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
+  inline def provide[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[Any, E1, T] =
     ${SpecLayerMacros.provideImpl[Any, R, E1, T]('self, 'layer)}
 
-  def provideSome[R0 ] =
+  def provideSome[R0] =
     new provideSomePartiallyApplied[R0, R, E, T](self)
 
-  def provideSomeShared[R0 ] =
+  def provideSomeShared[R0] =
     new provideSomeSharedPartiallyApplied[R0, R, E, T](self)
 
   /**
@@ -34,14 +34,14 @@ trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustom[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
+  inline def provideCustom[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[TestEnvironment, E1, T] =
     ${SpecLayerMacros.provideImpl[TestEnvironment, R, E1, T]('self, 'layer)}
 
   /**
    * Automatically assembles a layer for the spec, sharing
    * services between all tests.
    */
-  inline def provideShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
+  inline def provideShared[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[Any, E1, T] =
     ${SpecLayerMacros.provideSharedImpl[Any, R, E1, T]('self, 'layer)}
 
   /**
@@ -63,16 +63,16 @@ trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustomShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
+  inline def provideCustomShared[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[TestEnvironment, E1, T] =
     ${SpecLayerMacros.provideSharedImpl[TestEnvironment, R, E1, T]('self, 'layer)}
 }
 
 private final class provideSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-  ${SpecLayerMacros.provideImpl[R0, R, E1, T]('self, 'layer)}
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[R0, E1, T] =
+    ${SpecLayerMacros.provideImpl[R0, R, E1, T]('self, 'layer)}
 }
 
 private final class provideSomeSharedPartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-  ${SpecLayerMacros.provideSharedImpl[R0, R, E1, T]('self, 'layer)}
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*)(using ev: NeedsEnv[R]): Spec[R0, E1, T] =
+    ${SpecLayerMacros.provideSharedImpl[R0, R, E1, T]('self, 'layer)}
 }


### PR DESCRIPTION
This PR restores having the `NeedsEnv[R]` implicit on the macro-calling overloads of `provide*`, to allow statically detecting whether this effect indeed requires some R. This helps tooling (mainly, IntelliJ) detect these erroneous situations and offer a fix.

I've asked @kitlangton for this fix, but couldn't resist trying it myself :D

- [x] Ensure all tests pass
- [x] Ensure Scala 3 macros still work