### PR TITLE
Improve Implementation of Cron Like Schedules

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -320,9 +320,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val input = List(inTimeSecondNanosec, inTimeSecond, beforeTime, afterTime).map((_, ()))
 
         assertZIO(runManually(Schedule.secondOfMinute(1), input).map(toOffsetDateTime)) {
-          val expected          = originOffset.withSecond(1)
-          val afterTimeExpected = expected.withMinute(expected.getMinute + 1)
-          equalTo(List(inTimeSecondNanosec, inTimeSecond, inTimeSecond, afterTimeExpected))
+          val expected             = originOffset.withSecond(1)
+          val inTimeSecondExpected = expected.withMinute(expected.getMinute + 1)
+          val beforeTimeExpected   = expected.withMinute(expected.getMinute + 2)
+          val afterTimeExpected    = expected.withMinute(expected.getMinute + 3)
+          equalTo(List(inTimeSecondNanosec, inTimeSecondExpected, beforeTimeExpected, afterTimeExpected))
         }
       },
       test("throw IllegalArgumentException on invalid `second` argument of `secondOfMinute`") {
@@ -345,9 +347,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val input = List(inTimeMinuteNanosec, inTimeMinute, beforeTime, afterTime).map((_, ()))
 
         assertZIO(runManually(Schedule.minuteOfHour(1), input).map(toOffsetDateTime)) {
-          val expected          = originOffset.withMinute(1)
-          val afterTimeExpected = expected.withHour(expected.getHour + 1)
-          equalTo(List(inTimeMinuteNanosec, inTimeMinute, inTimeMinute, afterTimeExpected))
+          val expected             = originOffset.withMinute(1)
+          val inTimeMinuteExpected = expected.withHour(expected.getHour + 1)
+          val beforeTimeExpected   = expected.withHour(expected.getHour + 2)
+          val afterTimeExpected    = expected.withHour(expected.getHour + 3)
+          equalTo(List(inTimeMinuteNanosec, inTimeMinuteExpected, beforeTimeExpected, afterTimeExpected))
         }
       },
       test("throw IllegalArgumentException on invalid `minute` argument of `minuteOfHour`") {
@@ -372,9 +376,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val input = List(inTimeHourSecond, inTimeHour, beforeTime, afterTime).map((_, ()))
 
         assertZIO(runManually(Schedule.hourOfDay(1), input).map(toOffsetDateTime)) {
-          val expected          = originOffset.withHour(1)
-          val afterTimeExpected = expected.withDayOfYear(expected.getDayOfYear).plusDays(1L)
-          equalTo(List(inTimeHourSecond, inTimeHour, inTimeHour, afterTimeExpected))
+          val expected           = originOffset.withHour(1)
+          val inTimeHourExpected = expected.withDayOfYear(expected.getDayOfYear).plusDays(1L)
+          val beforeTimeExpected = expected.withDayOfYear(expected.getDayOfYear).plusDays(2L)
+          val afterTimeExpected  = expected.withDayOfYear(expected.getDayOfYear).plusDays(3L)
+          equalTo(List(inTimeHourSecond, inTimeHourExpected, beforeTimeExpected, afterTimeExpected))
         }
       },
       test("throw IllegalArgumentException on invalid `hour` argument of `hourOfDay`") {
@@ -399,9 +405,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val input = List(tuesdayHour, tuesday, monday, wednesday).map((_, ()))
 
         assertZIO(runManually(Schedule.dayOfWeek(2), input).map(toOffsetDateTime)) {
-          val expectedTuesday = originOffset.`with`(ChronoField.DAY_OF_WEEK, 2)
-          val nextTuesday     = expectedTuesday.plusDays(7).`with`(ChronoField.DAY_OF_WEEK, 2)
-          equalTo(List(tuesdayHour, tuesday, tuesday, nextTuesday))
+          val expectedTuesday   = originOffset.`with`(ChronoField.DAY_OF_WEEK, 2)
+          val tuesdayExpected   = expectedTuesday.plusDays(7).`with`(ChronoField.DAY_OF_WEEK, 2)
+          val mondayExpected    = expectedTuesday.plusDays(14).`with`(ChronoField.DAY_OF_WEEK, 2)
+          val wednesdayExpected = expectedTuesday.plusDays(21).`with`(ChronoField.DAY_OF_WEEK, 2)
+          equalTo(List(tuesdayHour, tuesdayExpected, mondayExpected, wednesdayExpected))
         }
       },
       test("throw IllegalArgumentException on invalid `day` argument of `dayOfWeek`") {
@@ -428,9 +436,11 @@ object ScheduleSpec extends ZIOBaseSpec {
         val input = List(inTimeDate1, inTimeDate2, before, after).map((_, ()))
 
         assertZIO(runManually(Schedule.dayOfMonth(2), input).map(toOffsetDateTime)) {
-          val expectedBefore = originOffset.withDayOfMonth(2)
-          val expectedAfter  = originOffset.withDayOfMonth(2).plusMonths(1)
-          equalTo(List(inTimeDate1, inTimeDate2, expectedBefore, expectedAfter))
+          val expectedBefore      = originOffset.withDayOfMonth(2)
+          val inTimeDate2Expected = expectedBefore.plusMonths(1)
+          val beforeExpected      = expectedBefore.plusMonths(2)
+          val afterExpected       = expectedBefore.plusMonths(3)
+          equalTo(List(inTimeDate1, inTimeDate2Expected, beforeExpected, afterExpected))
         }
       },
       test("recur only in months containing valid number of days") {

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1409,10 +1409,10 @@ object Schedule {
    *
    * NOTE: `second` parameter is validated lazily. Must be in range 0...59.
    */
-  def secondOfMinute(second0: => Int)(implicit trace: Trace): Schedule.WithState[Long, Any, Any, Long] =
+  def secondOfMinute(second0: => Int)(implicit trace: Trace): Schedule.WithState[(OffsetDateTime, Long), Any, Any, Long] =
     new Schedule[Any, Any, Long] {
-      type State = Long
-      val initial = 0L
+      type State = (OffsetDateTime, Long)
+      val initial = (OffsetDateTime.MIN, 0L)
       def step(now: OffsetDateTime, in: Any, state: State)(implicit
         trace: Trace
       ): ZIO[Any, Nothing, (State, Long, Decision)] =
@@ -1421,11 +1421,13 @@ object Schedule {
             new IllegalArgumentException(s"Invalid argument in `secondOfMinute($second)`. Must be in range 0...59")
           )
         } else {
-          val second00 = nextSecond(now, second0)
-          val start    = maxOffsetDateTime(beginningOfSecond(second00), now)
+          val (end0, n) = state
+          val now0     = maxOffsetDateTime(end0, now)
+          val second00 = nextSecond(now0, second0)
+          val start    = maxOffsetDateTime(beginningOfSecond(second00), now0)
           val end      = endOfSecond(second00)
           val interval = Interval(start, end)
-          ZIO.succeedNow((state + 1, state, Decision.Continue(interval)))
+          ZIO.succeedNow(((end, n + 1), n, Decision.Continue(interval)))
         }
     }
 
@@ -1436,21 +1438,23 @@ object Schedule {
    *
    * NOTE: `minute` parameter is validated lazily. Must be in range 0...59.
    */
-  def minuteOfHour(minute: Int)(implicit trace: Trace): Schedule.WithState[Long, Any, Any, Long] =
+  def minuteOfHour(minute: Int)(implicit trace: Trace): Schedule.WithState[(OffsetDateTime, Long), Any, Any, Long] =
     new Schedule[Any, Any, Long] {
-      type State = Long
-      val initial = 0L
+      type State = (OffsetDateTime, Long)
+      val initial = (OffsetDateTime.MIN, 0L)
       def step(now: OffsetDateTime, in: Any, state: State)(implicit
         trace: Trace
       ): ZIO[Any, Nothing, (State, Long, Decision)] =
         if (minute < 0 || 59 < minute) {
           ZIO.die(new IllegalArgumentException(s"Invalid argument in `minuteOfHour($minute)`. Must be in range 0...59"))
         } else {
-          val minute0  = nextMinute(now, minute)
-          val start    = maxOffsetDateTime(beginningOfMinute(minute0), now)
+          val (end0, n) = state
+          val now0     = maxOffsetDateTime(end0, now)
+          val minute0  = nextMinute(maxOffsetDateTime(end0, now0), minute)
+          val start    = maxOffsetDateTime(beginningOfMinute(minute0), now0)
           val end      = endOfMinute(minute0)
           val interval = Interval(start, end)
-          ZIO.succeedNow((state + 1, state, Decision.Continue(interval)))
+          ZIO.succeedNow(((end, n + 1), n, Decision.Continue(interval)))
         }
     }
 
@@ -1460,21 +1464,23 @@ object Schedule {
    *
    * NOTE: `hour` parameter is validated lazily. Must be in range 0...23.
    */
-  def hourOfDay(hour: Int)(implicit trace: Trace): Schedule.WithState[Long, Any, Any, Long] =
+  def hourOfDay(hour: Int)(implicit trace: Trace): Schedule.WithState[(OffsetDateTime, Long), Any, Any, Long] =
     new Schedule[Any, Any, Long] {
-      type State = Long
-      val initial = 0L
+      type State = (OffsetDateTime, Long)
+      val initial = (OffsetDateTime.MIN, 0L)
       def step(now: OffsetDateTime, in: Any, state: State)(implicit
         trace: Trace
       ): ZIO[Any, Nothing, (State, Long, Decision)] =
         if (hour < 0 || 23 < hour) {
           ZIO.die(new IllegalArgumentException(s"Invalid argument in `hourOfDay($hour)`. Must be in range 0...23"))
         } else {
-          val hour0    = nextHour(now, hour)
-          val start    = maxOffsetDateTime(beginningOfHour(hour0), now)
+          val (end0, n) = state
+          val now0     = maxOffsetDateTime(end0, now)
+          val hour0    = nextHour(now0, hour)
+          val start    = maxOffsetDateTime(beginningOfHour(hour0), now0)
           val end      = endOfHour(hour0)
           val interval = Interval(start, end)
-          ZIO.succeedNow((state + 1, state, Decision.Continue(interval)))
+          ZIO.succeedNow(((end, n + 1), n, Decision.Continue(interval)))
         }
     }
 
@@ -1485,10 +1491,10 @@ object Schedule {
    * NOTE: `day` parameter is validated lazily. Must be in range 1 (Monday)...7
    * (Sunday).
    */
-  def dayOfWeek(day: Int)(implicit trace: Trace): Schedule.WithState[Long, Any, Any, Long] =
+  def dayOfWeek(day: Int)(implicit trace: Trace): Schedule.WithState[(OffsetDateTime, Long), Any, Any, Long] =
     new Schedule[Any, Any, Long] {
-      type State = Long
-      val initial = 0L
+      type State = (OffsetDateTime, Long)
+      val initial = (OffsetDateTime.MIN, 0L)
       def step(now: OffsetDateTime, in: Any, state: State)(implicit
         trace: Trace
       ): ZIO[Any, Nothing, (State, Long, Decision)] =
@@ -1499,11 +1505,13 @@ object Schedule {
             )
           )
         } else {
-          val day0     = nextDay(now, day)
-          val start    = maxOffsetDateTime(beginningOfDay(day0), now)
+          val (end0, n) = state
+          val now0     = maxOffsetDateTime(end0, now)
+          val day0     = nextDay(now0, day)
+          val start    = maxOffsetDateTime(beginningOfDay(day0), now0)
           val end      = endOfDay(day0)
           val interval = Interval(start, end)
-          ZIO.succeedNow((state + 1, state, Decision.Continue(interval)))
+          ZIO.succeedNow(((end, n + 1), n, Decision.Continue(interval)))
         }
     }
 
@@ -1515,21 +1523,23 @@ object Schedule {
    *
    * NOTE: `day` parameter is validated lazily. Must be in range 1...31.
    */
-  def dayOfMonth(day: Int)(implicit trace: Trace): Schedule.WithState[Long, Any, Any, Long] =
+  def dayOfMonth(day: Int)(implicit trace: Trace): Schedule.WithState[(OffsetDateTime, Long), Any, Any, Long] =
     new Schedule[Any, Any, Long] {
-      type State = Long
-      val initial = 0L
+      type State = (OffsetDateTime, Long)
+      val initial = (OffsetDateTime.MIN, 0L)
       def step(now: OffsetDateTime, in: Any, state: State)(implicit
         trace: Trace
       ): ZIO[Any, Nothing, (State, Long, Decision)] =
         if (day < 1 || 31 < day) {
           ZIO.die(new IllegalArgumentException(s"Invalid argument in `dayOfMonth($day)`. Must be in range 1...31"))
         } else {
-          val day0     = nextDayOfMonth(now, day)
-          val start    = maxOffsetDateTime(beginningOfDay(day0), now)
+          val (end0, n) = state
+          val now0     = maxOffsetDateTime(end0, now)
+          val day0     = nextDayOfMonth(now0, day)
+          val start    = maxOffsetDateTime(beginningOfDay(day0), now0)
           val end      = endOfDay(day0)
           val interval = Interval(start, end)
-          ZIO.succeedNow((state + 1, state, Decision.Continue(interval)))
+          ZIO.succeedNow(((end, n + 1), n, Decision.Continue(interval)))
         }
     }
 


### PR DESCRIPTION
Currently schedules for fixed intervals of time, such as `dayOfWeek`, are willing to recur immediately if it is in their interval for recurrence, and are potentially willing to recur multiple times in that same interval if the driver calls them again.

This can be problematic because if a workflow is repeated and the time the workflow takes to execute is less than the interval size the workflow may be executed multiple times, whereas if we do something like `workflow.repeat(Schedule.secondOfMinute(1))` I think we expect the workflow to be repeated once each minute in the specified second.

We can improve this by having the schedule's internal state include the last recurrence, so once we have recurred once in a particular interval we are willing to recur again in the next interval, not again in the current one.