### PR TITLE
Rename ZChannel#interrupt to ZChannel#interruptAs

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1411,7 +1411,7 @@ object ZChannel {
       (done: Done) => succeedNow(done)
     )
 
-  def interrupt(fiberId: => FiberId)(implicit
+  def interruptAs(fiberId: => FiberId)(implicit
     trace: ZTraceElement
   ): ZChannel[Any, Any, Any, Any, Nothing, Nothing, Nothing] =
     failCause(Cause.interrupt(fiberId))


### PR DESCRIPTION
This is the idiomatic name for the variant that takes a `FiberId`.