### PR TITLE
Improved Assertions for TestOutput. Print ExecutionEvent when parent …

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -49,7 +49,7 @@ object ChunkSpec extends ZIOBaseSpec {
       },
       test("fromIterable size must match length") {
         val chunk = Chunk.fromIterable(List("1", "2", "3"))
-        assert(chunk.size)(equalTo(chunk.length))
+        assert(chunk.size)(equalTo(chunk.length + 5))
       },
       test("single size must match length") {
         val chunk = Chunk.single(true)

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -49,7 +49,7 @@ object ChunkSpec extends ZIOBaseSpec {
       },
       test("fromIterable size must match length") {
         val chunk = Chunk.fromIterable(List("1", "2", "3"))
-        assert(chunk.size)(equalTo(chunk.length + 5))
+        assert(chunk.size)(equalTo(chunk.length))
       },
       test("single size must match length") {
         val chunk = Chunk.single(true)

--- a/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[Live]] =
     if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
-    else Chunk(TestAspect.timeout(120.seconds))
+    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential)
 
   sealed trait ZIOTag {
     val value: String

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3625,7 +3625,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               value <- ref.get
             } yield assert(value)(equalTo(true))
           }
-        ) @@ TestAspect.timeout(15.seconds),
+        ) @@ TestAspect.timeout(40.seconds),
         suite("timeout")(
           test("succeed") {
             assertM(

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -65,6 +65,7 @@ abstract class BaseTestTask(
         case NewSpecWrapper(zioSpec) =>
           Runtime(ZEnvironment.empty, zioSpec.hook(zioSpec.runtime.runtimeConfig)).unsafeRun {
             run(eventHandler, zioSpec)
+              .tapError(e => ZIO.succeed(println(e.getMessage)))
           }
           Array()
         case LegacySpecWrapper(abstractRunnableSpec) =>

--- a/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
@@ -5,5 +5,5 @@ import zio._
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment]] =
     if (TestPlatform.isJVM) Chunk(TestAspect.timeout(60.seconds))
-    else Chunk(TestAspect.timeout(60.seconds))
+    else Chunk(TestAspect.timeout(60.seconds), TestAspect.sequential)
 }

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -46,7 +46,6 @@ object TestExecutor {
       (for {
         sink      <- ZIO.service[ExecutionEventSink]
         topParent <- SuiteId.newRandom
-        _         <- sink.process(ExecutionEvent.SectionStart(List.empty, topParent, List.empty))
         _ <- {
           def loop(
             labels: List[String],
@@ -104,9 +103,6 @@ object TestExecutor {
             loop(List.empty, scopedSpec, defExec, List.empty, topParent)
           }
         }
-        _ <- sink.process(
-               ExecutionEvent.SectionEnd(List.empty, topParent, List.empty)
-             )
 
         summary <- sink.getSummary
       } yield summary).provideLayer(sinkLayer)

--- a/test/shared/src/main/scala/zio/test/TestOutput.scala
+++ b/test/shared/src/main/scala/zio/test/TestOutput.scala
@@ -72,7 +72,8 @@ object TestOutput {
               case Some(parentId) =>
                 appendToSectionContents(parentId, sectionOutput)
               case None =>
-                ZIO.dieMessage("Suite tried to send its output to a nonexistent parent")
+                // TODO If we can't find cause of failure in CI, unsafely print to console instead of failing
+                ZIO.dieMessage("Suite tried to send its output to a nonexistent parent. ExecutionEvent: " + end)
             }
           }
 


### PR DESCRIPTION
…failure is encountered. Report failed tests in ScalaJS runner.

The Assertions in TestOutputSpec will be improved. They were already partly implemented when the parent failure showed up in CI, so I figure it's better to have them in their current state than not at all.