### PR TITLE
`Int` & `Long` backed `BitChunk`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
@@ -3,7 +3,7 @@ package zio
 import zio.test.Assertion._
 import zio.test._
 
-object BitChunkSpec extends ZIOBaseSpec {
+object BitChunkByteSpec extends ZIOBaseSpec {
 
   val genByteChunk: Gen[Sized, Chunk[Byte]] =
     for {

--- a/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
@@ -16,7 +16,7 @@ object BitChunkByteSpec extends ZIOBaseSpec {
   def toBinaryString(byte: Byte): String =
     String.format("%8s", (byte.toInt & 0xff).toBinaryString).replace(' ', '0')
 
-  def spec = suite("BitChunkSpec")(
+  def spec = suite("BitChunkByteSpec")(
     test("drop") {
       check(genByteChunk, genInt) { (bytes, n) =>
         val actual   = bytes.asBits.drop(n).toBinaryString

--- a/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
@@ -19,49 +19,49 @@ object BitChunkByteSpec extends ZIOBaseSpec {
   def spec = suite("BitChunkByteSpec")(
     test("drop") {
       check(genByteChunk, genInt) { (bytes, n) =>
-        val actual   = bytes.asBits.drop(n).toBinaryString
+        val actual   = bytes.asBitsByte.drop(n).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.drop(n)
         assert(actual)(equalTo(expected))
       }
     },
     test("drop and then drop") {
       check(genByteChunk, genInt, genInt) { (bytes, n, m) =>
-        val actual   = bytes.asBits.drop(n).drop(m).toBinaryString
+        val actual   = bytes.asBitsByte.drop(n).drop(m).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.drop(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
     test("drop and then take") {
       check(genByteChunk, genInt, genInt) { (bytes, n, m) =>
-        val actual   = bytes.asBits.drop(n).take(m).toBinaryString
+        val actual   = bytes.asBitsByte.drop(n).take(m).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.drop(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
     test("take") {
       check(genByteChunk, genInt) { (bytes, n) =>
-        val actual   = bytes.asBits.take(n).toBinaryString
+        val actual   = bytes.asBitsByte.take(n).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.take(n)
         assert(actual)(equalTo(expected))
       }
     },
     test("take and then drop") {
       check(genByteChunk, genInt, genInt) { (bytes, n, m) =>
-        val actual   = bytes.asBits.take(n).drop(m).toBinaryString
+        val actual   = bytes.asBitsByte.take(n).drop(m).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.take(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
     test("take and then take") {
       check(genByteChunk, genInt, genInt) { (bytes, n, m) =>
-        val actual   = bytes.asBits.take(n).take(m).toBinaryString
+        val actual   = bytes.asBitsByte.take(n).take(m).toBinaryString
         val expected = bytes.map(toBinaryString).mkString.take(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
     test("toBinaryString") {
       check(genByteChunk) { bytes =>
-        val actual   = bytes.asBits.toBinaryString
+        val actual   = bytes.asBitsByte.toBinaryString
         val expected = bytes.map(toBinaryString).mkString
         assert(actual)(equalTo(expected))
       }

--- a/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
@@ -13,12 +13,12 @@ object BitChunkByteSpec extends ZIOBaseSpec {
   val genInt: Gen[Sized, Int] =
     Gen.small(Gen.const(_))
 
-  val genBitChunk: Gen[Sized, Chunk.BitChunk] =
+  val genBitChunk: Gen[Sized, Chunk.BitChunkByte] =
     for {
       chunk <- genByteChunk
       i     <- Gen.int(0, chunk.length * 8)
       j     <- Gen.int(0, chunk.length * 8)
-    } yield Chunk.BitChunk(chunk, i min j, i max j)
+    } yield Chunk.BitChunkByte(chunk, i min j, i max j)
 
   def toBinaryString(byte: Byte): String =
     String.format("%8s", (byte.toInt & 0xff).toBinaryString).replace(' ', '0')

--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -14,12 +14,12 @@ object BitChunkIntSpec extends ZIOBaseSpec {
   val genInt: Gen[Random with Sized, Int] =
     Gen.small(Gen.const(_))
 
-  val genEndianness: Gen[Random with Sized, Chunk.Endianness] =
-    Gen.elements(Chunk.Endianness.BigEndian, Chunk.Endianness.LittleEndian)
+  val genEndianness: Gen[Random with Sized, Chunk.BitChunk.Endianness] =
+    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
-  def toBinaryString(endianness: Chunk.Endianness)(int: Int): String = {
+  def toBinaryString(endianness: Chunk.BitChunk.Endianness)(int: Int): String = {
     val endiannessLong =
-      if (endianness == Chunk.Endianness.BigEndian) int else java.lang.Integer.reverse(int)
+      if (endianness == Chunk.BitChunk.Endianness.BigEndian) int else java.lang.Integer.reverse(int)
     String.format("%32s", endiannessLong.toBinaryString).replace(' ', '0')
   }
 

--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -1,0 +1,78 @@
+package zio
+
+import zio.random.Random
+import zio.test.Assertion.equalTo
+import zio.test._
+
+object BitChunkIntSpec extends ZIOBaseSpec {
+
+  val genIntChunk: Gen[Random with Sized, Chunk[Int]] =
+    for {
+      ints <- Gen.listOf(Gen.anyInt)
+    } yield Chunk.fromIterable(ints)
+
+  val genInt: Gen[Random with Sized, Int] =
+    Gen.small(Gen.const(_))
+
+  val genEndianness: Gen[Random with Sized, Chunk.Endianness] =
+    Gen.elements(Chunk.Endianness.BigEndian, Chunk.Endianness.LittleEndian)
+
+  def toBinaryString(endianness: Chunk.Endianness)(int: Int): String = {
+    val endiannessLong =
+      if (endianness == Chunk.Endianness.BigEndian) int else java.lang.Integer.reverse(int)
+    String.format("%32s", endiannessLong.toBinaryString).replace(' ', '0')
+  }
+
+  def spec: ZSpec[Environment, Failure] = suite("BitChunkIntSpec")(
+    testM("drop") {
+      check(genIntChunk, genInt, genEndianness) { (ints, n, endianness) =>
+        val actual   = ints.asBitsInt(endianness).drop(n).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.drop(n)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("drop and then drop") {
+      check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
+        val actual   = ints.asBitsInt(endianness).drop(n).drop(m).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.drop(n).drop(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("drop and then take") {
+      check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
+        val actual   = ints.asBitsInt(endianness).drop(n).take(m).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.drop(n).take(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take") {
+      check(genIntChunk, genInt, genEndianness) { (ints, n, endianness) =>
+        val actual   = ints.asBitsInt(endianness).take(n).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.take(n)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take and then drop") {
+      check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
+        val actual   = ints.asBitsInt(endianness).take(n).drop(m).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.take(n).drop(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take and then take") {
+      check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
+        val actual   = ints.asBitsInt(endianness).take(n).take(m).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString.take(n).take(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("toBinaryString") {
+      check(genIntChunk, genEndianness) { (ints, endianness) =>
+        val actual   = ints.asBitsInt(endianness).toBinaryString
+        val expected = ints.map(toBinaryString(endianness)).mkString
+        assert(actual)(equalTo(expected))
+      }
+    }
+  )
+
+}

--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -1,20 +1,19 @@
 package zio
 
-import zio.random.Random
-import zio.test.Assertion.equalTo
+import zio.test.Assertion._
 import zio.test._
 
 object BitChunkIntSpec extends ZIOBaseSpec {
 
-  val genIntChunk: Gen[Random with Sized, Chunk[Int]] =
+  val genIntChunk: Gen[Sized, Chunk[Int]] =
     for {
-      ints <- Gen.listOf(Gen.anyInt)
+      ints <- Gen.listOf(Gen.int)
     } yield Chunk.fromIterable(ints)
 
-  val genInt: Gen[Random with Sized, Int] =
+  val genInt: Gen[Sized, Int] =
     Gen.small(Gen.const(_))
 
-  val genEndianness: Gen[Random with Sized, Chunk.BitChunk.Endianness] =
+  val genEndianness: Gen[Sized, Chunk.BitChunk.Endianness] =
     Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(int: Int): String = {
@@ -23,50 +22,50 @@ object BitChunkIntSpec extends ZIOBaseSpec {
     String.format("%32s", endiannessLong.toBinaryString).replace(' ', '0')
   }
 
-  def spec: ZSpec[Environment, Failure] = suite("BitChunkIntSpec")(
-    testM("drop") {
+  def spec = suite("BitChunkIntSpec")(
+    test("drop") {
       check(genIntChunk, genInt, genEndianness) { (ints, n, endianness) =>
         val actual   = ints.asBitsInt(endianness).drop(n).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.drop(n)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("drop and then drop") {
+    test("drop and then drop") {
       check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
         val actual   = ints.asBitsInt(endianness).drop(n).drop(m).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.drop(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("drop and then take") {
+    test("drop and then take") {
       check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
         val actual   = ints.asBitsInt(endianness).drop(n).take(m).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.drop(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take") {
+    test("take") {
       check(genIntChunk, genInt, genEndianness) { (ints, n, endianness) =>
         val actual   = ints.asBitsInt(endianness).take(n).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.take(n)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take and then drop") {
+    test("take and then drop") {
       check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
         val actual   = ints.asBitsInt(endianness).take(n).drop(m).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.take(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take and then take") {
+    test("take and then take") {
       check(genIntChunk, genInt, genInt, genEndianness) { (ints, n, m, endianness) =>
         val actual   = ints.asBitsInt(endianness).take(n).take(m).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString.take(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("toBinaryString") {
+    test("toBinaryString") {
       check(genIntChunk, genEndianness) { (ints, endianness) =>
         val actual   = ints.asBitsInt(endianness).toBinaryString
         val expected = ints.map(toBinaryString(endianness)).mkString

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -14,12 +14,12 @@ object BitChunkLongSpec extends ZIOBaseSpec {
   val genInt: Gen[Random with Sized, Int] =
     Gen.small(Gen.const(_))
 
-  val genEndianness: Gen[Random with Sized, Chunk.Endianness] =
-    Gen.elements(Chunk.Endianness.BigEndian, Chunk.Endianness.LittleEndian)
+  val genEndianness: Gen[Random with Sized, Chunk.BitChunk.Endianness] =
+    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
-  def toBinaryString(endianness: Chunk.Endianness)(long: Long): String = {
+  def toBinaryString(endianness: Chunk.BitChunk.Endianness)(long: Long): String = {
     val endiannessLong =
-      if (endianness == Chunk.Endianness.BigEndian) long else java.lang.Long.reverse(long)
+      if (endianness == Chunk.BitChunk.Endianness.BigEndian) long else java.lang.Long.reverse(long)
     String.format("%64s", endiannessLong.toBinaryString).replace(' ', '0')
   }
 

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -1,0 +1,78 @@
+package zio
+
+import zio.random.Random
+import zio.test.Assertion.equalTo
+import zio.test._
+
+object BitChunkLongSpec extends ZIOBaseSpec {
+
+  val genLongChunk: Gen[Random with Sized, Chunk[Long]] =
+    for {
+      longs <- Gen.listOf(Gen.anyLong)
+    } yield Chunk.fromIterable(longs)
+
+  val genInt: Gen[Random with Sized, Int] =
+    Gen.small(Gen.const(_))
+
+  val genEndianness: Gen[Random with Sized, Chunk.Endianness] =
+    Gen.elements(Chunk.Endianness.BigEndian, Chunk.Endianness.LittleEndian)
+
+  def toBinaryString(endianness: Chunk.Endianness)(long: Long): String = {
+    val endiannessLong =
+      if (endianness == Chunk.Endianness.BigEndian) long else java.lang.Long.reverse(long)
+    String.format("%64s", endiannessLong.toBinaryString).replace(' ', '0')
+  }
+
+  def spec: ZSpec[Environment, Failure] = suite("BitChunkLongSpec")(
+    testM("drop") {
+      check(genLongChunk, genInt, genEndianness) { (longs, n, endianness) =>
+        val actual   = longs.asBitsLong(endianness).drop(n).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.drop(n)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("drop and then drop") {
+      check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
+        val actual   = longs.asBitsLong(endianness).drop(n).drop(m).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.drop(n).drop(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("drop and then take") {
+      check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
+        val actual   = longs.asBitsLong(endianness).drop(n).take(m).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.drop(n).take(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take") {
+      check(genLongChunk, genInt, genEndianness) { (longs, n, endianness) =>
+        val actual   = longs.asBitsLong(endianness).take(n).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.take(n)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take and then drop") {
+      check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
+        val actual   = longs.asBitsLong(endianness).take(n).drop(m).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.take(n).drop(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("take and then take") {
+      check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
+        val actual   = longs.asBitsLong(endianness).take(n).take(m).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString.take(n).take(m)
+        assert(actual)(equalTo(expected))
+      }
+    },
+    testM("toBinaryString") {
+      check(genLongChunk, genEndianness) { (longs, endianness) =>
+        val actual   = longs.asBitsLong(endianness).toBinaryString
+        val expected = longs.map(toBinaryString(endianness)).mkString
+        assert(actual)(equalTo(expected))
+      }
+    }
+  )
+
+}

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -1,20 +1,19 @@
 package zio
 
-import zio.random.Random
-import zio.test.Assertion.equalTo
+import zio.test.Assertion._
 import zio.test._
 
 object BitChunkLongSpec extends ZIOBaseSpec {
 
-  val genLongChunk: Gen[Random with Sized, Chunk[Long]] =
+  val genLongChunk: Gen[Sized, Chunk[Long]] =
     for {
-      longs <- Gen.listOf(Gen.anyLong)
+      longs <- Gen.listOf(Gen.long)
     } yield Chunk.fromIterable(longs)
 
-  val genInt: Gen[Random with Sized, Int] =
+  val genInt: Gen[Sized, Int] =
     Gen.small(Gen.const(_))
 
-  val genEndianness: Gen[Random with Sized, Chunk.BitChunk.Endianness] =
+  val genEndianness: Gen[Sized, Chunk.BitChunk.Endianness] =
     Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(long: Long): String = {
@@ -23,50 +22,50 @@ object BitChunkLongSpec extends ZIOBaseSpec {
     String.format("%64s", endiannessLong.toBinaryString).replace(' ', '0')
   }
 
-  def spec: ZSpec[Environment, Failure] = suite("BitChunkLongSpec")(
-    testM("drop") {
+  def spec = suite("BitChunkLongSpec")(
+    test("drop") {
       check(genLongChunk, genInt, genEndianness) { (longs, n, endianness) =>
         val actual   = longs.asBitsLong(endianness).drop(n).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.drop(n)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("drop and then drop") {
+    test("drop and then drop") {
       check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
         val actual   = longs.asBitsLong(endianness).drop(n).drop(m).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.drop(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("drop and then take") {
+    test("drop and then take") {
       check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
         val actual   = longs.asBitsLong(endianness).drop(n).take(m).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.drop(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take") {
+    test("take") {
       check(genLongChunk, genInt, genEndianness) { (longs, n, endianness) =>
         val actual   = longs.asBitsLong(endianness).take(n).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.take(n)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take and then drop") {
+    test("take and then drop") {
       check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
         val actual   = longs.asBitsLong(endianness).take(n).drop(m).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.take(n).drop(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("take and then take") {
+    test("take and then take") {
       check(genLongChunk, genInt, genInt, genEndianness) { (longs, n, m, endianness) =>
         val actual   = longs.asBitsLong(endianness).take(n).take(m).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString.take(n).take(m)
         assert(actual)(equalTo(expected))
       }
     },
-    testM("toBinaryString") {
+    test("toBinaryString") {
       check(genLongChunk, genEndianness) { (longs, endianness) =>
         val actual   = longs.asBitsLong(endianness).toBinaryString
         val expected = longs.map(toBinaryString(endianness)).mkString

--- a/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/ChunkBuilder.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.Chunk.BitChunk
+import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
@@ -138,7 +138,7 @@ object ChunkBuilder {
     }
     def result(): Chunk[SBoolean] = {
       val bytes: Chunk[SByte] = Chunk.fromArray(arrayBuilder.result() :+ lastByte)
-      BitChunk(bytes, 0, 8 * (bytes.length - 1) + maxBitIndex)
+      BitChunkByte(bytes, 0, 8 * (bytes.length - 1) + maxBitIndex)
     }
     override def ++=(as: TraversableOnce[SBoolean]): this.type = {
       as.foreach(+= _)

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.Chunk.BitChunk
+import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
@@ -138,7 +138,7 @@ object ChunkBuilder {
     }
     def result(): Chunk[SBoolean] = {
       val bytes: Chunk[SByte] = Chunk.fromArray(arrayBuilder.result() :+ lastByte)
-      BitChunk(bytes, 0, 8 * (bytes.length - 1) + maxBitIndex)
+      BitChunkByte(bytes, 0, 8 * (bytes.length - 1) + maxBitIndex)
     }
     override def addAll(as: IterableOnce[SBoolean]): this.type = {
       as.iterator.foreach(addOne _)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1034,12 +1034,6 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
 
 object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
-  sealed trait Endianness
-  object Endianness {
-    case object BigEndian    extends Endianness
-    case object LittleEndian extends Endianness
-  }
-
   /**
    * Returns a chunk from a number of values.
    */

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1267,9 +1267,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       case x: Slice[_]       => x.classTag.asInstanceOf[ClassTag[A]]
       case x: Update[_]      => x.classTag.asInstanceOf[ClassTag[A]]
       case x: VectorChunk[_] => x.classTag.asInstanceOf[ClassTag[A]]
-      case _: BitChunkByte   => ClassTag.Boolean.asInstanceOf[ClassTag[A]]
-      case _: BitChunkInt    => ClassTag.Int.asInstanceOf[ClassTag[A]]
-      case _: BitChunkLong   => ClassTag.Long.asInstanceOf[ClassTag[A]]
+      case _: BitChunk[_]    => ClassTag.Boolean.asInstanceOf[ClassTag[A]]
     }
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1795,67 +1795,6 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
 
     protected def foreachElement[A](f: Boolean => A, elem: T): Unit
-    private def nthByte(n: Int): Byte = {
-      val offset    = minBitIndex & 7
-      val startByte = (minBitIndex >> 3)
-      if (offset == 0) {
-        bytes(n + startByte)
-      } else {
-        val leftover = minBitIndex + (n + 1) * 8 - maxBitIndex
-        if (leftover <= 0) {
-          val index  = n + startByte
-          val first  = ((255 >> offset) & bytes(index)) << offset
-          val second = (255 << (8 - offset) & 255 & bytes(index + 1)) >> (8 - offset)
-          (first | second).asInstanceOf[Byte]
-        } else {
-          throw new ArrayIndexOutOfBoundsException(s"There are only $leftover bits left.")
-        }
-      }
-    }
-
-    private def bitwise(that: BitChunk, f: (Byte, Byte) => Byte, g: (Boolean, Boolean) => Boolean): BitChunk = {
-      val bits      = self.length min that.length
-      val bytes     = bits >> 3
-      val leftovers = bits - bytes * 8
-      val arr = Array.ofDim[Byte](
-        if (leftovers == 0) bytes else bytes + 1
-      )
-
-      (0 until bytes).foreach { n =>
-        arr(n) = f(self.nthByte(n), that.nthByte(n))
-      }
-
-      if (leftovers != 0) {
-        val offset     = bytes * 8
-        var last: Byte = null.asInstanceOf[Byte]
-        var mask       = 128
-        var i          = 0
-        while (i < leftovers) {
-          if (g(self.apply(offset + self.minBitIndex + i), that.apply(offset + that.minBitIndex + i)))
-            last = (last | mask).asInstanceOf[Byte]
-          i += 1
-          mask >>= 1
-        }
-        arr(bytes) = last
-      }
-
-      BitChunk(Chunk.fromArray(arr), 0, bits)
-    }
-
-    def and(that: BitChunk): BitChunk =
-      bitwise(that, (l, r) => (l & r).asInstanceOf[Byte], _ && _)
-
-    def or(that: BitChunk): BitChunk =
-      bitwise(that, (l, r) => (l | r).asInstanceOf[Byte], _ || _)
-
-    def xor(that: BitChunk): BitChunk =
-      bitwise(that, (l, r) => (l ^ r).asInstanceOf[Byte], _ ^ _)
-
-    override def take(n: Int): BitChunk = {
-      val index  = (minBitIndex + n) min maxBitIndex
-      val toTake = (index + 7) >> 3
-      BitChunk(bytes.take(toTake), minBitIndex, index)
-    }
 
     override def toArray[A1 >: Boolean](n: Int, dest: Array[A1]): Unit = {
       var i = n
@@ -1916,6 +1855,62 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       f((byte & 1) != 0)
       ()
     }
+
+    private def nthByte(n: Int): Byte = {
+      val offset    = minBitIndex & 7
+      val startByte = (minBitIndex >> 3)
+      if (offset == 0) {
+        bytes(n + startByte)
+      } else {
+        val leftover = minBitIndex + (n + 1) * 8 - maxBitIndex
+        if (leftover <= 0) {
+          val index  = n + startByte
+          val first  = ((255 >> offset) & bytes(index)) << offset
+          val second = (255 << (8 - offset) & 255 & bytes(index + 1)) >> (8 - offset)
+          (first | second).asInstanceOf[Byte]
+        } else {
+          throw new ArrayIndexOutOfBoundsException(s"There are only $leftover bits left.")
+        }
+      }
+    }
+
+    private def bitwise(that: BitChunkByte, f: (Byte, Byte) => Byte, g: (Boolean, Boolean) => Boolean): BitChunkByte = {
+      val bits      = self.length min that.length
+      val bytes     = bits >> 3
+      val leftovers = bits - bytes * 8
+      val arr = Array.ofDim[Byte](
+        if (leftovers == 0) bytes else bytes + 1
+      )
+
+      (0 until bytes).foreach { n =>
+        arr(n) = f(self.nthByte(n), that.nthByte(n))
+      }
+
+      if (leftovers != 0) {
+        val offset     = bytes * 8
+        var last: Byte = null.asInstanceOf[Byte]
+        var mask       = 128
+        var i          = 0
+        while (i < leftovers) {
+          if (g(self.apply(offset + self.minBitIndex + i), that.apply(offset + that.minBitIndex + i)))
+            last = (last | mask).asInstanceOf[Byte]
+          i += 1
+          mask >>= 1
+        }
+        arr(bytes) = last
+      }
+
+      BitChunkByte(Chunk.fromArray(arr), 0, bits)
+    }
+
+    def and(that: BitChunkByte): BitChunkByte =
+      bitwise(that, (l, r) => (l & r).asInstanceOf[Byte], _ && _)
+
+    def or(that: BitChunkByte): BitChunkByte =
+      bitwise(that, (l, r) => (l | r).asInstanceOf[Byte], _ || _)
+
+    def xor(that: BitChunkByte): BitChunkByte =
+      bitwise(that, (l, r) => (l ^ r).asInstanceOf[Byte], _ ^ _)
 
   }
 

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -106,7 +106,7 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
   /**
    * Converts a chunk of bytes to a chunk of bits.
    */
-  final def asBits(implicit ev: A <:< Byte): Chunk[Boolean] =
+  final def asBitsByte(implicit ev: A <:< Byte): Chunk[Boolean] =
     Chunk.BitChunkByte(self.map(ev), 0, length << 3)
 
   /**

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -63,13 +63,13 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
   /**
    * Converts this `NonEmptyChunk` of ints to a `NonEmptyChunk` of bits.
    */
-  def asBitsInt(endianness: Chunk.Endianness)(implicit ev: A <:< Int): NonEmptyChunk[Boolean] =
+  def asBitsInt(endianness: Chunk.BitChunk.Endianness)(implicit ev: A <:< Int): NonEmptyChunk[Boolean] =
     nonEmpty(chunk.asBitsInt(endianness))
 
   /**
    * Converts this `NonEmptyChunk` of longs to a `NonEmptyChunk` of bits.
    */
-  def asBitsLong(endianness: Chunk.Endianness)(implicit ev: A <:< Long): NonEmptyChunk[Boolean] =
+  def asBitsLong(endianness: Chunk.BitChunk.Endianness)(implicit ev: A <:< Long): NonEmptyChunk[Boolean] =
     nonEmpty(chunk.asBitsLong(endianness))
 
   /**

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -61,6 +61,18 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
     nonEmpty(chunk :+ a)
 
   /**
+   * Converts this `NonEmptyChunk` of ints to a `NonEmptyChunk` of bits.
+   */
+  def asBitsInt(endianness: Chunk.Endianness)(implicit ev: A <:< Int): NonEmptyChunk[Boolean] =
+    nonEmpty(chunk.asBitsInt(endianness))
+
+  /**
+   * Converts this `NonEmptyChunk` of longs to a `NonEmptyChunk` of bits.
+   */
+  def asBitsLong(endianness: Chunk.Endianness)(implicit ev: A <:< Long): NonEmptyChunk[Boolean] =
+    nonEmpty(chunk.asBitsLong(endianness))
+
+  /**
    * Converts this `NonEmptyChunk` of bytes to a `NonEmptyChunk` of bits.
    */
   def asBits(implicit ev: A <:< Byte): NonEmptyChunk[Boolean] =

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -76,7 +76,7 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) { self =>
    * Converts this `NonEmptyChunk` of bytes to a `NonEmptyChunk` of bits.
    */
   def asBits(implicit ev: A <:< Byte): NonEmptyChunk[Boolean] =
-    nonEmpty(chunk.asBits)
+    nonEmpty(chunk.asBitsByte)
 
   /**
    * Returns whether this `NonEmptyChunk` and the specified `NonEmptyChunk` are


### PR DESCRIPTION
- `BitChunk` versions for underlying `Chunk[Int]` / `Chunk[Long]` (#6849)
- Extract abstract class with common logic for BitChunk's
