### PR TITLE
Fix Issue With ZStream#zipWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3775,11 +3775,11 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
     ): ZIO[R1, Nothing, Exit[Option[E1], (Chunk[A3], State[A1, A2])]] =
       state match {
         case PullBoth =>
-          pullLeft
-            .zipPar(pullRight)
+          pullLeft.unsome
+            .zipPar(pullRight.unsome)
             .foldZIO(
-              err => ZIO.succeedNow(Exit.fail(err)),
-              { case (leftChunk, rightChunk) =>
+              err => ZIO.succeedNow(Exit.fail(Some(err))),
+              { case (Some(leftChunk), Some(rightChunk)) =>
                 if (leftChunk.isEmpty && rightChunk.isEmpty)
                   pull(PullBoth, pullLeft, pullRight)
                 else if (leftChunk.isEmpty)
@@ -3788,6 +3788,7 @@ class ZStream[-R, +E, +A](val channel: ZChannel[R, Any, Any, Any, E, Chunk[A], A
                   pull(PullRight(leftChunk), pullLeft, pullRight)
                 else
                   ZIO.succeedNow(Exit.succeed(zipWithChunks(leftChunk, rightChunk)))
+                case _ => ZIO.succeedNow(Exit.fail(None))
               }
             )
         case PullLeft(rightChunk) =>


### PR DESCRIPTION
Currently we use `ZIO#zipWith` internally in `ZStream#zipWith` when we pull from both streams where pull has signature `ZIO[R, Option[E], Chunk[A]]`. This has the consequence that if one side is done and the other side has more elements we interrupt the other side and then return a `Cause` that includes the interruption. I don't think this is correct as one stream possibly being done before the other is an expected condition and it can result in a fiber failure in code that is behaving as expected.