### PR TITLE
Implement Runtime.removeDefaultLoggers

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -450,6 +450,11 @@ object Runtime extends RuntimePlatformSpecific {
     ZLayer.scoped(FiberRef.currentRuntimeFlags.locallyScopedWith(_ + RuntimeFlag.LogRuntime))
   }
 
+  val removeDefaultLoggers: ZLayer[Any, Nothing, Unit] = {
+    implicit val trace = Trace.empty
+    ZLayer.scoped(FiberRef.currentLoggers.locallyScopedWith(_ -- Runtime.defaultLoggers))
+  }
+
   def setBlockingExecutor(executor: Executor)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentBlockingExecutor.locallyScoped(executor))
 


### PR DESCRIPTION
Alternative to #6771. Resolves #6767.

I think we could say that if including the `defaultLoggers` is the default, then removing them represents an intentional user choice not to include them and it is unlikely that another application would be adding them (since they are already the default). So we can add an operator to remove the default loggers with relatively little impact on goals around compositional updates.

This makes it easier to remove the default loggers because you can just do so directly versus needing to use a different runtime and then customize it.