### PR TITLE
Restore spec spec cases

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -36,7 +36,7 @@ object SpecSpec extends ZIOBaseSpec {
         for {
           _ <- execute(spec)
         } yield assertCompletes
-      } @@ TestAspect.ignore, // TODO Restore during follow-up ComposedSpec work for #6483
+      },
       test("does not acquire the environment if the suite is ignored") {
         val spec = suite("suite")(
           test("test1") {
@@ -68,7 +68,7 @@ object SpecSpec extends ZIOBaseSpec {
         for {
           summary <- execute(spec)
         } yield assertTrue(summary.success == 1) && assertTrue(summary.fail == 2)
-      } @@ TestAspect.ignore // TODO Restore during follow-up ComposedSpec work for #6483
+      }
     ),
     suite("provideSomeLayerShared")(
       test("leaves the remainder of the environment") {
@@ -97,7 +97,7 @@ object SpecSpec extends ZIOBaseSpec {
           _      <- execute(spec)
           result <- ref.get
         } yield assert(result)(hasSize(isGreaterThan(1)))
-      } @@ TestAspect.ignore, // TODO Restore during follow-up ComposedSpec work for #6483
+      },
       test("does not cause the remainder to be shared") {
         val spec = suite("suite")(
           test("test1") {
@@ -144,7 +144,7 @@ object SpecSpec extends ZIOBaseSpec {
           log       <- ref.get.map(_.reverse)
         } yield assert(succeeded)(isTrue) &&
           assert(log)(equalTo(List("Acquiring", "Releasing", "Acquiring", "Releasing")))
-      } @@ TestAspect.ignore, // TODO Restore during follow-up ComposedSpec work for #6483
+      },
       test("correctly handles nested suites") {
         val spec =
           suite("a")(


### PR DESCRIPTION
Partial resolution for #6483 

We still have 1 disabled test here
https://github.com/swoogles/zio/blob/series%2F2.x/test-tests/shared/src/test/scala/zio/test/ZIOSpecSpec.scala#L22-L22

@adamgfraser You would probably know best what needs to be modified for it to pass after the recent runtime changes