### PR TITLE
forkWithErrorHandler should follow type parameters of onError

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1032,7 +1032,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   /**
    * Like fork but handles an error with the provided handler.
    */
-  final def forkWithErrorHandler(handler: E => UIO[Any])(implicit trace: ZTraceElement): URIO[R, Fiber.Runtime[E, A]] =
+  final def forkWithErrorHandler[R1 <: R](handler: E => URIO[R1, Any])(implicit
+    trace: ZTraceElement
+  ): URIO[R1, Fiber.Runtime[E, A]] =
     onError(c => c.failureOrCause.fold(handler, ZIO.failCause(_))).fork
 
   /**


### PR DESCRIPTION
Fixes #6260 

It is a breaking change in the API, but I don't see other ways of fixing it.