### PR TITLE
Fixes grammatical errors and code snippets

### DIFF
--- a/docs/overview/basic_operations.md
+++ b/docs/overview/basic_operations.md
@@ -6,6 +6,7 @@ title:  "Basic Operations"
 ```scala mdoc:invisible
 import zio._
 import zio.Console._
+import java.io.IOException
 ```
 
 ## Mapping

--- a/docs/overview/basic_operations.md
+++ b/docs/overview/basic_operations.md
@@ -29,14 +29,14 @@ Note that mapping over an effect's success or error channel does not change the 
 
 ## Chaining
 
-You can execute two effects in sequence with the `flatMap` method, which requires that you pass a callback, which will receive the value of the first effect, and can return a second effect that depends on this value:
+You can execute two effects sequentially with the `flatMap` method; this requires that you pass a callback, which will receive the value of the first effect and can return a second effect that depends on this value:
 
 ```scala mdoc:silent
-val sequenced = 
+val sequenced: ZIO[Console, IOException, Unit] =
   readLine.flatMap(input => printLine(s"You entered: $input"))
 ```
 
-If the first effect fails, the callback passed to `flatMap` will never be invoked, and the composed effect returned by `flatMap` will also fail.
+If the first effect fails, the callback passed to `flatMap` will never be invoked and the composed effect returned by `flatMap` will also fail.
 
 In _any_ chain of effects, the first failure will short-circuit the whole chain, just like throwing an exception will prematurely exit a sequence of statements.
 
@@ -45,7 +45,7 @@ In _any_ chain of effects, the first failure will short-circuit the whole chain,
 Because the `ZIO` data type supports both `flatMap` and `map`, you can use Scala's _for comprehensions_ to build sequential effects:
 
 ```scala mdoc:silent
-val program = 
+val program: ZIO[Console, IOException, Unit] =
   for {
     _    <- printLine("Hello! What is your name?")
     name <- readLine
@@ -66,23 +66,23 @@ val zipped: UIO[(String, Int)] =
 
 Note that `zip` operates sequentially: the effect on the left side is executed before the effect on the right side.
 
-In any `zip` operation, if either the left or right hand sides fail, then the composed effect will fail, because _both_ values are required to construct the tuple.
+In any `zip` operation, if either the left or right-hand side fails, the composed effect will fail because _both_ values are required to construct the tuple.
 
-Sometimes, when the success value of an effect is not useful (for example, it is `Unit`), it can be more convenient to use the `ZIO#zipLeft` or `ZIO#zipRight` functions, which first perform a `zip`, and then map over the tuple to discard one side or the other:
+Sometimes, when the success value of an effect is not useful (for example, if it is `Unit`), it can be more convenient to use the `ZIO#zipLeft` or `ZIO#zipRight` functions, which first perform a `zip` and then map over the tuple to discard one side or the other:
 
 ```scala mdoc:silent
-val zipRight1 = 
+val zipRight1: ZIO[Console, IOException, String] =
   printLine("What is your name?").zipRight(readLine)
 ```
 
 The `zipRight` and `zipLeft` functions have symbolic aliases, known as `*>` and `<*`, respectively. Some developers find these operators easier to read:
 
 ```scala mdoc:silent
-val zipRight2 = 
+val zipRight2: ZIO[Console, IOException, String] =
   printLine("What is your name?") *>
-  readLine
+    readLine
 ```
 
 ## Next Step
 
-If you are comfortable with the basic operations on ZIO effects, then the next step is to learn about [error handling](handling_errors.md).
+If you are comfortable with the basic operations on ZIO effects, the next step is to learn about [error handling](handling_errors.md).


### PR DESCRIPTION
Made minor grammatical adjustments and added missing type annotations in code snippets.