### PR TITLE
Add ZPipeline.mapChunksZIO

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -105,6 +105,16 @@ object ZPipelineSpec extends ZIOBaseSpec {
           testSplitLines(Seq(Chunk("abc\r", "\nabc")))
         }
       ),
+      suite("mapChunksZIO")(
+        test("maps chunks with effect") {
+          val pipeline = ZPipeline.mapChunksZIO { (chunk: Chunk[Int]) =>
+            ZIO.succeed(chunk.map(_.toString.reverse))
+          }
+          assertM(
+            pipeline(ZStream(12, 23, 34)).runCollect
+          )(equalTo(Chunk("21", "32", "43")))
+        }
+      ),
       suite("splitOn")(
         test("preserves data")(check(Gen.chunkOf(Gen.string.filter(!_.contains("|")).filter(_.nonEmpty))) { lines =>
           val data     = lines.mkString("|")

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -384,6 +384,32 @@ object ZPipeline extends ZPipelineCompanionVersionSpecific with ZPipelinePlatfor
     }
 
   /**
+   * Creates a pipeline that maps chunks of elements with the specified effect.
+   */
+  def mapChunksZIO[Env, Err, In, Out](
+    f: Chunk[In] => ZIO[Env, Err, Chunk[Out]]
+  ): ZPipeline.WithOut[
+    Nothing,
+    Env,
+    Err,
+    Any,
+    Nothing,
+    In,
+    ({ type OutEnv[Env] = Env })#OutEnv,
+    ({ type OutErr[Err] = Err })#OutErr,
+    ({ type OutElem[Elem] = Out })#OutElem
+  ] =
+    new ZPipeline[Nothing, Env, Err, Any, Nothing, In] {
+      type OutEnv[Env]   = Env
+      type OutErr[Err]   = Err
+      type OutElem[Elem] = Out
+      def apply[Env1 <: Env, Err1 >: Err, Elem <: In](stream: ZStream[Env1, Err1, Elem])(implicit
+        trace: ZTraceElement
+      ): ZStream[Env1, Err1, Out] =
+        stream.mapChunksZIO(f)
+    }
+
+  /**
    * Creates a pipeline that maps elements with the specified function.
    */
   def mapError[InError, OutError](


### PR DESCRIPTION
We have `mapZIO` and `mapChunks`, but not this one.

zio-kafka has ZTransducer uses where this is a fitting migration.