### PR TITLE
Implement ZStream#tapSink

### DIFF
--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -1451,19 +1451,16 @@ val stream: ZIO[Console with Random with Clock, IOException, Unit] =
     .map(_ % 100)
     .tap(e => printLine(s"Emit $e element before broadcasting"))
     .broadcast(2, 5)
-    .use {
-      case s1 :: s2 :: Nil =>
+    .use { streams =>
         for {
-          out1 <- s1.runFold(0)((acc, e) => Math.max(acc, e))
+          out1 <- streams(0).runFold(0)((acc, e) => Math.max(acc, e))
                     .flatMap(x => printLine(s"Maximum: $x"))
                     .fork
-          out2 <- s2.schedule(Schedule.spaced(1.second))
+          out2 <- streams(1).schedule(Schedule.spaced(1.second))
                     .foreach(x => printLine(s"Logging to the Console: $x"))
                     .fork
           _    <- out1.join.zipPar(out2.join)
         } yield ()
-
-      case _ => ZIO.dieMessage("unhandled case")
     }
 ```
 ### Distribution

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3182,25 +3182,25 @@ object ZStreamSpec extends ZIOBaseSpec {
         suite("tapSink")(
           test("sink that is done after stream") {
             for {
-              ref <- Ref.make(0)
-              sink   = ZSink.foreach[Any, Nothing, Int](n => ref.update(_ + n))
-              stream = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
+              ref      <- Ref.make(0)
+              sink      = ZSink.foreach[Any, Nothing, Int](n => ref.update(_ + n))
+              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
               elements <- stream.runCollect
               done     <- ref.get
             } yield assertTrue(elements == Chunk(1, 1, 2, 3, 5, 8) && done == 20)
           },
           test("sink that is done before stream") {
             for {
-              ref <- Ref.make(0)
-              sink   = ZSink.take[Int](3).map(_.sum).mapZIO(n => ref.update(_ + n))
-              stream = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
+              ref      <- Ref.make(0)
+              sink      = ZSink.take[Int](3).map(_.sum).mapZIO(n => ref.update(_ + n))
+              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
               elements <- stream.runCollect
               done     <- ref.get
             } yield assertTrue(elements == Chunk(1, 1, 2, 3, 5, 8) && done == 4)
           },
           test("sink that fails before stream") {
             for {
-              ref <- Ref.make(0)
+              ref   <- Ref.make(0)
               sink   = ZSink.fail("error")
               stream = ZStream.never.tapSink(sink, 8)
               error <- stream.runCollect.flip

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3492,8 +3492,8 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
     catchAll(e => ZStream.fromZIO(f(e) *> ZIO.fail(e)))
 
   /**
-   * Sends all elements emitted by this stream to the specified sink in
-   * addition to emitting them.
+   * Sends all elements emitted by this stream to the specified sink in addition
+   * to emitting them.
    */
   final def tapSink[R1 <: R, E1 >: E](
     sink: ZSink[R1, E1, A, Any, Any],

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -257,7 +257,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
    */
   final def broadcast(n: Int, maximumLag: Int)(implicit
     trace: ZTraceElement
-  ): ZManaged[R, Nothing, List[ZStream[Any, E, A]]] =
+  ): ZManaged[R, Nothing, Chunk[ZStream[Any, E, A]]] =
     self
       .broadcastedQueues(n, maximumLag)
       .map(_.map(ZStream.fromQueueWithShutdown(_).flattenTake))
@@ -284,10 +284,10 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def broadcastedQueues(
     n: Int,
     maximumLag: Int
-  )(implicit trace: ZTraceElement): ZManaged[R, Nothing, List[Dequeue[Take[E, A]]]] =
+  )(implicit trace: ZTraceElement): ZManaged[R, Nothing, Chunk[Dequeue[Take[E, A]]]] =
     for {
       hub    <- Hub.bounded[Take[E, A]](maximumLag).toManaged
-      queues <- ZManaged.collectAll(List.fill(n)(hub.subscribe))
+      queues <- ZManaged.collectAll(Chunk.fill(n)(hub.subscribe))
       _      <- self.runIntoHubManaged(hub).fork
     } yield queues
 
@@ -3499,8 +3499,8 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
     sink: ZSink[R1, E1, A, Any, Any],
     maximumLag: Int
   )(implicit trace: ZTraceElement): ZStream[R1, E1, A] =
-    ZStream.managed(broadcast(2, maximumLag)).flatMap { case left :: right :: Nil =>
-      left.drainFork(ZStream.fromZIO(right.run(sink)))
+    ZStream.managed(broadcast(2, maximumLag)).flatMap { streams =>
+      streams(0).drainFork(ZStream.fromZIO(streams(1).run(sink)))
     }
 
   /**


### PR DESCRIPTION
Allows sending all elements emitted from a stream to a sink in addition to emitting them.