### PR TITLE
Support Not Using Default Logger

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -7,6 +7,7 @@ import scala.concurrent.ExecutionContext
 
 object BenchmarkUtil extends Runtime[Any] {
   val environment = Runtime.default.environment
+  val fiberRefs   = FiberRefs.empty
 
   implicit val futureExecutionContext: ExecutionContext =
     ExecutionContext.global

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -10,7 +10,7 @@ object FiberRefsSpec extends ZIOBaseSpec {
         fiberRef <- FiberRef.make(false)
         queue    <- Queue.unbounded[FiberRefs]
         producer <- (fiberRef.set(true) *> ZIO.getFiberRefs.flatMap(queue.offer)).fork
-        consumer <- (queue.take.flatMap(ZIO.setFiberRefs(_)) *> fiberRef.get).fork
+        consumer <- (queue.take.flatMap(ZIO.inheritFiberRefs(_)) *> fiberRef.get).fork
         _        <- producer.join
         value    <- consumer.join
       } yield assertTrue(value)

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -78,6 +78,8 @@ object FiberId {
 
   private[zio] val _fiberCounter = new java.util.concurrent.atomic.AtomicInteger(0)
 
+  private[zio] val none: FiberId.Runtime = null
+
   case object None                                                          extends FiberId
   final case class Runtime(id: Int, startTimeSeconds: Int, location: Trace) extends FiberId
   final case class Composite(fiberIds: Set[FiberId.Runtime])                extends FiberId

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -404,16 +404,16 @@ object FiberRef {
     FiberRef.unsafeMakeSet(Runtime.defaultFatal)
 
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
-    FiberRef.unsafeMakeSet(Runtime.defaultLoggers)
+    FiberRef.unsafeMakeSet(Set.empty)
 
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
     FiberRef.unsafeMake(Runtime.defaultReportFatal)
 
   private[zio] val currentRuntimeFlags: FiberRef.WithPatch[Set[RuntimeFlag], SetPatch[RuntimeFlag]] =
-    FiberRef.unsafeMakeSet(Runtime.defaultFlags)
+    FiberRef.unsafeMakeSet(Set.empty)
 
   private[zio] val currentSupervisors: FiberRef.WithPatch[Set[Supervisor[Any]], SetPatch[Supervisor[Any]]] =
-    FiberRef.unsafeMakeSet(Runtime.defaultSupervisors)
+    FiberRef.unsafeMakeSet(Set.empty)
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -453,7 +453,7 @@ object Runtime extends RuntimePlatformSpecific {
    * configured with the the default runtime configuration, which is optimized
    * for typical ZIO applications.
    */
-  val default: Runtime[Any] =
+  lazy val default: Runtime[Any] =
     Runtime.defaultLoggers.foldLeft(bootstrap)(_.addLogger(_))
 
   val enableCurrentFiber: ZLayer[Any, Nothing, Unit] = {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4127,11 +4127,11 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     ZIO.scopeWith(_.fork.flatMap(_.extend[R](zio)))
 
   /**
-   * Sets the `FiberRef` values for the fiber running this effect to the values
-   * in the specified collection of `FiberRef` values.
+   * Inherits the `FiberRef` values for the fiber running this effect from the
+   * specified collection of `FiberRef` values.
    */
-  def setFiberRefs(fiberRefs: => FiberRefs)(implicit trace: Trace): UIO[Unit] =
-    ZIO.suspendSucceed(fiberRefs.setAll)
+  def inheritFiberRefs(fiberRefs: => FiberRefs)(implicit trace: Trace): UIO[Unit] =
+    ZIO.suspendSucceed(fiberRefs.inheritRefs)
 
   /**
    * Sets a state in the environment to the specified value.


### PR DESCRIPTION
If we want to follow the principle that customizations to the runtime should be "additive" and we want to support the full range of user desired customization, then the logical implication is that we must provide an "empty" runtime with no customizations at all that can be the basis for the full range of user defined customization.

This is in some tension with our goal to provide a default experience that is as good as possible, for example providing a default console logger.

We can resolve by implementing a separate runtime, called `bootstrap` here, that has the minimum possible configuration. This runtime is not suitable for typical applications (e.g. it has no logger) but provides full customizability. So users could use this implementation of the `Runtime` in `ZIOApp` and then use layers to add their own desired logging and so on.

One disadvantage of this approach relative to providing a layer such as `disableDefaultLogger` is that it requires users to make modifications in two places (`runtime` and `bootstrap`) and potentially also add other desired default functionality since they would be starting from a "blank slate" 