### PR TITLE
Restore DefaultTestReporterSpec cases

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -1,6 +1,5 @@
 package zio.test
 
-import zio.test.Assertion._
 import zio.test.ReportingTestUtils._
 import zio.test.TestAspect._
 
@@ -8,47 +7,45 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
 
   def spec =
     suite("DefaultTestReporterSpec")(
-      test("correctly reports a successful test") {
-        assertM(runLog(test1))(equalTo(test1Expected.mkString + reportStats(1, 0, 0)))
-      },
-      test("correctly reports a failed test") {
-        assertM(runLog(test3))(equalTo(test3Expected.mkString + "\n" + reportStats(0, 0, 1)))
-      },
-      test("correctly reports an error in a test") {
-        for {
-          log <- runLog(test4)
-        } yield assertTrue(log.contains("Test 4 Fail"))
-      },
-      test("correctly reports successful test suite") {
-        assertM(runLog(suite1))(equalTo(suite1Expected.mkString + reportStats(2, 0, 0)))
-      },
-      test("correctly reports failed test suite") {
-        assertM(runLog(suite2))(equalTo(suite2Expected.mkString + "\n" + reportStats(2, 0, 1)))
-      },
-      test("correctly reports multiple test suites") {
-        assertM(runLog(suite3))(equalTo(suite3Expected.mkString + "\n" + reportStats(4, 0, 2)))
-      },
-      test("correctly reports empty test suite") {
-        assertM(runLog(suite4))(equalTo(suite4Expected.mkString + "\n" + reportStats(2, 0, 1)))
-      },
-      test("correctly reports failure of simple assertion") {
-        assertM(runLog(test5))(equalTo(test5Expected.mkString + "\n" + reportStats(0, 0, 1)))
-      },
-      test("correctly reports multiple nested failures") {
-        assertM(runLog(test6))(equalTo(test6Expected.mkString + "\n" + reportStats(0, 0, 1)))
-      },
-      test("correctly reports labeled failures") {
-        assertM(runLog(test7))(equalTo(test7Expected.mkString + "\n" + reportStats(0, 0, 1)))
-      },
-      test("correctly reports labeled failures for assertTrue") {
-        for {
-          log <- runLog(test9)
-        } yield assertTrue(log.contains("""?? "third""""), log.contains("""?? "fourth""""))
-      },
-      test("correctly reports negated failures") {
-        assertM(runLog(test8))(equalTo(test8Expected.mkString + "\n" + reportStats(0, 0, 1)))
-      }
-      // TODO Scrutinize changed behavior for next PR
-      //     This whole Spec might disappear with the underlying Reporter
-    ) @@ silent @@ TestAspect.ignore
+      suite("reports")(
+        test("a successful test") {
+          runLog(test1).map(res => assertTrue(test1Expected == res))
+        },
+        test("a failed test") {
+          runLog(test3).map(res => test3Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("an error in a test") {
+          runLog(test4).map(log => assertTrue(log.contains("Test 4 Fail")))
+        },
+        test("successful test suite") {
+          runLog(suite1).map(res => suite1Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("failed test suite") {
+          runLog(suite2).map(res => suite2Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("multiple test suites") {
+          runLog(suite3).map(res => suite3Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("empty test suite") {
+          runLog(suite4).map(res => suite4Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("failure of simple assertion") {
+          runLog(test5).map(res => test5Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("multiple nested failures") {
+          runLog(test6).map(res => test6Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("labeled failures") {
+          runLog(test7).map(res => test7Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        },
+        test("labeled failures for assertTrue") {
+          for {
+            log <- runLog(test9)
+          } yield assertTrue(log.contains("""?? "third""""), log.contains("""?? "fourth""""))
+        },
+        test("negated failures") {
+          runLog(test8).map(res => test8Expected.map(expected => assertTrue(res.contains(expected))).reduce(_ && _))
+        }
+      )
+    ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -96,7 +96,7 @@ object ReportingTestUtils {
     withOffset(4)(
       s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
     ),
-    withOffset(4)(assertSourceLocation() + "\n\n") // TODO Check on extra newline
+    withOffset(4)(assertSourceLocation() + "\n\n")
   )
 
   def test4(implicit trace: ZTraceElement): Spec[Any, TestFailure[String], Nothing] =

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -86,17 +86,17 @@ object ReportingTestUtils {
   def test3(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
     test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
   def test3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
-    expectedFailure("Value falls within range"),
-    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
-    withOffset(2)(
+    withOffset(2)(expectedFailure("Value falls within range")),
+    withOffset(4)(s"${blue("52")} did not satisfy ${cyan("equalTo(42)")}\n"),
+    withOffset(4)(
       s"${blue("52")} did not satisfy ${cyan("(") + yellow("equalTo(42)") + cyan(" || (isGreaterThan(5) && isLessThan(10)))")}\n"
     ),
-    withOffset(2)(assertSourceLocation() + "\n\n"),
-    withOffset(2)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
-    withOffset(2)(
+    withOffset(4)(assertSourceLocation() + "\n\n"),
+    withOffset(4)(s"${blue("52")} did not satisfy ${cyan("isLessThan(10)")}\n"),
+    withOffset(4)(
       s"${blue("52")} did not satisfy ${cyan("(equalTo(42) || (isGreaterThan(5) && ") + yellow("isLessThan(10)") + cyan("))")}\n"
     ),
-    withOffset(2)(assertSourceLocation() + "\n")
+    withOffset(4)(assertSourceLocation() + "\n\n") // TODO Check on extra newline
   )
 
   def test4(implicit trace: ZTraceElement): Spec[Any, TestFailure[String], Nothing] =
@@ -171,21 +171,21 @@ object ReportingTestUtils {
     suite("Suite1")(test1, test2)
   def suite1Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedSuccess("Suite1"),
-    withOffset(2)(test1Expected),
-    withOffset(2)(test2Expected)
+    withOffset(4)(test1Expected),
+    withOffset(4)(test2Expected)
   )
 
   def suite2(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
     suite("Suite2")(test1, test2, test3)
   def suite2Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
-    expectedFailure("Suite2"),
-    withOffset(2)(test1Expected),
-    withOffset(2)(test2Expected)
+    expectedSuccess("Suite2"),
+    withOffset(4)(test1Expected),
+    withOffset(4)(test2Expected)
   ) ++ test3Expected.map(withOffset(2)(_))
 
   def suite3(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
     suite("Suite3")(suite1, suite2, test3)
-  def suite3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(expectedFailure("Suite3")) ++
+  def suite3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(expectedSuccess("Suite3")) ++
     suite1Expected.map(withOffset(2)) ++
     suite2Expected.map(withOffset(2)) ++
     Vector("\n") ++
@@ -193,10 +193,19 @@ object ReportingTestUtils {
 
   def suite4(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
     suite("Suite4")(suite1, suite("Empty")(), test3)
-  def suite4Expected(implicit trace: ZTraceElement): Vector[String] = Vector(expectedFailure("Suite4")) ++
-    suite1Expected.map(withOffset(2)) ++
-    Vector(withOffset(2)(expectedIgnored("Empty"))) ++
-    test3Expected.map(withOffset(2))
+  def suite4Expected(implicit trace: ZTraceElement): Vector[String] = {
+
+    def suite1ExpectedLocal(implicit trace: ZTraceElement): Vector[String] = Vector(
+      expectedSuccess("Suite1"),
+      withOffset(4)(test1Expected),
+      withOffset(4)(test2Expected)
+    )
+
+    Vector(expectedSuccess("Suite4")) ++
+      suite1ExpectedLocal.map(withOffset(4)) ++
+      Vector(withOffset(4)(expectedSuccess("Empty"))) ++
+      test3Expected.map(withOffset(2))
+  }
 
   def assertSourceLocation()(implicit trace: ZTraceElement): String =
     Option(trace).collect { case ZTraceElement(_, path, line) =>

--- a/test/shared/src/main/scala/zio/test/ReporterEventRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/ReporterEventRenderer.scala
@@ -7,6 +7,6 @@ object ReporterEventRenderer {
   def render(executionEvent: ExecutionEvent): Chunk[String] =
     Chunk.fromIterable(
       ConsoleRenderer
-        .render(DefaultTestReporter.render(executionEvent, false), TestAnnotationRenderer.timed)
+        .render(DefaultTestReporter.render(executionEvent, true), TestAnnotationRenderer.timed)
     )
 }


### PR DESCRIPTION
Had to relax the test expectations a bit to account for our non-deterministic ordering within suites.

Usually I would make some helper functions to reduce the size of each test, but that's not trivial since our assertions include source code line numbers generated by macros.

<img width="509" alt="Screen Shot 2022-04-03 at 10 53 26 AM" src="https://user-images.githubusercontent.com/2054940/161438961-8d572558-8a87-4ea2-9564-c56f5e679e04.png">

