### PR TITLE
Report error messages to sbt events which end up in JUnit XML

### DIFF
--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing._
-import zio.test.{ExecutedSpec, TestAnnotation, TestFailure, TestSuccess}
+import zio.test.{DefaultTestReporter, ExecutedSpec, TestAnnotation, TestAnnotationRenderer, TestFailure, TestSuccess}
 
 final case class ZTestEvent(
   fullyQualifiedName: String,
@@ -22,24 +22,24 @@ object ZTestEvent {
     fingerprint: Fingerprint
   ): Seq[ZTestEvent] = {
 
-    def loop(executedSpec: ExecutedSpec[E], labels: List[String]): Seq[ZTestEvent] =
+    def loop(executedSpec: ExecutedSpec[E], label: Option[String]): Seq[ZTestEvent] =
       executedSpec.caseValue match {
-        case ExecutedSpec.LabeledCase(label, spec) => loop(spec, label :: labels)
-        case ExecutedSpec.MultipleCase(specs)      => specs.flatMap(spec => loop(spec, labels))
+        case ExecutedSpec.LabeledCase(label, spec) => loop(spec, Some(label))
+        case ExecutedSpec.MultipleCase(specs)      => specs.flatMap(loop(_, label))
         case ExecutedSpec.TestCase(result, annotations) =>
           Seq(
             ZTestEvent(
               fullyQualifiedName,
-              new TestSelector(labels.headOption.getOrElse("")),
+              new TestSelector(label.getOrElse("")),
               toStatus(result),
-              None,
+              toThrowable(executedSpec, label, result),
               annotations.get(TestAnnotation.timing).toMillis,
               fingerprint
             )
           )
       }
 
-    loop(executedSpec, List.empty)
+    loop(executedSpec, None)
   }
 
   private def toStatus[E](result: Either[TestFailure[E], TestSuccess]) = result match {
@@ -47,4 +47,19 @@ object ZTestEvent {
     case Right(TestSuccess.Succeeded(_)) => Status.Success
     case Right(TestSuccess.Ignored)      => Status.Ignored
   }
+
+  private def toThrowable[E](
+    spec: ExecutedSpec[E],
+    label: Option[String],
+    result: Either[TestFailure[E], TestSuccess]
+  ) = result.left.toOption.map {
+    case TestFailure.Assertion(_) => new AssertionError(render(spec, label))
+    case TestFailure.Runtime(_)   => new RuntimeException(render(spec, label))
+  }
+
+  private def render[E](spec: ExecutedSpec[E], label: Option[String]) = DefaultTestReporter
+    .render(label.fold(spec)(ExecutedSpec.labeled(_, spec)), TestAnnotationRenderer.default, includeCause = true)
+    .flatMap(_.rendered)
+    .mkString("\n")
+    .replaceAll("\u001B\\[[;\\d]*m", "")
 }


### PR DESCRIPTION
This is a quick and dirty solution reusing `DefaultTestReporter`
and subsequently stripping the ANSI colors from the result.

A more elegant solution would involve writing a new reporter,
or adding an option to render without colors to `DefaultTestReporter`,
but this is probably a major issue for anyone running ZIO test in CI,
so I think the quick win is worth it.

Closes #4803