### PR TITLE
Consider Renaming EnvironmentTag To CompositeTag

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentIssuesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentIssuesSpec.scala
@@ -22,11 +22,11 @@ object ZEnvironmentIssuesSpec extends ZIOSpecDefault {
       }
     } @@ ignore,
     test("tags") {
-      def tagForThing[A](value: A)(implicit tag: EnvironmentTag[A]): EnvironmentTag[A] = {
+      def tagForThing[A](value: A)(implicit tag: CompositeTag[A]): CompositeTag[A] = {
         val _ = value
         tag
       }
-      assertTrue(tagForThing(Clock.ClockLive).tag <:< EnvironmentTag[Clock].tag)
+      assertTrue(tagForThing(Clock.ClockLive).tag <:< CompositeTag[Clock].tag)
     } @@ exceptScala3
   )
 }

--- a/core-tests/shared/src/test/scala/zio/autowire/InjectParameterizedServicesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/autowire/InjectParameterizedServicesSpec.scala
@@ -1,6 +1,6 @@
 package zio.autowire
 
-import zio.{EnvironmentTag, UIO, ZIO, ZLayer}
+import zio.{CompositeTag, UIO, ZIO, ZLayer}
 import zio.test._
 import zio.ULayer
 
@@ -31,7 +31,7 @@ object InjectParameterizedServicesSpec extends ZIOSpecDefault {
   }
 
   object ParameterizedService {
-    def something[A: EnvironmentTag]: ZIO[ParameterizedService[A], Nothing, Unit] =
+    def something[A: CompositeTag]: ZIO[ParameterizedService[A], Nothing, Unit] =
       ZIO.serviceWithZIO[ParameterizedService[A]](_.something)
   }
 

