### PR TITLE
Fix Diff[Nothing] issue

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
-import zio.test.SmartTestTypes._
 import zio._
+import zio.test.SmartTestTypes._
 
 import java.time.LocalDateTime
 import scala.collection.immutable.SortedSet
@@ -470,13 +470,19 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         final case class Foo(string: String, int: Int)
         assertTrue(Foo(null, 1) == Foo("a", 1))
       } @@ failing
-    )
+    ),
+    suite("miscellaneous issues") {
+      test("implicit Diff between Option[Nothing] and None is resolved") {
+        val option: Option[Nothing] = Option.empty
+        assertTrue(option == None)
+      }
+    }
   )
 
   // The implicit trace will be used by assertTrue to report the
   // actual location.
   def customAssertion(string: String)(implicit trace: ZTraceElement): Assert =
-    assertTrue(string == "coool")
+    assertTrue(string == "cool")
 
   // Test Types
   sealed private trait Color

--- a/test/shared/src/main/scala/zio/test/diff/Diff.scala
+++ b/test/shared/src/main/scala/zio/test/diff/Diff.scala
@@ -102,6 +102,9 @@ trait DiffInstances extends LowPriDiff {
     DiffResult.Nested("Set", fields)
   }
 
+  implicit val nothingDiff: Diff[Nothing] =
+    (x: Nothing, _: Nothing) => DiffResult.Identical(x)
+
 }
 
 trait LowPriDiff {


### PR DESCRIPTION
This fixes the following issue that @jdegoes ran into:

```scala
[error] C:\Users\john\Documents\git\zio-webapp\zio-webapp-workshop\src\main\scala\webapp\workshop\02-http.scala:159:31: diverging implicit expansion for type zio.test.diff.Diff[A]
[error] starting with method setDiff in trait DiffInstances
```