### PR TITLE
Pull Only As Needed in ZStream#zipAllWith

### DIFF
--- a/docs/datatypes/stream/zstream.md
+++ b/docs/datatypes/stream/zstream.md
@@ -994,16 +994,6 @@ val s2 = ZStream(1, 2, 3).zipAllWith(
 // Output: (1, a), (2, b), (3, c), (0, d), (0, e)
 ```
 
-ZIO Stream also has a `ZStream#zipAllWithExec` function, which takes `ExecutionStrategy` as an argument. The execution strategy will be used to determine whether to pull from the streams sequentially or in parallel:
-
-```scala 
-def zipAllWithExec[R1 <: R, E1 >: E, O2, O3](
-  that: ZStream[R1, E1, O2]
-)(exec: ExecutionStrategy)(
-  left: O => O3, right: O2 => O3
-)(both: (O, O2) => O3): ZStream[R1, E1, O3] = ???
-```
-
 Sometimes we want to zip stream, but we do not want to zip two elements one by one. For example, we may have two streams with two different speeds, we do not want to wait for the slower one when zipping elements, assume need to zip elements with the latest element of the slower stream. The `ZStream#zipWithLates` do this for us. It zips two streams so that when a value is emitted by either of the two streams; it is combined with the latest value from the other stream to produce a result:
 
 ```scala mdoc:silent:nest

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3903,18 +3903,16 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(chars))
           }
         ),
-        test("zipAllSortedByKeyExecWith") {
-          val genExecutionStrategy =
-            Gen.elements(ExecutionStrategy.Parallel, ExecutionStrategy.Sequential)
+        test("zipAllSortedByKeyWith") {
           val genSortedByKey = for {
             map    <- Gen.mapOf(Gen.int(1, 100), Gen.int(1, 100))
             chunk   = Chunk.fromIterable(map).sorted
             chunks <- splitChunks(Chunk(chunk))
           } yield chunks
-          check(genSortedByKey, genSortedByKey, genExecutionStrategy) { (as, bs, exec) =>
+          check(genSortedByKey, genSortedByKey) { (as, bs) =>
             val left   = ZStream.fromChunks(as: _*)
             val right  = ZStream.fromChunks(bs: _*)
-            val actual = left.zipAllSortedByKeyWithExec(right)(exec)(identity, identity)(_ + _)
+            val actual = left.zipAllSortedByKeyWith(right)(identity, identity)(_ + _)
             val expected = Chunk.fromIterable {
               as.flatten.toMap.foldLeft(bs.flatten.toMap) { case (map, (k, v)) =>
                 map.get(k).fold(map + (k -> v))(v1 => map + (k -> (v + v1)))


### PR DESCRIPTION
Prevents a potential memory leak by only pulling from both sides if we need additional input from both sides. I also deleted the `Exec` variant. It seemed strange that we had this variant for `zipAllWith` but not `zipWith`, it didn't appear to be being used anywhere, and since we only use it in the case when we need input from both sides at the same time it seemed less important.