### PR TITLE
Delete ZEnv

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -367,7 +367,7 @@ object FiberRefSpec extends ZIOBaseSpec {
         testConsole <- testConsole
         testRandom  <- testRandom
         testSystem  <- testSystem
-        fiberRef    <- FiberRef.makeEnvironment(ZEnv.Services.live)
+        fiberRef    <- FiberRef.makeEnvironment(DefaultServices.live)
         _           <- fiberRef.update(_.add(testClock))
         left        <- fiberRef.update(_.add(testConsole)).fork
         right       <- fiberRef.update(_.add(testRandom)).fork

--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -63,15 +63,15 @@ object ZLayerSpec extends ZIOBaseSpec {
       test("Size of Test layers") {
         for {
           r1 <- testSize(Annotations.live, 1, "Annotations.live")
-          r2 <- testSize(ZEnv.live >>> Live.default >>> TestConsole.debug, 1, "TestConsole.default")
-          r3 <- testSize(ZEnv.live >>> Live.default, 1, "Live.default")
-          r4 <- testSize(ZEnv.live >>> TestRandom.deterministic, 1, "TestRandom.live")
+          r2 <- testSize(liveEnvironment >>> Live.default >>> TestConsole.debug, 1, "TestConsole.default")
+          r3 <- testSize(liveEnvironment >>> Live.default, 1, "Live.default")
+          r4 <- testSize(liveEnvironment >>> TestRandom.deterministic, 1, "TestRandom.live")
           r5 <- testSize(Sized.live(100), 1, "Sized.live(100)")
           r6 <- testSize(TestSystem.default, 1, "TestSystem.default")
         } yield r1 && r2 && r3 && r4 && r5 && r6
       },
       test("Size of >>> (9)") {
-        val layer = ZEnv.live >>>
+        val layer = liveEnvironment >>>
           (Annotations.live ++ (Live.default >>> TestConsole.debug) ++
             Live.default ++ TestRandom.deterministic ++ Sized.live(100)
             ++ TestSystem.default)
@@ -517,9 +517,9 @@ object ZLayerSpec extends ZIOBaseSpec {
         } yield assertTrue(person == ZEnvironment(Person("Jane Doe", 42)))
       },
       test("preserves failures") {
-        val layer1   = ZEnv.live >>> TestEnvironment.live
+        val layer1   = liveEnvironment >>> TestEnvironment.live
         val layer2   = ZLayer.fromZIO(ZIO.fail("fail"))
-        val layer3   = ZEnv.live >>> TestEnvironment.live
+        val layer3   = liveEnvironment >>> TestEnvironment.live
         val combined = layer1 ++ layer2 ++ layer3
         for {
           exit <- ZIO.scoped(combined.build).exit

--- a/core/shared/src/main/scala-2/zio/internal/macros/ZLayerMakeMacros.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/ZLayerMakeMacros.scala
@@ -1,7 +1,7 @@
 package zio.internal.macros
 
 import zio.internal.ansi.AnsiStringOps
-import zio.{ZLayer, ZEnv}
+import zio.ZLayer
 
 import scala.reflect.macros.blackbox
 

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -19,27 +19,21 @@ package zio
 import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-object ZEnv {
-
-  private[zio] object Services {
-    val live: ZEnvironment[ZEnv] =
-      ZEnvironment[Clock, Console, System, Random](
-        Clock.ClockLive,
-        Console.ConsoleLive,
-        System.SystemLive,
-        Random.RandomLive
-      )
-  }
-
-  val any: ZLayer[ZEnv, Nothing, ZEnv] =
-    ZLayer.environment[ZEnv](Tracer.newTrace)
-
-  val live: Layer[Nothing, ZEnv] =
-    Clock.live ++ Console.live ++ System.live ++ Random.live
+object DefaultServices {
 
   /**
    * The default ZIO services.
    */
-  private[zio] val services: FiberRef.WithPatch[ZEnvironment[ZEnv], ZEnvironment.Patch[ZEnv, ZEnv]] =
-    FiberRef.unsafeMakeEnvironment(Services.live)
+  val live: ZEnvironment[Clock with Console with System with Random] =
+    ZEnvironment[Clock, Console, System, Random](
+      Clock.ClockLive,
+      Console.ConsoleLive,
+      System.SystemLive,
+      Random.RandomLive
+    )
+
+  private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[
+    Clock with Console with System with Random
+  ], ZEnvironment.Patch[Clock with Console with System with Random, Clock with Console with System with Random]] =
+    FiberRef.unsafeMakeEnvironment(live)
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2660,7 +2660,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * specified workflow.
    */
   def clockWith[R, E, A](f: Clock => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-    ZEnv.services.getWith(services => f(services.get[Clock]))
+    DefaultServices.currentServices.getWith(services => f(services.get[Clock]))
 
   /**
    * Evaluate each effect in the structure from left to right, collecting the
@@ -2869,7 +2869,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * specified workflow.
    */
   def consoleWith[R, E, A](f: Console => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-    ZEnv.services.getWith(services => f(services.get[Console]))
+    DefaultServices.currentServices.getWith(services => f(services.get[Console]))
 
   /**
    * Prints the specified message to the console for debugging purposes.
@@ -4020,7 +4020,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * specified workflow.
    */
   def randomWith[R, E, A](f: Random => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-    ZEnv.services.getWith(services => f(services.get[Random]))
+    DefaultServices.currentServices.getWith(services => f(services.get[Random]))
 
   /**
    * Reduces an `Iterable[IO]` to a single `IO`, working sequentially.
@@ -4264,7 +4264,7 @@ object ZIO extends ZIOCompanionPlatformSpecific {
    * specified workflow.
    */
   def systemWith[R, E, A](f: System => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-    ZEnv.services.getWith(services => f(services.get[System]))
+    DefaultServices.currentServices.getWith(services => f(services.get[System]))
 
   /**
    * Capture ZIO trace at the current point
@@ -4527,14 +4527,14 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def withClock[R, E, A <: Clock, B](clock: => A)(
     zio: => ZIO[R, E, B]
   )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
-    ZEnv.services.locallyWith(_.add(clock))(zio)
+    DefaultServices.currentServices.locallyWith(_.add(clock))(zio)
 
   /**
    * Sets the implementation of the clock service to the specified value and
    * restores it to its original value when the scope is closed.
    */
   def withClockScoped[A <: Clock](clock: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZEnv.services.locallyScopedWith(_.add(clock))
+    DefaultServices.currentServices.locallyScopedWith(_.add(clock))
 
   /**
    * Executes the specified workflow with the specified implementation of the
@@ -4543,14 +4543,14 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def withConsole[R, E, A <: Console, B](console: => A)(
     zio: => ZIO[R, E, B]
   )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
-    ZEnv.services.locallyWith(_.add(console))(zio)
+    DefaultServices.currentServices.locallyWith(_.add(console))(zio)
 
   /**
    * Sets the implementation of the console service to the specified value and
    * restores it to its original value when the scope is closed.
    */
   def withConsoleScoped[A <: Console](console: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZEnv.services.locallyScopedWith(_.add(console))
+    DefaultServices.currentServices.locallyScopedWith(_.add(console))
 
   /**
    * Runs the specified effect with the specified maximum number of fibers for
@@ -4573,14 +4573,14 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def withRandom[R, E, A <: Random, B](random: => A)(
     zio: => ZIO[R, E, B]
   )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
-    ZEnv.services.locallyWith(_.add(random))(zio)
+    DefaultServices.currentServices.locallyWith(_.add(random))(zio)
 
   /**
    * Sets the implementation of the random service to the specified value and
    * restores it to its original value when the scope is closed.
    */
   def withRandomScoped[A <: Random](random: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZEnv.services.locallyScopedWith(_.add(random))
+    DefaultServices.currentServices.locallyScopedWith(_.add(random))
 
   /**
    * Executes the specified workflow with the specified implementation of the
@@ -4589,14 +4589,14 @@ object ZIO extends ZIOCompanionPlatformSpecific {
   def withSystem[R, E, A <: System, B](system: => A)(
     zio: => ZIO[R, E, B]
   )(implicit tag: Tag[A], trace: Trace): ZIO[R, E, B] =
-    ZEnv.services.locallyWith(_.add(system))(zio)
+    DefaultServices.currentServices.locallyWith(_.add(system))(zio)
 
   /**
    * Sets the implementation of the system service to the specified value and
    * restores it to its original value when the scope is closed.
    */
   def withSystemScoped[A <: System](system: => A)(implicit tag: Tag[A], trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZEnv.services.locallyScopedWith(_.add(system))
+    DefaultServices.currentServices.locallyScopedWith(_.add(system))
 
   /**
    * Returns an effect that yields to the runtime system, starting on a fresh

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -27,8 +27,6 @@ package object zio
     with VersionSpecific
     with DurationModule {
 
-  type ZEnv = Clock with Console with System with Random
-
   type ZNothing <: Nothing
 
   type IO[+E, +A]   = ZIO[Any, E, A]         // Succeed with an `A`, may fail with `E`        , no requirements.

--- a/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-2/zio.stream/ZStreamVersionSpecific.scala
@@ -1,7 +1,7 @@
 package zio.stream
 
 import zio.internal.macros.LayerMacros
-import zio.{ZEnv, ZLayer}
+import zio.ZLayer
 
 private[stream] trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>
 

--- a/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
@@ -1,6 +1,6 @@
 package zio.stream
 
-import zio.{ZLayer, ZEnv}
+import zio.ZLayer
 import zio.internal.macros.LayerMacros
 
 trait ZStreamVersionSpecific[-R, +E, +O] { self: ZStream[R, E, O] =>

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -82,7 +82,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
     unsafeRun(
       scoped
         .provide(
-          Scope.default >>> (ZEnv.live >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+          Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
           ZIOAppArgs.empty,
           spec.bootstrap
         )
@@ -102,7 +102,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
           Console.ConsoleLive
         )
         .provide(
-          Scope.default >>> (ZEnv.live >>> TestEnvironment.live ++ ZLayer.environment[Scope] ++ spec.bootstrap),
+          Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope] ++ spec.bootstrap),
           ZIOAppArgs.empty
         )
     }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -3,16 +3,7 @@ package zio.test.sbt
 import sbt.testing.{Event, EventHandler, Logger, Status, Task, TaskDef}
 import zio.{CancelableFuture, Console, Runtime, Scope, UIO, ZEnvironment, ZIO, ZIOAppArgs, ZLayer, Trace}
 import zio.test.render.ConsoleRenderer
-import zio.test.{
-  ExecutionEvent,
-  FilteredSpec,
-  Summary,
-  TestArgs,
-  TestEnvironment,
-  TestLogger,
-  ZIOSpecAbstract,
-  ZTestEventHandler
-}
+import zio.test._
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -31,7 +22,7 @@ abstract class BaseTestTask[T](
     console: Console
   )(implicit trace: Trace): ZLayer[Any, Nothing, TestEnvironment with TestLogger with ZIOAppArgs with Scope] = {
     ZIOAppArgs.empty +!+ (
-      (zio.ZEnv.live ++ Scope.default) >>>
+      (liveEnvironment ++ Scope.default) >>>
         TestEnvironment.live >+> TestLogger.fromConsole(console)
     )
   } +!+ Scope.default

--- a/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/IntellijRendererSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion.equalTo
 import zio.test.ReportingTestUtils._
 import zio.test.TestAspect.silent
 import zio.test.render.IntelliJRenderer
-import zio.{Random, Scope, ZEnv, ZIO, ZIOAppArgs, ZLayer, Trace}
+import zio.{Random, Scope, ZIO, ZIOAppArgs, ZLayer, Trace}
 
 object IntellijRendererSpec extends ZIOBaseSpec {
   import IntelliJRenderUtils._
@@ -206,7 +206,7 @@ object IntelliJRenderUtils {
     TestRunner[TestEnvironment, String](
       executor = TestExecutor.default[TestEnvironment, String](
         Scope.default >>> testEnvironment,
-        (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
+        (liveEnvironment ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
         sinkLayer,
         _ => ZIO.unit // Does Intellij need to report events?
       ),

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio.test.Assertion.{equalTo, isGreaterThan, isLessThan, isRight, isSome, not}
 import zio.test.render.TestRenderer
-import zio.{Cause, Console, Scope, ZEnv, ZIO, ZIOAppArgs, ZLayer, Trace}
+import zio.{Cause, Console, Scope, ZIO, ZIOAppArgs, ZLayer, Trace}
 
 import scala.{Console => SConsole}
 
@@ -66,7 +66,7 @@ object ReportingTestUtils {
     TestRunner[TestEnvironment, String](
       executor = TestExecutor.default[TestEnvironment, String](
         Scope.default >>> testEnvironment,
-        (ZEnv.live ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
+        (liveEnvironment ++ Scope.default) >+> TestEnvironment.live ++ ZIOAppArgs.empty,
         sinkLayerWithConsole(console),
         _ => ZIO.unit // Might be useful for additional testing
       ),

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{Console, FiberRef, IO, Ref, UIO, URIO, ZEnv, ZIO, ZLayer, Trace}
+import zio.{Console, FiberRef, IO, Ref, UIO, URIO, ZIO, ZLayer, Trace}
 import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 

--- a/test/shared/src/main/scala/zio/test/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/TestSystem.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{IO, Layer, Ref, System, UIO, URIO, ZEnv, ZIO, ZLayer, Trace}
+import zio.{IO, Layer, Ref, System, UIO, URIO, ZIO, ZLayer, Trace}
 import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -41,7 +41,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
 
     runSpec.provideSomeLayer[ZIOAppArgs with Scope](
       ZLayer.environment[ZIOAppArgs with Scope] +!+
-        (ZEnv.live >>> TestEnvironment.live +!+ bootstrap +!+ TestLogger.fromConsole(Console.ConsoleLive))
+        (liveEnvironment >>> TestEnvironment.live +!+ bootstrap +!+ TestLogger.fromConsole(Console.ConsoleLive))
     )
   }
 
@@ -115,7 +115,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       environment1: ZEnvironment[ZIOAppArgs with Scope] = runtime.environment
       sharedLayer: ZLayer[Any, Any, Environment] =
         ZLayer.succeedEnvironment(environment0) >>> bootstrap
-      perTestLayer = (ZLayer.succeedEnvironment(environment1) ++ ZEnv.live) >>> (TestEnvironment.live ++ ZLayer
+      perTestLayer = (ZLayer.succeedEnvironment(environment1) ++ liveEnvironment) >>> (TestEnvironment.live ++ ZLayer
                        .environment[Scope] ++ ZLayer.environment[ZIOAppArgs])
       executionEventSinkLayer = sinkLayerWithConsole(console)
       runner =
@@ -159,7 +159,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       environment1: ZEnvironment[ZIOAppArgs with Scope] = castedRuntime.environment
       sharedLayer: ZLayer[Any, Nothing, Environment with ExecutionEventSink] =
         ZLayer.succeedEnvironment(castedRuntime.environment)
-      perTestLayer = (ZLayer.succeedEnvironment(environment1) ++ ZEnv.live) >>> (TestEnvironment.live ++ ZLayer
+      perTestLayer = (ZLayer.succeedEnvironment(environment1) ++ liveEnvironment) >>> (TestEnvironment.live ++ ZLayer
                        .environment[Scope] ++ ZLayer.environment[ZIOAppArgs])
       executionEventSinkLayer = sharedLayer
       runner =

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -7,10 +7,8 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
 
-  override val bootstrap: ZLayer[ZIOAppArgs with Scope, Any, TestEnvironment] = {
-    implicit val trace: zio.Trace = Tracer.newTrace
-    zio.ZEnv.live >>> TestEnvironment.live
-  }
+  override val bootstrap: ZLayer[ZIOAppArgs with Scope, Any, TestEnvironment] =
+    testEnvironment
 
   def spec: Spec[TestEnvironment with Scope, Any]
 }


### PR DESCRIPTION
The `ZEnv` type alias is a legacy from when the default services were in the environment and is now really only used internally.