### PR TITLE
Improve performance of Fiberrefs#join

### DIFF
--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -48,6 +48,10 @@ class FiberRefBenchmarks {
     createAndJoin(BenchmarkUtil)
 
   @Benchmark
+  def createAndJoinInitialValue(): Unit =
+    createAndJoinInitialValue(BenchmarkUtil)
+
+  @Benchmark
   def createAndJoinUpdatesWide(): Unit =
     createAndJoinUpdatesWide(BenchmarkUtil)
 
@@ -90,6 +94,15 @@ class FiberRefBenchmarks {
       for {
         fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
         _ <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
+        _ <- ZIO.collectAllParDiscard(List.fill(nFibers)(ZIO.unit))
+      } yield ()
+    }
+  }
+
+  private def createAndJoinInitialValue(runtime: Runtime[Any]) = runtime.unsafeRun {
+    ZIO.scoped {
+      for {
+        _ <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
         _ <- ZIO.collectAllParDiscard(List.fill(nFibers)(ZIO.unit))
       } yield ()
     }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -93,12 +93,12 @@ private[zio] final class FiberContext[E, A](
   final def id: FiberId.Runtime = fiberId
 
   final def inheritRefs(implicit trace: Trace): UIO[Unit] = ZIO.suspendSucceed {
-    val childFiberRefs = FiberRefs(fiberRefLocals.get)
+    val childFiberRefLocals = fiberRefLocals.get
 
-    if (childFiberRefs.fiberRefLocals.isEmpty) ZIO.unit
+    if (childFiberRefLocals.isEmpty) ZIO.unit
     else
       ZIO.updateFiberRefs { (parentFiberId, parentFiberRefs) =>
-        parentFiberRefs.join(parentFiberId)(childFiberRefs)
+        parentFiberRefs.join(parentFiberId)(FiberRefs(childFiberRefLocals))
       }
   }
 


### PR DESCRIPTION
resolves #6853 
```
Before:

FiberRefBenchmarks.createAndJoin               32      10000  thrpt   10  27,539 ± 0,718  ops/s
FiberRefBenchmarks.createAndJoinExpensive   32     10000  thrpt   10  2,718 ± 0,039  ops/s
FiberRefBenchmarks.createAndJoinInitialValue   32      10000  thrpt   10  27,621 ± 1,142  ops/s
FiberRefBenchmarks.createAndJoinUpdatesDeep    32      10000  thrpt   10   8,732 ± 0,532  ops/s
FiberRefBenchmarks.createAndJoinUpdatesWide    32      10000  thrpt   10  10,727 ± 0,127  ops/s

After:

FiberRefBenchmarks.createAndJoin               32      10000  thrpt   10  53,797 ± 1,778  ops/s
FiberRefBenchmarks.createAndJoinExpensive   32 10000  thrpt   10  41,947 ± 1,707  ops/s
FiberRefBenchmarks.createAndJoinInitialValue   32      10000  thrpt   10  53,137 ± 1,670  ops/s
FiberRefBenchmarks.createAndJoinUpdatesDeep    32      10000  thrpt   10   8,296 ± 0,364  ops/s
FiberRefBenchmarks.createAndJoinUpdatesWide    32      10000  thrpt   10  11,375 ± 0,175  ops/s
```

No microoptimizations, just short cicuiting when we can avoid calculating the patches.
As seen in `createAndJoinExpensive` this is has the strongest effect with Fiberrefs that are expensive to diff or upgrade.