### PR TITLE
Periodically Clean Up ZEnvironment

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -99,14 +99,18 @@ final class ZEnvironment[+R] private (
    * service collisions, which may not be reflected in statically known types,
    * the right hand side will be preferred.
    */
-  def unionAll[R1](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
+  def unionAll[R1](that: ZEnvironment[R1]): ZEnvironment[R with R1] = {
+    val (self0, that0) = if (self.index + that.index < self.index) (self.clean, that.clean) else (self, that)
     new ZEnvironment(
-      self.map ++ that.map.map { case (tag, (service, index)) => (tag, (service, self.index + index)) },
-      self.index + that.index
+      self0.map ++ that0.map.map { case (tag, (service, index)) => (tag, (service, self0.index + index)) },
+      self0.index + that0.index
     )
+  }
 
-  private def unsafeAdd[A](tag: LightTypeTag, a: A): ZEnvironment[R with A] =
-    new ZEnvironment(self.map + (tag -> (a -> index)), index + 1)
+  private def unsafeAdd[A](tag: LightTypeTag, a: A): ZEnvironment[R with A] = {
+    val self0 = if (index == Int.MaxValue) self.clean else self
+    new ZEnvironment(self0.map + (tag -> (a -> self0.index)), self0.index + 1)
+  }
 
   def unsafeGet[A](tag: LightTypeTag): A =
     self.cache.get(tag) match {
@@ -154,6 +158,14 @@ final class ZEnvironment[+R] private (
     map.foldLeft[Map[K, V]](Map.empty) { case (acc, (key, value)) =>
       if (f(key)) acc + (key -> value) else acc
     }
+
+  private def clean: ZEnvironment[R] = {
+    val (map, index) = self.map.toList.sortBy(_._2._2).foldLeft[(Map[LightTypeTag, (Any, Int)], Int)]((Map.empty, 0)) {
+      case ((map, index), (tag, (service, _))) =>
+        map + (tag -> (service -> index)) -> (index + 1)
+    }
+    new ZEnvironment(map, index)
+  }
 }
 
 object ZEnvironment {


### PR DESCRIPTION
When we add services to the environment we maintain an index to track the order in which these services were added. This creates the equivalent of a "sparse" vector because when we add a new service that replaces an existing service we just give it a new index that is one greater than the last index instead of reindexing all the other services. This makes sense for performance but creates the risk that the indices will grow extremely large after repeated unions. We need to reindex the map at a certain point to avoid this.