### PR TITLE
Adjusted grammar and formatting

### DIFF
--- a/docs/overview/handling_resources.md
+++ b/docs/overview/handling_resources.md
@@ -3,9 +3,9 @@ id: overview_handling_resources
 title:  "Handling Resources"
 ---
 
-This section looks at some of the common ways to safely handle resources using ZIO.
+This section looks at some common ways to safely handle resources using ZIO.
 
-ZIO's resource management features work across synchronous, asynchronous, concurrent, and other effect types, and provide strong guarantees even in the presence of failure, interruption, or defects in the application.
+ZIO's resource management features work across synchronous, asynchronous, concurrent, and other effect types and provide strong guarantees even in the case of failure, interruption, or defects.
 
 ```scala mdoc:invisible
 import zio._
@@ -18,7 +18,7 @@ ZIO provides similar functionality to `try` / `finally` with the `ZIO#ensuring` 
 Like `try` / `finally`, the `ensuring` operation guarantees that if an effect begins executing and then terminates (for whatever reason), then the finalizer will begin executing.
 
 ```scala mdoc
-val finalizer = 
+val finalizer: UIO[Unit] = 
   UIO.succeed(println("Finalizing!"))
 
 val finalized: IO[String, Unit] = 
@@ -27,7 +27,7 @@ val finalized: IO[String, Unit] =
 
 The finalizer is not allowed to fail, which means that it must handle any errors internally.
 
-Like `try` / `finally`, finalizers can be nested, and the failure of any inner finalizer will not affect outer finalizers. Nested finalizers will be executed in reverse order, and linearly (not in parallel).
+Like `try` / `finally`, finalizers can be nested and the failure of any inner finalizer will not affect outer finalizers. Nested finalizers will be executed in reverse order and linearly (not in parallel).
 
 Unlike `try` / `finally`, `ensuring` works across all types of effects, including asynchronous and concurrent effects.
 
@@ -59,7 +59,7 @@ def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 
 ```scala mdoc:silent
 val groupedFileData: IO[IOException, Unit] = 
-  openFile("data.json").acquireReleaseWith(closeFile(_)) { file =>
+  openFile("data.json").acquireReleaseWith(closeFile) { file =>
     for {
       data    <- decodeData(file)
       grouped <- groupData(data)
@@ -67,8 +67,8 @@ val groupedFileData: IO[IOException, Unit] =
   }
 ```
 
-Like `ensuring`, acquire releases have compositional semantics, so if one acquire release is nested inside another acquire release, and the outer resource is acquired, then the outer release will always be called, even if, for example, the inner release fails.
+Like `ensuring`, `acquireRelease` has compositional semantics, so if one `acquireRelease` is nested inside another `acquireRelease`, and the outer resource is acquired, then the outer release will always be called, even if, for example, the inner release fails.
 
 ## Next Steps
 
-If you are comfortable with resource handling, then the next step is to learn about [basic concurrency](basic_concurrency.md).
+If you are comfortable with resource handling, the next step is to learn about [basic concurrency](basic_concurrency.md).


### PR DESCRIPTION
Removed unnecessary commas, created inline code blocks for `acquireRelease`, and added type annotations to code examples where applicable.