### PR TITLE
Addresses minor grammatical errors and content updates

### DIFF
--- a/docs/overview/creating_effects.md
+++ b/docs/overview/creating_effects.md
@@ -3,7 +3,7 @@ id: overview_creating_effects
 title:  "Creating Effects"
 ---
 
-This section explores some of the common ways to create ZIO effects from values, from common Scala types, and from both synchronous and asynchronous side-effects.
+This section explores some of the common ways to create ZIO effects from values, common Scala types, and both synchronous and asynchronous side effects.
 
 ```scala mdoc:invisible
 import zio.{ ZIO, Task, UIO, URIO, IO }
@@ -41,7 +41,7 @@ Many applications will model failures with classes that extend `Throwable` or `E
 val f2 = Task.fail(new Exception("Uh oh!"))
 ```
 
-Note that unlike the other effect companion objects, the `UIO` companion object does not have `UIO.fail`, because `UIO` values cannot fail.
+Note that, unlike the other effect companion objects, the `UIO` companion object does not have a `fail` method because `UIO` values cannot fail.
 
 ## From Scala Values
 
@@ -55,10 +55,10 @@ An `Option` can be converted into a ZIO effect using `ZIO.fromOption`:
 val zoption: IO[Option[Nothing], Int] = ZIO.fromOption(Some(2))
 ```
 
-The error type of the resulting effect is `Option[Nothing]`, which provides no information on why the value is not there. You can change the `Option[Nothing]` into a more specific error type using `ZIO#mapError`:
+The error type of the resulting effect is `Option[Nothing]`, signifying that the returned value is `None`. You can transform the `Option[Nothing]` into a more specific error type using `orElseFail`:
 
 ```scala mdoc:silent
-val zoption2: IO[String, Int] = zoption.mapError(_ => "It wasn't there!")
+val zoption2: IO[String, Int] = zoption.orElseFail("It wasn't there!")
 ```
 
 You can also readily compose it with other operators while preserving the optional nature of the result (similar to an `OptionT`)
@@ -88,7 +88,7 @@ An `Either` can be converted into a ZIO effect using `ZIO.fromEither`:
 val zeither = ZIO.fromEither(Right("Success!"))
 ```
 
-The error type of the resulting effect will be whatever type the `Left` case has, while the success type will be whatever type the `Right` case has.
+The error type of the resulting effect will be that of `Left` case, while the success type will be that of the `Right` case.
 
 ### Try
 
@@ -100,7 +100,7 @@ import scala.util.Try
 val ztry = ZIO.fromTry(Try(42 / 0))
 ```
 
-The error type of the resulting effect will always be `Throwable`, because `Try` can only fail with values of type `Throwable`.
+The error type of the resulting effect will always be `Throwable` because `Try` can only fail with values of type `Throwable`.
 
 ### Future
 
@@ -117,19 +117,19 @@ val zfuture: Task[String] =
   }
 ```
 
-The function passed to `fromFuture` is passed an `ExecutionContext`, which allows ZIO to manage where the `Future` runs (of course, you can ignore this `ExecutionContext`).
+The function passed to `fromFuture` is provided an `ExecutionContext`, which allows ZIO to manage where the `Future` runs (of course, you can ignore this `ExecutionContext`).
 
-The error type of the resulting effect will always be `Throwable`, because `Future` can only fail with values of type `Throwable`.
+The error type of the resulting effect will always be `Throwable` because `Future` can only fail with values of type `Throwable`.
 
-## From Side-Effects
+## From Side Effects
 
-ZIO can convert both synchronous and asynchronous side-effects into ZIO effects (pure values).
+ZIO can convert both synchronous and asynchronous side effects into ZIO effects (pure values).
 
-These functions can be used to wrap procedural code, allowing you to seamlessly use all features of ZIO with legacy Scala and Java code, as well as third-party libraries.
+These functions can wrap procedural code, allowing you to seamlessly use all features of ZIO with legacy Scala and Java code, as well as third-party libraries.
 
-### Synchronous Side-Effects
+### Synchronous Side Effects
 
-A synchronous side-effect can be converted into a ZIO effect using `ZIO.attempt`:
+A synchronous side effect can be converted into a ZIO effect using `ZIO.attempt`:
 
 ```scala mdoc:silent
 import scala.io.StdIn
