### PR TITLE
Prevent Inconsistent State From Being Observed Outside STM Transaction

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -203,7 +203,8 @@ object ZSTMConcurrencyTests {
   )
   @State
   class ConcurrentGetAndSet {
-    val outer: TRef[TRef[Boolean]] = runtime.unsafeRun(TRef.makeCommit(false).flatMap(TRef.makeCommit(_)))
+    val inner: TRef[Boolean]       = runtime.unsafeRun(TRef.makeCommit(false))
+    val outer: TRef[TRef[Boolean]] = runtime.unsafeRun(TRef.makeCommit(inner))
 
     @Actor
     def actor1(): Unit = {

--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -189,4 +189,38 @@ object ZSTMConcurrencyTests {
       r.r1 = permits.toInt
     }
   }
+
+  /*
+   * Tests that no transaction can be committed based on an inconsistent state.
+   * We should never observed a case where the transaction fails based on a
+   * value that was set by another fiber but never committed.
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("0"), expect = Expect.ACCEPTABLE, desc = "permit is released")
+    )
+  )
+  @State
+  class ConcurrentGetAndSet {
+    val outer: TRef[TRef[Boolean]] = runtime.unsafeRun(TRef.makeCommit(false).flatMap(TRef.makeCommit(_)))
+
+    @Actor
+    def actor1(): Unit = {
+      val stm = for {
+        fresh <- TRef.make(false)
+        inner <- outer.get
+        value <- inner.get
+        _ <- if (value) ZSTM.fail("fail")
+             else inner.set(true) *> outer.set(fresh)
+      } yield value
+      val zio = ZIO.foreachParDiscard(1 to 1000)(_ => stm.commit)
+      runtime.unsafeRun(zio)
+      ()
+    }
+
+    @Arbiter
+    def arbiter(r: I_Result): Unit =
+      r.r1 = 0
+  }
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -269,7 +269,7 @@ trait Runtime[+R] {
 
             val trace = ZTrace(fiberId, stackTraceBuilder.value.result())
 
-            throw new ZIO.ZioError(Exit.fail(cause.traced(trace)), trace0)
+            throw new ZIO.ZioError(Exit.failCause(cause.traced(trace)), trace0)
         }
 
     }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2935,7 +2935,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     succeedWith { (runtimeConfig, _) =>
       try effect
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t), trace)
       }
     }
 
@@ -5189,7 +5189,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     suspendSucceedWith { (runtimeConfig, _) =>
       try rio
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t), trace)
       }
     }
 
@@ -5224,7 +5224,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     suspendSucceedWith((runtimeConfig, fiberId) =>
       try f(runtimeConfig, fiberId)
       catch {
-        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Cause.fail(t), trace)
+        case t: Throwable if !runtimeConfig.fatal(t) => throw new ZioError(Exit.fail(t), trace)
       }
     )
 
@@ -6178,7 +6178,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     final val SetRuntimeConfig       = 29
   }
 
-  private[zio] final case class ZioError[E](cause: Cause[E], trace: ZTraceElement) extends Throwable with NoStackTrace
+  private[zio] final case class ZioError[E, A](exit: Exit[E, A], trace: ZTraceElement)
+      extends Throwable
+      with NoStackTrace
 
   private[zio] trait TracedCont[-A0, -R, +E, +A] extends (A0 => ZIO[R, E, A]) {
     val trace: ZTraceElement

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -514,8 +514,16 @@ private[zio] final class FiberContext[E, A](
             // Prevent interruption of interruption:
             unsafeSetInterrupting(true)
 
-          case ZIO.ZioError(cause, trace) =>
-            curZio = ZIO.failCause(cause)(trace)
+          case ZIO.ZioError(exit, trace) =>
+            exit match {
+              case Exit.Success(value) =>
+                curZio = unsafeNextEffect(value)
+
+              case Exit.Failure(cause) =>
+                val trace = curZio.trace
+
+                curZio = ZIO.failCause(cause)(trace)
+            }
 
           // Catastrophic error handler. Any error thrown inside the interpreter is
           // either a bug in the interpreter or a bug in the user's code. Let the

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -2063,6 +2063,9 @@ object ZSTM {
                 }
 
               case _ =>
+                Sync(globalLock) {
+                  if (isInvalid(journal)) loop = true
+                }
             }
           }
         }
@@ -2182,6 +2185,9 @@ object ZSTM {
                 }
 
               case _ =>
+                Sync(globalLock) {
+                  if (isInvalid(journal)) loop = true
+                }
             }
           }
         }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -973,12 +973,7 @@ object ZSTM {
     ZIO.environmentWithZIO[R] { r =>
       ZIO.suspendSucceedWith { (runtimeConfig, fiberId) =>
         tryCommitSync(runtimeConfig, fiberId, stm, r) match {
-          case TryCommit.Done(exit) =>
-            exit match {
-              case Exit.Success(value) => ZIO.succeedNow(value)
-              case Exit.Failure(cause) => throw new ZIO.ZioError(cause, trace)
-            }
-
+          case TryCommit.Done(exit) => throw new ZIO.ZioError(exit, trace)
           case TryCommit.Suspend(journal) =>
             val txnId = makeTxnId()
             val state = new AtomicReference[State[E, A]](State.Running)


### PR DESCRIPTION
Resolves #6168.

Even when the result of an STM transaction is not successful we still have to confirm that the journal is valid with the global lock before executing the to dos.