### PR TITLE
Specialize Spec

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SystemSpec.scala
@@ -7,7 +7,7 @@ import java.io.File
 
 object SystemSpec extends ZIOBaseSpec {
 
-  def spec: Spec[Live with Annotations, TestFailure[Any], TestSuccess] = suite("SystemSpec")(
+  def spec: Spec[Live with Annotations, Any, TestSuccess] = suite("SystemSpec")(
     suite("Fetch an environment variable and check that")(
       test("If it exists, return a reasonable value") {
         assertM(live(System.env("PATH")))(isSome(containsString(File.separator + "bin")))

--- a/core-tests/jvm/src/test/scala/zio/SystemSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SystemSpec.scala
@@ -7,7 +7,7 @@ import java.io.File
 
 object SystemSpec extends ZIOBaseSpec {
 
-  def spec: Spec[Live with Annotations, Any, TestSuccess] = suite("SystemSpec")(
+  def spec: Spec[Live with Annotations, Any] = suite("SystemSpec")(
     suite("Fetch an environment variable and check that")(
       test("If it exists, return a reasonable value") {
         assertM(live(System.env("PATH")))(isSome(containsString(File.separator + "bin")))

--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -14,7 +14,7 @@ object JavaSpec extends ZIOBaseSpec {
 
   import ZIOTag._
 
-  def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = suite("JavaSpec")(
+  def spec: Spec[Annotations, Any, TestSuccess] = suite("JavaSpec")(
     suite("`Task.fromFutureJava` must")(
       test("be lazy on the `Future` parameter") {
         var evaluated         = false

--- a/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/interop/JavaSpec.scala
@@ -14,7 +14,7 @@ object JavaSpec extends ZIOBaseSpec {
 
   import ZIOTag._
 
-  def spec: Spec[Annotations, Any, TestSuccess] = suite("JavaSpec")(
+  def spec: Spec[Annotations, Any] = suite("JavaSpec")(
     suite("`Task.fromFutureJava` must")(
       test("be lazy on the `Future` parameter") {
         var evaluated         = false

--- a/core-tests/shared/src/test/scala-2.x/zio.internal/CleanCodePrinterSpec.scala
+++ b/core-tests/shared/src/test/scala-2.x/zio.internal/CleanCodePrinterSpec.scala
@@ -13,7 +13,7 @@ object CleanCodePrinterSpec extends ZIOBaseSpec {
   def containsStringWithoutAnsi(element: String): Assertion[String] =
     Assertion.assertion("containsStringWithoutAnsi")(param(element))(_.removingAnsiCodes.contains(element))
 
-  def spec: ZSpec[Environment, Failure] =
+  def spec: Spec[Environment, Failure] =
     suite("AutoLayerSpec")(
       suite(".showTree") {
         test("prints trees for expressions") {

--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -5,7 +5,7 @@ import zio.test._
 
 object LoggingSpec extends ZIOBaseSpec {
 
-  def spec: ZSpec[Any, Any] =
+  def spec: Spec[Any, Any] =
     suite("LoggingSpec")(
       test("simple log message") {
         for {

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -7,7 +7,7 @@ object PromiseSpec extends ZIOBaseSpec {
 
   import ZIOTag._
 
-  def spec: Spec[Any, TestFailure[Any], TestSuccess] = suite("PromiseSpec")(
+  def spec: Spec[Any, TestFailure[Any]] = suite("PromiseSpec")(
     test("complete a promise using succeed") {
       for {
         p <- Promise.make[Nothing, Int]

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -708,8 +708,8 @@ object ScheduleSpec extends ZIOBaseSpec {
     isCase(
       "Runtime",
       {
-        case TestFailure.Runtime(c) => c.dieOption
-        case _                      => None
+        case TestFailure.Runtime(c, _) => c.dieOption
+        case _                         => None
       },
       assertion
     )

--- a/core-tests/shared/src/test/scala/zio/TaggedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/TaggedSpec.scala
@@ -6,7 +6,7 @@ import zio.test._
 
 object TaggedSpec extends ZIOBaseSpec {
 
-  def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = suite("TaggedSpec")(
+  def spec: Spec[Annotations, TestFailure[Any]] = suite("TaggedSpec")(
     test("tags can be derived for polymorphic services") {
       val result = typeCheck {
         """

--- a/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/HubSpec.scala
@@ -180,28 +180,28 @@ object HubSpec extends ZIOBaseSpec {
     math.pow(2, nextPow.toDouble).toInt.max(2)
   }
 
-  def publishPoll(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishPoll(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent publish and poll")(
       publishPoll1To1(makeHub, false),
       publishPoll1ToN(makeHub, false),
       publishPollNToN(makeHub, false)
     )
 
-  def publishPollLimitedCapacity(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishPollLimitedCapacity(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("with limited capacity")(
       publishPoll1To1(_ => makeHub(1), false),
       publishPoll1ToN(_ => makeHub(1), false),
       publishPollNToN(_ => makeHub(1), false)
     )
 
-  def publishPollDynamic(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishPollDynamic(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("with concurrent subscribes and unsubscribes")(
       publishPoll1To1(_ => makeHub(1), true),
       publishPoll1ToN(_ => makeHub(1), true),
       publishPollNToN(_ => makeHub(1), true)
     )
 
-  def emptyFull(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def emptyFull(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent isEmpty and isFull")(
       isEmpty(makeHub),
       isFull(makeHub),
@@ -209,51 +209,51 @@ object HubSpec extends ZIOBaseSpec {
       publishNonFull(makeHub)
     )
 
-  def publishAllPollUpTo(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishAllPollUpTo(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent publishAll and pollUpTo")(
       publishAllPollUpTo1To1(makeHub),
       publishAllPollUpToNToN(makeHub)
     )
 
-  def slidingPublishPoll(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPoll(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent sliding publish and poll")(
       slidingPublishPoll1To1(makeHub, false),
       slidingPublishPoll1ToN(makeHub, false),
       slidingPublishPollNToN(makeHub, false)
     )
 
-  def slidingPublishPollLimitedCapacity(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPollLimitedCapacity(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("with limited capacity")(
       slidingPublishPoll1To1(_ => makeHub(1), false),
       slidingPublishPoll1ToN(_ => makeHub(1), false),
       slidingPublishPollNToN(_ => makeHub(1), false)
     )
 
-  def slidingPublishPollDynamic(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPollDynamic(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("with concurrent subscribes and unsubscribes")(
       slidingPublishPoll1To1(_ => makeHub(1), true),
       slidingPublishPoll1ToN(_ => makeHub(1), true),
       slidingPublishPollNToN(_ => makeHub(1), true)
     )
 
-  def slidingPublishAllPollUpTo(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishAllPollUpTo(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent sliding publishAll and pollUpTo")(
       slidingPublishAllPollUpTo1To1(makeHub),
       slidingPublishAllPollUpToNToN(makeHub)
     )
 
-  def concurrentUnsubscribe(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def concurrentUnsubscribe(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent unsubscribe")(
       concurrentPublishUnsubscribe(makeHub),
       concurrentPollUnsubscribe(makeHub)
     )
 
-  def concurrentPoll(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def concurrentPoll(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     suite("concurrent poll")(
       poll("with two pollers")(_ => makeHub(1))
     )
 
-  def publishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def publishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
@@ -272,7 +272,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def publishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def publishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with one publisher and two subscribers") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length)
@@ -297,7 +297,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def publishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def publishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length * 2)
@@ -326,7 +326,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def isEmpty(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def isEmpty(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("isEmpty always returns false on a subscription that is not empty") {
       check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(1000)
@@ -353,7 +353,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def isFull(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def isFull(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("isFull always returns false on a hub that is not full") {
       check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(10000)
@@ -377,7 +377,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def publishNonFull(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishNonFull(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("publishing to a hub that is not full always succeeds") {
       check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(10000)
@@ -399,7 +399,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def pollNonEmpty(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def pollNonEmpty(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("polling from a hub that is not empty always succeeds") {
       check(Gen.listOf(smallInt)) { as =>
         val hub           = makeHub(1000)
@@ -422,7 +422,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def publishAllPollUpTo1To1(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishAllPollUpTo1To1(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
       check(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
         val hub          = makeHub(1000)
@@ -435,7 +435,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def publishAllPollUpToNToN(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def publishAllPollUpToNToN(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
       check(Gen.listOf(Gen.chunkOf(smallInt)), smallInt) { (chunks, chunkSize) =>
         val hub           = makeHub(1000)
@@ -455,7 +455,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def poll(label: String)(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def poll(label: String)(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test(label) {
       check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
@@ -473,7 +473,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def slidingPublishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPoll1To1(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub          = makeHub(as.length)
@@ -490,7 +490,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def slidingPublishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPoll1ToN(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with one publisher and two subscribers") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length)
@@ -511,7 +511,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def slidingPublishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishPollNToN(makeHub: Int => Hub[Int], dynamic: Boolean): Spec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
       check(Gen.listOf1(smallInt)) { as =>
         val hub           = makeHub(as.length * 2)
@@ -536,7 +536,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def slidingPublishAllPollUpTo1To1(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishAllPollUpTo1To1(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with one publisher and one subscriber") {
       check(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
         val chunks       = as.sorted.grouped(chunkSize).map(Chunk.fromIterable).toList
@@ -551,7 +551,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def slidingPublishAllPollUpToNToN(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def slidingPublishAllPollUpToNToN(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with two publishers and two subscribers") {
       check(Gen.listOf(smallInt), smallInt) { (as, chunkSize) =>
         val leftChunks    = as.sorted.grouped(chunkSize).map(Chunk.fromIterable).toList
@@ -574,7 +574,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     }
 
-  def concurrentPublishUnsubscribe(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def concurrentPublishUnsubscribe(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with publish") {
       val hub          = makeHub(2)
       val subscription = hub.subscribe()
@@ -595,7 +595,7 @@ object HubSpec extends ZIOBaseSpec {
         assert(values)(equalTo(List(2, 3, 4, 5, 6)))
     }
 
-  def concurrentPollUnsubscribe(makeHub: Int => Hub[Int]): ZSpec[TestEnvironment, Nothing] =
+  def concurrentPollUnsubscribe(makeHub: Int => Hub[Int]): Spec[TestEnvironment, Nothing] =
     test("with poll") {
       val hub          = makeHub(2)
       val subscription = hub.subscribe()
@@ -617,7 +617,7 @@ object HubSpec extends ZIOBaseSpec {
         assert(values)(equalTo(List(2, 3, 4, 5, 6)))
     }
 
-  lazy val basicOperationsPow2: ZSpec[TestEnvironment, Nothing] =
+  lazy val basicOperationsPow2: Spec[TestEnvironment, Nothing] =
     suite("basic operations")(
       test("publish and poll a single value") {
         val hub          = Hub.bounded[Int](2)
@@ -666,7 +666,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     )
 
-  lazy val basicOperationsUnbounded: ZSpec[TestEnvironment, Nothing] =
+  lazy val basicOperationsUnbounded: Spec[TestEnvironment, Nothing] =
     suite("basic operations")(
       test("publish and poll a single value") {
         val hub           = Hub.unbounded[Int]
@@ -775,7 +775,7 @@ object HubSpec extends ZIOBaseSpec {
       }
     )
 
-  lazy val basicOperationsSingle: ZSpec[TestEnvironment, Nothing] =
+  lazy val basicOperationsSingle: Spec[TestEnvironment, Nothing] =
     suite("basic operations")(
       test("publish and poll a single value") {
         val hub          = Hub.bounded[Int](1)

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/ConcurrentSummarySpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/ConcurrentSummarySpec.scala
@@ -6,7 +6,7 @@ import zio.test.TestAspect._
 import zio.metrics._
 
 object ConcurrentSummarySpec extends ZIOBaseSpec {
-  override def spec: ZSpec[Environment, Any] =
+  override def spec: Spec[Environment, Any] =
     suite("ConcurrentSummary")(
       test("single observe works with maxSize = 0") {
         val summary = ConcurrentMetricHooks.summary(

--- a/docs/datatypes/test/assertion.md
+++ b/docs/datatypes/test/assertion.md
@@ -430,11 +430,11 @@ In order to understand the `Assertion` data type, let's first look at the `test`
 def test[In](label: String)(assertion: => In)(implicit testConstructor: TestConstructor[Nothing, In]): testConstructor.Out
 ```
 
-Its signature is a bit complicated and uses _path dependent types_, but it doesn't matter. We can think of a `test` as a function from `TestResult` (or its effectful versions such as `ZIO[R, E, TestResult]` or `ZSTM[R, E, TestResult]`) to the `ZSpec[R, E]` data type:
+Its signature is a bit complicated and uses _path dependent types_, but it doesn't matter. We can think of a `test` as a function from `TestResult` (or its effectful versions such as `ZIO[R, E, TestResult]` or `ZSTM[R, E, TestResult]`) to the `Spec[R, E]` data type:
 
 ```scala
-def test(label: String)(assertion: => TestResult): ZSpec[Any, Nothing]
-def test(label: String)(assertion: => ZIO[R, E, TestResult]): ZSpec[R, E]
+def test(label: String)(assertion: => TestResult): Spec[Any, Nothing]
+def test(label: String)(assertion: => ZIO[R, E, TestResult]): Spec[R, E]
 ```
 
 Therefore, the function `test` needs a `TestResult`. The most common way to produce a `TestResult` is to resort to `assert` or its effectful counterpart `assertM`. The former one is for creating ordinary `TestResult` values and the latter one is for producing effectful `TestResult` values. Both of them accept a value of type `A` (effectful version wrapped in a `ZIO`) and an `Assertion[A]`.

--- a/docs/datatypes/test/environment/index.md
+++ b/docs/datatypes/test/environment/index.md
@@ -22,7 +22,7 @@ If we are using ZIO Test and extending `ZIOSpecDefault` a `TestEnvironment` cont
 ```scala mdoc:invisible:nest
 import zio.Scope
 import zio.test._
-val myProgram: ZSpec[TestEnvironment, Nothing] =
+val myProgram: Spec[TestEnvironment, Nothing] =
   test("my suite")(assertTrue(true))
 ```
 
@@ -36,7 +36,7 @@ If we are only interested in one of the test implementations for our application
 
 ```scala mdoc:invisible:nest
 import zio.test._
-val myProgram: ZSpec[TestConsole, Nothing] = test("my suite")(assertTrue(true))
+val myProgram: Spec[TestConsole, Nothing] = test("my suite")(assertTrue(true))
 ```
 
 ```scala mdoc:compile-only

--- a/docs/datatypes/test/index.md
+++ b/docs/datatypes/test/index.md
@@ -156,9 +156,9 @@ import zio.test.{test, _}
 import zio.test.Assertion._
 
 val kafkaLayer: ZLayer[Any, Nothing, Int] = ZLayer.succeed(1)
-val test1: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
-val test2: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
-val test3: ZSpec[Int, Nothing] = test("kafkatest")(assertTrue(true))
+val test1: Spec[Int, Nothing] = test("kafkatest")(assertTrue(true))
+val test2: Spec[Int, Nothing] = test("kafkatest")(assertTrue(true))
+val test3: Spec[Int, Nothing] = test("kafkatest")(assertTrue(true))
 ```
 
 ```scala mdoc:compile-only

--- a/examples/shared/src/test/scala/zio/examples/test/ZLayerInjectExampleSpec.scala
+++ b/examples/shared/src/test/scala/zio/examples/test/ZLayerInjectExampleSpec.scala
@@ -12,7 +12,7 @@
 //      Console.printLine(s"There was an old who lady swallowed:\n- ${contents.mkString("\n- ")}").orDie
 //    }
 //
-//  def spec: ZSpec[Environment, Failure] =
+//  def spec: Spec[Environment, Failure] =
 //    suite("AutoLayerExampleSpec")(
 //      test("inject") {
 //        assertM(exampleZio)(anything)

--- a/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/ZSinkPlatformSpecificSpec.scala
@@ -11,7 +11,7 @@ import java.security.MessageDigest
 
 object ZSinkPlatformSpecificSpec extends ZIOBaseSpec {
 
-  override def spec: ZSpec[Any, Throwable] = suite("ZSink JVM")(
+  override def spec: Spec[Any, Throwable] = suite("ZSink JVM")(
     suite("fromFile")(
       test("writes to an existing file") {
         val data = (0 to 100).mkString

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -2,7 +2,7 @@
 
 // import org.apache.maven.cli.MavenCli
 // import zio.test.Assertion._
-// import zio.test.{DefaultRunnableSpec, ZSpec, _}
+// import zio.test.{DefaultRunnableSpec, Spec, _}
 // import zio.{System => _, _}
 
 // import java.io.File
@@ -18,7 +18,7 @@
 //  */
 // object MavenJunitSpec extends DefaultRunnableSpec {
 
-//   def spec: ZSpec[Environment, Failure] = suite("MavenJunitSpec")(
+//   def spec: Spec[Environment, Any] = suite("MavenJunitSpec")(
 //     test("FailingSpec results are properly reported") {
 //       for {
 //         mvn       <- makeMaven

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -58,7 +58,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   lazy val getDescription: Description = {
     val description = Description.createSuiteDescription(className)
     def traverse[R, E](
-      spec: ZSpec[R, E],
+      spec: Spec[R, E],
       description: Description,
       path: Vector[String] = Vector.empty
     ): ZIO[R with Scope, Any, Unit] =
@@ -93,7 +93,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   override def run(notifier: RunNotifier): Unit = {
     val _ = zio.Runtime(ZEnvironment.empty, spec.runtime.runtimeConfig).unsafeRun {
 
-      val instrumented: ZSpec[spec.Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
+      val instrumented: Spec[spec.Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
         instrumentSpec(filteredSpec, new JUnitNotifier(notifier))
       spec
         .runSpec(
@@ -144,9 +144,9 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   }
 
   private def instrumentSpec[R, E](
-    zspec: ZSpec[R, E],
+    zspec: Spec[R, E],
     notifier: JUnitNotifier
-  ): ZSpec[R, E] = {
+  ): Spec[R, E] = {
     type ZSpecCase = Spec.SpecCase[R, E, Spec[R, E]]
     def instrumentTest(label: String, path: Vector[String], test: ZIO[R, TestFailure[E], TestSuccess]) =
       notifier.fireTestStarted(label, path) *> test.tapBoth(

--- a/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveDiffSpec.scala
+++ b/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveDiffSpec.scala
@@ -17,7 +17,7 @@ object DeriveDiffSpec extends ZIOSpecDefault {
     final case class Green(isCool: Boolean)                                 extends Color
   }
 
-  def spec: Spec[Any, TestFailure[Any], TestSuccess] = suite("DeriveDiffSpec")(
+  def spec: Spec[Any, TestFailure[Any]] = suite("DeriveDiffSpec")(
     suite("derivation")(
       test("case classes can be derived") {
         val l1 = List("Alpha", "This is a wonderful \"way\" to dance and party", "Potato")

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -76,7 +76,7 @@ object FrameworkSpecInstances {
   lazy val failingSpecFQN = SimpleFailingSharedSpec.getClass.getName
 
   object SimpleFailingSharedSpec extends ZIOSpecDefault {
-    def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = zio.test.suite("some suite")(
+    def spec: Spec[Annotations, TestFailure[Any]] = zio.test.suite("some suite")(
       test("failing test") {
         zio.test.assert(1)(Assertion.equalTo(2))
       },

--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -8,10 +8,12 @@ object AnnotationsSpec extends ZIOBaseSpec {
   def spec = suite("annotationsSpec")(
     test("withAnnotation executes specified effect with an empty annotation map") {
       for {
-        _   <- Annotations.annotate(count, 1)
-        a   <- Annotations.get(count)
-        map <- Annotations.withAnnotation(ZIO.unit <* Annotations.annotate(count, 2)).map(_._2)
-        b    = map.get(count)
+        _ <- Annotations.annotate(count, 1)
+        a <- Annotations.get(count)
+        map <- Annotations
+                 .withAnnotation(Annotations.annotate(count, 2) *> ZIO.succeed(TestSuccess.Ignored()))
+                 .map(_.annotations)
+        b = map.get(count)
       } yield assert(a)(equalTo(1)) && assert(b)(equalTo(2))
     },
     test("withAnnotation returns annotation map with result") {

--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -16,8 +16,11 @@ object AnnotationsSpec extends ZIOBaseSpec {
     },
     test("withAnnotation returns annotation map with result") {
       for {
-        map <- Annotations.withAnnotation(Annotations.annotate(count, 3) *> ZIO.fail("fail")).flip.map(_._2)
-        c    = map.get(count)
+        map <- Annotations
+                 .withAnnotation(Annotations.annotate(count, 3) *> ZIO.fail(TestFailure.fail("fail")))
+                 .flip
+                 .map(_.annotations)
+        c = map.get(count)
       } yield assert(c)(equalTo(3))
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 
 object AssertionSpec extends ZIOBaseSpec {
 
-  def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = suite("AssertionSpec")(
+  def spec: Spec[Annotations, TestFailure[Any]] = suite("AssertionSpec")(
     test("and must succeed when both assertions are satisfied") {
       assert(sampleUser)(nameStartsWithU && ageGreaterThan20)
     },

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -188,7 +188,7 @@ object IntelliJRenderUtils {
 
   // TODO de-dup layer creation
   def runLog(
-    spec: ZSpec[TestEnvironment, String]
+    spec: Spec[TestEnvironment, String]
   )(implicit trace: ZTraceElement): ZIO[TestEnvironment with Scope, Nothing, String] =
     for {
       _ <-

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -108,7 +108,7 @@ object ReportingTestUtils {
     withOffset(4)(assertSourceLocation() + "\n\n")
   )
 
-  def test4(implicit trace: ZTraceElement): Spec[Any, String, Nothing] =
+  def test4(implicit trace: ZTraceElement): Spec[Any, String] =
     Spec.labeled("Failing test", Spec.test(failed(Cause.fail("Test 4 Fail")), TestAnnotationMap.empty))
 
   def test5(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
@@ -176,7 +176,7 @@ object ReportingTestUtils {
     assertTrue(1 == 0).map(_.label("fourth"))
   }
 
-  def suite1(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
+  def suite1(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     suite("Suite1")(test1, test2)
   def suite1Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedSuccess("Suite1"),
@@ -184,7 +184,7 @@ object ReportingTestUtils {
     withOffset(4)(test2Expected)
   )
 
-  def suite2(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
+  def suite2(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     suite("Suite2")(test1, test2, test3)
   def suite2Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedSuccess("Suite2"),
@@ -192,7 +192,7 @@ object ReportingTestUtils {
     withOffset(4)(test2Expected)
   ) ++ test3Expected.map(withOffset(2)(_))
 
-  def suite3(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
+  def suite3(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     suite("Suite3")(suite1, suite2, test3)
   def suite3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(expectedSuccess("Suite3")) ++
     suite1Expected.map(withOffset(2)) ++
@@ -200,7 +200,7 @@ object ReportingTestUtils {
     Vector("\n") ++
     test3Expected.map(withOffset(2))
 
-  def suite4(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
+  def suite4(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     suite("Suite4")(suite1, suite("Empty")(), test3)
   def suite4Expected(implicit trace: ZTraceElement): Vector[String] = {
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -108,7 +108,7 @@ object ReportingTestUtils {
     withOffset(4)(assertSourceLocation() + "\n\n")
   )
 
-  def test4(implicit trace: ZTraceElement): Spec[Any, TestFailure[String], Nothing] =
+  def test4(implicit trace: ZTraceElement): Spec[Any, String, Nothing] =
     Spec.labeled("Failing test", Spec.test(failed(Cause.fail("Test 4 Fail")), TestAnnotationMap.empty))
 
   def test5(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
@@ -176,7 +176,7 @@ object ReportingTestUtils {
     assertTrue(1 == 0).map(_.label("fourth"))
   }
 
-  def suite1(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
+  def suite1(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
     suite("Suite1")(test1, test2)
   def suite1Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedSuccess("Suite1"),
@@ -184,7 +184,7 @@ object ReportingTestUtils {
     withOffset(4)(test2Expected)
   )
 
-  def suite2(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
+  def suite2(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
     suite("Suite2")(test1, test2, test3)
   def suite2Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedSuccess("Suite2"),
@@ -192,7 +192,7 @@ object ReportingTestUtils {
     withOffset(4)(test2Expected)
   ) ++ test3Expected.map(withOffset(2)(_))
 
-  def suite3(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
+  def suite3(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
     suite("Suite3")(suite1, suite2, test3)
   def suite3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(expectedSuccess("Suite3")) ++
     suite1Expected.map(withOffset(2)) ++
@@ -200,7 +200,7 @@ object ReportingTestUtils {
     Vector("\n") ++
     test3Expected.map(withOffset(2))
 
-  def suite4(implicit trace: ZTraceElement): Spec[Any, TestFailure[Nothing], TestSuccess] =
+  def suite4(implicit trace: ZTraceElement): Spec[Any, Nothing, TestSuccess] =
     suite("Suite4")(suite1, suite("Empty")(), test3)
   def suite4Expected(implicit trace: ZTraceElement): Vector[String] = {
 

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -44,7 +44,7 @@ object ReportingTestUtils {
 
   // TODO de-dup layers?
   def runLog(
-    spec: ZSpec[TestEnvironment, String]
+    spec: Spec[TestEnvironment, String]
   )(implicit trace: ZTraceElement): ZIO[TestEnvironment with Scope, Nothing, String] =
     for {
       console <- ZIO.console
@@ -59,7 +59,7 @@ object ReportingTestUtils {
       output <- TestConsole.output
     } yield output.mkString
 
-  def runSummary(spec: ZSpec[TestEnvironment, String]): ZIO[TestEnvironment, Nothing, String] =
+  def runSummary(spec: Spec[TestEnvironment, String]): ZIO[TestEnvironment, Nothing, String] =
     for {
       console <- ZIO.console
       summary <-
@@ -85,14 +85,14 @@ object ReportingTestUtils {
       reporter = DefaultTestReporter(TestRenderer.default, TestAnnotationRenderer.default)
     )
 
-  def test1(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(2)))
-  val test1Expected: String                                     = expectedSuccess("Addition works fine")
+  def test1(implicit trace: ZTraceElement): Spec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(2)))
+  val test1Expected: String                                    = expectedSuccess("Addition works fine")
 
-  def test2(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
+  def test2(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     test("Subtraction works fine")(assert(1 - 1)(equalTo(0)))
   val test2Expected: String = expectedSuccess("Subtraction works fine")
 
-  def test3(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
+  def test3(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
   def test3Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     withOffset(2)(expectedFailure("Value falls within range")),
@@ -111,7 +111,7 @@ object ReportingTestUtils {
   def test4(implicit trace: ZTraceElement): Spec[Any, String] =
     Spec.labeled("Failing test", Spec.test(failed(Cause.fail("Test 4 Fail")), TestAnnotationMap.empty))
 
-  def test5(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
+  def test5(implicit trace: ZTraceElement): Spec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
   // the captured expression for `1+1` is different between dotty and 2.x
   def expressionIfNotRedundant(expr: String, value: Any): String =
     Option(expr).filterNot(_ == value.toString).fold(value.toString)(e => s"`$e` = $value")
@@ -123,7 +123,7 @@ object ReportingTestUtils {
     withOffset(2)(assertSourceLocation() + "\n")
   )
 
-  def test6(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
+  def test6(implicit trace: ZTraceElement): Spec[Any, Nothing] =
     test("Multiple nested failures")(assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4)))))
   def test6Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
     expectedFailure("Multiple nested failures"),
@@ -137,7 +137,7 @@ object ReportingTestUtils {
     withOffset(2)(assertSourceLocation() + "\n")
   )
 
-  def test7(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("labeled failures") {
+  def test7(implicit trace: ZTraceElement): Spec[Any, Nothing] = test("labeled failures") {
     for {
       a <- ZIO.succeed(Some(1))
       b <- ZIO.succeed(Some(1))
@@ -157,7 +157,7 @@ object ReportingTestUtils {
     withOffset(2)(assertSourceLocation() + "\n")
   )
 
-  def test8(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("Not combinator") {
+  def test8(implicit trace: ZTraceElement): Spec[Any, Nothing] = test("Not combinator") {
     assert(100)(not(equalTo(100)))
   }
   def test8Expected(implicit trace: ZTraceElement): Vector[String] = Vector(
@@ -169,7 +169,7 @@ object ReportingTestUtils {
     withOffset(2)(assertSourceLocation() + "\n")
   )
 
-  def test9(implicit trace: ZTraceElement): ZSpec[Any, Nothing] = test("labeled failures") {
+  def test9(implicit trace: ZTraceElement): Spec[Any, Nothing] = test("labeled failures") {
     assertTrue(1 == 1).map(_.label("first")) &&
     assertTrue(1 == 1).map(_.label("second")) &&
     assertTrue(1 == 0).map(_.label("third")) &&

--- a/test-tests/shared/src/test/scala/zio/test/ScopedSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ScopedSpec.scala
@@ -25,7 +25,7 @@ object ScopedSpec extends ZIOBaseSpec {
       ZIO.serviceWithZIO(_.incrementAndGet)
   }
 
-  def spec: Spec[Annotations, TestFailure[Any], TestSuccess] = suite("ScopedSpec")(
+  def spec: Spec[Annotations, TestFailure[Any]] = suite("ScopedSpec")(
     suite("scoped shared")(
       suite("first suite")(
         test("first test") {

--- a/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ShowExpressionSpec.scala
@@ -8,7 +8,7 @@ object ShowExpressionSpec extends ZIOBaseSpec {
   case class Nested(bar: Int)
   class SomeClass(val str: String = "")
 
-  override def spec: ZSpec[Annotations, Any] = suite("ShowExprSpec")(
+  override def spec: Spec[Annotations, Any] = suite("ShowExprSpec")(
     test("Some(1)", showExpression(Some(1)), "Some(1)"),
     test("Some(Right(1))", showExpression(Some(Right(1))), "Some(Right(1))"),
     test("class member val", showExpression(fooVal), "fooVal"),
@@ -57,7 +57,7 @@ object ShowExpressionSpec extends ZIOBaseSpec {
 
   def methodWithDefaultArgs(arg: String = "") = arg
 
-  def test(desc: String, actual: String, expected: String): ZSpec[Any, Nothing] =
+  def test(desc: String, actual: String, expected: String): Spec[Any, Nothing] =
     test(desc) {
       val code = actual
       assert(code)(equalTo(expected))

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -10,7 +10,7 @@ object SpecSpec extends ZIOBaseSpec {
   val specLayer: ZLayer[Any, Nothing, Unit] =
     ZLayer.succeed(())
 
-  def spec: Spec[TestEnvironment, TestFailure[Nothing], TestSuccess] = suite("SpecSpec")(
+  def spec: Spec[TestEnvironment, TestFailure[Nothing]] = suite("SpecSpec")(
     suite("provideCustomLayer")(
       test("provides the part of the environment that is not part of the `TestEnvironment`") {
         for {

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -110,8 +110,8 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("failure makes tests pass on an expected assertion failure") {
       assert(true)(equalTo(false))
     } @@ failing[TestFailure[Any]] {
-      case TestFailure.Assertion(_) => true
-      case TestFailure.Runtime(_)   => false
+      case TestFailure.Assertion(_, _) => true
+      case TestFailure.Runtime(_, _)   => false
     },
     test("flaky retries a test that fails") {
       for {
@@ -332,8 +332,8 @@ object TestAspectSpec extends ZIOBaseSpec {
     diesWith(ct.unapply(_).isDefined)
 
   def diesWith(assertion: Throwable => Boolean): TestFailure[Any] => Boolean = {
-    case TestFailure.Assertion(_) => false
-    case TestFailure.Runtime(cause) =>
+    case TestFailure.Assertion(_, _) => false
+    case TestFailure.Runtime(cause, _) =>
       cause.dieOption match {
         case Some(t) => assertion(t)
         case None    => false

--- a/test-tests/shared/src/test/scala/zio/test/TestOutputSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestOutputSpec.scala
@@ -59,7 +59,7 @@ object TestOutputSpec extends ZIOSpecDefault {
 
   val fakePrinterLayer: ZLayer[Any, Nothing, ExecutionEventHolder] = ZLayer.fromZIO(makeFakePrinter)
 
-  override def spec: ZSpec[TestEnvironment with Scope, Any] = suite("TestOutputSpec")(
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("TestOutputSpec")(
     test("nested events without flushing") {
       val events =
         List(

--- a/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestUtils.scala
@@ -4,7 +4,7 @@ import zio.{Console, ExecutionStrategy, UIO}
 
 object TestUtils {
 
-  def execute[E](spec: ZSpec[TestEnvironment, E]): UIO[Summary] =
+  def execute[E](spec: Spec[TestEnvironment, E]): UIO[Summary] =
     TestExecutor
       .default(
         testEnvironment,
@@ -14,11 +14,11 @@ object TestUtils {
       )
       .run(spec, ExecutionStrategy.Sequential)
 
-  def isIgnored[E](spec: ZSpec[TestEnvironment, E]): UIO[Boolean] =
+  def isIgnored[E](spec: Spec[TestEnvironment, E]): UIO[Boolean] =
     execute(spec)
       .map(_.ignore > 0)
 
-  def succeeded[E](spec: ZSpec[TestEnvironment, E]): UIO[Boolean] =
+  def succeeded[E](spec: Spec[TestEnvironment, E]): UIO[Boolean] =
     execute(spec).map { summary =>
       summary.fail == 0
     }

--- a/test/shared/src/main/scala-2/zio/test/SpecLayerMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SpecLayerMacros.scala
@@ -7,18 +7,21 @@ import zio.internal.macros.ProvideMethod.Provide
 import scala.reflect.macros.blackbox
 
 class SpecLayerMacros(val c: blackbox.Context) extends LayerMacroUtils {
-  def provideSharedImpl[R: c.WeakTypeTag, E, A](
-    layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[Any, E, A]] =
-    provideBaseImpl[Spec, Any, R, E, A](layer, "provideLayerShared", ProvideMethod.Provide)
 
-  def provideCustomSharedImpl[R: c.WeakTypeTag, E, A](
-    layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[TestEnvironment, E, A]] =
-    provideBaseImpl[Spec, TestEnvironment, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideCustom)
+  private type ZSpec[-R, +E, +T] = Spec[R, E]
 
-  def provideSomeSharedImpl[R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
+  def provideSharedImpl[R: c.WeakTypeTag, E](
     layer: c.Expr[ZLayer[_, E, _]]*
-  ): c.Expr[Spec[R0, E, A]] =
-    provideBaseImpl[Spec, R0, R, E, A](layer, "provideLayerShared", ProvideMethod.ProvideSome)
+  ): c.Expr[Spec[Any, E]] =
+    provideBaseImpl[ZSpec, Any, R, E, TestSuccess](layer, "provideLayerShared", ProvideMethod.Provide)
+
+  def provideCustomSharedImpl[R: c.WeakTypeTag, E](
+    layer: c.Expr[ZLayer[_, E, _]]*
+  ): c.Expr[Spec[TestEnvironment, E]] =
+    provideBaseImpl[ZSpec, TestEnvironment, R, E, TestSuccess](layer, "provideLayerShared", ProvideMethod.ProvideCustom)
+
+  def provideSomeSharedImpl[R0: c.WeakTypeTag, R: c.WeakTypeTag, E](
+    layer: c.Expr[ZLayer[_, E, _]]*
+  ): c.Expr[Spec[R0, E]] =
+    provideBaseImpl[ZSpec, R0, R, E, TestSuccess](layer, "provideLayerShared", ProvideMethod.ProvideSome)
 }

--- a/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/SpecVersionSpecific.scala
@@ -3,13 +3,15 @@ package zio.test
 import zio.ZLayer
 import zio.internal.macros.LayerMacros
 
-private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
+private[test] trait SpecVersionSpecific[-R, +E] { self: Spec[R, E] =>
+
+  type ZSpec[R, E, T] = Spec[R, E]
 
   /**
    * Automatically assembles a layer for the spec, translating it up a level.
    */
-  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
-    macro LayerMacros.provideImpl[Spec, R, E1, T]
+  def provide[E1 >: E](layer: ZLayer[_, E1, _]*): ZSpec[Any, E1, TestSuccess] =
+    macro LayerMacros.provideImpl[ZSpec, R, E1, TestSuccess]
 
   /**
    * Automatically constructs the part of the environment that is not part of
@@ -29,8 +31,8 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   spec.provideCustom(userRepoLayer, databaseLayer)
    * }}}
    */
-  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
-    macro LayerMacros.provideCustomImpl[Spec, TestEnvironment, R, E1, T]
+  def provideCustom[E1 >: E](layer: ZLayer[_, E1, _]*): ZSpec[TestEnvironment, E1, TestSuccess] =
+    macro LayerMacros.provideCustomImpl[ZSpec, TestEnvironment, R, E1, TestSuccess]
 
   /**
    * Splits the environment into two parts, providing each test with one part
@@ -43,15 +45,15 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    * val spec2: ZSpec[Random, Nothing] = spec.provideSome[Random](clockLayer)
    * }}}
    */
-  def provideSome[R0]: provideSomePartiallyApplied[R0, R, E, T] =
-    new provideSomePartiallyApplied[R0, R, E, T](self)
+  def provideSome[R0]: provideSomePartiallyApplied[R0, R, E] =
+    new provideSomePartiallyApplied[R0, R, E](self)
 
   /**
    * Automatically assembles a layer for the spec, sharing services between all
    * tests.
    */
-  def provideShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
-    macro SpecLayerMacros.provideSharedImpl[R, E1, T]
+  def provideShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[Any, E1] =
+    macro SpecLayerMacros.provideSharedImpl[R, E1]
 
   /**
    * Automatically constructs the part of the environment that is not part of
@@ -72,8 +74,8 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   spec.provideCustomShared(userRepoLayer, databaseLayer)
    * }}}
    */
-  def provideCustomShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
-    macro SpecLayerMacros.provideCustomSharedImpl[R, E1, T]
+  def provideCustomShared[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1] =
+    macro SpecLayerMacros.provideCustomSharedImpl[R, E1]
 
   /**
    * Splits the environment into two parts, providing all tests with a shared
@@ -87,28 +89,32 @@ private[test] trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    * val spec2 = spec.provideSomeShared[Random](intLayer)
    * }}}
    */
-  final def provideSomeShared[R0]: provideSomeSharedPartiallyApplied[R0, R, E, T] =
-    new provideSomeSharedPartiallyApplied[R0, R, E, T](self)
+  final def provideSomeShared[R0]: provideSomeSharedPartiallyApplied[R0, R, E] =
+    new provideSomeSharedPartiallyApplied[R0, R, E](self)
 }
 
-private final class provideSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
+private final class provideSomePartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
+
+  type ZSpec[-R, +E, +A] = Spec[R, E]
 
   def provideLayer[E1 >: E](
     layer: ZLayer[R0, E1, R]
-  ): Spec[R0, E1, T] =
+  ): Spec[R0, E1] =
     self.provideLayer(layer)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-    macro LayerMacros.provideSomeImpl[Spec, R0, R, E1, T]
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZSpec[R0, E1, TestSuccess] =
+    macro LayerMacros.provideSomeImpl[ZSpec, R0, R, E1, TestSuccess]
 }
 
-private final class provideSomeSharedPartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
+private final class provideSomeSharedPartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
+
+  type ZSpec[-R, +E, +A] = Spec[R, E]
 
   def provideLayerShared[E1 >: E](
     layer: ZLayer[R0, E1, R]
-  ): Spec[R0, E1, T] =
+  ): Spec[R0, E1] =
     self.provideLayerShared(layer)
 
-  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-    macro SpecLayerMacros.provideSomeSharedImpl[R0, R, E1, T]
+  def apply[E1 >: E](layer: ZLayer[_, E1, _]*): ZSpec[R0, E1, TestSuccess] =
+    macro SpecLayerMacros.provideSomeSharedImpl[R0, R, E1]
 }

--- a/test/shared/src/main/scala-3/zio/test/SpecProvideServiceAutoMacros.scala
+++ b/test/shared/src/main/scala-3/zio/test/SpecProvideServiceAutoMacros.scala
@@ -6,14 +6,14 @@ import zio.internal.macros._
 import zio._
 
 object SpecLayerMacros {
-  def provideImpl[R0: Type, R: Type, E: Type, T: Type]
-  (spec: Expr[Spec[R, E, T]], layer: Expr[Seq[ZLayer[_,E,_]]])(using Quotes): Expr[Spec[R0, E, T]] = {
+  def provideImpl[R0: Type, R: Type, E: Type]
+  (spec: Expr[Spec[R, E]], layer: Expr[Seq[ZLayer[_,E,_]]])(using Quotes): Expr[Spec[R0, E]] = {
     val expr = LayerMacros.constructLayer[R0, R, E](layer)
     '{$spec.provideLayer($expr)}
   }
 
-  def provideSharedImpl[R0: Type, R: Type, E: Type, T: Type]
-  (spec: Expr[Spec[R,E,T]], layer: Expr[Seq[ZLayer[_,E,_]]])(using Quotes): Expr[Spec[R0,E,T]] = {
+  def provideSharedImpl[R0: Type, R: Type, E: Type]
+  (spec: Expr[Spec[R,E]], layer: Expr[Seq[ZLayer[_,E,_]]])(using Quotes): Expr[Spec[R0,E]] = {
     val expr = LayerMacros.constructLayer[R0, R, E](layer)
     '{$spec.provideLayerShared($expr)}
   }

--- a/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
@@ -2,20 +2,20 @@ package zio.test
 
 import zio.{ZIO, ZLayer}
 
-trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
+trait SpecVersionSpecific[-R, +E] { self: Spec[R, E] =>
 
   /**
    * Automatically assembles a layer for the spec, translating it
    * up a level.
    */
-  inline def provide[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
-    ${SpecLayerMacros.provideImpl[Any, R, E1, T]('self, 'layer)}
+  inline def provide[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1] =
+    ${SpecLayerMacros.provideImpl[Any, R, E1]('self, 'layer)}
 
   def provideSome[R0] =
-    new provideSomePartiallyApplied[R0, R, E, T](self)
+    new provideSomePartiallyApplied[R0, R, E](self)
 
   def provideSomeShared[R0] =
-    new provideSomeSharedPartiallyApplied[R0, R, E, T](self)
+    new provideSomeSharedPartiallyApplied[R0, R, E](self)
 
   /**
    * Automatically constructs the part of the environment that is not part of the
@@ -34,15 +34,15 @@ trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustom[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
-    ${SpecLayerMacros.provideImpl[TestEnvironment, R, E1, T]('self, 'layer)}
+  inline def provideCustom[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1] =
+    ${SpecLayerMacros.provideImpl[TestEnvironment, R, E1]('self, 'layer)}
 
   /**
    * Automatically assembles a layer for the spec, sharing
    * services between all tests.
    */
-  inline def provideShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1, T] =
-    ${SpecLayerMacros.provideSharedImpl[Any, R, E1, T]('self, 'layer)}
+  inline def provideShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[Any, E1] =
+    ${SpecLayerMacros.provideSharedImpl[Any, R, E1]('self, 'layer)}
 
   /**
    * Automatically constructs the part of the environment that is not part of the
@@ -63,16 +63,16 @@ trait SpecVersionSpecific[-R, +E, +T] { self: Spec[R, E, T] =>
    *   zio.provideCustom(oldLadyLayer, flyLayer)
    * }}}
    */
-  inline def provideCustomShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1, T] =
-    ${SpecLayerMacros.provideSharedImpl[TestEnvironment, R, E1, T]('self, 'layer)}
+  inline def provideCustomShared[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[TestEnvironment, E1] =
+    ${SpecLayerMacros.provideSharedImpl[TestEnvironment, R, E1]('self, 'layer)}
 }
 
-private final class provideSomePartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-    ${SpecLayerMacros.provideImpl[R0, R, E1, T]('self, 'layer)}
+private final class provideSomePartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1] =
+    ${SpecLayerMacros.provideImpl[R0, R, E1]('self, 'layer)}
 }
 
-private final class provideSomeSharedPartiallyApplied[R0, -R, +E, +T](val self: Spec[R, E, T]) extends AnyVal {
-  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1, T] =
-    ${SpecLayerMacros.provideSharedImpl[R0, R, E1, T]('self, 'layer)}
+private final class provideSomeSharedPartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
+  inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1] =
+    ${SpecLayerMacros.provideSharedImpl[R0, R, E1]('self, 'layer)}
 }

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -17,9 +17,9 @@ import scala.collection.immutable.SortedSet
 trait Annotations extends Serializable {
   def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: ZTraceElement): UIO[Unit]
   def get[V](key: TestAnnotation[V])(implicit trace: ZTraceElement): UIO[V]
-  def withAnnotation[R, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
+  def withAnnotation[R, E](zio: ZIO[R, TestFailure[E], TestSuccess])(implicit
     trace: ZTraceElement
-  ): ZIO[R, TestFailure[E], Annotated[A]]
+  ): ZIO[R, TestFailure[E], TestSuccess]
   def supervisedFibers(implicit trace: ZTraceElement): UIO[SortedSet[Fiber.Runtime[Any, Any]]]
 }
 
@@ -58,11 +58,11 @@ object Annotations {
           fiberRef.update(_.annotate(key, value))
         def get[V](key: TestAnnotation[V])(implicit trace: ZTraceElement): UIO[V] =
           fiberRef.get.map(_.get(key))
-        def withAnnotation[R, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
+        def withAnnotation[R, E](zio: ZIO[R, TestFailure[E], TestSuccess])(implicit
           trace: ZTraceElement
-        ): ZIO[R, TestFailure[E], Annotated[A]] =
+        ): ZIO[R, TestFailure[E], TestSuccess] =
           fiberRef.locally(TestAnnotationMap.empty) {
-            zio.foldZIO(e => fiberRef.get.map(e.annotated).flip, a => fiberRef.get.map((a, _)))
+            zio.foldZIO(e => fiberRef.get.map(e.annotated).flip, a => fiberRef.get.map(a.annotated))
           }
         def supervisedFibers(implicit trace: ZTraceElement): UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
           ZIO.descriptorWith { descriptor =>
@@ -84,8 +84,8 @@ object Annotations {
    * specified effect with an empty annotation map, returning the annotation map
    * along with the result of execution.
    */
-  def withAnnotation[R <: Annotations, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
+  def withAnnotation[R <: Annotations, E](zio: ZIO[R, TestFailure[E], TestSuccess])(implicit
     trace: ZTraceElement
-  ): ZIO[R, TestFailure[E], Annotated[A]] =
+  ): ZIO[R, TestFailure[E], TestSuccess] =
     ZIO.serviceWithZIO[Annotations](_.withAnnotation(zio))
 }

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -17,7 +17,9 @@ import scala.collection.immutable.SortedSet
 trait Annotations extends Serializable {
   def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: ZTraceElement): UIO[Unit]
   def get[V](key: TestAnnotation[V])(implicit trace: ZTraceElement): UIO[V]
-  def withAnnotation[R, E, A](zio: ZIO[R, E, A])(implicit trace: ZTraceElement): ZIO[R, Annotated[E], Annotated[A]]
+  def withAnnotation[R, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
+    trace: ZTraceElement
+  ): ZIO[R, TestFailure[E], Annotated[A]]
   def supervisedFibers(implicit trace: ZTraceElement): UIO[SortedSet[Fiber.Runtime[Any, Any]]]
 }
 
@@ -56,11 +58,11 @@ object Annotations {
           fiberRef.update(_.annotate(key, value))
         def get[V](key: TestAnnotation[V])(implicit trace: ZTraceElement): UIO[V] =
           fiberRef.get.map(_.get(key))
-        def withAnnotation[R, E, A](zio: ZIO[R, E, A])(implicit
+        def withAnnotation[R, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
           trace: ZTraceElement
-        ): ZIO[R, Annotated[E], Annotated[A]] =
+        ): ZIO[R, TestFailure[E], Annotated[A]] =
           fiberRef.locally(TestAnnotationMap.empty) {
-            zio.foldZIO(e => fiberRef.get.map((e, _)).flip, a => fiberRef.get.map((a, _)))
+            zio.foldZIO(e => fiberRef.get.map(e.annotated).flip, a => fiberRef.get.map((a, _)))
           }
         def supervisedFibers(implicit trace: ZTraceElement): UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
           ZIO.descriptorWith { descriptor =>
@@ -82,8 +84,8 @@ object Annotations {
    * specified effect with an empty annotation map, returning the annotation map
    * along with the result of execution.
    */
-  def withAnnotation[R <: Annotations, E, A](zio: ZIO[R, E, A])(implicit
+  def withAnnotation[R <: Annotations, E, A](zio: ZIO[R, TestFailure[E], A])(implicit
     trace: ZTraceElement
-  ): ZIO[R, Annotated[E], Annotated[A]] =
+  ): ZIO[R, TestFailure[E], Annotated[A]] =
     ZIO.serviceWithZIO[Annotations](_.withAnnotation(zio))
 }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -74,8 +74,8 @@ object DefaultTestReporter {
               case Left(_) => Status.Failed
               case Right(value: TestSuccess) =>
                 value match {
-                  case TestSuccess.Succeeded(_) => Status.Passed
-                  case TestSuccess.Ignored      => Status.Ignored
+                  case TestSuccess.Succeeded(_, _) => Status.Passed
+                  case TestSuccess.Ignored(_)      => Status.Ignored
                 }
             },
             initialDepth * 2,
@@ -84,7 +84,7 @@ object DefaultTestReporter {
               val label = labels.last
 
               val renderedResult = results match {
-                case Right(TestSuccess.Succeeded(_)) =>
+                case Right(TestSuccess.Succeeded(_, _)) =>
                   Some(
                     rendered(
                       ResultType.Test,
@@ -94,7 +94,7 @@ object DefaultTestReporter {
                       fr(labels.last).toLine
                     )
                   )
-                case Right(TestSuccess.Ignored) =>
+                case Right(TestSuccess.Ignored(_)) =>
                   Some(
                     rendered(
                       ResultType.Test,

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -104,7 +104,7 @@ object DefaultTestReporter {
                       warn(label).toLine
                     )
                   )
-                case Left(TestFailure.Assertion(result)) =>
+                case Left(TestFailure.Assertion(result, _)) =>
                   result
                     .fold[Option[TestResult]] {
                       case result: AssertionResult.FailureDetailsResult => Some(BoolAlgebra.success(result))
@@ -143,7 +143,7 @@ object DefaultTestReporter {
                       )
                     }
 
-                case Left(TestFailure.Runtime(cause)) =>
+                case Left(TestFailure.Runtime(cause, _)) =>
                   Some(
                     renderRuntimeCause(cause, labels.reverse.mkString(" - "), depth, includeCause)
                   )
@@ -154,8 +154,8 @@ object DefaultTestReporter {
         )
       case ExecutionEvent.RuntimeFailure(_, _, failure, _) =>
         failure match {
-          case TestFailure.Assertion(_) => throw new NotImplementedError("Assertion failures are not supported")
-          case TestFailure.Runtime(_)   => throw new NotImplementedError("Runtime failures are not supported")
+          case TestFailure.Assertion(_, _) => throw new NotImplementedError("Assertion failures are not supported")
+          case TestFailure.Runtime(_, _)   => throw new NotImplementedError("Runtime failures are not supported")
         }
       case SectionEnd(_, _, _) =>
         Nil

--- a/test/shared/src/main/scala/zio/test/FilteredSpec.scala
+++ b/test/shared/src/main/scala/zio/test/FilteredSpec.scala
@@ -20,11 +20,11 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.ZTraceElement
 
 /**
- * Filters a given `ZSpec` based on the command-line arguments. If no arguments
+ * Filters a given `Spec` based on the command-line arguments. If no arguments
  * were specified, the spec returns unchanged.
  */
 private[zio] object FilteredSpec {
-  def apply[R, E](spec: ZSpec[R, E], args: TestArgs)(implicit trace: ZTraceElement): ZSpec[R, E] =
+  def apply[R, E](spec: Spec[R, E], args: TestArgs)(implicit trace: ZTraceElement): Spec[R, E] =
     (args.testSearchTerms, args.tagSearchTerms) match {
       case (Nil, Nil) =>
         spec

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -318,7 +318,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
    * {{{
    * val loggingLayer: ZLayer[Any, Nothing, Logging] = ???
    *
-   * val spec: ZSpec[TestEnvironment with Logging, Nothing] = ???
+   * val spec: Spec[TestEnvironment with Logging, Nothing] = ???
    *
    * val spec2 = spec.provideCustomLayer(loggingLayer)
    * }}}
@@ -338,7 +338,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
    * {{{
    * val loggingLayer: ZLayer[Any, Nothing, Logging] = ???
    *
-   * val spec: ZSpec[TestEnvironment with Logging, Nothing] = ???
+   * val spec: Spec[TestEnvironment with Logging, Nothing] = ???
    *
    * val spec2 = spec.provideCustomLayerShared(loggingLayer)
    * }}}
@@ -413,7 +413,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
    * {{{
    * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
    *
-   * val spec: ZSpec[Clock with Random, Nothing] = ???
+   * val spec: Spec[Clock with Random, Nothing] = ???
    *
    * val spec2 = spec.provideSomeLayer[Random](clockLayer)
    * }}}
@@ -429,7 +429,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
    * {{{
    * val clockLayer: ZLayer[Any, Nothing, Clock] = ???
    *
-   * val spec: ZSpec[Clock with Random, Nothing] = ???
+   * val spec: Spec[Clock with Random, Nothing] = ???
    *
    * val spec2 = spec.provideSomeLayerShared[Random](clockLayer)
    * }}}

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -21,18 +21,17 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.Spec._
 
 /**
- * A `Spec[R, E, T]` is the backbone of _ZIO Test_. Every spec is either a
- * suite, which contains other specs, or a test of type `T`. All specs require
- * an environment of type `R` and may potentially fail with an error of type
- * `E`.
+ * A `Spec[R, E]` is the backbone of _ZIO Test_. Every spec is either a suite,
+ * which contains other specs, or a test. All specs require an environment of
+ * type `R` and may potentially fail with an error of type `E`.
  */
-final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) extends SpecVersionSpecific[R, E, T] {
+final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends SpecVersionSpecific[R, E] {
   self =>
 
   /**
    * Combines this spec with the specified spec.
    */
-  def +[R1 <: R, E1 >: E, T1 >: T](that: Spec[R1, E1, T1]): Spec[R1, E1, T1] =
+  def +[R1 <: R, E1 >: E](that: Spec[R1, E1]): Spec[R1, E1] =
     (self.caseValue, that.caseValue) match {
       case (MultipleCase(self), MultipleCase(that)) => Spec.multiple(self ++ that)
       case (MultipleCase(self), _)                  => Spec.multiple(self :+ that)
@@ -46,16 +45,16 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * test("foo") { assert(42, equalTo(42)) } @@ ignore
    * }}}
    */
-  final def @@[R0 <: R1, R1 <: R, E0 >: E, E1 >: E0](
-    aspect: TestAspect[R0, R1, E0, E1]
-  )(implicit ev: T <:< TestSuccess, trace: ZTraceElement): ZSpec[R1, E0] =
-    aspect(self.mapTest(ev))
+  final def @@[R0 <: R1, R1 <: R, E0 >: E, E1 >: E0](aspect: TestAspect[R0, R1, E0, E1])(implicit
+    trace: ZTraceElement
+  ): Spec[R1, E0] =
+    aspect(self)
 
   /**
    * Annotates each test in this spec with the specified test annotation.
    */
-  final def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: ZTraceElement): Spec[R, E, T] =
-    transform[R, E, T] {
+  final def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: ZTraceElement): Spec[R, E] =
+    transform[R, E] {
       case TestCase(test, annotations) => Spec.TestCase(test, annotations.annotate(key, value))
       case c                           => c
     }
@@ -63,12 +62,12 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   /**
    * Returns a new spec with the annotation map at each node.
    */
-  final def annotated(implicit trace: ZTraceElement): Spec[R with Annotations, E, Annotated[T]] =
-    transform[R with Annotations, E, Annotated[T]] {
+  final def annotated(implicit trace: ZTraceElement): Spec[R with Annotations, E] =
+    transform[R with Annotations, E] {
       case ExecCase(exec, spec)     => ExecCase(exec, spec)
       case LabeledCase(label, spec) => LabeledCase(label, spec)
       case ScopedCase(scoped) =>
-        ScopedCase[R with Annotations, E, Spec[R with Annotations, E, Annotated[T]]](
+        ScopedCase[R with Annotations, E, Spec[R with Annotations, E]](
           scoped
         )
       case MultipleCase(specs)         => MultipleCase(specs)
@@ -81,12 +80,12 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def provideSomeEnvironment[R0](
     f: ZEnvironment[R0] => ZEnvironment[R]
-  )(implicit trace: ZTraceElement): Spec[R0, E, T] =
-    transform[R0, E, T] {
+  )(implicit trace: ZTraceElement): Spec[R0, E] =
+    transform[R0, E] {
       case ExecCase(exec, spec)     => ExecCase(exec, spec)
       case LabeledCase(label, spec) => LabeledCase(label, spec)
       case ScopedCase(scoped) =>
-        ScopedCase[R0, E, Spec[R0, E, T]](
+        ScopedCase[R0, E, Spec[R0, E]](
           scoped.provideSomeEnvironment[R0 with Scope](in => f(in).add[Scope](in.get[Scope]))
         )
       case MultipleCase(specs)         => MultipleCase(specs)
@@ -94,31 +93,18 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
     }
 
   /**
-   * Returns the number of tests in the spec that satisfy the specified
-   * predicate.
-   */
-  final def countTests(f: T => Boolean)(implicit trace: ZTraceElement): ZIO[R with Scope, TestFailure[E], Int] =
-    fold[ZIO[R with Scope, TestFailure[E], Int]] {
-      case ExecCase(_, spec)    => spec
-      case LabeledCase(_, spec) => spec
-      case ScopedCase(scoped)   => scoped.flatten
-      case MultipleCase(specs)  => ZIO.collectAll(specs).map(_.sum)
-      case TestCase(test, _)    => test.map(t => if (f(t)) 1 else 0)
-    }
-
-  /**
    * Returns an effect that models execution of this spec.
    */
   final def execute(defExec: ExecutionStrategy)(implicit
     trace: ZTraceElement
-  ): ZIO[R with Scope, Nothing, Spec[Any, E, T]] =
+  ): ZIO[R with Scope, Nothing, Spec[Any, E]] =
     ZIO.environmentWithZIO(provideEnvironment(_).foreachExec(defExec)(ZIO.failCause(_), ZIO.succeedNow))
 
   /**
    * Determines if any node in the spec is satisfied by the given predicate.
    */
   final def exists[R1 <: R, E1 >: E](
-    f: SpecCase[R, E, T, Any] => ZIO[R1, E1, Boolean]
+    f: SpecCase[R, E, Any] => ZIO[R1, E1, Boolean]
   )(implicit trace: ZTraceElement): ZIO[R1 with Scope, TestFailure[E1], Boolean] =
     fold[ZIO[R1 with Scope, TestFailure[E1], Boolean]] {
       case c @ ExecCase(_, spec)    => spec.zipWith(f(c).mapError(TestFailure.fail))(_ || _)
@@ -136,7 +122,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def filterAnnotations[V](
     key: TestAnnotation[V]
-  )(f: V => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E, T]] =
+  )(f: V => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E]] =
     caseValue match {
       case ExecCase(exec, spec) =>
         spec.filterAnnotations(key)(f).map(spec => Spec.exec(exec, spec))
@@ -159,7 +145,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * spec. If no labels satisfy the specified predicate then returns `Some` with
    * an empty suite if this is a suite or `None` otherwise.
    */
-  final def filterLabels(f: String => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E, T]] =
+  final def filterLabels(f: String => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E]] =
     caseValue match {
       case ExecCase(exec, spec) =>
         spec.filterLabels(f).map(spec => Spec.exec(exec, spec))
@@ -181,13 +167,13 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * returns `Some` with an empty suite with the root label if this is a suite
    * or `None` otherwise.
    */
-  final def filterTags(f: String => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E, T]] =
+  final def filterTags(f: String => Boolean)(implicit trace: ZTraceElement): Option[Spec[R, E]] =
     filterAnnotations(TestAnnotation.tagged)(_.exists(f))
 
   /**
    * Folds over all nodes to produce a final result.
    */
-  final def fold[Z](f: SpecCase[R, E, T, Z] => Z)(implicit trace: ZTraceElement): Z =
+  final def fold[Z](f: SpecCase[R, E, Z] => Z)(implicit trace: ZTraceElement): Z =
     caseValue match {
       case ExecCase(exec, spec)     => f(ExecCase(exec, spec.fold(f)))
       case LabeledCase(label, spec) => f(LabeledCase(label, spec.fold(f)))
@@ -202,7 +188,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def foldScoped[R1 <: R, E1, Z](
     defExec: ExecutionStrategy
-  )(f: SpecCase[R, E, T, Z] => ZIO[R1 with Scope, E1, Z])(implicit trace: ZTraceElement): ZIO[R1 with Scope, E1, Z] =
+  )(f: SpecCase[R, E, Z] => ZIO[R1 with Scope, E1, Z])(implicit trace: ZTraceElement): ZIO[R1 with Scope, E1, Z] =
     caseValue match {
       case ExecCase(exec, spec)     => spec.foldScoped[R1, E1, Z](exec)(f).flatMap(z => f(ExecCase(exec, z)))
       case LabeledCase(label, spec) => spec.foldScoped[R1, E1, Z](defExec)(f).flatMap(z => f(LabeledCase(label, z)))
@@ -222,7 +208,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * Determines if all node in the spec are satisfied by the given predicate.
    */
   final def forall[R1 <: R, E1 >: E](
-    f: SpecCase[R, E, T, Any] => ZIO[R1, E1, Boolean]
+    f: SpecCase[R, E, Any] => ZIO[R1, E1, Boolean]
   )(implicit trace: ZTraceElement): ZIO[R1 with Scope, TestFailure[E1], Boolean] =
     fold[ZIO[R1 with Scope, TestFailure[E1], Boolean]] {
       case c @ ExecCase(_, spec)    => spec.zipWith(f(c).mapError(TestFailure.fail))(_ && _)
@@ -238,12 +224,15 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * effectfully transforming every test with the provided function, finally
    * reconstructing the spec with the same structure.
    */
-  final def foreachExec[R1 <: R, E1, A](
+  final def foreachExec[R1 <: R, E1](
     defExec: ExecutionStrategy
-  )(failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], A], success: T => ZIO[R1, E1, A])(implicit
+  )(
+    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], TestSuccess],
+    success: TestSuccess => ZIO[R1, E1, TestSuccess]
+  )(implicit
     trace: ZTraceElement
-  ): ZIO[R1 with Scope, Nothing, Spec[R1, E1, A]] =
-    foldScoped[R1, Nothing, Spec[R1, E1, A]](defExec) {
+  ): ZIO[R1 with Scope, Nothing, Spec[R1, E1]] =
+    foldScoped[R1, Nothing, Spec[R1, E1]](defExec) {
       case ExecCase(exec, spec)     => ZIO.succeedNow(Spec.exec(exec, spec))
       case LabeledCase(label, spec) => ZIO.succeedNow(Spec.labeled(label, spec))
       case ScopedCase(scoped) =>
@@ -265,10 +254,10 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * effectfully transforming every test with the provided function, finally
    * reconstructing the spec with the same structure.
    */
-  final def foreach[R1 <: R, E1, A](
-    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], A],
-    success: T => ZIO[R1, E1, A]
-  )(implicit trace: ZTraceElement): ZIO[R1 with Scope, Nothing, Spec[R1, E1, A]] =
+  final def foreach[R1 <: R, E1](
+    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], TestSuccess],
+    success: TestSuccess => ZIO[R1, E1, TestSuccess]
+  )(implicit trace: ZTraceElement): ZIO[R1 with Scope, Nothing, Spec[R1, E1]] =
     foreachExec(ExecutionStrategy.Sequential)(failure, success)
 
   /**
@@ -276,10 +265,10 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * effectfully transforming every test with the provided function, finally
    * reconstructing the spec with the same structure.
    */
-  final def foreachPar[R1 <: R, E1, A](
-    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], A],
-    success: T => ZIO[R1, E1, A]
-  )(implicit trace: ZTraceElement): ZIO[R1 with Scope, Nothing, Spec[R1, E1, A]] =
+  final def foreachPar[R1 <: R, E1](
+    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], TestSuccess],
+    success: TestSuccess => ZIO[R1, E1, TestSuccess]
+  )(implicit trace: ZTraceElement): ZIO[R1 with Scope, Nothing, Spec[R1, E1]] =
     foreachExec(ExecutionStrategy.Parallel)(failure, success)
 
   /**
@@ -287,33 +276,24 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * effectfully transforming every test with the provided function, finally
    * reconstructing the spec with the same structure.
    */
-  final def foreachParN[R1 <: R, E1, A](
+  final def foreachParN[R1 <: R, E1](
     n: Int
-  )(failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], A], success: T => ZIO[R1, E1, A])(implicit
+  )(
+    failure: Cause[TestFailure[E]] => ZIO[R1, TestFailure[E1], TestSuccess],
+    success: TestSuccess => ZIO[R1, E1, TestSuccess]
+  )(implicit
     trace: ZTraceElement
-  ): ZIO[R1 with Scope, Nothing, Spec[R1, E1, A]] =
+  ): ZIO[R1 with Scope, Nothing, Spec[R1, E1]] =
     foreachExec(ExecutionStrategy.ParallelN(n))(failure, success)
-
-  /**
-   * Returns a new spec with remapped errors and tests.
-   */
-  final def mapBoth[E1, T1](f: E => E1, g: T => T1)(implicit ev: CanFail[E], trace: ZTraceElement): Spec[R, E1, T1] =
-    transform[R, E1, T1] {
-      case ExecCase(exec, spec)        => ExecCase(exec, spec)
-      case LabeledCase(label, spec)    => LabeledCase(label, spec)
-      case ScopedCase(scoped)          => ScopedCase[R, E1, Spec[R, E1, T1]](scoped.mapError(_.map(f)))
-      case MultipleCase(specs)         => MultipleCase(specs)
-      case TestCase(test, annotations) => TestCase(test.mapBoth(_.map(f), g), annotations)
-    }
 
   /**
    * Returns a new spec with remapped errors.
    */
-  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E], trace: ZTraceElement): Spec[R, E1, T] =
-    transform[R, E1, T] {
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E], trace: ZTraceElement): Spec[R, E1] =
+    transform[R, E1] {
       case ExecCase(exec, spec)        => ExecCase(exec, spec)
       case LabeledCase(label, spec)    => LabeledCase(label, spec)
-      case ScopedCase(scoped)          => ScopedCase[R, E1, Spec[R, E1, T]](scoped.mapError(_.map(f)))
+      case ScopedCase(scoped)          => ScopedCase[R, E1, Spec[R, E1]](scoped.mapError(_.map(f)))
       case MultipleCase(specs)         => MultipleCase(specs)
       case TestCase(test, annotations) => TestCase(test.mapError(_.map(f)), annotations)
     }
@@ -321,25 +301,13 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   /**
    * Returns a new spec with remapped labels.
    */
-  final def mapLabel(f: String => String)(implicit trace: ZTraceElement): Spec[R, E, T] =
-    transform[R, E, T] {
+  final def mapLabel(f: String => String)(implicit trace: ZTraceElement): Spec[R, E] =
+    transform[R, E] {
       case ExecCase(exec, spec)        => ExecCase(exec, spec)
       case LabeledCase(label, spec)    => LabeledCase(f(label), spec)
-      case ScopedCase(scoped)          => ScopedCase[R, E, Spec[R, E, T]](scoped)
+      case ScopedCase(scoped)          => ScopedCase[R, E, Spec[R, E]](scoped)
       case MultipleCase(specs)         => MultipleCase(specs)
       case TestCase(test, annotations) => TestCase(test, annotations)
-    }
-
-  /**
-   * Returns a new spec with remapped tests.
-   */
-  final def mapTest[T1](f: T => T1)(implicit trace: ZTraceElement): Spec[R, E, T1] =
-    transform[R, E, T1] {
-      case ExecCase(exec, spec)        => ExecCase(exec, spec)
-      case LabeledCase(label, spec)    => LabeledCase(label, spec)
-      case ScopedCase(scoped)          => ScopedCase[R, E, Spec[R, E, T1]](scoped)
-      case MultipleCase(specs)         => MultipleCase(specs)
-      case TestCase(test, annotations) => TestCase(test.map(f), annotations)
     }
 
   /**
@@ -359,7 +327,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
     ev: TestEnvironment with R1 <:< R,
     tagged: EnvironmentTag[R1],
     trace: ZTraceElement
-  ): Spec[TestEnvironment, E1, T] =
+  ): Spec[TestEnvironment, E1] =
     provideSomeLayer[TestEnvironment](layer)
 
   /**
@@ -379,13 +347,13 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
     ev: TestEnvironment with R1 <:< R,
     tagged: EnvironmentTag[R1],
     trace: ZTraceElement
-  ): Spec[TestEnvironment, E1, T] =
+  ): Spec[TestEnvironment, E1] =
     provideSomeLayerShared(layer)
 
   /**
    * Provides each test in this spec with its required environment
    */
-  final def provideEnvironment(r: ZEnvironment[R])(implicit trace: ZTraceElement): Spec[Any, E, T] =
+  final def provideEnvironment(r: ZEnvironment[R])(implicit trace: ZTraceElement): Spec[Any, E] =
     provideSomeEnvironment(_ => r)
 
   /**
@@ -395,7 +363,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   final def provideService[Service <: R](service: Service)(implicit
     tag: Tag[Service],
     trace: ZTraceElement
-  ): Spec[Any, E, T] =
+  ): Spec[Any, E] =
     provideEnvironment(ZEnvironment(service))
 
   /**
@@ -403,12 +371,12 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def provideLayer[E1 >: E, R0](
     layer: ZLayer[R0, E1, R]
-  )(implicit trace: ZTraceElement): Spec[R0, E1, T] =
-    transform[R0, E1, T] {
+  )(implicit trace: ZTraceElement): Spec[R0, E1] =
+    transform[R0, E1] {
       case ExecCase(exec, spec)     => ExecCase(exec, spec)
       case LabeledCase(label, spec) => LabeledCase(label, spec)
       case ScopedCase(scoped) =>
-        ScopedCase[R0, E1, Spec[R0, E1, T]](
+        ScopedCase[R0, E1, Spec[R0, E1]](
           layer.mapError(TestFailure.fail).build.flatMap(r => scoped.provideSomeEnvironment[Scope](r.union[Scope](_)))
         )
       case MultipleCase(specs)         => MultipleCase(specs)
@@ -420,7 +388,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def provideLayerShared[E1 >: E, R0](
     layer: ZLayer[R0, E1, R]
-  )(implicit trace: ZTraceElement): Spec[R0, E1, T] =
+  )(implicit trace: ZTraceElement): Spec[R0, E1] =
     caseValue match {
       case ExecCase(exec, spec)     => Spec.exec(exec, spec.provideLayerShared(layer))
       case LabeledCase(label, spec) => Spec.labeled(label, spec.provideLayerShared(layer))
@@ -450,8 +418,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * val spec2 = spec.provideSomeLayer[Random](clockLayer)
    * }}}
    */
-  final def provideSomeLayer[R0]: Spec.ProvideSomeLayer[R0, R, E, T] =
-    new Spec.ProvideSomeLayer[R0, R, E, T](self)
+  final def provideSomeLayer[R0]: Spec.ProvideSomeLayer[R0, R, E] =
+    new Spec.ProvideSomeLayer[R0, R, E](self)
 
   /**
    * Splits the environment into two parts, providing all tests with a shared
@@ -466,8 +434,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * val spec2 = spec.provideSomeLayerShared[Random](clockLayer)
    * }}}
    */
-  final def provideSomeLayerShared[R0]: Spec.ProvideSomeLayerShared[R0, R, E, T] =
-    new Spec.ProvideSomeLayerShared[R0, R, E, T](self)
+  final def provideSomeLayerShared[R0]: Spec.ProvideSomeLayerShared[R0, R, E] =
+    new Spec.ProvideSomeLayerShared[R0, R, E](self)
 
   /**
    * Computes the size of the spec, i.e. the number of tests in the spec.
@@ -484,13 +452,13 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   /**
    * Transforms the spec one layer at a time.
    */
-  final def transform[R1, E1, T1](
-    f: SpecCase[R, E, T, Spec[R1, E1, T1]] => SpecCase[R1, E1, T1, Spec[R1, E1, T1]]
-  )(implicit trace: ZTraceElement): Spec[R1, E1, T1] =
+  final def transform[R1, E1](
+    f: SpecCase[R, E, Spec[R1, E1]] => SpecCase[R1, E1, Spec[R1, E1]]
+  )(implicit trace: ZTraceElement): Spec[R1, E1] =
     caseValue match {
       case ExecCase(exec, spec)     => Spec(f(ExecCase(exec, spec.transform(f))))
       case LabeledCase(label, spec) => Spec(f(LabeledCase(label, spec.transform(f))))
-      case ScopedCase(scoped)       => Spec(f(ScopedCase[R, E, Spec[R1, E1, T1]](scoped.map(_.transform[R1, E1, T1](f)))))
+      case ScopedCase(scoped)       => Spec(f(ScopedCase[R, E, Spec[R1, E1]](scoped.map(_.transform[R1, E1](f)))))
       case MultipleCase(specs)      => Spec(f(MultipleCase(specs.map(_.transform(f)))))
       case t @ TestCase(_, _)       => Spec(f(t))
     }
@@ -498,11 +466,11 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
   /**
    * Transforms the spec statefully, one layer at a time.
    */
-  final def transformAccum[R1, E1, T1, Z](
+  final def transformAccum[R1, E1, Z](
     z0: Z
   )(
-    f: (Z, SpecCase[R, E, T, Spec[R1, E1, T1]]) => (Z, SpecCase[R1, E1, T1, Spec[R1, E1, T1]])
-  )(implicit trace: ZTraceElement): ZIO[R with Scope, TestFailure[E], (Z, Spec[R1, E1, T1])] =
+    f: (Z, SpecCase[R, E, Spec[R1, E1]]) => (Z, SpecCase[R1, E1, Spec[R1, E1]])
+  )(implicit trace: ZTraceElement): ZIO[R with Scope, TestFailure[E], (Z, Spec[R1, E1])] =
     caseValue match {
       case ExecCase(exec, spec) =>
         spec.transformAccum(z0)(f).map { case (z, spec) =>
@@ -525,7 +493,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
         }
       case MultipleCase(specs) =>
         ZIO
-          .foldLeft[R with Scope, TestFailure[E], (Z, Chunk[Spec[R1, E1, T1]]), Spec[R, E, T]](specs)(
+          .foldLeft[R with Scope, TestFailure[E], (Z, Chunk[Spec[R1, E1]]), Spec[R, E]](specs)(
             z0 -> Chunk.empty
           ) { case ((z, vector), spec) =>
             spec.transformAccum(z)(f).map { case (z1, spec1) => z1 -> (vector :+ spec1) }
@@ -544,20 +512,20 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    * Updates a service in the environment of this effect.
    */
   final def updateService[M] =
-    new Spec.UpdateService[R, E, T, M](self)
+    new Spec.UpdateService[R, E, M](self)
 
   /**
    * Updates a service at the specified key in the environment of this effect.
    */
-  final def updateServiceAt[Service]: Spec.UpdateServiceAt[R, E, T, Service] =
-    new Spec.UpdateServiceAt[R, E, T, Service](self)
+  final def updateServiceAt[Service]: Spec.UpdateServiceAt[R, E, Service] =
+    new Spec.UpdateServiceAt[R, E, Service](self)
 
   /**
    * Runs the spec only if the specified predicate is satisfied.
    */
   final def when(
     b: => Boolean
-  )(implicit ev: T <:< TestSuccess, trace: ZTraceElement): Spec[R with Annotations, E, TestSuccess] =
+  )(implicit trace: ZTraceElement): Spec[R with Annotations, E] =
     whenZIO(ZIO.succeedNow(b))
 
   /**
@@ -565,7 +533,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
    */
   final def whenZIO[R1 <: R, E1 >: E](
     b: ZIO[R1, E1, Boolean]
-  )(implicit ev: T <:< TestSuccess, trace: ZTraceElement): Spec[R1 with Annotations, E1, TestSuccess] =
+  )(implicit trace: ZTraceElement): Spec[R1 with Annotations, E1] =
     caseValue match {
       case ExecCase(exec, spec) =>
         Spec.exec(exec, spec.whenZIO(b))
@@ -574,7 +542,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
       case ScopedCase(scoped) =>
         Spec.scoped[R1 with Annotations](
           b.mapError(TestFailure.fail).flatMap { b =>
-            if (b) scoped.map(_.mapTest(ev))
+            if (b) scoped
             else ZIO.succeedNow(Spec.empty)
           }
         )
@@ -583,8 +551,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
       case TestCase(test, annotations) =>
         Spec.test(
           b.mapError(TestFailure.fail).flatMap { b =>
-            if (b) test.map(ev)
-            else Annotations.annotate(TestAnnotation.ignored, 1).as(TestSuccess.Ignored)
+            if (b) test
+            else Annotations.annotate(TestAnnotation.ignored, 1).as(TestSuccess.Ignored())
           },
           annotations
         )
@@ -592,8 +560,8 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) e
 }
 
 object Spec {
-  sealed abstract class SpecCase[-R, +E, +T, +A] { self =>
-    final def map[B](f: A => B)(implicit trace: ZTraceElement): SpecCase[R, E, T, B] = self match {
+  sealed abstract class SpecCase[-R, +E, +A] { self =>
+    final def map[B](f: A => B)(implicit trace: ZTraceElement): SpecCase[R, E, B] = self match {
       case ExecCase(label, spec)       => ExecCase(label, f(spec))
       case LabeledCase(label, spec)    => LabeledCase(label, f(spec))
       case ScopedCase(scoped)          => ScopedCase[R, E, B](scoped.map(f))
@@ -601,53 +569,53 @@ object Spec {
       case TestCase(test, annotations) => TestCase(test, annotations)
     }
   }
-  final case class ExecCase[+Spec](exec: ExecutionStrategy, spec: Spec) extends SpecCase[Any, Nothing, Nothing, Spec]
-  final case class LabeledCase[+Spec](label: String, spec: Spec)        extends SpecCase[Any, Nothing, Nothing, Spec]
+  final case class ExecCase[+Spec](exec: ExecutionStrategy, spec: Spec) extends SpecCase[Any, Nothing, Spec]
+  final case class LabeledCase[+Spec](label: String, spec: Spec)        extends SpecCase[Any, Nothing, Spec]
   final case class ScopedCase[-R, +E, +Spec](scoped: ZIO[Scope with R, TestFailure[E], Spec])
-      extends SpecCase[R, E, Nothing, Spec]
-  final case class MultipleCase[+Spec](specs: Chunk[Spec]) extends SpecCase[Any, Nothing, Nothing, Spec]
-  final case class TestCase[-R, +E, +T](test: ZIO[R, TestFailure[E], T], annotations: TestAnnotationMap)
-      extends SpecCase[R, E, T, Nothing]
+      extends SpecCase[R, E, Spec]
+  final case class MultipleCase[+Spec](specs: Chunk[Spec]) extends SpecCase[Any, Nothing, Spec]
+  final case class TestCase[-R, +E](test: ZIO[R, TestFailure[E], TestSuccess], annotations: TestAnnotationMap)
+      extends SpecCase[R, E, Nothing]
 
-  final def exec[R, E, T](exec: ExecutionStrategy, spec: Spec[R, E, T]): Spec[R, E, T] =
+  final def exec[R, E](exec: ExecutionStrategy, spec: Spec[R, E]): Spec[R, E] =
     Spec(ExecCase(exec, spec))
 
-  final def labeled[R, E, T](label: String, spec: Spec[R, E, T]): Spec[R, E, T] =
+  final def labeled[R, E](label: String, spec: Spec[R, E]): Spec[R, E] =
     Spec(LabeledCase(label, spec))
 
   final def scoped[R]: ScopedPartiallyApplied[R] =
     new ScopedPartiallyApplied[R]
 
-  final def multiple[R, E, T](specs: Chunk[Spec[R, E, T]]): Spec[R, E, T] =
+  final def multiple[R, E](specs: Chunk[Spec[R, E]]): Spec[R, E] =
     Spec(MultipleCase(specs))
 
-  final def test[R, E, T](test: ZIO[R, TestFailure[E], T], annotations: TestAnnotationMap)(implicit
+  final def test[R, E](test: ZIO[R, TestFailure[E], TestSuccess], annotations: TestAnnotationMap)(implicit
     trace: ZTraceElement
-  ): Spec[R, E, T] =
+  ): Spec[R, E] =
     Spec(TestCase(test, annotations))
 
-  val empty: Spec[Any, Nothing, Nothing] =
+  val empty: Spec[Any, Nothing] =
     Spec.multiple(Chunk.empty)
 
-  final class ProvideSomeLayer[R0, -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
+  final class ProvideSomeLayer[R0, -R, +E](private val self: Spec[R, E]) extends AnyVal {
     def apply[E1 >: E, R1](
       layer: ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
       tagged: EnvironmentTag[R1],
       trace: ZTraceElement
-    ): Spec[R0, E1, T] =
-      self.asInstanceOf[Spec[R0 with R1, E, T]].provideLayer(ZLayer.environment[R0] ++ layer)
+    ): Spec[R0, E1] =
+      self.asInstanceOf[Spec[R0 with R1, E]].provideLayer(ZLayer.environment[R0] ++ layer)
   }
 
-  final class ProvideSomeLayerShared[R0, -R, +E, +T](private val self: Spec[R, E, T]) extends AnyVal {
+  final class ProvideSomeLayerShared[R0, -R, +E](private val self: Spec[R, E]) extends AnyVal {
     def apply[E1 >: E, R1](
       layer: ZLayer[R0, E1, R1]
     )(implicit
       ev: R0 with R1 <:< R,
       tagged: EnvironmentTag[R1],
       trace: ZTraceElement
-    ): Spec[R0, E1, T] =
+    ): Spec[R0, E1] =
       self.caseValue match {
         case ExecCase(exec, spec)     => Spec.exec(exec, spec.provideSomeLayerShared(layer))
         case LabeledCase(label, spec) => Spec.labeled(label, spec.provideSomeLayerShared(layer))
@@ -672,21 +640,21 @@ object Spec {
   }
 
   final class ScopedPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, T](scoped: => ZIO[Scope with R, TestFailure[E], Spec[R, E, T]]): Spec[R, E, T] =
-      Spec(ScopedCase[R, E, Spec[R, E, T]](scoped))
+    def apply[E, T](scoped: => ZIO[Scope with R, TestFailure[E], Spec[R, E]]): Spec[R, E] =
+      Spec(ScopedCase[R, E, Spec[R, E]](scoped))
   }
 
-  final class UpdateService[-R, +E, +T, M](private val self: Spec[R, E, T]) extends AnyVal {
+  final class UpdateService[-R, +E, M](private val self: Spec[R, E]) extends AnyVal {
     def apply[R1 <: R with M](
       f: M => M
-    )(implicit tag: Tag[M], trace: ZTraceElement): Spec[R1, E, T] =
+    )(implicit tag: Tag[M], trace: ZTraceElement): Spec[R1, E] =
       self.provideSomeEnvironment(_.update(f))
   }
 
-  final class UpdateServiceAt[-R, +E, +T, Service](private val self: Spec[R, E, T]) extends AnyVal {
+  final class UpdateServiceAt[-R, +E, Service](private val self: Spec[R, E]) extends AnyVal {
     def apply[R1 <: R with Map[Key, Service], Key](key: => Key)(
       f: Service => Service
-    )(implicit tag: Tag[Map[Key, Service]], trace: ZTraceElement): Spec[R1, E, T] =
+    )(implicit tag: Tag[Map[Key, Service]], trace: ZTraceElement): Spec[R1, E] =
       self.provideSomeEnvironment(_.updateAt(key)(f))
   }
 }

--- a/test/shared/src/main/scala/zio/test/SuiteConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/SuiteConstructor.scala
@@ -7,76 +7,70 @@ import zio.stm.ZSTM
 trait SuiteConstructor[In] {
   type OutEnvironment
   type OutError
-  type OutSuccess
-  def apply(spec: In)(implicit trace: ZTraceElement): Spec[OutEnvironment, OutError, OutSuccess]
+  def apply(spec: In)(implicit trace: ZTraceElement): Spec[OutEnvironment, OutError]
 }
 
 object SuiteConstructor extends SuiteConstructorLowPriority1 {
 
-  type WithOut[In, OutEnvironment0, OutError0, OutSuccess0] =
+  type WithOut[In, OutEnvironment0, OutError0] =
     SuiteConstructor[In] {
       type OutEnvironment = OutEnvironment0
       type OutError       = OutError0
-      type OutSuccess     = OutSuccess0
     }
 
-  implicit val NothingConstructor: SuiteConstructor.WithOut[Nothing, Any, Nothing, Nothing] =
+  implicit val NothingConstructor: SuiteConstructor.WithOut[Nothing, Any, Nothing] =
     new SuiteConstructor[Nothing] {
       type OutEnvironment = Any
       type OutError       = Nothing
       type OutSuccess     = Nothing
-      def apply(spec: Nothing)(implicit trace: ZTraceElement): Spec[Any, Nothing, Nothing] =
+      def apply(spec: Nothing)(implicit trace: ZTraceElement): Spec[Any, Nothing] =
         Spec.multiple(Chunk.empty)
     }
 }
 
 trait SuiteConstructorLowPriority1 extends SuiteConstructorLowPriority2 {
 
-  implicit def SpecConstructor[R, E, T]: SuiteConstructor.WithOut[Spec[R, E, T], R, E, T] =
-    new SuiteConstructor[Spec[R, E, T]] {
+  implicit def SpecConstructor[R, E, T]: SuiteConstructor.WithOut[Spec[R, E], R, E] =
+    new SuiteConstructor[Spec[R, E]] {
       type OutEnvironment = R
       type OutError       = E
-      type OutSuccess     = T
-      def apply(spec: Spec[R, E, T])(implicit trace: ZTraceElement): Spec[R, E, T] =
+      def apply(spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec
     }
 }
 
 trait SuiteConstructorLowPriority2 extends SuiteConstructorLowPriority3 {
 
-  implicit def IterableConstructor[R, E, T, Collection[+Element] <: Iterable[Element]]
-    : SuiteConstructor.WithOut[Collection[Spec[R, E, T]], R, E, T] =
-    new SuiteConstructor[Collection[Spec[R, E, T]]] {
+  implicit def IterableConstructor[R, E, Collection[+Element] <: Iterable[Element]]
+    : SuiteConstructor.WithOut[Collection[Spec[R, E]], R, E] =
+    new SuiteConstructor[Collection[Spec[R, E]]] {
       type OutEnvironment = R
       type OutError       = E
-      type OutSuccess     = T
-      def apply(spec: Collection[Spec[R, E, T]])(implicit trace: ZTraceElement): Spec[R, E, T] =
+      def apply(spec: Collection[Spec[R, E]])(implicit trace: ZTraceElement): Spec[R, E] =
         Spec.multiple(Chunk.fromIterable(spec))
     }
 }
 
 trait SuiteConstructorLowPriority3 extends SuiteConstructorLowPriority4 {
 
-  implicit def ZIOConstructor[R, R1, E <: E2, E1 <: E2, E2, T, Collection[+Element] <: Iterable[Element]]
-    : SuiteConstructor.WithOut[ZIO[R, E, Collection[Spec[R1, E1, T]]], R with R1, E2, T] =
-    new SuiteConstructor[ZIO[R, E, Collection[Spec[R1, E1, T]]]] {
+  implicit def ZIOConstructor[R, R1, E <: E2, E1 <: E2, E2, Collection[+Element] <: Iterable[Element]]
+    : SuiteConstructor.WithOut[ZIO[R, E, Collection[Spec[R1, E1]]], R with R1, E2] =
+    new SuiteConstructor[ZIO[R, E, Collection[Spec[R1, E1]]]] {
       type OutEnvironment = R with R1
       type OutError       = E2
-      type OutSuccess     = T
-      def apply(specs: ZIO[R, E, Collection[Spec[R1, E1, T]]])(implicit trace: ZTraceElement): Spec[R with R1, E2, T] =
+      def apply(specs: ZIO[R, E, Collection[Spec[R1, E1]]])(implicit trace: ZTraceElement): Spec[R with R1, E2] =
         Spec.scoped[R with R1](specs.mapBoth(TestFailure.fail, specs => Spec.multiple(Chunk.fromIterable(specs))))
     }
 }
 
 trait SuiteConstructorLowPriority4 {
 
-  implicit def ZSTMConstructor[R, R1, E <: E2, E1 <: E2, E2, T, Collection[+Element] <: Iterable[Element]]
-    : SuiteConstructor.WithOut[ZSTM[R, E, Collection[Spec[R1, E1, T]]], R with R1, E2, T] =
-    new SuiteConstructor[ZSTM[R, E, Collection[Spec[R1, E1, T]]]] {
+  implicit def ZSTMConstructor[R, R1, E <: E2, E1 <: E2, E2, Collection[+Element] <: Iterable[Element]]
+    : SuiteConstructor.WithOut[ZSTM[R, E, Collection[Spec[R1, E1]]], R with R1, E2] =
+    new SuiteConstructor[ZSTM[R, E, Collection[Spec[R1, E1]]]] {
       type OutEnvironment = R with R1
       type OutError       = E2
-      type OutSuccess     = T
-      def apply(specs: ZSTM[R, E, Collection[Spec[R1, E1, T]]])(implicit trace: ZTraceElement): Spec[R with R1, E2, T] =
+      def apply(specs: ZSTM[R, E, Collection[Spec[R1, E1]]])(implicit trace: ZTraceElement): Spec[R with R1, E2] =
         Spec.scoped[R with R1](
           specs.mapBoth(TestFailure.fail, specs => Spec.multiple(Chunk.fromIterable(specs))).commit
         )

--- a/test/shared/src/main/scala/zio/test/SuiteConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/SuiteConstructor.scala
@@ -64,7 +64,7 @@ trait SuiteConstructorLowPriority3 extends SuiteConstructorLowPriority4 {
       type OutError       = E2
       type OutSuccess     = T
       def apply(specs: ZIO[R, E, Collection[Spec[R1, E1, T]]])(implicit trace: ZTraceElement): Spec[R with R1, E2, T] =
-        Spec.scoped[R with R1](specs.map(specs => Spec.multiple(Chunk.fromIterable(specs))))
+        Spec.scoped[R with R1](specs.mapBoth(TestFailure.fail, specs => Spec.multiple(Chunk.fromIterable(specs))))
     }
 }
 
@@ -77,6 +77,8 @@ trait SuiteConstructorLowPriority4 {
       type OutError       = E2
       type OutSuccess     = T
       def apply(specs: ZSTM[R, E, Collection[Spec[R1, E1, T]]])(implicit trace: ZTraceElement): Spec[R with R1, E2, T] =
-        Spec.scoped[R with R1](specs.map(specs => Spec.multiple(Chunk.fromIterable(specs))).commit)
+        Spec.scoped[R with R1](
+          specs.mapBoth(TestFailure.fail, specs => Spec.multiple(Chunk.fromIterable(specs))).commit
+        )
     }
 }

--- a/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
+++ b/test/shared/src/main/scala/zio/test/SummaryBuilder.scala
@@ -25,16 +25,16 @@ object SummaryBuilder {
 
   def buildSummary(reporterEvent: ExecutionEvent, oldSummary: Summary)(implicit trace: ZTraceElement): Summary = {
     val success = countTestResults(reporterEvent) {
-      case Right(TestSuccess.Succeeded(_)) => true
-      case _                               => false
+      case Right(TestSuccess.Succeeded(_, _)) => true
+      case _                                  => false
     }
     val fail = countTestResults(reporterEvent) {
       case Right(_) => false
       case _        => true
     }
     val ignore = countTestResults(reporterEvent) {
-      case Right(TestSuccess.Ignored) => true
-      case _                          => false
+      case Right(TestSuccess.Ignored(_)) => true
+      case _                             => false
     }
     val failures = extractFailures(reporterEvent)
 

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -33,22 +33,22 @@ abstract class TestAspect[+LowerR, -UpperR, +LowerE, -UpperE] { self =>
    * Applies the aspect to some tests in the spec, chosen by the provided
    * predicate.
    */
-  def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E]
+  def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E]
 
   /**
    * An alias for [[all]].
    */
-  final def apply[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: ZSpec[R, E])(implicit
+  final def apply[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: Spec[R, E])(implicit
     trace: ZTraceElement
-  ): ZSpec[R, E] =
+  ): Spec[R, E] =
     all(spec)
 
   /**
    * Applies the aspect to every test in the spec.
    */
-  final def all[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: ZSpec[R, E])(implicit
+  final def all[R >: LowerR <: UpperR, E >: LowerE <: UpperE](spec: Spec[R, E])(implicit
     trace: ZTraceElement
-  ): ZSpec[R, E] =
+  ): Spec[R, E] =
     some[R, E](spec)
 
   /**
@@ -60,8 +60,8 @@ abstract class TestAspect[+LowerR, -UpperR, +LowerE, -UpperE] { self =>
   ): TestAspect[LowerR1, UpperR1, LowerE1, UpperE1] =
     new TestAspect[LowerR1, UpperR1, LowerE1, UpperE1] {
       def some[R >: LowerR1 <: UpperR1, E >: LowerE1 <: UpperE1](
-        spec: ZSpec[R, E]
-      )(implicit trace: ZTraceElement): ZSpec[R, E] =
+        spec: Spec[R, E]
+      )(implicit trace: ZTraceElement): Spec[R, E] =
         that.some(self.some(spec))
     }
 
@@ -86,7 +86,7 @@ object TestAspect extends TimeoutVariants {
    */
   val identity: TestAspectPoly =
     new TestAspectPoly {
-      def some[R, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec
     }
 
@@ -95,7 +95,7 @@ object TestAspect extends TimeoutVariants {
    */
   val ignore: TestAspectAtLeastR[Annotations] =
     new TestAspectAtLeastR[Annotations] {
-      def some[R <: Annotations, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R <: Annotations, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec.when(false)
     }
 
@@ -123,7 +123,7 @@ object TestAspect extends TimeoutVariants {
    */
   def annotate[V](key: TestAnnotation[V], value: V): TestAspectPoly =
     new TestAspectPoly {
-      def some[R, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec.annotate(key, value)
     }
 
@@ -156,7 +156,7 @@ object TestAspect extends TimeoutVariants {
     before: ZIO[R0, E0, A0]
   )(after: A0 => ZIO[R0, Nothing, Any]): TestAspect[Nothing, R0, E0, Any] =
     new TestAspect[Nothing, R0, E0, Any] {
-      def some[R <: R0, E >: E0](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R <: R0, E >: E0](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         Spec.scoped[R](
           ZIO.acquireRelease(before)(after).mapError(TestFailure.fail).as(spec)
         )
@@ -222,8 +222,8 @@ object TestAspect extends TimeoutVariants {
   def diagnose(duration: Duration): TestAspectAtLeastR[Live with Annotations] =
     new TestAspectAtLeastR[Live with Annotations] {
       def some[R <: Live with Annotations, E](
-        spec: ZSpec[R, E]
-      )(implicit trace: ZTraceElement): ZSpec[R, E] = {
+        spec: Spec[R, E]
+      )(implicit trace: ZTraceElement): Spec[R, E] = {
         def diagnose[R <: Live with Annotations, E](
           label: String,
           test: ZIO[R, TestFailure[E], TestSuccess]
@@ -333,7 +333,7 @@ object TestAspect extends TimeoutVariants {
    */
   def executionStrategy(exec: ExecutionStrategy): TestAspectPoly =
     new TestAspectPoly {
-      def some[R, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         Spec.exec(exec, spec)
     }
 
@@ -452,7 +452,7 @@ object TestAspect extends TimeoutVariants {
    */
   def ifEnvOption(env: String)(assertion: Option[String] => Boolean): TestAspectAtLeastR[Live with Annotations] =
     new TestAspectAtLeastR[Live with Annotations] {
-      def some[R <: Live with Annotations, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R <: Live with Annotations, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec.whenZIO(Live.live(System.env(env)).orDie.map(assertion))
     }
 
@@ -482,7 +482,7 @@ object TestAspect extends TimeoutVariants {
    */
   def ifPropOption(prop: String)(assertion: Option[String] => Boolean): TestAspectAtLeastR[Live with Annotations] =
     new TestAspectAtLeastR[Live with Annotations] {
-      def some[R <: Live with Annotations, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      def some[R <: Live with Annotations, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] =
         spec.whenZIO(Live.live(System.property(prop)).orDie.map(assertion))
     }
 
@@ -985,7 +985,7 @@ object TestAspect extends TimeoutVariants {
    */
   lazy val withLiveClock: TestAspectAtLeastR[Live] =
     new TestAspectAtLeastR[Live] {
-      def some[R <: Live, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] = {
+      def some[R <: Live, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] = {
         val layer = ZLayer.scoped {
           for {
             clock <- live(ZIO.clock)
@@ -1001,7 +1001,7 @@ object TestAspect extends TimeoutVariants {
    */
   lazy val withLiveConsole: TestAspectAtLeastR[Live] =
     new TestAspectAtLeastR[Live] {
-      def some[R <: Live, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] = {
+      def some[R <: Live, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] = {
         val layer = ZLayer.scoped {
           for {
             console <- live(ZIO.console)
@@ -1026,7 +1026,7 @@ object TestAspect extends TimeoutVariants {
    */
   lazy val withLiveRandom: TestAspectAtLeastR[Live] =
     new TestAspectAtLeastR[Live] {
-      def some[R <: Live, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] = {
+      def some[R <: Live, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] = {
         val layer = ZLayer.scoped {
           for {
             random <- live(ZIO.random)
@@ -1042,7 +1042,7 @@ object TestAspect extends TimeoutVariants {
    */
   lazy val withLiveSystem: TestAspectAtLeastR[Live] =
     new TestAspectAtLeastR[Live] {
-      def some[R <: Live, E](spec: ZSpec[R, E])(implicit trace: ZTraceElement): ZSpec[R, E] = {
+      def some[R <: Live, E](spec: Spec[R, E])(implicit trace: ZTraceElement): Spec[R, E] = {
         val layer = ZLayer.scoped {
           for {
             system <- live(ZIO.system)
@@ -1060,8 +1060,8 @@ object TestAspect extends TimeoutVariants {
     )(implicit trace: ZTraceElement): ZIO[R, TestFailure[E], TestSuccess]
 
     final def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE](
-      spec: ZSpec[R, E]
-    )(implicit trace: ZTraceElement): ZSpec[R, E] =
+      spec: Spec[R, E]
+    )(implicit trace: ZTraceElement): Spec[R, E] =
       spec.transform[R, E] {
         case Spec.TestCase(test, annotations) => Spec.TestCase(perTest(test), annotations)
         case c                                => c

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -246,7 +246,7 @@ object TestAspect extends TimeoutVariants {
             })
           }
 
-        spec.transform[R, E, TestSuccess] {
+        spec.transform[R, E] {
           case Spec.TestCase(test, annotations) => Spec.TestCase(diagnose("", test), annotations)
           case c                                => c
         }
@@ -911,7 +911,7 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: ZTraceElement): ZIO[R, TestFailure[E], TestSuccess] =
         test.flatMap {
-          case TestSuccess.Ignored =>
+          case TestSuccess.Ignored(_) =>
             ZIO.fail(TestFailure.Runtime(Cause.die(new RuntimeException("Test was ignored."))))
           case x => ZIO.succeedNow(x)
         }
@@ -1062,7 +1062,7 @@ object TestAspect extends TimeoutVariants {
     final def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE](
       spec: ZSpec[R, E]
     )(implicit trace: ZTraceElement): ZSpec[R, E] =
-      spec.transform[R, E, TestSuccess] {
+      spec.transform[R, E] {
         case Spec.TestCase(test, annotations) => Spec.TestCase(perTest(test), annotations)
         case c                                => c
       }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -246,7 +246,7 @@ object TestAspect extends TimeoutVariants {
             })
           }
 
-        spec.transform[R, TestFailure[E], TestSuccess] {
+        spec.transform[R, E, TestSuccess] {
           case Spec.TestCase(test, annotations) => Spec.TestCase(diagnose("", test), annotations)
           case c                                => c
         }
@@ -583,8 +583,8 @@ object TestAspect extends TimeoutVariants {
   def nonTermination(duration: Duration): TestAspectAtLeastR[Live] =
     timeout(duration) >>>
       failing {
-        case TestFailure.Assertion(_) => false
-        case TestFailure.Runtime(cause) =>
+        case TestFailure.Assertion(_, _) => false
+        case TestFailure.Runtime(cause, _) =>
           cause.dieOption match {
             case Some(t) => t.getMessage == s"Timeout of ${duration.render} exceeded."
             case None    => false
@@ -1062,7 +1062,7 @@ object TestAspect extends TimeoutVariants {
     final def some[R >: LowerR <: UpperR, E >: LowerE <: UpperE](
       spec: ZSpec[R, E]
     )(implicit trace: ZTraceElement): ZSpec[R, E] =
-      spec.transform[R, TestFailure[E], TestSuccess] {
+      spec.transform[R, E, TestSuccess] {
         case Spec.TestCase(test, annotations) => Spec.TestCase(perTest(test), annotations)
         case c                                => c
       }

--- a/test/shared/src/main/scala/zio/test/TestConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/TestConstructor.scala
@@ -5,31 +5,31 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stm.ZSTM
 
 trait TestConstructor[-Environment, In] {
-  type Out <: ZSpec[Environment, Any]
+  type Out <: Spec[Environment, Any]
   def apply(label: String)(assertion: => In)(implicit trace: ZTraceElement): Out
 }
 
 object TestConstructor extends TestConstructorLowPriority1 {
   type WithOut[Environment, In, Out0] = TestConstructor[Environment, In] { type Out = Out0 }
 
-  implicit def TestResultConstructor[A <: TestResult]: TestConstructor.WithOut[Any, A, ZSpec[Any, Nothing]] =
+  implicit def TestResultConstructor[A <: TestResult]: TestConstructor.WithOut[Any, A, Spec[Any, Nothing]] =
     new TestConstructor[Any, A] {
-      type Out = ZSpec[Any, Nothing]
+      type Out = Spec[Any, Nothing]
       def apply(label: String)(
         assertion: => A
-      )(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
+      )(implicit trace: ZTraceElement): Spec[Any, Nothing] =
         test(label)(ZIO.succeed(assertion))
     }
 }
 
 trait TestConstructorLowPriority1 extends TestConstructorLowPriority2 {
 
-  implicit def TestResultZIOConstructor[R, E, A <: TestResult]: TestConstructor.WithOut[R, ZIO[R, E, A], ZSpec[R, E]] =
+  implicit def TestResultZIOConstructor[R, E, A <: TestResult]: TestConstructor.WithOut[R, ZIO[R, E, A], Spec[R, E]] =
     new TestConstructor[R, ZIO[R, E, A]] {
-      type Out = ZSpec[R, E]
+      type Out = Spec[R, E]
       def apply(
         label: String
-      )(assertion: => ZIO[R, E, A])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      )(assertion: => ZIO[R, E, A])(implicit trace: ZTraceElement): Spec[R, E] =
         Spec.labeled(
           label,
           Spec
@@ -41,37 +41,36 @@ trait TestConstructorLowPriority1 extends TestConstructorLowPriority2 {
 
 trait TestConstructorLowPriority2 extends TestConstructorLowPriority3 {
 
-  implicit def TestResultZSTMConstructor[R, E, A <: TestResult]
-    : TestConstructor.WithOut[R, ZSTM[R, E, A], ZSpec[R, E]] =
+  implicit def TestResultZSTMConstructor[R, E, A <: TestResult]: TestConstructor.WithOut[R, ZSTM[R, E, A], Spec[R, E]] =
     new TestConstructor[R, ZSTM[R, E, A]] {
-      type Out = ZSpec[R, E]
+      type Out = Spec[R, E]
       def apply(label: String)(
         assertion: => ZSTM[R, E, A]
-      )(implicit trace: ZTraceElement): ZSpec[R, E] =
+      )(implicit trace: ZTraceElement): Spec[R, E] =
         test(label)(assertion.commit)
     }
 }
 
 trait TestConstructorLowPriority3 extends TestConstructorLowPriority4 {
 
-  implicit def AssertConstructor[A <: Assert]: TestConstructor.WithOut[Any, A, ZSpec[Any, Nothing]] =
+  implicit def AssertConstructor[A <: Assert]: TestConstructor.WithOut[Any, A, Spec[Any, Nothing]] =
     new TestConstructor[Any, A] {
-      type Out = ZSpec[Any, Nothing]
+      type Out = Spec[Any, Nothing]
       def apply(label: String)(
         assertion: => A
-      )(implicit trace: ZTraceElement): ZSpec[Any, Nothing] =
+      )(implicit trace: ZTraceElement): Spec[Any, Nothing] =
         test(label)(ZIO.succeed(assertion))
     }
 }
 
 trait TestConstructorLowPriority4 extends TestConstructorLowPriority5 {
 
-  implicit def AssertZIOConstructor[R, E, A <: Assert]: TestConstructor.WithOut[R, ZIO[R, E, A], ZSpec[R, E]] =
+  implicit def AssertZIOConstructor[R, E, A <: Assert]: TestConstructor.WithOut[R, ZIO[R, E, A], Spec[R, E]] =
     new TestConstructor[R, ZIO[R, E, A]] {
-      type Out = ZSpec[R, E]
+      type Out = Spec[R, E]
       def apply(
         label: String
-      )(assertion: => ZIO[R, E, A])(implicit trace: ZTraceElement): ZSpec[R, E] =
+      )(assertion: => ZIO[R, E, A])(implicit trace: ZTraceElement): Spec[R, E] =
         Spec.labeled(
           label,
           Spec
@@ -83,12 +82,12 @@ trait TestConstructorLowPriority4 extends TestConstructorLowPriority5 {
 
 trait TestConstructorLowPriority5 {
 
-  implicit def AssertZSTMConstructor[R, E, A <: Assert]: TestConstructor.WithOut[R, ZSTM[R, E, A], ZSpec[R, E]] =
+  implicit def AssertZSTMConstructor[R, E, A <: Assert]: TestConstructor.WithOut[R, ZSTM[R, E, A], Spec[R, E]] =
     new TestConstructor[R, ZSTM[R, E, A]] {
-      type Out = ZSpec[R, E]
+      type Out = Spec[R, E]
       def apply(label: String)(
         assertion: => ZSTM[R, E, A]
-      )(implicit trace: ZTraceElement): ZSpec[R, E] =
+      )(implicit trace: ZTraceElement): Spec[R, E] =
         test(label)(assertion.commit)
     }
 }

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -25,7 +25,7 @@ import zio.{ExecutionStrategy, ZIO, ZTraceElement}
  * environment `R` and may fail with an `E`.
  */
 abstract class TestExecutor[+R, E] {
-  def run(spec: ZSpec[R, E], defExec: ExecutionStrategy)(implicit
+  def run(spec: Spec[R, E], defExec: ExecutionStrategy)(implicit
     trace: ZTraceElement
   ): UIO[Summary]
 
@@ -38,7 +38,7 @@ object TestExecutor {
     env: ZLayer[Scope, Nothing, R],
     sinkLayer: Layer[Nothing, ExecutionEventSink]
   ): TestExecutor[R, E] = new TestExecutor[R, E] {
-    def run(spec: ZSpec[R, E], defExec: ExecutionStrategy)(implicit
+    def run(spec: Spec[R, E], defExec: ExecutionStrategy)(implicit
       trace: ZTraceElement
     ): UIO[
       Summary

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -49,7 +49,7 @@ object TestExecutor {
         _ <- {
           def loop(
             labels: List[String],
-            spec: Spec[Scope, E, Annotated[TestSuccess]],
+            spec: Spec[Scope, E],
             exec: ExecutionStrategy,
             ancestors: List[SuiteId],
             sectionId: SuiteId
@@ -112,10 +112,10 @@ object TestExecutor {
 
     val environment = env
 
-    private def extract(result: Either[TestFailure[E], (TestSuccess, TestAnnotationMap)]) =
+    private def extract(result: Either[TestFailure[E], TestSuccess]) =
       result match {
-        case Left(testFailure)                 => (Left(testFailure), testFailure.annotations)
-        case Right((testSuccess, annotations)) => (Right(testSuccess), annotations)
+        case Left(testFailure)  => (Left(testFailure), testFailure.annotations)
+        case Right(testSuccess) => (Right(testSuccess), testSuccess.annotations)
       }
   }
 

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -49,7 +49,7 @@ object TestExecutor {
         _ <- {
           def loop(
             labels: List[String],
-            spec: Spec[Scope, Annotated[TestFailure[E]], Annotated[TestSuccess]],
+            spec: Spec[Scope, E, Annotated[TestSuccess]],
             exec: ExecutionStrategy,
             ancestors: List[SuiteId],
             sectionId: SuiteId
@@ -112,34 +112,10 @@ object TestExecutor {
 
     val environment = env
 
-    private def extract(result: Either[(TestFailure[E], TestAnnotationMap), (TestSuccess, TestAnnotationMap)]) =
+    private def extract(result: Either[TestFailure[E], (TestSuccess, TestAnnotationMap)]) =
       result match {
-        case Left(
-              (
-                testFailure: TestFailure[
-                  E
-                ],
-                annotations
-              )
-            ) =>
-          (
-            Left(
-              testFailure
-            ),
-            annotations
-          )
-        case Right(
-              (
-                testSuccess,
-                annotations
-              )
-            ) =>
-          (
-            Right(
-              testSuccess
-            ),
-            annotations
-          )
+        case Left(testFailure)                 => (Left(testFailure), testFailure.annotations)
+        case Right((testSuccess, annotations)) => (Right(testSuccess), annotations)
       }
   }
 

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -52,7 +52,7 @@ final case class TestRunner[R, E](
    * Runs the spec, producing the execution results.
    */
   def run(
-    spec: ZSpec[R, E]
+    spec: Spec[R, E]
   )(implicit
     trace: ZTraceElement
   ): UIO[
@@ -69,7 +69,7 @@ final case class TestRunner[R, E](
    * An unsafe, synchronous run of the specified spec.
    */
   def unsafeRun(
-    spec: ZSpec[R, E]
+    spec: Spec[R, E]
   )(implicit trace: ZTraceElement): Unit =
     runtime.unsafeRun(run(spec).provideLayer(bootstrap))
 
@@ -77,7 +77,7 @@ final case class TestRunner[R, E](
    * An unsafe, asynchronous run of the specified spec.
    */
   def unsafeRunAsync(
-    spec: ZSpec[R, E]
+    spec: Spec[R, E]
   )(
     k: => Unit
   )(implicit trace: ZTraceElement): Unit =
@@ -90,7 +90,7 @@ final case class TestRunner[R, E](
    * An unsafe, synchronous run of the specified spec.
    */
   def unsafeRunSync(
-    spec: ZSpec[R, E]
+    spec: Spec[R, E]
   )(implicit trace: ZTraceElement): Exit[Nothing, Unit] =
     runtime.unsafeRunSync(run(spec).unit.provideLayer(bootstrap))
 

--- a/test/shared/src/main/scala/zio/test/TestSuccess.scala
+++ b/test/shared/src/main/scala/zio/test/TestSuccess.scala
@@ -18,9 +18,25 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-sealed abstract class TestSuccess
+sealed abstract class TestSuccess { self =>
+
+  /**
+   * Retrieves the annotations associated with this test success.
+   */
+  def annotations: TestAnnotationMap
+
+  /**
+   * Annotates this test success with the specified test annotations.
+   */
+  def annotated(annotations: TestAnnotationMap): TestSuccess =
+    self match {
+      case TestSuccess.Succeeded(result, _) => TestSuccess.Succeeded(result, self.annotations ++ annotations)
+      case TestSuccess.Ignored(_)           => TestSuccess.Ignored(self.annotations ++ annotations)
+    }
+}
 
 object TestSuccess {
-  final case class Succeeded(result: BoolAlgebra[Unit]) extends TestSuccess
-  case object Ignored                                   extends TestSuccess
+  final case class Succeeded(result: BoolAlgebra[Unit], annotations: TestAnnotationMap = TestAnnotationMap.empty)
+      extends TestSuccess
+  final case class Ignored(annotations: TestAnnotationMap = TestAnnotationMap.empty) extends TestSuccess
 }

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -29,9 +29,9 @@ trait TimeoutVariants {
   ): TestAspectAtLeastR[Live] =
     new TestAspect[Nothing, Live, Nothing, Any] {
       def some[R <: Live, E](
-        spec: ZSpec[R, E]
-      )(implicit trace: ZTraceElement): ZSpec[R, E] = {
-        def loop(labels: List[String], spec: ZSpec[R, E]): ZSpec[R with Live, E] =
+        spec: Spec[R, E]
+      )(implicit trace: ZTraceElement): Spec[R, E] = {
+        def loop(labels: List[String], spec: Spec[R, E]): Spec[R with Live, E] =
           spec.caseValue match {
             case Spec.ExecCase(exec, spec)     => Spec.exec(exec, loop(labels, spec))
             case Spec.LabeledCase(label, spec) => Spec.labeled(label, loop(label :: labels, spec))

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -38,6 +38,6 @@ abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
   def suite[In](label: String)(specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
     trace: ZTraceElement
-  ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError, suiteConstructor.OutSuccess] =
+  ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
     zio.test.suite(label)(specs: _*)
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -26,7 +26,7 @@ import zio.test.render._
 abstract class ZIOSpecAbstract extends ZIOApp {
   self =>
 
-  def spec: ZSpec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any]
+  def spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any]
 
   def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment with ZIOAppArgs]] =
     Chunk(TestAspect.fibers)
@@ -61,7 +61,7 @@ abstract class ZIOSpecAbstract extends ZIOApp {
           summary1
         }
 
-      def spec: ZSpec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
+      def spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
         self.aspects.foldLeft(self.spec)(_ @@ _) + that.aspects.foldLeft(that.spec)(_ @@ _)
 
       def tag: EnvironmentTag[Environment] = {
@@ -98,7 +98,7 @@ abstract class ZIOSpecAbstract extends ZIOApp {
   }
 
   private[zio] def runSpec(
-    spec: ZSpec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any],
+    spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any],
     testArgs: TestArgs,
     console: Console
   )(implicit

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -12,5 +12,5 @@ abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
     zio.ZEnv.live >>> TestEnvironment.live
   }
 
-  def spec: ZSpec[TestEnvironment with Scope, Any]
+  def spec: Spec[TestEnvironment with Scope, Any]
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -244,7 +244,7 @@ package object test extends CompileVariants {
    * A `ZSpec[R, E]` is the canonical spec for testing ZIO programs. The spec's
    * test type is a ZIO effect that requires an `R` and might fail with an `E`.
    */
-  type ZSpec[-R, +E] = Spec[R, E, TestSuccess]
+  type ZSpec[-R, +E] = Spec[R, E]
 
   /**
    * An `Annotated[A]` contains a value of type `A` along with zero or more test
@@ -606,7 +606,7 @@ package object test extends CompileVariants {
    * Creates an ignored test result.
    */
   val ignored: UIO[TestSuccess] =
-    ZIO.succeedNow(TestSuccess.Ignored)
+    ZIO.succeedNow(TestSuccess.Ignored())
 
   /**
    * Passes platform specific information to the specified function, which will
@@ -624,7 +624,7 @@ package object test extends CompileVariants {
   def suite[In](label: String)(specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
     trace: ZTraceElement
-  ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError, suiteConstructor.OutSuccess] =
+  ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
     Spec.labeled(
       label,
       if (specs.isEmpty) Spec.empty

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -244,7 +244,7 @@ package object test extends CompileVariants {
    * A `ZSpec[R, E]` is the canonical spec for testing ZIO programs. The spec's
    * test type is a ZIO effect that requires an `R` and might fail with an `E`.
    */
-  type ZSpec[-R, +E] = Spec[R, TestFailure[E], TestSuccess]
+  type ZSpec[-R, +E] = Spec[R, E, TestSuccess]
 
   /**
    * An `Annotated[A]` contains a value of type `A` along with zero or more test

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -241,12 +241,6 @@ package object test extends CompileVariants {
   }
 
   /**
-   * A `ZSpec[R, E]` is the canonical spec for testing ZIO programs. The spec's
-   * test type is a ZIO effect that requires an `R` and might fail with an `E`.
-   */
-  type ZSpec[-R, +E] = Spec[R, E]
-
-  /**
    * An `Annotated[A]` contains a value of type `A` along with zero or more test
    * annotations.
    */


### PR DESCRIPTION
The polymorphism of `Spec` is not buying us much. By specializing the error type to `TestFailure` and the success type to `TestSuccess` we can improve the experience of working with tests by eliminating the need to map the failure type of layers to a `TestFailure` as well as simplify the code.