### PR TITLE
Implement ZStream.debug

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4561,6 +4561,12 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     ZStream.suspend(streams.foldLeft[ZStream[R, E, O]](empty)(_ ++ _))
 
   /**
+   * Prints the specified message to the console for debugging purposes.
+   */
+  def debug(value: => Any)(implicit trace: ZTraceElement): ZStream[Any, Nothing, Unit] =
+    ZStream.fromZIO(ZIO.debug(println(value)))
+
+  /**
    * The stream that dies with the `ex`.
    */
   def die(ex: => Throwable)(implicit trace: ZTraceElement): ZStream[Any, Nothing, Nothing] =

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4564,7 +4564,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Prints the specified message to the console for debugging purposes.
    */
   def debug(value: => Any)(implicit trace: ZTraceElement): ZStream[Any, Nothing, Unit] =
-    ZStream.fromZIO(ZIO.debug(println(value)))
+    ZStream.fromZIO(ZIO.debug(value))
 
   /**
    * The stream that dies with the `ex`.


### PR DESCRIPTION
Resolves #6281.

There is some ambiguity whether this should return a stream that produces a single value `Unit` or an empty stream. This is the implementation you want if you are using `flatMap` but not if you are concatenating streams. I think `flatMap` is more common so this makes sense.