### PR TITLE
Implement ZIO#using

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScopeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScopeSpec.scala
@@ -54,7 +54,25 @@ object ScopeSpec extends ZIOBaseSpec {
                }
         } yield assertCompletes
       }
-    )
+    ),
+    test("using") {
+      for {
+        ref1 <- Ref.make[Chunk[Action]](Chunk.empty)
+        ref2 <- Ref.make[Chunk[Action]](Chunk.empty)
+        _ <- ZIO.scoped {
+               for {
+                 _ <- ZIO.using(resource(1)(ref1)) { _ =>
+                        ref1.update(_ :+ Action.Use(1)) *>
+                          resource(2)(ref2)
+                      }
+                 _ <- ref2.update(_ :+ Action.Use(2))
+               } yield ()
+             }
+        actions1 <- ref1.get
+        actions2 <- ref2.get
+      } yield assertTrue(actions1 == Chunk(Action.acquire(1), Action.use(1), Action.release(1))) &&
+        assertTrue(actions2 == Chunk(Action.acquire(2), Action.use(2), Action.release(2)))
+    }
   )
 
   sealed trait Action

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4404,6 +4404,13 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.serviceWithZIO(_.update(f))
 
   /**
+   * Scopes all resources acquired by `resource` to the lifetime of `use`
+   * without effecting the scope of any resources acquired by `use`.
+   */
+  def using[R]: UsingPartiallyApplied[R] =
+    new ZIO.UsingPartiallyApplied[R]
+
+  /**
    * Feeds elements of type `A` to `f` and accumulates all errors in error
    * channel or successes in success channel.
    *
@@ -4788,6 +4795,19 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   final class ScopedPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](zio: => ZIO[Scope with R, E, A])(implicit trace: ZTraceElement): ZIO[R, E, A] =
       Scope.make.flatMap(_.use[R](zio))
+  }
+
+  final class UsingPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
+    def apply[R1, E, A, B](
+      resource: ZIO[R with Scope, E, A]
+    )(use: A => ZIO[R, E, B])(implicit trace: ZTraceElement): ZIO[R, E, B] =
+      ZIO.acquireReleaseExitWith {
+        Scope.make
+      } { (scope: Scope.Closeable, exit: Exit[Any, Any]) =>
+        scope.close(exit)
+      } { scope =>
+        scope.extend[R](resource).flatMap(use)
+      }
   }
 
   final class ServiceAtPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {


### PR DESCRIPTION
Makes it easier to close the scope of one resource without effecting the scope of other resources potentially used by a workflow.