### PR TITLE
Release Outer Resource if Inner Acquire Fails in ZStream.unwrapManaged

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1291,7 +1291,15 @@ object ZChannel {
   )(implicit trace: ZTraceElement): ZChannel[R, Any, Any, Any, E, A, Any] =
     acquireReleaseOutExitWith(
       ReleaseMap.make.flatMap { releaseMap =>
-        ZManaged.currentReleaseMap.locally(releaseMap)(m.zio).map { case (_, out) => (out, releaseMap) }
+        ZIO.uninterruptibleMask { restore =>
+          ZManaged.currentReleaseMap
+            .locally(releaseMap)(restore(m.zio))
+            .foldCauseZIO(
+              cause =>
+                releaseMap.releaseAll(Exit.failCause(cause), ExecutionStrategy.Sequential) *> ZIO.failCause(cause),
+              { case (_, out) => ZIO.succeedNow((out, releaseMap)) }
+            )
+        }
       }
     ) { case ((_, releaseMap), exit) =>
       releaseMap.releaseAll(exit, ExecutionStrategy.Sequential)


### PR DESCRIPTION
In the `ChannelExecutor` interpretation of `BracketOut` if `acquire` fails then `release` is not run. This makes sense in general but can create problems when managed resources are implemented in terms of this because `acquire` can fail for an inner resource but an out resource that was successfully acquired still needs to be released.