### PR TITLE
Fix Resource Handling In ZChannel#PipeToOrFail

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2842,7 +2842,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               assert(result)(equalTo(Chunk(1, 1, 1))) && assert(state)(isFalse) && assert(finalState)(isTrue)
             }
           )
-        ) @@ ignore,
+        ),
         suite("scan")(
           test("scan")(check(pureStreamOfInts) { s =>
             for {


### PR DESCRIPTION
We can handle errors using `pipeTo` instead of `catchAll` to preserve the scope of resources.