### PR TITLE
Make ZChannel.end strict again

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1465,7 +1465,7 @@ object ZChannel {
     readOrFail(None)
 
   def succeed[Z](z: => Z)(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
-    end(z)
+    effectTotal(z)
 
   val unit: ZChannel[Any, Any, Any, Any, Nothing, Nothing, Unit] =
     succeed(())(ZTraceElement.empty)

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1468,7 +1468,7 @@ object ZChannel {
     effectTotal(z)
 
   val unit: ZChannel[Any, Any, Any, Any, Nothing, Nothing, Unit] =
-    succeed(())(ZTraceElement.empty)
+    end(())(ZTraceElement.empty)
 
   def unwrap[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
     channel: ZIO[Env, OutErr, ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]]

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1207,8 +1207,8 @@ object ZChannel {
   )(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
     EffectSuspendTotal(() => effect)
 
-  def end[Z](result: => Z)(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
-    effectTotal(result)
+  def end[Z](result: Z)(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
+    Done(result)
 
   def endWith[R, Z](f: ZEnvironment[R] => Z)(implicit
     trace: ZTraceElement

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1445,7 +1445,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
    * A sink that immediately ends with the specified value.
    */
   def succeed[Z](z: => Z)(implicit trace: ZTraceElement): ZSink[Any, Nothing, Any, Nothing, Z] = new ZSink(
-    ZChannel.effectTotal(z)
+    ZChannel.succeed(z)
   )
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1445,7 +1445,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
    * A sink that immediately ends with the specified value.
    */
   def succeed[Z](z: => Z)(implicit trace: ZTraceElement): ZSink[Any, Nothing, Any, Nothing, Z] = new ZSink(
-    ZChannel.succeed(z)
+    ZChannel.effectTotal(z)
   )
 
   /**


### PR DESCRIPTION
A few weeks ago while trying to make all the stream/sink tests pass I changed `ZChannel.end` to lazy, backed by `effectTotal`, just to support the lazyness of `ZSink.succeed`.

This is very bad for performance and channels are low level enough to provide both a strict `end` and a lazy `effectTotal` for its users, so in this I change it back and only use `effectTotal` for `ZSink.succeed`.

(I have no idea why didn't I do this the first time)