### PR TITLE
Don't Apply Auto Supervision To Fibers Forked In A Scope

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1039,7 +1039,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def forkScoped(implicit trace: ZTraceElement): ZIO[R with Scope, Nothing, Fiber.Runtime[E, A]] =
     ZIO.uninterruptibleMask { restore =>
-      restore(self).fork.tap(fiber => ZIO.addFinalizer(fiber.interrupt))
+      restore(self).forkDaemon.tap(fiber => ZIO.addFinalizer(fiber.interrupt))
     }
 
   /**


### PR DESCRIPTION
When a fiber is forked in an explicit scope the user is indicating the intended lifetime of the fiber, so it could be confusing if the fiber was terminated before that due to automatic supervision.