### PR TITLE
Rename ZIO App Layer To Bootstrap

### DIFF
--- a/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
@@ -12,7 +12,7 @@ trait DefaultJvmMetrics {
 
   /** A ZIO application that periodically updates the JVM metrics */
   lazy val app: ZIOAppDefault = new ZIOAppDefault {
-    override val environmentLayer: ZLayer[ZIOAppArgs, Any, Any]  = live
+    override val bootstrap: ZLayer[ZIOAppArgs, Any, Any]         = live
     override def run: ZIO[Environment with ZIOAppArgs, Any, Any] = ZIO.unit
   }
 

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -148,7 +148,7 @@ object ZIOApp {
       type Environment = R
       def environmentTag: EnvironmentTag[Environment] = tagged
       override def hook                               = hook0
-      def bootstrap                            = layer0
+      def bootstrap                                   = layer0
       def run                                         = run0
     }
 

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -36,7 +36,7 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    * A layer that manages the acquisition and release of services necessary for
    * the application to run.
    */
-  def environmentLayer: ZLayer[ZIOAppArgs with Scope, Any, Environment]
+  def bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Environment]
 
   /**
    * The main function of the application, which can access the command-line
@@ -52,7 +52,7 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    * that executes the logic of both applications.
    */
   final def <>(that: ZIOApp)(implicit trace: Trace): ZIOApp =
