### PR TITLE
Several minor documentation fixes (Part 2)

### DIFF
--- a/docs/datatypes/concurrency/index.md
+++ b/docs/datatypes/concurrency/index.md
@@ -5,37 +5,37 @@ title: "Introduction"
 
 ## Overview
 
-Most of the time, in concurrent programming we have a single state that we need to read and update that concurrently. When we have multiple fibers reading or writing to the same memory location we encounter the race condition. The main goal in every concurrent program is to have a consistent view of states among all threads.
+Most of the time in concurrent programming we have a single state that we need to read and update concurrently. When we have multiple fibers reading or writing to the same memory location we encounter the race condition. The main goal in every concurrent program is to have a consistent view of states among all threads.
 
-There is two major concurrency model which tries to solve this problem:
+There are two major concurrency models which try to solve this problem:
 
 1. **Shared State** — In this model, all threads communicate with each other by sharing the same memory location.
 
 2. **Message Passing (Distributed State)** — This model provides primitives for sending and receiving messages, and the state is distributed. Each thread of execution has its own state. 
 
-The _Shared Memory_ model has two main solutions:
+The _Shared State_ model has two main solutions:
 
-1. **Lock-Based** — In the locking model, the general primitives for synchronization are ـlocksـ, that control access to critical sections. When a thread wants to modify the critical section, it acquires the lock and says I'm the only thread that is allowed to modify the state right now, after it's work finished it unlocks the critical section and says I'm done, all other threads can modify this memory section.
+1. **Lock-based** — In the locking model, the general primitives for synchronization are _locks_ that control access to critical sections. When a thread wants to modify the critical section, it acquires the lock and says _I'm the only thread that is allowed to modify the state right now_, and after its work finished it unlocks the critical section and says _I'm done, any other thread can modify this memory section_.
 
 2. **Non-blocking** — Non-blocking algorithms usually use hardware-intrinsic atomic operations like `compare-and-swap` (CAS), without using any locks. This method follows an optimistic design with a transactional memory mechanism to roll back in conflict situations.
 
-## Implication of Locking Mechanism
+## Implications of Locking Mechanism
 
-There are lots of drawback with lock-based concurrency:
+There are several drawbacks with lock-based concurrency:
 
-1. Incorrect use of locks can lead to deadlock. We need to care about the locking orders. If we don't place the locks in the right order, we may encounter a deadlock situation.
+1. Incorrect use of locks can lead to deadlocks. We need to care about the locking orders. If we don't place the locks in the right order, we may encounter a deadlock situation.
 
-2. Identifying the critical section of a code that is vulnerable to race conditions is overwhelming. We should always care about them and remember to lock everywhere it's required.
+2. Identifying the critical section of code that is vulnerable to race conditions is overwhelming. We should always care about them and remember to lock everywhere it's required.
 
 3. It makes our software design very sophisticated to become scalable and reliable. It doesn't scale with program size and complexity.
 
 4. To prevent missing the releasing of the acquired locks, we should always care about exceptions and error handling inside locking sections. 
 
-5. The locking mechanism violates the encapsulation property of our pieces of programs. So systems that build with locking mechanism are difficult to compose without knowing about their internals.
+5. The locking mechanism violates the encapsulation property of the pieces of our programs. So systems that are built on a locking mechanism are difficult to compose without knowing about their internals.
 
 ## Lock-free Concurrency Model
 
-As the lock-oriented programming does not compose and has lots of drawbacks, ZIO uses a _lock-free concurrency model_ which is a variation of non-blocking algorithms. The magic behind all of ZIO concurrency primitives is that they use CAS (_compare-and-set_) operation. 
+As the lock-oriented programming does not compose and has lots of drawbacks, ZIO uses a _lock-free concurrency model_ which is a variation of non-blocking algorithms. The magic behind all of ZIO concurrency primitives is that they use the CAS (_compare-and-set_) operation. 
 
 Let's see how the `modify` function of `Ref` is implemented without any locking mechanism:
 
@@ -64,21 +64,21 @@ The idea behind the `modify` is that a variable is only updated if it still has 
 
 ## Advantage of Using ZIO Concurrency
 
-Here we are going to enumerate some points that why the ZIO concurrency model helps us to do our job well:
+Let's point out the key properties of the ZIO concurrency model:
 
-1. **Composable** — Due to the use of the lock-free concurrency model, ZIO brings us a composable concurrent primitive and lots of great combinators in a declarative style.
+1. **Composable** — Due to the use of the lock-free concurrency model, ZIO brings us composable concurrency primitives and lots of great combinators in a declarative style.
 
-> **Note:** `Ref` and `Promise` and subsequently all other ZIO concurrent primitives that are on top of these two basic primitives **are not transactionally composable**.
+> **Note:** `Ref` and `Promise` and subsequently all other ZIO concurrency primitives that are on top of these two basic primitives **are not _transactionally_ composable**.
 >
-> We cannot do transactional changes across two or more such concurrent primitives. They are susceptible to race conditions and deadlocks. **So don't use them if you need to perform an atomic operation on top of a composed sequence of multiple state-changing operations. use [`STM`](../stm/index.md) instead**. 
+> We cannot do transactional changes across two or more of such concurrency primitives. They are susceptible to race conditions and deadlocks. **So don't use them if you need to perform an atomic operation on top of a composed sequence of multiple state-changing operations. In such a case use [`STM`](../stm/index.md) instead**. 
 
 2. **Non-blocking** — All of the ZIO primitives are a hundred percent asynchronous and nonblocking.
 
 3. **Resource Safety** — ZIO concurrency model comes with strong guarantees of resource safety. If any interruption occurs in between concurrent operations, it won't leak any resource. So it allows us to write compositional operators like timeout and racing without worrying about any leaks.
 
-## Concurrent Primitives
+## Concurrency Primitives
 
-Let's take a quick look at ZIO concurrent primitives, what are they and why they exist.
+Let's take a quick look at ZIO concurrency primitives, what they are and why they exist.
 
 ### Basic Operations
 

--- a/docs/datatypes/concurrency/promise.md
+++ b/docs/datatypes/concurrency/promise.md
@@ -7,13 +7,13 @@ A `Promise[E, A]` is a variable of `IO[E, A]` type that can be set exactly once.
 
 Promise is a **purely functional synchronization primitive** which represents a single value that may not yet be available. When we create a Promise, it always started with an empty value, then it can be completed exactly once at some point, and then it will never become empty or modified again.
 
-Promise is a synchronization primitive. So, it is useful whenever we want to wait for something to happen. Whenever we need to synchronize a fiber with another fiber, we can use Promise. It allows us to have fibers waiting for other fibers to do things. Any time we want to handoff of a work from one fiber to another fiber or anytime we want to suspend a fiber until some other fiber does a certain amount of work, well we need to be using a Promise. Also, We can use `Promise` with `Ref` to build other concurrent primitives, like Queue and Semaphore. 
+Promise is a synchronization primitive. So, it is useful whenever we want to wait for something to happen. Whenever we need to synchronize a fiber with another fiber, we can use Promise. It allows us to have fibers waiting for other fibers to do things. Any time we want to hand over work from one fiber to another fiber or anytime we want to suspend a fiber until some other fiber does a certain amount of work, we may want to use a Promise. Also, we can use `Promise` with `Ref` to build other concurrent primitives, like Queue and Semaphore.
 
-By calling `await` on the Promise, the current fiber blocks, until that event happens. As we know, blocking thread in ZIO, don't actually block kernel threads. They are semantic blocking, so when a fiber is blocked the underlying thread is free to run all other fibers.
+By calling `await` on the Promise, the current fiber blocks until that event happens. As we know, blocking fibers in ZIO don't actually block kernel threads. They are just blocking semantically, so when a fiber is blocked the underlying thread is free to run all other fibers.
 
 Promise is the equivalent of Scala's Promise. It's almost the same, except it has two type parameters, instead of one. Also instead of calling `future`, we need to call `await` on ZIO Promise to wait for the Promise to be completed.
 
-Promises can be failed with a value of type `E` and succeeded that is completed with success with the value of type `A`. So there are two ways we can complete a Promise, with failure or success and then whoever is waiting on the Promise will get back that failure or success. 
+Promises can be failed with a value of type `E` or succeeded with a value of type `A`. So there are two ways we can complete a Promise, with failure or success, and whoever is waiting on the Promise will get back that failure or success. 
 
 
 ## Operations
