### PR TITLE
Several minor documentation fixes

### DIFF
--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -124,7 +124,7 @@ for {
 } yield assert(value == 1)
 ```
 
-> _**Note**_:  
+> **Note**:  
 >
 > The `update` is not the composition of `get` and `set`, this composition is not concurrently safe. So whenever we need to update our state, we should not compose `get` and `set` to manage our state in a concurrent environment. Instead, we should use the `update` operation which modifies its `Ref` atomically. 
 

--- a/docs/datatypes/contextual/index.md
+++ b/docs/datatypes/contextual/index.md
@@ -33,16 +33,16 @@ val eliminated: ZIO[Any, IOException, String] =
   }
 ```
 
-ZIO provide this facility through the following concept and data types:
+ZIO provides this facility through the following concepts and data types:
 1. [ZIO Environment](#1-zio-environment) — The `R` type parameter of `ZIO[R, E, A]` data type.
 2. [ZEnvironment](zenvironment.md) — Built-in type-level map for maintaining the environment of a `ZIO` data type. 
 3. [ZLayer](zlayer.md) — Describes how to build one or more services in our application.
 
-Next, we will discuss _ZIO Environment_ and _ZLayer_ and finally how to write ZIO services using _Service Pattern_.
+Next, we will discuss _ZIO Environment_ and _ZLayer_ and finally how to write ZIO services using the _Service Pattern_.
 
 ## 1. ZIO Environment
 
-The `ZIO[-R, +E, +A]` data type describes an effect that requires an input type of `R`, as an environment, may fail with an error of type `E` or succeed and produces a value of type `A`.
+The `ZIO[-R, +E, +A]` data type describes an effect that requires an input of type `R`, as an environment, may fail with an error of type `E`, or succeed with a value of type `A`.
 
 The input type is also known as _environment type_. This type-parameter indicates that to run an effect we need one or some services as an environment of that effect. In other word, `R` represents the _requirement_ for the effect to run, meaning we need to fulfill the requirement in order to make the effect _runnable_.
 
@@ -174,7 +174,7 @@ object ConsoleLive extends Console {
 
 Finally, we can provide the `ConsoleLive` to our application and run the whole:
 
-```mdoc:compile-only
+```scala mdoc:fail:silent
 import zio._
 
 object MainApp extends ZIOAppDefault {
@@ -193,9 +193,9 @@ object MainApp extends ZIOAppDefault {
 
 ```
 
-In the above example, we discard the fact that we can use the ZIO environment and utilize the `R` parameter of the `ZIO` data type. So instead we tried to write the application with the `Task` data type which ignore the ZIO environment. To create our application testable, we gathered all console functionalities into the same interface called, `Console` and implement that in another object called, `ConsoleLive`. Finally, at the end of the day, we provide the implementation of the `Console` service, i.e. `ConsoleLive`, to our application.
+In the above example, we discard the fact that we could use the ZIO environment and utilize the `R` parameter of the `ZIO` data type. So instead we tried to write the application with the `Task` data type, which ignores the ZIO environment. To create our application testable, we gathered all console functionalities into the same interface called `Console`, and implemented that in another object called `ConsoleLive`. Finally, at the end of the day, we provide the implementation of the `Console` service, i.e. `ConsoleLive`, to our application.
 
-**While this technique works for small programs, it doesn't scale.** Assume we have multiple services, and we use them in our application logic like bellow:
+**While this technique works for small programs, it doesn't scale.** Assume we have multiple services, and we use them in our application logic like below:
 
 ```scala
 def foo(
@@ -241,7 +241,7 @@ def bar(arg1: Int, arg2: String, arg3: Double, arg4: Int): ZIO[Service1 & Servic
 
 ZIO environment facility enables us to:
 
-1. **Code to Interface** — like object-oriented paradigm, in ZIO we encouraged to code to interface and defer the implementation. It is the best practice, but ZIO does not enforce us to do that.
+1. **Code to Interface** — Like object-oriented paradigm, in ZIO we are encouraged to code to interface and defer the implementation. It is the best practice, but ZIO does not enforce us to do that.
 
 2. **Write a Testable Code** — By coding to an interface, whenever we want to test our effects, we can easily mock any external services, by providing a _test_ version of those instead of the _live_ version.
 
@@ -280,7 +280,7 @@ In the example above, the compiler can infer the environment type of the `myApp`
 
 We have two types of accessors for the ZIO environment:
 1. **Service Accessor (`ZIO.service`)** is used to access a specific service from the environment.
-2. **Service Members Accessors (`ZIO.serviceWith` and `ZIO.serviceWithZIO`)** are used to access capabilities of a specific service from the environment.
+2. **Service Member Accessors (`ZIO.serviceWith` and `ZIO.serviceWithZIO`)** are used to access capabilities of a specific service from the environment.
 
 > **Note**:
 >
@@ -332,7 +332,7 @@ for {
 
 When creating ZIO layers that have multiple dependencies, this can be helpful. We will discuss this pattern in the [Service Pattern](#service-pattern) section.
 
-#### Service Members Accessors
+#### Service Member Accessors
 
 Sometimes instead of accessing a service, we need to access the capabilities (members) of a service. Based on the return type of each capability, we can use one of these accessors:
 - **ZIO.serviceWith**
@@ -403,21 +403,21 @@ val myApp: ZIO[Logging & Console, Throwable, Unit] =
 
 `ZLayer[-RIn, +E, +ROut]` is a recipe to build an environment of type `ROut`, starting from a value `RIn`, and possibly producing an error `E` during creation.
 
-`ZLayer` combined with the _ZIO Environment_, allow us to use ZIO for _dependency injection_. There are two parts for dependency injection:
+`ZLayer` combined with the _ZIO Environment_, allow us to use ZIO for _dependency injection_. There are two parts of dependency injection:
 1. **Building Dependency Graph**
 2. **Dependency Propagation**
 
-ZIO has a full solution to the dependency injection problem. It solves the first problem by using [compositional properties](zlayer.md#manual-layer-construction) of `ZLayer`. Assume we have several services with their dependencies, and we need a way to compose and wiring up these dependencies and create the dependency graph of the application. `ZLayer` is a ZIO solution for this problem. It allows us to build up the whole application dependency graph by composing layers horizontally and vertically. 
+ZIO has a full solution to the dependency injection problem. It solves the first problem by using [compositional properties](zlayer.md#manual-layer-construction) of `ZLayer`. Assume we have several services with their dependencies, and we need a way to compose and wire up these dependencies to create the dependency graph of the application. `ZLayer` is a ZIO solution for this problem. It allows us to build up the whole application dependency graph by composing layers horizontally and vertically. 
 
 ZIO also solves the second problem by using [ZIO Environment facilities like `ZIO#provide`](zlayer.md#dependency-propagation).
 
 > **Note:**
 > 
-> By using ZLayer and ZIO Environment we can solve the propagation and wire-up problems in dependency injection. Note that it doesn't necessary to use it, and we can still use things like [Guice](https://github.com/google/guice) with ZIO, or we might like to use [izumi distage](https://izumi.7mind.io/distage/index.html) solution for dependency injection.
+> By using ZLayer and ZIO Environment we can solve the propagation and wire-up problems in dependency injection. Note that we are not enforced to use this approach, as we can still use things like [Guice](https://github.com/google/guice) with ZIO, or we might like to use [izumi distage](https://izumi.7mind.io/distage/index.html) solution for dependency injection.
 
 ## Defining ZIO Services
 
-Defining service in ZIO is not very different from object-oriented style, it has the same principle: coding to an interface, not an implementation. Therefore, ZIO encourages us to implement this principle by using the _Service Pattern_, which is quite similar to the object-oriented style.
+Defining services in ZIO is not very different from object-oriented style, it has the same principle: coding to an interface, not an implementation. Therefore, ZIO encourages us to implement this principle by using _Service Pattern_, which is quite similar to the object-oriented style.
 
 Before diving into writing services in ZIO style, let's review how we define them in an object-oriented fashion in the next section.
 
@@ -425,7 +425,7 @@ Before diving into writing services in ZIO style, let's review how we define the
 
 Here are the steps we take to implement a service in object-oriented programming:
 
-1. **Service Definition** — In object-oriented programming, we define services with traits. A service is a bundle of related functionality which are defined in a trait:
+1. **Service Definition** — In object-oriented programming, we define services with traits. A service is a bundle of related functionality that is defined in a trait:
 
 ```scala mdoc:silent:nest
 trait FooService {
@@ -475,7 +475,7 @@ A service is a group of functions that deals with only one concern. Keeping the 
 
 `ZIO` itself provides the basic capabilities through modules, e.g. see how `ZEnv` is defined.
 
-In the functional Scala as well as in object-oriented programming the best practice is to _Program to an Interface, Not an Implementation_. This is the most important design principle in software development and helps us to write maintainable code by:
+In functional Scala as well as in object-oriented programming the best practice is to _Program to an Interface, Not an Implementation_. This is the most important design principle in software development and helps us to write maintainable code by:
 
 * Allowing the client to hold an interface as a contract and don't worry about the implementation. The interface signature determines all operations that should be done.
 
@@ -483,7 +483,7 @@ In the functional Scala as well as in object-oriented programming the best pract
 
 * Providing the ability to write more modular applications. So we can plug in different implementations for different purposes without a major modification.
 
-It is not mandatory but ZIO encourages us to follow this principle by bundling related functionality as an interface by using _Service Pattern_.
+It is not mandatory, but ZIO encourages us to follow this principle by bundling related functionality as an interface by using the _Service Pattern_.
 
 The core idea is that a layer depends upon the interfaces exposed by the layers immediately below itself, but is completely unaware of its dependencies' internal implementations.
 
@@ -491,13 +491,13 @@ In object-oriented programming:
 
 - **Service Definition** is done by using _interfaces_ (Scala trait or Java Interface).
 - **Service Implementation** is done by implementing interfaces using _classes_ or creating _new object_ of the interface.
-- **Defining Dependencies** is done by using _constructors_. They allow us to build classes, give their dependencies. This is called constructor-based dependency injection.
+- **Defining Dependencies** is done by using _constructors_. They allow us to build classes, given their dependencies. This is called constructor-based dependency injection.
 
-We have a similar analogy in Service Pattern, except instead of using _constructors_ we use **`ZLayer`** to define dependencies. So in ZIO fashion, we can think of `ZLayer` as a service constructor.
+We have a similar analogy in the Service Pattern, except instead of using _constructors_ we use **`ZLayer`** to define dependencies. So in ZIO fashion, we can think of `ZLayer` as a service constructor.
 
 ### Service Pattern
 
-Writing services in ZIO using _Service Pattern_ is much similar to the object-oriented way of defining services. We use scala traits to define services, classes to implement services, and constructors to define service dependencies. Finally, we lift the class constructor into the `ZLayer`.
+Writing services in ZIO using the _Service Pattern_ is very similar to the object-oriented way of defining services. We use scala traits to define services, classes to implement services, and constructors to define service dependencies. Finally, we lift the class constructor into the `ZLayer`.
 
 Let's start learning this service pattern by writing a `Logging` service:
 
@@ -516,7 +516,7 @@ trait Logging {
 2. **Service Implementation** — It is the same as what we did in an object-oriented fashion. We implement the service with the Scala class. By convention, we name the live version of its implementation as `LoggingLive`:
 
 ```scala mdoc:compile-only
-case class LoggingLiveee() extends Logging {
+case class LoggingLive() extends Logging {
   override def log(line: String): UIO[Unit] = 
     ZIO.succeed(print(line))
 }
@@ -575,7 +575,7 @@ object Logging {
 
 Accessor methods allow us to utilize all the features inside the service through the ZIO Environment. That means, if we call `Logging.log`, we don't need to pull out the `log` function from the ZIO Environment. The `ZIO.serviceWithZIO` constructor helps us to access the environment and reduce the redundant operations, every time.
 
-This is how ZIO services are created. Let's use the `Logging` service in our application. We should provide the live layer of `Logging` service to be able to run the application:
+This is how ZIO services are created. Let's use the `Logging` service in our application. We should provide the live layer of the `Logging` service to be able to run the application:
 
 ```scala mdoc:compile-only
 import zio._
@@ -601,9 +601,9 @@ That's it! Very simple! ZIO encourages us to follow some of the best practices i
 
 ### Defining Polymorphic Services in ZIO
 
-As we discussed [here](zenvironment.md) the `ZEnvironment`, which is the underlying data type used by `ZLayer`, is backed by a type-level mapping from types of services to implementations of those services. This functionality is backed by `izumi.reflect.Tag`, which captures a type as a value. 
+As we discussed [here](zenvironment.md), the `ZEnvironment`, which is the underlying data type used by `ZLayer`, is backed by a type-level mapping from types of services to implementations of those services. This functionality is backed by `izumi.reflect.Tag`, which captures a type as a value. 
 
-We just need to know what is the type of service when we put it in the `ZEnvironment` because `ZEnvironment` is essentially a map from _service types (interfaces)_ to _implementation of those interfaces_. To implement the map the `ZEnvironment` needs a type tag for the new service, and also needs a way to remove the old service from the type level map. So we should have service type information at the runtime. 
+We just need to know what is the type of service when we put it in the `ZEnvironment` because `ZEnvironment` is essentially a map from _service types (interfaces)_ to _implementation of those interfaces_. To implement the map, the `ZEnvironment` needs a type tag for the new service, and also needs a way to remove the old service from the type level map. So we should have service type information at the runtime. 
 
 We can think of `Tag[A]` as like a `TypeTag[A]` or `ClassTag[A]` from the Scala standard library but available on a cross-version and cross-platform basis. Basically, it carries information about a certain type into runtime that was available at compile time. Methods that construct `ZEnvironment` values generally require a tag for the value being included in the “bundle of services”. 
 
@@ -623,7 +623,7 @@ trait KeyValueStore[K, V, E, F[_, _]] {
 
 In the next step, we are going to write its accessors. We might end up with the following snippet code:
 
-```scala mdoc:fail
+```scala mdoc:fail:silent
 import zio._
 
 object KeyValueStore {
@@ -636,6 +636,31 @@ object KeyValueStore {
   def remove[K, V, E](key: K): ZIO[KeyValueStore[K, V, E, IO], E, Unit] =
     ZIO.serviceWithZIO(_.remove(key))
 }
+
+// error: could not find implicit value for izumi.reflect.Tag[K]. Did you forget to put on a Tag, TagK or TagKK context bound on one of the parameters in K? e.g. def x[T: Tag, F[_]: TagK] = ...
+// 
+// 
+// <trace>: 
+//   deriving Tag for K, dealiased: K:
+//   could not find implicit value for Tag[K]: K is a type parameter without an implicit Tag!
+//     ZIO.serviceWithZIO[KeyValueStore[K, V, E, IO]](_.get(key))
+//                                                   ^
+// error: could not find implicit value for izumi.reflect.Tag[K]. Did you forget to put on a Tag, TagK or TagKK context bound on one of the parameters in K? e.g. def x[T: Tag, F[_]: TagK] = ...
+// 
+// 
+// <trace>: 
+//   deriving Tag for K, dealiased: K:
+//   could not find implicit value for Tag[K]: K is a type parameter without an implicit Tag!
+//     ZIO.serviceWithZIO[KeyValueStore[K, V, E, IO]](_.set(key, value))
+//                                                   ^
+// error: could not find implicit value for izumi.reflect.Tag[K]. Did you forget to put on a Tag, TagK or TagKK context bound on one of the parameters in K? e.g. def x[T: Tag, F[_]: TagK] = ...
+// 
+// 
+// <trace>: 
+//   deriving Tag for K, dealiased: K:
+//   could not find implicit value for Tag[K]: K is a type parameter without an implicit Tag!
+//     ZIO.serviceWithZIO(_.remove(key))
+//                       ^
 ```
 
 The compiler generates the following errors:
@@ -731,9 +756,6 @@ object KeyValueStore {
 }
 ```
 
-```scala mdoc:compile-only
-
-```
 
 ### Generating Accessor Methods Using Macros
 
@@ -765,7 +787,7 @@ Also, to enable macro expansion we need to setup our project:
 
 #### Monomorphic Services
 
-We can `@accessible` macro to generate _capability accessors_:
+We can use the `@accessible` macro to generate _service member accessors_:
 
 ```scala
 import zio._
@@ -1062,7 +1084,7 @@ case class LoggingLive(console: Console, clock: Clock) extends Logging {
 
 So keep in mind, we can't do something like this:
 
-```scala mdoc:fail
+```scala mdoc:fail:silent
 case class LoggingLive() extends Logging {
   override def log(line: String) =
     for {
@@ -1072,6 +1094,13 @@ case class LoggingLive() extends Logging {
       _       <- console.printLine(s"$current--$line").orDie
     } yield ()
 }
+
+// error: type mismatch;
+//  found   : zio.ZIO[zio.Console & zio.Clock,Nothing,Unit]
+//     (which expands to)  zio.ZIO[zio.Console with zio.Clock,Nothing,Unit]
+//  required: zio.ZIO[Logging,Nothing,Unit]
+//   def log(line: String): URIO[Logging, Unit] = ZIO.serviceWithZIO[Logging](_.log(line))
+//                                                                            ^^^^^^^^^^^
 ```
 
 3. **Business Logic** — Finally, in the business logic we should use the ZIO environment to consume services.

--- a/docs/datatypes/contextual/services/clock.md
+++ b/docs/datatypes/contextual/services/clock.md
@@ -14,15 +14,15 @@ import java.time.DateTimeException
 ```
 
 ```scala mdoc:silent
-val inMiliseconds: URIO[Clock, Long] = Clock.currentTime(TimeUnit.MILLISECONDS)
+val inMilliseconds: URIO[Clock, Long] = Clock.currentTime(TimeUnit.MILLISECONDS)
 val inDays:        URIO[Clock, Long] = Clock.currentTime(TimeUnit.DAYS)
 ```
 
-To get current data time in the current timezone the `currentDateTime` function returns a ZIO effect containing `OffsetDateTime`.
+To get current date time in the current timezone the `currentDateTime` function returns a ZIO effect containing `OffsetDateTime`.
 
-Also, the Clock service has a very useful functionality for sleeping and creating a delay between jobs. The `sleep` takes a `Duration` and sleep for the specified duration. It is analogous to `java.lang.Thread.sleep` function, but it doesn't block any underlying thread. It's completely non-blocking.
+Also, the Clock service has a very useful functionality for sleeping and creating a delay between jobs. The `sleep` takes a `Duration` and sleeps for the specified duration. It is analogous to `java.lang.Thread.sleep` function, but it doesn't block any underlying thread. It's completely non-blocking.
 
-In following example we are going to print the current time periodically by placing a one second`sleep` between each print call:
+In the following example we are going to print the current time periodically by placing a one second `sleep` between each print call:
 
 ```scala mdoc:silent
 def printTimeForever: ZIO[Console & Clock, Throwable, Nothing] =

--- a/docs/datatypes/contextual/services/console.md
+++ b/docs/datatypes/contextual/services/console.md
@@ -15,7 +15,7 @@ The Console service contains simple I/O operations for reading/writing strings f
 
 All functions of the Console service are effectful, this means they are just descriptions of reading/writing from/to the console. 
 
-As ZIO data type support monadic operations, we can compose these functions with for-comprehension which helps us to write our program pretty much like an imperative program:
+As ZIO data type supports monadic operations, we can compose these functions with for-comprehension which helps us to write our program pretty much like an imperative program:
 
 ```scala mdoc:compile-only
 import java.io.IOException

--- a/docs/datatypes/contextual/services/index.md
+++ b/docs/datatypes/contextual/services/index.md
@@ -3,7 +3,7 @@ id: index
 title: "Introduction"
 ---
 
-ZIO already provided four build-in services:
+ZIO already provides four build-in services:
 
 1. **[Console](console.md)** — Operations for reading/writing strings from/to the standard input, output, and error console.
 2. **[Clock](clock.md)** — Contains some functionality related to time and scheduling.

--- a/docs/datatypes/contextual/services/random.md
+++ b/docs/datatypes/contextual/services/random.md
@@ -18,7 +18,7 @@ for {
 } yield ()
 ```
 
-Random service has a `setSeed` which helps us to alter the state of the random generator. It is useful when writing the test version of Random service when we need a generation of the same sequence of numbers.
+Random service has a `setSeed` which helps us to alter the state of the random generator. It is useful for setting up a test version of Random service when we need to reproduce always the same sequence of numbers.
 
 ```scala mdoc:compile-only
 import zio._
@@ -29,11 +29,11 @@ for {
 } yield assert(nextInts == (-1155484576,-723955400))
 ```
 
-Also, it has a utility to shuffle a list or generating random samples from Gaussian distribution:
+Also, it has a utility to shuffle a list and to generate random samples from Gaussian distribution:
 
 * **shuffle** - Takes a list as an input and shuffles it.
 * **nextGaussian** — Returns the next pseudorandom, Gaussian ("normally") distributed double value with mean 0.0 and standard deviation 1.0.
 
-> _**Note**:_
+> **Note**:
 >
 > Random numbers that are generated via Random service are not cryptographically strong. Therefore it's not safe to use the ZIO Random service for security domains where a high level of security and randomness is required, such as password generation.

--- a/docs/datatypes/contextual/services/system.md
+++ b/docs/datatypes/contextual/services/system.md
@@ -3,12 +3,12 @@ id: system
 title: "System"
 ---
 
-System service contains several useful functions related to system environments and properties. Both of **system environments** and **system properties** are key/value pairs. They used to pass user-defined information to our application.
+System service contains several useful functions related to system environments and properties. Both of **system environments** and **system properties** are key/value pairs. They are used to pass user-defined information to our application.
 
-Environment variables are global operating system level variables available to all applications running on the same machine while the properties are application-level variables provided to our application.
+Environment variables are global operating system level variables available to all applications running on the same machine, while properties are application-level variables provided to our application.
 
 ## System Environment
-The `env` function retrieve the value of an environment variable:
+The `env` function retrieves the value of an environment variable:
 
 ```scala mdoc:compile-only
 import zio._
@@ -25,7 +25,7 @@ for {
 ```
 
 ## System Property
-Also, the System service has a `property function to retrieve the value of a system property:
+Also, the System service has a `property` function to retrieve the value of a system property:
 
 ```scala mdoc:compile-only
 import zio._

--- a/docs/datatypes/contextual/zenvironment.md
+++ b/docs/datatypes/contextual/zenvironment.md
@@ -32,7 +32,7 @@ ZEnvironment(
 )
 ```
 
-From a ZIO Environment point of view, we can think of `ZIO` as the following function:
+From a ZIO environment point of view, we can think of `ZIO` as the following function:
 
 ```scala
 type ZIO[R, E, A] = ZEnvironment[R] => Either[E, A]
@@ -63,7 +63,7 @@ val originalEffect: ZIO[Console & Random, IOException, Unit] =
 
 By providing `ZEnvironment[Console & Random]` we can eliminate the environment of the `originalEffect`:
 
-```
+```scala
 val eliminatedEffect: IO[IOException, Unit] =
   originalEffect.provideEnvironment(
     ZEnvironment(
@@ -106,8 +106,7 @@ To create the default ZIO environment:
 ```scala mdoc:compile-only
 import zio._
 
-val default: ZEnvironment[ZEnv] = 
-  ZEnvironment.default 
+val default: ZEnvironment[ZEnv] = ZEnvironment.default 
 ```
 
 To create an empty ZIO environment:
@@ -171,7 +170,7 @@ trait Database
 
 ```scala mdoc:silent:nest
 val database: URIO[Map[String, Database], Option[Database]] =
-  ZIO.serviceAt[Database]("persistent")
+  ZIO.serviceAt[Database]("inmemory")
 ```
 
 A service can be updated at the specified key using the `ZIO#updateServiceAt` operator.

--- a/docs/datatypes/core/cause.md
+++ b/docs/datatypes/core/cause.md
@@ -12,17 +12,17 @@ title: "Cause"
 
 1. `Fail[+E](value: E)` contains the cause of expected failure of type `E`.
 
-2. `Die(value: Throwable)` contains the cause of a defect or in other words, an unexpected failure of type `Throwable`. If we have a bug in our code and something throws an unexpected exception, that information would be described inside a Die.
+2. `Die(value: Throwable)` contains the cause of a defect or in other words, an unexpected failure of type `Throwable`. If we have a bug in our code and something throws an unexpected exception, that information would be described inside a `Die`.
 
 3. `Interrupt(fiberId)` contains information of the fiber id that causes fiber interruption.
 
-4. `Traced(cause, trace)` store stack traces and execution traces.
+4. `Traced(cause, trace)` stores stack traces and execution traces.
 
 5. `Meta(cause, data)`
 
-6. `Both(left, right)` & `Then(left, right)` store composition of two parallel and sequential causes. Sometimes fibers can fail for more than one reason. If we are doing two things at once and both of them fail then we actually have two errors. Examples:
-  + If we perform ZIO's analog of try-finally (e.g. ZIO#ensuring), and both of `try` and `finally` blocks fail, so their causes are encoded with `Then`.
-  + If we run two parallel fibers with `zipPar` and all of them fail, so their causes will be encoded with `Both`.
+6. `Both(left, right)` & `Then(left, right)` store a composition of two parallel and sequential causes, respectively. Sometimes fibers can fail for more than one reason. If we are doing two things at once and both of them fail then we actually have two errors. Examples:
+    + If we perform ZIO's analog of try-finally (e.g. ZIO#ensuring), and both of `try` and `finally` blocks fail, then their causes are encoded with `Then`.
+    + If we run two parallel fibers with `zipPar` and both of them fail, then their causes are encoded with `Both`.
 
 Let's try to create some of these causes:
 
@@ -40,5 +40,5 @@ for {
 ```
 
 ## Lossless Error Model
-ZIO is very aggressive about preserving the full information related to a failure. ZIO capture all type of errors into the `Cause` data type. So its error model is lossless. It doesn't throw information related to the failure result. So we can figure out exactly what happened during the operation of our effects.
+ZIO is very strict about preserving the full information related to a failure. ZIO captures all types of errors into the `Cause` data type. So its error model is lossless. It doesn't throw away any information related to the failure result. So we can figure out exactly what happened during the operation of our effects.
 

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -14,9 +14,9 @@ To run an effect, we need a `Runtime`, which is capable of executing effects. Ru
 
 Whenever we write a ZIO program, we create a ZIO effect from ZIO constructors plus using its combinators. We are building a blueprint. ZIO effect is just a data structure that describes the execution of a concurrent program. So we end up with a tree data structure that contains lots of different data structures combined together to describe what the ZIO effect should do. This data structure doesn't do anything, it is just a description of a concurrent program.
 
-So the most thing we should keep in mind when we are working with a functional effect system like ZIO is that when we are writing code, printing a string onto the console, reading a file, querying a database, and so forth; We are just writing a workflow or blueprint of an application. We are just building a data structure.
+So the most important thing we should keep in mind when we are working with a functional effect system like ZIO is that when we are writing code, printing a string onto the console, reading a file, querying a database, and so forth; We are just writing a workflow or blueprint of an application. We are just building a data structure.
 
-So how ZIO run these workflows? This is where ZIO Runtime System comes into play. Whenever we run an `unsaferun` function, the Runtime System is responsible to step through all the instructions described by the ZIO effect and execute them.
+So how can ZIO run these workflows? This is where ZIO Runtime System comes into play. Whenever we run an `unsaferun` function, the Runtime System is responsible to step through all the instructions described by the ZIO effect and execute them.
 
 To simplify everything, we can think of a Runtime System like a black box that takes both the ZIO effect (`ZIO[R, E, A]`) and its environment (`R`), it will run this effect and then will return its result as an `Either[E, A]` value.
 
@@ -233,7 +233,7 @@ val runtime = Runtime.default.mapRuntimeConfig(
 
 ### Benchmarking
 
-To do benchmark operation, we need a `Runtime` with settings suitable for that. It would be better to disable tracing and auto-yielding. ZIO has a built-in `RuntimeConfig` proper for benchmark operations, called `RuntimeConfig.benchmark` which we can map the default `RuntimeConfig` to the benchmark version:
+To do benchmark operations, we need a `Runtime` with settings suitable for that, in particular with tracing and auto-yielding disabled. ZIO has a built-in `RuntimeConfig` proper for benchmark operations, called `RuntimeConfig.benchmark`, so we can map the default `RuntimeConfig` to the benchmark version:
 
 ```scala mdoc:silent:nest
 val benchmarkRuntime = Runtime.default.mapRuntimeConfig(_ => RuntimeConfig.benchmark)
@@ -255,7 +255,7 @@ It has the following constructors:
 | `RuntimeConfigAspect.setExecutor`         | `executor: Executor`          | `RuntimeConfigAspect` |
 
 
-The `ZIOAppDefault` (and also the `ZIOApp`) has a `hook` member of a type `RuntimeConfigAspect`. The following code illustrates how to hook into the ZIO runtime system by creating and composing multiple aspects:
+The `ZIOAppDefault` (and also the `ZIOApp`) has a `hook` member of type `RuntimeConfigAspect`. The following code illustrates how to hook into the ZIO runtime system by creating and composing multiple aspects:
 
 ```scala mdoc:invisible
 val myAppLogic = ZIO.succeed(???)

--- a/docs/datatypes/core/zio/io.md
+++ b/docs/datatypes/core/zio/io.md
@@ -19,7 +19,7 @@ import zio.ZIO
 type IO[+E, +A] = ZIO[Any, E, A]
 ```
 
-So the `IO` just equal to `ZIO` which doesn't need any requirement.
+So `IO` is equal to a `ZIO` that doesn't need any requirement.
 
 `ZIO` values of type `IO[E, Nothing]` (where the value type is `Nothing`) are considered _unproductive_, because the `Nothing` type is _uninhabitable_, i.e. there can be no actual values of type `Nothing`. Values of this type may fail with an `E`, but will never produce a value.
 
@@ -29,4 +29,4 @@ So the `IO` just equal to `ZIO` which doesn't need any requirement.
 >
 > Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
 >
-> So there is no need to convert type aliases to the `ZIO` data type, whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
+> So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.

--- a/docs/datatypes/core/zio/rio.md
+++ b/docs/datatypes/core/zio/rio.md
@@ -18,7 +18,7 @@ import zio.ZIO
 type RIO[-R, +A]  = ZIO[R, Throwable, A]
 ```
 
-So the `RIO` just equal to `ZIO` which its error channel is `Throwable`.
+So `RIO` is equal to a `ZIO` that requires `R`, and whose error channel is `Throwable`. It succeeds with `A`.
 
 
 > **Note:** _Principle of The Least Power_
@@ -27,4 +27,4 @@ So the `RIO` just equal to `ZIO` which its error channel is `Throwable`.
 >
 > Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
 >
-> So there is no need to convert type aliases to the `ZIO` data type, whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
+> So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.

--- a/docs/datatypes/core/zio/task.md
+++ b/docs/datatypes/core/zio/task.md
@@ -5,6 +5,10 @@ title: "Task"
 
 `Task[A]` is a type alias for `ZIO[Any, Throwable, A]`, which represents an effect that has no requirements, and may fail with a `Throwable` value, or succeed with an `A`.
 
+> **Note:**
+>
+> In Scala, the _type alias_ is a way to give a name to another type, to avoid having to repeat the original type again and again. It doesn't affect the type-checking process. It just helps us to have an expressive API design.
+
 Let's see how the `Task` type alias is defined:
 
 ```scala mdoc:invisible
@@ -15,13 +19,9 @@ import zio.ZIO
 type Task[+A] = ZIO[Any, Throwable, A]
 ```
 
-So the `Task` just equal to `ZIO` which doesn't require any dependency. Its error channel is `Throwable`, so it may fail with `Throwable` and may succeed with an `A` value.
+So a `Task` is equal to a `ZIO` that doesn't need any requirement, and may fail with a `Throwable`, or succeed with an `A` value.
 
-> **Note:**
->
-> In Scala, the _type alias_ is a way to give a name to another type, to avoid having to repeat the original type again and again. It doesn't affect the type-checking process. It just helps us to have an expressive API design.
-
-Some time, we know that our effect may fail, but we don't care the type of that exception, this is where we can use `Task`. The type signature of this type-alias is similar to the `Future[T]` and Cats `IO`.
+Sometimes, we know that our effect may fail, but we don't care about the type of that exception. This is where we can use `Task`. The type signature of this type-alias is similar to the `Future[T]` and Cats `IO`.
 
 If we want to be less precise and want to eliminate the need to think about requirements and error types, we can use `Task`. This type-alias is a good start point for anyone who wants to refactor the current code base which is written in Cats `IO` or Monix `Task`. 
 
@@ -31,4 +31,4 @@ If we want to be less precise and want to eliminate the need to think about requ
 >
 > Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
 >
-> So there is no need to convert type aliases to the `ZIO` data type, whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
+> So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.

--- a/docs/datatypes/core/zio/uio.md
+++ b/docs/datatypes/core/zio/uio.md
@@ -19,14 +19,11 @@ import zio.ZIO
 type UIO[+A] = ZIO[Any, Nothing, A]
 ```
 
-So the `UIO` just equal to `ZIO` which doesn't need any requirement and cannot fail because in the Scala the `Nothing` type has no inhabitant, we can't create an instance of type `Nothing`.
+So `UIO` is equal to a `ZIO` that doesn't need any requirement (because it accepts `Any` environment) and that cannot fail (because in Scala the `Nothing` type is _uninhabitable_, i.e. there can be no actual value of type `Nothing`). It succeeds with `A`.
 
-`ZIO` values of type `UIO[A]` (where the error type is `Nothing`) are considered _infallible_,
-because the `Nothing` type is _uninhabitable_, i.e. there can be no actual values of type `Nothing`. Values of this type may produce an `A`, but will never fail with an `E`.
+`ZIO` values of type `UIO[A]` are considered _infallible_. Values of this type may produce an `A`, but will never fail.
 
-Let's write a fibonacci function. As we don't expect any failure, it is an unexceptional effect:
-
-In the following example, the `fib`, doesn't have any requirement, as it is an unexceptional effect, we don't except any failure, and it succeeds with value of type `Int`:
+Let's write a Fibonacci function. In the following example, the `fib` function is an unexceptional effect, since it has no requirements, we don't expect any failure, and it succeeds with a value of type `Int`:
 
 ```scala mdoc:reset:silent
 import zio.UIO
@@ -50,4 +47,4 @@ def fib(n: Int): UIO[Int] =
 >
 > Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
 >
-> So there is no need to convert type aliases to the `ZIO` data type, whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
+> So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.

--- a/docs/datatypes/core/zio/urio.md
+++ b/docs/datatypes/core/zio/urio.md
@@ -19,9 +19,9 @@ import zio.ZIO
 type URIO[-R, +A] = ZIO[R, Nothing, A]
 ```
 
-So the `URIO` just equal to `ZIO` which requires `R` and cannot fail because in the Scala the `Nothing` type has no inhabitant, we can't create an instance of type `Nothing`. It succeeds with `A`.
+So `URIO` is equal to a `ZIO` that requires `R` and cannot fail (because in Scala the `Nothing` type has no inhabitant, so we can't create an instance of type `Nothing`). It succeeds with `A`.
 
-In following example, the type of `printLine` is `URIO[Console, Unit]` which means, it requires `Console` service as an environment, and it succeeds with `Unit` value:
+In the following example, the type of `printLine` is `URIO[Console, Unit]`, which means that it requires `Console` service as an environment, and it succeeds with `Unit` value:
 
 ```scala mdoc:invisible:reset
 import zio._
@@ -41,4 +41,4 @@ def printLine(line: => String): ZIO[Console, IOException, Unit] =
 >
 > Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
 >
-> So there is no need to convert type aliases to the `ZIO` data type, whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
+> So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.

--- a/docs/datatypes/core/zio/zio.md
+++ b/docs/datatypes/core/zio/zio.md
@@ -111,7 +111,7 @@ The error type of the resulting effect is `Option[Nothing]`, which provides no i
 val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
 ```
 
-We can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
+We can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`):
 
 ```scala mdoc:invisible
 trait Team
@@ -225,7 +225,7 @@ for {
 A `Fiber` can be converted into a ZIO effect using `ZIO.fromFiber`:
 
 ```scala mdoc:silent
-val io: IO[Nothing, String] = ZIO.fromFiber(Fiber.succeed("Hello From Fiber!"))
+val io: IO[Nothing, String] = ZIO.fromFiber(Fiber.succeed("Hello from Fiber!"))
 ```
 
 ### From Side-Effects
@@ -441,7 +441,7 @@ for {
 } yield ()
 ```
 
-When we interrupt this loop after one second, it will not interrupted. It will only stop when the entire JVM stops. So the `attemptBlocking` doesn't translate the ZIO interruption into thread interruption (`Thread.interrupt`).
+When we interrupt this loop after one second, it will still not stop. It will only stop when the entire JVM stops. So the `attemptBlocking` doesn't translate the ZIO interruption into thread interruption (`Thread.interrupt`).
 
 Instead, we should use `attemptBlockingInterrupt` to create interruptible blocking effects:
 
@@ -499,7 +499,7 @@ final case class BlockingService() {
 }
 ```
 
-So, to translate ZIO interruption into cancellation of these types of blocking operations we should use `attemptBlockingCancelable`. This method takes a `cancel` effect which responsible to signal the blocking code to close itself when ZIO interruption occurs:
+So, to translate ZIO interruption into cancellation of these types of blocking operations we should use `attemptBlockingCancelable`. This method takes a `cancel` effect which is responsible to signal the blocking code to close itself when ZIO interruption occurs:
 
 ```scala mdoc:silent:nest
 val myApp =
@@ -518,7 +518,7 @@ val myApp =
   } yield ()
 ```
 
-Here is another example of the cancelation of a blocking operation. When we `accept` a server socket, this blocking operation will never interrupted until we close that using `ServerSocket#close` method:
+Here is another example of the cancelation of a blocking operation. When we `accept` a server socket, this blocking operation will never be interrupted until we close that using `ServerSocket#close` method:
 
 ```scala mdoc:silent:nest
 import java.net.{Socket, ServerSocket}
@@ -552,7 +552,7 @@ val mappedError: IO[Exception, String] =
 ### mapAttempt
 `mapAttempt` returns an effect whose success is mapped by the specified side-effecting `f` function, translating any thrown exceptions into typed failed effects.
 
-Converting literal "Five" String to Int by calling `toInt` is a side effecting because it will throws `NumberFormatException` exception:
+Converting literal "Five" String to Int by calling `toInt` is side-effecting because it throws a `NumberFormatException` exception:
 
 ```scala mdoc:silent
 val task: RIO[Any, Int] = ZIO.succeed("hello").mapAttempt(_.toInt)
@@ -627,12 +627,12 @@ The following table summarizes some of the sequential operations and their corre
 
 | **Description**              | **Sequential**    | **Parallel**         |
 | ---------------------------: | :---------------: | :------------------: |
-| Zips two effects into one    | `ZIO#zip`         | `ZIO#zipPar`         |
-| Zips two effects into one    | `ZIO#zipWith`     | `ZIO#zipWithPar`     |
-| Collects from many effects   | `ZIO.collectAll`  | `ZIO.collectAllPar`  |
+| Zip two effects into one    | `ZIO#zip`         | `ZIO#zipPar`         |
+| Zip two effects into one    | `ZIO#zipWith`     | `ZIO#zipWithPar`     |
+| Collect from many effects   | `ZIO.collectAll`  | `ZIO.collectAllPar`  |
 | Effectfully loop over values | `ZIO.foreach`     | `ZIO.foreachPar`     |
-| Reduces many values          | `ZIO.reduceAll`   | `ZIO.reduceAllPar`   |
-| Merges many values           | `ZIO.mergeAll`    | `ZIO.mergeAllPar`    |
+| Reduce many values          | `ZIO.reduceAll`   | `ZIO.reduceAllPar`   |
+| Merge many values           | `ZIO.mergeAll`    | `ZIO.mergeAllPar`    |
 
 For all the parallel operations, if one effect fails, then others will be interrupted, to minimize unnecessary computation.
 
@@ -669,7 +669,7 @@ If an effect times out, then instead of continuing to execute in the background,
 | `ZIO#either`  | `ZIO[R, E, A]`            | `URIO[R, Either[E, A]]` |
 | `ZIO.absolve` | `ZIO[R, E, Either[E, A]]` | `ZIO[R, E, A]`          |
 
-We can surface failures with `ZIO#either`, which takes an `ZIO[R, E, A]` and produces a `ZIO[R, Nothing, Either[E, A]]`.
+We can surface failures with `ZIO#either`, which takes a `ZIO[R, E, A]` and produces a `ZIO[R, Nothing, Either[E, A]]`.
 
 ```scala mdoc:silent:nest
 val zeither: UIO[Either[String, Int]] = 
@@ -758,7 +758,7 @@ val primaryOrBackupData: IO[IOException, Array[Byte]] =
 | `foldCauseZIO` | `failure: Cause[E] => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]`              | `ZIO[R1, E2, B]` |
 | `foldTraceZIO` | `failure: ((E, Option[ZTrace])) => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]` | `ZIO[R1, E2, B]` |
 
-Scala's `Option` and `Either` data types have `fold`, which let us handle both failure and success at the same time. In a similar fashion, `ZIO` effects also have several methods that allow us to handle both failure and success.
+Scala's `Option` and `Either` data types have `fold`, which lets us handle both failure and success at the same time. In a similar fashion, `ZIO` effects also have several methods that allow us to handle both failure and success.
 
 The first fold method, `fold`, lets us non-effectfully handle both failure and success by supplying a non-effectful handler for each case:
 
@@ -842,10 +842,10 @@ ZIO's resource management features work across synchronous, asynchronous, concur
 
 ### Finalizing
 
-Scala has a `try` / `finally` construct which helps us to make sure we don't leak resources because no matter what happens in the try, the `finally` block will be executed. So we can open files in the try block, and then we can close them in the `finally` block, and that gives us the guarantee that we will not leak resources.
+Scala has a `try` / `finally` construct which helps us to make sure we don't leak resources because no matter what happens in the `try`, the `finally` block will be executed. So we can open files in the `try` block, and then we can close them in the `finally` block, and that gives us the guarantee that we will not leak resources.
 
 #### Asynchronous Try / Finally
-The problem with the `try` / `finally` construct is that it only applies to synchronous code, meaning it doesn't work for asynchronous code. ZIO gives us a method called `ensuring` that works with either synchronous or asynchronous actions. So we have a functional try/finally but across the async region of our code, also our finalizer could have async regions.
+The problem with the `try` / `finally` construct is that it only applies to synchronous code, meaning it doesn't work for asynchronous code. ZIO gives us a method called `ensuring` that works with either synchronous or asynchronous actions. So we have a functional `try` / `finally` even for asynchronous regions of our code.
 
 Like `try` / `finally`, the `ensuring` operation guarantees that if an effect begins executing and then terminates (for whatever reason), then the finalizer will begin executing:
 
@@ -863,7 +863,7 @@ Like `try` / `finally`, finalizers can be nested, and the failure of any inner f
 
 Unlike `try` / `finally`, `ensuring` works across all types of effects, including asynchronous and concurrent effects.
 
-Here is another example of ensuring that our clean-up action called before our effect is done:
+Here is another example of ensuring that our clean-up action is called before our effect is done:
 
 ```scala mdoc:silent
 import zio.Task
@@ -875,7 +875,8 @@ val cleanupAction: UIO[Unit] = UIO.succeed(i -= 1)
 val composite = action.ensuring(cleanupAction)
 ```
 
-> _**Note:**
+> _**Note:**_
+> 
 > Finalizers offer very powerful guarantees, but they are low-level, and should generally not be used for releasing resources. For higher-level logic built on `ensuring`, see `ZIO#acquireReleaseWith` in the acquire release section.
 
 #### Unstoppable Finalizers
@@ -892,7 +893,7 @@ try {
 } finally f3
 ```
 
-Also in ZIO like `try` / `finally`, the finalizers are unstoppable. This means if we have a buggy finalizer, and it is going to leak some resources that unfortunately happens, we will leak the minimum amount of resources because all other finalizers will be run in the correct order.
+Also in ZIO like `try` / `finally`, the finalizers are unstoppable. This means if we have a buggy finalizer that is going to leak some resources, we will leak the minimum amount of resources because all other finalizers will still be run in the correct order.
 
 ```scala
 val io = ???
@@ -917,7 +918,7 @@ ZIO encapsulates this common pattern with `ZIO#acquireRelease`, which allows us 
  
 The release action is guaranteed to be executed by the runtime system, even if the utilize action throws an exception or the executing fiber is interrupted.
 
-Acquire release is a built-in primitive that let us safely acquire and release resources. It is used for a similar purpose as `try/catch/finally`, only acquire release work with synchronous and asynchronous actions, work seamlessly with fiber interruption, and is built on a different error model that ensures no errors are ever swallowed.
+Acquire release is a built-in primitive that let us safely acquire and release resources. It is used for a similar purpose as `try` / `catch` / `finally`, only acquire release work with synchronous and asynchronous actions, work seamlessly with fiber interruption, and is built on a different error model that ensures no errors are ever swallowed.
 
 Acquire release consist of an *acquire* action, a *utilize* action (which uses the acquired resource), and a *release* action.
 
@@ -960,16 +961,8 @@ object Main extends ZIOAppDefault {
   def closeStream(is: FileInputStream) =
     ZIO.succeed(is.close())
 
-  // helper method to work around in Java 8
-  def readAll(fis: FileInputStream, len: Long): Array[Byte] = {
-    val content: Array[Byte] = Array.ofDim(len.toInt)
-    fis.read(content)
-    content
-  }
-
   def convertBytes(is: FileInputStream, len: Long) =
-    Task.attempt(println(new String(readAll(is, len), StandardCharsets.UTF_8))) // Java 8
-  //Task.attempt(println(new String(is.readAllBytes(), StandardCharsets.UTF_8))) // Java 11+
+    Task.attempt(println(new String(is.readAllBytes(), StandardCharsets.UTF_8)))
 
   // myAcquireRelease is just a value. Won't execute anything here until interpreted
   val myAcquireRelease: Task[Unit] = for {
@@ -1015,9 +1008,9 @@ IO.fail("e1")
 There are two types of concerns in an application, _core concerns_, and _cross-cutting concerns_. Cross-cutting concerns are shared among different parts of our application. We usually find them scattered and duplicated across our application, or they are tangled up with our primary concerns. This reduces the level of modularity of our programs.
 
 A cross-cutting concern is more about _how_ we do something than _what_ we are doing. For example, when we are downloading a bunch of files, creating a socket to download each one is the core concern because it is a question of _what_ rather than the _how_, but the following concerns are cross-cutting ones:
-- Downloading files _sequentially_ or in _parallel_
-_ _Retrying_ and _timing out_ the download process
-_ _Logging_ and _monitoring_ the download process
+ - Downloading files _sequentially_ or in _parallel_
+ - _Retrying_ and _timing out_ the download process
+ - _Logging_ and _monitoring_ the download process
 
 So they don't affect the return type of our workflows, but they add some new aspects or change their behavior.
 

--- a/docs/datatypes/core/zioapp.md
+++ b/docs/datatypes/core/zioapp.md
@@ -14,7 +14,6 @@ The `ZIOAppDefault` has a `run` function, which is the main entry point for runn
 
 ```scala mdoc:compile-only
 import zio._
-import zio.Console
 
 object MyApp extends ZIOAppDefault {
   def run = for {
@@ -27,10 +26,11 @@ object MyApp extends ZIOAppDefault {
 
 ## Accessing Command-line Arguments
 
-ZIO has a service that contains command-line arguments of an application called `ZIOAppArgs`. We can access command-line arguments using built-in `getArgs` method, which is a helper method:
+ZIO has a service that contains command-line arguments of an application called `ZIOAppArgs`. We can access command-line arguments using the built-in `getArgs` method:
 
 ```scala mdoc:compile-only
 import zio._
+
 object HelloApp extends ZIOAppDefault {
   def run = for {
     args <- getArgs
@@ -45,7 +45,7 @@ object HelloApp extends ZIOAppDefault {
 
 ## Customized Runtime
 
-In the ZIO app, by overriding the `runtime` we can map the current runtime to a newly customized one. Let's try customizing it by introducing our own executor:
+In the ZIO app, by overriding its `runtime` value, we can map the current runtime to a customized one. Let's customize it by introducing our own executor:
 
 ```scala mdoc:invisible
 import zio._
@@ -87,7 +87,7 @@ A detailed explanation of the `RuntimeConfigAspect` can be found on the [runtime
 
 ## Composing ZIO Applications
 
-To compose ZIO application, we can use `<>` operator:
+To compose ZIO applications, we can use `<>` operator:
 
 ```scala mdoc:invisible
 import zio._

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -156,7 +156,7 @@ def fib(n: Int): UIO[Int] =
 ## Error Model
 The `IO` error model is simple, consistent, permits both typed errors and termination, and does not violate any laws in the `Functor` hierarchy.
 
-An `IO[E, A]` value may only raise errors of type `E`. These errors are recoverable by using the `either` method.  The resulting effect cannot fail, because the failure case bas been exposed as part of the `Either` success case.  
+An `IO[E, A]` value may only raise errors of type `E`. These errors are recoverable by using the `either` method.  The resulting effect cannot fail, because the failure case has been exposed as part of the `Either` success case.  
 
 ```scala mdoc:silent
 val error: Task[String] = IO.fail(new RuntimeException("Some Error"))

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -316,7 +316,7 @@ If a CPU Work doesn't yield quickly, then that is going to monopolize a thread. 
 
 The best practice is to run those huge CPU Work on a dedicated thread pool, by lifting them with the `blocking` operator in the `ZIO.blocking` package.
 
-> _**Note**:_
+> **Note**:
 >
 > So as a rule of thumb, when we have a huge CPU Work that is not chunked with built-in ZIO operations and going to monopolize the underlying thread, we should run that on a dedicated thread pool that is designed to perform CPU-driven tasks.
 

--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -26,17 +26,17 @@ ZIO contains a few data types that can help you solve complex problems in asynch
  - **[ZIOApp](core/zioapp.md)** — `ZIOApp` and the `ZIOAppDefault` are entry points for ZIO applications.
  - **[Runtime](core/runtime.md)** — `Runtime[R]` is capable of executing tasks within an environment `R`.
  - **[Exit](core/exit.md)** — `Exit[E, A]` describes the result of executing an `IO` value.
- - **[Cause](core/cause.md)** - `Cause[E]` is a description of a full story of a fiber failure. 
+ - **[Cause](core/cause.md)** — `Cause[E]` is a description of a full story of a fiber failure. 
  - **[Runtime](core/runtime.md)** — A `Runtime[R]` is capable of executing tasks within an environment `R`.
 
 ## Contextual Data Types
 - **[ZEnvironment](contextual/zenvironment.md)** — `ZEnvironment[R]` is a built-in type-level map for the `ZIO` data type which is responsible for maintaining the environment of a `ZIO` effect.
-- **[ZLayer](contextual/zlayer.md)** — The `ZIO[-R, +E, +A]` data type describes an effect that requires an input type of `R`, as an environment, may fail with an error of type `E` or succeed and produces a value of type `A`.
+- **[ZLayer](contextual/zlayer.md)** — The `ZIO[-R, +E, +A]` data type describes an effect that requires an input type of `R`, as an environment, may fail with an error of type `E` or succeed, and produces a value of type `A`.
     + **[RLayer](contextual/rlayer.md)** — `RLayer[-RIn, +ROut]` is a type alias for `ZLayer[RIn, Throwable, ROut]`, which represents a layer that requires `RIn` as its input, it may fail with `Throwable` value, or returns `ROut` as its output.
-    + **[ULayer](contextual/ulayer.md)** — ULayer[+ROut] is a type alias for ZLayer[Any, Nothing, ROut], which represents a layer that doesn't require any services as its input, it can't fail, and returns ROut as its output.
-    + **[Layer](contextual/layer.md)** — Layer[+E, +ROut] is a type alias for ZLayer[Any, E, ROut], which represents a layer that doesn't require any services, it may fail with an error type of E, and returns ROut as its output.
-    + **[URLayer](contextual/urlayer.md)** — URLayer[-RIn, +ROut] is a type alias for ZLayer[RIn, Nothing, ROut], which represents a layer that requires RIn as its input, it can't fail, and returns ROut as its output.
-    + **[TaskLayer](contextual/task-layer.md)** — TaskLayer[+ROut] is a type alias for ZLayer[Any, Throwable, ROut], which represents a layer that doesn't require any services as its input, it may fail with Throwable value, and returns ROut as its output.
+    + **[ULayer](contextual/ulayer.md)** — `ULayer[+ROut]` is a type alias for `ZLayer[Any, Nothing, ROut]`, which represents a layer that doesn't require any services as its input, it can't fail, and returns `ROut` as its output.
+    + **[Layer](contextual/layer.md)** — `Layer[+E, +ROut]` is a type alias for `ZLayer[Any, E, ROut]`, which represents a layer that doesn't require any services, it may fail with an error type of `E`, and returns `ROut` as its output.
+    + **[URLayer](contextual/urlayer.md)** — `URLayer[-RIn, +ROut]` is a type alias for `ZLayer[RIn, Nothing, ROut]`, which represents a layer that requires `RIn` as its input, it can't fail, and returns `ROut` as its output.
+    + **[TaskLayer](contextual/task-layer.md)** — `TaskLayer[+ROut]` is a type alias for `ZLayer[Any, Throwable, ROut]`, which represents a layer that doesn't require any services as its input, it may fail with `Throwable` value, and returns `ROut` as its output.
 
 ## Concurrency
 
@@ -47,7 +47,7 @@ ZIO contains a few data types that can help you solve complex problems in asynch
  - **[FiberId](fiber/fiberid.md)** — `FiberId` describe the unique identity of a Fiber.
  
 ### Concurrency Primitives
- - **[Hub](concurrency/hub.md)** - A `Hub` is an asynchronous message hub that allows publishers to efficiently broadcast values to many subscribers.
+ - **[Hub](concurrency/hub.md)** — A `Hub` is an asynchronous message hub that allows publishers to efficiently broadcast values to many subscribers.
  - **[Promise](concurrency/promise.md)** — A `Promise` is a model of a variable that may be set a single time, and awaited on by many fibers.
  - **[Semaphore](concurrency/semaphore.md)** — A `Semaphore` is an asynchronous (non-blocking) semaphore that plays well with ZIO's interruption.
 - **[ZRef](concurrency/zref.md)** — A `ZRef[EA, EB, A, B]` is a polymorphic, purely functional description of a mutable reference. The fundamental operations of a `ZRef` are `set` and `get`.
@@ -67,16 +67,16 @@ ZIO contains a few data types that can help you solve complex problems in asynch
 
 ### STM
 
-- **[STM](stm/stm.md)** - An `STM` represents an effect that can be performed transactionally resulting in a failure or success.
-- **[TArray](stm/tarray.md)** - A `TArray` is an array of mutable references that can participate in transactions.
-- **[TSet](stm/tset.md)** - A `TSet` is a mutable set that can participate in transactions.
-- **[TMap](stm/tmap.md)** - A `TMap` is a mutable map that can participate in transactions.
-- **[TRef](stm/tref.md)** - A `TRef` is a mutable reference to an immutable value that can participate in transactions.
-- **[TPriorityQueue](stm/tpriorityqueue.md)** - A `TPriorityQueue` is a mutable priority queue that can participate in transactions.
-- **[TPromise](stm/tpromise.md)** - A `TPromise` is a mutable reference that can be set exactly once and can participate in transactions.
-- **[TQueue](stm/tqueue.md)** - A `TQueue` is a mutable queue that can participate in transactions.
-- **[TReentrantLock](stm/treentrantlock.md)** - A `TReentrantLock` is a reentrant read / write lock that can be composed.
-- **[TSemaphore](stm/tsemaphore.md)** - A `TSemaphore` is a semaphore that can participate in transactions.
+- **[STM](stm/stm.md)** — An `STM` represents an effect that can be performed transactionally resulting in a failure or success.
+- **[TArray](stm/tarray.md)** — A `TArray` is an array of mutable references that can participate in transactions.
+- **[TSet](stm/tset.md)** — A `TSet` is a mutable set that can participate in transactions.
+- **[TMap](stm/tmap.md)** — A `TMap` is a mutable map that can participate in transactions.
+- **[TRef](stm/tref.md)** — A `TRef` is a mutable reference to an immutable value that can participate in transactions.
+- **[TPriorityQueue](stm/tpriorityqueue.md)** — A `TPriorityQueue` is a mutable priority queue that can participate in transactions.
+- **[TPromise](stm/tpromise.md)** — A `TPromise` is a mutable reference that can be set exactly once and can participate in transactions.
+- **[TQueue](stm/tqueue.md)** — A `TQueue` is a mutable queue that can participate in transactions.
+- **[TReentrantLock](stm/treentrantlock.md)** — A `TReentrantLock` is a reentrant read / write lock that can be composed.
+- **[TSemaphore](stm/tsemaphore.md)** — A `TSemaphore` is a semaphore that can participate in transactions.
 
 ## Resource Management
 - **[ZManaged](resource/zmanaged.md)** — A `ZManaged` is a value that describes a perishable resource that may be consumed only once inside a given scope.
@@ -90,9 +90,9 @@ ZIO contains a few data types that can help you solve complex problems in asynch
 ## Streaming
 - **[ZStream](stream/zstream.md)** — `ZStream` is a lazy, concurrent, asynchronous source of values.
    + **[Stream](stream/stream.md)** — `Stream[E, A]` is a type alias for `ZStream[Any, E, A]`, which represents a ZIO stream that does not require any services, and may fail with an `E`, or produce elements with an `A`. 
-- **[ZSink](stream/zsink.md)** — `ZSink` is a consumer of values from a `ZStream`, which may produces a value when it has consumed enough.
+- **[ZSink](stream/zsink.md)** — `ZSink` is a consumer of values from a `ZStream`, which may produce a value when it has consumed enough.
    + **[Sink](stream/sink.md)** — `Sink[InErr, A, OutErr, L, B]` is a type alias for `ZSink[Any, InErr, A, OutErr, L, B]`.
-- **[ZPipeline](stream/zpipeline.md)** - `ZPipeline` is a polymorphic stream transformer.
+- **[ZPipeline](stream/zpipeline.md)** — `ZPipeline` is a polymorphic stream transformer.
 - **[SubscriptionRef](stream/subscriptionref.md)** — `SubscriptionRef[A]` contains a current value of type `A` and a stream that can be consumed to observe all changes to that value.
  
 ## Miscellaneous

--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -31,7 +31,7 @@ ZIO contains a few data types that can help you solve complex problems in asynch
 
 ## Contextual Data Types
 - **[ZEnvironment](contextual/zenvironment.md)** — `ZEnvironment[R]` is a built-in type-level map for the `ZIO` data type which is responsible for maintaining the environment of a `ZIO` effect.
-- **[ZLayer](contextual/zlayer.md)** — The `ZIO[-R, +E, +A]` data type describes an effect that requires an input type of `R`, as an environment, may fail with an error of type `E` or succeed, and produces a value of type `A`.
+- **[ZLayer](contextual/zlayer.md)** — `ZLayer[-RIn, +E, +ROut]` is a recipe to build an environment of type `ROut`, starting from a value `RIn`, and possibly producing an error `E` during creation.
     + **[RLayer](contextual/rlayer.md)** — `RLayer[-RIn, +ROut]` is a type alias for `ZLayer[RIn, Throwable, ROut]`, which represents a layer that requires `RIn` as its input, it may fail with `Throwable` value, or returns `ROut` as its output.
     + **[ULayer](contextual/ulayer.md)** — `ULayer[+ROut]` is a type alias for `ZLayer[Any, Nothing, ROut]`, which represents a layer that doesn't require any services as its input, it can't fail, and returns `ROut` as its output.
     + **[Layer](contextual/layer.md)** — `Layer[+E, +ROut]` is a type alias for `ZLayer[Any, E, ROut]`, which represents a layer that doesn't require any services, it may fail with an error type of `E`, and returns `ROut` as its output.

--- a/docs/datatypes/stream/zsink.md
+++ b/docs/datatypes/stream/zsink.md
@@ -242,7 +242,7 @@ ZStream(1, 2, 2, 4, 2, 1, 1, 1, 0, 2, 1, 2)
 // Output: Chunk(1,2,2),Chunk(4),Chunk(2,1,1,1,0),Chunk(2,1,2)
 ```
 
-> _**Note**_
+> **Note**:
 >
 > The `ZSink.foldWeighted` cannot decompose elements whose weight is more than the `max` number. So elements that have an individual cost larger than `max` will force the pipeline to cross the `max` cost. In the last example, if the source stream was `ZStream(1, 2, 2, 4, 2, 1, 6, 1, 0, 2, 1, 2)` the output would be `Chunk(1,2,2),Chunk(4),Chunk(2,1),Chunk(6),Chunk(1,0,2,1),Chunk(2)`. As we see, the `6` element crossed the `max` cost.
 >


### PR DESCRIPTION
This PR fixes several minor issues in the documentation of ZIO v2.x. In order to avoid too big PRs and to get some early feedback on my very first ZIO contribution, I focused so far only on the Sections `Data Types / {Overview, Core Data Types, Contextual Types}`. After this PR is merged, I would continue with the next sections in a similar way.

* fixed several tiny typos, errors and formatting issues
* unified the usage of `**Note**` instead of variants such as `_**Note**_`
* removed a dedicated Java 8 fragment from a code example
* changed `mdoc:fail` codeblocks into `mdoc:fail:silent` to suppress the auto-generated output which contained a lot of unrelated messages, and added only the intended error output manually as comments instead
* propose alternative formulations for some sentences that sounded wrong or clumsy to me (please review these changes carefully, since I am not a native speaker)

I tried to exclude any refactorings that could trigger an opinionated discussion (e.g. whether we may also denote URIO an unexeptional effect), and collect such semantical discussions for future work.