### PR TITLE
Preparing for final changes to metric system

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOMetricSpec.scala
@@ -8,10 +8,10 @@ object ZIOMetricSpec extends ZIOBaseSpec {
 
   private val labels1 = Set(MetricLabel("x", "a"), MetricLabel("y", "b"))
 
-  def spec = suite("ZIOMetric")(
+  def spec = suite("Metric")(
     suite("Counter")(
       test("custom increment as aspect") {
-        val c = ZIOMetric.counter("c1").tagged(labels1).fromConst(1L)
+        val c = Metric.counter("c1").tagged(labels1).fromConst(1L)
 
         for {
           _     <- ZIO.unit @@ c
@@ -20,7 +20,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Counter(2.0))
       },
       test("direct increment") {
-        val c = ZIOMetric.counter("c2").tagged(labels1)
+        val c = Metric.counter("c2").tagged(labels1)
 
         for {
           _     <- c.increment
@@ -29,7 +29,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Counter(2.0))
       },
       test("custom increment by value as aspect") {
-        val c = ZIOMetric.counter("c3").tagged(labels1)
+        val c = Metric.counter("c3").tagged(labels1)
 
         for {
           _     <- ZIO.succeed(10L) @@ c
@@ -39,25 +39,25 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       },
       test("count") {
         for {
-          _     <- ZIO.unit @@ ZIOMetric.counter("c5").tagged(labels1).contramap[Unit](_ => 1)
-          _     <- ZIO.unit @@ ZIOMetric.counter("c5").tagged(labels1).contramap[Unit](_ => 1)
-          state <- ZIOMetric.counter("c5").tagged(labels1).value
+          _     <- ZIO.unit @@ Metric.counter("c5").tagged(labels1).contramap[Unit](_ => 1)
+          _     <- ZIO.unit @@ Metric.counter("c5").tagged(labels1).contramap[Unit](_ => 1)
+          state <- Metric.counter("c5").tagged(labels1).value
         } yield assertTrue(
           state == MetricState.Counter(2.0)
         )
       },
       test("countValue") {
         for {
-          _     <- ZIO.succeed(10L) @@ ZIOMetric.counter("c6").tagged(labels1)
-          _     <- ZIO.succeed(5L) @@ ZIOMetric.counter("c6").tagged(labels1)
-          state <- ZIOMetric.counter("c6").tagged(labels1).value
+          _     <- ZIO.succeed(10L) @@ Metric.counter("c6").tagged(labels1)
+          _     <- ZIO.succeed(5L) @@ Metric.counter("c6").tagged(labels1)
+          state <- Metric.counter("c6").tagged(labels1).value
         } yield assertTrue(
           state == MetricState.Counter(15.0),
           state.count == 15.0
         )
       },
       test("countValueWith") {
-        val c = ZIOMetric.counter("c7").tagged(labels1).contramap[String](_.length.toLong)
+        val c = Metric.counter("c7").tagged(labels1).contramap[String](_.length.toLong)
         for {
           _     <- ZIO.succeed("hello") @@ c
           _     <- ZIO.succeed("!") @@ c
@@ -68,7 +68,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("countErrors") {
-        val c = ZIOMetric.counter("c8").contramap[Unit](_ => 1)
+        val c = Metric.counter("c8").contramap[Unit](_ => 1)
 
         for {
           _     <- (ZIO.unit @@ c *> ZIO.fail("error") @@ c).ignore
@@ -79,7 +79,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("count + taggedWith") {
-        val base = ZIOMetric
+        val base = Metric
           .counter("c10")
           .tagged(MetricLabel("static", "0"))
           .contramap[String](_ => 1)
@@ -96,7 +96,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
     ),
     suite("Gauge")(
       test("custom set as aspect") {
-        val g = ZIOMetric.gauge("g1").tagged(labels1)
+        val g = Metric.gauge("g1").tagged(labels1)
 
         for {
           _     <- ZIO.succeed(1.0) @@ g
@@ -105,7 +105,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Gauge(3.0))
       },
       test("direct increment") {
-        val g = ZIOMetric.gauge("g2").tagged(labels1)
+        val g = Metric.gauge("g2").tagged(labels1)
 
         for {
           _     <- g.update(1.0)
@@ -114,7 +114,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Gauge(3.0))
       },
       test("custom adjust as aspect") {
-        val g = ZIOMetric.gauge("g3").tagged(labels1)
+        val g = Metric.gauge("g3").tagged(labels1)
 
         for {
           _     <- ZIO.succeed(10.0) @@ g
@@ -123,7 +123,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Gauge(5.0))
       },
       test("direct adjust") {
-        val g = ZIOMetric.gauge("g4").tagged(labels1)
+        val g = Metric.gauge("g4").tagged(labels1)
 
         for {
           _     <- g.update(10.0)
@@ -132,7 +132,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Gauge(5.0))
       },
       test("setGauge") {
-        val g5 = ZIOMetric.gauge("g5").tagged(labels1)
+        val g5 = Metric.gauge("g5").tagged(labels1)
 
         for {
           _     <- ZIO.succeed(1.0) @@ g5
@@ -141,7 +141,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state == MetricState.Gauge(3.0))
       },
       test("setGaugeWith") {
-        val g = ZIOMetric.gauge("g7").tagged(labels1).contramap[Int](_.toDouble)
+        val g = Metric.gauge("g7").tagged(labels1).contramap[Int](_.toDouble)
         for {
           _     <- ZIO.succeed(1) @@ g
           _     <- ZIO.succeed(3) @@ g
@@ -151,7 +151,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
     ),
     suite("Histogram")(
       test("custom observe as aspect") {
-        val h = ZIOMetric.histogram("h1", Histogram.Boundaries.linear(0, 1.0, 10)).tagged(labels1)
+        val h = Metric.histogram("h1", Histogram.Boundaries.linear(0, 1.0, 10)).tagged(labels1)
 
         for {
           _     <- ZIO.succeed(1.0) @@ h
@@ -160,7 +160,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.count == 2L, state.sum == 4.0)
       },
       test("direct observe") {
-        val h = ZIOMetric.histogram("h2", Histogram.Boundaries.linear(0, 1.0, 10)).tagged(labels1)
+        val h = Metric.histogram("h2", Histogram.Boundaries.linear(0, 1.0, 10)).tagged(labels1)
 
         for {
           _     <- h.update(1.0)
@@ -170,7 +170,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       },
       test("observeDurations") {
         val h =
-          ZIOMetric
+          Metric
             .histogram("h3", Histogram.Boundaries.linear(0, 1.0, 10))
             .tagged(labels1)
             .contramap[Duration](_.toMillis.toDouble / 1000.0)
@@ -190,7 +190,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("observeHistogram") {
-        val h = ZIOMetric
+        val h = Metric
           .histogram("h4", Histogram.Boundaries.linear(0, 1.0, 10))
           .tagged(labels1)
 
@@ -204,7 +204,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("observeHistogramWith") {
-        val h = ZIOMetric
+        val h = Metric
           .histogram("h5", Histogram.Boundaries.linear(0, 1.0, 10))
           .tagged(labels1)
           .contramap[String](_.length.toDouble)
@@ -218,7 +218,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
       test("observeHistogramWith + taggedWith") {
         val boundaries = Histogram.Boundaries.linear(0, 1.0, 10)
 
-        val base = ZIOMetric
+        val base = Metric
           .histogram("h6", boundaries)
           .tagged(labels1)
           .contramap[String](_.length.toDouble)
@@ -236,7 +236,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
     ),
     suite("Summary")(
       test("custom observe as aspect") {
-        val s = ZIOMetric
+        val s = Metric
           .summary("s1", 1.minute, 10, 0.0, Chunk(0.0, 1.0, 10.0))
           .tagged(labels1)
 
@@ -247,7 +247,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.count == 2L, state.sum == 4.0)
       },
       test("direct observe") {
-        val s = ZIOMetric
+        val s = Metric
           .summary("s2", 1.minute, 10, 0.0, Chunk(0.0, 1.0, 10.0))
           .tagged(labels1)
 
@@ -258,7 +258,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.count == 2L, state.sum == 4.0)
       },
       test("observeSummary") {
-        val s = ZIOMetric
+        val s = Metric
           .summary("s3", 1.minute, 10, 0.0, Chunk(0.0, 1.0, 10.0))
           .tagged(labels1)
 
@@ -269,7 +269,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.count == 2L, state.sum == 4.0)
       },
       test("observeSummaryWith") {
-        val s = ZIOMetric
+        val s = Metric
           .summary("s4", 1.minute, 10, 0.0, Chunk(0.0, 1.0, 10.0))
           .tagged(labels1)
           .contramap[String](_.length.toDouble)
@@ -281,7 +281,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.count == 2L, state.sum == 4.0)
       },
       test("observeSummaryWith + taggedWith") {
-        val s0 = ZIOMetric
+        val s0 = Metric
           .summary("s6", 1.minute, 10, 0.0, Chunk(0.0, 1.0, 10.0))
           .tagged(labels1)
           .contramap[String](_.length.toDouble)
@@ -299,7 +299,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
     ),
     suite("Frequency")(
       test("custom observe as aspect") {
-        val sc = ZIOMetric
+        val sc = Metric
           .frequency("sc1")
           .tagged(labels1)
 
@@ -313,7 +313,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("direct observe") {
-        val sc = ZIOMetric
+        val sc = Metric
           .frequency("sc2")
           .tagged(labels1)
 
@@ -327,7 +327,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("occurrences") {
-        val sc = ZIOMetric
+        val sc = Metric
           .frequency("sc3")
           .tagged(labels1)
 
@@ -341,7 +341,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         )
       },
       test("occurrencesWith") {
-        val sc = ZIOMetric
+        val sc = Metric
           .frequency("sc4")
           .tagged(labels1)
           .contramap[Int](_.toString)
@@ -354,7 +354,7 @@ object ZIOMetricSpec extends ZIOBaseSpec {
         } yield assertTrue(state.occurrences.toSet == Set("1" -> 2L, "100" -> 1L))
       },
       test("occurrences + taggedWith") {
-        val sc0 = ZIOMetric
+        val sc0 = Metric
           .frequency("sc6")
           .tagged(labels1)
 

--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -4,7 +4,7 @@ import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram
 import zio.test._
 
-object ZIOMetricSpec extends ZIOBaseSpec {
+object MetricSpec extends ZIOBaseSpec {
 
   private val labels1 = Set(MetricLabel("x", "a"), MetricLabel("y", "b"))
 

--- a/core/jvm/src/main/scala/zio/metrics/jvm/BufferPools.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/BufferPools.scala
@@ -15,16 +15,16 @@ trait BufferPools extends JvmMetrics {
   override val featureTag = Tag[BufferPools]
 
   /** Used bytes of a given JVM buffer pool. */
-  private def bufferPoolUsedBytes(pool: String): ZIOMetric.Gauge[Long] =
-    ZIOMetric.gauge("jvm_buffer_pool_used_bytes").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+  private def bufferPoolUsedBytes(pool: String): Metric.Gauge[Long] =
+    Metric.gauge("jvm_buffer_pool_used_bytes").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   /** Bytes capacity of a given JVM buffer pool. */
-  private def bufferPoolCapacityBytes(pool: String): ZIOMetric.Gauge[Long] =
-    ZIOMetric.gauge("jvm_buffer_pool_capacity_bytes").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+  private def bufferPoolCapacityBytes(pool: String): Metric.Gauge[Long] =
+    Metric.gauge("jvm_buffer_pool_capacity_bytes").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   /** Used buffers of a given JVM buffer pool. */
-  private def bufferPoolUsedBuffers(pool: String): ZIOMetric.Gauge[Long] =
-    ZIOMetric.gauge("jvm_buffer_pool_used_buffers").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+  private def bufferPoolUsedBuffers(pool: String): Metric.Gauge[Long] =
+    Metric.gauge("jvm_buffer_pool_used_buffers").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   private def reportBufferPoolMetrics(
     bufferPoolMXBeans: List[BufferPoolMXBean]

--- a/core/jvm/src/main/scala/zio/metrics/jvm/ClassLoading.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/ClassLoading.scala
@@ -1,7 +1,7 @@
 package zio.metrics.jvm
 
-import zio.metrics.ZIOMetric
-import zio.metrics.ZIOMetric.Gauge
+import zio.metrics.Metric
+import zio.metrics.Metric.Gauge
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -13,21 +13,21 @@ trait ClassLoading extends JvmMetrics {
 
   /** The number of classes that are currently loaded in the JVM */
   private val loadedClassCount: Gauge[Int] =
-    ZIOMetric.gauge("jvm_classes_loaded").contramap(_.toDouble)
+    Metric.gauge("jvm_classes_loaded").contramap(_.toDouble)
 
   /**
    * The total number of classes that have been loaded since the JVM has started
    * execution
    */
   private val totalLoadedClassCount: Gauge[Long] =
-    ZIOMetric.gauge("jvm_classes_loaded_total").contramap(_.toDouble)
+    Metric.gauge("jvm_classes_loaded_total").contramap(_.toDouble)
 
   /**
    * The total number of classes that have been unloaded since the JVM has
    * started execution
    */
   private val unloadedClassCount: Gauge[Long] =
-    ZIOMetric.gauge("jvm_classes_unloaded_total").contramap(_.toDouble)
+    Metric.gauge("jvm_classes_unloaded_total").contramap(_.toDouble)
 
   private def reportClassLoadingMetrics(
     classLoadingMXBean: ClassLoadingMXBean

--- a/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
@@ -1,6 +1,7 @@
 package zio.metrics.jvm
 
 import zio._
+
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**

--- a/core/jvm/src/main/scala/zio/metrics/jvm/GarbageCollector.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/GarbageCollector.scala
@@ -4,7 +4,7 @@ import com.github.ghik.silencer.silent
 
 import zio._
 import zio.metrics._
-import zio.metrics.ZIOMetric.Gauge
+import zio.metrics.Metric.Gauge
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.management.{GarbageCollectorMXBean, ManagementFactory}
@@ -17,13 +17,13 @@ trait GarbageCollector extends JvmMetrics {
 
   /** Time spent in a given JVM garbage collector in seconds. */
   private def gcCollectionSecondsSum(gc: String): Gauge[Long] =
-    ZIOMetric
+    Metric
       .gauge("jvm_gc_collection_seconds_sum")
       .tagged(MetricLabel("gc", gc))
       .contramap((ms: Long) => ms.toDouble / 1000.0)
 
   private def gcCollectionSecondsCount(gc: String): Gauge[Long] =
-    ZIOMetric.gauge("jvm_gc_collection_seconds_count").tagged(MetricLabel("gc", gc)).contramap(_.toDouble)
+    Metric.gauge("jvm_gc_collection_seconds_count").tagged(MetricLabel("gc", gc)).contramap(_.toDouble)
 
   private def reportGarbageCollectionMetrics(
     garbageCollectors: List[GarbageCollectorMXBean]

--- a/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
@@ -5,7 +5,7 @@ import com.github.ghik.silencer.silent
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.metrics._
-import zio.metrics.ZIOMetric.Counter
+import zio.metrics.Metric.Counter
 
 import com.sun.management.GarbageCollectionNotificationInfo
 import java.lang.management.ManagementFactory
@@ -24,7 +24,7 @@ trait MemoryAllocation extends JvmMetrics {
    * not continuously.
    */
   private def countAllocations(pool: String): Counter[Long] =
-    ZIOMetric.counter("jvm_memory_pool_allocated_bytes_total").tagged(MetricLabel("pool", pool))
+    Metric.counter("jvm_memory_pool_allocated_bytes_total").tagged(MetricLabel("pool", pool))
 
   private class Listener(runtime: Runtime[Any]) extends NotificationListener {
     private val lastMemoryUsage: mutable.Map[String, Long] = mutable.HashMap.empty

--- a/core/jvm/src/main/scala/zio/metrics/jvm/MemoryPools.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/MemoryPools.scala
@@ -4,7 +4,7 @@ import com.github.ghik.silencer.silent
 
 import zio._
 import zio.metrics._
-import zio.metrics.ZIOMetric.Gauge
+import zio.metrics.Metric.Gauge
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.management.{ManagementFactory, MemoryMXBean, MemoryPoolMXBean, MemoryUsage}
@@ -21,35 +21,35 @@ trait MemoryPools extends JvmMetrics {
 
   /** Used bytes of a given JVM memory area. */
   private def memoryBytesUsed(area: Area): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_bytes_used").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_bytes_used").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
 
   /** Committed (bytes) of a given JVM memory area. */
   private def memoryBytesCommitted(area: Area): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_bytes_committed").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_bytes_committed").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
 
   /** Max (bytes) of a given JVM memory area. */
   private def memoryBytesMax(area: Area): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_bytes_max").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_bytes_max").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
 
   /** Initial bytes of a given JVM memory area. */
   private def memoryBytesInit(area: Area): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_bytes_init").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_bytes_init").tagged(MetricLabel("area", area.label)).contramap(_.toDouble)
 
   /** Used bytes of a given JVM memory pool. */
   private def poolBytesUsed(pool: String): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_pool_bytes_used").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_pool_bytes_used").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   /** Committed bytes of a given JVM memory pool. */
   private def poolBytesCommitted(pool: String): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_pool_bytes_committed").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_pool_bytes_committed").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   /** Max bytes of a given JVM memory pool. */
   private def poolBytesMax(pool: String): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_pool_bytes_max").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_pool_bytes_max").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   /** Initial bytes of a given JVM memory pool. */
   private def poolBytesInit(pool: String): Gauge[Long] =
-    ZIOMetric.gauge("jvm_memory_pool_bytes_init").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
+    Metric.gauge("jvm_memory_pool_bytes_init").tagged(MetricLabel("pool", pool)).contramap(_.toDouble)
 
   private def reportMemoryUsage(usage: MemoryUsage, area: Area)(implicit
     trace: ZTraceElement

--- a/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
@@ -1,6 +1,6 @@
 package zio.metrics.jvm
 
-import zio.metrics.ZIOMetric
+import zio.metrics.Metric
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -10,34 +10,34 @@ import java.nio.charset.StandardCharsets
 import scala.util.{Failure, Success, Try}
 
 trait Standard extends JvmMetrics {
-  import ZIOMetric.Gauge
+  import Metric.Gauge
 
   override type Feature = Standard
   override val featureTag = Tag[Standard]
 
   /** Total user and system CPU time spent in seconds. */
   private val cpuSecondsTotal: Gauge[Long] =
-    ZIOMetric.gauge("process_cpu_seconds_total").contramap(_.toDouble / 1.0e09)
+    Metric.gauge("process_cpu_seconds_total").contramap(_.toDouble / 1.0e09)
 
   /** Start time of the process since unix epoch in seconds. */
   private val processStartTime: Gauge[Long] =
-    ZIOMetric.gauge("process_start_time_seconds").contramap(_.toDouble / 1000.0)
+    Metric.gauge("process_start_time_seconds").contramap(_.toDouble / 1000.0)
 
   /** Number of open file descriptors. */
   private val openFdCount: Gauge[Long] =
-    ZIOMetric.gauge("process_open_fds").contramap(_.toDouble)
+    Metric.gauge("process_open_fds").contramap(_.toDouble)
 
   /** Maximum number of open file descriptors. */
   private val maxFdCount: Gauge[Long] =
-    ZIOMetric.gauge("process_max_fds").contramap(_.toDouble)
+    Metric.gauge("process_max_fds").contramap(_.toDouble)
 
   /** Virtual memory size in bytes. */
   private val virtualMemorySize: Gauge[Double] =
-    ZIOMetric.gauge("process_virtual_memory_bytes")
+    Metric.gauge("process_virtual_memory_bytes")
 
   /** Resident memory size in bytes. */
   private val residentMemorySize: Gauge[Double] =
-    ZIOMetric.gauge("process_resident_memory_bytes")
+    Metric.gauge("process_resident_memory_bytes")
 
   class MXReflection(getterName: String, obj: PlatformManagedObject) {
     private val cls: Class[_ <: PlatformManagedObject] = obj.getClass

--- a/core/jvm/src/main/scala/zio/metrics/jvm/Thread.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/Thread.scala
@@ -7,26 +7,26 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import java.lang.management.{ManagementFactory, ThreadMXBean}
 
 trait Thread extends JvmMetrics {
-  import ZIOMetric.Gauge
+  import Metric.Gauge
 
   override type Feature = Thread
   override val featureTag: Tag[Thread] = Tag[Thread]
 
   /** Current thread count of a JVM */
   private val threadsCurrent: Gauge[Int] =
-    ZIOMetric.gauge("jvm_threads_current").contramap(_.toDouble)
+    Metric.gauge("jvm_threads_current").contramap(_.toDouble)
 
   /** Daemon thread count of a JVM */
   private val threadsDaemon: Gauge[Int] =
-    ZIOMetric.gauge("jvm_threads_daemon").contramap(_.toDouble)
+    Metric.gauge("jvm_threads_daemon").contramap(_.toDouble)
 
   /** Peak thread count of a JVM */
   private val threadsPeak: Gauge[Int] =
-    ZIOMetric.gauge("jvm_threads_peak").contramap(_.toDouble)
+    Metric.gauge("jvm_threads_peak").contramap(_.toDouble)
 
   /** Started thread count of a JVM */
   private val threadsStartedTotal: Gauge[Long] =
-    ZIOMetric
+    Metric
       .gauge("jvm_threads_started_total")
       .contramap(
         _.toDouble
@@ -37,18 +37,18 @@ trait Thread extends JvmMetrics {
    * monitors or ownable synchronizers
    */
   private val threadsDeadlocked: Gauge[Int] =
-    ZIOMetric.gauge("jvm_threads_deadlocked").contramap(_.toDouble)
+    Metric.gauge("jvm_threads_deadlocked").contramap(_.toDouble)
 
   /**
    * Cycles of JVM-threads that are in deadlock waiting to acquire object
    * monitors
    */
   private val threadsDeadlockedMonitor: Gauge[Int] =
-    ZIOMetric.gauge("jvm_threads_deadlocked_monitor").contramap(_.toDouble)
+    Metric.gauge("jvm_threads_deadlocked_monitor").contramap(_.toDouble)
 
   /** Current count of threads by state */
   private def threadsState(state: java.lang.Thread.State): Gauge[Long] =
-    ZIOMetric.gauge("jvm_threads_state").tagged(MetricLabel("state", state.name())).contramap(_.toDouble)
+    Metric.gauge("jvm_threads_state").tagged(MetricLabel("state", state.name())).contramap(_.toDouble)
 
   private def getThreadStateCounts(
     threadMXBean: ThreadMXBean

--- a/core/jvm/src/main/scala/zio/metrics/jvm/VersionInfo.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/VersionInfo.scala
@@ -9,8 +9,8 @@ trait VersionInfo extends JvmMetrics {
   override val featureTag: Tag[VersionInfo] = Tag[VersionInfo]
 
   /** JVM version info */
-  def jvmInfo(version: String, vendor: String, runtime: String): ZIOMetric.Gauge[Unit] =
-    ZIOMetric
+  def jvmInfo(version: String, vendor: String, runtime: String): Metric.Gauge[Unit] =
+    Metric
       .gauge(
         "jvm_info"
       )

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4594,7 +4594,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Logs the specified cause at the current log level.
    */
   def logCause(cause: => Cause[Any])(implicit trace: ZTraceElement): UIO[Unit] =
-    new Logged(() => "", cause, None, trace)
+    new Logged(() => "An error occurred", cause, None, trace)
 
   /**
    * Logs the specified message and cause at the current log level.

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.metrics.{ZIOMetric, MetricLabel}
+import zio.metrics.{Metric, MetricLabel}
 import scala.concurrent.ExecutionContext
 
 trait ZIOAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =>

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -1297,13 +1297,13 @@ private[zio] object FiberContext {
 
   import zio.metrics._
 
-  lazy val fiberFailureCauses = ZIOMetric.frequency("zio_fiber_failure_causes")
-  lazy val fiberForkLocations = ZIOMetric.frequency("zio_fiber_fork_locations")
+  lazy val fiberFailureCauses = Metric.frequency("zio_fiber_failure_causes")
+  lazy val fiberForkLocations = Metric.frequency("zio_fiber_fork_locations")
 
-  lazy val fibersStarted  = ZIOMetric.counter("zio_fiber_started")
-  lazy val fiberSuccesses = ZIOMetric.counter("zio_fiber_successes")
-  lazy val fiberFailures  = ZIOMetric.counter("zio_fiber_failures")
-  lazy val fiberLifetimes = ZIOMetric.histogram("zio_fiber_lifetimes", fiberLifetimeBoundaries)
+  lazy val fibersStarted  = Metric.counter("zio_fiber_started")
+  lazy val fiberSuccesses = Metric.counter("zio_fiber_successes")
+  lazy val fiberFailures  = Metric.counter("zio_fiber_failures")
+  lazy val fiberLifetimes = Metric.histogram("zio_fiber_lifetimes", fiberLifetimeBoundaries)
 
   lazy val fiberLifetimeBoundaries = MetricKeyType.Histogram.Boundaries.exponential(1.0, 2.0, 100)
 

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -24,7 +24,7 @@ import zio.metrics._
  * A `PollingMetric[Type, Out]` is a combination of a metric and an effect that
  * polls for updates to the metric.
  */
-sealed trait PollingMetric[-R, +E, +Out] { self =>
+trait PollingMetric[-R, +E, +Out] { self =>
   type Type
   type In
 
@@ -104,6 +104,9 @@ object PollingMetric {
   type Full[Type0, In0, -R, +E, +Out] =
     PollingMetric[R, E, Out] { type Type = Type0; type In = In0 }
 
+  /**
+   * Constructs a new polling metric from a metric and poll effect.
+   */
   def apply[Type0, In0, R, E, Out](
     metric0: Metric[Type0, In0, Out],
     poll0: ZIO[R, E, In0]
@@ -117,6 +120,10 @@ object PollingMetric {
       def poll(implicit trace: ZTraceElement): ZIO[R, E, In] = poll0
     }
 
+  /**
+   * Collects all of the polling metrics into a single polling metric, which
+   * polls for, updates, and produces the outputs of all individual metrics.
+   */
   def collectAll[R, E, Out](
     in0: Iterable[PollingMetric[R, E, Out]]
   ): PollingMetric[R, E, Chunk[Out]] =

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -56,6 +56,15 @@ trait PollingMetric[-R, +E, +Out] { self =>
     ZIO.acquireRelease((pollAndUpdate *> metric.value).repeat(schedule).forkDaemon)(_.interrupt)
 
   /**
+   * Returns an effect that will launch the polling metric in a background
+   * fiber, using the specified schedule and the specified clock.
+   */
+  final def launchUsing[R1 <: R, B](schedule: Schedule[R1, Out, B], clock: Clock)(implicit
+    trace: ZTraceElement
+  ): ZIO[R1 with Scope, Nothing, Fiber[E, B]] =
+    ZIO.acquireRelease(clock.repeat(pollAndUpdate *> metric.value)(schedule).forkDaemon)(_.interrupt)
+
+  /**
    * An effect that polls a value that may be fed to the metric.
    */
   def poll(implicit trace: ZTraceElement): ZIO[R, E, In]
@@ -80,6 +89,23 @@ trait PollingMetric[-R, +E, +Out] { self =>
       def metric = self.metric
 
       def poll(implicit trace: ZTraceElement) = self.poll.retry(policy)
+    }
+
+  /**
+   * Returns a new polling metric whose poll function will be retried with the
+   * specified retry policy using the specified clock.
+   */
+  final def retryUsing[R1 <: R, E1 >: E](
+    policy: Schedule[R1, E1, Any],
+    clock: Clock
+  ): PollingMetric.Full[Type, In, R1, E1, Out] =
+    new PollingMetric[R1, E1, Out] {
+      type Type = self.Type
+      type In   = self.In
+
+      def metric = self.metric
+
+      def poll(implicit trace: ZTraceElement) = clock.retry(self.poll)(policy)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.metrics
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import zio._
+import zio.metrics._
+
+/**
+ * A `PollingMetric[Type, Out]` is a combination of a metric and an effect that
+ * polls for updates to the metric.
+ */
+sealed trait PollingMetric[-R, +E, +Out] { self =>
+  type Type
+  type In
+
+  /**
+   * Create a new `PollingMetric` that will poll on the blocking thread pool.
+   */
+  final def blocking: PollingMetric.Full[Type, In, R, E, Out] =
+    new PollingMetric[R, E, Out] {
+      type Type = self.Type
+      type In   = self.In
+
+      def metric = self.metric
+
+      def poll(implicit trace: ZTraceElement) = ZIO.blocking(self.poll)
+    }
+
+  /**
+   * The metric that this `PollingMetric` polls to update.
+   */
+  def metric: Metric[Type, In, Out]
+
+  /**
+   * Returns an effect that will launch the polling metric in a background
+   * fiber, using the specified schedule.
+   */
+  final def launch[R1 <: R, B](schedule: Schedule[R1, Out, B])(implicit
+    trace: ZTraceElement
+  ): ZIO[R1 with Clock, Nothing, Fiber[E, B]] =
+    (pollAndUpdate *> metric.value).repeat(schedule).fork
+
+  /**
+   * An effect that polls a value that may be fed to the metric.
+   */
+  def poll(implicit trace: ZTraceElement): ZIO[R, E, In]
+
+  /**
+   * An effect that polls for a value and uses the value to update the metric.
+   */
+  final def pollAndUpdate(implicit trace: ZTraceElement): ZIO[R, E, Unit] =
+    poll.flatMap(metric.update(_))
+
+  /**
+   * Returns a new polling metric whose poll function will be retried with the
+   * specified retry policy.
+   */
+  final def retry[R1 <: R, E1 >: E](
+    policy: Schedule[R1, E1, Any]
+  ): PollingMetric.Full[Type, In, R1 with Clock, E1, Out] =
+    new PollingMetric[R1 with Clock, E1, Out] {
+      type Type = self.Type
+      type In   = self.In
+
+      def metric = self.metric
+
+      def poll(implicit trace: ZTraceElement) = self.poll.retry(policy)
+    }
+
+  /**
+   * Zips this polling metric with the specified polling metric.
+   */
+  final def zip[R1 <: R, E1 >: E, Out2](that: PollingMetric[R1, E1, Out2])(implicit
+    z1: Zippable[self.Type, that.Type],
+    z2: Zippable[Out, Out2]
+  ): PollingMetric.Full[z1.Out, (self.In, that.In), R1, E1, z2.Out] =
+    new PollingMetric[R1, E1, z2.Out] {
+      type Type = z1.Out
+      type In   = (self.In, that.In)
+
+      def metric: Metric[z1.Out, In, z2.Out] =
+        self.metric.zip(that.metric)
+
+      def poll(implicit trace: ZTraceElement): ZIO[R1, E1, In] =
+        self.poll.zip(that.poll)
+    }
+}
+object PollingMetric {
+  type Full[Type0, In0, -R, +E, +Out] =
+    PollingMetric[R, E, Out] { type Type = Type0; type In = In0 }
+
+  def apply[Type0, In0, R, E, Out](
+    metric0: Metric[Type0, In0, Out],
+    poll0: ZIO[R, E, In0]
+  ): PollingMetric[R, E, Out] { type Type = Type0; type In = In0 } =
+    new PollingMetric[R, E, Out] {
+      type Type = Type0
+      type In   = In0
+
+      def metric: Metric[Type, In, Out] = metric0
+
+      def poll(implicit trace: ZTraceElement): ZIO[R, E, In] = poll0
+    }
+
+  def collectAll[R, E, Out](
+    in0: Iterable[PollingMetric[R, E, Out]]
+  ): PollingMetric[R, E, Chunk[Out]] =
+    new PollingMetric[R, E, Chunk[Out]] {
+      val in = Chunk.fromIterable(in0)
+      type Type = Chunk[Any]
+      type In   = Chunk[Any]
+
+      def metric: Metric[Type, In, Chunk[Out]] = {
+        val start =
+          Metric.succeed(Chunk.empty).mapType(_ => Chunk.empty)
+
+        in.zipWithIndex.foldLeft[Metric[Type, In, Chunk[Out]]](start) { case (acc, (metric, index)) =>
+          metric.metric.mapType(Chunk(_)).map(Chunk(_)).contramap[In](chunk => chunk(index).asInstanceOf[metric.In])
+        }
+      }
+
+      def poll(implicit trace: ZTraceElement): ZIO[R, E, In] = ZIO.foreach(in)(_.poll)
+    }
+}

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -52,8 +52,8 @@ trait PollingMetric[-R, +E, +Out] { self =>
    */
   final def launch[R1 <: R, B](schedule: Schedule[R1, Out, B])(implicit
     trace: ZTraceElement
-  ): ZIO[R1 with Clock, Nothing, Fiber[E, B]] =
-    (pollAndUpdate *> metric.value).repeat(schedule).fork
+  ): ZIO[R1 with Clock with Scope, Nothing, Fiber[E, B]] =
+    ZIO.acquireRelease((pollAndUpdate *> metric.value).repeat(schedule).forkDaemon)(_.interrupt)
 
   /**
    * An effect that polls a value that may be fed to the metric.

--- a/docs/datatypes/metrics/counter.md
+++ b/docs/datatypes/metrics/counter.md
@@ -31,7 +31,7 @@ Create a counter named `countAll` which is incremented by `1` every time it is i
 ```scala mdoc:silent:nest
 import zio._
 import zio.metrics._
-val countAll = ZIOMetric.counter("countAll").fromConst(1)
+val countAll = Metric.counter("countAll").fromConst(1)
 ```
 
 Now the counter can be applied to any effect. Note, that the same aspect can be applied to more than one effect. In the example we would count the sum of executions of both effects in the for comprehension:
@@ -46,13 +46,13 @@ val myApp = for {
 Or we can apply them in recurrence situations:
 
 ```scala mdoc:silent:nest
-(zio.Random.nextLongBounded(10) @@ ZIOMetric.counter("request_counts")).repeatUntil(_ == 7)
+(zio.Random.nextLongBounded(10) @@ Metric.counter("request_counts")).repeatUntil(_ == 7)
 ```
 
 Create a counter named `countBytes` that can be applied to effects having the output type `Double`:
 
 ```scala mdoc:silent:nest
-val countBytes = ZIOMetric.counter("countBytes")
+val countBytes = Metric.counter("countBytes")
 ```
 
 Now we can apply it to effects producing `Double` (in a real application the value might be the number of bytes read from a stream or something similar):

--- a/docs/datatypes/metrics/gauge.md
+++ b/docs/datatypes/metrics/gauge.md
@@ -29,13 +29,13 @@ Create a gauge that can be set to absolute values, it can be applied to effects 
 ```scala mdoc:silent:nest
 import zio._
 import zio.metrics._
-val absoluteGauge = ZIOMetric.gauge("setGauge")
+val absoluteGauge = Metric.gauge("setGauge")
 ```
 
 Now we can apply these gauges to effects having an output type `Double`. Note that we can instrument an effect with any number of aspects if the type constraints are satisfied:
 
 ```scala mdoc:invisible
-val countAll = ZIOMetric.counter("countAll").fromConst(1)
+val countAll = Metric.counter("countAll").fromConst(1)
 ```
 
 ```scala mdoc:silent:nest

--- a/docs/datatypes/metrics/metriclabel.md
+++ b/docs/datatypes/metrics/metriclabel.md
@@ -17,7 +17,7 @@ For example, we can append following labels (dimensions) to our metric aspects:
 
 ```scala
 import zio._
-val counter = ZIOMetric.counter("http_requests")
+val counter = Metric.counter("http_requests")
   .tagged(
     MetricLabel("env", "production")
     MetricLabel("method", "GET"),


### PR DESCRIPTION
 - [x] Rename `ZIOMetric` to `Metric`
 - [x] Introduce `PollingMetric` for metrics that should be updated with effects on a schedule
 - [ ] Leverage `PollingMetric` in JVM metrics