### PR TITLE
WIP Fixed #5595 - Added GraalVM native test aspects

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -84,6 +84,9 @@ object TestAspectSpec extends ZIOBaseSpec {
     test("exceptNative runs tests on all platforms except ScalaNative") {
       assert(TestPlatform.isNative)(isFalse)
     } @@ exceptNative,
+    test("exceptGraalVM runs tests on all platforms except GraalVM") {
+      assert(TestPlatform.isGraalVM)(isFalse)
+    } @@ exceptGraalVM,
     test("exceptScala2 runs tests on all versions except Scala 2") {
       assert(TestVersion.isScala2)(isFalse)
     } @@ exceptScala2,
@@ -216,6 +219,19 @@ object TestAspectSpec extends ZIOBaseSpec {
       val spec   = test("JVM-only")(assert(TestPlatform.isJVM)(isTrue)) @@ jvmOnly
       val result = if (TestPlatform.isJVM) succeeded(spec) else isIgnored(spec)
       assertZIO(result)(isTrue)
+    },
+    test("graalVM applies test aspect only on GraalVM") {
+      for {
+        ref    <- Ref.make(false)
+        spec    = test("test")(assert(true)(isTrue)) @@ graalVM(after(ref.set(true)))
+        _      <- execute(spec)
+        result <- ref.get
+      } yield assert(if (TestPlatform.isGraalVM) result else !result)(isTrue)
+    },
+    test("graalVMOnly runs tests only on GraalVM") {
+      val spec   = test("GraalVM-only")(assert(TestPlatform.isGraalVM)(isTrue)) @@ graalVMOnly
+      val result = if (TestPlatform.isGraalVM) succeeded(spec) else isIgnored(spec)
+      assertM(result)(isTrue)
     },
     test("native applies test aspect only on ScalaNative") {
       for {

--- a/test/js/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/js/src/main/scala/zio/test/TestPlatform.scala
@@ -38,4 +38,10 @@ object TestPlatform {
    * Returns whether the current platform is Scala Native.
    */
   final val isNative = false
+
+  /**
+   * Returns whether the current platform is GraalVM native.
+   */
+  final val isGraalVM = false
+
 }

--- a/test/jvm/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/jvm/src/main/scala/zio/test/TestPlatform.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import java.lang.{System => JSystem}
 
 /**
  * `TestPlatform` provides information about the platform tests are being run on
@@ -38,4 +39,12 @@ object TestPlatform {
    * Returns whether the current platform is Scala Native.
    */
   final val isNative = false
+
+  /**
+   * Returns whether the current platform is GraalVM native.
+   */
+  final val isGraalVM =
+    Option(JSystem.getProperty("java.vm.version")).exists(_.toLowerCase.contains("graalvm")) &&
+      Option(JSystem.getProperty("org.graalvm.nativeimage.imagecode")).contains("runtime")
+
 }

--- a/test/native/src/main/scala/zio/test/TestPlatform.scala
+++ b/test/native/src/main/scala/zio/test/TestPlatform.scala
@@ -38,4 +38,10 @@ object TestPlatform {
    * Returns whether the current platform is Scala Native.
    */
   final val isNative = true
+
+  /**
+   * Returns whether the current platform is GraalVM native.
+   */
+  final val isGraalVM = false
+
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -292,6 +292,12 @@ object TestAspect extends TimeoutVariants {
     if (TestPlatform.isJVM) ignore else identity
 
   /**
+   * An aspect that runs tests on all platforms except GraalVM.
+   */
+  val exceptGraalVM: TestAspectAtLeastR[Annotations] =
+    if (TestPlatform.isGraalVM) ignore else identity
+
+  /**
    * An aspect that runs tests on all platforms except ScalaNative.
    */
   val exceptNative: TestAspectAtLeastR[Annotations] =
@@ -546,6 +552,20 @@ object TestAspect extends TimeoutVariants {
    */
   val jvmOnly: TestAspectAtLeastR[Annotations] =
     if (TestPlatform.isJVM) identity else ignore
+
+  /**
+   * An aspect that applies the specified aspect on GraalVM.
+   */
+  def graalVM[LowerR, UpperR, LowerE, UpperE](
+    that: TestAspect[LowerR, UpperR, LowerE, UpperE]
+  ): TestAspect[LowerR, UpperR, LowerE, UpperE] =
+    if (TestPlatform.isGraalVM) that else identity
+
+  /**
+   * An aspect that only runs tests on GraalVM.
+   */
+  val graalVMOnly: TestAspectAtLeastR[Annotations] =
+    if (TestPlatform.isGraalVM) identity else ignore
 
   /**
    * An aspect that runs only on operating systems accepted by the specified


### PR DESCRIPTION
Adds a new flag in TestPlatform, which is `isGraalVM` and also TestAspects `graalVMOnly` and `exceptGraalVM`.