### PR TITLE
Delete Extraneous Type Member

### DIFF
--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -28,8 +28,6 @@ abstract class ZIOSpecAbstract extends ZIOApp {
 
   def spec: ZSpec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any]
 
-  type Failure
-
   def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment with ZIOAppArgs]] =
     Chunk(TestAspect.fibers)
 


### PR DESCRIPTION
The `Failure` type member in `ZIOSpecAbstract` is a holdover from the previous `AbstractRunnableSpec`.