### PR TITLE
Apply Hook To All Uses Of Runtime In ZIOApp

### DIFF
--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -10,8 +10,9 @@ trait ZIOAppPlatformSpecific { self: ZIOApp =>
    */
   final def main(args0: Array[String]): Unit = {
     implicit val trace = Tracer.newTrace
-    runtime.unsafeRunAsync {
-      invoke(Chunk.fromIterable(args0))
+    val newRuntime     = runtime.mapRuntimeConfig(hook)
+    newRuntime.unsafeRunAsync {
+      invokeWith(newRuntime)(Chunk.fromIterable(args0))
         .provideEnvironment(runtime.environment)
         .tapErrorCause(ZIO.logErrorCause(_))
         .exitCode

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -10,10 +10,11 @@ trait ZIOAppPlatformSpecific { self: ZIOApp =>
    */
   final def main(args0: Array[String]): Unit = {
     implicit val trace: ZTraceElement = ZTraceElement.empty
+    val newRuntime                    = runtime.mapRuntimeConfig(hook)
 
-    runtime.unsafeRun {
+    newRuntime.unsafeRun {
       (for {
-        fiber <- invoke(Chunk.fromIterable(args0)).provideEnvironment(runtime.environment).fork
+        fiber <- invokeWith(newRuntime)(Chunk.fromIterable(args0)).provideEnvironment(newRuntime.environment).fork
         _ <-
           IO.succeed(Platform.addShutdownHook { () =>
             if (!shuttingDown.getAndSet(true)) {
@@ -27,7 +28,7 @@ trait ZIOAppPlatformSpecific { self: ZIOApp =>
                     "Check the logs for more details and consider overriding `RuntimeConfig.reportFatal` to capture context."
                 )
               } else {
-                try runtime.unsafeRunSync(fiber.interrupt)
+                try newRuntime.unsafeRunSync(fiber.interrupt)
                 catch { case _: Throwable => }
               }
 

--- a/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -10,8 +10,9 @@ trait ZIOAppPlatformSpecific { self: ZIOApp =>
    */
   final def main(args0: Array[String]): Unit = {
     implicit val trace = Tracer.newTrace
-    runtime.unsafeRunAsync {
-      invoke(Chunk.fromIterable(args0))
+    val newRuntime     = runtime.mapRuntimeConfig(hook)
+    newRuntime.unsafeRunAsync {
+      invokeWith(newRuntime)(Chunk.fromIterable(args0))
         .provideEnvironment(runtime.environment)
         .tapErrorCause(ZIO.logErrorCause(_))
         .exitCode

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -102,15 +102,17 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
       }
     }.ignore
 
-  protected def invokeWith(runtime: Runtime[Any])(args: Chunk[String])(implicit trace: ZTraceElement): ZIO[Any, Any, Any] =
+  protected def invokeWith(
+    runtime: Runtime[Any]
+  )(args: Chunk[String])(implicit trace: ZTraceElement): ZIO[Any, Any, Any] =
     ZIO.suspendSucceed {
       val newLayer =
         Scope.default +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
           layer +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
       for {
-        _          <- installSignalHandlers(runtime)
-        result     <- runtime.run(run.provideLayer(newLayer))
+        _      <- installSignalHandlers(runtime)
+        result <- runtime.run(run.provideLayer(newLayer))
       } yield result
     }
 }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -84,23 +84,11 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    * Invokes the main app. Designed primarily for testing.
    */
   final def invoke(args: Chunk[String])(implicit trace: ZTraceElement): ZIO[Any, Any, Any] =
-    ZIO.suspendSucceed {
-      val newLayer =
-        ZLayer.environment[Scope] +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
-          layer +!+ ZLayer.environment[ZIOAppArgs with Scope]
-
-      ZIO.scoped {
-        for {
-          _          <- installSignalHandlers
-          newRuntime <- ZIO.runtime[Scope].map(_.mapRuntimeConfig(hook))
-          result     <- newRuntime.run(run.provideLayer(newLayer))
-        } yield result
-      }
-    }
+    invokeWith(runtime.mapRuntimeConfig(hook))(args)
 
   def runtime: Runtime[Any] = Runtime.default
 
-  protected def installSignalHandlers(implicit trace: ZTraceElement): UIO[Any] =
+  protected def installSignalHandlers(runtime: Runtime[Any])(implicit trace: ZTraceElement): UIO[Any] =
     ZIO.attempt {
       if (!ZIOApp.installedSignals.getAndSet(true)) {
         val dumpFibers = () => runtime.unsafeRun(Fiber.dumpAll)
@@ -113,6 +101,18 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
         }
       }
     }.ignore
+
+  protected def invokeWith(runtime: Runtime[Any])(args: Chunk[String])(implicit trace: ZTraceElement): ZIO[Any, Any, Any] =
+    ZIO.suspendSucceed {
+      val newLayer =
+        Scope.default +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
+          layer +!+ ZLayer.environment[ZIOAppArgs with Scope]
+
+      for {
+        _          <- installSignalHandlers(runtime)
+        result     <- runtime.run(run.provideLayer(newLayer))
+      } yield result
+    }
 }
 object ZIOApp {
   private val installedSignals = new java.util.concurrent.atomic.AtomicBoolean(false)


### PR DESCRIPTION
Resolves zio/zio-logging#444.

We need to modify all uses of the `runtime` with the `hook` in `ZIOApp`.