### PR TITLE
Implement ZIO.stateful

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZStateSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZStateSpec.scala
@@ -1,20 +1,18 @@
 package zio
 
-import zio.test.Assertion._
-import zio.test.TestAspect._
 import zio.test._
 
 object ZStateSpec extends ZIOSpecDefault {
 
   def spec =
-    suite("StateSpec")(
+    suite("ZStateSpec")(
       test("state can be updated") {
-        final case class MyState(counter: Int)
-        val zio = for {
-          _     <- ZIO.updateState[MyState](state => state.copy(counter = state.counter + 1))
-          count <- ZIO.getStateWith[MyState](_.counter)
-        } yield count
-        assertM(zio.provideLayer(ZState.make(MyState(0)).toLayer))(equalTo(1))
+        ZIO.stateful(0) {
+          for {
+            _     <- ZIO.updateState[Int](_ + 1)
+            state <- ZIO.getState[Int]
+          } yield assertTrue(state == 1)
+        }
       }
-    ) @@ exceptScala3
+    )
 }


### PR DESCRIPTION
We can implement a `stateful` operator on ZIO that allows eliminating `ZState` from the environment much like `scoped` eliminates a `Scope` from the environment. This provides a consistent approach to introducing and eliminating capabilities and focuses more on intent versus mechanics as opposed to providing the state directly.