### PR TITLE
ZPipeline#mapError

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -1,7 +1,7 @@
 package zio.stream
 
 import zio._
-import zio.test.Assertion.equalTo
+import zio.test.Assertion.{equalTo, fails}
 import zio.test._
 
 import scala.io.Source
@@ -140,6 +140,18 @@ object ZPipelineSpec extends ZIOBaseSpec {
             ZStream(1, 2, 3, 4, 5).via(ZPipeline.take(100)).runCollect
           )(equalTo(Chunk(1, 2, 3, 4, 5)))
         }
+      ),
+      test("mapError")(
+        assertZIO(
+          ZStream(1, 2, 3)
+            .via(
+              ZPipeline
+                .fromChannel(ZChannel.fail("failed"))
+                .mapError(_ + "!!!")
+            )
+            .runCollect
+            .exit
+        )(fails(equalTo("failed!!!")))
       )
     )
 

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -114,6 +114,14 @@ class ZPipeline[-Env, +Err, -In, +Out](val channel: ZChannel[Env, ZNothing, Chun
     that: => ZPipeline[Env1, Err1, In2, In]
   )(implicit trace: Trace): ZPipeline[Env1, Err1, In2, Out] =
     self <<< that
+
+  /**
+   * Transforms the errors emitted by this pipeline using `f`.
+   */
+  def mapError[Err2](
+    f: Err => Err2
+  )(implicit trace: Trace): ZPipeline[Env, Err2, In, Out] =
+    new ZPipeline(self.channel.mapError(f))
 }
 
 object ZPipeline extends ZPipelinePlatformSpecificConstructors {


### PR DESCRIPTION
This seems to be useful based on migrating libs to RC6