### PR TITLE
Fix Flaky Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CachedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CachedSpec.scala
@@ -1,7 +1,6 @@
 package zio
 
 import zio.test._
-import zio.test.TestAspect._
 
 object CachedSpec extends ZIOBaseSpec {
   def spec = suite("CachedSpec")(

--- a/core-tests/shared/src/test/scala/zio/CachedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CachedSpec.scala
@@ -20,7 +20,7 @@ object CachedSpec extends ZIOBaseSpec {
         value1 <- cached.get
         value2 <- ref.set(1) *> TestClock.adjust(10.seconds) *> cached.get
       } yield assertTrue(value1 == 0) && assertTrue(value2 == 1)
-    } @@ timeout(10.seconds),
+    },
     test("failed refresh doesn't affect cached value") {
       for {
         ref    <- Ref.make[Either[String, Int]](Right(0))


### PR DESCRIPTION
I have occasionally observed this test being flaky. Current hypothesis is that the timeout is too short in CI environment where test may be started but then immediately have to yield and we don't get to complete executing test before the timeout.