-    ZIOApp(self.run.zipPar(that.run), self.environmentLayer +!+ that.environmentLayer, self.hook >>> that.hook)
+    ZIOApp(self.run.zipPar(that.run), self.bootstrap +!+ that.bootstrap, self.hook >>> that.hook)
 
   /**
    * A helper function to obtain access to the command-line arguments of the
@@ -108,7 +108,7 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
     ZIO.suspendSucceed {
       val newLayer =
         Scope.default +!+ ZLayer.succeed(ZIOAppArgs(args)) >>>
-          environmentLayer +!+ ZLayer.environment[ZIOAppArgs with Scope]
+          bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
       for {
         _      <- installSignalHandlers(runtime)
@@ -127,8 +127,8 @@ object ZIOApp {
     type Environment = app.Environment
     override final def hook: RuntimeConfigAspect =
       app.hook
-    final def environmentLayer: ZLayer[ZIOAppArgs with Scope, Any, Environment] =
-      app.environmentLayer
+    final def bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Environment] =
+      app.bootstrap
     override final def run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any] =
       app.run
     implicit final def environmentTag: EnvironmentTag[Environment] =
@@ -148,7 +148,7 @@ object ZIOApp {
       type Environment = R
       def environmentTag: EnvironmentTag[Environment] = tagged
       override def hook                               = hook0
-      def environmentLayer                            = layer0
+      def bootstrap                            = layer0
       def run                                         = run0
     }
 

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -40,7 +40,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   type Environment = Any
 
-  val environmentLayer: ZLayer[ZIOAppArgs with Scope, Any, Any] = ZLayer.empty
+  val bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Any] = ZLayer.empty
 
   val environmentTag: EnvironmentTag[Any] = EnvironmentTag[Any]
 

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -84,7 +84,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
         .provide(
           Scope.default >>> (ZEnv.live >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
           ZIOAppArgs.empty,
-          spec.environmentLayer
+          spec.bootstrap
         )
     )
     description

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -68,7 +68,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
 
     val specTasks: Array[ZIOSpecAbstract] = defs.map(disectTask(_, testClassLoader))
     val sharedLayerFromSpecs: ZLayer[Any, Any, Any] =
-      (Scope.default ++ ZIOAppArgs.empty) >>> specTasks.map(_.environmentLayer).reduce(_ +!+ _)
+      (Scope.default ++ ZIOAppArgs.empty) >>> specTasks.map(_.bootstrap).reduce(_ +!+ _)
 
     val sharedLayer: ZLayer[Any, Any, ExecutionEventSink] =
       sharedLayerFromSpecs +!+ sinkLayer

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -34,7 +34,7 @@ object FrameworkSpecInstances {
     }
 
   object SimpleSpec extends zio.test.ZIOSpec[Int] {
-    override def environmentLayer = ZLayer.succeed(1)
+    override def bootstrap = ZLayer.succeed(1)
 
     def spec =
       suite("simple suite")(
@@ -55,7 +55,7 @@ object FrameworkSpecInstances {
   }
 
   object RuntimeExceptionSpec extends zio.test.ZIOSpec[Int] {
-    override def environmentLayer = ZLayer.succeed(1)
+    override def bootstrap = ZLayer.succeed(1)
 
     def spec =
       suite("explording suite")(
@@ -83,7 +83,7 @@ object FrameworkSpecInstances {
 //  }
 
   object Spec1UsingSharedLayer extends zio.test.ZIOSpec[Int] {
-    override def environmentLayer = sharedLayer
+    override def bootstrap = sharedLayer
 
     def spec =
       suite("suite with shared layer")(
@@ -95,7 +95,7 @@ object FrameworkSpecInstances {
   }
 
   object Spec2UsingSharedLayer extends zio.test.ZIOSpec[Int] {
-    override def environmentLayer = sharedLayer
+    override def bootstrap = sharedLayer
 
     def spec =
       zio.test.test("test completes with shared layer 2") {

--- a/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
@@ -12,7 +12,7 @@ object ZIOSpecAbstractSpec extends ZIOSpecDefault {
     test("highlighting composed layer failures") {
       // We must define this here rather than as a standalone spec, because it will prevent all the tests from running
       val specWithBrokenLayer = new ZIOSpec[Int] {
-        override val environmentLayer = ZLayer.fromZIO(ZIO.attempt(???))
+        override val bootstrap = ZLayer.fromZIO(ZIO.attempt(???))
         override def spec =
           test("should never see this label printed") {
             assertTrue(true)

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -41,7 +41,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
 
     runSpec.provideSomeLayer[ZIOAppArgs with Scope](
       ZLayer.environment[ZIOAppArgs with Scope] +!+
-        (ZEnv.live >>> TestEnvironment.live +!+ environmentLayer +!+ TestLogger.fromConsole(Console.ConsoleLive))
+        (ZEnv.live >>> TestEnvironment.live +!+ bootstrap +!+ TestLogger.fromConsole(Console.ConsoleLive))
     )
   }
 
@@ -50,7 +50,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       type Environment = self.Environment with that.Environment
 
       def bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Environment] =
-        self.environmentLayer +!+ that.environmentLayer
+        self.bootstrap +!+ that.bootstrap
 
       def spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =
         self.aspects.foldLeft(self.spec)(_ @@ _) + that.aspects.foldLeft(that.spec)(_ @@ _)
@@ -115,7 +115,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       environment1: ZEnvironment[ZIOAppArgs with Scope] = runtime.environment
       runtimeConfig                                     = hook(runtime.runtimeConfig)
       sharedLayer: ZLayer[Any, Any, Environment] =
-        ZLayer.succeedEnvironment(environment0) >>> environmentLayer
+        ZLayer.succeedEnvironment(environment0) >>> bootstrap
       perTestLayer = (ZLayer.succeedEnvironment(environment1) ++ ZEnv.live) >>> (TestEnvironment.live ++ ZLayer
                        .environment[Scope] ++ ZLayer.environment[ZIOAppArgs])
       executionEventSinkLayer = sinkLayerWithConsole(console)

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -49,7 +49,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
     new ZIOSpecAbstract {
       type Environment = self.Environment with that.Environment
 
-      def environmentLayer: ZLayer[ZIOAppArgs with Scope, Any, Environment] =
+      def bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Environment] =
         self.environmentLayer +!+ that.environmentLayer
 
       def spec: Spec[Environment with TestEnvironment with ZIOAppArgs with Scope, Any] =

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -7,7 +7,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
 
-  override val environmentLayer: ZLayer[ZIOAppArgs with Scope, Any, TestEnvironment] = {
+  override val bootstrap: ZLayer[ZIOAppArgs with Scope, Any, TestEnvironment] = {
     implicit val trace: zio.Trace = Tracer.newTrace
     zio.ZEnv.live >>> TestEnvironment.live
   }


### PR DESCRIPTION
There was some feedback that `environmentLayer` was an awkward name and with the deletion of `RuntimeConfigAspect` and `hook` in `ZIOApp` this value is going to be increasingly important for installing low level functionality so I think this is a better name.