### PR TITLE
Implement ZIO#withEarlyRelease

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScopeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScopeSpec.scala
@@ -86,6 +86,19 @@ object ScopeSpec extends ZIOBaseSpec {
           actions.indexOf(Action.release(4)) < actions.indexOf(Action.release(3))
         }
       }
+    },
+    test("withEarlyRelease") {
+      for {
+        ref     <- Ref.make[Chunk[Action]](Chunk.empty)
+        left     = resource(1)(ref)
+        right    = resource(2)(ref).withEarlyRelease
+        _       <- left *> right.flatMap { case (release, _) => release }
+        actions <- ref.get
+      } yield assertTrue {
+        actions(0) == Action.acquire(1) &&
+        actions(1) == Action.acquire(2) &&
+        actions(2) == Action.release(2)
+      }
     }
   )
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2208,9 +2208,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def withEarlyRelease(implicit trace: Trace): ZIO[R with Scope, E, (UIO[Unit], A)] =
     ZIO.scopeWith { parent =>
-      scope.fork.flatMap { child =>
+      parent.fork.flatMap { child =>
         child.extend[R](self).map { a =>
-          (ZIO.fiberIdWith(fiberId => scope.close(Exit.interrupt(fiberId))), a)
+          (ZIO.fiberIdWith(fiberId => child.close(Exit.interrupt(fiberId))), a)
         }
       }
     }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2203,6 +2203,19 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
     ZIO.whenZIO(p)(self)
 
   /**
+   * Returns a new scoped workflow that returns the result of this workflow as
+   * well as a finalizer that can be run to close the scope of this workflow.
+   */
+  final def withEarlyRelease(implicit trace: Trace): ZIO[R with Scope, E, (UIO[Unit], A)] =
+    ZIO.scopeWith { parent =>
+      scope.fork.flatMap { child =>
+        child.extend[R](self).map { a =>
+          (ZIO.fiberIdWith(fiberId => scope.close(Exit.interrupt(fiberId))), a)
+        }
+      }
+    }
+
+  /**
    * Treats this effect as the acquisition of a resource and adds the specified
    * finalizer to the current scope. This effect will be run uninterruptibly and
    * the finalizer will be run when the scope is closed.


### PR DESCRIPTION
Returns a new scoped workflow that returns the result of the original scoped workflow as well as a finalizer that can be run to close the scope. This can be useful when the original resource is determined to be invalid and we want to release it immediately before trying to acquire a new resource.