### PR TITLE
Specify Return Type Of Sink.summarized

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -347,7 +347,7 @@ class ZSink[-R, +E, -In, +L, +Z](val channel: ZChannel[R, ZNothing, Chunk[In], A
    */
   final def summarized[R1 <: R, E1 >: E, B, C](
     summary: => ZIO[R1, E1, B]
-  )(f: (B, B) => C)(implicit trace: Trace) =
+  )(f: (B, B) => C)(implicit trace: Trace): ZSink[R1, E1, In, L, (Z, C)] =
     new ZSink[R1, E1, In, L, (Z, C)](
       ZChannel.unwrap {
         ZIO.succeed(summary).map { summary =>


### PR DESCRIPTION
We should specify the return type to document the API.