### PR TITLE
How to configure a hot-reloading dev server

### DIFF
--- a/docs/howto/hot-reload.md
+++ b/docs/howto/hot-reload.md
@@ -1,0 +1,23 @@
+---
+id: hot-reload
+title: "How to configure a hot-reloading dev server?"
+---
+
+### How to configure hot-reloading
+For an efficient development process of server applications, a file-watching and hot-reloading development server should be used.
+
+ZIO applications, like most Scala applications, can use [sbt-revolver](https://github.com/spray/sbt-revolver) to do so.
+
+Add the following dependency to your `project/plugins.sbt`
+
+```scala
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+```
+
+Then start your development server from an sbt console using
+
+```scala
+~reStart
+```
+
+This will watch the source code for changes and re-compile when files are changed and then restart the server.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -123,11 +123,13 @@
   "howto-sidebar": {
     "Overview": ["howto/index"],
     "How to": [
+      "getting_started",
       "howto/use-test-assertions",
       "howto/test-effects",
       "howto/mock-services",
       "howto/handle-errors",
       "howto/access-system-information",
+      "howto/hot-reload",
       "howto/use-zio-macros"
     ],
     "Interop": [


### PR DESCRIPTION
Added a documentation on how to configure sbt-revolver, which adds file-watching and hot-reloading capabilities
Added the getting-started documentation to the howtos, as it is otherwise missed by the impatient (skipping the start page)