### PR TITLE
Handle Very Large Stacks

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
@@ -60,7 +60,22 @@ object StackSpec extends ZIOBaseSpec {
         readers <- ZIO.forkAll(List.fill(100)(ZIO.succeed(stack.toList.forall(_ != null))))
         noNulls <- readers.join.map(_.forall(a => a)) <* fiber.interrupt
       } yield assertTrue(noNulls)
-    } @@ nonFlaky
+    } @@ nonFlaky,
+    test("stack safety") {
+      val stack = Stack[String]()
+      val n     = 1000000
+      var i     = 0
+      while (i <= n) {
+        stack.push("1")
+        i += 1
+      }
+      i = n
+      while (i >= 0) {
+        stack.pop()
+        i -= 1
+      }
+      assertCompletes
+    }
   )
 
   sealed trait Boolean {

--- a/core/shared/src/main/scala/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/zio/internal/Stack.scala
@@ -25,11 +25,11 @@ private[zio] final class Stack[A <: AnyRef]() extends Iterable[A] { self =>
   private[this] var array  = new Array[AnyRef](13)
   private[this] var packed = 0
 
-  private def getUsed: Int          = packed & 0xffff
-  private def setUsed(n: Int): Unit = packed = (packed & 0xffff0000) + (n & 0xffff)
+  private def getUsed: Int          = packed & 0xf
+  private def setUsed(n: Int): Unit = packed = (packed & 0xfffffff0) + (n & 0xf)
 
-  private def getNesting: Int          = (packed >> 16)
-  private def setNesting(n: Int): Unit = packed = (packed & 0x0000ffff) + (n << 16)
+  private def getNesting: Int          = (packed >>> 4)
+  private def setNesting(n: Int): Unit = packed = (packed & 0xf) + (n << 4)
 
   override def size: Int = getUsed + (12 * getNesting)
 


### PR DESCRIPTION
For very large stacks the `nesting` field can overflow the 16 bits allocated to it. We only need 4 bits for `used` so we can reallocate the rest to `nesting` which allows us to represent all sizes that could practically fit in memory.