### PR TITLE
Optimize rechunk

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -6235,6 +6235,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       }
     }
 
+    def isEmpty: Boolean =
+      pos == 0
+
     def emitIfNotEmpty()(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Unit] =
       if (pos != 0) {
         ZChannel.write(builder.result())


### PR DESCRIPTION
Optimizes rechunk in case the chunks are already have the desired length. I originally wrote it as part of https://github.com/zio/zio/pull/6108 where it improved performance by eliminating unnecessary chunk building for `rechunk(1)` on `Gen` streams already having single element chunks.

I thought it is a good improvement in general too.