### PR TITLE
Rename ZIOApp Tag To EnvironmentTag

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
   private[zio] val shuttingDown = new AtomicBoolean(false)
 
-  implicit def tag: EnvironmentTag[Environment]
+  implicit def environmentTag: EnvironmentTag[Environment]
 
   type Environment
 
@@ -129,8 +129,8 @@ object ZIOApp {
       app.layer
     override final def run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any] =
       app.run
-    implicit final def tag: EnvironmentTag[Environment] =
-      app.tag
+    implicit final def environmentTag: EnvironmentTag[Environment] =
+      app.environmentTag
   }
 
   /**
@@ -144,7 +144,7 @@ object ZIOApp {
   )(implicit tagged: EnvironmentTag[R]): ZIOApp =
     new ZIOApp {
       type Environment = R
-      def tag: EnvironmentTag[Environment] = tagged
+      def environmentTag: EnvironmentTag[Environment] = tagged
       override def hook                    = hook0
       def layer                            = layer0
       def run                              = run0

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -145,9 +145,9 @@ object ZIOApp {
     new ZIOApp {
       type Environment = R
       def environmentTag: EnvironmentTag[Environment] = tagged
-      override def hook                    = hook0
-      def layer                            = layer0
-      def run                              = run0
+      override def hook                               = hook0
+      def layer                                       = layer0
+      def run                                         = run0
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -42,7 +42,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   val layer: ZLayer[ZIOAppArgs with Scope, Any, Any] = ZLayer.empty
 
-  val tag: EnvironmentTag[Any] = EnvironmentTag[Any]
+  val environmentTag: EnvironmentTag[Any] = EnvironmentTag[Any]
 
 }
 

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -22,7 +22,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
   type Environment = R
 
-  final val tag: EnvironmentTag[R] = EnvironmentTag[R]
+  final val environmentTag: EnvironmentTag[R] = EnvironmentTag[R]
 
   /**
    * Builds a spec with a single test.

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -64,9 +64,9 @@ abstract class ZIOSpecAbstract extends ZIOApp {
       def spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
         self.aspects.foldLeft(self.spec)(_ @@ _) + that.aspects.foldLeft(that.spec)(_ @@ _)
 
-      def tag: EnvironmentTag[Environment] = {
-        implicit val selfTag: EnvironmentTag[self.Environment] = self.tag
-        implicit val thatTag: EnvironmentTag[that.Environment] = that.tag
+      def environmentTag: EnvironmentTag[Environment] = {
+        implicit val selfTag: EnvironmentTag[self.Environment] = self.environmentTag
+        implicit val thatTag: EnvironmentTag[that.Environment] = that.environmentTag
         val _                                                  = (selfTag, thatTag)
         EnvironmentTag[Environment]
       }


### PR DESCRIPTION
The `tag` name is relatively common and conflicts with the `tag` test aspect.