### PR TITLE
Optimize ZStream#groupByKey

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5770,9 +5770,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   private def groupBy[K, V](values: Iterable[V])(f: V => K): Chunk[(K, Chunk[V])] = {
 
     class GroupedBuilder extends Function1[K, ChunkBuilder[V]] { self =>
-      val builder = ChunkBuilder.make[(K, ChunkBuilder[V])]
+      val builder = ChunkBuilder.make[(K, ChunkBuilder[V])]()
       def apply(key: K): ChunkBuilder[V] = {
-        val builder = ChunkBuilder.make[V]
+        val builder = ChunkBuilder.make[V]()
         self.builder += key -> builder
         builder
       }


### PR DESCRIPTION
Resolves #4191.

This is two orders of magnitude faster with the default chunk size.

Before:

```
[info] Benchmark                       (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt  Score   Error  Units
[info] StreamBenchmarks.zioGroupByKey           100         4096              50  thrpt   25  1.902 ± 0.093  ops/s
```

After:

```
[info] Benchmark                       (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioGroupByKey           100         4096              50  thrpt   25  210.437 ± 5.933  ops/s
```