### PR TITLE
Fix Stack Overflow Issue In Tests

### DIFF
--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -56,8 +56,16 @@ private[test] object Fun {
    * `hashCode` in a way that is consistent with equality.
    */
   def makeHash[R, A, B](f: A => URIO[R, B])(hash: A => Int)(implicit trace: Trace): ZIO[R, Nothing, Fun[A, B]] =
-    ZIO.runtime[R].map { runtime =>
-      Fun(a => runtime.unsafeRun(f(a).onExecutor(funExecutor)), hash)
+    ZIO.executor.flatMap { executor =>
+      ZIO.acquireReleaseWith {
+        ZIO.shift(funExecutor)
+      } { _ =>
+        ZIO.shift(executor) *> ZIO.unshift
+      } { _ =>
+        ZIO.runtime[R].map { runtime =>
+          Fun(a => runtime.unsafeRun(f(a)), hash)
+        }
+      }
     }
 
   /**

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -56,10 +56,8 @@ private[test] object Fun {
    * `hashCode` in a way that is consistent with equality.
    */
   def makeHash[R, A, B](f: A => URIO[R, B])(hash: A => Int)(implicit trace: Trace): ZIO[R, Nothing, Fun[A, B]] =
-    ZIO.onExecutor(funExecutor) {
-      ZIO.runtime[R].map { runtime =>
-        Fun(a => runtime.unsafeRun(f(a)), hash)
-      }
+    ZIO.runtime[R].map { runtime =>
+      Fun(a => runtime.unsafeRun(f(a).onExecutor(funExecutor)), hash)
     }
 
   /**


### PR DESCRIPTION
When we shift to a new executor we can stay on that executor if we are done if we are not locked on another executor but we never want to do that with the executor that is used internally for generating functions in property based tests.