### PR TITLE
A minor fix to ThreadLocalBridge layer - make makeFiberRef signature …

### DIFF
--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -5,22 +5,22 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicReference
 
-trait ThreadLocalBridge {
-  def makeFiberRef[A](initialValue: A, link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]]
+  trait ThreadLocalBridge {
+  def makeFiberRef[A](initialValue: A)(link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]]
 }
 
 object ThreadLocalBridge {
   private implicit val trace: Trace = Trace.empty
 
   def makeFiberRef[A](initialValue: A)(link: A => Unit): ZIO[Scope with ThreadLocalBridge, Nothing, FiberRef[A]] =
-    ZIO.serviceWithZIO[ThreadLocalBridge](_.makeFiberRef(initialValue, link))
+    ZIO.serviceWithZIO[ThreadLocalBridge](_.makeFiberRef(initialValue)(link))
 
   val live: ZLayer[Any, Nothing, ThreadLocalBridge] = ZLayer.suspend {
     val supervisor      = new FiberRefTrackingSupervisor
     val supervisorLayer = Runtime.addSupervisor(supervisor)
     val bridgeLayer = ZLayer.succeed {
       new ThreadLocalBridge {
-        def makeFiberRef[A](initialValue: A, link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]] =
+        def makeFiberRef[A](initialValue: A)(link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]] =
           for {
             fiberRef <- FiberRef.make(initialValue)
             _         = link(initialValue)

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -5,7 +5,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicReference
 
-  trait ThreadLocalBridge {
+trait ThreadLocalBridge {
   def makeFiberRef[A](initialValue: A)(link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]]
 }
 


### PR DESCRIPTION
make `makeFiberRef` signature match the accessor on the companion object (be curried)