### PR TITLE
Fix acquireReleaseWith docstring

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2475,18 +2475,18 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.suspendSucceed(acquire.ensuring(ZIO.addFinalizerExit(release)))
 
   /**
-   * When this effect represents acquisition of a resource (for example, opening
-   * a file, launching a thread, etc.), `acquireReleaseWith` can be used to
-   * ensure the acquisition is not interrupted and the resource is always
+   * Given an effect representing acquisition of a resource (for example,
+   * opening a file, launching a thread, etc.), `acquireReleaseWith` can be used
+   * to ensure the acquisition is not interrupted and the resource is always
    * released.
    *
    * The function does two things:
    *
-   *   1. Ensures this effect, which acquires the resource, will not be
-   *      interrupted. Of course, acquisition may fail for internal reasons (an
-   *      uncaught exception). 2. Ensures the `release` effect will not be
-   *      interrupted, and will be executed so long as this effect successfully
-   *      acquires the resource.
+   *   1. Ensures this `acquire` effect will not be interrupted. Of course,
+   *      acquisition may fail for internal reasons (an uncaught exception).
+   *
+   *   1. Ensures the `release` effect will not be interrupted, and will be
+   *      executed so long as this effect successfully acquires the resource.
    *
    * In between acquisition and release of the resource, the `use` effect is
    * executed.
@@ -2496,7 +2496,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * produced by the `release` effect can be caught and ignored.
    *
    * {{{
-   * openFile("data.json").acquireReleaseWith(closeFile) { file =>
+   * ZIO.acquireReleaseWith(openFile("data.json"))(closeFile) { file =>
    *   for {
    *     header <- readHeader(file)
    *     ...


### PR DESCRIPTION
The docstring was written for the trait, rather than the companion object.