### PR TITLE
Make Chunk Extend IterableFactory

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -407,7 +407,7 @@ object ChunkSpec extends ZIOBaseSpec {
       assert(actual)(equalTo(expected))
     },
     test("toArray for an empty Chunk of type String") {
-      assert(Chunk.empty.toArray[String])(equalTo(Array.empty[String]))
+      assert(Chunk.empty[String].toArray)(equalTo(Array.empty[String]))
     },
     test("to Array for an empty Chunk using filter") {
       assert(Chunk(1).filter(_ == 2).map(_.toString).toArray[String])(equalTo(Array.empty[String]))
@@ -421,7 +421,7 @@ object ChunkSpec extends ZIOBaseSpec {
     },
     suite("collect")(
       test("collect empty Chunk") {
-        assert(Chunk.empty.collect { case _ => 1 })(isEmpty)
+        assert(Chunk.empty[Nothing].collect { case _ => 1 })(isEmpty)
       },
       test("collect chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
@@ -430,7 +430,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectZIO")(
       test("collectZIO empty Chunk") {
-        assertM(Chunk.empty.collectZIO { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
+        assertM(Chunk.empty[Nothing].collectZIO { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
       },
       test("collectZIO chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))
@@ -447,7 +447,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectWhile")(
       test("collectWhile empty Chunk") {
-        assert(Chunk.empty.collectWhile { case _ => 1 })(isEmpty)
+        assert(Chunk.empty[Nothing].collectWhile { case _ => 1 })(isEmpty)
       },
       test("collectWhile chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, Int](intGen)
@@ -458,7 +458,7 @@ object ChunkSpec extends ZIOBaseSpec {
     ),
     suite("collectWhileZIO")(
       test("collectWhileZIO empty Chunk") {
-        assertM(Chunk.empty.collectWhileZIO { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
+        assertM(Chunk.empty[Nothing].collectWhileZIO { case _ => UIO.succeed(1) })(equalTo(Chunk.empty))
       },
       test("collectWhileZIO chunk") {
         val pfGen = Gen.partialFunction[Random with Sized, Int, UIO[Int]](Gen.successes(intGen))

--- a/core/shared/src/main/scala-2.11-2.12/zio/ChunkFactory.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/ChunkFactory.scala
@@ -20,7 +20,4 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.generic.IndexedSeqFactory
 
-private[zio] trait ChunkFactory extends IndexedSeqFactory[Chunk] {
-  def newBuilder[A]: ChunkBuilder[A] =
-    ChunkBuilder.make()
-}
+private[zio] trait ChunkFactory extends IndexedSeqFactory[Chunk]

--- a/core/shared/src/main/scala-2.13+/zio/ChunkFactory.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkFactory.scala
@@ -18,9 +18,13 @@ package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-private[zio] trait ChunkFactory {
-  def apply[A](as: A*): Chunk[A]
-  def fill[A](n: Int)(elem: => A): Chunk[A]
+import scala.collection.{IterableFactory, IterableOnce}
+import scala.collection.mutable.Builder
+
+private[zio] trait ChunkFactory extends IterableFactory[Chunk] {
+
+  final def from[A](iterable: IterableOnce[A]): Chunk[A] =
+    Chunk.fromIterator(iterable.iterator)
 
   /**
    * Extracts the elements from a `Chunk`.

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1066,7 +1066,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
   /**
    * Returns the empty chunk.
    */
-  def empty[A]: Chunk[A] =
+  override def empty[A]: Chunk[A] =
     Empty
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1058,16 +1058,16 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
 object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
   /**
-   * Returns the empty chunk.
-   */
-  val empty: Chunk[Nothing] =
-    Empty
-
-  /**
    * Returns a chunk from a number of values.
    */
   override def apply[A](as: A*): Chunk[A] =
     fromIterable(as)
+
+  /**
+   * Returns the empty chunk.
+   */
+  def empty[A]: Chunk[A] =
+    Empty
 
   /**
    * Returns a chunk backed by an array.
@@ -1203,6 +1203,9 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       }
       builder.result()
     }
+
+  def newBuilder[A]: ChunkBuilder[A] =
+    ChunkBuilder.make()
 
   /**
    * Returns a singleton chunk, eagerly evaluated.


### PR DESCRIPTION
Resolves #6464.

This requires changing the signature of `Chunk.empty` from:

```scala
object Chunk {
  val empty: Chunk[Nothing] =
    ???
}
```

to:

```scala
object Chunk {
  def empty[A]: Chunk[A] =
    ???
}
```

I tend to think this is actually a positive change. The current signature is more theoretically correct ( there is only one empty chunk and due to variance it is a subtype of all other types of chunks. However, it is inconsistent with the signature of `empty` on all other Scala collections and I have seen it create issues for users when they try to do `Chunk.empty[A]` when a widened type is required (for example if the chunk is the initial value in a fold).