### PR TITLE
Crossbuild scalafix 2

### DIFF
--- a/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
@@ -464,11 +464,6 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
           serviceMatchers ++ List(serviceMigrator.normalizedOld, serviceMigrator.normalizedOldService)
         }.map(pf).foldLeft {pf1} {pf2}
       }
-      /*
-        [error]     (which expands to)  scala.meta.Tree => Option[scalafix.patch.Patch]
-        [error]     (which expands to)  PartialFunction[scala.meta.Tree,Option[scalafix.patch.Patch]]
-
-       */
 
       def unapply(tree: Tree)(implicit sdoc: SemanticDocument): Option[Patch] =
         importeeRenames.apply(tree)

--- a/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
+++ b/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala
@@ -441,7 +441,9 @@ class Zio2Upgrade extends SemanticRule("Zio2Upgrade") {
 
         val pf1:PartialFunction[Tree, Option[Patch]] = { case (_: Tree) => None }
         val pf2: Function2[PartialFunction[Tree, Option[Patch]], PartialFunction[Tree, Patch], PartialFunction[Tree, Option[Patch]]] = {
-          case (totalPatch, nextPatch) => (tree: Tree) => nextPatch.lift(tree).orElse(totalPatch(tree))
+          case (totalPatch, nextPatch) => {
+            case (tree: Tree) => nextPatch.lift(tree).orElse(totalPatch(tree))
+          }
         }
 
         List(


### PR DESCRIPTION
This fixes these errors when running scalafix against `zio-akka-cluster` (and hopefully all other projects where scalafix is running under Scala 2.11/2.12): 

```
[error] (scalafixAll) scalafix.sbt.InvalidArgument: 4 errors
[error] [E0] /var/folders/7f/s_dm8hkd2z78nfn6r6trdw200000gn/T/scalafix6263622877825292869/Zio2Upgrade.scala11639604956246027123.scala:450:13 error: wrong number of type parameters for method map: [B, That](f: scalafix.v1.SymbolMatcher => B)(implicit bf: scala.collection.generic.CanBuildFrom[List[scalafix.v1.SymbolMatcher],B,That])That
[error]         }.map[PartialFunction[Tree, Patch]](symbolMatcher => { case t @ ImporteeNameOrRename(symbolMatcher(_)) =>
[error]              ^
[error]
[error] [E1] /var/folders/7f/s_dm8hkd2z78nfn6r6trdw200000gn/T/scalafix6263622877825292869/Zio2Upgrade.scala11639604956246027123.scala:450:61 error: missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]         }.map[PartialFunction[Tree, Patch]](symbolMatcher => { case t @ ImporteeNameOrRename(symbolMatcher(_)) =>
[error]                                                              ^
[error]
[error] [E2] /var/folders/7f/s_dm8hkd2z78nfn6r6trdw200000gn/T/scalafix6263622877825292869/Zio2Upgrade.scala11639604956246027123.scala:453:36 error: value lift is not a member of Any
[error]           (tree: Tree) => nextPatch.lift(tree).orElse(totalPatch(tree))
[error]                                     ^
[error]
[error] [E3] /var/folders/7f/s_dm8hkd2z78nfn6r6trdw200000gn/T/scalafix6263622877825292869/Zio2Upgrade.scala11639604956246027123.scala:453:64 error: Any does not take parameters
[error]           (tree: Tree) => nextPatch.lift(tree).orElse(totalPatch(tree))
[error]                                                                 ^
[error]
[error] Total time: 7 s, completed Dec 16, 2021, 8:10:31 PM
```

Thanks to @justcoon for helping me diagnose and fix!