### PR TITLE
Fix splitLines issue #6360

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -45,6 +45,11 @@ object ZPipelineSpec extends ZIOBaseSpec {
         },
         test("\\r\\n on the boundary") {
           testSplitLines(Seq(Chunk("abc\r", "\nabc")))
+        },
+        test("issue #6360") {
+          ZStream.fromChunk(Chunk("AAAAABBBB#\r\r\r\n", "test")).via(ZPipeline.splitLines).runCollect.map { res =>
+            assertTrue(res == Chunk("AAAAABBBB#\r\r", "test"))
+          }
         }
       ),
       suite("mapChunksZIO")(
@@ -112,7 +117,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
     val str      = input.flatMap(_.mkString).mkString
     val expected = Chunk.fromIterable(Source.fromString(str).getLines().toList)
     ZStream.fromChunks(input: _*).via(ZPipeline.splitLines).runCollect.map { res =>
-      assert(res)(equalTo(expected))
+      assertTrue(res == expected)
     }
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -618,7 +618,6 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
             val concatenated = carry concat string
 
             if (concatenated.nonEmpty) {
-
               // If we had a split CRLF, start reading from the last character of the leftover, which was the '\r'
               // Otherwise we just skip over the entire previous leftover, as it doesn't contain a newline.
               val continueFrom =
@@ -640,7 +639,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
                           (index + 2, true, false)
                         } else if (index == concatenated.length - 1)
                           (sliceStart, false, true)
-                        else (index, false, false)
+                        else (sliceStart, false, false)
                       case _ => (sliceStart, false, midCRLF)
                     }
                 } match {


### PR DESCRIPTION
Note that the `Source.fromString().getLines` used in `testSplitLines` treats the individual `\r`s as new lines too. I assumed we don't want to do that.