### PR TITLE
ZPool: Release Invalidated Items More Eagerly

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
@@ -71,7 +71,8 @@ object ZPoolSpec extends ZIOBaseSpec {
             _      <- count.get.repeatUntil(_ == 10)
             _      <- pool.invalidate(1)
             result <- ZIO.scoped(pool.get)
-          } yield assertTrue(result == 2)
+            value  <- count.get
+          } yield assertTrue(result == 2 && value == 10)
         } +
         test("compositional retry") {
           def cond(i: Int) = if (i <= 10) ZIO.fail(i) else ZIO.succeed(i)

--- a/core/shared/src/main/scala/zio/ZPool.scala
+++ b/core/shared/src/main/scala/zio/ZPool.scala
@@ -170,21 +170,15 @@ object ZPool {
             state.modify { case State(size, free) =>
               if (free > 0 || size >= range.end)
                 (
-                  items.take.flatMap { acquired =>
-                    acquired.result match {
+                  items.take.flatMap { attempted =>
+                    attempted.result match {
                       case Exit.Success(item) =>
                         invalidated.get.flatMap { set =>
-                          if (set.contains(item))
-                            acquired.forEach(a => invalidated.update(_ - a)) *>
-                              acquired.finalizer *>
-                              state.update(state => state.copy(free = state.free + 1)) *>
-                              allocate *>
-                              acquire
-                          else
-                            ZIO.succeedNow(acquired)
+                          if (set.contains(item)) release(attempted) *> acquire
+                          else ZIO.succeedNow(attempted)
                         }
                       case _ =>
-                        ZIO.succeedNow(acquired)
+                        ZIO.succeedNow(attempted)
                     }
                   },
                   State(size, free - 1)

--- a/core/shared/src/main/scala/zio/ZPool.scala
+++ b/core/shared/src/main/scala/zio/ZPool.scala
@@ -175,7 +175,9 @@ object ZPool {
                       case Exit.Success(item) =>
                         invalidated.get.flatMap { set =>
                           if (set.contains(item))
-                            state.update(state => state.copy(free = state.free + 1)) *>
+                            acquired.forEach(a => invalidated.update(_ - a)) *>
+                              acquired.finalizer *>
+                              state.update(state => state.copy(free = state.free + 1)) *>
                               allocate *>
                               acquire
                           else


### PR DESCRIPTION
Currently we only release invalidated items when we shrink the pool or the pool is shut down. I think we should probably also release them when we get an item and find that it has been invalidated before allocating a new item.