### PR TITLE
Apply `timed` via command line

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -23,11 +23,19 @@ final case class TestArgs(
   tagSearchTerms: List[String],
   testTaskPolicy: Option[String],
   testRenderer: Option[String],
-  printSummary: Boolean
+  printSummary: Boolean,
+  timed: Boolean
 )
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String], None, None, printSummary = true)
+  def empty: TestArgs = TestArgs(
+    testSearchTerms = Nil,
+    tagSearchTerms = Nil,
+    testTaskPolicy = None,
+    testRenderer = None,
+    printSummary = true,
+    timed = false
+  )
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
@@ -39,6 +47,7 @@ object TestArgs {
         case Array("-policy", name)   => ("policy", name)
         case Array("-renderer", name) => ("renderer", name)
         case Array("-summary", flag)  => ("summary", flag)
+        case Array("-timed", flag)    => ("timed", flag)
       }
       .toList
       .groupBy(_._1)
@@ -51,6 +60,7 @@ object TestArgs {
     val testTaskPolicy = parsedArgs.getOrElse("policy", Nil).headOption
     val testRenderer   = parsedArgs.getOrElse("renderer", Nil).headOption.map(_.toLowerCase)
     val printSummary   = parsedArgs.getOrElse("summary", Nil).headOption.forall(_.toBoolean)
-    TestArgs(terms, tags, testTaskPolicy, testRenderer, printSummary)
+    val timed          = parsedArgs.getOrElse("timed", Nil).headOption.forall(_.toBoolean)
+    TestArgs(terms, tags, testTaskPolicy, testRenderer, printSummary, timed)
   }
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -109,6 +109,8 @@ abstract class ZIOSpecAbstract extends ZIOApp {
   ] = {
     val filteredSpec = FilteredSpec(spec, testArgs)
 
+    val specToRun = if (testArgs.timed) filteredSpec @@ TestAspect.timed else filteredSpec
+
     for {
       runtime <-
         ZIO.runtime[
@@ -132,7 +134,7 @@ abstract class ZIOSpecAbstract extends ZIOApp {
         )
       testReporter = testArgs.testRenderer.fold(runner.reporter)(createTestReporter)
       summary <-
-        runner.withReporter(testReporter).run(aspects.foldLeft(filteredSpec)(_ @@ _))
+        runner.withReporter(testReporter).run(aspects.foldLeft(specToRun)(_ @@ _))
     } yield summary
   }
 


### PR DESCRIPTION
This PR adds a command-line flag to apply `TestAspect.timed` to the currently executing spec.
I need the timing to properly render test execution duration in IntelliJ, but this could also be useful for troubleshooting slow tests without recompiling, but also could be useful in other scenarios, such as CI (junit-xml generation with timing info, etc).