### PR TITLE
Delete ZIO#withFilter

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3776,41 +3776,6 @@ object ZIOSpec extends ZIOBaseSpec {
         ZIO.succeed(assertCompletes)
       }
     ),
-    suite("withFilter")(
-      test("tuple value is extracted correctly from task") {
-        for {
-          (i, j, k) <- Task((1, 2, 3))
-        } yield assert((i, j, k))(equalTo((1, 2, 3)))
-      },
-      test("condition in for-comprehension syntax works correctly for task") {
-        for {
-          n <- Task(3) if n > 0
-        } yield assert(n)(equalTo(3))
-      },
-      test("unsatisfied condition should fail with NoSuchElementException") {
-        val task =
-          for {
-            n <- Task(3) if n > 10
-          } yield n
-        assertM(task.exit)(fails(isSubtype[NoSuchElementException](anything)))
-      },
-      test("withFilter doesn't compile with IO that fails with type other than Throwable") {
-        val result = typeCheck {
-          """
-            import zio._
-            val io: IO[String, Int] = IO.succeed(1)
-            for {
-              n <- io if n > 0
-            } yield n
-              """
-        }
-
-        val expected =
-          "Pattern guards are only supported when the error type is a supertype of NoSuchElementException. However, your effect has String for the error type."
-        if (TestVersion.isScala2) assertM(result)(isLeft(equalTo(expected)))
-        else assertM(result)(isLeft(anything))
-      }
-    ),
     test("zip is compositional") {
       lazy val x1: Task[Int]                          = ???
       lazy val x2: Task[Unit]                         = ???

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -471,11 +471,9 @@ object ZLayerSpec extends ZIOBaseSpec {
         val fedB = (ZLayer.succeed(Config(1)) >>> aLayer) >>> bLayer
         val fedC = (ZLayer.succeed(Config(2)) >>> aLayer) >>> cLayer
         for {
-          (b, c) <- (fedB ++ fedC).build.useNow.map(v => (v.get[B], v.get[C]))
-        } yield {
-          assert(b.value)(equalTo(1)) &&
-          assert(c.value)(equalTo(1))
-        }
+          tuple <- (fedB ++ fedC).build.useNow.map(v => (v.get[B], v.get[C]))
+          (a, b) = tuple
+        } yield assert(a.value)(equalTo(b.value))
       }
     )
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5602,21 +5602,6 @@ object ZIO extends ZIOCompanionPlatformSpecific {
       }
   }
 
-  implicit final class ZIOWithFilterOps[R, E, A](private val self: ZIO[R, E, A]) extends AnyVal {
-
-    /**
-     * Enables to check conditions in the value produced by ZIO If the condition
-     * is not satisfied, it fails with NoSuchElementException this provide the
-     * syntax sugar in for-comprehension: for { (i, j) <- io1 positive <- io2 if
-     * positive > 0 } yield ()
-     */
-    def withFilter(predicate: A => Boolean)(implicit ev: CanFilter[E], trace: ZTraceElement): ZIO[R, E, A] =
-      self.flatMap { a =>
-        if (predicate(a)) ZIO.succeedNow(a)
-        else ZIO.fail(ev(new NoSuchElementException("The value doesn't satisfy the predicate")))
-      }
-  }
-
   final class Grafter(private val scope: ZScope) extends AnyVal {
     def apply[R, E, A](zio: => ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
       new ZIO.OverrideForkScope(() => zio, () => Some(scope), trace)


### PR DESCRIPTION
This method is not very polymorphic because it fixes the error type to a subtype of `Throwable`. In addition, it causes a very disproportionate number of user questions because it requires the error type to be a subtype of `Throwable` to do something like the below, which makes no sense conceptually.

```scala
for {
  (a, b) <- ZIO.succeed((1, 2))
} yield (a, b)
```

The translation of irrefutable pattern matches into `withFilter` statements is an issue that needs to be addressed at the Scala compiler level.