### PR TITLE
ZIO 1: Handle Fiber Failures In ZIO App

### DIFF
--- a/core/jvm/src/main/scala/zio/App.scala
+++ b/core/jvm/src/main/scala/zio/App.scala
@@ -71,7 +71,7 @@ trait App extends BootstrapRuntime {
                      val _ = unsafeRunSync(fiber.interrupt)
                    }
                }))
-          result <- fiber.join
+          result <- fiber.join.catchAllCause(_ => ZIO.succeed(ExitCode.failure))
           _      <- fiber.interrupt
         } yield result.code
       )


### PR DESCRIPTION
Resolves #6596. We should translate fiber failures into a failure exit code instead of failing the application.