### PR TITLE
Fix/lazy args

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1433,7 +1433,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * fibers forked within the original effect.
    */
   final def overrideForkScope(scope: => ZScope)(implicit trace: ZTraceElement): ZIO[R, E, A] =
-    new ZIO.OverrideForkScope(self, () => Some(scope), trace)
+    new ZIO.OverrideForkScope(() => self, () => Some(scope), trace)
 
   /**
    * Exposes all parallel errors in a single call
@@ -1522,7 +1522,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * supervise any fibers forked within the original effect.
    */
   final def resetForkScope(implicit trace: ZTraceElement): ZIO[R, E, A] =
-    new ZIO.OverrideForkScope(self, () => None, trace)
+    new ZIO.OverrideForkScope(() => self, () => None, trace)
 
   /**
    * Returns an effect that races this effect with the specified effect,
@@ -5619,7 +5619,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
 
   final class Grafter(private val scope: ZScope) extends AnyVal {
     def apply[R, E, A](zio: => ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
-      new ZIO.OverrideForkScope(zio, () => Some(scope), trace)
+      new ZIO.OverrideForkScope(() => zio, () => Some(scope), trace)
   }
 
   final class InterruptStatusRestore private (private val flag: zio.InterruptStatus) extends AnyVal {
@@ -6413,7 +6413,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   }
 
   private[zio] final class OverrideForkScope[R, E, A](
-    val zio: ZIO[R, E, A],
+    val zio: () => ZIO[R, E, A],
     val forkScope: () => Option[ZScope],
     val trace: ZTraceElement
   ) extends ZIO[R, E, A] {

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -457,7 +457,7 @@ private[zio] final class FiberContext[E, A](
 
                     unsafeAddFinalizer(ZIO.succeed(unsafeSetRef(forkScopeOverride, oldForkScopeOverride))(zio.trace))
 
-                    curZio = zio.zio
+                    curZio = zio.zio()
 
                   case ZIO.Tags.Ensuring =>
                     val zio = curZio.asInstanceOf[ZIO.Ensuring[Any, Any, Any]]


### PR DESCRIPTION
This PR improves lazy evaluation of the `zio` values within:
- `OverrideForkScope`
- `InterruptStatusRestore`

cc @mikearnaldi 