### PR TITLE
Smart Spec Macro

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
@@ -8,33 +8,32 @@ object SuiteSpec extends ZIOSpecDefault {
 
       val hello = "hello"
 
-      test("test")(
-        assertTrue(hello.startsWith("h"))
-      )
+        test("test 1 ")(
+          assertTrue(hello.startsWith("h"))
+        )
+
 
       val cool = 123
 
       test("another test")(
-        assertTrue(hello.startsWith("h"))
+        ZIO.service[Int].map { x =>
+          assertTrue(x == cool)
+        }
       )
 
-      suite("Nested") {
-
-        val another = 123
-
-        test("test 2")(
-          ZIO.service[Int].map { int =>
-            assertTrue(cool == int)
-          }
+      suiteAll("NEST") {
+        test("nest test 1")(
+          assertTrue(hello.endsWith("o"))
         )
 
-        test("test 3")(
-          ZIO.service[Int].map { int =>
-            assertTrue(another == int)
-          }
+        test("nest test 2")(
+          assertCompletes
         )
       }
+
+
+
     }
-      .provide(ZLayer.succeed(123))
+  .provide(ZLayer.succeed(123))
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
@@ -8,10 +8,9 @@ object SuiteSpec extends ZIOSpecDefault {
 
       val hello = "hello"
 
-        test("test 1 ")(
-          assertTrue(hello.startsWith("h"))
-        )
-
+      test("test 1 ")(
+        assertTrue(hello.startsWith("h"))
+      )
 
       val cool = 123
 
@@ -31,9 +30,7 @@ object SuiteSpec extends ZIOSpecDefault {
         )
       }
 
-
-
     }
-  .provide(ZLayer.succeed(123))
+      .provide(ZLayer.succeed(123))
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SuiteSpec.scala
@@ -1,10 +1,11 @@
 package zio.test
 import zio._
 
-object SweetSpec extends ZIOSpecDefault {
+object SuiteSpec extends ZIOSpecDefault {
 
-  def spec: Spec[Any, Any] =
+  def spec =
     suiteAll("SweetSpec!") {
+
       val hello = "hello"
 
       test("test")(
@@ -13,7 +14,14 @@ object SweetSpec extends ZIOSpecDefault {
 
       val cool = 123
 
-      suiteAll("Nested") {
+      test("another test")(
+        assertTrue(hello.startsWith("h"))
+      )
+
+      suite("Nested") {
+
+        val another = 123
+
         test("test 2")(
           ZIO.service[Int].map { int =>
             assertTrue(cool == int)
@@ -22,7 +30,7 @@ object SweetSpec extends ZIOSpecDefault {
 
         test("test 3")(
           ZIO.service[Int].map { int =>
-            assertTrue(cool == int)
+            assertTrue(another == int)
           }
         )
       }

--- a/test-tests/shared/src/test/scala/zio/test/SweetSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SweetSpec.scala
@@ -1,0 +1,32 @@
+package zio.test
+import zio._
+
+object SweetSpec extends ZIOSpecDefault {
+
+  def spec: Spec[Any, Any] =
+    suiteAll("SweetSpec!") {
+      val hello = "hello"
+
+      test("test")(
+        assertTrue(hello.startsWith("h"))
+      )
+
+      val cool = 123
+
+      suiteAll("Nested") {
+        test("test 2")(
+          ZIO.service[Int].map { int =>
+            assertTrue(cool == int)
+          }
+        )
+
+        test("test 3")(
+          ZIO.service[Int].map { int =>
+            assertTrue(cool == int)
+          }
+        )
+      }
+    }
+      .provide(ZLayer.succeed(123))
+
+}

--- a/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
@@ -53,7 +53,7 @@ class SmartSpecMacros(val c: whitebox.Context) {
           q"""
 ..${acc.reverse}
 suite($name)(
-  ..${names.reverse.map(name => Ident(TermName(name))).reduce[Tree]((a, b) => q"$a + $b")}
+  ..${names.reverse.map(name => Ident(TermName(name)))}
 )"""
       }
 

--- a/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
@@ -2,6 +2,7 @@ package zio.test
 
 import zio.{Chunk, ZIO}
 
+import scala.annotation.tailrec
 import scala.reflect.macros.whitebox
 
 class SmartSpecMacros(val c: whitebox.Context) {
@@ -35,6 +36,7 @@ class SmartSpecMacros(val c: whitebox.Context) {
   def suiteImpl(name: c.Expr[String])(spec: c.Tree): c.Tree = {
     val result = collectTests(spec)
 
+    @tailrec
     def loop(remaining: List[TestOrStatement], acc: List[Tree], names: List[String]): Tree =
       remaining match {
         case head :: tail =>

--- a/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartSpecMacros.scala
@@ -1,0 +1,62 @@
+package zio.test
+
+import zio.{Chunk, ZIO}
+
+import scala.reflect.macros.whitebox
+
+class SmartSpecMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  sealed trait TestOrStatement extends Product with Serializable
+
+  object TestOrStatement {
+    final case class Test(tree: Tree)      extends TestOrStatement
+    final case class Statement(tree: Tree) extends TestOrStatement
+  }
+
+  def collectTests(tree: Tree): List[TestOrStatement] =
+    tree match {
+      case Block(statements, finalStatement) =>
+        statements.flatMap(collectTests) ++ collectTests(finalStatement)
+
+      case test if test.tpe <:< c.weakTypeOf[Spec[_, _]] =>
+        List(TestOrStatement.Test(test))
+
+      case test if test.tpe <:< c.weakTypeOf[ZIO[_, _, Chunk[Spec[_, _]]]] =>
+        List(TestOrStatement.Test(test))
+
+      case test if test.tpe <:< c.weakTypeOf[Chunk[Spec[_, _]]] =>
+        List(TestOrStatement.Test(test))
+
+      case other =>
+        List(TestOrStatement.Statement(other))
+    }
+
+  def suiteImpl(name: c.Expr[String])(spec: c.Tree): c.Tree = {
+    val result = collectTests(spec)
+
+    def loop(remaining: List[TestOrStatement], acc: List[Tree], names: List[String]): Tree =
+      remaining match {
+        case head :: tail =>
+          head match {
+            case TestOrStatement.Test(tree) =>
+              val newName  = c.freshName("test")
+              val newNames = newName :: names
+              val newTree  = q"val ${TermName(newName)} = $tree"
+              loop(tail, newTree :: acc, newNames)
+            case TestOrStatement.Statement(tree) =>
+              loop(tail, tree :: acc, names)
+          }
+        case Nil =>
+          q"""
+..${acc.reverse}
+suite($name)(
+  ..${names.reverse.map(name => Ident(TermName(name))).reduce[Tree]((a, b) => q"$a + $b")}
+)"""
+      }
+
+    val finalSuite = loop(result, Nil, Nil)
+
+    c.untypecheck(finalSuite)
+  }
+}

--- a/test/shared/src/main/scala-2/zio/test/ZIOSpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/ZIOSpecVersionSpecific.scala
@@ -1,0 +1,8 @@
+package zio.test
+
+trait ZIOSpecVersionSpecific[R] {
+  // SCALA 2
+
+  def suiteAll(name: String)(spec: Any): Spec[Nothing, Nothing] =
+    macro SmartSpecMacros.suiteImpl
+}

--- a/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
@@ -1,0 +1,89 @@
+package zio.test
+
+import scala.quoted.*
+
+trait ZIOSpecVersionSpecific[R] { self: ZIOSpec[R] =>
+
+  transparent inline def suiteAll(inline name: String)(inline spec: Any): Any =
+     ${ ZIOSpecVersionSpecificMacros.suiteAllImpl('name, 'spec) }
+
+}
+
+
+object ZIOSpecVersionSpecificMacros {
+
+  def suiteAllImpl(name: Expr[String], spec: Expr[Any])(using ctx: Quotes) = {
+    import ctx.reflect._
+
+    enum TestOrStatement {
+      case SpecCase(term: Term)
+      case StatementCase(statement: Statement) 
+    }
+
+    def collectTests(tree: Tree): List[TestOrStatement] =
+      tree match {
+
+        case Block(stats, expr) =>
+          stats.flatMap(collectTests) ++ collectTests(expr)
+
+        case vd @ ValDef(_, _, _) => 
+          List(TestOrStatement.StatementCase(vd))
+        
+        case spec: Term if spec.tpe <:< TypeRepr.of[Spec[_,_]] =>
+          List(TestOrStatement.SpecCase(spec))
+
+        case other =>
+
+          throw new Error("UNHANDLED: " + other)
+      }
+
+    var idx = 0
+
+    def loop(results: List[TestOrStatement], acc: List[Statement], refs: List[Ref]): Term =
+      results match {
+        case TestOrStatement.StatementCase(tree) :: rest =>
+          loop(rest, tree :: acc, refs)
+        case TestOrStatement.SpecCase(spec) :: rest =>
+          val name = "spec" + idx
+          idx += 1
+          val symbol = Symbol.newVal(Symbol.spliceOwner, name, spec.tpe, Flags.EmptyFlags, Symbol.noSymbol)
+          val valDef = ValDef(symbol, Some(spec))
+          val ref = Ref(symbol)
+          loop(rest, valDef :: acc, ref :: refs)
+        case Nil =>
+
+
+
+          val mySuite =  {
+              val combinedTypes = refs.map(_.tpe).reduce(OrType(_, _)).widen
+              val names = 
+                combinedTypes.asType match {
+                  case '[specType] =>
+                    Varargs(refs.map{a => 
+                      a.asExprOf[specType]
+                    }).asExprOf[Seq[specType]]
+                }
+              
+              names match {
+                case '{ $specNames: Seq[Spec[a, b]] } =>
+                  '{ suite($name)($specNames) }
+              }
+          }
+
+          Block(
+            acc.reverse,
+            mySuite.asTerm
+          )
+      }
+
+    spec.asTerm match {
+      case Inlined(a, b, expr) =>
+        val results = collectTests(expr)
+        val combined = Inlined(a, b, loop(results, Nil, Nil))
+        // println("--")
+        // println(combined.tpe.dealias.widen.simplified)
+        combined.asExpr
+    }
+
+  }
+}

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
+abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract with ZIOSpecVersionSpecific[R] { self =>
   type Environment = R
 
   final val tag: EnvironmentTag[R] = EnvironmentTag[R]
@@ -41,6 +41,4 @@ abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
   ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
     zio.test.suite(label)(specs: _*)
 
-  def suiteAll(name: String)(spec: Any): Spec[Nothing, Nothing] =
-    macro SmartSpecMacros.suiteImpl
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -35,12 +35,12 @@ abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
   ): testConstructor.Out =
     zio.test.test(label)(assertion)
 
-  def suite[In](label: String)(spec: In, specs: In*)(implicit
+  def suite[In](label: String)(specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
     trace: ZTraceElement
   ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
-    zio.test.suite(label)((spec +: specs): _*)
+    zio.test.suite(label)(specs: _*)
 
-  def suiteAll(name: String)(spec: Any): Spec[Nothing, Any] =
+  def suiteAll(name: String)(spec: Any): Spec[Nothing, Nothing] =
     macro SmartSpecMacros.suiteImpl
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -35,9 +35,12 @@ abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract { self =>
   ): testConstructor.Out =
     zio.test.test(label)(assertion)
 
-  def suite[In](label: String)(specs: In*)(implicit
+  def suite[In](label: String)(spec: In, specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
     trace: ZTraceElement
   ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
-    zio.test.suite(label)(specs: _*)
+    zio.test.suite(label)((spec +: specs): _*)
+
+  def suiteAll(name: String)(spec: Any): Spec[Nothing, Any] =
+    macro SmartSpecMacros.suiteImpl
 }


### PR DESCRIPTION
- [x] Implement for Scala 2
- [ ] Implement for Scala 3

A macro `suiteAll` which allows a MutableSpec like syntax, but simply rewrites the following:
```scala
  def spec =
    suiteAll("SweetSpec!") {
      val hello = "hello"

      test("test")(
        assertTrue(hello.startsWith("h"))
      )

      val cool = 123

      suiteAll("Nested") {
        test("test 2")(
          ZIO.service[Int].map { int =>
            assertTrue(cool == int)
          }
        )

        test("test 3")(
          ZIO.service[Int].map { int =>
            assertTrue(cool == int)
          }
        )
      }
    }
      .provide(ZLayer.succeed(123))
```

into

```scala
  def spec =
    suite("SweetSpec!") {
      val hello = "hello"

      val $test1 = test("test")(
        assertTrue(hello.startsWith("h"))
      )

      val cool = 123

      val $suite1 = suite("Nested") {
        val $test2 = test("test 2")(
          ZIO.service[Int].map { int =>
            assertTrue(cool == int)
          }
        )

        val $test3 = test("test 3")(
          ZIO.service[Int].map { int =>
            assertTrue(cool == int)
          }
        )

        test2 + $test3
      }

      $test1 + $suite1
    }
      .provide(ZLayer.succeed(123))
```

This has to be a whitebox macro, so IntelliJ will not know the full type. However, when used to define a single suite inside of `def spec`, the compiler error fired by #6669 will still fire (as well as when calling `.provide` without all the required layers).