### PR TITLE
Add IHS Markit to Adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Want to see your company here? [Submit a PR](https://github.com/zio/zio/edit/mas
 * [greyflower.media GmbH](https://greyflower.media)
 * [Hunters.AI](https://hunters.ai)
 * [iHeartRadio](https://www.iheart.com/)
+* [IHS Markit](https://ihsmarkit.com/)
 * [Investsuite](https://investsuite.com/)
 * [Kaizen Solutions](https://kaizen-solutions.net/)
 * [Kamon APM](https://kamon.io/)


### PR DESCRIPTION
Add IHS Markit as a user of zio libraries in production.