### PR TITLE
add Runtime.setLogger to complement existing addLogger

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -418,6 +418,9 @@ object Runtime extends RuntimePlatformSpecific {
   def addLogger(logger: ZLogger[String, Any])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentLoggers.locallyScopedWith(_ + logger))
 
+  def setLogger(logger: ZLogger[String, Any])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
+    ZLayer.scoped(FiberRef.currentLoggers.locallyScoped(logger))
+
   def addSupervisor(supervisor: Supervisor[Any])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentSupervisors.locallyScopedWith(_ + supervisor))
 


### PR DESCRIPTION
There was a new method `Runtime.addLogger` added in https://github.com/zio/zio/pull/6742
However I want to remove the default logger and replace it with a custom one (this is for logging a simple format for an AWS lambda)
I couldn't find a way to do it in my application, as the mechanics needed are private.
I propose to add a setLogger method so this can be done by using `Runtime.setLogger` to create a layer that replaces the logger in that scope.
Totally happy to go with any other approach or suggestion.