### PR TITLE
Delete ZIO.succeedWith and ZIO.suspendWith

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2131,10 +2131,6 @@ object ZIOSpec extends ZIOBaseSpec {
         val io = ZIO.suspend[Any, Nothing](throw ExampleError).either
         assertZIO(io)(isLeft(equalTo(ExampleError)))
       },
-      test("suspendWith must catch throwable") {
-        val io = ZIO.suspendWith[Any, Nothing]((_, _) => throw ExampleError).either
-        assertZIO(io)(isLeft(equalTo(ExampleError)))
-      },
       test("suspendSucceed must be evaluatable") {
         assertZIO(ZIO.suspendSucceed(ZIO.succeed(42)))(equalTo(42))
       },

--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -35,7 +35,7 @@ private[zio] trait FiberPlatformSpecific {
           val cf = cs.toCompletableFuture
           if (cf.isDone) {
             ZIO
-              .suspendWith((isFatal, _) => javaz.unwrapDone(isFatal)(cf))
+              .isFatalWith(isFatal => javaz.unwrapDone(isFatal)(cf))
               .fold(Exit.fail, Exit.succeed)
               .map(Some(_))
           } else {
@@ -70,7 +70,7 @@ private[zio] trait FiberPlatformSpecific {
         ZIO.suspendSucceed {
           if (ftr.isDone) {
             ZIO
-              .suspendWith((isFatal, _) => javaz.unwrapDone(isFatal)(ftr))
+              .isFatalWith(isFatal => javaz.unwrapDone(isFatal)(ftr))
               .fold(Exit.fail, Exit.succeed)
               .map(Some(_))
           } else {

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionException
 private[zio] object javaz {
 
   def asyncWithCompletionHandler[T](op: CompletionHandler[T, Any] => Any)(implicit trace: Trace): Task[T] =
-    ZIO.suspendSucceedWith[Any, Throwable, T] { (isFatal, _) =>
+    ZIO.isFatalWith[Any, Throwable, T] { isFatal =>
       ZIO.async { k =>
         val handler = new CompletionHandler[T, Any] {
           def completed(result: T, u: Any): Unit = k(ZIO.succeedNow(result))
@@ -68,7 +68,7 @@ private[zio] object javaz {
 
   def fromCompletionStage[A](thunk: => CompletionStage[A])(implicit trace: Trace): Task[A] =
     ZIO.attempt(thunk).flatMap { cs =>
-      ZIO.suspendSucceedWith { (isFatal, _) =>
+      ZIO.isFatalWith { isFatal =>
         val cf = cs.toCompletableFuture
         if (cf.isDone) {
           unwrapDone(isFatal)(cf)
@@ -92,7 +92,7 @@ private[zio] object javaz {
    */
   def fromFutureJava[A](thunk: => Future[A])(implicit trace: Trace): Task[A] =
     ZIO.attempt(thunk).flatMap { future =>
-      ZIO.suspendSucceedWith { (isFatal, _) =>
+      ZIO.isFatalWith { isFatal =>
         if (future.isDone) {
           unwrapDone(isFatal)(future)
         } else {

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -152,7 +152,7 @@ object Hub {
           }
         }
       def shutdown(implicit trace: Trace): UIO[Unit] =
-        ZIO.suspendSucceedWith { (_, fiberId) =>
+        ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
             .whenZIO(shutdownHook.succeed(())) {
@@ -219,7 +219,7 @@ object Hub {
       def offerAll(as: Iterable[Nothing])(implicit trace: Trace): UIO[Boolean] =
         ZIO.succeedNow(false)
       def shutdown(implicit trace: Trace): UIO[Unit] =
-        ZIO.suspendSucceedWith { (_, fiberId) =>
+        ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
             .whenZIO(shutdownHook.succeed(())) {
@@ -235,7 +235,7 @@ object Hub {
           else ZIO.succeedNow(subscription.size())
         }
       def take(implicit trace: Trace): UIO[A] =
-        ZIO.suspendSucceedWith { (_, fiberId) =>
+        ZIO.fiberIdWith { fiberId =>
           if (shutdownFlag.get) ZIO.interrupt
           else {
             val empty   = null.asInstanceOf[A]
@@ -374,7 +374,7 @@ object Hub {
         as: Iterable[A],
         isShutDown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] =
-        ZIO.suspendSucceedWith { (_, fiberId) =>
+        ZIO.fiberIdWith { fiberId =>
           val promise = Promise.unsafeMake[Nothing, Boolean](fiberId)
           ZIO.suspendSucceed {
             unsafeOffer(as, promise)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -205,7 +205,7 @@ object Queue {
       }
 
     def shutdown(implicit trace: Trace): UIO[Unit] =
-      ZIO.suspendSucceedWith { (_, fiberId) =>
+      ZIO.fiberIdWith { fiberId =>
         shutdownFlag.set(true)
 
         ZIO
@@ -218,7 +218,7 @@ object Queue {
     def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
 
     def take(implicit trace: Trace): UIO[A] =
-      ZIO.suspendSucceedWith { (_, fiberId) =>
+      ZIO.fiberIdWith { fiberId =>
         if (shutdownFlag.get) ZIO.interrupt
         else {
           queue.poll(null.asInstanceOf[A]) match {
@@ -329,7 +329,7 @@ object Queue {
         takers: MutableConcurrentQueue[Promise[Nothing, A]],
         isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] =
-        ZIO.suspendSucceedWith { (_, fiberId) =>
+        ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafeMake[Nothing, Boolean](fiberId)
 
           ZIO.suspendSucceed {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3558,9 +3558,15 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   )(implicit trace: Trace): ZIO[R, E, A] =
     checkInterruptible(flag => k(ZIO.InterruptStatusRestore(flag)).interruptible)
 
+  /**
+   * Retrieves the definition of a fatal error.
+   */
   def isFatal(implicit trace: Trace): UIO[Throwable => Boolean] =
     isFatalWith(isFatal => ZIO.succeedNow(isFatal))
 
+  /**
+   * Constructs an effect based on the definition of a fatal error.
+   */
   def isFatalWith[R, E, A](f: (Throwable => Boolean) => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
     FiberRef.currentFatal.getWith(fatal => f(t => fatal.exists(_.isAssignableFrom(t.getClass))))
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -355,7 +355,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
   )(implicit ev1: CanFail[E], ev2: E <:< Throwable, trace: Trace): ZIO[R1, E2, A1] = {
 
     def hh(e: E) =
-      ZIO.suspendSucceedWith((isFatal, _) => if (isFatal(e)) ZIO.die(e) else h(e))
+      ZIO.isFatalWith(isFatal => if (isFatal(e)) ZIO.die(e) else h(e))
     self.foldZIO[R1, E2, A1](hh, ZIO.succeedNow)
   }
 
@@ -2598,10 +2598,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * }}}
    */
   def attempt[A](effect: => A)(implicit trace: Trace): Task[A] =
-    succeedWith { (isFatal, _) =>
-      try effect
-      catch {
-        case t: Throwable if !isFatal(t) => throw new ZioError(Exit.fail(t), trace)
+    isFatalWith { isFatal =>
+      ZIO.succeedNow {
+        try effect
+        catch {
+          case t: Throwable if !isFatal(t) => throw new ZioError(Exit.fail(t), trace)
+        }
       }
     }
 
@@ -3556,6 +3558,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   )(implicit trace: Trace): ZIO[R, E, A] =
     checkInterruptible(flag => k(ZIO.InterruptStatusRestore(flag)).interruptible)
 
+  def isFatal(implicit trace: Trace): UIO[Throwable => Boolean] =
+    isFatalWith(isFatal => ZIO.succeedNow(isFatal))
+
+  def isFatalWith[R, E, A](f: (Throwable => Boolean) => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    FiberRef.currentFatal.getWith(fatal => f(t => fatal.exists(_.isAssignableFrom(t.getClass))))
+
   /**
    * Iterates with the specified effectual function. The moral equivalent of:
    *
@@ -4217,19 +4225,12 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     blocking(ZIO.succeed(a))
 
   /**
-   * The same as [[ZIO.succeed]], but also provides access to the definition of
-   * a fatal error and fiber id.
-   */
-  def succeedWith[A](f: (Throwable => Boolean, FiberId) => A)(implicit trace: Trace): UIO[A] =
-    new ZIO.SucceedWith(f, trace)
-
-  /**
    * Returns a lazily constructed effect, whose construction may itself require
    * effects. When no environment is required (i.e., when R == Any) it is
    * conceptually equivalent to `flatten(effect(io))`.
    */
   def suspend[R, A](rio: => RIO[R, A])(implicit trace: Trace): RIO[R, A] =
-    suspendSucceedWith { (isFatal, _) =>
+    ZIO.isFatalWith { isFatal =>
       try rio
       catch {
         case t: Throwable if !isFatal(t) => throw new ZioError(Exit.fail(t), trace)
@@ -4245,31 +4246,6 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   def suspendSucceed[R, E, A](zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
     new ZIO.Suspend(() => zio, trace)
-
-  /**
-   * Returns a lazily constructed effect, whose construction may itself require
-   * effects. The effect must not throw any exceptions. When no environment is
-   * required (i.e., when R == Any) it is conceptually equivalent to
-   * `flatten(succeed(zio))`. If you wonder if the effect throws exceptions, do
-   * not use this method, use [[ZIO.suspend]] or [[ZIO.suspend]].
-   */
-  def suspendSucceedWith[R, E, A](f: (Throwable => Boolean, FiberId) => ZIO[R, E, A])(implicit
-    trace: Trace
-  ): ZIO[R, E, A] =
-    new ZIO.SuspendWith(f, trace)
-
-  /**
-   * Returns a lazily constructed effect, whose construction may itself require
-   * effects. When no environment is required (i.e., when R == Any) it is
-   * conceptually equivalent to `flatten(effect(io))`.
-   */
-  def suspendWith[R, A](f: (Throwable => Boolean, FiberId) => RIO[R, A])(implicit trace: Trace): RIO[R, A] =
-    suspendSucceedWith((isFatal, fiberId) =>
-      try f(isFatal, fiberId)
-      catch {
-        case t: Throwable if !isFatal(t) => throw new ZioError(Exit.fail(t), trace)
-      }
-    )
 
   /**
    * Retreives the `System` service for this workflow.
@@ -5178,28 +5154,26 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     final val SucceedNow             = 4
     final val Fail                   = 5
     final val Succeed                = 6
-    final val SucceedWith            = 7
-    final val Suspend                = 8
-    final val SuspendWith            = 9
-    final val Async                  = 10
-    final val InterruptStatus        = 11
-    final val CheckInterrupt         = 12
-    final val Fork                   = 13
-    final val Descriptor             = 14
-    final val Shift                  = 15
-    final val Yield                  = 16
-    final val FiberRefNew            = 17
-    final val FiberRefModify         = 18
-    final val CaptureTrace           = 19
-    final val RaceWith               = 20
-    final val Supervise              = 21
-    final val GetForkScope           = 22
-    final val OverrideForkScope      = 23
-    final val Logged                 = 24
-    final val FiberRefModifyAll      = 25
-    final val FiberRefLocally        = 26
-    final val FiberRefDelete         = 27
-    final val FiberRefWith           = 28
+    final val Suspend                = 7
+    final val Async                  = 8
+    final val InterruptStatus        = 9
+    final val CheckInterrupt         = 10
+    final val Fork                   = 11
+    final val Descriptor             = 12
+    final val Shift                  = 13
+    final val Yield                  = 14
+    final val FiberRefNew            = 15
+    final val FiberRefModify         = 16
+    final val CaptureTrace           = 17
+    final val RaceWith               = 18
+    final val Supervise              = 19
+    final val GetForkScope           = 20
+    final val OverrideForkScope      = 21
+    final val Logged                 = 22
+    final val FiberRefModifyAll      = 23
+    final val FiberRefLocally        = 24
+    final val FiberRefDelete         = 25
+    final val FiberRefWith           = 26
   }
 
   private[zio] final case class ZioError[E, A](exit: Exit[E, A], trace: Trace) extends Throwable with NoStackTrace
@@ -5245,29 +5219,11 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     override def tag = Tags.Succeed
   }
 
-  private[zio] final class SucceedWith[A](val effect: (Throwable => Boolean, FiberId) => A, val trace: Trace)
-      extends UIO[A] {
-    def unsafeLog: () => String =
-      () => s"SucceedWith at ${trace}"
-
-    override def tag = Tags.SucceedWith
-  }
-
   private[zio] final class Suspend[R, E, A](val make: () => ZIO[R, E, A], val trace: Trace) extends ZIO[R, E, A] {
     def unsafeLog: () => String =
       () => s"Suspend at ${trace}"
 
     override def tag = Tags.Suspend
-  }
-
-  private[zio] final class SuspendWith[R, E, A](
-    val make: (Throwable => Boolean, FiberId) => ZIO[R, E, A],
-    val trace: Trace
-  ) extends ZIO[R, E, A] {
-    def unsafeLog: () => String =
-      () => s"SuspendWith at ${trace}"
-
-    override def tag = Tags.SuspendWith
   }
 
   private[zio] final class Async[R, E, A](

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -204,18 +204,6 @@ private[zio] final class FiberContext[E, A](
 
                         curZio = k(value)
 
-                      case ZIO.Tags.SucceedWith =>
-                        val io2    = nested.asInstanceOf[ZIO.SucceedWith[Any]]
-                        val effect = io2.effect
-
-                        val isFatal = unsafeGetIsFatal()
-
-                        extraTrace = zio.trace
-                        val value = effect(isFatal, fiberId)
-                        extraTrace = emptyTraceElement
-
-                        curZio = k(value)
-
                       case ZIO.Tags.Yield =>
                         extraTrace = zio.trace
                         unsafeRunLater(k(()))
@@ -243,14 +231,6 @@ private[zio] final class FiberContext[E, A](
                     val effect = zio.effect
 
                     curZio = unsafeNextEffect(effect())
-
-                  case ZIO.Tags.SucceedWith =>
-                    val zio    = curZio.asInstanceOf[ZIO.SucceedWith[Any]]
-                    val effect = zio.effect
-
-                    val isFatal = unsafeGetIsFatal()
-
-                    curZio = unsafeNextEffect(effect(isFatal, fiberId))
 
                   case ZIO.Tags.Fail =>
                     val zio = curZio.asInstanceOf[ZIO.Fail[Any]]
@@ -302,13 +282,6 @@ private[zio] final class FiberContext[E, A](
                     val zio = curZio.asInstanceOf[ZIO.Suspend[Any, Any, Any]]
 
                     curZio = zio.make()
-
-                  case ZIO.Tags.SuspendWith =>
-                    val zio = curZio.asInstanceOf[ZIO.SuspendWith[Any, Any, Any]]
-
-                    val isFatal = unsafeGetIsFatal()
-
-                    curZio = zio.make(isFatal, fiberId)
 
                   case ZIO.Tags.InterruptStatus =>
                     val zio = curZio.asInstanceOf[ZIO.InterruptStatus[Any, Any, Any]]

--- a/docs/datatypes/core/zio/zio.md
+++ b/docs/datatypes/core/zio/zio.md
@@ -357,8 +357,6 @@ Asynchronous ZIO effects are much easier to use than callback-based APIs, and th
 |--------------------------|---------------------------------------------------|----------------|
 | `suspend`                | `RIO[R, A]`                                       | `RIO[R, A]`    |
 | `suspendSucceed`         | `ZIO[R, E, A]`                                    | `ZIO[R, E, A]` |
-| `suspendSucceedWith`     | `(Throwable => Boolean, FiberId) => ZIO[R, E, A]` | `ZIO[R, E, A]` |
-| `suspendWith`            | `(Throwable => Boolean, FiberId) => RIO[R, A]`    | `RIO[R, A]`    |
 
 A `RIO[R, A]` effect can be suspended using `suspend` function:
 

--- a/docs/howto/migrate/migration-guide.md
+++ b/docs/howto/migrate/migration-guide.md
@@ -272,8 +272,6 @@ Here are some of the most important changes:
 | `ZIO.effectBlockingInterrupt`  | `ZIO.attemptBlockingInterrupt`    |
 | `ZIO.effectSuspend`            | `ZIO.suspend`                     |
 | `ZIO.effectSuspendTotal`       | `ZIO.suspendSucceed`              |
-| `ZIO.effectSuspendTotalWith`   | `ZIO.suspendSucceedWith`          |
-| `ZIO.effectSuspendWith`        | `ZIO.suspendWith`                 |
 | `ZIO.effectTotal`              | `ZIO.succeed`                     |
 |                                |                                   |
 | `ZIO.foreach_`                 | `ZIO.foreachDiscard`              |


### PR DESCRIPTION
These operators were always a little strange in giving access to the `FiberId` and the `RuntimeConfig`, which is a bit of an arbitrary combination of data that I don't think was ever actually used together. This is even more true now that `RuntimeConfig` has been deleted and this just provides access to the `FiberId` and the definition of a fatal error. It is also represented by primitives in the runtime, which is too much for such limited functionality.

We can replace with `isFatal` and `isFatalWith` operators that give access to the runtime's definition of a fatal error, and then operators can either get that or the `FiberId` directly.