### PR TITLE
Don't Warn About Types Being Inferred As Any

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -168,7 +168,7 @@ object ZSTMConcurrencyTests {
 
     @Actor
     def actor1(): Unit = {
-      val zio = ZIO.scoped[Any](semaphore.withPermitScoped)
+      val zio = ZIO.scoped(semaphore.withPermitScoped)
       fiber = runtime.unsafeRun(zio.fork)
       runtime.unsafeRun(promise.succeed(()))
       runtime.unsafeRun(fiber.await)

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -364,7 +364,7 @@ object ZLayerSpec extends ZIOBaseSpec {
         val layer1 = ZLayer.fail("foo")
         val layer2 = ZLayer.succeed("bar")
         val layer3 = ZLayer.succeed("baz")
-        val layer4 = ZLayer.scoped[Any](ZIO.acquireRelease(sleep)(_ => sleep))
+        val layer4 = ZLayer.scoped(ZIO.acquireRelease(sleep)(_ => sleep))
         val env    = layer1 ++ ((layer2 ++ layer3) >+> layer4)
         assertM(ZIO.unit.provideCustomLayer(env).exit)(fails(equalTo("foo")))
       },

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -45,7 +45,7 @@ object BuildHelper {
     "-language:existentials",
     "-explaintypes",
     "-Yrangepos",
-    "-Xlint:_,-missing-interpolator,-type-parameter-shadow",
+    "-Xlint:_,-missing-interpolator,-type-parameter-shadow,-infer-any",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
   )
@@ -146,7 +146,6 @@ object BuildHelper {
           "-Ypartial-unification",
           "-Yno-adapted-args",
           "-Ywarn-inaccessible",
-          "-Ywarn-infer-any",
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit",
           "-Ywarn-unused:params,-implicits",
@@ -160,7 +159,6 @@ object BuildHelper {
           "-Ypartial-unification",
           "-Yno-adapted-args",
           "-Ywarn-inaccessible",
-          "-Ywarn-infer-any",
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit",
           "-Xexperimental",

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -838,7 +838,7 @@ object ZSinkSpec extends ZIOBaseSpec {
         suite("take")(
           test("take")(
             check(Gen.chunkOf(Gen.small(Gen.chunkOfN(_)(Gen.int))), Gen.int) { (chunks, n) =>
-              ZIO.scoped[Any] {
+              ZIO.scoped {
                 ZStream
                   .fromChunks(chunks: _*)
                   .peel(ZSink.take[Int](n))


### PR DESCRIPTION
This can lead to spurious warnings in ZIO code bases since `Any` is frequently used to represent a workflow that does not have any requirements.