### PR TITLE
Initial work toward metrics refactoring

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -54,6 +54,18 @@ trait ZIOAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =>
       )(implicit trace: ZTraceElement): ZIO[R, E, A] =
         that(self(zio))
     }
+
+  /**
+   * Returns a new aspect that flips the behavior it applies to error and
+   * success channels. If the old aspect affected success values in some way,
+   * then the new aspect will affect error values in the same way.
+   */
+  def flip: ZIOAspect[LowerR, UpperR, LowerA, UpperA, LowerE, UpperE] =
+    new ZIOAspect[LowerR, UpperR, LowerA, UpperA, LowerE, UpperE] {
+      def apply[R >: LowerR <: UpperR, E >: LowerA <: UpperA, A >: LowerE <: UpperE](zio: ZIO[R, E, A])(implicit
+        trace: ZTraceElement
+      ): ZIO[R, E, A] = self(zio.flip).flip
+    }
 }
 
 object ZIOAspect {

--- a/core/shared/src/main/scala/zio/internal/metrics/Counter.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/Counter.scala
@@ -24,7 +24,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A `Counter` is a metric representing a single numerical value that may be
  * incremented over time. A typical use of this metric would be to track the
  * number of a certain type of request received. With a counter the quantity of
- * interest is the cumulative value over time, as opposed to a gauge where the
+ * interest is the cummulative value over time, as opposed to a gauge, where the
  * quantity of interest is the value as of a specific point in time.
  */
 private[zio] trait Counter {

--- a/core/shared/src/main/scala/zio/internal/metrics/MetricHook.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/MetricHook.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal.metrics
+
+final case class MetricHook[-In, +Out](
+  update: In => Unit,
+  get: () => Out
+) { self =>
+  def contramap[In2](f: In2 => In): MetricHook[In2, Out] =
+    MetricHook(update.compose(f), get)
+
+  def map[Out2](f: Out => Out2): MetricHook[In, Out2] =
+    MetricHook(update, () => f(get()))
+
+  def zip[In2, Out2](that: MetricHook[In2, Out2]): MetricHook[(In, In2), (Out, Out2)] =
+    MetricHook(
+      t => {
+        self.update(t._1)
+        that.update(t._2)
+      },
+      () => (self.get(), that.get())
+    )
+}

--- a/core/shared/src/main/scala/zio/internal/metrics/ModifiedMetricHook.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ModifiedMetricHook.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal.metrics
+
+final case class ModifiedMetricHook[In0, Out0, -In, +Out](
+  hook: MetricHook[In0, Out0],
+  contramapper: In => In0,
+  mapper: Out0 => Out
+) { self =>
+  def contramap[In2](f: In2 => In): ModifiedMetricHook[In0, Out0, In2, Out] =
+    copy(contramapper = f.andThen(self.contramapper))
+
+  val get: () => Out = () => mapper(hook.get())
+
+  def map[Out2](f: Out => Out2): ModifiedMetricHook[In0, Out0, In, Out2] =
+    copy(mapper = self.mapper.andThen(f))
+
+  val update: In => Unit = contramapper.andThen(hook.update)
+
+  def zip[In1, Out1, In2, Out2](
+    that: ModifiedMetricHook[In1, Out1, In2, Out2]
+  ): ModifiedMetricHook[(In0, In1), (Out0, Out1), (In, In2), (Out, Out2)] =
+    ModifiedMetricHook(
+      hook.zip(that.hook),
+      (i: (In, In2)) => (self.contramapper(i._1), that.contramapper(i._2)),
+      (o: (Out0, Out1)) => (self.mapper(o._1), that.mapper(o._2))
+    )
+}
+object ModifiedMetricHook {
+  def apply[In, Out](hook: MetricHook[In, Out]): ModifiedMetricHook[In, Out, In, Out] =
+    ModifiedMetricHook(hook, identity(_), identity(_))
+}

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -40,24 +40,24 @@ object MetricClient {
   /**
    * Unsafely installs the specified metric listener.
    */
-  final def unsafeInstallListener(listener: MetricListener): Unit =
+  private[zio] final def unsafeInstallListener(listener: MetricListener): Unit =
     metricState.installListener(listener)
 
   /**
    * Unsafely removed the specified metric listener.
    */
-  final def unsafeRemoveListener(listener: MetricListener): Unit =
+  private[zio] final def unsafeRemoveListener(listener: MetricListener): Unit =
     metricState.removeListener(listener)
 
   /**
    * Unsafely captures a snapshot of all metrics recorded by the application.
    */
-  final def unsafeStates: Map[MetricKey, MetricState] =
+  private[zio] final def unsafeStates: Map[MetricKey, MetricState] =
     metricState.states
 
   /**
    * Unsafely looks up the state of a metric by its key.
    */
-  final def unsafeState(key: MetricKey): Option[MetricState] =
+  private[zio] final def unsafeState(key: MetricKey): Option[MetricState] =
     metricState.state(key)
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricKey2.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKey2.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.metrics
+
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+/**
+ * A `MetricKey` is a unique key associated with each metric. The key is based
+ * on a combination of the metric type, the name and tags associated with the
+ * metric, and any other information to describe a a metric, such as the
+ * boundaries of a histogram. In this way, it is impossible to ever create
+ * different metrics with conflicting keys.
+ */
+sealed abstract case class MetricKey2[+Type <: MetricKeyType, In0, Out0] private (
+  name: String,
+  tags: Chunk[MetricLabel],
+  keyType: Type { type In = In0; type Out = Out0 }
+) { self =>
+  private[zio] lazy val metricHook: internal.metrics.MetricHook[In0, Out0] =
+    unsafeGetMetricHook(keyType)
+
+  /**
+   * Returns a new `MetricKey` with the specified tag appended.
+   */
+  def tagged(key: String, value: String): MetricKey2[Type, In0, Out0] =
+    tagged(Chunk(MetricLabel(key, value)))
+
+  /**
+   * Returns a new `MetricKey` with the specified tags appended.
+   */
+  def tagged(extraTag: MetricLabel, extraTags: MetricLabel*): MetricKey2[Type, In0, Out0] =
+    tagged(Chunk(extraTag) ++ Chunk.fromIterable(extraTags))
+
+  /**
+   * Returns a new `MetricKey` with the specified tags appended.
+   */
+  def tagged(extraTags: Chunk[MetricLabel]): MetricKey2[Type, In0, Out0] =
+    if (tags.isEmpty) self
+    else MetricKey2[Type, In0, Out0](name, tags ++ extraTags, keyType)
+}
+object MetricKey2 {
+  import zio.ZIOMetric.Histogram.Boundaries
+
+  def apply[Type <: MetricKeyType, In0, Out0](
+    name: String,
+    tags: Chunk[MetricLabel],
+    keyType: Type { type In = In0; type Out = Out0 }
+  ): MetricKey2[Type, In0, Out0] = new MetricKey2(name, tags, keyType) {}
+
+  /**
+   * Creates a metric key for a counter, with the specified name & parameters.
+   */
+  def counter(name: String): MetricKey2[MetricKeyType.Counter, Double, MetricState2.Counter] =
+    MetricKey2(name, Chunk.empty, MetricKeyType.Counter)
+
+  /**
+   * Creates a metric key for a gauge, with the specified name & parameters.
+   */
+  def gauge(name: String): MetricKey2[MetricKeyType.Gauge, Double, MetricState2.Gauge] =
+    MetricKey2(name, Chunk.empty, MetricKeyType.Gauge)
+
+  /**
+   * Creates a metric key for a histogram, with the specified name & parameters.
+   */
+  def histogram(
+    name: String,
+    boundaries: Boundaries
+  ): MetricKey2[MetricKeyType.Histogram, Double, MetricState2.Histogram] =
+    MetricKey2(name, Chunk.empty, MetricKeyType.Histogram(boundaries))
+
+  /**
+   * Creates a metric key for a summary, with the specified name & parameters.
+   */
+  def summary(
+    name: String,
+    maxAge: Duration,
+    maxSize: Int,
+    error: Double,
+    quantiles: Chunk[Double]
+  ): MetricKey2[MetricKeyType.Summary, Double, MetricState2.Summary] =
+    MetricKey2(name, Chunk.empty, MetricKeyType.Summary(maxAge, maxSize, error, quantiles))
+
+  /**
+   * Creates a metric key for a set count, with the specified name & parameters.
+   */
+  def setCount(name: String, setTag: String): MetricKey2[MetricKeyType.SetCount, String, MetricState2.SetCount] =
+    MetricKey2(name, Chunk.empty, MetricKeyType.SetCount(setTag))
+}

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.metrics
+
+import zio._
+
+sealed trait MetricKeyType {
+  type In
+  type Out
+}
+object MetricKeyType {
+  type Counter = Counter.type
+
+  case object Counter extends MetricKeyType {
+    type In  = Double
+    type Out = MetricState2.Counter
+  }
+
+  type Gauge = Gauge.type
+  case object Gauge extends MetricKeyType {
+    type In  = Double
+    type Out = MetricState2.Gauge
+  }
+
+  final case class Histogram(
+    boundaries: ZIOMetric.Histogram.Boundaries
+  ) extends MetricKeyType {
+    type In  = Double
+    type Out = MetricState2.Histogram
+  }
+
+  final case class Summary(
+    maxAge: Duration,
+    maxSize: Int,
+    error: Double,
+    quantiles: Chunk[Double]
+  ) extends MetricKeyType {
+    type In  = Double
+    type Out = MetricState2.Summary
+  }
+
+  final case class SetCount(setTag: String) extends MetricKeyType {
+    type In  = String
+    type Out = MetricState2.SetCount
+  }
+}

--- a/core/shared/src/main/scala/zio/metrics/MetricListener.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricListener.scala
@@ -22,7 +22,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A `MetricListener` is capable of taking some action in response to a metric
  * being recorded, such as sending that metric to a third party service.
  */
-trait MetricListener { self =>
+private[zio] trait MetricListener { self =>
   def unsafeGaugeObserved(key: MetricKey.Gauge, value: Double, delta: Double): Unit
   def unsafeCounterObserved(key: MetricKey.Counter, absValue: Double, delta: Double): Unit
   def unsafeHistogramObserved(key: MetricKey.Histogram, value: Double): Unit

--- a/core/shared/src/main/scala/zio/metrics/MetricState.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricState.scala
@@ -20,6 +20,37 @@ import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
+ * A `MetricState` describes the state of a metric. The type parameter of a
+ * metric state corresponds to the type of the metric key (MetricKeyType). This
+ * phantom type parameter is used to tie keys to their expected states.
+ */
+sealed trait MetricState2[+Type]
+
+object MetricState2 {
+  final case class Counter(count: Double) extends MetricState2[MetricKeyType.Counter]
+
+  final case class Gauge(value: Double) extends MetricState2[MetricKeyType.Gauge]
+
+  final case class Histogram(
+    buckets: Chunk[(Double, Long)],
+    count: Long,
+    sum: Double
+  ) extends MetricState2[MetricKeyType.Histogram]
+
+  final case class Summary(
+    error: Double,
+    quantiles: Chunk[(Double, Option[Double])],
+    count: Long,
+    sum: Double
+  ) extends MetricState2[MetricKeyType.Summary]
+
+  final case class SetCount(
+    setTag: String,
+    occurrences: Chunk[(String, Long)]
+  ) extends MetricState2[MetricKeyType.SetCount]
+}
+
+/**
  * `MetricState` represents a snapshot of the current state of a metric as of a
  * poiint in time.
  */

--- a/core/shared/src/main/scala/zio/metrics/ZIOMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/ZIOMetric.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.metrics
+
+import zio._
+import zio.metrics.MetricKey
+import zio.ZIOMetric.Histogram
+
+import zio.internal.metrics._
+
+/**
+ * A `ZIOMetric[In, Out]` represents a concurrent metric, which accepts updates
+ * of type `In`, which are aggregated to a stateful value of type `Out`.
+ *
+ * For example, a counter metric would have type `ZIOMetric2[Double, Double]`,
+ * representing the fact that the metric can be updated with doubles (the amount
+ * to increment or decrement the counter by), and the state of the counter is a
+ * double.
+ *
+ * There are five primitive metric types supported by ZIO:
+ *
+ *   - Counters
+ *   - Gauges
+ *   - Histograms
+ *   - Summaries
+ *   - Set Counts
+ *
+ * The companion object contains constructors for these primitive metrics. All
+ * metrics are derived from these primitive metrics.
+ */
+trait ZIOMetric2[+Type <: MetricKeyType, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In] { self =>
+  type KeyIn
+  type KeyOut
+
+  /**
+   * Retrieves the metric key associated with the metric, which uniquely
+   * identifies the metric, including its name, type, tags, and construction
+   * parameters.
+   */
+  val key: MetricKey2[Type, KeyIn, KeyOut]
+
+  /**
+   * Retrieves the metric hook that powers the metric. There is no need to use
+   * this in application-level code.
+   */
+  private[zio] def hook: ModifiedMetricHook[KeyIn, KeyOut, In, Out]
+
+  /**
+   * Applies the metric computation to the result of the specified effect.
+   */
+  final def apply[R, E, A1 <: In](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+    zio.tap(update(_))
+
+  /**
+   * Returns a new metric that is powered by this one, but which accepts updates
+   * of the specified new type, which must be transformable to the input type of
+   * this metric.
+   */
+  def contramap[In2](f: In2 => In): ZIOMetric2.Full[Type, KeyIn, KeyOut, In2, Out] =
+    ZIOMetric2(key, hook.contramap(f))
+
+  /**
+   * Returns a new metric that is powered by this one, but which outputs a new
+   * state type, determined by transforming the state type of this metric by the
+   * specified function.
+   */
+  def map[Out2](f: Out => Out2): ZIOMetric2.Full[Type, KeyIn, KeyOut, In, Out2] =
+    ZIOMetric2(key, hook.map(f))
+
+  /**
+   * Returns a new metric, which is identical in every way to this one, except
+   * the specified tag will be added to the tags of this metric.
+   */
+  def tagged(key: String, value: String): ZIOMetric2.Full[Type, KeyIn, KeyOut, In, Out] =
+    tagged(MetricLabel(key, value))
+
+  /**
+   * Returns a new metric, which is identical in every way to this one, except
+   * the specified tags have been added to the tags of this metric.
+   */
+  def tagged(extraTag: MetricLabel, extraTags: MetricLabel*): ZIOMetric2.Full[Type, KeyIn, KeyOut, In, Out] =
+    tagged(Chunk(extraTag) ++ Chunk.fromIterable(extraTags))
+
+  /**
+   * Returns a new metric, which is identical in every way to this one, except
+   * the specified tags have been added to the tags of this metric.
+   */
+  def tagged(extraTags: Chunk[MetricLabel]): ZIOMetric2.Full[Type, KeyIn, KeyOut, In, Out] =
+    ZIOMetric2(key.tagged(extraTags), hook)
+
+  /**
+   * Returns a ZIO aspect that can update a metric derived from this one, but
+   * which can dynamically augment the metric with new tags based on the success
+   * value of the effects that it is applied to. Note that this method does not
+   * return a new metric, because it cannot: dynamically computing tags based on
+   * success values results in the loss of structure that all metrics must have.
+   */
+  def taggedWith[In1 <: In](f: In1 => Chunk[MetricLabel]): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In1] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In1] {
+      def apply[R, E, A1 <: In1](zio: ZIO[R, E, A1])(implicit trace: ZTraceElement): ZIO[R, E, A1] =
+        zio.map { (a: A1) =>
+          key.tagged(f(a)).metricHook.update(self.hook.contramapper(a))
+
+          a
+        }
+    }
+
+  /**
+   * Updates the metric with the specified update message. For example, if the
+   * metric were a counter, the update would increment the method by the
+   * provided amount.
+   */
+  def update(in: In)(implicit trace: ZTraceElement): UIO[Unit] = ZIO.succeed(unsafeUpdate(in))
+
+  /**
+   * Retrieves a snapshot of the value of the metric at this moment in time.
+   */
+  def value(implicit trace: ZTraceElement): UIO[Out] = ZIO.succeed(unsafeValue())
+
+  private[zio] def unsafeUpdate(in: In): Unit = hook.update(in)
+
+  private[zio] def unsafeValue(): Out = hook.get()
+}
+object ZIOMetric2 {
+  type Full[+Type <: MetricKeyType, KeyIn0, KeyOut0, -In, +Out] =
+    ZIOMetric2[Type, In, Out] { type KeyIn = KeyIn0; type KeyOut = KeyOut0 }
+
+  type Counter[-In]   = ZIOMetric2[MetricKeyType.Counter, In, MetricState2.Counter]
+  type Gauge[-In]     = ZIOMetric2[MetricKeyType.Gauge, In, MetricState2.Gauge]
+  type Histogram[-In] = ZIOMetric2[MetricKeyType.Histogram, In, MetricState2.Histogram]
+  type Summary[-In]   = ZIOMetric2[MetricKeyType.Summary, In, MetricState2.Summary]
+  type SetCount[-In]  = ZIOMetric2[MetricKeyType.SetCount, In, MetricState2.SetCount]
+
+  implicit class CounterSyntax[In](counter: Counter[In]) {
+    def increment(implicit numeric: Numeric[In]): UIO[Unit] = counter.update(numeric.fromInt(1))
+
+    def increment(value: In): UIO[Unit] = counter.update(value)
+
+    def count: UIO[Double] = counter.value.map(_.count)
+  }
+
+  implicit class GaugeSyntax[In](gauge: Gauge[In]) {
+    def set(value: In): UIO[Unit] = gauge.update(value)
+  }
+
+  implicit class HistogramSyntax[In](histogram: Histogram[In]) {
+    def observe(value: In): UIO[Unit] = histogram.update(value)
+  }
+
+  implicit class SummarySyntax[In](summary: Summary[In]) {
+    def observe(value: In): UIO[Unit] = summary.update(value)
+  }
+
+  implicit class SetCountSyntax[In](setCount: Summary[In]) {
+    def observe(value: In): UIO[Unit] = setCount.update(value)
+  }
+
+  def fromMetricKey[Type <: MetricKeyType, In, Out](
+    key: MetricKey2[Type, In, Out]
+  ): ZIOMetric2.Full[Type, In, Out, In, Out] =
+    ZIOMetric2(key, ModifiedMetricHook(key.metricHook))
+
+  def apply[Type <: MetricKeyType, KeyIn0, KeyOut0, In, Out](
+    key0: MetricKey2[Type, KeyIn0, KeyOut0],
+    hook0: ModifiedMetricHook[KeyIn0, KeyOut0, In, Out]
+  ): ZIOMetric2.Full[Type, KeyIn0, KeyOut0, In, Out] =
+    new ZIOMetric2[Type, In, Out] {
+      type KeyIn  = KeyIn0
+      type KeyOut = KeyOut0
+
+      val key: MetricKey2[Type, KeyIn, KeyOut]             = key0
+      def hook: ModifiedMetricHook[KeyIn, KeyOut, In, Out] = hook0
+    }
+
+  /**
+   * A counter, which can be incremented.
+   */
+  def counter(name: String): Counter[Double] =
+    fromMetricKey(MetricKey2.counter(name))
+
+  /**
+   * A gauge, which can be set to a value.
+   */
+  def gauge(name: String): Gauge[Double] =
+    fromMetricKey(MetricKey2.gauge(name))
+
+  /**
+   * A numeric histogram metric, which keeps track of the count of numbers that
+   * fall in buckets of the specified boundaries.
+   */
+  def histogram(name: String, boundaries: Histogram.Boundaries): Histogram[Double] =
+    fromMetricKey(MetricKey2.histogram(name, boundaries))
+
+  /**
+   * A summary metric.
+   */
+  def summary(name: String, maxAge: Duration, maxSize: Int, error: Double, quantiles: Chunk[Double]): Summary[Double] =
+    fromMetricKey(MetricKey2(name, Chunk.empty, MetricKeyType.Summary(maxAge, maxSize, error, quantiles)))
+
+  /**
+   * A string histogram metric, which keeps track of the counts of different
+   * strings.
+   */
+  def setCount(name: String, setTag: String): SetCount[String] =
+    fromMetricKey(MetricKey2(name, Chunk.empty, MetricKeyType.SetCount(setTag)))
+}

--- a/core/shared/src/main/scala/zio/metrics/package.scala
+++ b/core/shared/src/main/scala/zio/metrics/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import zio.internal.metrics._
+
+package object metrics {
+  private[zio] def unsafeGetMetricHook[Type <: MetricKeyType](key: Type): MetricHook[key.In, key.Out] = ???
+
+  def updateMetric[Type <: MetricKeyType, In, Out](key: MetricKey2[Type, In, Out], value: In): UIO[Unit] =
+    ZIO.succeed(key.metricHook.update(value))
+
+  def getMetric[Type <: MetricKeyType, In, Out](key: MetricKey2[Type, In, Out]): UIO[Out] =
+    ZIO.succeed(key.metricHook.get())
+}


### PR DESCRIPTION
This is a WIP for a refactoring of metrics that aims to solve several problems:

1. **Clean separation between metrics and aspect**. Early metrics were designed to be used only as aspects. Although this was later updated, so that metrics could be manually updated, the code remains a strange mix of two worlds: constructors and methods are sometimes aspect-oriented, and sometimes metric-oriented. In the new design, the metrics are designed first and foremost to be manually updated; as an afterthought, they can be used as aspects. However, it is my intention to introduce aspects that are more powerful than the default aspects you get for free with the built in metric types.
2. **Compositional, strongly-typed metrics**. In the new design, metrics are arrow-like, accepting update messages of some type (e.g. `Double`), and being queryable for some output type (e.g. `MetricState.Histogram`). As a result, things that were awkward or impossible to do before are quite easy, e.g. contramapping a Double metric to one that takes Any (`metric.contramap(_ => 1.0)`).
3. **Fewer layers**. In the old design, there are metric types inside the internal metrics package, which expose pure and impure methods, and then wrapper types in the outer package, which expose pure methods. When finished, in the new design, there will be no wrapper types, and all metrics will have a uniform type, with a type parameter used primarily for documentation purposes to describe the fundamental type from which a metric was created (counter, gauge, histogram, etc.).

This is not yet finished, although most of the surface-level API has been designed, it has not been wired up to the backend. In addition, there are naming and organizational changes I wish to make, e.g. making SetCount and DoubleHistogram both types of histograms (string versus double histogram). 

However, giving the significant nature of these changes, it's worth opening up this PR in case anyone has feedback before the final refactoring and even more breaking changes are completed.