### PR TITLE
Fix #6395

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -115,6 +115,13 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .runCollect
                 .map(_.toList.flatten)
             )(equalTo(data))
+          },
+          test("issue 6395") {
+            assertM(
+              ZStream(1, 2, 3)
+                .aggregateAsync(ZSink.collectAllN[Int](2))
+                .runCollect
+            )(equalTo(Chunk(Chunk(1, 2), Chunk(3))))
           }
         ),
         suite("transduce")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -137,7 +137,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def aggregateAsync[R1 <: R, E1 >: E, A1 >: A, B](
     sink: => ZSink[R1, E1, A1, A1, B]
   )(implicit trace: ZTraceElement): ZStream[R1 with Clock, E1, B] =
-    aggregateAsyncWithin(sink, Schedule.forever)
+    aggregateAsyncWithin(sink, Schedule.recurs(0))
 
   /**
    * Like `aggregateAsyncWithinEither`, but only returns the `Right` results.


### PR DESCRIPTION
The `Schedule.forever` was continuously emitting "schedule ended" events while aggregating upstream, which then emitted an empty result chunk for each.

I think for `aggregateAsync` we completely want to turn off the timeout functionality instead - while for `aggregateAsyncWithin` we want the current behavior of emitting an empty sink result in case of timeout. Calling it with `forever` does not really make any sense though.
