### PR TITLE
Improve Array Diffing

### DIFF
--- a/test/shared/src/main/scala/zio/test/diff/Diff.scala
+++ b/test/shared/src/main/scala/zio/test/diff/Diff.scala
@@ -103,7 +103,7 @@ trait DiffInstances extends LowPriDiff {
 }
 
 trait LowPriDiff {
-  
+
   implicit def anyDiff[A]: Diff[A] = new Diff[A] {
 
     override def diff(x: A, y: A): DiffResult =

--- a/test/shared/src/main/scala/zio/test/diff/Diff.scala
+++ b/test/shared/src/main/scala/zio/test/diff/Diff.scala
@@ -103,9 +103,8 @@ trait DiffInstances extends LowPriDiff {
 }
 
 trait LowPriDiff {
-  implicit val anyValDiff: Diff[AnyVal] = anyDiff[AnyVal]
-
-  def anyDiff[A]: Diff[A] = new Diff[A] {
+  
+  implicit def anyDiff[A]: Diff[A] = new Diff[A] {
 
     override def diff(x: A, y: A): DiffResult =
       if (x == y) DiffResult.Identical(x)


### PR DESCRIPTION
Only having the low priority instance available for `AnyVal` prevents it from being available for invariant data types like `Array` that are parameterized on subtypes of `AnyVal`, among other things. I think we need to directly make a low priority `Diff` instance available for any type so that we can do diffing of collections of arbitrary types.