### PR TITLE
ZIO Managed: Preserve Interruptibility Of Acquire In Scoped

### DIFF
--- a/managed-tests/jvm/src/test/scala/zio/managed/ZManagedPlatformSpecificSpec.scala
+++ b/managed-tests/jvm/src/test/scala/zio/managed/ZManagedPlatformSpecificSpec.scala
@@ -1,5 +1,6 @@
-package zio
+package zio.managed
 
+import zio._
 import zio.test.Assertion._
 import zio.test._
 

--- a/managed-tests/shared/src/test/scala/zio/managed/ZIOBaseSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZIOBaseSpec.scala
@@ -1,0 +1,48 @@
+package zio.managed
+
+import zio._
+import zio.test._
+
+import scala.annotation.tailrec
+
+trait ZIOBaseSpec extends ZIOSpecDefault {
+  override def aspects: Chunk[TestAspectAtLeastR[Live]] =
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
+    else Chunk(TestAspect.sequential, TestAspect.timeout(120.seconds))
+
+  sealed trait ZIOTag {
+    val value: String
+    val subTags: List[ZIOTag] = Nil
+  }
+  object ZIOTag {
+    case object errors extends ZIOTag { override val value = "errors" }
+    case object future extends ZIOTag { override val value = "future" }
+    case object interop extends ZIOTag {
+      override val value                 = "interop"
+      override val subTags: List[ZIOTag] = List(future)
+    }
+    case object interruption extends ZIOTag { override val value = "interruption" }
+    case object regression   extends ZIOTag { override val value = "regression"   }
+    case object supervision  extends ZIOTag { override val value = "supervision"  }
+  }
+
+  def zioTag(zioTag: ZIOTag, zioTags: ZIOTag*): TestAspectPoly = {
+    val tags = zioTags.map(_.value) ++ getSubTags(zioTag) ++ zioTags.flatMap(getSubTags)
+    TestAspect.tag(zioTag.value, tags.distinct: _*)
+  }
+
+  private def getSubTags(zioTag: ZIOTag): List[String] = {
+    @tailrec
+    def loop(currentZioTag: ZIOTag, remainingZioTags: List[ZIOTag], result: List[String]): List[String] =
+      (currentZioTag.subTags, remainingZioTags) match {
+        case (Nil, Nil)      => currentZioTag.value :: result
+        case (Nil, t :: ts)  => loop(t, ts, currentZioTag.value :: result)
+        case (st :: sts, ts) => loop(st, sts ++ ts, currentZioTag.value :: result)
+      }
+    zioTag.subTags match {
+      case t :: ts => loop(t, ts, Nil)
+      case Nil     => Nil
+    }
+  }
+
+}

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -1275,21 +1275,6 @@ object ZManagedSpec extends ZIOBaseSpec {
         } yield assert(res)(isNone)
       }
     ),
-    suite("toLayerMany")(
-      test("converts a managed effect to a layer") {
-        val managed = ZManaged {
-          Scope.make.flatMap { scope =>
-            ZEnv.live.build
-              .provideSomeEnvironment[ZEnv](_ ++ [Scope] ZEnvironment(scope))
-              .map(r => ((exit: Exit[Any, Any]) => scope.close(exit), r))
-          }
-        }
-        val layer = managed.toLayerEnvironment
-        val zio1  = ZIO.environment[ZEnv]
-        val zio2  = zio1.provideLayer(layer)
-        assertM(zio2)(anything)
-      }
-    ),
     suite("withEarlyRelease")(
       test("Provides a canceler that can be used to eagerly evaluate the finalizer") {
         for {

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -1,6 +1,6 @@
 package zio.managed
 
-import zio.{test => _, _}
+import zio._
 import zio.Exit.Failure
 import zio.managed.ZManaged.ReleaseMap
 import zio.test.Assertion._

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -992,7 +992,13 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
     ZManaged.unsandbox(f(self.sandbox))
 
   def scoped(implicit trace: ZTraceElement): ZIO[R with Scope, E, A] =
-    ZIO.acquireReleaseExit(self.zio) { case ((finalizer, _), exit) => finalizer(exit) }.map(_._2)
+    for {
+      scope      <- ZIO.scope
+      releaseMap <- ZManaged.ReleaseMap.make
+      _          <- scope.addFinalizerExit(releaseMap.releaseAll(_, ExecutionStrategy.Sequential))
+      tuple      <- ZManaged.currentReleaseMap.locally(releaseMap)(zio)
+      (_, a)      = tuple
+    } yield a
 
   /**
    * Converts an option on values into an option on errors.


### PR DESCRIPTION
Preserve the interruptibility of the `acquire` workflow when converting from a `ZManaged` to a scoped `ZIO`.