--- a/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
@@ -16,7 +16,7 @@ private object TagMacros {
         Expr.summon[Tag[A]] match {
           case Some(tag) => tag
           case None =>
-            (Expr.summon[EnvironmentTag[A]], Expr.summon[IsNotIntersection[A]]) match {
+            (Expr.summon[CompositeTag[A]], Expr.summon[IsNotIntersection[A]]) match {
               case (Some(tagExpr), Some(isNotIntersectionExpr)) =>
               '{ Tag[A]($tagExpr, $isNotIntersectionExpr) }
               case _ =>
@@ -27,7 +27,7 @@ private object TagMacros {
         report.errorAndAbort(s"You must not use an intersection type, yet have provided ${Type.show[A]}")
       case tpe =>
         '{
-          val tag0 = EnvironmentTag[A]
+          val tag0 = CompositeTag[A]
           new Tag[A] {
             def tag: LightTypeTag =  tag0.tag
             def closestClass: Class[_] = tag0.closestClass

--- a/core/shared/src/main/scala/zio/VersionSpecific.scala
+++ b/core/shared/src/main/scala/zio/VersionSpecific.scala
@@ -22,8 +22,8 @@ import izumi.reflect.macrortti.LightTypeTagRef
 
 private[zio] trait VersionSpecific {
 
-  type EnvironmentTag[A] = izumi.reflect.Tag[A]
-  lazy val EnvironmentTag = izumi.reflect.Tag
+  type CompositeTag[A] = izumi.reflect.Tag[A]
+  lazy val CompositeTag = izumi.reflect.Tag
 
   type TagK[F[_]] = izumi.reflect.TagK[F]
   lazy val TagK = izumi.reflect.TagK
@@ -59,7 +59,7 @@ private[zio] trait VersionSpecific {
   private[zio] def taggedIsSubtype(left: LightTypeTag, right: LightTypeTag): Boolean =
     left <:< right
 
-  private[zio] def taggedTagType[A](tagged: EnvironmentTag[A]): LightTypeTag =
+  private[zio] def taggedTagType[A](tagged: CompositeTag[A]): LightTypeTag =
     tagged.tag
 
   /**

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -26,7 +26,7 @@ final class ZEnvironment[+R] private (
   private var cache: Map[LightTypeTag, Any] = Map.empty
 ) extends Serializable { self =>
 
-  def ++[R1: EnvironmentTag](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
+  def ++[R1: CompositeTag](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
     self.union[R1](that)
 
   /**
@@ -50,7 +50,7 @@ final class ZEnvironment[+R] private (
    * Retrieves a service from the environment corresponding to the specified
    * key.
    */
-  def getAt[K, V](k: K)(implicit ev: R <:< Map[K, V], tagged: EnvironmentTag[Map[K, V]]): Option[V] =
+  def getAt[K, V](k: K)(implicit ev: R <:< Map[K, V], tagged: CompositeTag[Map[K, V]]): Option[V] =
     unsafeGet[Map[K, V]](taggedTagType(tagged)).get(k)
 
   override def hashCode: Int =
@@ -60,7 +60,7 @@ final class ZEnvironment[+R] private (
    * Prunes the environment to the set of services statically known to be
    * contained within it.
    */
-  def prune[R1 >: R](implicit tagged: EnvironmentTag[R1]): ZEnvironment[R1] = {
+  def prune[R1 >: R](implicit tagged: CompositeTag[R1]): ZEnvironment[R1] = {
     val tag = taggedTagType(tagged)
     val set = taggedGetServices(tag)
 
@@ -90,7 +90,7 @@ final class ZEnvironment[+R] private (
   /**
    * Combines this environment with the specified environment.
    */
-  def union[R1: EnvironmentTag](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
+  def union[R1: CompositeTag](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
     self.unionAll[R1](that.prune)
 
   /**
@@ -298,6 +298,6 @@ object ZEnvironment {
       patch.asInstanceOf[Patch[Any, Any]]
   }
 
-  private lazy val TaggedAny: EnvironmentTag[Any] =
-    implicitly[EnvironmentTag[Any]]
+  private lazy val TaggedAny: CompositeTag[Any] =
+    implicitly[CompositeTag[Any]]
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3598,7 +3598,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Gets a state from the environment.
    */
-  def getState[S: EnvironmentTag](implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, S] =
+  def getState[S: CompositeTag](implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, S] =
     ZIO.serviceWithZIO(_.get)
 
   /**
@@ -4037,7 +4037,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
 
   def provideLayer[RIn, E, ROut, RIn2, ROut2](layer: ZLayer[RIn, E, ROut])(
     zio: ZIO[ROut with RIn2, E, ROut2]
-  )(implicit ev: EnvironmentTag[RIn2], tag: EnvironmentTag[ROut], trace: ZTraceElement): ZIO[RIn with RIn2, E, ROut2] =
+  )(implicit ev: CompositeTag[RIn2], tag: CompositeTag[ROut], trace: ZTraceElement): ZIO[RIn with RIn2, E, ROut2] =
     zio.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer)
 
   /**
@@ -4174,7 +4174,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Sets a state in the environment to the specified value.
    */
-  def setState[S: EnvironmentTag](s: => S)(implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, Unit] =
+  def setState[S: CompositeTag](s: => S)(implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, Unit] =
     ZIO.serviceWith(_.set(s))
 
   /**
@@ -4421,7 +4421,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   /**
    * Updates a state in the environment with the specified function.
    */
-  def updateState[S: EnvironmentTag](f: S => S)(implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, Unit] =
+  def updateState[S: CompositeTag](f: S => S)(implicit trace: ZTraceElement): ZIO[ZState[S], Nothing, Unit] =
     ZIO.serviceWithZIO(_.update(f))
 
   /**
@@ -4673,7 +4673,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
       layer: => ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
+      tagged: CompositeTag[R1],
       trace: ZTraceElement
     ): ZIO[R0, E1, A] =
       self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
@@ -4814,7 +4814,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   final class ServiceAtPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
     def apply[Key](
       key: => Key
-    )(implicit tag: EnvironmentTag[Map[Key, Service]], trace: ZTraceElement): URIO[Map[Key, Service], Option[Service]] =
+    )(implicit tag: CompositeTag[Map[Key, Service]], trace: ZTraceElement): URIO[Map[Key, Service], Option[Service]] =
       ZIO.environmentWith(_.getAt(key))
   }
 
@@ -4842,12 +4842,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   final class StatefulPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[S, E, A](
       s: S
-    )(zio: => ZIO[ZState[S] with R, E, A])(implicit tag: EnvironmentTag[S], trace: ZTraceElement): ZIO[R, E, A] =
+    )(zio: => ZIO[ZState[S] with R, E, A])(implicit tag: CompositeTag[S], trace: ZTraceElement): ZIO[R, E, A] =
       zio.provideSomeLayer[R](ZState.initial(s))
   }
 
   final class GetStateWithPartiallyApplied[S](private val dummy: Boolean = true) extends AnyVal {
-    def apply[A](f: S => A)(implicit tag: EnvironmentTag[S], trace: ZTraceElement): ZIO[ZState[S], Nothing, A] =
+    def apply[A](f: S => A)(implicit tag: CompositeTag[S], trace: ZTraceElement): ZIO[ZState[S], Nothing, A] =
       ZIO.serviceWithZIO(_.get.map(f))
   }
 

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -145,9 +145,9 @@ object ZIOApp {
     new ZIOApp {
       type Environment = R
       def tag: CompositeTag[Environment] = tagged
-      override def hook                    = hook0
-      def layer                            = layer0
-      def run                              = run0
+      override def hook                  = hook0
+      def layer                          = layer0
+      def run                            = run0
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
   private[zio] val shuttingDown = new AtomicBoolean(false)
 
-  implicit def tag: EnvironmentTag[Environment]
+  implicit def tag: CompositeTag[Environment]
 
   type Environment
 
@@ -129,7 +129,7 @@ object ZIOApp {
       app.layer
     override final def run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any] =
       app.run
-    implicit final def tag: EnvironmentTag[Environment] =
+    implicit final def tag: CompositeTag[Environment] =
       app.tag
   }
 
@@ -141,10 +141,10 @@ object ZIOApp {
     run0: ZIO[R with ZIOAppArgs with Scope, Any, Any],
     layer0: ZLayer[ZIOAppArgs with Scope, Any, R],
     hook0: RuntimeConfigAspect
-  )(implicit tagged: EnvironmentTag[R]): ZIOApp =
+  )(implicit tagged: CompositeTag[R]): ZIOApp =
     new ZIOApp {
       type Environment = R
-      def tag: EnvironmentTag[Environment] = tagged
+      def tag: CompositeTag[Environment] = tagged
       override def hook                    = hook0
       def layer                            = layer0
       def run                              = run0

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -42,7 +42,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   val layer: ZLayer[ZIOAppArgs with Scope, Any, Any] = ZLayer.empty
 
-  val tag: EnvironmentTag[Any] = EnvironmentTag[Any]
+  val tag: CompositeTag[Any] = CompositeTag[Any]
 
 }
 

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -62,7 +62,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    */
   final def ++[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
-  )(implicit tag: EnvironmentTag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
+  )(implicit tag: CompositeTag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
     self.zipWithPar(that)(_.union[ROut2](_))
 
   /**
@@ -78,7 +78,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    */
   final def and[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
-  )(implicit tag: EnvironmentTag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
+  )(implicit tag: CompositeTag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
     self.++[E1, RIn2, ROut1, ROut2](that)
 
   /**
@@ -87,7 +87,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
   final def andTo[E1 >: E, RIn2 >: ROut, ROut1 >: ROut, ROut2](
     that: ZLayer[RIn2, E1, ROut2]
   )(implicit
-    tagged: EnvironmentTag[ROut2],
+    tagged: CompositeTag[ROut2],
     trace: ZTraceElement
   ): ZLayer[RIn, E1, ROut1 with ROut2] =
     self.>+>[E1, RIn2, ROut1, ROut2](that)
@@ -679,8 +679,8 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
      * passes through the inputs.
      */
     def passthrough(implicit
-      in: EnvironmentTag[RIn],
-      out: EnvironmentTag[ROut],
+      in: CompositeTag[RIn],
+      out: CompositeTag[ROut],
       trace: ZTraceElement
     ): ZLayer[RIn, E, RIn with ROut] =
       ZLayer.environment[RIn] ++ self
@@ -1019,9 +1019,9 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
     final def apply[R, E1 >: E, A](
       zio: ZIO[ROut with R, E1, A]
     )(implicit
-      ev1: EnvironmentTag[R],
-      ev2: EnvironmentTag[ROut],
-      ev3: EnvironmentTag[RIn],
+      ev1: CompositeTag[R],
+      ev2: CompositeTag[ROut],
+      ev3: CompositeTag[RIn],
       trace: ZTraceElement
     ): ZIO[RIn with R, E1, A] =
       ZIO.provideLayer[RIn, E1, ROut, R, A](self)(zio)
@@ -1033,7 +1033,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
      */
     def >>>[RIn2, E1 >: E, ROut2](
       that: ZLayer[ROut with RIn2, E1, ROut2]
-    )(implicit tag: EnvironmentTag[ROut], trace: ZTraceElement): ZLayer[RIn with RIn2, E1, ROut2] =
+    )(implicit tag: CompositeTag[ROut], trace: ZTraceElement): ZLayer[RIn with RIn2, E1, ROut2] =
       ZLayer.To(ZLayer.environment[RIn2] ++ self, that)
 
     /**
@@ -1054,8 +1054,8 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
     def >+>[RIn2, E1 >: E, ROut2](
       that: ZLayer[ROut with RIn2, E1, ROut2]
     )(implicit
-      tagged: EnvironmentTag[ROut],
-      tagged2: EnvironmentTag[ROut2],
+      tagged: CompositeTag[ROut],
+      tagged2: CompositeTag[ROut2],
       trace: ZTraceElement
     ): ZLayer[RIn with RIn2, E1, ROut with ROut2] =
       self ++ self.>>>[RIn2, E1, ROut2](that)
@@ -1068,7 +1068,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
     def >+>[E1 >: E, RIn2 >: ROut, ROut1 >: ROut, ROut2](
       that: ZLayer[RIn2, E1, ROut2]
     )(implicit
-      tagged: EnvironmentTag[ROut2],
+      tagged: CompositeTag[ROut2],
       trace: ZTraceElement
     ): ZLayer[RIn, E1, ROut1 with ROut2] =
       self.zipWithPar(self >>> that)(_.union[ROut2](_))

--- a/core/shared/src/main/scala/zio/ZLogger.scala
+++ b/core/shared/src/main/scala/zio/ZLogger.scala
@@ -105,8 +105,8 @@ trait ZLogger[-Message, +Output] { self =>
     )
 }
 object ZLogger {
-  private[zio] val stringTag: LightTypeTag = EnvironmentTag[String].tag
-  private[zio] val causeTag: LightTypeTag  = EnvironmentTag[Cause[Any]].tag
+  private[zio] val stringTag: LightTypeTag = CompositeTag[String].tag
+  private[zio] val causeTag: LightTypeTag  = CompositeTag[Cause[Any]].tag
 
   import Predef.{Set => ScalaSet, _}
 

--- a/core/shared/src/main/scala/zio/ZState.scala
+++ b/core/shared/src/main/scala/zio/ZState.scala
@@ -62,7 +62,7 @@ object ZState {
   /**
    * A layer that allocates the initial state of a stateful workflow.
    */
-  def initial[S: EnvironmentTag](s: => S)(implicit trace: ZTraceElement): ZLayer[Any, Nothing, ZState[S]] =
+  def initial[S: CompositeTag](s: => S)(implicit trace: ZTraceElement): ZLayer[Any, Nothing, ZState[S]] =
     ZLayer.scoped {
       for {
         fiberRef <- FiberRef.make(s)

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -51,12 +51,12 @@ package object zio
 
   type ZTraceElement = Tracer.instance.Type with Tracer.Traced
 
-  trait Tag[A] extends EnvironmentTag[A] {
+  trait Tag[A] extends CompositeTag[A] {
     def tag: LightTypeTag
   }
 
   object Tag extends TagVersionSpecific {
-    def apply[A](implicit tag0: EnvironmentTag[A], isNotIntersection: IsNotIntersection[A]): Tag[A] =
+    def apply[A](implicit tag0: CompositeTag[A], isNotIntersection: IsNotIntersection[A]): Tag[A] =
       new Tag[A] {
         def tag: zio.LightTypeTag = tag0.tag
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1419,7 +1419,7 @@ object ZSTM {
   final class ServiceAtPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
     def apply[Key](
       key: => Key
-    )(implicit tag: EnvironmentTag[Map[Key, Service]]): ZSTM[Map[Key, Service], Nothing, Option[Service]] =
+    )(implicit tag: CompositeTag[Map[Key, Service]]): ZSTM[Map[Key, Service], Nothing, Option[Service]] =
       ZSTM.environmentWith(_.getAt(key))
   }
 

--- a/internal-macros/shared/src/main/scala-2/zio/internal/macros/IsNotIntersectionVersionSpecific.scala
+++ b/internal-macros/shared/src/main/scala-2/zio/internal/macros/IsNotIntersectionVersionSpecific.scala
@@ -18,7 +18,7 @@ class InternalMacros(val c: blackbox.Context) {
               val intersectionType      = c.typecheck(q"_root_.zio.IsNotIntersection[$x]").tpe
               val isNotIntersectionTree = c.inferImplicitValue(intersectionType, silent = false)
 
-              val envTagType = c.typecheck(q"_root_.zio.EnvironmentTag[$x]").tpe
+              val envTagType = c.typecheck(q"_root_.zio.CompositeTag[$x]").tpe
               val envTagTree = c.inferImplicitValue(envTagType, silent = false)
 
               q"_root_.zio.Tag[$tpe]($envTagTree, $isNotIntersectionTree)"

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1265,7 +1265,7 @@ object ZManaged extends ZManagedPlatformSpecific {
     def apply[Key](
       key: => Key
     )(implicit
-      tag: EnvironmentTag[Map[Key, Service]],
+      tag: CompositeTag[Map[Key, Service]],
       trace: ZTraceElement
     ): ZManaged[Map[Key, Service], Nothing, Option[Service]] =
       ZManaged.environmentWith(_.getAt(key))
@@ -1318,7 +1318,7 @@ object ZManaged extends ZManagedPlatformSpecific {
       layer: => ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
+      tagged: CompositeTag[R1],
       trace: ZTraceElement
     ): ZManaged[R0, E1, A] =
       self.asInstanceOf[ZManaged[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
@@ -2440,8 +2440,8 @@ object ZManaged extends ZManagedPlatformSpecific {
   def provideLayer[RIn, E, ROut, RIn2, ROut2](layer: ZLayer[RIn, E, ROut])(
     managed: ZManaged[ROut with RIn2, E, ROut2]
   )(implicit
-    ev: EnvironmentTag[RIn2],
-    tag: EnvironmentTag[ROut],
+    ev: CompositeTag[RIn2],
+    tag: CompositeTag[ROut],
     trace: ZTraceElement
   ): ZManaged[RIn with RIn2, E, ROut2] =
     managed.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer)

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1583,8 +1583,8 @@ object ZChannel {
   def provideLayer[Env0, Env, Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone](layer: ZLayer[Env0, OutErr, Env])(
     channel: => ZChannel[Env with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone]
   )(implicit
-    ev: EnvironmentTag[Env],
-    tag: EnvironmentTag[Env1],
+    ev: CompositeTag[Env],
+    tag: CompositeTag[Env1],
     trace: ZTraceElement
   ): ZChannel[Env0 with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
     ZChannel.suspend(channel.provideSomeLayer[Env0 with Env1](ZLayer.environment[Env1] ++ layer))
@@ -1813,7 +1813,7 @@ object ZChannel {
       layer: => ZLayer[Env0, OutErr1, Env1]
     )(implicit
       ev: Env0 with Env1 <:< Env,
-      tagged: EnvironmentTag[Env1],
+      tagged: CompositeTag[Env1],
       trace: ZTraceElement
     ): ZChannel[Env0, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
       self
@@ -1857,7 +1857,7 @@ object ZChannel {
     def apply[Key](
       key: => Key
     )(implicit
-      tag: EnvironmentTag[Map[Key, Service]],
+      tag: CompositeTag[Map[Key, Service]],
       trace: ZTraceElement
     ): ZChannel[Map[Key, Service], Any, Any, Any, Nothing, Nothing, Option[Service]] =
       ZChannel.environmentWith(_.getAt(key))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4534,8 +4534,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def provideLayer[RIn, E, ROut, RIn2, ROut2](layer: ZLayer[RIn, E, ROut])(
     stream: => ZStream[ROut with RIn2, E, ROut2]
   )(implicit
-    ev: EnvironmentTag[RIn2],
-    tag: EnvironmentTag[ROut],
+    ev: CompositeTag[RIn2],
+    tag: CompositeTag[ROut],
     trace: ZTraceElement
   ): ZStream[RIn with RIn2, E, ROut2] =
     ZStream.suspend(stream.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer))
@@ -4809,7 +4809,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def apply[Key](
       key: => Key
     )(implicit
-      tag: EnvironmentTag[Map[Key, Service]],
+      tag: CompositeTag[Map[Key, Service]],
       trace: ZTraceElement
     ): ZStream[Map[Key, Service], Nothing, Option[Service]] =
       ZStream.environmentWith(_.getAt(key))
@@ -4935,7 +4935,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       layer: => ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
+      tagged: CompositeTag[R1],
       trace: ZTraceElement
     ): ZStream[R0, E1, A] =
       self.asInstanceOf[ZStream[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -354,7 +354,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   def provideCustomLayer[E1 >: E, R1](layer: ZLayer[TestEnvironment, E1, R1])(implicit
     ev: TestEnvironment with R1 <:< R,
-    tagged: EnvironmentTag[R1],
+    tagged: CompositeTag[R1],
     trace: ZTraceElement
   ): Spec[TestEnvironment, E1, T] =
     provideSomeLayer[TestEnvironment](layer)
@@ -374,7 +374,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   def provideCustomLayerShared[E1 >: E, R1](layer: ZLayer[TestEnvironment, E1, R1])(implicit
     ev: TestEnvironment with R1 <:< R,
-    tagged: EnvironmentTag[R1],
+    tagged: CompositeTag[R1],
     trace: ZTraceElement
   ): Spec[TestEnvironment, E1, T] =
     provideSomeLayerShared(layer)
@@ -624,7 +624,7 @@ object Spec {
       layer: ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
+      tagged: CompositeTag[R1],
       trace: ZTraceElement
     ): Spec[R0, E1, T] =
       self.asInstanceOf[Spec[R0 with R1, E, T]].provideLayer(ZLayer.environment[R0] ++ layer)
@@ -635,7 +635,7 @@ object Spec {
       layer: ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
+      tagged: CompositeTag[R1],
       trace: ZTraceElement
     ): Spec[R0, E1, T] =
       self.caseValue match {

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -29,7 +29,7 @@ final class TestAnnotation[V] private (
   val identifier: String,
   val initial: V,
   val combine: (V, V) => V,
-  private val tag: EnvironmentTag[V]
+  private val tag: CompositeTag[V]
 ) extends Serializable {
 
   override def equals(that: Any): Boolean = (that: @unchecked) match {
@@ -43,7 +43,7 @@ final class TestAnnotation[V] private (
 object TestAnnotation {
 
   def apply[V](identifier: String, initial: V, combine: (V, V) => V)(implicit
-    tag: EnvironmentTag[V]
+    tag: CompositeTag[V]
   ): TestAnnotation[V] =
     new TestAnnotation(identifier, initial, combine, tag)
 

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -19,10 +19,10 @@ package zio.test
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
+abstract class ZIOSpec[R: CompositeTag] extends ZIOSpecAbstract { self =>
   type Environment = R
 
-  final val tag: EnvironmentTag[R] = EnvironmentTag[R]
+  final val tag: CompositeTag[R] = CompositeTag[R]
 
   /**
    * Builds a spec with a single test.

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -64,11 +64,11 @@ abstract class ZIOSpecAbstract extends ZIOApp {
       def spec: ZSpec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
         self.aspects.foldLeft(self.spec)(_ @@ _) + that.aspects.foldLeft(that.spec)(_ @@ _)
 
-      def tag: EnvironmentTag[Environment] = {
-        implicit val selfTag: EnvironmentTag[self.Environment] = self.tag
-        implicit val thatTag: EnvironmentTag[that.Environment] = that.tag
+      def tag: CompositeTag[Environment] = {
+        implicit val selfTag: CompositeTag[self.Environment] = self.tag
+        implicit val thatTag: CompositeTag[that.Environment] = that.tag
         val _                                                  = (selfTag, thatTag)
-        EnvironmentTag[Environment]
+        CompositeTag[Environment]
       }
 
       override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment with ZIOAppArgs]] =

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -67,7 +67,7 @@ abstract class ZIOSpecAbstract extends ZIOApp {
       def tag: CompositeTag[Environment] = {
         implicit val selfTag: CompositeTag[self.Environment] = self.tag
         implicit val thatTag: CompositeTag[that.Environment] = that.tag
-        val _                                                  = (selfTag, thatTag)
+        val _                                                = (selfTag, thatTag)
         CompositeTag[Environment]
       }
 


### PR DESCRIPTION
I don't love this, though I think my concerns also reflect weaknesses with the current naming convention. Basically we have:

* `Tag` - preserves type information at runtime and provides the type is not an intersection type
* `EnvironmentTag` / `CompositeTag` - preserves type information at runtime

`CompositeTag` is potentially a step in the right direction in that it is not necessarily related to the environment. However, it seems less than ideal in that it introduces the concept of being a "composite" that is not really relevant and potentially confusing. The tag can be for an intersection type or a type that is not an intersection type. It doesn't care. It is just a type tag.

It seems like the more logical naming convention would be something like `ServiceTag` being a tag that is also not an intersection and `Tag` just being a tag. The concept of not being an intersection is really only relevant to `ZEnvironment` which idiomatically holds services.

The obvious downside of this is that the current `Tag` is used much more commonly than `EnvironmentTag`, so this would make the common name longer though I think more clear.