### PR TITLE
Fix Initialization Issue On Scala 3

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -215,7 +215,7 @@ object ZEnvironment {
   /**
    * The empty environment containing no services.
    */
-  lazy val empty: ZEnvironment[Any] =
+  val empty: ZEnvironment[Any] =
     new ZEnvironment[Any](Map.empty, 0, Map(taggedTagType(TaggedAny) -> (())))
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3618,10 +3618,8 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Like [[never]], but fibers that running this effect won't be garbage
    * collected unless interrupted.
    */
-  val infinity: UIO[Nothing] =
-    ZIO
-      .sleep(Duration.fromNanos(Long.MaxValue))(ZTraceElement.empty)
-      .zipRight(ZIO.never(ZTraceElement.empty))(ZTraceElement.empty)
+  def infinity(implicit trace: ZTraceElement): UIO[Nothing] =
+    ZIO.sleep(Duration.fromNanos(Long.MaxValue)) *> ZIO.never
 
   /**
    * Returns an effect that is interrupted as if by the fiber calling this


### PR DESCRIPTION
Resolves #6544.

I think we need to reduce out use of lazy values where we can. Here we had an issue where having the `ZEnvironment.empty` be lazy could cause a deadlock during initialization on Scala 3. We needed that to prevent another issue with too eagerly initializing the `Clock`, but I think the solution to that is just to make `ZIO.infinity` a `def` rather than a `val` which also lets it take a trace.