### PR TITLE
Delete Provide Service

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -713,16 +713,6 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
     }
 
   /**
-   * Returns a new schedule with the single service it requires provided to it.
-   * If the schedule requires multiple services use `provideEnvironment`
-   * instead.
-   */
-  def provideService[Service <: Env](
-    service: Service
-  )(implicit tag: Tag[Service]): Schedule.WithState[self.State, Any, In, Out] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Transforms the environment being provided to this schedule with the
    * specified function.
    */

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1260,15 +1260,6 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     }
 
   /**
-   * Provides the `ZIO` effect with the single service it requires. If the
-   * effect requires multiple services use `provideEnvironment` instead.
-   */
-  final def provideService[Service <: R](
-    service: => Service
-  )(implicit tag: Tag[Service], trace: ZTraceElement): IO[E, A] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Transforms the environment being provided to this effect with the specified
    * function.
    */

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -487,15 +487,6 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     provideSomeEnvironment(_ => r)
 
   /**
-   * Provides the transaction with the single service it requires. If the
-   * transaction requires multiple services use `provideEnvironment` instead.
-   */
-  def provideService[Service <: R](
-    service: Service
-  )(implicit tag: Tag[Service]): STM[E, A] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Transforms the environment being provided to this effect with the specified
    * function.
    */

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -680,17 +680,6 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
     provideSomeEnvironment(_ => r)
 
   /**
-   * Provides the `ZManaged` effect with the single service it requires. If the
-   * managed effect requires more than one service use `provideEnvironment`
-   * instead.
-   */
-  def provideService[Service <: R](service: Service)(implicit
-    tag: Tag[Service],
-    trace: ZTraceElement
-  ): Managed[E, A] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Provides a layer to the `ZManaged`, which translates it to another level.
    */
   final def provideLayer[E1 >: E, R0](

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1428,7 +1428,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               s = ZStream.finalizer(fins.update(1 :: _)) *>
                     ZStream.finalizer(fins.update(2 :: _))
               result <- Scope.make.flatMap { scope =>
-                          s.toPull.provideService(scope).flatMap { pull =>
+                          scope.extend(s.toPull).flatMap { pull =>
                             pull *> scope.close(Exit.unit) *> fins.get
                           }
                         }

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -389,7 +389,7 @@ trait ZStreamPlatformSpecificConstructors {
                       }
                     )
                   }
-                  .flatMap(scopedConn => scopedConn.provideService(registerConnection))
+                  .flatMap(scopedConn => registerConnection.extend(scopedConn))
               }
     } yield conn
 

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -845,16 +845,6 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
     ZChannel.unwrapScoped[Env0](layer.build.map(env => self.provideEnvironment(env)))
 
   /**
-   * Provides the channel with the single service it requires. If the channel
-   * requires multiple services use `provideEnvironment` instead.
-   */
-  final def provideService[Service <: Env](service: => Service)(implicit
-    tag: Tag[Service],
-    trace: ZTraceElement
-  ): ZChannel[Any, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Transforms the environment being provided to the channel with the specified
    * function.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2423,18 +2423,6 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
     new ZStream(channel.provideEnvironment(r))
 
   /**
-   * Provides the stream with the single service it requires. If the stream
-   * requires multiple services use `provideEnvironment` instead.
-   */
-  final def provideService[Service <: R](
-    service: Service
-  )(implicit
-    tag: Tag[Service],
-    trace: ZTraceElement
-  ): ZStream[Any, E, A] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Provides a layer to the stream, which translates it to another level.
    */
   final def provideLayer[E1 >: E, R0](

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -337,16 +337,6 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
     }
 
   /**
-   * Provides each test in this spec with the single service it requires. If
-   * this spec requires multiple services use `provideEnvironment` instead.
-   */
-  final def provideService[Service <: R](service: Service)(implicit
-    tag: Tag[Service],
-    trace: ZTraceElement
-  ): Spec[Any, E] =
-    provideEnvironment(ZEnvironment(service))
-
-  /**
    * Transforms the environment being provided to each test in this spec with
    * the specified function.
    */


### PR DESCRIPTION
With the benefit of hindsight I think violating the "the thing you provide to your workflow is a layer" principle to implement `provideService` was a mistake.

This operator was originally intended to make the situation of needing to do `zio.provideService(clock)` in the implementation of service interfaces easier. However, it introduced another `provide` variant that only works in limited cases where you have a single service and want to provide the entire environment.

In addition, the situation has significantly changed since this operator was originally implemented because we deleted the default services from the environment. With that change and if other services are written in an idiomatic way, there should actually never be a need to provide an environment in a service implementation. In fact that was the explicit goal of eliminating the default services from the environment. So I think if anything this operator is encoding an anti-pattern at this point.