### PR TITLE
More ZPipeline error handling

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4428,7 +4428,6 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     repeatZIOChunkOption {
       queue
         .takeBetween(1, maxChunkSize)
-        .map(Chunk.fromIterable)
         .catchAllCause(c =>
           queue.isShutdown.flatMap { down =>
             if (down && c.isInterrupted) Pull.end


### PR DESCRIPTION
- I was missing `orDie` in some cases when dealing with the new `utf8Decode` which can fail
- Added some more missing variants too to make it in sync with other types
- Removed an unnecessary `Chunk.fromIterable`