### PR TITLE
Propagate Errors In ZStream#peel

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2397,7 +2397,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
       )
 
       for {
-        _ <- self.runScoped(consumer).forkScoped
+        _ <- self.tapErrorCause(cause => p.failCause(cause)).runScoped(consumer).forkScoped
         z <- p.await
       } yield (z, new ZStream(producer))
     }).flatten


### PR DESCRIPTION
Sinks can introduce new errors but don't handle errors. So since we fork the original stream and never join it we need to complete the promise ourselves here to signal failure.