### PR TITLE
Implement Operators For Updating Default Services

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnv.scala
+++ b/core/shared/src/main/scala/zio/ZEnv.scala
@@ -40,6 +40,6 @@ object ZEnv {
   /**
    * The default ZIO services.
    */
-  val services: FiberRef.WithPatch[ZEnvironment[ZEnv], ZEnvironment.Patch[ZEnv, ZEnv]] =
+  private[zio] val services: FiberRef.WithPatch[ZEnvironment[ZEnv], ZEnvironment.Patch[ZEnv, ZEnv]] =
     FiberRef.unsafeMakeEnvironment(Services.live)
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4521,6 +4521,34 @@ object ZIO extends ZIOCompanionPlatformSpecific {
     }
 
   /**
+   * Executes the specified workflow with the specified implementation of the
+   * clock service.
+   */
+  def withClock[R, E, A <: Clock, B](clock: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+    ZEnv.services.locallyWith(_.add(clock))(zio)
+
+  /**
+   * Sets the implementation of the clock service to the specified value and
+   * restores it to its original value when the scope is closed.
+   */
+  def withClockScoped[A <: Clock](clock: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
+    ZEnv.services.locallyScopedWith(_.add(clock))
+
+  /**
+   * Executes the specified workflow with the specified implementation of the
+   * console service.
+   */
+  def withConsole[R, E, A <: Console, B](console: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+    ZEnv.services.locallyWith(_.add(console))(zio)
+
+  /**
+   * Sets the implementation of the console service to the specified value and
+   * restores it to its original value when the scope is closed.
+   */
+  def withConsoleScoped[A <: Console](console: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
+    ZEnv.services.locallyScopedWith(_.add(console))
+
+  /**
    * Runs the specified effect with the specified maximum number of fibers for
    * parallel operators.
    */
@@ -4533,6 +4561,34 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    */
   def withParallelismUnbounded[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
     ZIO.suspendSucceed(Parallelism.locally(None)(zio))
+
+  /**
+   * Executes the specified workflow with the specified implementation of the
+   * random service.
+   */
+  def withRandom[R, E, A <: Random, B](random: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+    ZEnv.services.locallyWith(_.add(random))(zio)
+
+  /**
+   * Sets the implementation of the random service to the specified value and
+   * restores it to its original value when the scope is closed.
+   */
+  def withRandomScoped[A <: Random](random: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
+    ZEnv.services.locallyScopedWith(_.add(random))
+
+  /**
+   * Executes the specified workflow with the specified implementation of the
+   * system service.
+   */
+  def withSystem[R, E, A <: System, B](system: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+    ZEnv.services.locallyWith(_.add(system))(zio)
+
+  /**
+   * Sets the implementation of the system service to the specified value and
+   * restores it to its original value when the scope is closed.
+   */
+  def withSystemScoped[A <: System](system: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
+    ZEnv.services.locallyScopedWith(_.add(system))
 
   /**
    * Returns an effect that yields to the runtime system, starting on a fresh

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4524,7 +4524,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Executes the specified workflow with the specified implementation of the
    * clock service.
    */
-  def withClock[R, E, A <: Clock, B](clock: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+  def withClock[R, E, A <: Clock, B](clock: => A)(
+    zio: => ZIO[R, E, B]
+  )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
     ZEnv.services.locallyWith(_.add(clock))(zio)
 
   /**
@@ -4538,7 +4540,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Executes the specified workflow with the specified implementation of the
    * console service.
    */
-  def withConsole[R, E, A <: Console, B](console: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+  def withConsole[R, E, A <: Console, B](console: => A)(
+    zio: => ZIO[R, E, B]
+  )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
     ZEnv.services.locallyWith(_.add(console))(zio)
 
   /**
@@ -4566,7 +4570,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Executes the specified workflow with the specified implementation of the
    * random service.
    */
-  def withRandom[R, E, A <: Random, B](random: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+  def withRandom[R, E, A <: Random, B](random: => A)(
+    zio: => ZIO[R, E, B]
+  )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
     ZEnv.services.locallyWith(_.add(random))(zio)
 
   /**
@@ -4580,7 +4586,9 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * Executes the specified workflow with the specified implementation of the
    * system service.
    */
-  def withSystem[R, E, A <: System, B](system: => A)(zio: => ZIO[R, E, B])(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
+  def withSystem[R, E, A <: System, B](system: => A)(
+    zio: => ZIO[R, E, B]
+  )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
     ZEnv.services.locallyWith(_.add(system))(zio)
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1005,7 +1005,7 @@ object TestAspect extends TimeoutVariants {
         val layer = ZLayer.scoped {
           for {
             clock <- live(ZIO.clock)
-            _     <- ZEnv.services.locallyScopedWith(_.add(clock))
+            _     <- ZIO.withClockScoped(clock)
           } yield ()
         }
         spec.provideSomeLayer[R](layer)
@@ -1021,7 +1021,7 @@ object TestAspect extends TimeoutVariants {
         val layer = ZLayer.scoped {
           for {
             console <- live(ZIO.console)
-            _       <- ZEnv.services.locallyScopedWith(_.add(console))
+            _       <- ZIO.withConsoleScoped(console)
           } yield ()
         }
         spec.provideSomeLayer[R](layer)
@@ -1046,7 +1046,7 @@ object TestAspect extends TimeoutVariants {
         val layer = ZLayer.scoped {
           for {
             random <- live(ZIO.random)
-            _      <- ZEnv.services.locallyScopedWith(_.add(random))
+            _      <- ZIO.withRandomScoped(random)
           } yield ()
         }
         spec.provideSomeLayer[R](layer)
@@ -1062,7 +1062,7 @@ object TestAspect extends TimeoutVariants {
         val layer = ZLayer.scoped {
           for {
             system <- live(ZIO.system)
-            _      <- ZEnv.services.locallyScopedWith(_.add(system))
+            _      <- ZIO.withSystemScoped(system)
           } yield ()
         }
         spec.provideSomeLayer[R](layer)

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -421,7 +421,7 @@ object TestClock extends Serializable {
         warningState          <- Ref.Synchronized.make(WarningData.start)
         suspendedWarningState <- Ref.Synchronized.make(SuspendedWarningData.start)
         test                   = Test(clockState, live, annotations, warningState, suspendedWarningState)
-        _                     <- ZEnv.services.locallyScopedWith(_.add(test))
+        _                     <- ZIO.withClockScoped(test)
         _                     <- ZIO.addFinalizer(test.warningDone *> test.suspendedWarningDone)
       } yield test
     }

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -219,7 +219,7 @@ object TestConsole extends Serializable {
         ref      <- ZIO.succeed(Ref.unsafeMake(data))
         debugRef <- FiberRef.make(debug)
         test      = Test(ref, live, debugRef)
-        _        <- ZEnv.services.locallyScopedWith(_.add(test))
+        _        <- ZIO.withConsoleScoped(test)
       } yield test
     }
 

--- a/test/shared/src/main/scala/zio/test/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/TestRandom.scala
@@ -779,7 +779,7 @@ object TestRandom extends Serializable {
         data   <- ZIO.succeed(Ref.unsafeMake(data))
         buffer <- ZIO.succeed(Ref.unsafeMake(Buffer()))
         test    = Test(data, buffer)
-        _      <- ZEnv.services.locallyScopedWith(_.add(test))
+        _      <- ZIO.withRandomScoped(test)
       } yield test
     }
   }

--- a/test/shared/src/main/scala/zio/test/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/TestSystem.scala
@@ -193,7 +193,7 @@ object TestSystem extends Serializable {
       for {
         ref <- ZIO.succeed(Ref.unsafeMake(data))
         test = Test(ref)
-        _   <- ZEnv.services.locallyScopedWith(_.add(test))
+        _   <- ZIO.withSystemScoped(test)
       } yield test
     }
   }


### PR DESCRIPTION
The current way of updating the default services using `ZEnv.services` is relatively low level in it requires users to work directly with `FiberRef` and `ZEnvironment`. Instead we can implement a set of operators that allow updating each of the default services. This creates a simpler interface for users where they can just do `ZIO.withClock(myClock)(myWorkFlow)`. It also allows us to enforce guarantees that the set of services can only be modified in a scoped way and that services can only be added and never removed. 