### PR TITLE
Improve Reporting of Test Timing

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -72,8 +72,8 @@ object TestAnnotation {
   /**
    * An annotation for timing.
    */
-  val timing: TestAnnotation[Duration] =
-    TestAnnotation("timing", Duration.Zero, _ + _)
+  val timing: TestAnnotation[TestDuration] =
+    TestAnnotation("timing", TestDuration.zero, _ <> _)
 
   /**
    * An annotation for capturing the trace information, including source

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -926,8 +926,9 @@ object TestAspect extends TimeoutVariants {
       def perTest[R <: Live with Annotations, E](
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: ZTraceElement): ZIO[R, TestFailure[E], TestSuccess] =
-        Live.withLive(test)(_.either.timed).flatMap { case (duration, result) =>
-          ZIO.fromEither(result).ensuring(Annotations.annotate(TestAnnotation.timing, duration))
+        Live.withLive(test)(_.either.summarized(Clock.instant)(TestDuration.fromInterval)).flatMap {
+          case (duration, result) =>
+            ZIO.fromEither(result).ensuring(Annotations.annotate(TestAnnotation.timing, duration))
         }
     }
 

--- a/test/shared/src/main/scala/zio/test/TestDuration.scala
+++ b/test/shared/src/main/scala/zio/test/TestDuration.scala
@@ -1,0 +1,50 @@
+package zio.test
+
+import zio._
+
+import java.time.Instant
+
+sealed trait TestDuration { self =>
+  import TestDuration._
+
+  final def <>(that: TestDuration): TestDuration =
+    (self, that) match {
+      case (Zero, Zero)  => Zero
+      case (Zero, right) => right
+      case (left, Zero)  => left
+      case (Finite(leftStart, leftEnd), Finite(rightStart, rightEnd)) =>
+        val start = if (leftStart.isBefore(rightStart)) leftStart else rightStart
+        val end   = if (leftEnd.isAfter(rightEnd)) leftEnd else rightEnd
+        Finite(start, end)
+    }
+
+  final def isZero: Boolean =
+    toDuration.isZero
+
+  final def render: String =
+    toDuration.render
+
+  final def toDuration: Duration =
+    self match {
+      case Zero               => Duration.Zero
+      case Finite(start, end) => Duration.fromInterval(start, end)
+    }
+
+  final def toMillis: Long =
+    toDuration.toMillis
+
+  final def toNanos: Long =
+    toDuration.toNanos
+}
+
+object TestDuration {
+
+  private final case class Finite(start: Instant, end: Instant) extends TestDuration
+  private case object Zero                                      extends TestDuration
+
+  def fromInterval(start: Instant, end: Instant): TestDuration =
+    Finite(start, end)
+
+  val zero: TestDuration =
+    Zero
+}

--- a/test/shared/src/main/scala/zio/test/TestDuration.scala
+++ b/test/shared/src/main/scala/zio/test/TestDuration.scala
@@ -9,7 +9,6 @@ sealed trait TestDuration { self =>
 
   final def <>(that: TestDuration): TestDuration =
     (self, that) match {
-      case (Zero, Zero)  => Zero
       case (Zero, right) => right
       case (left, Zero)  => left
       case (Finite(leftStart, leftEnd), Finite(rightStart, rightEnd)) =>


### PR DESCRIPTION
Resolves #6197.

I've always regarded the way the duration of a spec is reported as the sum of the durations of its children, even though the children are typically run in parallel, as a bit of a wart. For example, if you had two tests that ran in parallel and each took four seconds the time for the suite would be reported as eight seconds.

This PR implements a more sophisticated data type for representing test durations that keeps track of the start and end times for each test. Composition is then defined based on the earliest start time and latest end time. This way in the example above the total time for the suite would be correctly reported as four seconds.