### PR TITLE
Have TestAspect.fibers in ZIOBaseSpec

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
@@ -4,6 +4,6 @@ import zio._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment]] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
-    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential)
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds), TestAspect.fibers)
+    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential, TestAspect.fibers)
 }


### PR DESCRIPTION
Unless it was removed for some specific reason.. 
for me it was surprising that `diagnose` did not work so I feel it's better to have it by default.