### PR TITLE
Un-deprecate RunnableSpec & DefaultRunnableSpec

### DIFF
--- a/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultRunnableSpec.scala
@@ -23,7 +23,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A default runnable spec that provides testable versions of all of the modules
  * in ZIO (Clock, Random, etc).
  */
-@deprecated("Use ZIOSpecDefault")
 abstract class DefaultRunnableSpec extends RunnableSpec[TestEnvironment, Any] {
 
   override def aspects: List[TestAspectAtLeastR[TestEnvironment]] =

--- a/test/shared/src/main/scala/zio/test/RunnableSpec.scala
+++ b/test/shared/src/main/scala/zio/test/RunnableSpec.scala
@@ -22,7 +22,6 @@ import zio.test.render._
 /**
  * A `RunnableSpec` has a main function and can be run by the JVM / Scala.js.
  */
-@deprecated("ZIOSpec extends ZIOApp now, making this redundant")
 abstract class RunnableSpec[R, E] extends AbstractRunnableSpec {
   override type Environment = R
   override type Failure     = E


### PR DESCRIPTION
We want to get the new features of ZIOSpec ironed out before really pushing people to convert