### PR TITLE
Make Semaphore Its Own Data Type

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -14,9 +14,9 @@ object SerializableSpec extends ZIOBaseSpec {
       val n = 20L
       for {
         semaphore   <- Semaphore.make(n)
-        count       <- semaphore.available.commit
+        count       <- semaphore.available
         returnSem   <- serializeAndBack(semaphore)
-        returnCount <- returnSem.available.commit
+        returnCount <- returnSem.available
       } yield assert(returnCount)(equalTo(count))
     },
     test("Clock is serializable") {

--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -3,7 +3,6 @@ package zio.stm
 import org.openjdk.jcstress.annotations._
 import org.openjdk.jcstress.infra.results.{II_Result, I_Result}
 import zio._
-import zio.stm._
 
 object ZSTMConcurrencyTests {
 

--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -3,6 +3,7 @@ package zio.stm
 import org.openjdk.jcstress.annotations._
 import org.openjdk.jcstress.infra.results.{II_Result, I_Result}
 import zio._
+import zio.stm._
 
 object ZSTMConcurrencyTests {
 
@@ -27,7 +28,7 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentAcquireAndInterruptDone {
     val promise: Promise[Nothing, Unit] = Promise.unsafeMake[Nothing, Unit](FiberId.None)
-    val semaphore: Semaphore            = runtime.unsafeRun(Semaphore.make(1L))
+    val semaphore: TSemaphore           = runtime.unsafeRun(TSemaphore.makeCommit(1L))
     var fiber: Fiber[Nothing, Unit]     = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
@@ -73,7 +74,7 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentAcquireAndInterruptSuspend {
     val promise: Promise[Nothing, Unit] = Promise.unsafeMake[Nothing, Unit](FiberId.None)
-    val semaphore: Semaphore            = runtime.unsafeRun(Semaphore.make(0L))
+    val semaphore: TSemaphore           = runtime.unsafeRun(TSemaphore.makeCommit(0L))
     var fiber: Fiber[Nothing, Unit]     = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
@@ -123,7 +124,7 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentWithPermit {
     val promise: Promise[Nothing, Unit] = Promise.unsafeMake[Nothing, Unit](FiberId.None)
-    val semaphore: Semaphore            = runtime.unsafeRun(Semaphore.make(1L))
+    val semaphore: TSemaphore           = runtime.unsafeRun(TSemaphore.makeCommit(1L))
     var fiber: Fiber[Nothing, Unit]     = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
@@ -163,7 +164,7 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentWithPermitScoped {
     val promise: Promise[Nothing, Unit] = Promise.unsafeMake[Nothing, Unit](FiberId.None)
-    val semaphore: Semaphore            = runtime.unsafeRun(Semaphore.make(1L))
+    val semaphore: TSemaphore           = runtime.unsafeRun(TSemaphore.makeCommit(1L))
     var fiber: Fiber[Nothing, Unit]     = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -26,7 +26,7 @@ import zio.stm.TSemaphore
  * in the acquiring fiber being suspended until the specified number of permits
  * become available.
  */
-sealed trait Semaphore {
+sealed trait Semaphore extends Serializable {
 
   /**
    * Returns the number of available permits.

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -19,11 +19,66 @@ package zio
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stm.TSemaphore
 
+/**
+ * An asynchronous semaphore, which is a generalization of a mutex. Semaphores
+ * have a certain number of permits, which can be held and released concurrently
+ * by different parties. Attempts to acquire more permits than available result
+ * in the acquiring fiber being suspended until the specified number of permits
+ * become available.
+ */
+sealed trait Semaphore {
+
+  /**
+   * Returns the number of available permits.
+   */
+  def available: UIO[Long]
+
+  /**
+   * Executes the specified workflow, acquiring a permit immediately before the
+   * workflow begins execution and releasing it immediately after the workflow
+   * completes execution, whether by success, failure, or interruption.
+   */
+  def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A]
+
+  /**
+   * Returns a scoped workflow that describes acquiring a permit as the
+   * `acquire` action and releasing it as the `release` action.
+   */
+  def withPermitScoped(implicit trace: ZTraceElement): ZIO[Scope, Nothing, Unit]
+
+  /**
+   * Executes the specified workflow, acquiring the specified number of permits
+   * immediately before the workflow begins execution and releasing them
+   * immediately after the workflow completes execution, whether by success,
+   * failure, or interruption.
+   */
+  def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A]
+
+  /**
+   * Returns a scoped workflow that describes acquiring the specified number of
+   * permits and releasing them when the scope is closed.
+   */
+  def withPermitsScoped(n: Long)(implicit trace: ZTraceElement): ZIO[Scope, Nothing, Unit]
+}
+
 object Semaphore {
 
   /**
    * Creates a new `Semaphore` with the specified number of permits.
    */
   def make(permits: => Long)(implicit trace: ZTraceElement): UIO[Semaphore] =
-    TSemaphore.make(permits).commit
+    for {
+      semaphore <- TSemaphore.makeCommit(permits)
+    } yield new Semaphore {
+      def available: UIO[Long] =
+        semaphore.available.commit
+      def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
+        semaphore.withPermit(zio)
+      def withPermitScoped(implicit trace: ZTraceElement): ZIO[Scope, Nothing, Unit] =
+        semaphore.withPermitScoped
+      def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
+        semaphore.withPermits(n)(zio)
+      def withPermitsScoped(n: Long)(implicit trace: ZTraceElement): ZIO[Scope, Nothing, Unit] =
+        semaphore.withPermitsScoped(n)
+    }
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -31,7 +31,7 @@ sealed trait Semaphore {
   /**
    * Returns the number of available permits.
    */
-  def available: UIO[Long]
+  def available(implicit trace: ZTraceElement): UIO[Long]
 
   /**
    * Executes the specified workflow, acquiring a permit immediately before the
@@ -70,7 +70,7 @@ object Semaphore {
     for {
       semaphore <- TSemaphore.makeCommit(permits)
     } yield new Semaphore {
-      def available: UIO[Long] =
+      def available(implicit trace: ZTraceElement): UIO[Long] =
         semaphore.available.commit
       def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
         semaphore.withPermit(zio)

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -54,8 +54,6 @@ package object zio
   type RefM[A] = Ref.Synchronized[A]
   val RefM: Ref.Synchronized.type = Ref.Synchronized
 
-  type Semaphore = stm.TSemaphore
-
   type ZTraceElement = Tracer.instance.Type with Tracer.Traced
 
   trait Tag[A] extends EnvironmentTag[A] {

--- a/docs/howto/migrate/migration-guide.md
+++ b/docs/howto/migrate/migration-guide.md
@@ -1306,42 +1306,7 @@ To perform the migration, after renaming these types to the newer ones (e.g. `Re
 
 ## Semaphore and TSemaphore
 
-In ZIO 1.x, we have two versions of Semaphore, `zio.Semaphore` and `zio.stm.TSemaphore`. The former is the ordinary semaphore, and the latter is the STM one.
-
-In ZIO 2.x, we removed the implementation of `zio.stm.Semaphore` and used the `TSemaphore` as its implementation. So, now the `Semaphore` uses the `TSemaphore` in its underlying. So to migrate a `Semaphore` code base to the ZIO 2.x, we just need to commit `STM` values to get back to the `ZIO` world.
-
-ZIO 1.x:
-
-```scala
-import zio._
-import zio.console.Console
-
-val myApp: ZIO[Console, Nothing, Unit] =
-  for {
-    semaphore <- Semaphore.make(4)
-    available <- ZIO.foreach((1 to 10).toList) { _ =>
-      semaphore.withPermit(semaphore.available)
-    }
-    _ <- zio.console.putStrLn(available.toString()).orDie
-  } yield ()
-```
-
-ZIO 2.x:
-
-```scala mdoc:silent:nest
-import zio._
-
-val myApp: ZIO[Any, Nothing, Unit] =
-  for {
-    semaphore <- Semaphore.make(4)
-    available <- ZIO.foreach((1 to 10).toList) { _ =>
-      semaphore.withPermit(semaphore.available.commit)
-    }
-    _ <- Console.printLine(available.toString()).orDie
-  } yield ()
-```
-
-Also, there is a slight change on `TSemaphore#withPermit` method. In ZIO 2.x, instead of accepting `STM` values, it accepts only `ZIO` values and returns the `ZIO` value.
+There is a slight change on `TSemaphore#withPermit` method. In ZIO 2.x, instead of accepting `STM` values, it accepts only `ZIO` values and returns the `ZIO` value.
 
 | `withPermit` | Input          | Output         |
 |--------------|----------------|----------------|


### PR DESCRIPTION
With recent changes in ZIO 2 `Semaphore` is now the only concurrent data structure in ZIO that is a type alias for something else (`TSemaphore`). This can lead to more complex error messages and also confuse users who do not know what they are supposed to do with the more "advanced" STM operators on `TSemaphore`. This PR adds a new `Semaphore` data type that just delegates to an underlying `TSemaphore`. This also has the advantage that we could replace it with a different implementation in the future if we wanted to.