### PR TITLE
Clean Up ZChannel.scoped

### DIFF
--- a/managed/shared/src/main/scala/zio/managed/package.scala
+++ b/managed/shared/src/main/scala/zio/managed/package.scala
@@ -185,12 +185,12 @@ package object managed extends ZManagedCompatPlatformSpecific {
     def managed[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone, A](m: => ZManaged[Env, OutErr, A])(
       use: A => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
     )(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-      ZChannel.scoped[Env](m.scoped)(use)
+      ZChannel.unwrapScoped[Env](m.scoped.map(use))
 
     def managedOut[R, E, A](
       m: => ZManaged[R, E, A]
     )(implicit trace: ZTraceElement): ZChannel[R, Any, Any, Any, E, A, Any] =
-      ZChannel.scopedOut[R](m.scoped)
+      ZChannel.scoped[R](m.scoped)
 
     def unwrapManaged[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
       channel: => ZManaged[Env, OutErr, ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]]

--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -366,10 +366,10 @@ object ZChannelSpec extends ZIOBaseSpec {
           )
         }
       ),
-      suite("ZChannel#scopedOut")(
+      suite("ZChannel#scoped")(
         test("failure") {
           for {
-            exit <- ZChannel.scopedOut(ZIO.fail("error")).runCollect.exit
+            exit <- ZChannel.scoped(ZIO.fail("error")).runCollect.exit
           } yield assert(exit)(fails(equalTo("error")))
         }
       ),

--- a/streams/jvm/src/main/scala/zio/stream/Deflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/Deflate.scala
@@ -16,7 +16,7 @@ object Deflate {
     strategy: CompressionStrategy = CompressionStrategy.DefaultStrategy,
     flushMode: FlushMode = FlushMode.NoFlush
   )(implicit trace: ZTraceElement): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-    ZChannel.scoped {
+    ZChannel.unwrapScoped {
       ZIO
         .acquireRelease(ZIO.succeed {
           val deflater = new Deflater(level.jValue, noWrap)
@@ -25,28 +25,29 @@ object Deflate {
         }) { case (deflater, _) =>
           ZIO.succeed(deflater.end())
         }
-    } {
-      case (deflater, buffer) => {
+        .map {
+          case (deflater, buffer) => {
 
-        lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-          ZChannel.readWithCause(
-            chunk =>
-              ZChannel.succeed {
-                deflater.setInput(chunk.toArray)
-                pullOutput(deflater, buffer, flushMode)
-              }.flatMap(chunk => ZChannel.write(chunk) *> loop),
-            ZChannel.failCause(_),
-            done =>
-              ZChannel.succeed {
-                deflater.finish()
-                val out = pullOutput(deflater, buffer, flushMode)
-                deflater.reset()
-                out
-              }.flatMap(chunk => ZChannel.write(chunk).as(done))
-          )
+            lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
+              ZChannel.readWithCause(
+                chunk =>
+                  ZChannel.succeed {
+                    deflater.setInput(chunk.toArray)
+                    pullOutput(deflater, buffer, flushMode)
+                  }.flatMap(chunk => ZChannel.write(chunk) *> loop),
+                ZChannel.failCause(_),
+                done =>
+                  ZChannel.succeed {
+                    deflater.finish()
+                    val out = pullOutput(deflater, buffer, flushMode)
+                    deflater.reset()
+                    out
+                  }.flatMap(chunk => ZChannel.write(chunk).as(done))
+              )
 
-        loop
-      }
+            loop
+          }
+        }
     }
 
   private def pullOutput(deflater: Deflater, buffer: Array[Byte], flushMode: FlushMode): Chunk[Byte] = {

--- a/streams/jvm/src/main/scala/zio/stream/Gzip.scala
+++ b/streams/jvm/src/main/scala/zio/stream/Gzip.scala
@@ -11,30 +11,31 @@ object Gzip {
     strategy: CompressionStrategy = CompressionStrategy.DefaultStrategy,
     flushMode: FlushMode = FlushMode.NoFlush
   )(implicit trace: ZTraceElement): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-    ZChannel.scoped {
+    ZChannel.unwrapScoped {
       ZIO
         .acquireRelease(
           Gzipper.make(bufferSize, level, strategy, flushMode)
         ) { gzipper =>
           ZIO.succeed(gzipper.close())
         }
-    } {
-      case gzipper => {
+        .map {
+          case gzipper => {
 
-        lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-          ZChannel.readWithCause(
-            chunk =>
-              ZChannel.fromZIO {
-                gzipper.onChunk(chunk)
-              }.flatMap(chunk => ZChannel.write(chunk) *> loop),
-            ZChannel.failCause(_),
-            done =>
-              ZChannel.fromZIO {
-                gzipper.onNone
-              }.flatMap(chunk => ZChannel.write(chunk).as(done))
-          )
+            lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
+              ZChannel.readWithCause(
+                chunk =>
+                  ZChannel.fromZIO {
+                    gzipper.onChunk(chunk)
+                  }.flatMap(chunk => ZChannel.write(chunk) *> loop),
+                ZChannel.failCause(_),
+                done =>
+                  ZChannel.fromZIO {
+                    gzipper.onNone
+                  }.flatMap(chunk => ZChannel.write(chunk).as(done))
+              )
 
-        loop
-      }
+            loop
+          }
+        }
     }
 }

--- a/streams/jvm/src/main/scala/zio/stream/Inflate.scala
+++ b/streams/jvm/src/main/scala/zio/stream/Inflate.scala
@@ -13,40 +13,41 @@ object Inflate {
     bufferSize: Int = 64 * 1024,
     noWrap: Boolean = false
   )(implicit trace: ZTraceElement): ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-    ZChannel.scoped {
+    ZChannel.unwrapScoped {
       ZIO
         .acquireRelease(ZIO.succeed((new Array[Byte](bufferSize), new Inflater(noWrap)))) { case (_, inflater) =>
           ZIO.succeed(inflater.end())
         }
-    } { case (buffer, inflater) =>
-      lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
-        ZChannel.readWithCause(
-          chunk =>
-            ZChannel.fromZIO {
-              ZIO.attempt {
-                inflater.setInput(chunk.toArray)
-                pullAllOutput(inflater, buffer, chunk)
-              }.refineOrDie { case e: DataFormatException =>
-                CompressionException(e)
-              }
-            }.flatMap(chunk => ZChannel.write(chunk) *> loop),
-          ZChannel.failCause(_),
-          done =>
-            ZChannel.fromZIO {
-              ZIO.attempt {
-                if (inflater.finished()) {
-                  inflater.reset()
-                  Chunk.empty
-                } else {
-                  throw CompressionException("Inflater is not finished when input stream completed")
-                }
-              }.refineOrDie { case e: DataFormatException =>
-                CompressionException(e)
-              }
-            }.flatMap(chunk => ZChannel.write(chunk).as(done))
-        )
+        .map { case (buffer, inflater) =>
+          lazy val loop: ZChannel[Any, Err, Chunk[Byte], Done, Err, Chunk[Byte], Done] =
+            ZChannel.readWithCause(
+              chunk =>
+                ZChannel.fromZIO {
+                  ZIO.attempt {
+                    inflater.setInput(chunk.toArray)
+                    pullAllOutput(inflater, buffer, chunk)
+                  }.refineOrDie { case e: DataFormatException =>
+                    CompressionException(e)
+                  }
+                }.flatMap(chunk => ZChannel.write(chunk) *> loop),
+              ZChannel.failCause(_),
+              done =>
+                ZChannel.fromZIO {
+                  ZIO.attempt {
+                    if (inflater.finished()) {
+                      inflater.reset()
+                      Chunk.empty
+                    } else {
+                      throw CompressionException("Inflater is not finished when input stream completed")
+                    }
+                  }.refineOrDie { case e: DataFormatException =>
+                    CompressionException(e)
+                  }
+                }.flatMap(chunk => ZChannel.write(chunk).as(done))
+            )
 
-      loop
+          loop
+        }
     }
 
   // Pulls all available output from the inflater.

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -711,7 +711,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
   def mapOutZIOPar[Env1 <: Env, OutErr1 >: OutErr, OutElem2](n: Int)(
     f: OutElem => ZIO[Env1, OutErr1, OutElem2]
   )(implicit trace: ZTraceElement): ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem2, OutDone] =
-    ZChannel.scoped[Env1] {
+    ZChannel.unwrapScoped[Env1] {
       ZIO.withChildren { getChildren =>
         for {
           _           <- ZIO.addFinalizer(getChildren.flatMap(Fiber.interruptAll(_)))
@@ -744,20 +744,20 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                  .interruptible
                  .forkScoped
         } yield queue
-      }
-    } { queue =>
-      lazy val consumer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
-        ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
-          queue.take.flatten.foldCause(
-            ZChannel.failCause(_),
-            {
-              case Left(outDone)  => ZChannel.succeedNow(outDone)
-              case Right(outElem) => ZChannel.write(outElem) *> consumer
-            }
-          )
-        }
+      }.map { queue =>
+        lazy val consumer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
+          ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
+            queue.take.flatten.foldCause(
+              ZChannel.failCause(_),
+              {
+                case Left(outDone)  => ZChannel.succeedNow(outDone)
+                case Right(outElem) => ZChannel.write(outElem) *> consumer
+              }
+            )
+          }
 
-      consumer
+        consumer
+      }
     }
 
   def mergeOut[Env1 <: Env, InErr1 <: InErr, InElem1 <: InElem, InDone1 <: InDone, OutErr1 >: OutErr, OutElem2](
@@ -842,7 +842,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
   final def provideLayer[OutErr1 >: OutErr, Env0](
     layer: => ZLayer[Env0, OutErr1, Env]
   )(implicit trace: ZTraceElement): ZChannel[Env0, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
-    ZChannel.scoped[Env0](layer.build)(env => self.provideEnvironment(env))
+    ZChannel.unwrapScoped[Env0](layer.build.map(env => self.provideEnvironment(env)))
 
   /**
    * Provides the channel with the single service it requires. If the channel
@@ -1416,11 +1416,8 @@ object ZChannel {
   ): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Nothing] =
     failCause(Cause.interrupt(fiberId))
 
-  def scoped[Env]: ScopedPartiallyApplied[Env] =
-    new ScopedPartiallyApplied[Env]
-
-  def scopedOut[R]: ScopedOutPartiallyApplied[R] =
-    new ScopedOutPartiallyApplied[R]
+  def scoped[R]: ScopedPartiallyApplied[R] =
+    new ScopedPartiallyApplied[R]
 
   def mergeAll[Env, InErr, InElem, InDone, OutErr, OutElem](
     channels: => ZChannel[
@@ -1482,7 +1479,7 @@ object ZChannel {
   )(
     f: (OutDone, OutDone) => OutDone
   )(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-    scoped[Env] {
+    unwrapScoped[Env] {
       ZIO.withChildren { getChildren =>
         for {
           n             <- ZIO.succeed(n)
@@ -1564,20 +1561,20 @@ object ZChannel {
                  .repeatWhileEquals(true)
                  .forkScoped
         } yield queue
-      }
-    } { queue =>
-      lazy val consumer: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone] =
-        unwrap[Env, Any, Any, Any, OutErr, OutElem, OutDone] {
-          queue.take.flatten.foldCause(
-            cause => failCause(cause),
-            {
-              case Left(outDone)  => succeedNow(outDone)
-              case Right(outElem) => write(outElem) *> consumer
-            }
-          )
-        }
+      }.map { queue =>
+        lazy val consumer: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone] =
+          unwrap[Env, Any, Any, Any, OutErr, OutElem, OutDone] {
+            queue.take.flatten.foldCause(
+              cause => failCause(cause),
+              {
+                case Left(outDone)  => succeedNow(outDone)
+                case Right(outElem) => write(outElem) *> consumer
+              }
+            )
+          }
 
-      consumer
+        consumer
+      }
     }
 
   def provideLayer[Env0, Env, Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone](layer: ZLayer[Env0, OutErr, Env])(
@@ -1671,7 +1668,7 @@ object ZChannel {
   def fromHub[Err, Done, Elem](
     hub: => Hub[Either[Exit[Err, Done], Elem]]
   )(implicit trace: ZTraceElement): ZChannel[Any, Any, Any, Any, Err, Elem, Done] =
-    ZChannel.scoped(hub.subscribe)(fromQueue(_))
+    ZChannel.unwrapScoped(hub.subscribe.map(fromQueue(_)))
 
   def fromHubScoped[Err, Done, Elem](
     hub: => Hub[Either[Exit[Err, Done], Elem]]
@@ -1821,20 +1818,7 @@ object ZChannel {
         .provideLayer(ZLayer.environment[Env0] ++ layer)
   }
 
-  final class ScopedPartiallyApplied[Env](private val dummy: Boolean = true) extends AnyVal {
-    def apply[InErr, InElem, InDone, OutErr, OutElem, OutDone, A](zio: => ZIO[Scope with Env, OutErr, A])(
-      use: A => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
-    )(implicit trace: ZTraceElement): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-      acquireReleaseExitWith[Env, InErr, InElem, InDone, OutErr, Scope.Closeable, OutElem, OutDone] {
-        Scope.make
-      } { (scope, exit) =>
-        scope.close(exit)
-      } { scope =>
-        ZChannel.fromZIO(scope.extend[Env](zio)).flatMap(use)
-      }
-  }
-
-  final class ScopedOutPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+  final class ScopedPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](
       zio: => ZIO[Scope with R, E, A]
     )(implicit trace: ZTraceElement): ZChannel[R, Any, Any, Any, E, A, Any] =
@@ -1895,7 +1879,7 @@ object ZChannel {
     )(implicit
       trace: ZTraceElement
     ): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-      ZChannel.concatAllWith(scopedOut[Env](channel))((d, _) => d, (d, _) => d)
+      ZChannel.concatAllWith(scoped[Env](channel))((d, _) => d, (d, _) => d)
   }
 
   final class UpdateService[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone, Service](

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -221,24 +221,26 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
             )
 
         ZChannel
-          .scoped[R1](timeout.forkScoped) { fiber =>
-            (handoffConsumer pipeToOrFail sink.channel).doneCollect.flatMap { case (leftovers, b) =>
-              ZChannel.fromZIO(fiber.interrupt *> sinkLeftovers.set(leftovers.flatten)) *>
-                ZChannel.unwrap {
-                  sinkEndReason.modify {
-                    case ScheduleEnd(c) =>
-                      (ZChannel.write(Chunk(Right(b), Left(c))).as(Some(b)), SinkEnd)
+          .unwrapScoped[R1] {
+            timeout.forkScoped.map { fiber =>
+              (handoffConsumer pipeToOrFail sink.channel).doneCollect.flatMap { case (leftovers, b) =>
+                ZChannel.fromZIO(fiber.interrupt *> sinkLeftovers.set(leftovers.flatten)) *>
+                  ZChannel.unwrap {
+                    sinkEndReason.modify {
+                      case ScheduleEnd(c) =>
+                        (ZChannel.write(Chunk(Right(b), Left(c))).as(Some(b)), SinkEnd)
 
-                    case ScheduleTimeout =>
-                      (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
+                      case ScheduleTimeout =>
+                        (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
 
-                    case SinkEnd =>
-                      (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
+                      case SinkEnd =>
+                        (ZChannel.write(Chunk(Right(b))).as(Some(b)), SinkEnd)
 
-                    case UpstreamEnd =>
-                      (ZChannel.write(Chunk(Right(b))).as(None), UpstreamEnd) // leftovers??
+                      case UpstreamEnd =>
+                        (ZChannel.write(Chunk(Right(b))).as(None), UpstreamEnd) // leftovers??
+                    }
                   }
-                }
+              }
             }
           }
           .flatMap {
@@ -333,20 +335,22 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def buffer(capacity: => Int)(implicit trace: ZTraceElement): ZStream[R, E, A] = {
     val queue = self.toQueueOfElements(capacity)
     new ZStream(
-      ZChannel.scoped[R](queue) { queue =>
-        lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-          ZChannel.fromZIO {
-            queue.take
-          }.flatMap { (exit: Exit[Option[E], A]) =>
-            exit.fold(
-              Cause
-                .flipCauseOption(_)
-                .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.failCause(_)),
-              value => ZChannel.write(Chunk.single(value)) *> process
-            )
-          }
+      ZChannel.unwrapScoped[R] {
+        queue.map { queue =>
+          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+            ZChannel.fromZIO {
+              queue.take
+            }.flatMap { (exit: Exit[Option[E], A]) =>
+              exit.fold(
+                Cause
+                  .flipCauseOption(_)
+                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.failCause(_)),
+                value => ZChannel.write(Chunk.single(value)) *> process
+              )
+            }
 
-        process
+          process
+        }
       }
     )
   }
@@ -361,19 +365,21 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def bufferChunks(capacity: => Int)(implicit trace: ZTraceElement): ZStream[R, E, A] = {
     val queue = self.toQueue(capacity)
     new ZStream(
-      ZChannel.scoped[R](queue) { queue =>
-        lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-          ZChannel.fromZIO {
-            queue.take
-          }.flatMap { (take: Take[E, A]) =>
-            take.fold(
-              ZChannel.unit,
-              error => ZChannel.failCause(error),
-              value => ZChannel.write(value) *> process
-            )
-          }
+      ZChannel.unwrapScoped[R] {
+        queue.map { queue =>
+          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+            ZChannel.fromZIO {
+              queue.take
+            }.flatMap { (take: Take[E, A]) =>
+              take.fold(
+                ZChannel.unit,
+                error => ZChannel.failCause(error),
+                value => ZChannel.write(value) *> process
+              )
+            }
 
-        process
+          process
+        }
       }
     )
   }
@@ -486,16 +492,14 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
       process
     }
 
-    ZChannel.scoped[R1] {
+    ZChannel.unwrapScoped[R1] {
       for {
         queue <- scoped
         start <- Promise.make[Nothing, Unit]
         _     <- start.succeed(())
         ref   <- Ref.make(start)
         _     <- (channel >>> producer(queue, ref)).runScoped.fork
-      } yield queue
-    } { queue =>
-      consumer(queue)
+      } yield consumer(queue)
     }
   }
 
@@ -506,19 +510,21 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def bufferUnbounded(implicit trace: ZTraceElement): ZStream[R, E, A] = {
     val queue = self.toQueueUnbounded
     new ZStream(
-      ZChannel.scoped[R](queue) { queue =>
-        lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-          ZChannel.fromZIO {
-            queue.take
-          }.flatMap { (take: Take[E, A]) =>
-            take.fold(
-              ZChannel.unit,
-              error => ZChannel.failCause(error),
-              value => ZChannel.write(value) *> process
-            )
-          }
+      ZChannel.unwrapScoped[R] {
+        queue.map { queue =>
+          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+            ZChannel.fromZIO {
+              queue.take
+            }.flatMap { (take: Take[E, A]) =>
+              take.fold(
+                ZChannel.unit,
+                error => ZChannel.failCause(error),
+                value => ZChannel.write(value) *> process
+              )
+            }
 
-        process
+          process
+        }
       }
     )
   }
@@ -835,19 +841,17 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
         )
 
     new ZStream(
-      ZChannel.scoped[R1] {
+      ZChannel.unwrapScoped[R1] {
         for {
-          left   <- ZStream.Handoff.make[Exit[Option[E], A]]
-          right  <- ZStream.Handoff.make[Exit[Option[E1], A2]]
-          latchL <- ZStream.Handoff.make[Unit]
-          latchR <- ZStream.Handoff.make[Unit]
-          _      <- (self.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(left, latchL)).runScoped.fork
-          _      <- (that.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(right, latchR)).runScoped.fork
-        } yield (left, right, latchL, latchR)
-      } { case (left, right, latchL, latchR) =>
-        val pullLeft: IO[Option[E], A]    = latchL.offer(()) *> left.take.flatMap(ZIO.done(_))
-        val pullRight: IO[Option[E1], A2] = latchR.offer(()) *> right.take.flatMap(ZIO.done(_))
-        ZStream.unfoldZIO(s)(s => f(s, pullLeft, pullRight).flatMap(ZIO.done(_).unsome)).channel
+          left     <- ZStream.Handoff.make[Exit[Option[E], A]]
+          right    <- ZStream.Handoff.make[Exit[Option[E1], A2]]
+          latchL   <- ZStream.Handoff.make[Unit]
+          latchR   <- ZStream.Handoff.make[Unit]
+          _        <- (self.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(left, latchL)).runScoped.fork
+          _        <- (that.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(right, latchR)).runScoped.fork
+          pullLeft  = latchL.offer(()) *> left.take.flatMap(ZIO.done(_))
+          pullRight = latchR.offer(()) *> right.take.flatMap(ZIO.done(_))
+        } yield ZStream.unfoldZIO(s)(s => f(s, pullLeft, pullRight).flatMap(ZIO.done(_).unsome)).channel
       }
     )
   }
@@ -878,19 +882,17 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
         )
 
     new ZStream(
-      ZChannel.scoped[R1] {
+      ZChannel.unwrapScoped[R1] {
         for {
-          left   <- ZStream.Handoff.make[Take[E, A]]
-          right  <- ZStream.Handoff.make[Take[E1, A2]]
-          latchL <- ZStream.Handoff.make[Unit]
-          latchR <- ZStream.Handoff.make[Unit]
-          _      <- (self.channel >>> producer(left, latchL)).runScoped.fork
-          _      <- (that.channel >>> producer(right, latchR)).runScoped.fork
-        } yield (left, right, latchL, latchR)
-      } { case (left, right, latchL, latchR) =>
-        val pullLeft  = latchL.offer(()) *> left.take.flatMap(_.done)
-        val pullRight = latchR.offer(()) *> right.take.flatMap(_.done)
-        ZStream.unfoldChunkZIO(s)(s => f(s, pullLeft, pullRight).flatMap(ZIO.done(_).unsome)).channel
+          left     <- ZStream.Handoff.make[Take[E, A]]
+          right    <- ZStream.Handoff.make[Take[E1, A2]]
+          latchL   <- ZStream.Handoff.make[Unit]
+          latchR   <- ZStream.Handoff.make[Unit]
+          _        <- (self.channel >>> producer(left, latchL)).runScoped.fork
+          _        <- (that.channel >>> producer(right, latchR)).runScoped.fork
+          pullLeft  = latchL.offer(()) *> left.take.flatMap(_.done)
+          pullRight = latchR.offer(()) *> right.take.flatMap(_.done)
+        } yield ZStream.unfoldChunkZIO(s)(s => f(s, pullLeft, pullRight).flatMap(ZIO.done(_).unsome)).channel
       }
     )
   }
@@ -1709,42 +1711,42 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
       )
 
     new ZStream(
-      ZChannel.scoped[R1] {
+      ZChannel.unwrapScoped[R1] {
         for {
           left  <- ZStream.Handoff.make[Take[E1, A1]]
           right <- ZStream.Handoff.make[Take[E1, A1]]
           _     <- (self.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(left)).runScoped.fork
           _     <- (that.channel.concatMap(ZChannel.writeChunk(_)) >>> producer(right)).runScoped.fork
-        } yield (left, right)
-      } { case (left, right) =>
-        def process(leftDone: Boolean, rightDone: Boolean): ZChannel[R1, E1, Boolean, Any, E1, Chunk[A1], Unit] =
-          ZChannel.readWithCause[R1, E1, Boolean, Any, E1, Chunk[A1], Unit](
-            bool =>
-              (bool, leftDone, rightDone) match {
-                case (true, false, _) =>
-                  ZChannel.fromZIO(left.take).flatMap { take =>
-                    take.fold(
-                      if (rightDone) ZChannel.unit else process(true, rightDone),
-                      cause => ZChannel.failCause(cause),
-                      chunk => ZChannel.write(chunk) *> process(leftDone, rightDone)
-                    )
-                  }
-                case (false, _, false) =>
-                  ZChannel.fromZIO(right.take).flatMap { take =>
-                    take.fold(
-                      if (leftDone) ZChannel.unit else process(leftDone, true),
-                      cause => ZChannel.failCause(cause),
-                      chunk => ZChannel.write(chunk) *> process(leftDone, rightDone)
-                    )
-                  }
-                case _ =>
-                  process(leftDone, rightDone)
-              },
-            cause => ZChannel.failCause(cause),
-            _ => ZChannel.unit
-          )
+        } yield {
+          def process(leftDone: Boolean, rightDone: Boolean): ZChannel[R1, E1, Boolean, Any, E1, Chunk[A1], Unit] =
+            ZChannel.readWithCause[R1, E1, Boolean, Any, E1, Chunk[A1], Unit](
+              bool =>
+                (bool, leftDone, rightDone) match {
+                  case (true, false, _) =>
+                    ZChannel.fromZIO(left.take).flatMap { take =>
+                      take.fold(
+                        if (rightDone) ZChannel.unit else process(true, rightDone),
+                        cause => ZChannel.failCause(cause),
+                        chunk => ZChannel.write(chunk) *> process(leftDone, rightDone)
+                      )
+                    }
+                  case (false, _, false) =>
+                    ZChannel.fromZIO(right.take).flatMap { take =>
+                      take.fold(
+                        if (leftDone) ZChannel.unit else process(leftDone, true),
+                        cause => ZChannel.failCause(cause),
+                        chunk => ZChannel.write(chunk) *> process(leftDone, rightDone)
+                      )
+                    }
+                  case _ =>
+                    process(leftDone, rightDone)
+                },
+              cause => ZChannel.failCause(cause),
+              _ => ZChannel.unit
+            )
 
-        b.channel.concatMap(ZChannel.writeChunk(_)) >>> process(false, false)
+          b.channel.concatMap(ZChannel.writeChunk(_)) >>> process(false, false)
+        }
       }
     )
   }
@@ -2369,9 +2371,11 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
   final def provideLayer[E1 >: E, R0](
     layer: => ZLayer[R0, E1, R]
   )(implicit trace: ZTraceElement): ZStream[R0, E1, A] =
-    new ZStream(ZChannel.scoped[R0](layer.build) { r =>
-      self.channel.provideEnvironment(r)
-    })
+    new ZStream(
+      ZChannel.unwrapScoped[R0] {
+        layer.build.map(r => self.channel.provideEnvironment(r))
+      }
+    )
 
   /**
    * Transforms the environment being provided to the stream with the specified
@@ -4802,7 +4806,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
 
   final class ScopedPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](zio: => ZIO[Scope with R, E, A])(implicit trace: ZTraceElement): ZStream[R, E, A] =
-      new ZStream(ZChannel.scopedOut[R](zio.map(Chunk.single)))
+      new ZStream(ZChannel.scoped[R](zio.map(Chunk.single)))
   }
 
   final class ServiceAtPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {


### PR DESCRIPTION
Cleans up `ZChannel.scoped` constructors by deleting the current version of `scoped` that takes a resource and a continuation and replacing usages of it with `ZChannel.unwrapScoped`. Renames the current `scopedOut` to `scoped`. 