### PR TITLE
Implement Environment Operators for Channels

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -836,6 +836,46 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
   ): ZChannel[Any, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
     ZChannel.Provide(() => env, self)
 
+  /**
+   * Provides the part of the environment that is not part of the `ZEnv`,
+   * leaving a channel that only depends on the `ZEnv`.
+   */
+  def provideCustomLayer[OutErr1 >: OutErr, Env1](
+    layer: => ZLayer[ZEnv, OutErr1, Env1]
+  )(implicit
+    ev: ZEnv with Env1 <:< Env,
+    tagged: Tag[Env1],
+    trace: ZTraceElement
+  ): ZChannel[ZEnv, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
+    provideSomeLayer[ZEnv](layer)
+
+  /**
+   * Provides a layer to the channel, which translates it to another level.
+   */
+  final def provideLayer[OutErr1 >: OutErr, Env0](
+    layer: => ZLayer[Env0, OutErr1, Env]
+  )(implicit trace: ZTraceElement): ZChannel[Env0, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
+    ZChannel.managed(layer.build)(env => self.provideEnvironment(env))
+
+  /**
+   * Transforms the environment being provided to the channel with the specified
+   * function.
+   */
+  final def provideSomeEnvironment[Env0](
+    f: ZEnvironment[Env0] => ZEnvironment[Env]
+  )(implicit ev: NeedsEnv[Env], trace: ZTraceElement): ZChannel[Env0, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.environmentWithChannel[Env0] { env =>
+      self.provideEnvironment(f(env))
+    }
+
+  /**
+   * Splits the environment into two parts, providing one part using the
+   * specified layer and leaving the remainder `Env0`.
+   */
+  final def provideSomeLayer[Env0]
+    : ZChannel.ProvideSomeLayer[Env0, Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    new ZChannel.ProvideSomeLayer[Env0, Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](self)
+
   def repeated(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Nothing] = {
     lazy val loop: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Nothing] = self *> loop
     loop
@@ -893,6 +933,20 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 
   def unit(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Unit] =
     self.as(())
+
+  /**
+   * Updates a service in the environment of this channel.
+   */
+  final def updateService[Service]
+    : ZChannel.UpdateService[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, Service] =
+    new ZChannel.UpdateService[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, Service](self)
+
+  /**
+   * Updates a service at the specified key in the environment of this channel.
+   */
+  final def updateServiceAt[Service]
+    : ZChannel.UpdateServiceAt[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, Service] =
+    new ZChannel.UpdateServiceAt[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, Service](self)
 
   def toPull(implicit trace: ZTraceElement): ZManaged[Env, Nothing, ZIO[Env, OutErr, Either[OutDone, OutElem]]] =
     ZManaged
@@ -1273,6 +1327,32 @@ object ZChannel {
     writer(0, outs.size)
   }
 
+  /**
+   * Accesses the whole environment of the channel.
+   */
+  def environment[Env](implicit
+    trace: ZTraceElement
+  ): ZChannel[Env, Any, Any, Any, Nothing, Nothing, ZEnvironment[Env]] =
+    ZChannel.fromZIO(ZIO.environment)
+
+  /**
+   * Accesses the environment of the channel.
+   */
+  def environmentWith[Env]: ZChannel.EnvironmentWithPartiallyApplied[Env] =
+    new ZChannel.EnvironmentWithPartiallyApplied[Env]
+
+  /**
+   * Accesses the environment of the channel in the context of a channel.
+   */
+  def environmentWithChannel[Env]: ZChannel.EnvironmentWithChannelPartiallyApplied[Env] =
+    new ZChannel.EnvironmentWithChannelPartiallyApplied[Env]
+
+  /**
+   * Accesses the environment of the channel in the context of an effect.
+   */
+  def environmentWithZIO[Env]: ZChannel.EnvironmentWithZIOPartiallyApplied[Env] =
+    new ZChannel.EnvironmentWithZIOPartiallyApplied[Env]
+
   def fail[E](e: => E)(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, E, Nothing, Nothing] =
     failCause(Cause.fail(e))
 
@@ -1498,6 +1578,15 @@ object ZChannel {
       consumer
     }
 
+  def provideLayer[Env0, Env, Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone](layer: ZLayer[Env0, OutErr, Env])(
+    channel: => ZChannel[Env with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  )(implicit
+    ev: Tag[Env],
+    tag: Tag[Env1],
+    trace: ZTraceElement
+  ): ZChannel[Env0 with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+    ZChannel.suspend(channel.provideSomeLayer[Env0 with Env1](ZLayer.environment[Env1] ++ layer))
+
   def readWithCause[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
     in: InElem => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
     halt: Cause[InErr] => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
@@ -1520,6 +1609,40 @@ object ZChannel {
 
   def read[In](implicit trace: ZTraceElement): ZChannel[Any, Any, In, Any, None.type, Nothing, In] =
     readOrFail(None)
+
+  /**
+   * Accesses the specified service in the environment of the channel.
+   */
+  def service[Service: Tag: IsNotIntersection](implicit
+    trace: ZTraceElement
+  ): ZChannel[Service, Any, Any, Any, Nothing, Nothing, Service] =
+    ZChannel.fromZIO(ZIO.service)
+
+  /**
+   * Accesses the service corresponding to the specified key in the environment.
+   */
+  def serviceAt[Service]: ZChannel.ServiceAtPartiallyApplied[Service] =
+    new ZChannel.ServiceAtPartiallyApplied[Service]
+
+  /**
+   * Accesses the specified service in the environment of the channel.
+   */
+  def serviceWith[Service]: ZChannel.ServiceWithPartiallyApplied[Service] =
+    new ZChannel.ServiceWithPartiallyApplied[Service]
+
+  /**
+   * Accesses the specified service in the environment of the channel in the
+   * context of a channel.
+   */
+  def serviceWithChannel[Service]: ZChannel.ServiceWithChannelPartiallyApplied[Service] =
+    new ZChannel.ServiceWithChannelPartiallyApplied[Service]
+
+  /**
+   * Accesses the specified service in the environment of the channel in the
+   * context of an effect.
+   */
+  def serviceWithZIO[Service]: ZChannel.ServiceWithZIOPartiallyApplied[Service] =
+    new ZChannel.ServiceWithZIOPartiallyApplied[Service]
 
   def succeed[Z](z: => Z)(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Z] =
     Succeed(() => z)
@@ -1660,5 +1783,105 @@ object ZChannel {
   object UpstreamPullStrategy {
     final case class PullAfterNext[+A](emitSeparator: Option[A])        extends UpstreamPullStrategy[A]
     final case class PullAfterAllEnqueued[+A](emitSeparator: Option[A]) extends UpstreamPullStrategy[A]
+  }
+
+  final class EnvironmentWithPartiallyApplied[Env](private val dummy: Boolean = true) extends AnyVal {
+    def apply[OutDone](f: ZEnvironment[Env] => OutDone)(implicit
+      trace: ZTraceElement
+    ): ZChannel[Env, Any, Any, Any, Nothing, Nothing, OutDone] =
+      ZChannel.environment.map(f)
+  }
+
+  final class EnvironmentWithChannelPartiallyApplied[Env](private val dummy: Boolean = true) extends AnyVal {
+    def apply[Env1 <: Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+      f: ZEnvironment[Env] => ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+    )(implicit trace: ZTraceElement): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+      ZChannel.environment.flatMap(f)
+  }
+
+  final class EnvironmentWithZIOPartiallyApplied[Env](private val dummy: Boolean = true) extends AnyVal {
+    def apply[Env1 <: Env, OutErr, OutDone](f: ZEnvironment[Env] => ZIO[Env1, OutErr, OutDone])(implicit
+      trace: ZTraceElement
+    ): ZChannel[Env1, Any, Any, Any, OutErr, Nothing, OutDone] =
+      ZChannel.environment.mapZIO(f)
+  }
+
+  final class ProvideSomeLayer[Env0, -Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone](
+    private val self: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ) extends AnyVal {
+    def apply[OutErr1 >: OutErr, Env1](
+      layer: => ZLayer[Env0, OutErr1, Env1]
+    )(implicit
+      ev: Env0 with Env1 <:< Env,
+      tagged: Tag[Env1],
+      trace: ZTraceElement
+    ): ZChannel[Env0, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
+      self
+        .asInstanceOf[ZChannel[Env0 with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone]]
+        .provideLayer(ZLayer.environment[Env0] ++ layer)
+  }
+
+  final class ServiceAtPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[Key](
+      key: => Key
+    )(implicit
+      tag: Tag[Map[Key, Service]],
+      trace: ZTraceElement
+    ): ZChannel[Map[Key, Service], Any, Any, Any, Nothing, Nothing, Option[Service]] =
+      ZChannel.environmentWith(_.getAt(key))
+  }
+
+  final class ServiceWithPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[OutDone](f: Service => OutDone)(implicit
+      ev: IsNotIntersection[Service],
+      tag: Tag[Service],
+      trace: ZTraceElement
+    ): ZChannel[Service, Any, Any, Any, Nothing, Nothing, OutDone] =
+      ZChannel.service[Service].map(f)
+  }
+
+  final class ServiceWithChannelPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[Env <: Service, InErr, InElem, InDone, OutErr, OutElem, OutDone](
+      f: Service => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+    )(implicit
+      ev: IsNotIntersection[Service],
+      tag: Tag[Service],
+      trace: ZTraceElement
+    ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+      ZChannel.service[Service].flatMap(f)
+  }
+
+  final class ServiceWithZIOPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[Env <: Service, OutErr, OutDone](f: Service => ZIO[Env, OutErr, OutDone])(implicit
+      ev: IsNotIntersection[Service],
+      tag: Tag[Service],
+      trace: ZTraceElement
+    ): ZChannel[Env, Any, Any, Any, OutErr, Nothing, OutDone] =
+      ZChannel.service[Service].mapZIO(f)
+  }
+
+  final class UpdateService[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone, Service](
+    private val self: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ) extends AnyVal {
+    def apply[Env1 <: Env with Service](
+      f: Service => Service
+    )(implicit
+      ev: IsNotIntersection[Service],
+      tag: Tag[Service],
+      trace: ZTraceElement
+    ): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+      self.provideSomeEnvironment(_.update(f))
+  }
+
+  final class UpdateServiceAt[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone, Service](
+    private val self: ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+  ) extends AnyVal {
+    def apply[Env1 <: Env with Map[Key, Service], Key](key: => Key)(
+      f: Service => Service
+    )(implicit
+      tag: Tag[Map[Key, Service]],
+      trace: ZTraceElement
+    ): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
+      self.provideSomeEnvironment(_.updateAt(key)(f))
   }
 }


### PR DESCRIPTION
If we are going to have channels we might as well have the same operators for working with the environment on them as we do for other ZIO data types.