### PR TITLE
Fix scalafix 3

### DIFF
--- a/scalafix/input/src/main/scala/fix/AbstractRunnableSpecToZioSpec.scala
+++ b/scalafix/input/src/main/scala/fix/AbstractRunnableSpecToZioSpec.scala
@@ -1,5 +1,5 @@
 /*
-rule = ZIOSpecMigration
+rule = Zio2Upgrade
  */
 package fix
 

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,3 +1,2 @@
 fix.CurriedAssert
 fix.Zio2Upgrade
-fix.Zio2ZIOSpec

--- a/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
@@ -587,7 +587,7 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
   }
 
   override def fix(implicit doc: SemanticDocument): Patch = {
-    new Zio2ZIOSpec().fix +
+    Zio2ZIOSpec.fix +
     doc.tree.collect {
       case BuiltInServiceFixer.ImporteeRenamer(patch) => patch
 

--- a/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
@@ -686,6 +686,31 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
     case Some(t: Term.Select) => unwindSelect(t)
     case _                    => t
   }
+  
+  object Zio2ZIOSpec extends SemanticRule("ZIOSpecMigration"){
+    val zio2UpgradeRule = new Zio2Upgrade()
+    val AbstractRunnableSpecRenames = zio2UpgradeRule.Renames(
+      List("zio.test.DefaultRunnableSpec" /* TODO What other types here? */),
+      Map(
+        "Failure"            -> "Any",
+      )
+    )
+
+    override def fix(implicit doc: SemanticDocument): Patch =
+      doc.tree.collect {
+        case AbstractRunnableSpecRenames.Matcher(patch) => patch
+
+        // TODO Check if we really want to do this, or if we want to keep it now that we might have a
+        //    meaningful Failure type
+        case t @ q"override def spec: $tpe = $body" if tpe.toString().contains("ZSpec[Environment, Failure]") =>
+          Patch.replaceTree(t, s"override def spec = $body")
+      }.asPatch + replaceSymbols
+
+    def replaceSymbols(implicit doc: SemanticDocument) = Patch.replaceSymbols(
+      "zio.test.DefaultRunnableSpec" -> "zio.test.ZIOSpecDefault"
+    )
+
+  }
 }
 
 private object ImporteeNameOrRename {

--- a/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
@@ -4,7 +4,7 @@ import scalafix.v1._
 
 import scala.meta._
 
-class Zio2ZIOSpec extends SemanticRule("ZIOSpecMigration"){
+class Zio2ZIOSpec() extends SemanticRule("ZIOSpecMigration"){
   val zio2UpgradeRule = new Zio2Upgrade()
   val AbstractRunnableSpecRenames = zio2UpgradeRule.Renames(
     List("zio.test.DefaultRunnableSpec" /* TODO What other types here? */),

--- a/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
@@ -4,7 +4,7 @@ import scalafix.v1._
 
 import scala.meta._
 
-class Zio2ZIOSpec() extends SemanticRule("ZIOSpecMigration"){
+object Zio2ZIOSpec extends SemanticRule("ZIOSpecMigration"){
   val zio2UpgradeRule = new Zio2Upgrade()
   val AbstractRunnableSpecRenames = zio2UpgradeRule.Renames(
     List("zio.test.DefaultRunnableSpec" /* TODO What other types here? */),

--- a/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
@@ -4,27 +4,3 @@ import scalafix.v1._
 
 import scala.meta._
 
-object Zio2ZIOSpec extends SemanticRule("ZIOSpecMigration"){
-  val zio2UpgradeRule = new Zio2Upgrade()
-  val AbstractRunnableSpecRenames = zio2UpgradeRule.Renames(
-    List("zio.test.DefaultRunnableSpec" /* TODO What other types here? */),
-    Map(
-      "Failure"            -> "Any",
-    )
-  )
-  
-  override def fix(implicit doc: SemanticDocument): Patch =
-    doc.tree.collect {
-      case AbstractRunnableSpecRenames.Matcher(patch) => patch
-
-      // TODO Check if we really want to do this, or if we want to keep it now that we might have a
-      //    meaningful Failure type
-      case t @ q"override def spec: $tpe = $body" if tpe.toString().contains("ZSpec[Environment, Failure]") =>
-        Patch.replaceTree(t, s"override def spec = $body")
-    }.asPatch + replaceSymbols
-
-  def replaceSymbols(implicit doc: SemanticDocument) = Patch.replaceSymbols(
-    "zio.test.DefaultRunnableSpec" -> "zio.test.ZIOSpecDefault"
-  )
-
-}

--- a/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2ZIOSpec.scala
@@ -1,6 +1,0 @@
-package fix
-
-import scalafix.v1._
-
-import scala.meta._
-


### PR DESCRIPTION
With assistance from @zagyi @zhrebicek 
Having the rules in separate files was breaking the process. Now this executes cleanly for the zio-crypto project (and hopefully all others!)