### PR TITLE
Generate xml test reports

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -1,14 +1,26 @@
 package zio.test.sbt
 
 import sbt.testing.{Event, EventHandler}
-import zio.{ZIO, ZLayer, durationInt}
-import zio.test.{Annotations, Assertion, Spec, TestAspect, TestFailure, ZIOSpecDefault, assertCompletes}
+import zio.{UIO, ZIO, ZLayer, durationInt}
+import zio.test.{
+  Annotations,
+  Assertion,
+  ExecutionEvent,
+  Spec,
+  TestAspect,
+  TestFailure,
+  ZIOSpecDefault,
+  ZTestEventHandler,
+  assertCompletes
+}
 
 import java.util.concurrent.atomic.AtomicInteger
 
 object FrameworkSpecInstances {
 
-  val dummyHandler: EventHandler = (_: Event) => ()
+  val dummyHandler: ZTestEventHandler = new ZTestEventHandler {
+    override def handle(event: ExecutionEvent.Test[_]): UIO[Unit] = ZIO.unit
+  }
 
   val counter = new AtomicInteger(0)
 

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkZioSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkZioSpec.scala
@@ -135,7 +135,7 @@ object ZTestFrameworkZioSpec extends ZIOSpecDefault {
     new ZTestFramework()
       .runner(testArgs, Array(), getClass.getClassLoader)
       .tasksZ(tasks)
-      .map(_.executeZ(FrameworkSpecInstances.dummyHandler))
+      .map(_.run(FrameworkSpecInstances.dummyHandler))
       .headOption
       .getOrElse(ZIO.unit)
   }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -38,7 +38,7 @@ abstract class BaseTestTask[T](
 
   private[zio] def run(
     eventHandlerZ: ZTestEventHandler
-  )(implicit trace: ZTraceElement): ZIO[Any, Throwable, Unit] =
+  )(implicit trace: ZTraceElement): ZIO[Any, Nothing, Unit] =
     ZIO.consoleWith { console =>
       (for {
         summary <- spec

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -21,6 +21,7 @@ object ZTestEvent {
     val status = statusFrom(test)
     val maybeThrowable = status match {
       case Status.Failure =>
+        // Includes ansii colors
         val failureMsg =
           ConsoleRenderer
             .renderToStringLines(Message(DefaultTestReporter.render(test, true).head.summaryLines))
@@ -33,7 +34,7 @@ object ZTestEvent {
       fullyQualifiedName = taskDef.fullyQualifiedName(),
       selector = new TestSelector(test.labels.mkString(" - ")),
       status = status,
-      maybeThrowable = maybeThrowable, // TODO More complete error message based on rendered failure
+      maybeThrowable = maybeThrowable,
       duration = test.annotations.get(TestAnnotation.timing).toMillis,
       fingerprint = ZioSpecFingerprint
     )

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEvent.scala
@@ -1,6 +1,7 @@
 package zio.test.sbt
 
 import sbt.testing._
+import zio.test.{ExecutionEvent, TestSuccess}
 
 final case class ZTestEvent(
   fullyQualifiedName: String,
@@ -11,4 +12,28 @@ final case class ZTestEvent(
   fingerprint: Fingerprint
 ) extends Event {
   def throwable(): OptionalThrowable = maybeThrowable.fold(new OptionalThrowable())(new OptionalThrowable(_))
+}
+
+object ZTestEvent {
+  def convertEvent(executionEvent: ExecutionEvent.Test[_], taskDef: TaskDef): Event = {
+    taskDef.selectors().foreach(println(_))
+    ZTestEvent(
+      fullyQualifiedName = taskDef.fullyQualifiedName(),
+      // taskDef.selectors() is "one to many" so we can expect nonEmpty here
+      selector = taskDef.selectors().head,
+      status = statusFrom(executionEvent),
+      maybeThrowable = None,
+      duration = 0L,
+      fingerprint = ZioSpecFingerprint
+    )
+  }
+
+  def statusFrom(test: ExecutionEvent.Test[_]) =
+    test.test match {
+      case Left(value) => Status.Failure
+      case Right(value) => value match {
+        case TestSuccess.Succeeded(result, annotations) => Status.Success
+        case TestSuccess.Ignored(annotations) => Status.Ignored
+      }
+    }
 }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
@@ -5,8 +5,6 @@ import zio.{UIO, ZIO}
 import zio.test.{ExecutionEvent, ZTestEventHandler}
 
 class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends ZTestEventHandler {
-
   def handle(event: ExecutionEvent.Test[_]): UIO[Unit] =
     ZIO.succeed(eventHandler.handle(ZTestEvent.convertEvent(event, taskDef)))
-//      eventHandler()
 }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
@@ -1,0 +1,12 @@
+package zio.test.sbt
+
+import sbt.testing.{EventHandler, TaskDef}
+import zio.{UIO, ZIO}
+import zio.test.{ExecutionEvent, ZTestEventHandler}
+
+class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends ZTestEventHandler {
+
+  def handle(event: ExecutionEvent.Test[_]): UIO[Unit] =
+    ZIO.succeed(eventHandler.handle(ZTestEvent.convertEvent(event, taskDef)))
+//      eventHandler()
+}

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -208,7 +208,7 @@ object IntelliJRenderUtils {
         Scope.default >>> testEnvironment,
         (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
         sinkLayer,
-        _ => ZIO.unit // TODO
+        _ => ZIO.unit // Does Intellij need to report events?
       ),
       reporter = DefaultTestReporter(IntelliJRenderer, TestAnnotationRenderer.default)
     )

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -207,7 +207,8 @@ object IntelliJRenderUtils {
       executor = TestExecutor.default[TestEnvironment, String](
         Scope.default >>> testEnvironment,
         (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
-        sinkLayer
+        sinkLayer,
+        _ => ZIO.unit // TODO
       ),
       reporter = DefaultTestReporter(IntelliJRenderer, TestAnnotationRenderer.default)
     )

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -69,7 +69,8 @@ object ReportingTestUtils {
       executor = TestExecutor.default[TestEnvironment, String](
         Scope.default >>> testEnvironment,
         (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
-        sinkLayerWithConsole(console)
+        sinkLayerWithConsole(console),
+        _ => ZIO.unit // TODO
       ),
       reporter = DefaultTestReporter(TestRenderer.default, TestAnnotationRenderer.default)
     )

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -70,7 +70,7 @@ object ReportingTestUtils {
         Scope.default >>> testEnvironment,
         (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
         sinkLayerWithConsole(console),
-        _ => ZIO.unit // TODO
+        _ => ZIO.unit // Might be useful for additional testing
       ),
       reporter = DefaultTestReporter(TestRenderer.default, TestAnnotationRenderer.default)
     )

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -43,7 +43,7 @@ object DefaultTestReporter {
   def render(
     reporterEvent: ExecutionEvent,
     includeCause: Boolean
-  )(implicit trace: ZTraceElement): Seq[ExecutionResult] =
+  )(implicit trace: ZTraceElement): Seq[ExecutionResult] = // This should return a single/Option ExecutionResult now.
     reporterEvent match {
       case SectionStart(labelsReversed, _, ancestors) =>
         val depth = labelsReversed.length - 1

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -36,7 +36,7 @@ object TestExecutor {
     sharedSpecLayer: ZLayer[Any, E, R],
     freshLayerPerSpec: ZLayer[Any, Nothing, TestEnvironment with ZIOAppArgs with Scope],
     sinkLayer: Layer[Nothing, ExecutionEventSink],
-    eventHandlerZ: ExecutionEvent.Test[_] => ZIO[Any, Throwable, Unit]
+    eventHandlerZ: ZTestEventHandler
   ): TestExecutor[R with TestEnvironment with ZIOAppArgs with Scope, E] =
     new TestExecutor[R with TestEnvironment with ZIOAppArgs with Scope, E] {
       def run(spec: Spec[R with TestEnvironment with ZIOAppArgs with Scope, E], defExec: ExecutionStrategy)(implicit
@@ -120,7 +120,7 @@ object TestExecutor {
                         sink.process(
                           event
                         ) *>
-                    eventHandlerZ(event)
+                        eventHandlerZ.handle(event)
                   } yield ()).catchAllCause { e =>
                     val event = ExecutionEvent.RuntimeFailure(sectionId, labels, TestFailure.Runtime(e), ancestors)
                     summary.update(

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -68,7 +68,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
 
   protected final def runSpec(implicit trace: ZTraceElement): ZIO[
     Environment with TestEnvironment with ZIOAppArgs with Scope,
-    Any,
+    Throwable,
     Summary
   ] =
     for {

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -141,7 +141,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
     testArgs: TestArgs,
     console: Console,
     runtime: Runtime[_],
-    eventHandlerZ: ExecutionEvent.Test[_] => zio.Task[Unit]
+    eventHandlerZ: ZTestEventHandler
   )(implicit
     trace: ZTraceElement
   ): URIO[

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -125,7 +125,8 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
             ](
               sharedLayer,
               perTestLayer,
-              executionEventSinkLayer
+              executionEventSinkLayer,
+              _ => ZIO.unit
             ),
           runtimeConfig
         )
@@ -139,7 +140,8 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
     spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any],
     testArgs: TestArgs,
     console: Console,
-    runtime: Runtime[_]
+    runtime: Runtime[_],
+    eventHandlerZ: ExecutionEvent.Test[_] => zio.Task[Unit]
   )(implicit
     trace: ZTraceElement
   ): URIO[
@@ -169,7 +171,8 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
             ](
               sharedLayer,
               perTestLayer,
-              executionEventSinkLayer
+              executionEventSinkLayer,
+              eventHandlerZ
             ),
           runtimeConfig
         )

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -77,6 +77,9 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       testArgs = TestArgs.parse(args.getArgs.toArray)
       _       <- ZIO.debug("runSpec")
       summary <- runSpecInfallible(spec, testArgs, console)
+      _ <- ZIO.when(summary.status == Summary.Failure)(
+             ZIO.fail(new Exception("Failed tests."))
+           )
     } yield summary
 
   private def createTestReporter(rendererName: String)(implicit trace: ZTraceElement): TestReporter[Any] = {

--- a/test/shared/src/main/scala/zio/test/ZTestEventHandler.scala
+++ b/test/shared/src/main/scala/zio/test/ZTestEventHandler.scala
@@ -1,0 +1,7 @@
+package zio.test
+
+import zio.UIO
+
+trait ZTestEventHandler {
+  def handle(event: ExecutionEvent.Test[_]): UIO[Unit]
+}

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -589,7 +589,7 @@ package object test extends CompileVariants {
         Scope.default >>> testEnvironment,
         (Scope.default >+> testEnvironment) ++ ZIOAppArgs.empty,
         sinkLayer,
-        _ => ZIO.unit // TODO Figure out what makes sense here.
+        _ => ZIO.unit // There is no EventHandler available here, so we can't do much.
       )
     )
   }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -588,7 +588,8 @@ package object test extends CompileVariants {
       TestExecutor.default(
         Scope.default >>> testEnvironment,
         (Scope.default >+> testEnvironment) ++ ZIOAppArgs.empty,
-        sinkLayer
+        sinkLayer,
+        _ => ZIO.unit // TODO Figure out what makes sense here.
       )
     )
   }


### PR DESCRIPTION
Potentially the last major missing pieces for ZIO test 2.0 🙂 

<img width="1396" alt="Screen Shot 2022-04-21 at 4 21 51 PM" src="https://user-images.githubusercontent.com/2054940/164561545-8f8c8139-259d-4022-bbdf-74f75d704caa.png">


Currently, we include the ansii codes unconditionally in our failure messages, so that might be something we want to strip out in the future.

Closes #6481