### PR TITLE
Propagate Interrupted Cause

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -581,9 +581,9 @@ private[zio] final class FiberContext[E, A](
         val newState = executing.copy(suppressed = Cause.empty)
 
         if (!state.compareAndSet(oldState, newState)) unsafeClearSuppressed()
-        else suppressed
+        else suppressed ++ oldState.interruptorsCause
 
-      case _ => Cause.empty
+      case _ => oldState.interruptorsCause
     }
   }
 


### PR DESCRIPTION
Resolves #6125.

We can currently lose an interrupted cause in the runtime when working with finalizers because when we observe interruption we call `clearSuppressedCause` to get the suppressed cause but an interrupt may have occurred after the suppressed cause was added. We need to return both the suppressed cause and the interruptors cause.