### PR TITLE
Report Interrupted tests after ctrl-c

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -18,6 +18,9 @@ package zio.test
 
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.test.render.{ConsoleRenderer, LogLine}
+import zio.test.render.LogLine.Fragment.Style
+import zio.test.render.LogLine.Message
 import zio.{ExecutionStrategy, ZIO, ZTraceElement}
 
 /**
@@ -123,6 +126,7 @@ object TestExecutor {
                         eventHandlerZ.handle(event)
                   } yield ()).catchAllCause { e =>
                     val event = ExecutionEvent.RuntimeFailure(sectionId, labels, TestFailure.Runtime(e), ancestors)
+                    ConsoleRenderer.render(e, labels).foreach(println)
                     summary.update(
                       _.add(event)
                     ) *>
@@ -155,7 +159,6 @@ object TestExecutor {
                 )
               )
           }
-
           summary <- summary.get
         } yield summary).provideLayer(sinkLayer)
 

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -16,6 +16,7 @@
 
 package zio.test.render
 
+import zio.Cause
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.render.ExecutionResult.{ResultType, Status}
 import zio.test.render.LogLine.Fragment.Style
@@ -114,5 +115,17 @@ trait ConsoleRenderer extends TestRenderer {
     s"""${summary.success} tests passed. ${summary.fail} tests failed. ${summary.ignore} tests ignored.
        |Executed in ${summary.duration.render}
        |""".stripMargin
+
+  def render(cause: Cause[_], labels: List[String]): Option[String] =
+    cause match {
+      case _: Cause.Interrupt =>
+        val renderedInterruption =
+          ConsoleRenderer.renderToStringLines(
+            Message(Seq(LogLine.Line(Vector(LogLine.Fragment(labels.mkString(" - "), Style.Error)))))
+          )
+
+        Some("Interrupted during execution: " + renderedInterruption.mkString("\n"))
+      case _ => None
+    }
 }
 object ConsoleRenderer extends ConsoleRenderer


### PR DESCRIPTION
Previously, ctrl-c quietly ended the tests-
<img width="465" alt="Screen Shot 2022-04-22 at 12 12 43 PM" src="https://user-images.githubusercontent.com/2054940/164771285-156b5974-0e9e-404e-be14-40fc25d0cf40.png">

But now we will watch for `Interrupted` events and print them immediately to the console-
<img width="1792" alt="Screen Shot 2022-04-22 at 12 09 18 PM" src="https://user-images.githubusercontent.com/2054940/164771382-89d984a5-7fce-4300-a901-e5a332d4e258.png">


Fixes #6694