### PR TITLE
Delete ZIOAspect.disableLogging

### DIFF
--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -1,6 +1,5 @@
 package zio
 
-import zio.ZIOAspect.disableLogging
 import zio.test._
 
 object LoggingSpec extends ZIOBaseSpec {
@@ -52,12 +51,6 @@ object LoggingSpec extends ZIOBaseSpec {
           output <- ZTestLogger.logOutput
           _      <- ZIO.debug(output(0).call(ZLogger.default))
         } yield assertTrue(true)
-      },
-      test("none") {
-        for {
-          _      <- ZIO.log("It's alive!") @@ disableLogging
-          output <- ZTestLogger.logOutput
-        } yield assertTrue(output.isEmpty)
       },
       test("log annotations") {
         val key   = "key"

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -103,15 +103,6 @@ object ZIOAspect {
     }
 
   /**
-   * An aspect that disables logging for the specified effect.
-   */
-  val disableLogging: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
-    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
-      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        FiberRef.currentLoggers.locally(Set.empty)(zio)
-    }
-
-  /**
    * An aspect that logs values by using [[ZIO.log]].
    */
   val logged: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =


### PR DESCRIPTION
We have worked towards the idea that customizations to the runtime should be additive whenever possible, so that making customizations is a commutative operation with well defined semantics in the presence of concurrency. For example, combining two ZIO applications that each want to add a logger results in a new ZIO application that uses both loggers.

In addition, in the context of observability we have worked towards the idea that inner regions should not be able to "shield themselves" from observability installed at higher levels of a program. For example you should not be able to remove a `Supervisor`.

The `disableLogging` operator violates both of these principles.