### PR TITLE
Added Automatic-Module-Name to JAR manifest

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -220,7 +220,13 @@ object BuildHelper {
     autoAPIMappings := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
     Compile / fork := true,
-    Test / fork    := false
+    Test / fork    := false,
+    // For compatibility with Java 9+ module system;
+    // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
+    Compile / packageBin / packageOptions +=
+      Package.ManifestAttributes(
+        "Automatic-Module-Name" -> s"${organization.value.replaceAll("-", ".")}.${prjName.replaceAll("-", ".")}"
+      )
   )
 
   def macroExpansionSettings = Seq(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -225,7 +225,7 @@ object BuildHelper {
     // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
     Compile / packageBin / packageOptions +=
       Package.ManifestAttributes(
-        "Automatic-Module-Name" -> s"${organization.value.replaceAll("-", ".")}.${prjName.replaceAll("-", ".")}"
+        "Automatic-Module-Name" -> s"${organization.value}.$prjName".replaceAll("-", ".")
       )
   )
 


### PR DESCRIPTION
Fixes #6838.

This PR enables support for the Java (9+) module system via the [Automatic-Module-Name](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) attribute.

The names for published modules are:
```
dev.zio.zio
dev.zio.zio.concurrent
dev.zio.zio.macros
dev.zio.zio.stacktracer
dev.zio.zio.streams
dev.zio.zio.test
dev.zio.zio.test.junit
dev.zio.zio.test.magnolia
dev.zio.zio.test.refined
dev.zio.zio.test.sbt
dev.zio.zio.test.scalacheck
```

Additionally, all JAR artifacts passed the `jdeps --jdk-internals` sanity check.

### Watch
[SBT support](https://github.com/sbt/sbt/issues/3368)
