### PR TITLE
Provide Environment in ChannelExecutor BracketOut

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2715,6 +2715,11 @@ object ZStreamSpec extends ZIOBaseSpec {
           val s1 = ZStream.succeed(1) ++ ZStream.fail("Boom")
           s1.orElseSucceed(2).runCollect.map(assert(_)(equalTo(Chunk(1, 2))))
         },
+        test("provide") {
+          val stream = ZStream.managed(ZManaged.service[Int])
+          val layer  = ZLayer.succeed(1)
+          assertM(stream.provideLayer(layer).runDrain)(Assertion.anything)
+        },
         suite("repeat")(
           test("repeat")(
             assertM(


### PR DESCRIPTION
We currently do not provide the environment to the `acquire` and `release` effects in the interpretation of `BracketOut` in the `ChannelExecutor`, deferring the provision of the environment to the `ZIO` effect resulting from running the channel. However, this is not sound because the `managedOut` channel may rely on a different scoped environment than the entire channel. Instead we must provide both of these effects with the current environment.