### PR TITLE
Delete ZIO#toLayer

### DIFF
--- a/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
@@ -10,7 +10,7 @@ object TagCorrectnessSpec extends ZIOSpecDefault {
       test("Issue #4802") {
         ZIO
           .serviceWithZIO[Ref[Int]](_.get)
-          .provide(Ref.make(10).toLayer)
+          .provide(ZLayer(Ref.make(10)))
           .map { int =>
             assertTrue(int == 10)
           }
@@ -59,7 +59,7 @@ object TagCorrectnessSpec extends ZIOSpecDefault {
       test("Issue #4564") {
         trait Svc[A]
         def testBaseLayer[R, A: Tag]: ZLayer[R, Nothing, Svc[A]] =
-          ZIO.environmentWith[R](_ => new Svc[A] {}).toLayer[Svc[A]]
+          ZLayer(ZIO.environmentWith[R](_ => new Svc[A] {}))
         def testSecondLayer[A: Tag]: ZLayer[Svc[A], Nothing, Svc[A]] =
           ZLayer.fromFunction[Svc[A], Svc[A]] { environment =>
             environment.get

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -407,7 +407,7 @@ object ZLayerSpec extends ZIOBaseSpec {
               boolean <- ZIO.service[Boolean]
             } yield FooService(ref, string, boolean)
           }
-        val provideRefInt = Ref.make(10).toLayer
+        val provideRefInt = ZLayer(Ref.make(10))
 
         val needsStringAndBoolean = provideRefInt >>> fooBuilder
 
@@ -434,7 +434,7 @@ object ZLayerSpec extends ZIOBaseSpec {
               boolean <- ZIO.service[Boolean]
             } yield FooService(ref, string, boolean)
           }
-        val provideRefInt = Ref.make(10).toLayer
+        val provideRefInt = ZLayer(Ref.make(10))
 
         val needsStringAndBoolean = provideRefInt >+> fooBuilder
 

--- a/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
@@ -34,7 +34,7 @@ object AutoWireSpec extends ZIOBaseSpec {
           },
           test("automatically memoizes non-val layers") {
             def sideEffectingLayer(ref: Ref[Int]): ZLayer[Any, Nothing, String] =
-              ref.update(_ + 1).as("Howdy").toLayer
+              ZLayer(ref.update(_ + 1).as("Howdy"))
 
             val layerA: URLayer[String, Int]     = ZLayer.succeed(1)
             val layerB: URLayer[String, Boolean] = ZLayer.succeed(true)
@@ -121,9 +121,11 @@ object AutoWireSpec extends ZIOBaseSpec {
             val doubleLayer = ZLayer.succeed(100.1)
             val stringLayer: ULayer[String] =
               ZLayer.succeed("this string is 28 chars long")
-            val intLayer = (ZIO.service[String] <*> ZIO.service[Double]).map { case (str, double) =>
-              str.length + double.toInt
-            }.toLayer
+            val intLayer = ZLayer {
+              (ZIO.service[String] <*> ZIO.service[Double]).map { case (str, double) =>
+                str.length + double.toInt
+              }
+            }
 
             val layer =
               ZLayer.make[Int](intLayer, stringLayer, doubleLayer)
@@ -151,9 +153,11 @@ object AutoWireSpec extends ZIOBaseSpec {
         suite("`ZLayer.makeSome`")(
           test("automatically constructs a layer, leaving off some remainder") {
             val stringLayer = ZLayer.succeed("this string is 28 chars long")
-            val intLayer = (ZIO.service[String] <*> ZIO.service[Double]).map { case (str, double) =>
-              str.length + double.toInt
-            }.toLayer
+            val intLayer = ZLayer {
+              (ZIO.service[String] <*> ZIO.service[Double]).map { case (str, double) =>
+                str.length + double.toInt
+              }
+            }
             val program = ZIO.service[Int]
 
             val layer =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2082,25 +2082,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     new ZIO.TimeoutTo(self, () => b)
 
   /**
-   * Constructs a layer from this effect.
-   */
-  final def toLayer[A1 >: A](implicit
-    tag: Tag[A1],
-    trace: ZTraceElement
-  ): ZLayer[R, E, A1] =
-    ZLayer.fromZIO[R, E, A1](self)
-
-  /**
-   * Constructs a layer from this effect, which must return one or more
-   * services.
-   */
-  final def toLayerEnvironment[B](implicit
-    ev: A <:< ZEnvironment[B],
-    trace: ZTraceElement
-  ): ZLayer[R, E, B] =
-    ZLayer.fromZIOEnvironment(self.map(ev))
-
-  /**
    * Converts the effect into a [[scala.concurrent.Future]].
    */
   final def toFuture(implicit ev2: E IsSubtypeOfError Throwable, trace: ZTraceElement): URIO[R, CancelableFuture[A]] =

--- a/core/shared/src/main/scala/zio/stm/TRandom.scala
+++ b/core/shared/src/main/scala/zio/stm/TRandom.scala
@@ -51,14 +51,16 @@ object TRandom extends Serializable {
 
   val live: ZLayer[Random, Nothing, TRandom] = {
     implicit val trace = Tracer.newTrace
-    Random.nextLong.flatMap { init =>
-      TRef
-        .make(init)
-        .map { seed =>
-          TRandomLive(seed)
-        }
-        .commit
-    }.toLayer
+    ZLayer {
+      Random.nextLong.flatMap { init =>
+        TRef
+          .make(init)
+          .map { seed =>
+            TRandomLive(seed)
+          }
+          .commit
+      }
+    }
   }
 
   /**

--- a/docs/datatypes/contextual/zlayer.md
+++ b/docs/datatypes/contextual/zlayer.md
@@ -181,13 +181,12 @@ val usersLayer : ZLayer[Any, Throwable, UserRepository] =
 
 ### From ZIO Effects
 
-We can create `ZLayer` from any `ZIO` effect by using `ZLayer.fromEffect` constructor, or calling `ZIO#toLayer` method:
+We can create `ZLayer` from any `ZIO` effect by using `ZLayer.fromZIO` constructor:
 
 ```scala mdoc:compile-only
 import zio._
 
-val layer1: ZLayer[Any, Nothing, String] = ZLayer.fromZIO(ZIO.succeed("Hello, World!"))
-val layer2: ZLayer[Any, Nothing, String] = ZIO.succeed("Hello, World!").toLayer
+val layer: ZLayer[Any, Nothing, String] = ZLayer.fromZIO(ZIO.succeed("Hello, World!"))
 ```
 
 For example, assume we have a `ZIO` effect that reads the application config from a file, we can create a layer from that:
@@ -505,9 +504,8 @@ object MainApp extends ZIOAppDefault {
 
 
   val appLayers: ZLayer[Any, Nothing, AppConfig] =
-    ZIO.succeed(AppConfig(5))
-      .debug("Application config initialized")
-      .toLayer ++ Console.live
+    ZLayer(ZIO.succeed(AppConfig(5)).debug("Application config initialized")) ++
+      Console.live
 
   val updatedConfig: ZLayer[Any, Nothing, AppConfig] =
     appLayers.update[AppConfig](c =>
@@ -552,9 +550,8 @@ object MainApp extends ZIOAppDefault {
 
 
   val appLayers: ZLayer[Any, Nothing, AppConfig] =
-    ZIO.succeed(AppConfig(5))
-      .debug("Application config initialized")
-      .toLayer ++ Console.live
+    ZLayer(ZIO.succeed(AppConfig(5)).debug("Application config initialized")) ++
+      Console.live
 
   val updatedConfig: ZLayer[Any, Nothing, AppConfig] =
     appLayers ++ ZLayer.succeed(AppConfig(8))
@@ -1096,7 +1093,7 @@ case class BLive(a: A) extends B
 case class CLive(a: A) extends C
 
 val a: ZLayer[Any, Nothing, A] =
-  ZIO.succeed(new A {}).debug("initialized").toLayer
+  ZLayer(ZIO.succeed(new A {}).debug("initialized"))
 
 val b: ZLayer[A, Nothing, B] =
   ZLayer {
@@ -1505,9 +1502,7 @@ class InmemeoryCache() extends Cache {
 
 object InmemoryCache {
   val layer: ZLayer[Any, Throwable, Cache] =
-    ZIO.attempt(new InmemeoryCache)
-      .debug("initialized")
-      .toLayer
+    ZLayer(ZIO.attempt(new InmemeoryCache).debug("initialized"))
 }
 
 class PersistentCache() extends Cache {
@@ -1520,9 +1515,7 @@ class PersistentCache() extends Cache {
 
 object PersistentCache {
   val layer: ZLayer[Any, Throwable, Cache] =
-    ZIO.attempt(new PersistentCache)
-      .debug("initialized")
-      .toLayer
+    ZLayer(ZIO.attempt(new PersistentCache).debug("initialized"))
 }
 
 case class Document(title: String, author: String, body: String)

--- a/examples/shared/src/main/scala-2/zio/examples/macros/AccessibleMacroExample.scala
+++ b/examples/shared/src/main/scala-2/zio/examples/macros/AccessibleMacroExample.scala
@@ -117,29 +117,30 @@ object AccessibleMacroExample {
   }
 
   val live: ZLayer[Console, Nothing, Service] =
-    ZIO
-      .service[Console]
-      .map(console =>
-        new Service {
-          val foo: UIO[Unit]                                              = UIO.unit
-          def foo2: UIO[Unit]                                             = UIO.unit
-          def foo3(): UIO[Unit]                                           = UIO.unit
-          def bar(n: Int): UIO[Unit]                                      = console.printLine(s"bar $n").orDie
-          def baz(x: Int, y: Int): IO[String, Int]                        = UIO.succeed(x + y)
-          def poly[A](a: A): IO[Long, A]                                  = UIO.succeed(a)
-          def poly2[A <: Foo](a: Wrapped[A]): IO[String, List[A]]         = UIO.succeed(List(a.value))
-          def dependent(n: Int): ZIO[Random, Long, Int]                   = Random.nextIntBounded(n)
-          val value: String                                               = "foo"
-          def value2: String                                              = "foo2"
-          def value3(): String                                            = "foo3"
-          def function(n: Int): String                                    = s"foo $n"
-          def stream(n: Int): ZStream[Any, String, Int]                   = ZStream.fromIterable(List(1, 2, 3))
-          def sink(n: Int): ZSink[Any, Nothing, Int, Nothing, Chunk[Int]] = ZSink.collectAll
-          def withEx(): String                                            = throw new Exception("test")
-          def withEx1(p: String): String                                  = throw new Exception("test")
-        }
-      )
-      .toLayer
+    ZLayer {
+      ZIO
+        .service[Console]
+        .map(console =>
+          new Service {
+            val foo: UIO[Unit]                                              = UIO.unit
+            def foo2: UIO[Unit]                                             = UIO.unit
+            def foo3(): UIO[Unit]                                           = UIO.unit
+            def bar(n: Int): UIO[Unit]                                      = console.printLine(s"bar $n").orDie
+            def baz(x: Int, y: Int): IO[String, Int]                        = UIO.succeed(x + y)
+            def poly[A](a: A): IO[Long, A]                                  = UIO.succeed(a)
+            def poly2[A <: Foo](a: Wrapped[A]): IO[String, List[A]]         = UIO.succeed(List(a.value))
+            def dependent(n: Int): ZIO[Random, Long, Int]                   = Random.nextIntBounded(n)
+            val value: String                                               = "foo"
+            def value2: String                                              = "foo2"
+            def value3(): String                                            = "foo3"
+            def function(n: Int): String                                    = s"foo $n"
+            def stream(n: Int): ZStream[Any, String, Int]                   = ZStream.fromIterable(List(1, 2, 3))
+            def sink(n: Int): ZSink[Any, Nothing, Int, Nothing, Chunk[Int]] = ZSink.collectAll
+            def withEx(): String                                            = throw new Exception("test")
+            def withEx1(p: String): String                                  = throw new Exception("test")
+          }
+        )
+    }
 
   // can use accessors even in the same compilation unit
   val program: URIO[

--- a/examples/shared/src/main/scala/zio/examples/types/OldLady.scala
+++ b/examples/shared/src/main/scala/zio/examples/types/OldLady.scala
@@ -50,6 +50,6 @@ object Fly {
   val live: URLayer[Console, Fly] = {
     println("FLY")
 
-    Console.printLine("Bzzzzzzzzzz...").orDie.as(new Fly {}).toLayer
+    ZLayer(Console.printLine("Bzzzzzzzzzz...").orDie.as(new Fly {}))
   }
 }

--- a/test-tests/shared/src/test/scala/zio/test/AutoWireSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AutoWireSpec.scala
@@ -93,7 +93,7 @@ object AutoWireSpec extends ZIOBaseSpec {
       ),
       suite(".provideShared") {
         val addOne   = ZIO.service[Ref[Int]].flatMap(_.getAndUpdate(_ + 1))
-        val refLayer = Ref.make(1).toLayer
+        val refLayer = ZLayer(Ref.make(1))
 
         suite("layers are shared between tests and suites")(
           suite("suite 1")(
@@ -115,7 +115,7 @@ object AutoWireSpec extends ZIOBaseSpec {
           ZIO
             .serviceWithZIO[IntService](_.add(1))
 
-        val refLayer: ULayer[IntService] = Ref.make(1).map(IntService(_)).toLayer
+        val refLayer: ULayer[IntService] = ZLayer(Ref.make(1).map(IntService(_)))
 
         suite("layers are shared between tests and suites")(
           suite("suite 1")(

--- a/test/shared/src/main/scala/zio/test/Live.scala
+++ b/test/shared/src/main/scala/zio/test/Live.scala
@@ -40,14 +40,15 @@ object Live {
    */
   val default: ZLayer[ZEnv, Nothing, Live] = {
     implicit val trace = Tracer.newTrace
-    ZIO
-      .environmentWith[ZEnv] { zenv =>
-        new Live {
-          def provide[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
-            ZEnv.services.locallyWith(_.unionAll(zenv))(zio)
+    ZLayer {
+      ZIO
+        .environmentWith[ZEnv] { zenv =>
+          new Live {
+            def provide[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
+              ZEnv.services.locallyWith(_.unionAll(zenv))(zio)
+          }
         }
-      }
-      .toLayer
+    }
   }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestLogger.scala
+++ b/test/shared/src/main/scala/zio/test/TestLogger.scala
@@ -26,11 +26,13 @@ trait TestLogger extends Serializable {
 object TestLogger {
 
   def fromConsole(implicit trace: ZTraceElement): ZLayer[Any, Nothing, TestLogger] =
-    ZIO.console.map { console =>
-      new TestLogger {
-        def logLine(line: String)(implicit trace: ZTraceElement): UIO[Unit] = console.printLine(line).orDie
+    ZLayer {
+      ZIO.console.map { console =>
+        new TestLogger {
+          def logLine(line: String)(implicit trace: ZTraceElement): UIO[Unit] = console.printLine(line).orDie
+        }
       }
-    }.toLayer
+    }
 
   def logLine(line: String)(implicit trace: ZTraceElement): URIO[TestLogger, Unit] =
     ZIO.serviceWithZIO(_.logLine(line))


### PR DESCRIPTION
Focuses on `ZLayer.apply` and `ZLayer.scoped` as the way to construct layers and creates consistency between creating layers from normal workflows with `apply` and scoped workflows with `scoped`.