### PR TITLE
Brought default behavior of jittered in line with purpose

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -618,11 +618,14 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
    * this schedule.
    */
   def jittered(implicit trace: ZTraceElement): Schedule.WithState[self.State, Env with Random, In, Out] =
-    jittered(0.0, 1.0)
+    jittered(0.8, 1.2)
 
   /**
    * Returns a new schedule that randomly modifies the size of the intervals of
    * this schedule.
+   *
+   * The new interval size is between `min * old interval size` and `max * old
+   * interval size`.
    */
   def jittered(min: Double, max: Double)(implicit
     trace: ZTraceElement

--- a/docs/datatypes/misc/schedule.md
+++ b/docs/datatypes/misc/schedule.md
@@ -257,6 +257,8 @@ val jitteredExp = Schedule.exponential(10.milliseconds).jittered
 
 When a resource is out of service due to overload or contention, retrying and backing off doesn't help us. If all failed API calls are backed off to the same point of time, they cause another overload or contention. Jitter adds some amount of randomness to the delay of the schedule. This helps us to avoid ending up accidentally synchronizing and taking the service down by accident.
 
+The form with parameters `min` and `max` creates a new schedule where the new interval size is randomly distributed between `min * old interval` and `max * old interval`.
+
 ### Collecting
 A `collectAll` is a combinator that when we call it on a schedule, produces a new schedule that collects the outputs of the first schedule into a chunk.
 

--- a/docs/howto/migrate/migration-guide.md
+++ b/docs/howto/migrate/migration-guide.md
@@ -1634,6 +1634,12 @@ Pipelines are basically an abstraction for composing a bunch of operations toget
 | `ZTransducer`   | `ZPipeline`                      |
 
 
+## ZIO Schedules
+
+`Schedule.jittered` in ZIO 1 is equivalent to `Schedule.jittered(0.0, 1.0)`. In ZIO this changed to `Schedule.jittered(0.8, 1.2)`.
+
+In ZIO 1 the average throughput of the updated schedule was twice the original schedule. In ZIO 2 the average thoughput of the updated schedule is the same as the orginal schedule.
+
 ## ZIO Services
 
 There are two significant changes in ZIO Services:


### PR DESCRIPTION
The purpose of adding jitter to a schedule is prevent the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem) as is well described in the ZIO documentation:

> When a resource is out of service due to overload or contention, retrying and backing off doesn't help us. If all failed API calls are backed off to the same point of time, they cause another overload or contention. Jitter adds some amount of randomness to the delay of the schedule. This helps us to avoid ending up accidentally synchronizing and taking the service down by accident.

The default form (without parameters) helps with reducing contention, but it does not help with preventing overload. In fact it actually increases the load! This is because the default form varies the new delay between 0.0 and 1.0 times the old delay giving an average delay of 0.5 times the previous value. Therefore, the load will increase by an amortized factor 2!

Secondly, when we used jittered for the first time, it was highly surprising to see two very rapid consecutive invocations while we used a spaced schedule of 2 minutes.

It would be better if the amortized load stays the same. This suggests that we need to vary the delay both down and up, and by the same amount.

For this PR I arbitrarily considered two pairs: (0.9, 1.1) and (0.8, 1.2). I settled on the latter because in very high contention system more spread probably works better. Also 0.2 is used as example value in Akka's documentation (for example [here](https://doc.akka.io/japi/akka/current/akka/pattern/BackoffOpts.html#onFailure(akka.actor.Props,java.lang.String,scala.concurrent.duration.FiniteDuration,scala.concurrent.duration.FiniteDuration,double))) when their jitter solution is described. (Note, ZIO's jitter is more versatile as Akka's solution is to always increase the delay, never to decrease it.)

In addition, this PR adds a bit more documentation because it might not be immediately clear how the min and max parameters work.