### PR TITLE
Return Leftovers in Queue#offerAll

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -579,7 +579,7 @@ object QueueSpec extends ZIOBaseSpec {
         v     <- queue.offerAll(List(1, 2, 3))
         size  <- queue.size
       } yield assert(size)(equalTo(2)) &&
-        assert(v)(isTrue)
+        assert(v)(isEmpty)
     },
     test("sliding strategy with enough capacity") {
       for {
@@ -596,7 +596,7 @@ object QueueSpec extends ZIOBaseSpec {
         v1    <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
         l     <- queue.takeAll
       } yield assert(l)(equalTo(Chunk(5, 6))) &&
-        assert(v1)(isTrue)
+        assert(v1)(isEmpty)
     },
     test("awaitShutdown") {
       for {
@@ -644,7 +644,7 @@ object QueueSpec extends ZIOBaseSpec {
         queue    <- Queue.dropping[Int](capacity)
         v1       <- queue.offerAll(Iterable(1, 2, 3, 4, 5, 6))
         _        <- queue.takeAll
-      } yield assert(v1)(isFalse)
+      } yield assert(v1)(equalTo(Chunk(3, 4, 5, 6)))
     },
     test("dropping strategy with offerAll, check ordering") {
       for {
@@ -665,7 +665,7 @@ object QueueSpec extends ZIOBaseSpec {
         oa       <- queue.offerAll(iter.toList)
         j        <- f.join
       } yield assert(j)(equalTo(1)) &&
-        assert(oa)(isFalse)
+        assert(oa)(equalTo(Chunk(4)))
     },
     test("sliding strategy with pending taker") {
       for {
@@ -677,7 +677,7 @@ object QueueSpec extends ZIOBaseSpec {
         oa       <- queue.offerAll(iter.toList)
         t        <- queue.take
       } yield assert(t)(equalTo(3)) &&
-        assert(oa)(isTrue)
+        assert(oa)(isEmpty)
     },
     test("sliding strategy, check offerAll returns true") {
       for {
@@ -685,7 +685,7 @@ object QueueSpec extends ZIOBaseSpec {
         queue    <- Queue.sliding[Int](capacity)
         iter      = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
-      } yield assert(oa)(isTrue)
+      } yield assert(oa)(isEmpty)
     },
     test("bounded strategy, check offerAll returns true") {
       for {
@@ -693,7 +693,7 @@ object QueueSpec extends ZIOBaseSpec {
         queue    <- Queue.bounded[Int](capacity)
         iter      = Range.inclusive(1, 3)
         oa       <- queue.offerAll(iter.toList)
-      } yield assert(oa)(isTrue)
+      } yield assert(oa)(isEmpty)
     },
     test("poll on empty queue") {
       for {

--- a/core/js/src/main/scala/zio/internal/BoundedHubArb.scala
+++ b/core/js/src/main/scala/zio/internal/BoundedHubArb.scala
@@ -50,7 +50,7 @@ private final class BoundedHubArb[A](requestedCapacity: Int) extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val n         = as.size
     val size      = (publisherIndex - subscribersIndex).toInt
     val available = capacity - size

--- a/core/js/src/main/scala/zio/internal/BoundedHubPow2.scala
+++ b/core/js/src/main/scala/zio/internal/BoundedHubPow2.scala
@@ -51,7 +51,7 @@ private final class BoundedHubPow2[A](requestedCapacity: Int) extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val n         = as.size
     val size      = (publisherIndex - subscribersIndex).toInt
     val available = capacity - size

--- a/core/js/src/main/scala/zio/internal/BoundedHubSingle.scala
+++ b/core/js/src/main/scala/zio/internal/BoundedHubSingle.scala
@@ -48,7 +48,7 @@ private final class BoundedHubSingle[A] extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] =
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] =
     if (as.isEmpty) Chunk.empty
     else {
       val a = as.head

--- a/core/js/src/main/scala/zio/internal/UnboundedHub.scala
+++ b/core/js/src/main/scala/zio/internal/UnboundedHub.scala
@@ -50,7 +50,7 @@ private final class UnboundedHub[A] extends Hub[A] {
     true
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val iterator = as.iterator
     while (iterator.hasNext) {
       val a = iterator.next()

--- a/core/jvm/src/main/scala/zio/internal/BoundedHubArb.scala
+++ b/core/jvm/src/main/scala/zio/internal/BoundedHubArb.scala
@@ -92,7 +92,7 @@ private final class BoundedHubArb[A](requestedCapacity: Int) extends Hub[A] {
     published
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     var currentState = state.get
     val iterator     = as.iterator
     var loop         = true

--- a/core/jvm/src/main/scala/zio/internal/BoundedHubPow2.scala
+++ b/core/jvm/src/main/scala/zio/internal/BoundedHubPow2.scala
@@ -93,7 +93,7 @@ private final class BoundedHubPow2[A](requestedCapacity: Int) extends Hub[A] {
     published
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     var currentState = state.get
     val iterator     = as.iterator
     var loop         = true

--- a/core/jvm/src/main/scala/zio/internal/BoundedHubSingle.scala
+++ b/core/jvm/src/main/scala/zio/internal/BoundedHubSingle.scala
@@ -69,7 +69,7 @@ private final class BoundedHubSingle[A] extends Hub[A] {
     published
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] =
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] =
     if (as.isEmpty) Chunk.empty
     else {
       val a = as.head

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -242,7 +242,7 @@ abstract class RingBuffer[A](override final val capacity: Int) extends MutableQu
     }
   }
 
-  override final def offerAll(as: Iterable[A]): Chunk[A] = {
+  override final def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val aCapacity = capacity
 
     val aSeq   = seq

--- a/core/jvm/src/main/scala/zio/internal/UnboundedHub.scala
+++ b/core/jvm/src/main/scala/zio/internal/UnboundedHub.scala
@@ -92,7 +92,7 @@ private final class UnboundedHub[A] extends Hub[A] {
     true
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val iterator = as.iterator
     while (iterator.hasNext) {
       val a = iterator.next()

--- a/core/native/src/main/scala/zio/internal/BoundedHubArb.scala
+++ b/core/native/src/main/scala/zio/internal/BoundedHubArb.scala
@@ -50,7 +50,7 @@ private final class BoundedHubArb[A](requestedCapacity: Int) extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val n         = as.size
     val size      = (publisherIndex - subscribersIndex).toInt
     val available = capacity - size

--- a/core/native/src/main/scala/zio/internal/BoundedHubPow2.scala
+++ b/core/native/src/main/scala/zio/internal/BoundedHubPow2.scala
@@ -51,7 +51,7 @@ private final class BoundedHubPow2[A](requestedCapacity: Int) extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val n         = as.size
     val size      = (publisherIndex - subscribersIndex).toInt
     val available = capacity - size

--- a/core/native/src/main/scala/zio/internal/BoundedHubSingle.scala
+++ b/core/native/src/main/scala/zio/internal/BoundedHubSingle.scala
@@ -48,7 +48,7 @@ private final class BoundedHubSingle[A] extends Hub[A] {
       true
     }
 
-  def publishAll(as: Iterable[A]): Chunk[A] =
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] =
     if (as.isEmpty) Chunk.empty
     else {
       val a = as.head

--- a/core/native/src/main/scala/zio/internal/UnboundedHub.scala
+++ b/core/native/src/main/scala/zio/internal/UnboundedHub.scala
@@ -50,7 +50,7 @@ private final class UnboundedHub[A] extends Hub[A] {
     true
   }
 
-  def publishAll(as: Iterable[A]): Chunk[A] = {
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     val iterator = as.iterator
     while (iterator.hasNext) {
       val a = iterator.next()

--- a/core/shared/src/main/scala/zio/Enqueue.scala
+++ b/core/shared/src/main/scala/zio/Enqueue.scala
@@ -45,20 +45,22 @@ trait Enqueue[-A] extends Serializable {
 
   /**
    * For Bounded Queue: uses the `BackPressure` Strategy, places the values in
-   * the queue and always returns true. If the queue has reached capacity, then
-   * the fiber performing the `offerAll` will be suspended until there is room
-   * in the queue.
+   * the queue and always returns no leftovers. If the queue has reached
+   * capacity, then the fiber performing the `offerAll` will be suspended until
+   * there is room in the queue.
    *
-   * For Unbounded Queue: Places all values in the queue and returns true.
+   * For Unbounded Queue: Places all values in the queue and returns no
+   * leftovers.
    *
    * For Sliding Queue: uses `Sliding` Strategy If there is room in the queue,
    * it places the values otherwise it removes the old elements and enqueues the
-   * new ones. Always returns true.
+   * new ones. Always returns no leftovers.
    *
    * For Dropping Queue: uses `Dropping` Strategy, It places the values in the
-   * queue but if there is no room it will not enqueue them and return false.
+   * queue but if there is no room it will not enqueue them and return the
+   * leftovers.
    */
-  def offerAll(as: Iterable[A])(implicit trace: Trace): UIO[Boolean]
+  def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]]
 
   /**
    * Interrupts any fibers that are suspended on `offer` or `take`. Future calls

--- a/core/shared/src/main/scala/zio/internal/Hub.scala
+++ b/core/shared/src/main/scala/zio/internal/Hub.scala
@@ -52,7 +52,7 @@ abstract class Hub[A] extends Serializable {
    * Publishes the specified values to the hub, returning the values that could
    * not be successfully published to the hub.
    */
-  def publishAll(as: Iterable[A]): Chunk[A]
+  def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1]
 
   /**
    * The current number of values in the hub.

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -68,8 +68,8 @@ protected[zio] abstract class MutableConcurrentQueue[A] {
   /**
    * A non-blocking enqueue of multiple elements.
    */
-  def offerAll(as: Iterable[A]): Chunk[A] = {
-    val builder  = ChunkBuilder.make[A]()
+  def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
+    val builder  = ChunkBuilder.make[A1]()
     val iterator = as.iterator
     var loop     = true
     while (loop && iterator.hasNext) {

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -48,7 +48,7 @@ private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with S
     success
   }
 
-  override def offerAll(as: Iterable[A]): Chunk[A] = {
+  override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     import collection.JavaConverters._
     jucConcurrentQueue.addAll(as.asJavaCollection): @silent("JavaConverters")
     enqueuedCounter.addAndGet(as.size.toLong)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -614,7 +614,7 @@ object ZSinkSpec extends ZIOBaseSpec {
 
             override def offer(a: A)(implicit trace: Trace): ZIO[Any, Nothing, Boolean] = q.offer(a)
 
-            override def offerAll(as: Iterable[A])(implicit trace: Trace): ZIO[Any, Nothing, Boolean] =
+            override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): ZIO[Any, Nothing, Chunk[A1]] =
               q.offerAll(as)
 
             override def shutdown(implicit trace: Trace): UIO[Unit] = ZIO.succeed(this.isShutDown = true)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5006,7 +5006,7 @@ object ZStreamSpec extends ZIOBaseSpec {
 
   trait ChunkCoordination[A] {
     def queue: Queue[Exit[Option[Nothing], Chunk[A]]]
-    def offer: UIO[Boolean]
+    def offer: UIO[Unit]
     def proceed: UIO[Unit]
     def awaitNext: UIO[Unit]
   }
@@ -5030,7 +5030,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                             val offer = ref.modify {
                               case x :: xs => (x, xs)
                               case Nil     => (Nil, Nil)
-                            }.flatMap(queue.offerAll)
+                            }.flatMap(queue.offerAll).unit
                             val proceed   = ps.offer(()).unit
                             val awaitNext = ps.take
                           }


### PR DESCRIPTION
Currently `Queue#offerAll` returns a `Boolean` to indicate whether the values were successfully offered to the queue. However, this is ambiguous because it isn't clear what happens if only some of the values can be offered to the queue. Furthermore, it can never provide as much information as the caller needs under concurrency because the caller doesn't know which items were not successfully published and thus require further handling.

We can improve this by having `offerAll` return a `Chunk` of leftovers. Then the semantic is quite clear that the leftovers represent the values that were not successfully offered and the caller can handle them as desired.