### PR TITLE
Optimise Chunk's dropRight & takeRight

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkIndexedSeqComparison.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkIndexedSeqComparison.scala
@@ -69,7 +69,10 @@ class ChunkIndexedSeqComparison {
   def distinct(): Chunk[Int] = chunk.distinct
 
   @Benchmark
-  def dropRight(): Chunk[Int] = chunk.dropRight(1)
+  def drop(): Chunk[Int] = chunk.drop(size / 2)
+
+  @Benchmark
+  def dropRight(): Chunk[Int] = chunk.dropRight(size / 2)
 
   @Benchmark
   def endsWith(): Boolean = chunk.endsWith(Seq(size - 1, size))
@@ -238,7 +241,10 @@ class ChunkIndexedSeqComparison {
   def tails(): Iterator[Chunk[Int]] = chunk.tails
 
   @Benchmark
-  def takeRight(): Chunk[Int] = chunk.takeRight(size)
+  def take(): Chunk[Int] = chunk.take(size / 2)
+
+  @Benchmark
+  def takeRight(): Chunk[Int] = chunk.takeRight(size / 2)
 
   @Benchmark
   def toIndexedSeq(bh: Blackhole): Unit = bh.consume(chunk.toIndexedSeq)

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -327,9 +327,19 @@ object ChunkSpec extends ZIOBaseSpec {
     testM("drop chunk") {
       check(largeChunks(intGen), intGen)((chunk, n) => assert(chunk.drop(n).toList)(equalTo(chunk.toList.drop(n))))
     },
+    testM("dropRight chunk") {
+      check(largeChunks(intGen), intGen)((chunk, n) =>
+        assert(chunk.dropRight(n).toList)(equalTo(chunk.toList.dropRight(n)))
+      )
+    },
     testM("take chunk") {
       check(chunkWithIndex(Gen.unit)) { case (c, n) =>
         assert(c.take(n).toList)(equalTo(c.toList.take(n)))
+      }
+    },
+    testM("takeRight chunk") {
+      check(chunkWithIndex(Gen.unit)) { case (c, n) =>
+        assert(c.takeRight(n).toList)(equalTo(c.toList.takeRight(n)))
       }
     },
     testM("dropWhile chunk") {

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -195,11 +195,23 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     else if (n >= len) Chunk.empty
     else
       self match {
-        case Chunk.Slice(c, o, l)        => Chunk.Slice(c, o + n, l - n)
-        case Chunk.Singleton(_) if n > 0 => Chunk.empty
-        case c @ Chunk.Singleton(_)      => c
-        case Chunk.Empty                 => Chunk.empty
-        case _                           => Chunk.Slice(self, n, len - n)
+        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o + n, l - n)
+        case _                    => Chunk.Slice(self, n, len - n)
+      }
+  }
+
+  /**
+   * Drops the last `n` elements of the chunk.
+   */
+  override def dropRight(n: Int): Chunk[A] = {
+    val len = self.length
+
+    if (n <= 0) self
+    else if (n >= len) Chunk.empty
+    else
+      self match {
+        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o, l - n)
+        case _                    => Chunk.Slice(self, 0, len - n)
       }
   }
 
@@ -767,12 +779,20 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     else if (n >= length) this
     else
       self match {
-        case Chunk.Empty => Chunk.Empty
-        case Chunk.Slice(c, o, l) =>
-          if (n >= l) this
-          else Chunk.Slice(c, o, n)
-        case c @ Chunk.Singleton(_) => c
-        case _                      => Chunk.Slice(self, 0, n)
+        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o, n)
+        case _                    => Chunk.Slice(self, 0, n)
+      }
+
+  /**
+   * Takes the last `n` elements of the chunk.
+   */
+  override def takeRight(n: Int): Chunk[A] =
+    if (n <= 0) Chunk.Empty
+    else if (n >= length) this
+    else
+      self match {
+        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o + l - n, n)
+        case _                    => Chunk.Slice(self, length - n, n)
       }
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -779,7 +779,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
     else if (n >= length) this
     else
       self match {
-        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o, n)
+        case Chunk.Slice(c, o, _) => Chunk.Slice(c, o, n)
         case _                    => Chunk.Slice(self, 0, n)
       }
 


### PR DESCRIPTION
I removed some dead code from `Chunk#take` and `Chunk#drop` and added similar optimised overrides for `takeRight` and `dropRight`. Plus some tests & benchmarks.

Before (89f5141eed6a8c8eefce90f6bc82077ea041591c):
```
benchmarks/jmh:run -wi 3 -i 3 -f 2  zio.chunks.ChunkIndexedSeqComparison.drop* zio.chunks.ChunkIndexedSeqComparison.take*
[info] Benchmark                            (size)  Mode  Cnt     Score     Error  Units
[info] ChunkIndexedSeqComparison.drop         1000  avgt    6     4.779 ±   0.139  ns/op
[info] ChunkIndexedSeqComparison.dropRight    1000  avgt    6  2302.008 ±  39.221  ns/op
[info] ChunkIndexedSeqComparison.take         1000  avgt    6     4.552 ±   0.065  ns/op
[info] ChunkIndexedSeqComparison.takeRight    1000  avgt    6  2939.276 ± 187.680  ns/op
```

After (2f1b4089cd1b183a790bc1fd15e9418ec64bc385):
```
benchmarks/jmh:run -wi 3 -i 3 -f 2  zio.chunks.ChunkIndexedSeqComparison.drop* zio.chunks.ChunkIndexedSeqComparison.take*
[info] Benchmark                            (size)  Mode  Cnt  Score   Error  Units
[info] ChunkIndexedSeqComparison.drop         1000  avgt    6  4.566 ± 0.086  ns/op
[info] ChunkIndexedSeqComparison.dropRight    1000  avgt    6  4.566 ± 0.059  ns/op
[info] ChunkIndexedSeqComparison.take         1000  avgt    6  4.525 ± 0.048  ns/op
[info] ChunkIndexedSeqComparison.takeRight    1000  avgt    6  4.753 ± 0.095  ns/op