### PR TITLE
Make ZScope.Local Private

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5041,6 +5041,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.suspendSucceedWith((runtimeConfig, _) => ZIO.succeedNow(runtimeConfig))
 
   /**
+   * Returns the current fiber's scope.
+   */
+  def scope(implicit trace: ZTraceElement): UIO[ZScope] =
+    descriptorWith(descriptor => ZIO.succeedNow(descriptor.scope))
+
+  /**
    * Passes the fiber's scope to the specified function, which creates an effect
    * that will be returned from this method.
    */

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -60,7 +60,7 @@ object ZScope {
     }
   }
 
-  final class Local(val fiberId: FiberId, parentRef: WeakReference[FiberContext[_, _]]) extends ZScope {
+  private final class Local(val fiberId: FiberId, parentRef: WeakReference[FiberContext[_, _]]) extends ZScope {
     private[zio] def unsafeAdd(runtimeConfig: RuntimeConfig, child: FiberContext[_, _])(implicit
       trace: ZTraceElement
     ): Boolean = {

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -23,7 +23,7 @@ import java.lang.ref.WeakReference
 
 /**
  * A `ZScope` represents the scope of a fiber lifetime. The scope of a fiber can
- * be retrieved using [[ZIO.descriptor]], and when forking fibers, you can
+ * be retrieved using [[ZIO.scope]], and when forking fibers, you can
  * specify a custom scope to fork them on by using the [[ZIO#forkIn]].
  */
 sealed trait ZScope {

--- a/core/shared/src/main/scala/zio/ZScope.scala
+++ b/core/shared/src/main/scala/zio/ZScope.scala
@@ -23,8 +23,8 @@ import java.lang.ref.WeakReference
 
 /**
  * A `ZScope` represents the scope of a fiber lifetime. The scope of a fiber can
- * be retrieved using [[ZIO.scope]], and when forking fibers, you can
- * specify a custom scope to fork them on by using the [[ZIO#forkIn]].
+ * be retrieved using [[ZIO.scope]], and when forking fibers, you can specify a
+ * custom scope to fork them on by using the [[ZIO#forkIn]].
  */
 sealed trait ZScope {
   def fiberId: FiberId


### PR DESCRIPTION
It exposes internal implementation regarding `FiberContext` and the `WeakReference` and there does not appear to be any reason that others need access to it.