### PR TITLE
Zio Test Inline Scope

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
@@ -19,7 +19,7 @@ object InlineScopeTestSpec extends ZIOBaseSpec {
 
   def spec = 
     suite("Inline Scope Spec")(
-      test("Inline scope shows errors") {
+      test("Inline scope is captured") {
         assertTrue(AnotherObject.foo() == 1)
       }
     )

--- a/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
@@ -1,0 +1,21 @@
+package zio
+
+import zio.Experimental._
+import zio.test._
+import zio.test.Assertion._
+import zio.Random
+import zio.test.Gen._
+
+import scala.annotation.experimental
+import scala.language.experimental.saferExceptions
+
+object InlineScopeTestSpec extends ZIOBaseSpec {
+
+  def spec = 
+    suite("Inline Scope Spec")(
+        test("Inline scope shows errors") {
+            assertTrue(true)
+        }
+    )
+    
+}

--- a/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/InlineScopeTestSpec.scala
@@ -1,21 +1,27 @@
 package zio
 
-import zio.Experimental._
 import zio.test._
 import zio.test.Assertion._
 import zio.Random
 import zio.test.Gen._
 
-import scala.annotation.experimental
-import scala.language.experimental.saferExceptions
+object AnObject {
+  def bar: Int = 1
+}
+
+object AnotherObject {
+  opaque type ATypeIsNeeded = Unit
+  val AnAlias = AnObject
+  inline def foo(): Int = AnAlias.bar
+}
 
 object InlineScopeTestSpec extends ZIOBaseSpec {
 
   def spec = 
     suite("Inline Scope Spec")(
-        test("Inline scope shows errors") {
-            assertTrue(true)
-        }
+      test("Inline scope shows errors") {
+        assertTrue(AnotherObject.foo() == 1)
+      }
     )
-    
+
 }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -138,7 +138,7 @@ class SmartAssertMacros(ctx: Quotes)  {
         val res = transformAs(body.asExprOf[TestLens[v]])(lhs)
         res.asInstanceOf[Expr[TestArrow[Any, A]]]
 
-      case Unseal(Inlined(_, _, expr)) => transform(expr.asExprOf[A])
+      case Unseal(Inlined(_, _, expr)) => Inlined(a,b,transform(expr.asExprOf[A]).asTerm).asExprOf[zio.test.TestArrow[Any, A]]
 
       case Unseal(Apply(Select(lhs, op @ (">" | ">=" | "<" | "<=")), List(rhs))) =>
         val span = rhs.span

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -138,7 +138,7 @@ class SmartAssertMacros(ctx: Quotes)  {
         val res = transformAs(body.asExprOf[TestLens[v]])(lhs)
         res.asInstanceOf[Expr[TestArrow[Any, A]]]
 
-      case Unseal(Inlined(_, _, expr)) => Inlined(a,b,transform(expr.asExprOf[A]).asTerm).asExprOf[zio.test.TestArrow[Any, A]]
+      case Unseal(Inlined(a, b, expr)) => Inlined(a, b, transform(expr.asExprOf[A]).asTerm).asExprOf[zio.test.TestArrow[Any, A]]
 
       case Unseal(Apply(Select(lhs, op @ (">" | ">=" | "<" | "<=")), List(rhs))) =>
         val span = rhs.span


### PR DESCRIPTION
Changed `Macros.scala` to capture and preserve local type information inside of an inline object

Co-authored by: [Alexander Ioffe](https://github.com/deusaquilus)