### PR TITLE
ZIO Test: Don't Unnecessarily Create Multiple Spec Cases

### DIFF
--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -579,6 +579,7 @@ package object test extends CompileVariants {
     Spec.labeled(
       label,
       if (specs.isEmpty) Spec.empty
+      else if (specs.length == 1) suiteConstructor(specs.head)
       else Spec.multiple(Chunk.fromIterable(specs).map(spec => suiteConstructor(spec)))
     )
 


### PR DESCRIPTION
If we have a suite with a single spec inside we can just represent it as a labeled case without adding a multiple case. This improves rendering in some cases where specs are composed with `+`