### PR TITLE
Include Cause of Failure in ZIO#debug

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -520,20 +520,18 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    * Taps the effect, printing the result of calling `.toString` on the value.
    */
   final def debug(implicit trace: ZTraceElement): ZIO[R, E, A] =
-    self.tapBoth(
-      error => ZIO.succeed(println(s"<FAIL> $error")),
-      value => ZIO.succeed(println(value))
-    )
+    self
+      .tap(value => ZIO.succeed(println(value)))
+      .tapErrorCause(error => ZIO.succeed(println(s"<FAIL> $error")))
 
   /**
    * Taps the effect, printing the result of calling `.toString` on the value.
    * Prefixes the output with the given message.
    */
   final def debug(prefix: => String)(implicit trace: ZTraceElement): ZIO[R, E, A] =
-    self.tapBoth(
-      error => ZIO.succeed(println(s"<FAIL> $prefix: $error")),
-      value => ZIO.succeed(println(s"$prefix: $value"))
-    )
+    self
+      .tap(value => ZIO.succeed(println(s"$prefix: $value")))
+      .tapErrorCause(error => ZIO.succeed(println(s"<FAIL> $prefix: $error")))
 
   /**
    * Returns an effect that is delayed from this effect by the specified


### PR DESCRIPTION
If we are debugging and dealing with fiber failures it is nice to be able to see them too. Otherwise it can potentially be confusing because we may think a workflow was never executed when in fact it was.