### PR TITLE
Make sure finalizers are run when stopping a ZIOApp

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -49,7 +49,7 @@ object ZIOAppSpec extends ZIOBaseSpec {
         }
       }
 
-      val app1 = ZIOAppDefault(ZIO.logInfo("") *> ZIO.fail("Uh oh!"), RuntimeConfigAspect.addLogger(logger1))
+      val app1 = ZIOAppDefault(ZIO.fail("Uh oh!"), RuntimeConfigAspect.addLogger(logger1))
 
       for {
         c <- app1.invoke(Chunk.empty).exitCode

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -76,11 +76,9 @@ trait Runtime[+R] {
    */
   final def run[E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): IO[E, A] =
     ZIO.fiberId.flatMap { fiberId =>
-      ZIO.blocking {
-        IO.asyncInterrupt[E, A] { callback =>
-          val canceler = unsafeRunAsyncCancelable(zio)(exit => callback(ZIO.done(exit)))
-          Left(ZIO.succeed(canceler(fiberId)))
-        }
+      IO.asyncInterrupt[E, A] { callback =>
+        val canceler = unsafeRunAsyncCancelable(zio)(exit => callback(ZIO.done(exit)))
+        Left(ZIO.succeedBlocking(canceler(fiberId)))
       }
     }
 

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -76,9 +76,11 @@ trait Runtime[+R] {
    */
   final def run[E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): IO[E, A] =
     ZIO.fiberId.flatMap { fiberId =>
-      IO.asyncInterrupt[E, A] { callback =>
-        val canceler = unsafeRunAsyncCancelable(zio)(exit => callback(ZIO.done(exit)))
-        Left(ZIO.succeed(canceler(fiberId)))
+      ZIO.blocking {
+        IO.asyncInterrupt[E, A] { callback =>
+          val canceler = unsafeRunAsyncCancelable(zio)(exit => callback(ZIO.done(exit)))
+          Left(ZIO.succeed(canceler(fiberId)))
+        }
       }
     }
 

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -75,8 +75,11 @@ trait Runtime[+R] {
    * Runs the effect "purely" through an async boundary. Useful for testing.
    */
   final def run[E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): IO[E, A] =
-    IO.async[E, A] { callback =>
-      unsafeRunAsyncWith(zio)(exit => callback(ZIO.done(exit)))
+    ZIO.fiberId.flatMap { fiberId =>
+      IO.asyncInterrupt[E, A] { callback =>
+        val canceler = unsafeRunAsyncCancelable(zio)(exit => callback(ZIO.done(exit)))
+        Left(ZIO.succeed(canceler(fiberId)))
+      }
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5215,7 +5215,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * specified value.
    */
   def succeedBlocking[A](a: => A)(implicit trace: ZTraceElement): UIO[A] =
-    blocking(ZIO.succeedNow(a))
+    blocking(ZIO.succeed(a))
 
   /**
    * The same as [[ZIO.succeed]], but also provides access to the underlying

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -91,11 +91,11 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
 
       for {
         _      <- installSignalHandlers
-        result <- run.provideLayer(newLayer)
+        result <- run.provideLayer(newLayer) @@ ZIOAspect.runtimeConfig(hook)
       } yield result
     }
 
-  def runtime: Runtime[ZEnv] = Runtime.default.mapRuntimeConfig(hook)
+  def runtime: Runtime[ZEnv] = Runtime.default
 
   protected def installSignalHandlers(implicit trace: ZTraceElement): UIO[Any] =
     ZIO.attempt {

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -90,13 +90,12 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
           layer +!+ ZLayer.environment[ZEnv with ZIOAppArgs]
 
       for {
-        _          <- installSignalHandlers
-        newRuntime <- ZIO.runtime[ZEnv].map(_.mapRuntimeConfig(hook))
-        result     <- newRuntime.run(run.provideLayer(newLayer))
+        _      <- installSignalHandlers
+        result <- run.provideLayer(newLayer)
       } yield result
     }
 
-  def runtime: Runtime[ZEnv] = Runtime.default
+  def runtime: Runtime[ZEnv] = Runtime.default.mapRuntimeConfig(hook)
 
   protected def installSignalHandlers(implicit trace: ZTraceElement): UIO[Any] =
     ZIO.attempt {

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -90,8 +90,9 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
           layer +!+ ZLayer.environment[ZEnv with ZIOAppArgs]
 
       for {
-        _      <- installSignalHandlers
-        result <- run.provideLayer(newLayer) @@ ZIOAspect.runtimeConfig(hook)
+        _          <- installSignalHandlers
+        newRuntime <- ZIO.runtime[ZEnv].map(_.mapRuntimeConfig(hook))
+        result     <- newRuntime.run(run.provideLayer(newLayer))
       } yield result
     }
 


### PR DESCRIPTION
There is a problem in ZIOApp (zio-2 rc2). Finalizers are not run when stopping a running application (SIGINT/SIGTERM). 
The application stops as it should, but the cleanup never happens.
This works fine in zio 1.0.13

I think the problem is that `newRuntime.run` in `ZIOApp.invoke` does not propagate interruption, but instead just kills the running effect.
This PR fixes the problem by removing the problematic runtime call. The hook invocation is moved out of `invoke` and added to `runtime` instead. Had to tweak one testcase because of the move.

Added test case to show the bug in the first commit. 