### PR TITLE
Improve test diffing

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
@@ -11,29 +11,29 @@ object MyersDiffSpec extends ZIOBaseSpec {
       val original = ""
       val modified = "ADDITIONS"
 
-      assert(MyersDiff.diffSingleLine(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffSingleLine(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for only deletions both ways") {
       val original = "DELETIONS"
       val modified = ""
 
-      assert(MyersDiff.diffSingleLine(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffSingleLine(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for two empty strings both ways") {
       val original = ""
       val modified = ""
 
-      assert(MyersDiff.diffSingleLine(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffSingleLine(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for Myers example both ways") {
       val original = "ABCABBA"
       val modified = "CBABAC"
 
-      assert(MyersDiff.diffSingleLine(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffSingleLine(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing for Myers example produces a sane DiffResult") {
       val original = "ABCABBA"
@@ -41,7 +41,7 @@ object MyersDiffSpec extends ZIOBaseSpec {
 
       import zio.test.internal.myers.Action._
       assertTrue(
-        MyersDiff.diffSingleLine(original, modified) ==
+        MyersDiff.diffWords(original, modified) ==
           DiffResult(
             Chunk(
               Delete("A"),
@@ -59,8 +59,8 @@ object MyersDiffSpec extends ZIOBaseSpec {
     },
     test("diffing works for all random strings both ways") {
       check(Gen.string, Gen.string) { (original, modified) =>
-        assert(MyersDiff.diffSingleLine(original, modified).applyChanges(original))(equalTo(modified)) &&
-        assert(MyersDiff.diffSingleLine(original, modified).invert.applyChanges(modified))(equalTo(original))
+        assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
+        assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
       }
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/MyersDiffSpec.scala
@@ -11,29 +11,29 @@ object MyersDiffSpec extends ZIOBaseSpec {
       val original = ""
       val modified = "ADDITIONS"
 
-      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffChars(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffChars(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for only deletions both ways") {
       val original = "DELETIONS"
       val modified = ""
 
-      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffChars(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffChars(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for two empty strings both ways") {
       val original = ""
       val modified = ""
 
-      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffChars(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffChars(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing works for Myers example both ways") {
       val original = "ABCABBA"
       val modified = "CBABAC"
 
-      assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
-      assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
+      assert(MyersDiff.diffChars(original, modified).applyChanges(original))(equalTo(modified)) &&
+      assert(MyersDiff.diffChars(original, modified).invert.applyChanges(modified))(equalTo(original))
     },
     test("diffing for Myers example produces a sane DiffResult") {
       val original = "ABCABBA"
@@ -41,7 +41,7 @@ object MyersDiffSpec extends ZIOBaseSpec {
 
       import zio.test.internal.myers.Action._
       assertTrue(
-        MyersDiff.diffWords(original, modified) ==
+        MyersDiff.diffChars(original, modified) ==
           DiffResult(
             Chunk(
               Delete("A"),
@@ -59,8 +59,8 @@ object MyersDiffSpec extends ZIOBaseSpec {
     },
     test("diffing works for all random strings both ways") {
       check(Gen.string, Gen.string) { (original, modified) =>
-        assert(MyersDiff.diffWords(original, modified).applyChanges(original))(equalTo(modified)) &&
-        assert(MyersDiff.diffWords(original, modified).invert.applyChanges(modified))(equalTo(original))
+        assert(MyersDiff.diffChars(original, modified).applyChanges(original))(equalTo(modified)) &&
+        assert(MyersDiff.diffChars(original, modified).invert.applyChanges(modified))(equalTo(original))
       }
     }
   )

--- a/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
@@ -1,19 +1,21 @@
 package zio.test
 
+import zio.internal.macros.StringUtils.StringOps
+
 object PrettyPrintSpec extends ZIOBaseSpec {
 
   def spec = suite("PrettyPrint")(
     test("String") {
-      assertTrue(PrettyPrint("A String") == "\"A String\"")
+      assertTrue(PrettyPrint("A String").unstyled == "\"A String\"")
     },
     test("List") {
-      assertTrue(PrettyPrint(List(1, 2, 3)) == "List(1, 2, 3)")
+      assertTrue(PrettyPrint(List(1, 2, 3)).unstyled == "List(1, 2, 3)")
     },
     test("List of String") {
-      assertTrue(PrettyPrint(List("1", "2", "3")) == "List(\"1\", \"2\", \"3\")")
+      assertTrue(PrettyPrint(List("1", "2", "3")).unstyled == "List(\"1\", \"2\", \"3\")")
     },
     test("Array of String") {
-      assertTrue(PrettyPrint(Array("1", "2", "3")) == "Array(\"1\", \"2\", \"3\")")
+      assertTrue(PrettyPrint(Array("1", "2", "3")).unstyled == "Array(\"1\", \"2\", \"3\")")
     },
     test("Map") {
       val expected = """
@@ -29,7 +31,7 @@ Map(
       assertTrue(
         PrettyPrint(
           Map("name" -> "Biff", "age" -> 123, "inventory" -> Map("food" -> "Cake", "candy" -> "Chocolate"))
-        ) == expected
+        ).unstyled == expected
       )
     },
     test("Case Class") {
@@ -41,9 +43,7 @@ Person(
 )
 """.trim
       assertTrue(
-        PrettyPrint(
-          Person("Glenda", 123)
-        ) == expected
+        PrettyPrint(Person("Glenda", 123)).unstyled == expected
       )
     } @@ TestAspect.exceptScala211 @@ TestAspect.exceptScala212
   )

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -13,7 +13,7 @@ object SmartAssertionSpec extends ZIOBaseSpec {
    * Switch TestAspect.failing to TestAspect.identity to easily preview
    * the error messages.
    */
-  val failing: TestAspectPoly = TestAspect.identity
+  val failing: TestAspectPoly = TestAspect.failing
 
   private val company: Company = Company("Ziverge", List(User("Bobo", List.tabulate(2)(n => Post(s"Post #$n")))))
 

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -13,7 +13,7 @@ object SmartAssertionSpec extends ZIOBaseSpec {
    * Switch TestAspect.failing to TestAspect.identity to easily preview
    * the error messages.
    */
-  val failing: TestAspectPoly = TestAspect.failing
+  val failing: TestAspectPoly = TestAspect.identity
 
   private val company: Company = Company("Ziverge", List(User("Bobo", List.tabulate(2)(n => Post(s"Post #$n")))))
 
@@ -324,7 +324,24 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         val l1 = Seq("Alpha", "This is a wonderful way to dance and party", "Potato")
         val l2 = Seq("Alpha", "This is a wonderful way to live and die", "Potato", "Bruce Lee", "Potato", "Ziverge")
         assertTrue(l1 == l2)
-      } @@ failing
+      } @@ failing,
+      suite("String diffs")(
+        test("words") {
+          val s1 = "This is a wonderful way to dance and party"
+          val s2 = "This is a wonderful way to live and die"
+          assertTrue(s1 == s2)
+        } @@ failing,
+        test("characters") {
+          val s1 = "abcdefghijklmnopqrstuvwxyz"
+          val s2 = "abCdefghiiJklmnopqrstuvwxyzZ"
+          assertTrue(s1 == s2)
+        } @@ failing,
+        test("multi-line") {
+          val s1 = "Hello\nThis is a wonderful way to dance and party\nThis is a wonderful way to live and die"
+          val s2 = "Hello\nThis is a wonderful way to live and die\nThis is a wonderful way to dance and party"
+          assertTrue(s1 == s2)
+        } @@ failing
+      )
     ),
     test("Package qualified identifiers") {
       assertTrue(zio.Duration.fromNanos(0) == zio.Duration.Zero)

--- a/test-tests/shared/src/test/scala/zio/test/StringDiffingSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/StringDiffingSpec.scala
@@ -1,0 +1,38 @@
+package zio.test
+
+import zio.internal.macros.StringUtils.StringOps
+import zio.test.diff.{Diff, DiffResult}
+
+object StringDiffingSpec extends ZIOBaseSpec {
+
+  def diff(a: String, b: String): DiffResult = Diff[String].diff(a, b)
+
+  def spec = suite("SmartAssertionSpec")(
+    test("simple difference") {
+      val result: DiffResult = diff("a", "b")
+      val expected           = DiffResult.Different("a", "b")
+      assertTrue(result == expected)
+    },
+    test("identical") {
+      val result: DiffResult = diff("a", "a")
+      val expected           = DiffResult.Identical("a")
+      assertTrue(result == expected)
+    },
+    test("word diffing") {
+      val result: DiffResult = diff(
+        "all my life I've been searching for something",
+        "all my life I've been hunting for beans"
+      )
+      val expected = "all my life I've been -searching+hunting for -something+beans"
+      assertTrue(result.render.unstyled == expected)
+    },
+    test("word diffing") {
+      val result: DiffResult = diff(
+        "thiswouldbebestifitwereassimpleasitcouldbe",
+        "thiswouldbeworstifitwereascomplexasitcouldbewow"
+      )
+      val expected = "thiswouldbe-b-e+w+o+rstifitwereas-s-i+c+omple+xasitcouldbe+w+o+w"
+      assertTrue(result.render.unstyled == expected)
+    }
+  )
+}

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -113,7 +113,7 @@ object DefaultTestReporter {
   ): (List[Line], List[Line]) = {
     val depth     = labels.length
     val label     = labels.last
-    val flatLabel = labels.mkString(" - ")
+    val flatLabel = labels.map(_.red).mkString(" / ".red.faint)
 
     val renderedResult = results match {
       case Right(TestSuccess.Succeeded(_)) =>

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -237,7 +237,7 @@ object DefaultTestReporter {
             Chunk(Line.fromString(testLabel.fold(codeString)(l => s"""$codeString ?? "$l""""))) ++
             nested.flatMap(renderFailureCase(_, offset, None)).map(_.withOffset(1)) ++
             Chunk.fromIterable(path.filterNot(t => t._1 == t._2).flatMap { case (label, value) =>
-              Chunk.fromIterable(value.split("\n").map(primary(_).toLine)) match {
+              Chunk.fromIterable(value.split("\n").map(Fragment(_).toLine)) match {
                 case head +: lines => (dim(s"${label.trim} = ") +: head) +: lines
                 case _             => Vector.empty
               }

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio.internal.ansi.AnsiStringOps
+import zio.internal.macros.StringUtils.StringOps
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.ExecutionEvent.{SectionEnd, SectionStart, Test, TopLevelFlush}
 import zio.test.render.ExecutionResult.ResultType.Suite
@@ -236,12 +237,14 @@ object DefaultTestReporter {
           errorMessageLines ++ labelLines ++
             Chunk(Line.fromString(testLabel.fold(codeString)(l => s"""$codeString ?? "$l""""))) ++
             nested.flatMap(renderFailureCase(_, offset, None)).map(_.withOffset(1)) ++
-            Chunk.fromIterable(path.filterNot(t => t._1 == t._2).flatMap { case (label, value) =>
-              Chunk.fromIterable(value.split("\n").map(Fragment(_).toLine)) match {
-                case head +: lines => (dim(s"${label.trim} = ") +: head) +: lines
-                case _             => Vector.empty
+            Chunk.fromIterable(
+              path.filterNot(t => t._1.unstyled == t._2.unstyled).flatMap { case (label, value) =>
+                Chunk.fromIterable(value.split("\n").map(Fragment(_).toLine)) match {
+                  case head +: lines => (dim(s"${label.trim} = ") +: head) +: lines
+                  case _             => Vector.empty
+                }
               }
-            }) ++
+            ) ++
             Chunk(detail(s"at $location").toLine)
 
         result.map(_.withOffset(offset + 1))

--- a/test/shared/src/main/scala/zio/test/ErrorMessage.scala
+++ b/test/shared/src/main/scala/zio/test/ErrorMessage.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.test.render.LogLine.Message
+import zio.test.render.LogLine.{Fragment, Message}
 import zio.test.render._
 
 import scala.io.AnsiColor
@@ -36,7 +36,7 @@ sealed trait ErrorMessage { self =>
   private[test] def render(isSuccess: Boolean): Message =
     self match {
       case ErrorMessage.Custom(custom) =>
-        Message(custom.split("\n").toIndexedSeq.map(error(_).toLine))
+        Message(custom.split("\n").toIndexedSeq.map(Fragment(_).toLine))
 
       case ErrorMessage.Choice(success, failure) =>
         (if (isSuccess) fr(success).ansi(AnsiColor.MAGENTA) else error(failure)).toLine.toMessage

--- a/test/shared/src/main/scala/zio/test/PrettyPrint.scala
+++ b/test/shared/src/main/scala/zio/test/PrettyPrint.scala
@@ -1,5 +1,6 @@
 package zio.test
 
+import zio.internal.ansi.AnsiStringOps
 import zio.{Chunk, NonEmptyChunk}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -9,55 +10,58 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * console during tests back into runnable code.
  */
 private[zio] object PrettyPrint extends PrettyPrintVersionSpecific {
-  def apply(any: Any): String = any match {
+  def apply(any: Any): String = {
+    val result = any match {
 //    case null => "null"
-    case nonEmptyChunk: NonEmptyChunk[_] =>
-      nonEmptyChunk.map(PrettyPrint.apply).mkString("NonEmptyChunk(", ", ", ")")
-    case chunk: Chunk[_] =>
-      chunk.map(PrettyPrint.apply).mkString("Chunk(", ", ", ")")
-    case array: Array[_] =>
-      array.map(PrettyPrint.apply).mkString("Array(", ", ", ")")
+      case nonEmptyChunk: NonEmptyChunk[_] =>
+        nonEmptyChunk.map(PrettyPrint.apply).mkString("NonEmptyChunk(", ", ", ")")
+      case chunk: Chunk[_] =>
+        chunk.map(PrettyPrint.apply).mkString("Chunk(", ", ", ")")
+      case array: Array[_] =>
+        array.map(PrettyPrint.apply).mkString("Array(", ", ", ")")
 
-    case Some(a) => s"Some(${PrettyPrint(a)})"
-    case None    => s"None"
-    case Nil     => "Nil"
+      case Some(a) => s"Some(${PrettyPrint(a)})"
+      case None    => s"None"
+      case Nil     => "Nil"
 
-    case set: Set[_] =>
-      set.map(PrettyPrint.apply).mkString(s"${className(set)}(", ", ", ")")
+      case set: Set[_] =>
+        set.map(PrettyPrint.apply).mkString(s"${className(set)}(", ", ", ")")
 
-    case iterable: Seq[_] =>
-      iterable.map(PrettyPrint.apply).mkString(s"${className(iterable)}(", ", ", ")")
+      case iterable: Seq[_] =>
+        iterable.map(PrettyPrint.apply).mkString(s"${className(iterable)}(", ", ", ")")
 
-    case map: Map[_, _] =>
-      val body = map.map { case (key, value) => s"${PrettyPrint(key)} -> ${PrettyPrint(value)}" }
-      s"""Map(
+      case map: Map[_, _] =>
+        val body = map.map { case (key, value) => s"${PrettyPrint(key)} -> ${PrettyPrint(value)}" }
+        s"""Map(
 ${indent(body.mkString(",\n"))}
 )"""
 
-    case product: Product =>
-      val name    = product.productPrefix
-      val labels0 = labels(product)
-      val body = labels0
-        .zip(product.productIterator)
-        .map { case (key, value) =>
-          s"$key = ${PrettyPrint(value)}"
-        }
-        .toList
-        .mkString(",\n")
-      val isMultiline  = body.split("\n").length > 1
-      val indentedBody = indent(body, if (isMultiline) 2 else 0)
-      val spacer       = if (isMultiline) "\n" else ""
-      s"""$name($spacer$indentedBody$spacer)"""
+      case product: Product =>
+        val name    = product.productPrefix
+        val labels0 = labels(product)
+        val body = labels0
+          .zip(product.productIterator)
+          .map { case (key, value) =>
+            s"${(key + " =").faint} ${PrettyPrint(value)}"
+          }
+          .toList
+          .mkString(",\n")
+        val isMultiline  = body.split("\n").length > 1
+        val indentedBody = indent(body, if (isMultiline) 2 else 0)
+        val spacer       = if (isMultiline) "\n" else ""
+        s"""$name($spacer$indentedBody$spacer)"""
 
-    case string: String =>
-      val surround = if (string.split("\n").length > 1) "\"\"\"" else "\""
-      string.replace("\"", """\"""").mkString(surround, "", surround)
+      case string: String =>
+        val surround = if (string.split("\n").length > 1) "\"\"\"" else "\""
+        string.replace("\"", """\"""").mkString(surround, "", surround)
 
-    case char: Char =>
-      s"'${char.toString}'"
+      case char: Char =>
+        s"'${char.toString}'"
 
-    case null  => "<null>"
-    case other => other.toString
+      case null  => "<null>"
+      case other => other.toString
+    }
+    Console.RESET + result + Console.RESET
   }
 
   private def indent(string: String, n: Int = 2): String =

--- a/test/shared/src/main/scala/zio/test/diff/DiffResult.scala
+++ b/test/shared/src/main/scala/zio/test/diff/DiffResult.scala
@@ -35,7 +35,7 @@ $label(
             }
             .mkString(",\n")
         )}
-)
+${Console.RESET})
          """.trim
     case Different(_, _, Some(custom)) =>
       custom

--- a/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
+++ b/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
@@ -288,13 +288,14 @@ object SmartAssertions {
                 case DiffResult.Different(_, _, None) =>
                   M.pretty(a) + M.equals + M.pretty(that)
                 case diffResult =>
-                  M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(that)) ++
+                  M.choice("There was no difference", "There was a difference") ++
+                    M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(that)) ++
                     M.custom(
                       ConsoleUtils.underlined(
                         "Diff"
                       ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+actual".faint
                     ) ++
-                    M.custom(diffResult.render)
+                    M.custom(scala.Console.RESET + diffResult.render)
               }
             case _ =>
               M.pretty(a) + M.equals + M.pretty(that)


### PR DESCRIPTION
_Intelligently_ switch between diff outputs for different string characteristics.
<img width="520" alt="CleanShot 2022-04-28 at 15 41 48@2x" src="https://user-images.githubusercontent.com/7587245/165833014-273da3e8-4925-4f24-b122-00d5ad016606.png">
<img width="511" alt="CleanShot 2022-04-28 at 15 41 54@2x" src="https://user-images.githubusercontent.com/7587245/165833017-a870a4cd-f223-475f-8f34-d32e18f37cca.png">
<img width="451" alt="CleanShot 2022-04-28 at 15 42 05@2x" src="https://user-images.githubusercontent.com/7587245/165833025-9e87ec11-c12a-4a2d-bf6b-a3a69d9aa40f.png">


Also—changing the label separator
<img width="492" alt="CleanShot 2022-04-28 at 15 45 22@2x" src="https://user-images.githubusercontent.com/7587245/165833504-13303435-cc8f-4ed3-bd0d-b651283e94f5.png">

