### PR TITLE
Change RuntimeConfigAspect.addReportFatal to RuntimeConfigAspect.setReportFatal

### DIFF
--- a/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
+++ b/core/shared/src/main/scala/zio/RuntimeConfigAspect.scala
@@ -29,9 +29,6 @@ object RuntimeConfigAspect extends ((RuntimeConfig => RuntimeConfig) => RuntimeC
   def addLogger(logger: ZLogger[String, Any]): RuntimeConfigAspect =
     RuntimeConfigAspect(self => self.copy(logger = self.logger +> logger))
 
-  def addReportFatal(f: Throwable => Nothing): RuntimeConfigAspect =
-    RuntimeConfigAspect(self => self.copy(reportFatal = t => { self.reportFatal(t); f(t) }))
-
   def addSupervisor(supervisor: Supervisor[Any]): RuntimeConfigAspect =
     RuntimeConfigAspect(self => self.copy(supervisor = self.supervisor ++ supervisor))
 
@@ -49,6 +46,9 @@ object RuntimeConfigAspect extends ((RuntimeConfig => RuntimeConfig) => RuntimeC
 
   def setExecutor(executor: Executor): RuntimeConfigAspect =
     RuntimeConfigAspect(_.copy(executor = executor))
+
+  def setReportFatal(reportFatal: Throwable => Nothing): RuntimeConfigAspect =
+    RuntimeConfigAspect(self => self.copy(reportFatal = reportFatal))
 
   val superviseOperations: RuntimeConfigAspect =
     RuntimeConfigAspect(self => self.copy(flags = self.flags + RuntimeConfigFlag.SuperviseOperations))


### PR DESCRIPTION
Resolves #6377.

The `addReportFatal` aspect is not well defined right now because the type signature of `reportFatal` is `Throwable => Nothing`, indicating that it can never return successfully. Thus, when we compose two `addReportFatal` instances the second one will never be run because the first one will never successfully complete execution.

This PR changes the aspect to be `setReportFatal`, treating the `reportFatal` as something that there can only be one of, similar to the `Executor`, rather than something that can be composed. This makes sense if we think of these functions as specifying how the program should terminate (e.g. what exit code) and the program can only be terminated with one exit code.