### PR TITLE
Adds withDynamicTags to metrics

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
@@ -1,0 +1,147 @@
+package zio
+
+import zio.ZIOMetric.Counter
+import zio.metrics.{MetricClient, MetricKey, MetricType}
+import zio.test._
+
+object ZIOMetricSpec extends ZIOBaseSpec {
+
+  private val labels1 = Chunk(MetricLabel("x", "a"), MetricLabel("y", "b"))
+
+  def spec = suite("ZIOMetric")(
+    suite("Counter")(
+      test("custom increment as aspect") {
+        val c = new Counter[Any]("c1", labels1) {
+          override def apply[R, E, A1 <: Any](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+            zio.tap(_ => increment)
+        }
+        for {
+          _ <- ZIO.unit @@ c
+          _ <- ZIO.unit @@ c
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c1", labels1)).map(_.details)
+        } yield assertTrue(r == Some(MetricType.Counter(2.0)))
+      },
+      test("direct increment") {
+        val c = new Counter[Any]("c2", labels1) {
+          override def apply[R, E, A1 <: Any](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+            zio
+        }
+        for {
+          _ <- c.increment
+          _ <- c.increment
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c2", labels1)).map(_.details)
+        } yield assertTrue(r == Some(MetricType.Counter(2.0)))
+      },
+      test("custom increment by value as aspect") {
+        val c = new Counter[Double]("c3", labels1) {
+          override def apply[R, E, A1 <: Double](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+            zio.tap(increment)
+        }
+        for {
+          _ <- ZIO.succeed(10.0) @@ c
+          _ <- ZIO.succeed(5.0) @@ c
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c3", labels1)).map(_.details)
+        } yield assertTrue(r == Some(MetricType.Counter(15.0)))
+      },
+      test("direct increment by value") {
+        val c = new Counter[Any]("c4", labels1) {
+          override def apply[R, E, A1 <: Any](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+            zio
+        }
+        for {
+          _ <- c.increment(10.0)
+          _ <- c.increment(5.0)
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c4", labels1)).map(_.details)
+        } yield assertTrue(r == Some(MetricType.Counter(15.0)))
+      },
+      test("count") {
+        for {
+          _ <- ZIO.unit @@ ZIOMetric.count("c5", labels1 : _*)
+          _ <- ZIO.unit @@ ZIOMetric.count("c5", labels1 : _*)
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c5", labels1)).map(_.details)
+          v <- ZIOMetric.count("c5", labels1 : _*).count
+        } yield assertTrue(
+          r == Some(MetricType.Counter(2.0)),
+          v == 2.0
+        )
+      },
+      test("countValue") {
+        for {
+          _ <- ZIO.succeed(10.0) @@ ZIOMetric.countValue("c6", labels1 : _*)
+          _ <- ZIO.succeed(5.0) @@ ZIOMetric.countValue("c6", labels1 : _*)
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c6", labels1)).map(_.details)
+          v <- ZIOMetric.count("c6", labels1 : _*).count
+        } yield assertTrue(
+          r == Some(MetricType.Counter(15.0)),
+          v == 15.0
+        )
+      },
+      test("countValueWith") {
+        val c = ZIOMetric.countValueWith[String]("c7", labels1 : _*)(_.length.toDouble)
+        for {
+          _ <- ZIO.succeed("hello") @@ c
+          _ <- ZIO.succeed("!") @@ c
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter(c.name, labels1)).map(_.details)
+          v <- c.count
+        } yield assertTrue(
+          r == Some(MetricType.Counter(6.0)),
+          v == 6.0
+        )
+      },
+      test("countErrors") {
+        val c = ZIOMetric.countErrors("c8")
+        for {
+          _ <- (ZIO.unit @@ c *> ZIO.fail("error") @@ c).ignore
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter(c.name, Chunk.empty)).map(_.details)
+          v <- c.count
+        } yield assertTrue(
+          r == Some(MetricType.Counter(1.0)),
+          v == 1.0
+        )
+      },
+      test("countValueWith + copy") {
+        val c = ZIOMetric
+          .countValueWith[String]("c9", labels1 : _*)(_.length.toDouble)
+          .copy("c9c", Chunk.empty)
+        for {
+          _ <- ZIO.succeed("hello") @@ c
+          _ <- ZIO.succeed("!") @@ c
+          states <- UIO(MetricClient.unsafeStates)
+          r0 = states.get(MetricKey.Counter("c9", labels1)).map(_.details)
+          r = states.get(MetricKey.Counter("c9c", Chunk.empty)).map(_.details)
+          v <- c.count
+        } yield assertTrue(
+          r0 == Some(MetricType.Counter(0.0)),
+          r == Some(MetricType.Counter(6.0)),
+          v == 6.0,
+          c.name == "c9c"
+        )
+      },
+      test("count + taggedWith") {
+        val c = ZIOMetric
+          .count("c10", MetricLabel("static", "0"))
+          .taggedWith {
+            case s: String => Chunk(MetricLabel("dyn", s))
+            case _ => Chunk.empty
+          }
+        for {
+          _ <- ZIO.succeed("hello") @@ c
+          _ <- ZIO.succeed("!") @@ c
+          _ <- ZIO.succeed("!") @@ c
+          states <- UIO(MetricClient.unsafeStates)
+          r = states.get(MetricKey.Counter("c10", Chunk(MetricLabel("static", "0"), MetricLabel("dyn", "!")))).map(_.details)
+        } yield assertTrue(
+          r == Some(MetricType.Counter(2.0)),
+        )
+      },
+    )
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
@@ -173,9 +173,9 @@ object ZIOMetricSpec extends ZIOBaseSpec {
             case _         => Chunk.empty
           }
         for {
+          _      <- ZIO.succeed("!") @@ c2
           _      <- ZIO.succeed("hello") @@ c1
           _      <- ZIO.succeed("!") @@ c1
-          _      <- ZIO.succeed("!") @@ c2
           states <- UIO(MetricClient.unsafeStates)
           r1 = states
                  .get(MetricKey.Counter("c11", Chunk(MetricLabel("static", "0"))))

--- a/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
@@ -16,10 +16,10 @@ object ZIOMetricSpec extends ZIOBaseSpec {
             zio.tap(_ => increment)
         }
         for {
-          _ <- ZIO.unit @@ c
-          _ <- ZIO.unit @@ c
+          _      <- ZIO.unit @@ c
+          _      <- ZIO.unit @@ c
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c1", labels1)).map(_.details)
+          r       = states.get(MetricKey.Counter("c1", labels1)).map(_.details)
         } yield assertTrue(r == Some(MetricType.Counter(2.0)))
       },
       test("direct increment") {
@@ -28,10 +28,10 @@ object ZIOMetricSpec extends ZIOBaseSpec {
             zio
         }
         for {
-          _ <- c.increment
-          _ <- c.increment
+          _      <- c.increment
+          _      <- c.increment
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c2", labels1)).map(_.details)
+          r       = states.get(MetricKey.Counter("c2", labels1)).map(_.details)
         } yield assertTrue(r == Some(MetricType.Counter(2.0)))
       },
       test("custom increment by value as aspect") {
@@ -40,10 +40,10 @@ object ZIOMetricSpec extends ZIOBaseSpec {
             zio.tap(increment)
         }
         for {
-          _ <- ZIO.succeed(10.0) @@ c
-          _ <- ZIO.succeed(5.0) @@ c
+          _      <- ZIO.succeed(10.0) @@ c
+          _      <- ZIO.succeed(5.0) @@ c
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c3", labels1)).map(_.details)
+          r       = states.get(MetricKey.Counter("c3", labels1)).map(_.details)
         } yield assertTrue(r == Some(MetricType.Counter(15.0)))
       },
       test("direct increment by value") {
@@ -52,19 +52,19 @@ object ZIOMetricSpec extends ZIOBaseSpec {
             zio
         }
         for {
-          _ <- c.increment(10.0)
-          _ <- c.increment(5.0)
+          _      <- c.increment(10.0)
+          _      <- c.increment(5.0)
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c4", labels1)).map(_.details)
+          r       = states.get(MetricKey.Counter("c4", labels1)).map(_.details)
         } yield assertTrue(r == Some(MetricType.Counter(15.0)))
       },
       test("count") {
         for {
-          _ <- ZIO.unit @@ ZIOMetric.count("c5", labels1 : _*)
-          _ <- ZIO.unit @@ ZIOMetric.count("c5", labels1 : _*)
+          _      <- ZIO.unit @@ ZIOMetric.count("c5", labels1: _*)
+          _      <- ZIO.unit @@ ZIOMetric.count("c5", labels1: _*)
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c5", labels1)).map(_.details)
-          v <- ZIOMetric.count("c5", labels1 : _*).count
+          r       = states.get(MetricKey.Counter("c5", labels1)).map(_.details)
+          v      <- ZIOMetric.count("c5", labels1: _*).count
         } yield assertTrue(
           r == Some(MetricType.Counter(2.0)),
           v == 2.0
@@ -72,24 +72,24 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       },
       test("countValue") {
         for {
-          _ <- ZIO.succeed(10.0) @@ ZIOMetric.countValue("c6", labels1 : _*)
-          _ <- ZIO.succeed(5.0) @@ ZIOMetric.countValue("c6", labels1 : _*)
+          _      <- ZIO.succeed(10.0) @@ ZIOMetric.countValue("c6", labels1: _*)
+          _      <- ZIO.succeed(5.0) @@ ZIOMetric.countValue("c6", labels1: _*)
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c6", labels1)).map(_.details)
-          v <- ZIOMetric.count("c6", labels1 : _*).count
+          r       = states.get(MetricKey.Counter("c6", labels1)).map(_.details)
+          v      <- ZIOMetric.count("c6", labels1: _*).count
         } yield assertTrue(
           r == Some(MetricType.Counter(15.0)),
           v == 15.0
         )
       },
       test("countValueWith") {
-        val c = ZIOMetric.countValueWith[String]("c7", labels1 : _*)(_.length.toDouble)
+        val c = ZIOMetric.countValueWith[String]("c7", labels1: _*)(_.length.toDouble)
         for {
-          _ <- ZIO.succeed("hello") @@ c
-          _ <- ZIO.succeed("!") @@ c
+          _      <- ZIO.succeed("hello") @@ c
+          _      <- ZIO.succeed("!") @@ c
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter(c.name, labels1)).map(_.details)
-          v <- c.count
+          r       = states.get(MetricKey.Counter(c.name, labels1)).map(_.details)
+          v      <- c.count
         } yield assertTrue(
           r == Some(MetricType.Counter(6.0)),
           v == 6.0
@@ -98,10 +98,10 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       test("countErrors") {
         val c = ZIOMetric.countErrors("c8")
         for {
-          _ <- (ZIO.unit @@ c *> ZIO.fail("error") @@ c).ignore
+          _      <- (ZIO.unit @@ c *> ZIO.fail("error") @@ c).ignore
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter(c.name, Chunk.empty)).map(_.details)
-          v <- c.count
+          r       = states.get(MetricKey.Counter(c.name, Chunk.empty)).map(_.details)
+          v      <- c.count
         } yield assertTrue(
           r == Some(MetricType.Counter(1.0)),
           v == 1.0
@@ -109,15 +109,15 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       },
       test("countValueWith + copy") {
         val c = ZIOMetric
-          .countValueWith[String]("c9", labels1 : _*)(_.length.toDouble)
+          .countValueWith[String]("c9", labels1: _*)(_.length.toDouble)
           .copy("c9c", Chunk.empty)
         for {
-          _ <- ZIO.succeed("hello") @@ c
-          _ <- ZIO.succeed("!") @@ c
+          _      <- ZIO.succeed("hello") @@ c
+          _      <- ZIO.succeed("!") @@ c
           states <- UIO(MetricClient.unsafeStates)
-          r0 = states.get(MetricKey.Counter("c9", labels1)).map(_.details)
-          r = states.get(MetricKey.Counter("c9c", Chunk.empty)).map(_.details)
-          v <- c.count
+          r0      = states.get(MetricKey.Counter("c9", labels1)).map(_.details)
+          r       = states.get(MetricKey.Counter("c9c", Chunk.empty)).map(_.details)
+          v      <- c.count
         } yield assertTrue(
           r0 == Some(MetricType.Counter(0.0)),
           r == Some(MetricType.Counter(6.0)),
@@ -130,18 +130,20 @@ object ZIOMetricSpec extends ZIOBaseSpec {
           .count("c10", MetricLabel("static", "0"))
           .taggedWith {
             case s: String => Chunk(MetricLabel("dyn", s))
-            case _ => Chunk.empty
+            case _         => Chunk.empty
           }
         for {
-          _ <- ZIO.succeed("hello") @@ c
-          _ <- ZIO.succeed("!") @@ c
-          _ <- ZIO.succeed("!") @@ c
+          _      <- ZIO.succeed("hello") @@ c
+          _      <- ZIO.succeed("!") @@ c
+          _      <- ZIO.succeed("!") @@ c
           states <- UIO(MetricClient.unsafeStates)
-          r = states.get(MetricKey.Counter("c10", Chunk(MetricLabel("static", "0"), MetricLabel("dyn", "!")))).map(_.details)
+          r = states
+                .get(MetricKey.Counter("c10", Chunk(MetricLabel("static", "0"), MetricLabel("dyn", "!"))))
+                .map(_.details)
         } yield assertTrue(
-          r == Some(MetricType.Counter(2.0)),
+          r == Some(MetricType.Counter(2.0))
         )
-      },
+      }
     )
   )
 }

--- a/core/shared/src/main/scala/zio/ZIOMetric.scala
+++ b/core/shared/src/main/scala/zio/ZIOMetric.scala
@@ -268,7 +268,7 @@ object ZIOMetric {
      * Converts this counter metric to one where the tags depend on the measured
      * effect's result value
      */
-    def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
+    def taggedWith(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
       new ZIOMetric[A] {
         override def apply[R, E, A1 <: A](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
           self.apply(zio.tap(changeCounter))
@@ -352,7 +352,7 @@ object ZIOMetric {
      * Converts this gauge metric to one where the tags depend on the measured
      * effect's result value
      */
-    def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
+    def taggedWith(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
       new ZIOMetric[A] {
         override def apply[R, E, A1 <: A](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
           self.apply(zio.tap(changeGauge))
@@ -456,7 +456,7 @@ object ZIOMetric {
      * Converts this histogram metric to one where the tags depend on the
      * measured effect's result value
      */
-    def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
+    def taggedWith(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
       new ZIOMetric[A] {
         override def apply[R, E, A1 <: A](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
           self.apply(zio.tap(changeHistogram))
@@ -594,7 +594,7 @@ object ZIOMetric {
      * Converts this summary metric to one where the tags depend on the measured
      * effect's result value
      */
-    def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
+    def taggedWith(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
       new ZIOMetric[A] {
         override def apply[R, E, A1 <: A](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
           self.apply(zio.tap(changeSummary))
@@ -681,7 +681,7 @@ object ZIOMetric {
      * Converts this set count metric to one where the tags depend on the
      * measured effect's result value
      */
-    def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
+    def taggedWith(f: A => Chunk[MetricLabel]): ZIOMetric[A] =
       new ZIOMetric[A] {
         override def apply[R, E, A1 <: A](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
           self.apply(zio.tap(changeSetCount))

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1299,13 +1299,13 @@ private[zio] object FiberContext {
 
   import zio.ZIOMetric
 
-  lazy val fiberFailureCauses = ZIOMetric.occurrences("zio_fiber_failure_causes", "class").setCount.initial
-  lazy val fiberForkLocations = ZIOMetric.occurrences("zio_fiber_fork", "location").setCount.initial
+  lazy val fiberFailureCauses = ZIOMetric.occurrences("zio_fiber_failure_causes", "class").setCount
+  lazy val fiberForkLocations = ZIOMetric.occurrences("zio_fiber_fork", "location").setCount
 
-  lazy val fibersStarted  = ZIOMetric.count("zio_fiber_started").counter.initial
-  lazy val fiberSuccesses = ZIOMetric.count("zio_fiber_successes").counter.initial
-  lazy val fiberFailures  = ZIOMetric.count("zio_fiber_failures").counter.initial
-  lazy val fiberLifetimes = ZIOMetric.observeHistogram("zio_fiber_lifetimes", fiberLifetimeBoundaries).histogram.initial
+  lazy val fibersStarted  = ZIOMetric.count("zio_fiber_started").counter
+  lazy val fiberSuccesses = ZIOMetric.count("zio_fiber_successes").counter
+  lazy val fiberFailures  = ZIOMetric.count("zio_fiber_failures").counter
+  lazy val fiberLifetimes = ZIOMetric.observeHistogram("zio_fiber_lifetimes", fiberLifetimeBoundaries).histogram
 
   lazy val fiberLifetimeBoundaries = ZIOMetric.Histogram.Boundaries.exponential(1.0, 2.0, 100)
 

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1299,13 +1299,13 @@ private[zio] object FiberContext {
 
   import zio.ZIOMetric
 
-  lazy val fiberFailureCauses = ZIOMetric.occurrences("zio_fiber_failure_causes", "class").setCount
-  lazy val fiberForkLocations = ZIOMetric.occurrences("zio_fiber_fork", "location").setCount
+  lazy val fiberFailureCauses = ZIOMetric.occurrences("zio_fiber_failure_causes", "class").setCount.initial
+  lazy val fiberForkLocations = ZIOMetric.occurrences("zio_fiber_fork", "location").setCount.initial
 
-  lazy val fibersStarted  = ZIOMetric.count("zio_fiber_started").counter
-  lazy val fiberSuccesses = ZIOMetric.count("zio_fiber_successes").counter
-  lazy val fiberFailures  = ZIOMetric.count("zio_fiber_failures").counter
-  lazy val fiberLifetimes = ZIOMetric.observeHistogram("zio_fiber_lifetimes", fiberLifetimeBoundaries).histogram
+  lazy val fibersStarted  = ZIOMetric.count("zio_fiber_started").counter.initial
+  lazy val fiberSuccesses = ZIOMetric.count("zio_fiber_successes").counter.initial
+  lazy val fiberFailures  = ZIOMetric.count("zio_fiber_failures").counter.initial
+  lazy val fiberLifetimes = ZIOMetric.observeHistogram("zio_fiber_lifetimes", fiberLifetimeBoundaries).histogram.initial
 
   lazy val fiberLifetimeBoundaries = ZIOMetric.Histogram.Boundaries.exponential(1.0, 2.0, 100)
 

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentState.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentState.scala
@@ -102,6 +102,8 @@ private[zio] class ConcurrentState {
         val (v, d) = counter.increment(value)
         listener.unsafeCounterObserved(key, v, d)
       }
+
+      override private[zio] def metricKey: MetricKey.Counter = key
     }
   }
 
@@ -126,6 +128,8 @@ private[zio] class ConcurrentState {
         }
       def value(implicit trace: ZTraceElement): UIO[Double] =
         ZIO.succeed(gauge.get)
+
+      override private[zio] def metricKey: MetricKey.Gauge = key
     }
   }
 
@@ -159,6 +163,8 @@ private[zio] class ConcurrentState {
         histogram.observe(value)
         listener.unsafeHistogramObserved(key, value)
       }
+
+      override private[zio] def metricKey: MetricKey.Histogram = key
     }
   }
 
@@ -188,6 +194,8 @@ private[zio] class ConcurrentState {
         ZIO.succeed(summary.summary.snapshot(Instant.now))
       def sum(implicit trace: ZTraceElement): zio.UIO[Double] =
         ZIO.succeed(summary.summary.getSum())
+
+      override private[zio] def metricKey: MetricKey.Summary = key
     }
   }
 
@@ -223,6 +231,8 @@ private[zio] class ConcurrentState {
 
       private[zio] def unsafeOccurrences(word: String): Long =
         setCount.setCount.getCount(word)
+
+      override private[zio] def metricKey: MetricKey.SetCount = key
     }
   }
 }

--- a/core/shared/src/main/scala/zio/internal/metrics/Counter.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/Counter.scala
@@ -51,6 +51,8 @@ private[zio] trait Counter {
 
   private[zio] final def unsafeIncrement(): Unit =
     unsafeIncrement(1.0)
+
+  private[zio] def metricKey: MetricKey.Counter
 }
 
 private[zio] object Counter {

--- a/core/shared/src/main/scala/zio/internal/metrics/Gauge.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/Gauge.scala
@@ -43,6 +43,8 @@ private[zio] trait Gauge {
    * The current value of the gauge.
    */
   def value(implicit trace: ZTraceElement): UIO[Double]
+
+  private[zio] def metricKey: MetricKey.Gauge
 }
 
 private[zio] object Gauge {

--- a/core/shared/src/main/scala/zio/internal/metrics/Histogram.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/Histogram.scala
@@ -52,6 +52,8 @@ private[zio] trait Histogram {
   def sum(implicit trace: ZTraceElement): UIO[Double]
 
   private[zio] def unsafeObserve(value: Double): Unit
+
+  private[zio] def metricKey: MetricKey.Histogram
 }
 
 private[zio] object Histogram {

--- a/core/shared/src/main/scala/zio/internal/metrics/SetCount.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/SetCount.scala
@@ -49,6 +49,8 @@ private[zio] trait SetCount {
   private[zio] def unsafeOccurrences: Chunk[(String, Long)]
 
   private[zio] def unsafeOccurrences(word: String): Long
+
+  private[zio] def metricKey: MetricKey.SetCount
 }
 
 private[zio] object SetCount {

--- a/core/shared/src/main/scala/zio/internal/metrics/Summary.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/Summary.scala
@@ -52,6 +52,7 @@ private[zio] trait Summary {
    */
   def sum(implicit trace: ZTraceElement): UIO[Double]
 
+  private[zio] def metricKey: MetricKey.Summary
 }
 
 private[zio] object Summary {


### PR DESCRIPTION
While migrating `zio-aws` to the new metrics API I ran into the problem of defining a metric aspect in which the tags depend on the result value of the wrapped effect. In this particular example, each AWS call returns a `Described[A]` value where the `Described` wrapper contains metadata about the call such as AWS service and operation name, which could be used as tags of the metric.

I tried to find a way in which required changes to the new the metric API are minimal while all the predefined and user defined metric aspects can be somehow used with this more dynamic tagging approach.

The result is a `def withDynamicTags(f: A => Chunk[MetricLabel]): ZIOMetric[A]` on each metric type which converts them to a metric which no longer exposes any metric-type specific API (as the tags are unknown) but are still valid metric aspects.