### PR TITLE
Fix read-ahead behavior of tapSink and mergeWith

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3340,7 +3340,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               stream = ZStream.never.tapSink(sink)
               error <- stream.runCollect.flip
             } yield assertTrue(error == "error")
-          }
+          },
+          test("does not read ahead") {
+            for {
+              ref    <- Ref.make(0)
+              stream  = ZStream(1, 2, 3, 4, 5).rechunk(1).forever
+              sink    = ZSink.foreach((n: Int) => ref.update(_ + n))
+              _      <- stream.tapSink(sink).take(3).runDrain
+              result <- ref.get
+            } yield assertTrue(result == 6)
+          } @@ nonFlaky
         ),
         suite("throttleEnforce")(
           test("free elements") {

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -605,8 +605,10 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 
           exit match {
             case Exit.Success(Right(elem)) =>
-              pull.forkDaemon.map { leftFiber =>
-                ZChannel.write(elem) *> go(both(leftFiber, fiber))
+              ZIO.succeed {
+                ZChannel.write(elem) *> ZChannel.fromZIO(pull.forkDaemon).flatMap { leftFiber =>
+                  go(both(leftFiber, fiber))
+                }
               }
 
             case Exit.Success(Left(z)) =>


### PR DESCRIPTION
Two changes:

1. In `mergeWith`, when an element is emitted, we no longer start the forked pull of the next element immediately but instead make it part of the result channel, so it is controlled by the channel executor, leading to more predictable behavior
2. Rewrote `tapSink` to not use `broadcast` - broadcasting upstream to the sink allows it to process more elements than the main branch, while the meaning of `tap` should be to get _exactly_ the same elements flowing through the stream in my opinion. The new implementation directly pushes the elements flowing through to the sink's queue.