### PR TITLE
Add .map operator to ZEnvironment (for single types)

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -307,6 +307,16 @@ object ZEnvironment {
       patch.asInstanceOf[Patch[Any, Any]]
   }
 
+  /**
+   * Extension methods for ZEnvironment of an R that is a single type (no
+   * intersection type), which is checked by there being a Tag[R] available.
+   */
+  implicit final class SingleEnvOps[R: Tag](private val self: ZEnvironment[R]) {
+
+    /** Maps the single type of this environment through the given function */
+    def map[ROut: Tag](f: R => ROut) = ZEnvironment(f(self.get))
+  }
+
   private lazy val TaggedAnyRef: EnvironmentTag[AnyRef] =
     implicitly[EnvironmentTag[AnyRef]]
 }


### PR DESCRIPTION
This commit adds a .map operator to ZEnvironment, for "simple" cases
where one wants to turn a ZLayer of one single type into another single
type.

In ZIO 1, the equivalent would be 
```
myLayer.map(_.someObject.subObject)
```

In current ZIO2, `ZLayer.map` expects the function to return `ZEnvironment`, so you can only write
```
myLayer.map(e => ZEnvironment(e.get.someObject.subObject))
```

This PR shortens that to
```
myLayer.map(_.map(_.someObject.subObject))
```

Potential alternative could be a specialized method on `ZLayer` itself.