### PR TITLE
Make Scope.default Return Scope Instead Of Closeable

### DIFF
--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -97,8 +97,14 @@ object Scope {
    * interruption. This can be used to close a scope when providing a layer to a
    * workflow.
    */
-  val default: ZLayer[Any, Nothing, Scope.Closeable] =
-    ZLayer.scope
+  val default: ZLayer[Any, Nothing, Scope] =
+    ZLayer.scopedEnvironment(
+      ZIO
+        .acquireReleaseExit(Scope.make(ZTraceElement.empty))((scope, exit) => scope.close(exit)(ZTraceElement.empty))(
+          ZTraceElement.empty
+        )
+        .map(ZEnvironment[Scope](_))(ZTraceElement.empty)
+    )(ZTraceElement.empty)
 
   /**
    * The global scope which is never closed. Finalizers added to this scope will

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -1362,21 +1362,6 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
     ZLayer.fromZIOEnvironment(ZIO.environment[A])
 
   /**
-   * A layer that constructs a scope and closes it when the workflow the layer
-   * is provided to completes execution, whether by success, failure, or
-   * interruption. This can be used to close a scope when providing a layer to a
-   * workflow.
-   */
-  val scope: ZLayer[Any, Nothing, Scope.Closeable] =
-    ZLayer.scopedEnvironment(
-      ZIO
-        .acquireReleaseExit(Scope.make(ZTraceElement.empty))((scope, exit) => scope.close(exit)(ZTraceElement.empty))(
-          ZTraceElement.empty
-        )
-        .map(ZEnvironment(_))(ZTraceElement.empty)
-    )(ZTraceElement.empty)
-
-  /**
    * Constructs a layer from the specified scoped effect.
    */
   def scoped[R]: ScopedPartiallyApplied[R] =


### PR DESCRIPTION
The `Scope` output by `Scope.default` is already automatically closed when the layer is finalized. Manually closing scopes is quite low level so I think a scope should only be closable if it was directly created by the user.

Also, I think it is more idiomatic to have layers that create a data type in the companion object of that data type rather than the `ZLayer` companion object so I deleted `ZLayer.scope`.