@@ -138,16 +138,16 @@ val readLine: Task[String] =
   ZIO.attempt(StdIn.readLine())
 ```
 
-The error type of the resulting effect will always be `Throwable`, because side-effects may throw exceptions with any value of type `Throwable`.
+The error type of the resulting effect will always be `Throwable` because side effects may throw exceptions with any value of type `Throwable`.
 
-If a given side-effect is known to not throw any exceptions, then the side-effect can be converted into a ZIO effect using `ZIO.succeed`:
+If a given side effect does not throw exceptions, the side effect can be converted into a ZIO effect using `ZIO.succeed`:
 
 ```scala mdoc:silent
 def printLine(line: String): UIO[Unit] =
   ZIO.succeed(println(line))
 ```
 
-You should be careful when using `ZIO.succeed`—when in doubt about whether or not a side-effect is total, prefer `ZIO.attempt` to convert the effect.
+Be careful when using `ZIO.succeed`—when in doubt about whether or not a side effect is total, opt to use `ZIO.attempt` to convert the effect.
 
 If you wish to refine the error type of an effect (by treating other errors as fatal), then you can use the `ZIO#refineToOrDie` method:
 
@@ -158,9 +158,9 @@ val readLine2: IO[IOException, String] =
   ZIO.attempt(StdIn.readLine()).refineToOrDie[IOException]
 ```
 
-### Asynchronous Side-Effects
+### Asynchronous Side Effects
 
-An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.async`:
+An asynchronous side effect with a callback-based API can be converted into a ZIO effect using `ZIO.async`:
 
 ```scala mdoc:invisible
 trait User { 
@@ -185,15 +185,15 @@ val login: IO[AuthError, User] =
   }
 ```
 
-Asynchronous ZIO effects are much easier to use than callback-based APIs, and they benefit from ZIO features like interruption, resource-safety, and superior error handling.
+Asynchronous ZIO effects are much easier to use than callback-based APIs and they benefit from ZIO features like interruption, resource-safety, and superior error handling.
 
-## Blocking Synchronous Side-Effects
+## Blocking Synchronous Side Effects
 
-Some side-effects use blocking IO or otherwise put a thread into a waiting state. If not carefully managed, these side-effects can deplete threads from your application's main thread pool, resulting in work starvation.
+Some side effects use blocking IO, or otherwise put a thread into a waiting state. If not carefully managed, these side-effects can deplete threads from your application's main thread pool, resulting in work starvation.
 
-ZIO provides `zio.Blocking`, which can be used to safely convert such blocking side-effects into ZIO effects.
+ZIO provides `zio.Blocking`, which can be used to safely convert such blocking side effects into ZIO effects.
 
-A blocking side-effect can be converted directly into a ZIO effect blocking with the `attemptBlocking` method:
+A blocking side effect can be converted directly into a ZIO effect, blocking with the `attemptBlocking` method:
 
 ```scala mdoc:silent
 val sleeping =
@@ -202,9 +202,9 @@ val sleeping =
 
 The resulting effect will be executed on a separate thread pool designed specifically for blocking effects.
 
-Blocking side-effects can be interrupted by invoking `Thread.interrupt` using the `attemptBlockingInterrupt` method.
+Blocking side effects can be interrupted by invoking `Thread.interrupt` using the `attemptBlockingInterrupt` method.
 
-Some blocking side-effects can only be interrupted by invoking a cancellation effect. You can convert these side-effects using the `attemptBlockingCancelable` method:
+Some blocking side effects can only be interrupted by invoking a cancellation effect. You can convert these side effects using the `attemptBlockingCancelable` method:
 
 ```scala mdoc:silent
 import java.net.ServerSocket
@@ -214,7 +214,7 @@ def accept(l: ServerSocket) =
   ZIO.attemptBlockingCancelable(l.accept())(UIO.succeed(l.close()))
 ```
 
-If a side-effect has already been converted into a ZIO effect, then instead of `attemptBlocking`, the `blocking` method can be used to ensure the effect will be executed on the blocking thread pool:
+If a side effect has already been converted into a ZIO effect, then instead of `attemptBlocking`, the `blocking` method can be used to ensure the effect will be executed on the blocking thread pool:
 
 ```scala mdoc:silent
 import scala.io.{ Codec, Source }


### PR DESCRIPTION
I removed unnecessary hyphens and made small adjustments to sentence structure. Additionally, I adjusted the `fromOption` example to use `orElseFail` rather than `mapError` when transforming the `None` case.