### PR TITLE
Override FiberFailure#toString

### DIFF
--- a/core/shared/src/main/scala/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/zio/FiberFailure.scala
@@ -36,4 +36,7 @@ final case class FiberFailure(cause: Cause[Any]) extends Throwable(null, null, t
     if (getSuppressed().length == 0) {
       cause.unified.iterator.drop(1).foreach(unified => addSuppressed(unified.toThrowable))
     }
+
+  override def toString =
+    cause.prettyPrint
 }


### PR DESCRIPTION
Now that a `Cause` can be rendered with a Java stack trace we can implement the `toString` method of `fiberFailure` in terms of it.