@@ -24,15 +24,15 @@ Promises can be created using `Promise.make[E, A]`, which returns `UIO[Promise[E
 
 ### Completing
 
-You can complete a `Promise[E, A]` in few different ways:
+You can complete a `Promise[E, A]` in different ways:
 * successfully with a value of type `A` using `succeed`
 * with `Exit[E, A]` using `done` - each `await` will get this exit propagated
 + with result of effect `IO[E, A]` using `complete` - the effect will be executed once and the result will be propagated to all waiting fibers
-* with effect `IO[E, A]` using `completeWith` - first fiber that calls `completeWith` wins and sets effect that **will be executed by each `await`ing fiber**, so be careful when using `p.completeWith(someEffect)` and rather use `p.complete(someEffect` unless executing `someEffect` by each `await`ing fiber is intent
+* with effect `IO[E, A]` using `completeWith` - first fiber that calls `completeWith` wins and sets the effect that **will be executed by each `await`ing fiber**, so be careful when using `p.completeWith(someEffect)` and rather use `p.complete(someEffect)` unless executing `someEffect` by each `await`ing fiber is intended
 * simply fail with `E` using `fail`
 * simply defect with `Throwable` using `die`
 * fail or defect with `Cause[E]` using `failCause`
-* interrupt it with `interrupt`
+* interrupt with `interrupt`
 
 Following example shows usage of all of them:
 ```scala mdoc:silent
@@ -52,7 +52,7 @@ val race: IO[String, Int] = for {
   } yield value
 ```
 
-The act of completing a Promise results in an `UIO[Boolean]`, where the `Boolean` represents whether the promise value has been set (`true`) or whether it was already set (`false`). This is demonstrated below:
+The act of completing a Promise results in an `UIO[Boolean]`, where the `Boolean` represents whether the Promise value has been set (`true`) or whether it was already set (`false`). This is demonstrated below:
 
 ```scala mdoc:silent
 val ioPromise1: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
@@ -70,7 +70,7 @@ To re-iterate, the `Boolean` tells us whether or not the operation took place su
 was set with the value or the error.
 
 ### Awaiting
-We can get a value from a Promise using `await`, calling fiber will suspend until Promise is completed.
+We can get a value from a Promise using `await`. The calling fiber will suspend until Promise is completed with a value or an error.
 
 ```scala mdoc:silent
 val ioPromise3: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
@@ -78,9 +78,7 @@ val ioGet: IO[Exception, String] = ioPromise3.flatMap(promise => promise.await)
 ```
 
 ### Polling
-The computation will suspend (in a non-blocking fashion) until the Promise is completed with a value or an error.
-
-If we don't want to suspend, and we only want to query the state of whether or not the Promise has been completed, we can use `poll`:
+If we don't want to suspend the fiber, but we only want to query the state of whether or not the Promise has been completed, we can use `poll`:
 
 ```scala mdoc:silent
 val ioPromise4: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
@@ -88,12 +86,12 @@ val ioIsItDone: UIO[Option[IO[Exception, String]]] = ioPromise4.flatMap(p => p.p
 val ioIsItDone2: IO[Option[Nothing], IO[Exception, String]] = ioPromise4.flatMap(p => p.poll.some)
 ```
 
-If the Promise was not completed when we called `poll` then the IO will fail with the `Unit` value otherwise, we obtain an `IO[E, A]`, where `E` represents if the Promise completed with an error and `A` indicates that the Promise successfully completed with an `A` value.
+If the Promise was not completed when we called `poll` then the IO will fail with the `Unit` value. Otherwise, we obtain an `IO[E, A]`, where `E` represents if the Promise completed with an error and `A` indicates that the Promise successfully completed with an `A` value.
 
-`isDone` returns `UIO[Boolean]` that evaluates to `true` if promise is already completed.
+`isDone` returns `UIO[Boolean]` that evaluates to `true` if Promise is already completed.
 
 ## Example Usage
-Here is a scenario where we use a `Promise` to hand-off a value between two `Fiber`s
+Here is a scenario where we use a `Promise` to hand over a value between two `Fiber`s:
 
 ```scala mdoc:silent
 import java.io.IOException
@@ -109,5 +107,5 @@ val program: ZIO[Console with Clock, IOException, Unit] =
   } yield ()
 ```
 
-In the example above, we create a Promise and have a Fiber (`fiberA`) complete that promise after 1 second and a second Fiber (`fiberB`) will call `await` on that Promise to obtain a `String` and then print it to screen. The example prints `hello world` to the screen after 1 second. Remember, this is just a description of the program and not the execution
+In the example above, we create a Promise and a Fiber (`fiberA`) that completes the Promise after 1 second, and a second Fiber (`fiberB`) that will call `await` on that Promise to obtain a `String` and then print it to screen. The example prints `hello world` to the screen after 1 second. Remember, this is just a description of the program and not the execution
 itself.

--- a/docs/datatypes/concurrency/queue.md
+++ b/docs/datatypes/concurrency/queue.md
@@ -23,9 +23,9 @@ A `Queue` can be bounded (with a limited capacity) or unbounded.
 
 There are several strategies to process new values when the queue is full:
 
-- The default `bounded` queue is back-pressured: when full, any offering fiber will be suspended until the queue is able to add the item;
-- A `dropping` queue will drop new items when the queue is full;
-- A `sliding` queue will drop old items when the queue is full.
+- The default `bounded` queue is back-pressured: when full, any offering fiber will be suspended until the queue is able to add the item
+- A `dropping` queue will drop new items when the queue is full
+- A `sliding` queue will drop old items when the queue is full
 
 To create a back-pressured bounded queue:
 ```scala mdoc:silent
@@ -139,7 +139,7 @@ val takeFromShutdownQueue: UIO[Unit] = for {
 } yield ()
 ```
 
-You can use `awaitShutdown` to execute an effect when the queue is shut down. This will wait until the queue is shut down. If the queue is already shutdown, it will resume right away.
+You can use `awaitShutdown` to execute an effect when the queue is shut down. This will wait until the queue is shut down. If the queue is already shut down, it will resume right away.
 
 ```scala mdoc:silent
 val awaitShutdown: UIO[Unit] = for {

--- a/docs/datatypes/concurrency/ref.md
+++ b/docs/datatypes/concurrency/ref.md
@@ -5,23 +5,24 @@ title: "Ref"
 
 `Ref[A]` models a **mutable reference** to a value of type `A` in which we can store **immutable** data. The two basic operations are `set`, which fills the `Ref` with a new value, and `get`, which retrieves its current content. All operations on a `Ref` are atomic and thread-safe, providing a reliable foundation for synchronizing concurrent programs.
 
-`Ref` is ZIO's analog to something like a State Monad in more Haskell-Oriented FP. We don't need State Monad in ZIO, because we have `Ref`s. `Ref`s allow us to get and set state, or update it.
+`Ref` is ZIO's analog to something like a State Monad in more Haskell-oriented FP. We don't need State Monad in ZIO, because we have `Ref`s. `Ref`s allow us to get and set state, or update it.
 
 When we write stateful applications, we need some mechanism to manage our state. We need a way to update the in-memory state in a functional way. So this is why we need `Ref`s.
 
 `Ref`s are:
-- Purely Functional and Referential Transparent
-- Concurrent-Safe and Lock-free
-- Update and Modify atomically
+- purely functional and referential transparent
+- concurrent-safe and lock-free
+- update and modify atomically
 
 ## Concurrent Stateful Application
-**`Ref`s are building blocks for writing concurrent stateful applications**. Without `Ref` or something equivalently, we can't do that. Anytime we need to share information between multiple fibers, and those fibers have to update the same information, they need to communicate through something that provides the guarantee of atomicity. So `Ref`s can update the state in an atomic way, consistent and isolated from all other concurrent updates.
+**`Ref`s are building blocks for writing concurrent stateful applications**. Without `Ref` or something equivalent, we can't do that. Anytime we need to share information between multiple fibers, and those fibers have to update the same information, they need to communicate through something that provides the guarantee of atomicity. So `Ref`s can update the state in an atomic way, consistent and isolated from all other concurrent updates.
 
 **`Ref`s are concurrent-safe**. we can share the same `Ref` among many fibers. All of them can update `Ref` concurrently. We don't have to worry about race conditions. Even we have ten thousand fibers all updating the same `Ref` as long as they are using atomic update and modify functions, we will have zero race conditions. 
 
 
 ## Operations
 The `Ref` has lots of operations. Here we are going to introduce the most important and common ones.
+
 ### make
 `Ref` is never empty and it always contains something. We can create `Ref` by providing the initial value to the `make`,  which is a constructor of the `Ref` data type. We should pass an **immutable value** of type `A` to the constructor, and it returns an `UIO[Ref[A]]` value:
 
@@ -69,13 +70,13 @@ val counterRef = Ref.make(init)
 ```
 
 ### get
-The `get` method returns the current value of the reference. Its return type is `IO[EB, B]`. Which `B` is the value type of returning effect and in the failure case, `EB` is the error type of that effect.
+The `get` method returns the current value of the reference. Its return type is `IO[EB, B]` in which `B` is the value type of the effect and in the failure case, `EB` is the error type of that effect.
 
 ```scala
 def get: IO[EB, B]
 ```
 
-As the `make` and `get` methods of `Ref` are effectful, we can chain them together with flatMap. In the following example, we create a `Ref` with `initial` value, and then we acquire the current state with the `get` method:
+As the `make` and `get` methods of `Ref` are effectful, we can chain them together with `flatMap`. In the following example, we create a `Ref` with `initial` value, and then we acquire the current state with the `get` method:
 
 ```scala mdoc:silent
 Ref.make("initial")
@@ -83,7 +84,7 @@ Ref.make("initial")
    .flatMap(current => Console.printLine(s"current value of ref: $current"))
 ```
 
-We can use syntactic sugar representation of flatMap series with for-comprehension:
+We can use syntactic sugar representation of a `flatMap` series with for-comprehension:
 
 ```scala mdoc:silent
 for {
@@ -106,7 +107,7 @@ for {
 ```
 
 ### update
-With `update`, we can atomically update the state of `Ref` with a given **pure** function. A function that we pass to the `update` needs to be a pure function, it needs to be deterministic and free of side effects.
+With `update`, we can atomically update the state of `Ref` with a given **pure** function, that is, it needs to be deterministic and free of side effects.
 
 ```scala
 def update(f: A => A): IO[E, Unit]
@@ -125,13 +126,13 @@ for {
 
 > **Note**:  
 >
-> The `update` is not the composition of `get` and `set`, this composition is not concurrently safe. So whenever we need to update our state, we should not compose `get` and `set` to manage our state in a concurrent environment. Instead, we should use the `update` operation which modifies its `Ref` atomically. 
+> The `update` is not the composition of `get` and `set`, since this composition is not concurrently safe. So whenever we need to update our state, we should not compose `get` and `set` to manage our state in a concurrent environment. Instead, we should use the `update` operation which modifies its `Ref` atomically. 
 
 The following snippet is not concurrent safe:
 
 ```scala mdoc:compile-only
 // Unsafe State Management
-object UnsafeCountRequests extends zio.ZIOAppDefault {
+object UnsafeCountRequests extends ZIOAppDefault {
 
   def request(counter: Ref[Int]) = for {
     current <- counter.get
@@ -154,8 +155,8 @@ object UnsafeCountRequests extends zio.ZIOAppDefault {
 The above snippet doesn't behave deterministically. This program sometimes print 2 and sometime print 1. So let's fix that issue by using `update` which behaves atomically:
 
 ```scala mdoc:compile-only
-// Unsafe State Management
-object CountRequests extends zio.ZIOAppDefault {
+// Safe State Management
+object CountRequests extends ZIOAppDefault {
 
   def request(counter: Ref[Int]): ZIO[Console, Nothing, Unit] = {
     for {
@@ -178,7 +179,7 @@ object CountRequests extends zio.ZIOAppDefault {
 }
 ```
 
-Here is another use case of `update` to write `repeat` combinator:
+Here is another use case of `update` to write a `repeat` combinator:
 
 ```scala mdoc:silent
 def repeat[E, A](n: Int)(io: IO[E, A]): IO[E, Unit] =
@@ -194,13 +195,13 @@ def repeat[E, A](n: Int)(io: IO[E, A]): IO[E, Unit] =
 ```
 
 ### modify
-`modify` is a more powerful version of the `update`. It atomically modifies its `Ref` with the given function and, also computes a return value. The function that we pass to the `modify` needs to be a pure function; it needs to be deterministic and free of side effects.
+`modify` is a more powerful version of `update`. It atomically modifies its `Ref` by the given function, and also computes a return value. The function that we pass to `modify` needs to be a pure function; it needs to be deterministic and free of side effects.
 
 ```scala
 def modify[B](f: A => (B, A)): IO[E, B]
 ```
 
-Remember the `CountRequest` example. What if we want to log the number of each request, inside the `request` function? Let's see what happen if we write that function with the composition of `update` and `get` methods:
+Remember the `CountRequest` example. What if we want to log the number of each request inside the `request` function? Let's see what happens if we write that function with the composition of `update` and `get` methods:
 
 ```scala mdoc:silent:nest
 // Unsafe in Concurrent Environment
@@ -212,7 +213,7 @@ def request(counter: Ref[Int]) = {
   } yield ()
 }
 ```
-What happens if between running the update and get, another update in another fiber performed? This function doesn't perform in a deterministic fashion in concurrent environments. So we need a way to perform **get and set and get** atomically. This is why we need the `modify` method. Let's fix the `request` function to do that atomically:
+What happens if between running the update and get, another update in another fiber occurred? This function doesn't perform in a deterministic fashion in concurrent environments. So we need a way to perform **get and set and get** atomically. This is why we need the `modify` method. Let's fix the `request` function to do that atomically:
 
 ```scala mdoc:silent:nest
 // Safe in Concurrent Environment
@@ -225,7 +226,7 @@ def request(counter: Ref[Int]) = {
 ```
 
 ## AtomicReference in Java 
-For Java programmers, we can think of `Ref` as an AtomicReference. Java has a `java.util.concurrent.atomic` package and that package contains `AtomicReference`, `AtomicLong`, `AtomicBoolean` and so forth. We can think of `Ref` as being an `AtomicReference`. It has roughly the same power, the same guarantees, and the same limitations. It packages it up in a higher-level context and of course, makes it ZIO friendly. 
+For Java programmers, we can think of `Ref` as an `AtomicReference`. Java has a `java.util.concurrent.atomic` package and that package contains `AtomicReference`, `AtomicLong`, `AtomicBoolean` and so forth. We can think of `Ref` as being an `AtomicReference`. It has roughly the same power, the same guarantees, and the same limitations. It packages it up in a higher-level context and of course, makes it ZIO friendly. 
  
 ## Ref vs. State Monad
 Basically `Ref` allows us to have all the power of State Monad inside ZIO. State Monad lacks two important features that we use in real-life application development:
@@ -234,12 +235,12 @@ Basically `Ref` allows us to have all the power of State Monad inside ZIO. State
 2. Error Handling
 
 ### Concurrency
-State Monad is its effect system that only includes state. It allows us to do pure stateful computations. We can only get, set and update related computations to managing the state. State Monad updates its state with series of stateful computations sequentially, but **we can't use the State Monad to do async or concurrent computations**. But `Ref`s have great support on concurrent and async programming.
+State Monad is an effect system that only includes state. It allows us to do pure stateful computations. We can only get, set and update (and related computations) to manage the state. State Monad updates its state with series of stateful computations sequentially, but **we can't use the State Monad to do async or concurrent computations**. But `Ref`s have great support on concurrent and async programming.
 
 ### Error Handling
-In real-life applications, we need error handling. In most real-life stateful applications, we will involve some database IO and API calls and or some concurrent and sync stuff that it can fail in different ways along the path of execution. So besides the state management, we need a way to do error handling. The State Monad doesn't have the ability to model error management. 
+In real-life applications, we need error handling. In most real-life stateful applications, we will involve some database IO and API calls and or some concurrent and sync operations that can fail in different ways along the path of execution. So besides the state management, we need a way to do error handling. The State Monad doesn't have the ability to model error management. 
 
-We can combine State Monad and Either Monad with StateT monad transformer, but it imposes massive performance overhead. It doesn't buy us anything that we can't do with a Ref. So it is an anti-pattern. In the ZIO model, errors are encoded in effects and Ref utilizes that. So besides state management, we have the ability to error-handling without any further work.
+We can combine State Monad and Either Monad with StateT monad transformer, but it imposes massive performance overhead. It doesn't buy us anything that we can't do with a `Ref`. So it is an anti-pattern. In the ZIO model, errors are encoded in effects and `Ref` utilizes that. So besides state management, we have the ability for error-handling without any further work.
 
 ## State Transformers
 
@@ -275,9 +276,9 @@ Ref.make(0).flatMap { idCounter =>
 
 `Ref` is low-level enough that it can serve as the foundation for other concurrency data types.
 
-Semaphores are a classic abstract data type for controlling access to shared resources. They are defined as a triple S = (v, P, V) where v is the number of units of the resource that are currently available, and P and V are operations that respectively decrement and increment v; P will only complete when v is non-negative and must wait if it isn't.
+For example, semaphores are a classic abstract data type for controlling access to shared resources. They are defined as a triplet `S = (v, P, V)` where `v` is the number of units of the resource that are currently available, and `P` and `V` are operations that decrement and increment `v`, respectively. `P` will only complete when `v` is non-negative and must wait if it isn't.
 
-Well, with `Ref`s, that's easy to do! The only difficulty is in `P`, where we must fail and retry when either `v` is negative or its value has changed between the moment we read it and the moment we try to update it. A naive implementation could look like:
+With `Ref`s, it's easy to implement such a semaphore! The only difficulty is in `P`, where we must fail and retry when either `v` is negative or its value has changed between the moment we read it and the moment we try to update it. A naive implementation could look like:
 
 ```scala mdoc:silent
 sealed trait S {

--- a/docs/datatypes/concurrency/semaphore.md
+++ b/docs/datatypes/concurrency/semaphore.md
@@ -8,10 +8,10 @@ A `Semaphore` datatype which allows synchronization between fibers with the `wit
 
 ## Operations
 
-For example a synchronization of asynchronous tasks can 
-be done via acquiring and releasing a semaphore with given number of permits it can spend.
-When the acquire operation cannot be performed, due to insufficient `permits` value in the semaphore, such task 
-is placed in internal suspended fibers queue and will be awaken when `permits` value is sufficient:
+For example, a synchronization of asynchronous tasks can 
+be done via acquiring and releasing a semaphore with a given number of permits it can spend.
+When the acquire operation cannot be performed due to no more available `permits` in the semaphore, such task 
+is semantically blocked, until the `permits` value is large enough again:
 
 ```scala mdoc:silent
 import java.util.concurrent.TimeUnit
@@ -41,8 +41,8 @@ val program = for {
 } yield ()
 ```
 
-As the binary semaphore is a special case of counting semaphore 
-we can acquire and release any value, regarding semaphore's permits:
+As the binary semaphore is a special case of a counting semaphore, 
+we can acquire and release any number of `permits`:
 
 ```scala mdoc:silent
 val semTaskN = (sem: Semaphore) => for {
@@ -50,4 +50,4 @@ val semTaskN = (sem: Semaphore) => for {
 } yield ()
 ```
 
-The guarantee of `withPermit` (and its corresponding counting version `withPermits`) is that acquisition will be followed by equivalent release, regardless of whether the task succeeds, fails, or is interrupted.
+The guarantee of `withPermit` (and its corresponding counting version `withPermits`) is that each acquisition will be followed by the equivalent number of releases, regardless of whether the task succeeds, fails, or is interrupted.

--- a/docs/datatypes/fiber/fiber.md
+++ b/docs/datatypes/fiber/fiber.md
@@ -1,11 +1,12 @@
 ---
 id: fiber
+slug: fiber.md
 title: "Fiber"
 ---
 
 To perform an effect without blocking the current process, we can use fibers, which are a lightweight concurrency mechanism.
 
-We can `fork` any `IO[E, A]` to immediately yield an `UIO[Fiber[E, A]]`. The provided `Fiber` can be used to `join` the fiber, which will resume on production of the fiber's value, or to `interrupt` the fiber, which immediately terminates the fiber and safely releases all resources acquired by the fiber.
+We can `fork` any `ZIO[R, E, A]` to immediately yield an `URIO[R, Fiber[E, A]]`. The provided `Fiber` can be used to `join` the fiber, which will resume on production of the fiber's value, or to `interrupt` the fiber, which immediately terminates the fiber and safely releases all resources acquired by the fiber.
 
 ```scala mdoc:invisible
 import zio._
@@ -36,9 +37,9 @@ val analyzed =
 ## Operations
 
 ### fork and join
-Whenever we need to start a fiber, we have to `fork` an effect, it gives us a fiber. It is similar to the `start` method on Java thread or submitting a new thread to the thread pool in Java, it is the same idea. Also, joining is a way of waiting for that fiber to compute its value. We are going to wait until it's done.
+Whenever we need to start a fiber, we have to `fork` an effect to get a new fiber. This is similar to the `start` method on Java thread or submitting a new thread to the thread pool in Java, it is the same idea. Also, joining is a way of waiting for that fiber to compute its value. We are going to wait until it's done and receive its result.
 
-In the following example, we are going to run sleep and printing on a separate fiber and at the end, waiting for that fiber to compute its value:
+In the following example, we create a separate fiber to output a delayed print message and then wait for that fiber to succeed with a value:
 
 ```scala mdoc:silent
 import zio._
@@ -52,9 +53,6 @@ for {
   _ <- printLine(s"Our fiber succeeded with $res")
 } yield ()
 ```
-
-### fork0
-A more powerful variant of `fork`, called `fork0`, allows specification of supervisor that will be passed any non-recoverable errors from the forked fiber, including all such errors that occur in finalizers. If this supervisor is not specified, then the supervisor of the parent fiber will be used, recursively, up to the root handler, which can be specified in `Runtime` (the default supervisor merely prints the stack trace).
 
 ### forkDaemon
 
@@ -84,10 +82,10 @@ val myApp = for {
 ```
 
 ### interrupt
-Whenever we want to get rid of our fiber, we can simply call interrupt on that. The interrupt operation does not resume until the fiber has completed or has been interrupted and all its finalizers have been run. These precise semantics allow construction of programs that do not leak resources.
+Whenever we want to get rid of our fiber, we can simply call `interrupt` on that. The interrupt operation does not resume until the fiber has completed or has been interrupted and all its finalizers have been run. These precise semantics allow construction of programs that do not leak resources.
 
 ### await
-To inspect whether our fiber succeeded or failed, we can call `await` on fiber. if we call `await` it will wait for that fiber to terminate, and it will give us back the fiber's value as an `Exit`. That exit value could be failure or success. 
+To inspect whether our fiber succeeded or failed, we can call `await` on that fiber. This call will wait for that fiber to terminate, and it will give us back the fiber's value as an `Exit`. That exit value could be failure or success:
 
 ```scala mdoc:silent
 import zio.Console._
@@ -103,7 +101,7 @@ for {
 } yield ()
 ```
 
-The `await` is similar to join but lower level than join. When we call join if the underlying fiber failed then our attempt to join it will also fail with the same error.  
+`await` is similar to `join`, but they react differently to errors and interruption: `await` always succeeds with `Exit` information, even if the fiber fails or is interrupted. In contrast to that, `join` on a fiber that fails will itself fail with the same error as the fiber, and `join` on a fiber that is interrupted will itself become interrupted.
 
 ### Parallelism
 To execute actions in parallel, the `zipPar` method can be used:
@@ -127,7 +125,7 @@ The `zipPar` combinator has resource-safe semantics. If one computation fails, t
 
 ### Racing
 
-Two `IO` actions can be *raced*, which means they will be executed in parallel, and the value of the first action that completes successfully will be returned.
+Two actions can be *raced*, which means they will be executed in parallel, and the value of the first action that completes successfully will be returned.
 
 ```scala
 fib(100) race fib(200)
@@ -154,9 +152,9 @@ def fib(n: Int): UIO[Int] =
 ```
 
 ## Error Model
-The `IO` error model is simple, consistent, permits both typed errors and termination, and does not violate any laws in the `Functor` hierarchy.
+The `ZIO` error model is simple, consistent, permits both typed errors and termination, and does not violate any laws in the `Functor` hierarchy.
 
-An `IO[E, A]` value may only raise errors of type `E`. These errors are recoverable by using the `either` method.  The resulting effect cannot fail, because the failure case has been exposed as part of the `Either` success case.  
+A `ZIO[R, E, A]` value may only raise errors of type `E`. These errors are recoverable by using the `either` method.  The resulting effect cannot fail, because the failure case has been exposed as part of the `Either` success case.  
 
 ```scala mdoc:silent
 val error: Task[String] = IO.fail(new RuntimeException("Some Error"))
@@ -167,28 +165,28 @@ Separately from errors of type `E`, a fiber may be terminated for the following 
 
 * **The fiber self-terminated or was interrupted by another fiber**. The "main" fiber cannot be interrupted because it was not forked from any other fiber.
 
-* **The fiber failed to handle some error of type `E`**. This can happen only when an `IO.fail` is not handled. For values of type `UIO[A]`, this type of failure is impossible.
+* **The fiber failed to handle some error of type `E`**. This can happen only when an `ZIO.fail` is not handled. For values of type `UIO[A]`, this type of failure is impossible.
 
 * **The fiber has a defect that leads to a non-recoverable error**. There are only two ways this can happen:
 
      1. A partial function is passed to a higher-order function such as `map` or `flatMap`. For example, `io.map(_ => throw e)`, or `io.flatMap(a => throw e)`. The solution to this problem is to not to pass impure functions to purely functional libraries like ZIO, because doing so leads to violations of laws and destruction of equational reasoning.
-     2. Error-throwing code was embedded into some value via `IO.succeed`, etc. For importing partial effects into `IO`, the proper solution is to use a method such as `IO.attempt`, which safely translates exceptions into values.
+     2. Error-throwing code was embedded into some value via `ZIO.succeed`, etc. For importing partial effects into `ZIO`, the proper solution is to use a method such as `ZIO.attempt`, which safely translates exceptions into values.
 
 When a fiber is terminated, the reason for the termination, expressed as a `Throwable`, is passed to the fiber's supervisor, which may choose to log, print the stack trace, restart the fiber, or perform some other action appropriate to the context.
 
 A fiber cannot stop its own interruption. However, all finalizers will be run during termination, even when some finalizers throw non-recoverable errors. Errors thrown by finalizers are passed to the fiber's supervisor.
 
-There are no circumstances in which any errors will be "lost", which makes the `IO` error model more diagnostic-friendly than the `try`/`catch`/`finally` construct that is baked into both Scala and Java, which can easily lose errors.
+There are no circumstances in which any errors will be "lost", which makes the `ZIO` error model more diagnostic-friendly than the `try`/`catch`/`finally` construct that is baked into both Scala and Java, which can easily lose errors.
 
 ## Fiber Interruption
 
-In Java, a thread can be interrupted via `Thread#interrupt` via another thread, but it may don't respect the interruption request. Unlike Java, in ZIO when a fiber interrupts another fiber, we know that the interruption occurs, and it always works.
+In Java, a thread can be interrupted via `Thread#interrupt` from another thread, but it may refuse the interruption request and continue processing. Unlike Java, in ZIO when a fiber interrupts another fiber, we know that the interruption occurs, and it always works.
 
 When working with ZIO fibers, we should consider these notes about fiber interruptions:
 
 ### Interruptible/Uninterruptible Regions
 
-All fibers are interruptible by default. To make an effect uninterruptible we can use `Fiber#uninterruptible`, `ZIO#uninterruptible` or `ZIO.uninterruptible`. We have also interruptible versions of these methods to make an uninterruptible effect, interruptible.
+All fibers are interruptible by default. To make an effect uninterruptible we can use `Fiber#uninterruptible`, `ZIO#uninterruptible` or `ZIO.uninterruptible`. ZIO provides also the reverse direction of these methods to make an uninterruptible effect interruptible.
 
 ```scala mdoc:silent:nest
 for {
@@ -205,7 +203,7 @@ Note that there is no way to stop interruption. We can only delay it, by making 
 
 ### Fiber Finalization on Interruption
 
-When a fiber done its work or even interrupted, the finalizer of that fiber is guaranteed to be executed:
+When a fiber has done its work or has been interrupted, the finalizer of that fiber is guaranteed to be executed:
 
 ```scala mdoc:silent:nest
 for {
@@ -224,11 +222,11 @@ for {
 } yield ()
 ```
 
-The `release` action may take some time freeing up resources. So it may slow down the fiber's interruption.
+In the above example, the release action takes some time for freeing up resources. So it slows down the call to `interrupt` the fiber.
 
 ### Fast Interruption
 
-As we saw in the previous section, the ZIO runtime gets stuck on interruption task until the fiber's finalizer finishes its job. We can prevent this behavior by using `ZIO#disconnect` or `Fiber#interruptFork` which perform fiber's interruption in the background or in separate daemon fiber:
+As we saw in the previous section, the ZIO runtime gets stuck on interruption until the fiber's finalizer finishes its job. We can prevent this behavior by using `ZIO#disconnect` or `Fiber#interruptFork` which perform fiber's interruption in the background or in separate daemon fiber:
 
 Let's try the `Fiber#interruptFork`:
 
@@ -251,7 +249,7 @@ for {
 
 ### Interrupting Blocking Operations
 
-The `zio.blocking.effectBlocking` is interruptible by default, but its interruption will not translate to the JVM thread interruption. Instead, we can use `zio.blocking.effectBlockingInterruptible` method. By using `effectBlockingInterruptible` method if that effect is interrupted, it will translate the ZIO interruption to the JVM thread interruption. ZIO has a comprehensive guide about blocking operations at [here](../core/zio/zio.md#blocking-operations).
+The `ZIO#attemptBlocking` is interruptible by default, but its interruption will not translate to JVM thread interruption. Instead, we can use `ZIO#attemptBlockingInterrupt` to translate the ZIO interruption of that effect into JVM thread interruption. For details and examples on interrupting blocking operations see [here](../core/zio/#blocking-operations).
 
 ### Automatic Interruption
 
@@ -261,13 +259,13 @@ If we never _cancel_ a running effect explicitly, ZIO performs **automatic inter
 
 2. **Parallelism** — If one effect fails during the execution of many effects in parallel, the others will be canceled. Examples include `foreachPar`, `zipPar`, and all other parallel operators.
 
-3. **Timeouts** — If a running effect being timed out has not been completed in the specified amount of time, then the execution is canceled.
+3. **Timeouts** — If a running effect with a `timeout` has not been completed in the specified amount of time, then the execution is canceled.
 
-4. **Racing** — The loser of a race, if still running, is canceled.
+4. **Racing** — The loser of a `race`, if still running, is canceled.
 
 ### Joining an Interrupted Fiber
 
-We can join an interrupted fiber, which will cause our fiber to become interrupted. And this process does not inhibit finalization. So, **ZIO's concurrency model respect brackets even we are going to _join_ an interrupted fiber**:
+We can join an interrupted fiber, which will cause our fiber to become interrupted. This process preserves the proper finalization of the caller. So, **ZIO's concurrency model respects brackets even when we _join_ an interrupted fiber**:
 
 ```scala mdoc:silent:nest
 val myApp =
@@ -287,43 +285,43 @@ val myApp =
 A fiber that is interrupted because of joining another interrupted fiber will properly finalize; this is a distinction between ZIO and the other effect systems, which _deadlock_ the joining fiber.
 
 ## Thread Shifting - JVM
-By default, fibers make no guarantees as to which thread they execute on. They may shift between threads, especially as they execute for long periods of time.
+By default, fibers give no guarantees as to which thread they execute on. They may shift between threads, especially as they execute for long periods of time.
 
 Fibers only ever shift onto the thread pool of the runtime system, which means that by default, fibers running for a sufficiently long time will always return to the runtime system's thread pool, even when their (asynchronous) resumptions were initiated from other threads.
 
 For performance reasons, fibers will attempt to execute on the same thread for a (configurable) minimum period, before yielding to other fibers. Fibers that resume from asynchronous callbacks will resume on the initiating thread, and continue for some time before yielding and resuming on the runtime thread pool.
 
-These defaults help guarantee stack safety and cooperative multitasking. They can be changed in `Runtime` if automatic thread shifting is not desired.
+These defaults help to guarantee stack safety and cooperative multitasking. They can be changed in `Runtime` if automatic thread shifting is not desired.
 
-## Type of Workloads
-Let's discuss the type of workloads that a fiber can handle. There are three types of workloads that a fiber can handle:
-1. **CPU Work/Pure CPU Bound** is a computation that uses the computational power of a CPU intensively and purely, without exceeding the computation boundary. By intensive, means a huge chunk of work which involves a significant amount of time to computed by CPU, e.g. complex numerical computation.
-2. **Blocking I/O** is a computation, which exceeds the computational boundary by doing communication in a blocking fashion. For example, waiting for a certain amount of time to elapse or waiting for an external event to happen are blocking I/O operations.
-3. **Asynchronous I/O** is a computation, which exceeds the computation boundary by doing communication asynchronously, e.g. registering a callback for a specific event.
+## Types of Workloads
+Let's discuss the types of workloads that a fiber can handle. There are three types of them:
+1. **CPU Work/Pure CPU Bound** is a workload that exploits the processing power of a CPU for pure computations of a huge chunk of work, e.g. complex numerical computations.
+4. **Blocking I/O** is a workload that goes beyond pure computation by doing communication in a blocking fashion. For example, waiting for a certain amount of time to elapse or waiting for an external event to happen are blocking I/O operations.
+5. **Asynchronous I/O** is a workload that goes beyond pure computation by doing communication asynchronously, e.g. registering a callback for a specific event.
 
 ### CPU Work
 What we refer to as CPU Work is pure computational firepower without involving any interaction and communication with the outside world. It doesn't involve any I/O operation. It's a pure computation. By I/O, we mean anything that involves reading from and writing to an external resource such as a file or a socket or web API, or anything that would be characterized as I/O. 
 
-Fibers are designed to be **cooperative** which means that **they will yield to each other as required to preserve some level of fairness**. If we have a fiber that's is doing CPU Work which passes through one or more ZIO operations such as flatMap or map, as long as there exists a touchpoint where the ZIO runtime system can sort of keep a tab on that ongoing CPU Work then that fiber will yield to other fibers. These touchpoints allow many fibers who are doing CPU Work to end up sharing the same thread.
+Fibers are designed to be **cooperative** which means that **they will yield to each other as required to preserve some level of fairness**. If we have a fiber that is doing CPU Work which passes through one or more ZIO operations such as `flatMap` or `map`, as long as there exists a touchpoint where the ZIO runtime system can sort of keep a tab on that ongoing CPU Work then that fiber will yield to other fibers. These touchpoints allow many fibers who are doing CPU Work to end up sharing the same thread.
 
-What if though, we have a CPU Work operation that takes a really long time to run? Let's say 30 seconds or something it does pure CPU Work very computationally intensive? What happens if we take that single gigantic function and put that into a `ZIO.attempt`? So there is no way for the ZIO Runtime that can force that fiber to yield to other fibers. In this situation, the ZIO Runtime cannot preserve some level of fairness, and that single big CPU operation monopolizes the underlying thread. It is not a good practice to monopolize the underlying thread.
+What if though, we have a CPU Work operation that takes a really long time to run? Let's say 30 seconds it does pure CPU Work very computationally intensive? What happens if we take that single gigantic function and put that into a `ZIO#attempt`? In that case there is no way for the ZIO Runtime to force that fiber to yield to other fibers. In this situation, the ZIO Runtime cannot preserve some level of fairness, and that single big CPU operation monopolizes the underlying thread. It is not a good practice to monopolize the underlying thread.
 
-ZIO has a special thread pool that can be used to do these computations. That's the **blocking thread pool**. There is a `ZIO.blocking._` package that contains an operator called `blocking`, which can be used to run a big CPU Work on a dedicated thread. So, it doesn't interfere with all the other work that is going on simultaneously in the ZIO Runtime system.
+ZIO has a special thread pool that can be used to do these computations. That's the **blocking thread pool**. The `ZIO#blocking` operator and its variants (see [here](../core/zio/#blocking-operations)) can be used to run a big CPU Work on a dedicated thread. So, it doesn't interfere with all the other work that is going on simultaneously in the ZIO Runtime system.
 
 If a CPU Work doesn't yield quickly, then that is going to monopolize a thread. So how can we determine that our CPU Work can yield quickly or not? 
-- If we wrote that CPU Work by composing many ZIO operations, even that CPU Work is very CPU intensive, due to the composition of ZIO operations, it has a chance to yield quickly to other fibers and don't monopolizing a thread.
-- If that CPU work doesn't compose any ZIO operation, or we lift that from a legacy library, the ZIO Runtime doesn't have any chance of yielding quickly to other fibers. So this fiber going to monopolize the underlying thread.
+- If that overall CPU Work composes many ZIO operations, then due to the composition of ZIO operations, it has a chance to yield quickly to other fibers and doesn't monopolize a thread.
+- If that CPU work doesn't compose any ZIO operations, or we lift that from a legacy library, then the ZIO Runtime doesn't have any chance of yielding quickly to other fibers. So this fiber is going to monopolize the underlying thread.
 
-The best practice is to run those huge CPU Work on a dedicated thread pool, by lifting them with the `blocking` operator in the `ZIO.blocking` package.
+The best practice is to run those huge CPU Work on a dedicated thread pool, by lifting them with `ZIO#blocking`.
 
 > **Note**:
 >
-> So as a rule of thumb, when we have a huge CPU Work that is not chunked with built-in ZIO operations and going to monopolize the underlying thread, we should run that on a dedicated thread pool that is designed to perform CPU-driven tasks.
+> So as a rule of thumb, when we have a huge CPU Work that is not chunked with built-in ZIO operations, and thus going to monopolize the underlying thread, we should run that on a dedicated thread pool that is designed to perform CPU-driven tasks.
 
 ### Blocking I/O
-Inside Java, there are many methods that we can call them that will put our thread to sleep. For example, if we call `read` on a socket and there is nothing to read right now because not enough bytes have been read from the other side over the TCP/IP protocol, then that will put our thread to sleep. 
+Inside Java, there are many methods that will put our thread to sleep. For example, if we call `read` on a socket and there is nothing to read right now because not enough bytes have been read from the other side over the TCP/IP protocol, then that will put our thread to sleep. 
 
-Most of the I/O operations and certainly all the classic I/O operations like `InputStream` and `OutputStream` are utilizing a locking mechanism that will parks a thread. When we `write` to the `OutputStream`, actually before the data has been written to that file, that method will just `block` it, and it will `park` the thread. The thread will `wait` until the data can actually be written and after it is actually written then it can return. It is the same way for `read` and similar blocking operations. Anytime we use a `lock`, anything in `java.util.concurrent.locks`, all those locks use this mechanism. All these operations are called blocking because they `park` the thread that is doing the work, and the thread that's doing the work goes to sleep.
+Most of the I/O operations and certainly all the classic I/O operations like `InputStream` and `OutputStream` are utilizing a locking mechanism that will `park` a thread. When we `write` to `OutputStream`, this method will `park` the thread and `wait` until the data has actually been written to file. It is the same way for `read` and similar blocking operations. Anytime we use a `lock`, anything in `java.util.concurrent.locks`, all those locks use this mechanism. All these operations are called blocking because they `park` the thread that is doing the work, and the thread that's doing the work goes to sleep.
 
 > _**Note:**_ 
 >
@@ -333,50 +331,49 @@ There are multiple types of overhead associated with parking a thread:
 
 1. When we `park` a thread then that thread is still consuming resources, it's still obviously consuming stack resources, the heap, and all metadata associated with the underlying thread in the JVM.
 
-2. Then even further down deeper, in the operating system because every JVM thread corresponds to an operating system level thread, there's a large amount of overhead. Every thread has a pre-allocated stack size so that memory is reserved even if that thread's not doing any work. That memory is sort of reserved for the thread, and we cannot touch it. 
+2. Since every JVM thread corresponds to an operating system level thread, there's a large amount of overhead even inside the operating system. Every thread has a pre-allocated stack size so that memory is reserved even if that thread is not doing any work. That memory is sort of reserved for the thread, and we cannot touch it. 
 
 3. Besides, the actual process of putting a thread to sleep and then later waking it up again is computationally intensive. It slows down our computations.
 
-This is why it has become a sort of best practice and part of the architectural pattern of reactive applications to design what is called **non-blocking application**. Non-blocking is synonymous with asynchronous. Non-blocking and asynchronous and to some degree even reactive, they're all trying to get at something which is we want scalable applications.
+This is why it has become a sort of best practice and part of the architectural pattern of reactive applications to design what is called **non-blocking application**. Non-blocking is synonymous with asynchronous. Non-blocking and asynchronous and to some degree even reactive, they're all trying to get at something which is what we want: scalable applications.
 
-Scalable applications cannot afford to have thousands of threads just sitting around doing nothing and just consuming work and taking a long time to wake up again. We cannot do so-called blocking I/O, in scalable applications. It is considered an anti-pattern because it is not efficient. That is not a way to build scalable applications and nonetheless, we have to support that use case. 
+Scalable applications cannot afford to have thousands of threads just sitting around doing nothing and just consuming work and taking a long time to wake up again. We cannot do blocking I/O in scalable applications. It is considered an anti-pattern because it is not efficient. That is not a way to build scalable applications, but nonetheless, we have to support that use case.
 
 Today, we have lots of common Java libraries that use blocking constructs, like `InputStream` and `OutputStream`, and `Reader` and `Writer`. Also, the JDBC is entirely blocking. The only way of doing database I/O in Java is blocking. So obviously, we have to do blocking I/O. We can do blocking I/O from a fiber. So is it best practice? No, it should be avoided whenever possible, but the reality is we have to do blocking I/O. 
 
-Whenever we lift a blocking I/O operation into ZIO, the ZIO Runtime is executing a fiber that is doing blocking I/O. The underlying thread will be parked, and it has to be woken up later. It doesn't have any ability to stop from happening. It can't stop an underlying thread from being parked that's just the way these APIs are designed. So, we have to block. There's no way around that. That fiber will be monopolizing the underneath thread and therefore that thread is not available for performing all the work of the other fibers in the system. So that can be a bottleneck point in our application. 
+Whenever we lift a blocking I/O operation into ZIO, the ZIO Runtime is executing a fiber that is doing blocking I/O. The underlying thread will be parked, and it has to be woken up later. It doesn't have any ability to avoid this. It can't stop an underlying thread from being parked. That's just the way these APIs are designed. So, we have to block. There's no way around that. That fiber will be monopolizing the underneath thread and therefore that thread is not available for performing all the work of the other fibers in the system. So that can be a bottleneck point in our application. 
 
-And again, the solution to this problem is the same as the solution to the first class of problems, the CPU Work. The solution is to run this **using the blocking thread pool** in ZIO which will ensure that this blocking code executes on its dedicated thread pool. **So it doesn't have to interfere or compete with the threads that are used for doing the bulk of work in your application**. So basically ZIO's philosophy is if we have to do CPU Work or if we have to do synchronous that's ok we can do that. Just we need to do it in the right place. So it doesn't interfere with our primary thread pool.
+And again, the solution to this problem is the same as the solution to the first class of problems, the CPU Work. The solution is to run this action **using the blocking thread pool** in ZIO which will ensure that this blocking code executes on its dedicated thread pool. **So it doesn't interfere or compete with the threads that are used for doing the bulk of work in your application**. So basically ZIO's philosophy is that if we _have_ to do CPU Work or blocking synchronous work that's ok we can do that. Just we need to do it in the right place. So it doesn't interfere with our primary thread pool.
 
 ZIO has one primary built-in fixed thread pool. This sort of workhorse thread pool is designed to be used for the majority of our application requirements. It has a certain number of threads in it and that stays constant over the lifetime of our application.
 
 Why is that the case? Well because for the majority of workloads in our applications, it does not actually help things to create more threads than the number of CPU cores. If we have eight cores, it does not accelerate any sort of processing to create more than eight threads. Because at the end of the day our hardware is only capable of running eight things at the same time. 
 
-If we create a thousand threads on a system that can only run eight of them in parallel at a time, then what does the operating system have to do? As we have not as much as the needed CPU core, the operating system starts giving a little slice of the eight core to all these threads by switching between them over and over again.
+If we create a thousand threads on a system that can only run eight of them in parallel at a time, then what does the operating system do? As we have not enough CPU cores, the operating system starts giving a little slice of the eight cores to all these threads by switching between them over and over again.
 
-The context switching overhead is significant. The CPU has to load in new registers, refill all its caches, it has to go through all these crazy complex processes that interfere with its main job to get stuff done. There's significant overhead associated with that. As a result, it's not going to be very efficient. We are going to waste a lot of our time and resources just switching back and forth between all these threads, that would kill our application.
+The overhead for context switching between threads is significant. The CPU has to load in new registers, refill all its caches, it has to go through all these crazy complex processes that interfere with its main job to get stuff done. There's significant overhead associated with that. As a result, it's not going to be very efficient. We are going to waste a lot of our time and resources just switching back and forth between all these threads, that would kill our application.
 
 So for that reason, ZIO's default thread pool is fixed with a number of threads equal to the number of CPU cores. That is the best practice. That means that no matter how much work we create if we create a hundred thousand fibers, they will still run on a fixed number of threads.
 
 Let's say we do blocking I/O on the main ZIO thread pool, so we have got eight threads all sitting and parked on a socket read. What happens to all the other 100000 fibers in our system? They line up in a queue waiting for their chance to run. That's not ideal. That's why we should take these effects that either do blocking I/O, or they do big CPU Work that's not chunked and run them using ZIO's blocking thread pool which will give us a dedicated thread. 
 
-That dedicated thread is not efficient but again, sometimes we have to interact with legacy code and legacy code is full of all blocking codes. We just need to be able to handle that gracefully and ZIO‌ does that using the blocking thread pool.
+That dedicated thread is not efficient, but again, sometimes we have to interact with legacy code and legacy code is full of blocking code. We just need to be able to handle that gracefully and ZIO does that using the blocking thread pool.
 
 ### Asynchronous I/O
-The third category is asynchronous I/O, and we refer to it as Async Work. Async Work is a code that whenever it runs into something that it needs to wait on, instead of blocking and parking the thread, it registers a callback, and returns immediately.
+The third category is asynchronous I/O, and we refer to it as Async Work. Async Work is code that whenever it runs into something that it needs to wait on, instead of blocking and parking the thread, it registers a callback, and returns immediately.
 
- It allows us to register a callback and then when that result is available then our callback will be invoked. Callbacks are the fundamental way by which all async code on the JVM works. There is no mechanism in the JVM right now to support async code natively and once that would probably happen in the Loom project, in the future, and will simplify a lot of things.
+ It allows us to register a callback and when that result is available then our callback will be invoked. Callbacks are the fundamental way by which all async code on the JVM works. There is no mechanism in the JVM right now to support async code natively, but once that would happen in the future, probably in the Loom project, it will simplify a lot of things.
 
-But for now, in current days, sort of JVM all published JVM versions there's no such thing. The only way we can get a non-blocking async code is to have this callback registering mechanism. 
+But for now, in current days, sort of all published JVM versions have no such thing. The only way we can get a non-blocking async code is to have this callback registering mechanism.
 
-Callbacks have the pro that they don't wait for CPU. Instead of waiting to read the next chunk from a socket or instead of waiting to acquire a lock, all we have to do is call it and give it a callback. It doesn't need to do anything else it can return control to the thread pool and then later on when that data has been read from the socket or when that lock has been acquired or when that amount of time has elapsed if we're sleeping for a certain amount of time then our callback can be invoked. 
+Callbacks have the pro that they don't wait for CPU. Instead of waiting to read the next chunk from a socket or instead of waiting to acquire a lock, all we have to do is call it and give it a callback. It doesn't need to do anything else. It can return control to the thread pool and then later on when that data has been read from the socket or when that lock has been acquired or when that amount of time has elapsed if we're sleeping for a certain amount of time, then our callback can be invoked. 
 
-It has the potential to be extraordinarily efficient. The drawback of callbacks is they are not so pretty and fun to work with. They don't compose well with try-finally constructs. Error handling is really terrible, we have to do error propagation on our own. So that is what gave rise to data types like `Future` which eliminates the need for callbacks. By using `Future`s we can wrap callback-based APIs and get the benefits of async but without the callbacks. Also, it has a for-comprehension that we can structure our code as a nice linear sequence. 
+It has the potential to be extraordinarily efficient. The drawback of callbacks is they are not so pretty and fun to work with. They don't compose well with `try` / `finally` constructs. Error handling is really terrible, we have to do error propagation on our own. So that is what gave rise to data types like `Future` which eliminates the need for callbacks. By using `Future`s we can wrap callback-based APIs and get the benefits of async but without the callbacks. Also, it supports for-comprehension, so we can structure our code as a nice linear sequence. 
 
-Similarly in ZIO we never see a callback with ZIO, but fundamentally everything boils down to asynchronous on the JVM in a callback fashion. Callback base code is obscenely efficient but it is extraordinarily painful to deal with directly. Data types like `Future` and `ZIO` allow us to avoid even seeing a callback in our code. 
+Similarly, in ZIO we never see a callback with ZIO, but fundamentally everything boils down to asynchronous operations on the JVM in a callback fashion. Callback base code is obscenely efficient, but it is extraordinarily painful to deal with directly. Data types like `Future` and `ZIO` allow us to avoid even seeing a callback in our code. 
 
-With ZIO, we do not have to think about a callback nonetheless sometimes when we need to integrate with legacy code. ZIO has an appropriate constructor to turn that ugly callback-based API into a ZIO effect. It is the `async` constructor.
+With ZIO, we do not have to think about callbacks, unless sometimes, when we need to integrate with legacy code. ZIO has an appropriate constructor to turn that ugly callback-based API into a ZIO effect. It is the `async` constructor.
 
-Every time we do one of ZIO blocking operations it doesn't actually block the underlying thread, but also it is a semantic blocking managed by ZIO. For example, every time we see something like `ZIO.sleep` or when we take something from a queue (`queue.take`) or offer something to a queue (`queue.offer`) or if we acquire a permit from a semaphore (`semaphore.withPermit`) and so forth, we are blocking semantically. If we use the same stuff in Java, like `Thread.sleep` or any of its `lock` machinery then those things are going to block a thread. So this is why we say ZIO is 100% blocking but the Java thread is not.
+Most of the ZIO operations that one would expect to be blocking do actually not block the underlying thread, but they offer blocking semantics managed by ZIO. For example, every time we see something like `ZIO.sleep` or when we take something from a queue (`queue.take`) or offer something to a queue (`queue.offer`) or if we acquire a permit from a semaphore (`semaphore.withPermit`) and so forth, we are just blocking semantically without actually blocking an underlying thread. If we use the corresponding methods in Java, like `Thread.sleep` or any of its `lock` machinery, then those methods are going to block a thread. So this is why we say that ZIO is 100% non-blocking, while Java threads are not.
 
-All of the pieces of machinery ZIO gives us are 100% asynchronous and non-blocking. As they don't block and monopolize the thread, all of the async work is executed on the primary thread pool in ZIO.
-
+All of the pieces of machinery that ZIO gives us are 100% asynchronous and non-blocking. As they don't block and monopolize the thread, all of the async work is executed on the primary thread pool in ZIO.

--- a/docs/datatypes/fiber/fiberid.md
+++ b/docs/datatypes/fiber/fiberid.md
@@ -3,5 +3,6 @@ id: fiberid
 title: "FiberId"
 ---
 
-The identity of a [Fiber](fiber.md), described by the time it began life (`startTimeMillis`), and a monotonically increasing sequence number generated from an atomic counter (`seqNumber`).
-
+`FiberId` is the identity of a [Fiber](fiber.md), described by a globally unique sequence number and the time when it began life:
+  * `id` — unique monotonically increasing sequence number `0,1,2,...`, derived from an atomic counter
+  * `startTimeSeconds` — UTC time seconds, derived from `java.lang.System.currentTimeMillis / 1000`

--- a/docs/datatypes/fiber/fiberstatus.md
+++ b/docs/datatypes/fiber/fiberstatus.md
@@ -3,9 +3,9 @@ id: fiberstatus
 title: "Fiber.Status"
 ---
 
-`Fiber.Status` describe the current status of a [Fiber](fiber.md).
+`Fiber.Status` describes the current status of a [Fiber](fiber.md).
 
-Each fiber can be in one of the following statues:
+Each fiber can be in one of the following status:
 - Done
 - Finishing
 - Running

--- a/docs/datatypes/fiber/index.md
+++ b/docs/datatypes/fiber/index.md
@@ -3,87 +3,85 @@ id: index
 title: "Introduction"
 ---
 
-A Fiber can be thought of as a virtual thread. A Fiber is the analog of a Java thread (`java.lang.thread`), but it performs much better. Fibers, on the other hand, are implemented in such a fashion that a single JVM thread will end up executing many fibers. We can think of fibers as unbounded JVM threads.
+A Fiber can be thought of as a virtual thread. A Fiber is the analog of a Java thread (`java.lang.Thread`), but it performs much better. Fibers are implemented in such a fashion that a single JVM thread will execute many fibers. We can think of fibers as unbounded JVM threads.
 
-> _**Warning**, if you are not an advanced programmer:_
+> **Warning** if you are not an experienced ZIO programmer:
 >
-> You should avoid fibers. If you can avoid fibers, then do it. ZIO gives you many concurrent primitives like `raceWith`, `zipPar`, `foreachPar`, and so forth, which allows you to avoid using fibers directly.
+> You should avoid using fibers manually. ZIO gives you many concurrent primitives like `raceWith`, `zipPar`, `foreachPar`, and so forth, which utilize fibers under the hood without any manual effort required.
 >
-> Fibers just like threads are low-level constructs. It's not generally recommended for an average programmer to manually use fibers. It is very easy to make lots of mistakes or to introduce performance problems by manually using them.
+> Fibers, just like threads, are low-level constructs. It's not generally recommended to deal with them in your code directly. It is very easy to make lots of mistakes or to introduce performance problems by manually using them.
 
 ## Why Fibers?
 
 There are some limitations with JVM threads:
 
-1. **They are scarce** — Threads on the JVM map to the operating system level threads which imposes an upper bound on the number of threads that we can have inside our application.
+1. **Threads are scarce** — Threads on the JVM map to the operating system level threads which imposes an upper bound on the number of threads that we can have inside our application.
 
-2. **Expensive on creation** — Their creation is expensive in terms of time and memory complexity.
+2. **Expensive on creation** — The creation of threads is expensive in terms of time and memory complexity.
 
-3. **Much Overhead on Context Switching** — Switching between the execution of one thread to another thread is not cheap, and it takes a lot of time.
+3. **Much Overhead on Context Switching** — Switching between the execution of one thread to another thread is not cheap, it takes a lot of time.
 
-4. **Lack of Composability** — Threads are not typed. They don't have a meaningful return type, due to this limitation, we cannot compose threads. Also, it has no type parameters for error and it is assumed if that thread started it might throw some exception of throwable type. In Java when we create a thread, we should provide a `run` function that returns void. It's a void returning method. So threads cannot finish with any specific value.
+4. **Lack of Composability** — Threads are not typed. They don't have a meaningful return type. In Java, when we create a thread, we have to provide a `run` function that returns void. So threads cannot finish with any specific value. Due to this limitation, we cannot compose threads. Also, a thread has no type parameter for error. It is expected to throw any exception of type `Throwable` to signal errors.
 
-5. **Synchronous**
-
-In the following sections, we are going to discuss the key features of fibers, and how fibers overcame Java thread drawbacks.
+In the following sections, we are going to discuss the key features of fibers, and how fibers overcome the drawbacks of Java threads.
 
 ### Unbounded Size
 
-So whereas the mapping from JVM threads to operating system threads is one-to-one, **the mapping of fiber to a thread is many-to-one**. That is to say, any JVM thread will end up executing anywhere from hundreds to thousands even tens of thousands of threads concurrently, by hopping back and forth between them as necessary. They give us virtual threads in which it has the benefits of threads but the scalability way beyond threads. In other words, fibers provide us massive concurrently with **lightweight green threading** on the JVM.
+So whereas the mapping from JVM threads to operating system threads is one-to-one, **the mapping of fibers to threads is many-to-one**. Each JVM thread will end up executing anywhere from hundreds to thousands or even tens of thousands of fibers concurrently, by hopping back and forth between them as necessary. This gives us virtual threads that have the benefits of threads, but the scalability way beyond threads. In other words, fibers offer us massive concurrent **lightweight green threading** on the JVM.
 
-As a rough rule of thumb, we can have an application with a thousand real threads. No problem, modern servers can support applications with a thousand threads. However, we cannot have an application with a hundred thousand threads, that application will die. That just won't make any progress. The JVM nor our operating system can physically support a hundred thousand threads. However, it is no problem to have a Scala application with a hundred thousand fibers that application can perform in a very high-performance fashion, and the miracle that enables that to happen is fiber.
+As a rough rule of thumb, we can have an application with a thousand real threads. No problem, modern servers can support applications with a thousand threads. However, we cannot have an application with a hundred thousand threads, that application will die. That just won't make any progress. The JVM nor our operating system can physically support a hundred thousand threads. However, it is no problem to have a Scala application with a hundred thousand fibers. Such an application can still perform in a very high-performance fashion, and the miracle that enables that to happen is fiber.
 
 ### Lightweight
 
-**JVM threads are expensive to create in order of time and memory complexity.** Also it takes a lot of time to switch between one thread of execution to another. Fibers are virtual and, and as they use **green threading**, they are considered to be **lightweight cooperative threads**, this means that fibers always _yield_ their executions to each other without the overhead of preemptive scheduling.
+**JVM threads are expensive to create in terms of time and memory complexity.** Also it takes a lot of time to switch between one thread of execution to another. In contrast to that, fibers are virtual, and as they use **green threading**, they are considered to be **lightweight cooperative threads**. This means that fibers always _yield_ their executions to each other without the overhead of preemptive scheduling.
 
 ### Asynchronous
 
-Fiber is asynchronous and, a thread is always synchronous. That is why fibers have higher scalability because they are asynchronous. Threads are not, that is why they don't scale as well.
+Fibers are asynchronous, while threads are always synchronous. That is why fibers scale better than threads.
 
 ### Typed and Composable
 
-**Fibers have typed error and success values**. So actually fiber has two type parameters `E` and `A`:
+**Fibers have typed error and success values**. A fiber has two type parameters, `E` and `A`:
 
 - The `E` corresponds to the error channel. It indicates the error type with which the fiber can fail.
 
-- The `A` corresponds to the success value of the computation. That is the type with which the fiber can succeed. Whereas fibers can finish with the value of type `A`.
+- The `A` corresponds to the success value of the computation. That is the type with which the fiber can succeed.
 
-The fact, that fibers are typed allows us to write more type-safe programs. Also, it increases the compositional properties of our programs. Because we can say, we are going to wait on that fiber to finish and when it's done, we are going to get its value of type `A`.
+The fact that fibers are typed allows us to write more type-safe programs. Also, it increases the compositional properties of our programs because we can wait on a fiber to finish and then expect to receive a value of type `A`.
 
 ### Interrupt Safe
 
-With threads in Java, it is not a safe operation to terminate them, by using the stop method. The stop operation has been [deprecated](https://docs.oracle.com/javase/1.5.0/docs/guide/misc/threadPrimitiveDeprecation.html). So this is not a safe operation to force kill a thread. Instead, we should try to request an interruption to the thread, but in this case, **the thread may not respond to our request, and it may just go forever**.
+Threads in Java can be terminated via the stop method, but this is not a safe operation. The stop operation has been [deprecated](https://docs.oracle.com/javase/1.5.0/docs/guide/misc/threadPrimitiveDeprecation.html). So this is not a safe way to force kill a thread. Instead, we should try to request an interruption of the thread, but in this case, **the thread may not respond to our request, and it may just go forever**.
 
 **Fiber has a safe version of this functionality that works very well**. Just like we can interrupt a thread, we can interrupt a fiber too, but interruption of fibers is much more reliable. It will always work, and **it probably works very fast**. We don't need to wait around, we can just try to interrupt them, and they will be gone very soon.
 
 ### Structured Concurrency
 
-Until now, we find that ZIO fiber solves a lot of drawbacks of using Java threads. With fibers, we can have hundreds of thousands and even thousands of thousands of fibers are started and working together. We reached a very massive concurrently with fibers. Now how can we manage them? Some of them are top-level fibers and some others are forked and become children of their parents. How can we manage their scopes, how to keep track of all fibers, and prevent them to leak? What happens during the execution of a child fiber, the parent execution interrupted? The child fibers should be scoped to their parent fibers. We need a way to manage these scopes automatically. This is where structured concurrency shines.
+With fibers, we can have hundreds of thousands and even millions of fibers that are started and working together. So we can reach a very massive concurrency with fibers. Now how can we manage all these fibers? Some of them are top-level fibers and some others are forked and become children of their parents. How can we manage their scopes, how to keep track of all fibers, and prevent them to leak? What happens to the execution of a child fiber if its parent execution is interrupted? The child fibers should be scoped to their parent fibers. We need a way to manage these scopes automatically. This is where structured concurrency shines.
 
 > _**Important**:_
 >
-> It's worth mentioning that in the ZIO model, all codes run on the fiber. There is no such thing as code that is executing outside of the fiber. When we create a main function in ZIO that returns an effect, even if we don't explicitly fork a fiber when we execute that effect, that effect will execute on what is called the main fiber. It's a top-level fiber.
+> It's worth mentioning that in the ZIO model, all code runs on fibers. There is no such thing as code that is executed outside of fibers. When we create a main function in ZIO that returns an effect, then even if we don't explicitly fork a fiber, the effect will be executed on what is called the main fiber. It's a top-level fiber.
 >
 >It's just like if we have a main function in Java then that main function will execute on the main thread. There is no code in Java that does not execute on a thread. All code executes on a thread even if you didn't create a thread.
 
-ZIO has support for structured concurrency. The way ZIO structured concurrency works is that **the child fibers are scoped to their parent fibers** which means **when the parent effect is done running then its child's effects will be automatically interrupted**. So when we fork, and we get back a fiber, the fiber's lifetime is bound to the parent fiber, that forked it. It is very difficult to leak fibers because child fibers are guaranteed to complete before their parents.
+ZIO provides structured concurrency. The way ZIO's structured concurrency works is that **the child fibers are scoped to their parent fibers** which means that **when the parent effect finishes execution, then all childs' effects will be automatically interrupted**. So when we fork, and we get back a fiber, the fiber's lifetime is bound to the parent fiber that forked it. It is almost impossible to leak fibers because child fibers are guaranteed to complete before their parents.
 
-The structure concurrency gives us a way to reason about fiber lifespans. We can statically reason about the lifetimes of children fibers just by looking at our code. We don't need to insert complicated logic to keep track of all the child fibers and manually shut them down.
+The structured concurrency gives us a way to reason about fiber lifespans. We can statically reason about the lifetimes of children fibers just by looking at our code. We don't need to insert complicated logic to keep track of all the child fibers and manually shut them down.
 
 #### Global Lifetime
 
-Sometimes we want a child fiber to outlive the scope of the parent. what do you do in that case? well, we have another operator called `forkDaemon`. The `forkDaemon` forks the fiber as a daemon fiber. Daemon fibers can outlive their parents. They can live forever. They run in the background doing their work until they end with failure or success. This gives us a way to spawn background jobs that should just keep on going regardless of what happens to the parent.
+Sometimes we want a child fiber to outlive the scope of the parent. What can we do in that case? Well, ZIO offers an operator called `forkDaemon` which forks the fiber as a daemon fiber. Daemon fibers can outlive their parents. They can live forever. They run in the background doing their work until they end with failure or success. This gives us a way to spawn background jobs that should just keep on going regardless of what happens to the parent.
 
 #### Fine-grained Scope
 
-If we need a very flexible fine-grained control over the lifetime of a fiber there is another operator called `forkin`. We can fork a fiber inside a specific scope, when that scope is closed then the fiber will be terminated.
+If we need a very flexible fine-grained control over the lifetime of a fiber there is another operator called `forkin`. We can fork a fiber inside a specific scope, and when that scope is closed then the fiber will be terminated.
 
 ## Fiber Data Types
 
-ZIO fiber contains a few data types that can help us solve complex problems:
+ZIO fiber contains a few data types that can help us to solve complex problems:
 
 - **[Fiber](fiber.md)** — A fiber value models an `IO` value that has started running, and is the moral equivalent of a green thread.
 - **[FiberRef](fiberref.md)** — `FiberRef[A]` models a mutable reference to a value of type `A`. As opposed to `Ref[A]`, a value is bound to an executing `Fiber` only.  You can think of it as Java's `ThreadLocal` on steroids.
-- **[Fiber.Status](fiberstatus.md)** — `Fiber.Status` describe the current status of a Fiber.
-- **[FiberId](fiberid.md)** — `FiberId` describe the unique identity of a Fiber.
+- **[Fiber.Status](fiberstatus.md)** — `Fiber.Status` describes the current status of a Fiber.
+- **[FiberId](fiberid.md)** — `FiberId` describes the unique identity of a Fiber.

--- a/docs/datatypes/stm/stm.md
+++ b/docs/datatypes/stm/stm.md
@@ -1,5 +1,6 @@
 ---
 id: stm
+slug: stm.md
 title: "STM"
 ---
 

--- a/docs/datatypes/stream/stream.md
+++ b/docs/datatypes/stream/stream.md
@@ -1,5 +1,6 @@
 ---
 id: stream
+slug: stream.md
 title: "Stream"
 ---
 


### PR DESCRIPTION
This PR is a follow-up of https://github.com/zio/zio/pull/6437 and fixes several minor issues in the documentation of ZIO v2.x. In order to avoid too big PRs, this PR focuses only on the Sections `Data Types / Concurrency / {ZIO Fibers, Concurrency Primitives}`. After this PR is merged, I would continue with the next sections in a similar way.

- fixed several tiny typos, errors and formatting issues
- propose alternative formulations for some sentences that sounded wrong or clumsy to me (please review these changes carefully, since I am not a native speaker)
- there was an issue with the three documentation URLs `/next/datatypes/fiber/` and `/next/datatypes/stm/` and `/next/datatypes/stream/`. To each of these URLs, two different Markdown files were mapped on them, namely, the introduction text (`index.md`) as well as the respective content file with the same name as its directory (`fiber.md`, `stm.md`, `stream.md`, respectively). This led to the fact that only one of both respective pages, either the introduction or the content page, was publically available, but not both (!), while the navigation bar highlights both of them. These URLs are now de-duplicated for v2.x by explicitly setting the URLs of the content-pages (via docusaurus' `slug`) to `xxx.md`, thus, for example, `/next/datatypes/fiber/` now always serves the introduction, while `/next/datatypes/fiber/fiber.md` serves the content-page. By choosing the `xxx.md` slug, we don't need to modify any documentation-internal links to this page. Note that this fix brings up now three new pages that were not publically visible before (!)
- the example in `fiberref#inheritrefs` claimed that two specific effects behave identically, which was not true, since the `inheritRefs` variant sometimes fails the assertion, since due to race conditions it sometimes merges the `FiberRef`'s value before it is set from 0 to 10 by the child fiber. These examples were modified to point out the main difference between `join` and `inheritRefs`, namely, that `join` waits and merges final values, while `inheritRefs` merges current values and continues.

As before, please review the details, but also tell me if you disagree with some general attitude of this PR, so that I can adapt to your feedback (e.g. I might be too picky on inserting articles `a` and `the` here and there).