### PR TITLE
Only Inherit FiberRefs Once

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -379,6 +379,12 @@ object FiberRefSpec extends ZIOBaseSpec {
         assertTrue(environment.get[Console] == testConsole) &&
         assertTrue(environment.get[Random] == testRandom) &&
         assertTrue(environment.get[System] == testSystem)
+    } @@ TestAspect.nonFlaky,
+    test("zipPar") {
+      for {
+        _ <- ZIO.unit.timeout(1.second) <& TestClock.adjust(1.second)
+        _ <- testClock
+      } yield assertCompletes
     } @@ TestAspect.nonFlaky
   ) @@ TestAspect.runtimeConfig(RuntimeConfigAspect.enableCurrentFiber)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -914,18 +914,12 @@ private[zio] final class FiberContext[E, A](
     @inline def complete[E0, E1, A, B](
       winner: Fiber[E0, A],
       loser: Fiber[E1, B],
-      cont: (Exit[E0, A], Fiber[E1, B]) => ZIO[R, E, C],
-      winnerExit: Exit[E0, A],
+      cont: (Fiber[E0, A], Fiber[E1, B]) => ZIO[R, E, C],
       ab: AtomicBoolean,
       cb: ZIO[R, E, C] => Any
     ): Any =
       if (ab.compareAndSet(true, false)) {
-        winnerExit match {
-          case exit: Exit.Success[_] =>
-            cb(winner.inheritRefs.flatMap(_ => cont(exit, loser)))
-          case exit: Exit.Failure[_] =>
-            cb(cont(exit, loser))
-        }
+        cb(cont(winner, loser))
       }
 
     val raceIndicator = new AtomicBoolean(true)
@@ -936,23 +930,19 @@ private[zio] final class FiberContext[E, A](
     ZIO
       .async[R, E, C](
         { cb =>
-          val leftRegister = left.unsafeAddObserverMaybe {
-            case exit0: Exit.Success[Exit[EL, A]] =>
-              complete[EL, ER, A, B](left, right, race.leftWins, exit0.value, raceIndicator, cb)
-            case exit: Exit.Failure[_] => complete(left, right, race.leftWins, exit, raceIndicator, cb)
+          val leftRegister = left.unsafeAddObserverMaybe { _ =>
+            complete(left, right, race.leftWins, raceIndicator, cb)
           }
 
           if (leftRegister ne null)
-            complete(left, right, race.leftWins, leftRegister, raceIndicator, cb)
+            complete(left, right, race.leftWins, raceIndicator, cb)
           else {
-            val rightRegister = right.unsafeAddObserverMaybe {
-              case exit0: Exit.Success[Exit[_, _]] =>
-                complete(right, left, race.rightWins, exit0.value, raceIndicator, cb)
-              case exit: Exit.Failure[_] => complete(right, left, race.rightWins, exit, raceIndicator, cb)
+            val rightRegister = right.unsafeAddObserverMaybe { _ =>
+              complete(right, left, race.rightWins, raceIndicator, cb)
             }
 
             if (rightRegister ne null)
-              complete(right, left, race.rightWins, rightRegister, raceIndicator, cb)
+              complete(right, left, race.rightWins, raceIndicator, cb)
           }
         },
         FiberId.combineAll(Set(left.fiberId, right.fiberId))


### PR DESCRIPTION
This PR addresses an issue where `FiberRef` values can be inherited twice, potentially resulting in a corruption of `FiberRef` state. The cause is the following line in the implementation of `ZIO#zipWithPar` that is evaluated when the first fiber has completed with a success value:

```scala
case Exit.Success(a) => loser.inheritRefs *> loser.join.map(f(a, _))
```

On inspection, this appears clearly erroneous. We are inheriting from the loser once in `loser.inheritRefs` and then if the loser completes successfully we are inheriting again in `join`. This is only correct if the `join` operator of the `FiberRef` is idempotent, which was not even guaranteed in ZIO 1.0 and is definitely not guaranteed in ZIO 2.0.

To address this we need to do a bit of work, because the behavior of immediately inheriting `FiberRef` values from the successful winner is built into the `RaceWith` implementation in `FiberContext`, but here we don't want to inherit `FiberRef` values until we know that the entire `zipPar` operation has been successful.

We can accomplish this by generalizing `RaceWith` slightly to provide access to both the winner and loser fibers. Then `ZIO#raceWith` and `ZIO#zipWithPar` can implement their appropriate logic for when to inherit in terms of that.