### PR TITLE
Add `DeriveGen[LocalTime]`

### DIFF
--- a/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
+++ b/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
@@ -7,7 +7,7 @@ import zio.test.GenUtils._
 import zio.test.magnolia.DeriveGen._
 import zio.test.{Sized, _}
 
-import java.time.{Instant, LocalDate, LocalDateTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util.UUID
 
 object DeriveGenSpec extends DefaultRunnableSpec {
@@ -94,6 +94,7 @@ object DeriveGenSpec extends DefaultRunnableSpec {
       test("instant")(assertDeriveGen[Instant]),
       test("localDateTime")(assertDeriveGen[LocalDateTime]),
       test("localDate")(assertDeriveGen[LocalDate]),
+      test("localTime")(assertDeriveGen[LocalTime]),
       test("bigDecimal")(assertDeriveGen[BigDecimal])
     ),
     suite("shrinking")(

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -79,7 +79,7 @@ object DeriveGen {
   implicit val genUUID: DeriveGen[UUID]                   = instance(Gen.anyUUID)
   implicit val genInstant: DeriveGen[Instant]             = instance(Gen.anyInstant)
   implicit val genLocalDateTime: DeriveGen[LocalDateTime] = instance(Gen.anyLocalDateTime)
-  implicit val genLocalDate: DeriveGen[LocalDate]         = instance(Gen.anyLocalDateTime.map(_.toLocalDate()))
+  implicit val genLocalDate: DeriveGen[LocalDate]         = instance(Gen.anyLocalDate)
   implicit val genLocalTime: DeriveGen[LocalTime]         = instance(Gen.anyLocalTime)
   implicit val genBigDecimal: DeriveGen[BigDecimal] = instance(
     Gen.bigDecimal(

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -21,7 +21,7 @@ import magnolia._
 import zio.Chunk
 import zio.random.Random
 
-import java.time.{Instant, LocalDate, LocalDateTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util.UUID
 
 /**
@@ -80,6 +80,7 @@ object DeriveGen {
   implicit val genInstant: DeriveGen[Instant]             = instance(Gen.anyInstant)
   implicit val genLocalDateTime: DeriveGen[LocalDateTime] = instance(Gen.anyLocalDateTime)
   implicit val genLocalDate: DeriveGen[LocalDate]         = instance(Gen.anyLocalDateTime.map(_.toLocalDate()))
+  implicit val genLocalTime: DeriveGen[LocalTime]         = instance(Gen.anyLocalTime)
   implicit val genBigDecimal: DeriveGen[BigDecimal] = instance(
     Gen.bigDecimal(
       BigDecimal(Double.MinValue) * BigDecimal(Double.MaxValue),

--- a/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
@@ -18,7 +18,7 @@ package zio.test.magnolia
 
 import zio.Chunk
 
-import java.time.{Instant, LocalDate, LocalDateTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util.UUID
 import scala.compiletime.{erasedValue, summonInline}
 import scala.deriving._
@@ -51,7 +51,8 @@ object DeriveGen {
     given DeriveGen[UUID] = instance(Gen.anyUUID)
     given DeriveGen[Instant] = instance(Gen.anyInstant)
     given DeriveGen[LocalDateTime] = instance(Gen.anyLocalDateTime)
-    given DeriveGen[LocalDate] = instance(Gen.anyLocalDateTime.map(_.toLocalDate()))
+    given DeriveGen[LocalDate] = instance(Gen.anyLocalDate)
+    given DeriveGen[LocalTime] = instance(Gen.anyLocalTime)
     given DeriveGen[BigDecimal] = instance(Gen.bigDecimal(
         BigDecimal(Double.MinValue) * BigDecimal(Double.MaxValue),
         BigDecimal(Double.MaxValue) * BigDecimal(Double.MaxValue)


### PR DESCRIPTION
This PR adds the `DeriveGen[LocalTime]` and accompanying tests. It also updates `DeriveGen[LocalDate]` to use the associated gen, allowing for consistent gen usage

Closes #6345 