### PR TITLE
Minor Improvements to ZStream#tapSink

### DIFF
--- a/core/shared/src/main/scala/zio/ZHub.scala
+++ b/core/shared/src/main/scala/zio/ZHub.scala
@@ -446,7 +446,8 @@ object ZHub {
           ZIO
             .whenZIO(shutdownHook.succeed(())) {
               ZIO.foreachPar(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
-                ZIO.succeed(subscription.unsubscribe())
+                ZIO.succeed(subscription.unsubscribe()) *>
+                ZIO.succeed(strategy.unsafeOnHubEmptySpace(hub, subscribers))
             }
             .unit
         }.uninterruptible

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3319,7 +3319,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               ref      <- Ref.make(0)
               sink      = ZSink.foreach[Any, Nothing, Int](n => ref.update(_ + n))
-              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
+              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink)
               elements <- stream.runCollect
               done     <- ref.get
             } yield assertTrue(elements == Chunk(1, 1, 2, 3, 5, 8) && done == 20)
@@ -3328,7 +3328,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               ref      <- Ref.make(0)
               sink      = ZSink.take[Int](3).map(_.sum).mapZIO(n => ref.update(_ + n))
-              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink, 8)
+              stream    = ZStream(1, 1, 2, 3, 5, 8).tapSink(sink)
               elements <- stream.runCollect
               done     <- ref.get
             } yield assertTrue(elements == Chunk(1, 1, 2, 3, 5, 8) && done == 4)
@@ -3337,7 +3337,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               ref   <- Ref.make(0)
               sink   = ZSink.fail("error")
-              stream = ZStream.never.tapSink(sink, 8)
+              stream = ZStream.never.tapSink(sink)
               error <- stream.runCollect.flip
             } yield assertTrue(error == "error")
           }


### PR DESCRIPTION
Removes `maximumLag` parameter since I don't think you want to be reading ahead in a tap and it simplifies the signature. Avoids intermediate allocations of `Either` values.