### PR TITLE
Fix Publishing Issue

### DIFF
--- a/docs/datatypes/core/zio/zio.md
+++ b/docs/datatypes/core/zio/zio.md
@@ -962,7 +962,11 @@ object Main extends ZIOAppDefault {
     ZIO.succeed(is.close())
 
   def convertBytes(is: FileInputStream, len: Long) =
-    Task.attempt(println(new String(is.readAllBytes(), StandardCharsets.UTF_8)))
+    Task.attempt {
+      val buffer = new Array[Byte](len.toInt)
+      is.read(buffer)
+      println(new String(buffer, StandardCharsets.UTF_8))
+    }
 
   // myAcquireRelease is just a value. Won't execute anything here until interpreted
   val myAcquireRelease: Task[Unit] = for {


### PR DESCRIPTION
`InputStream#readAllBytes` is only supported from Java 9 so it can cause publishing to fail when we use it in our documentation and release for Java 8.