### PR TITLE
Make ZEnvironment.TaggedAnyRef Lazy

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -221,6 +221,6 @@ object ZEnvironment {
       System.SystemLive
     )
 
-  private val TaggedAnyRef: Tag[AnyRef] =
+  private lazy val TaggedAnyRef: Tag[AnyRef] =
     implicitly[Tag[AnyRef]]
 }


### PR DESCRIPTION
Otherwise it can cause early initialization issues in some cases.