### PR TITLE
Full path reporting for test traces

### DIFF
--- a/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Macros.scala
+++ b/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Macros.scala
@@ -8,6 +8,17 @@ import zio.stacktracer.DisableAutoTrace
 @silent
 object Macros {
 
+  def sourceLocation(c: blackbox.Context): c.Tree = {
+    import c.universe._
+    val pos = c.macroApplication.pos
+    q"""
+      new zio.internal.stacktracer.SourceLocation(
+        path = ${pos.source.file.path},
+        line = ${pos.line}
+      )
+    """
+  }
+
   def traceInfo(c: blackbox.Context): String = {
 
     val location = {

--- a/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Macros.scala
+++ b/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/Macros.scala
@@ -12,7 +12,7 @@ object Macros {
     import c.universe._
     val pos = c.macroApplication.pos
     q"""
-      new zio.internal.stacktracer.SourceLocation(
+      _root_.zio.internal.stacktracer.SourceLocation(
         path = ${pos.source.file.path},
         line = ${pos.line}
       )

--- a/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/SourceLocation.scala
+++ b/stacktracer/shared/src/main/scala-2/zio/internal/stacktracer/SourceLocation.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal.stacktracer
+
+final case class SourceLocation(path: String, line: Int)
+object SourceLocation {
+  implicit def sourceLocation: SourceLocation = macro Macros.sourceLocation
+}

--- a/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Macros.scala
+++ b/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Macros.scala
@@ -9,6 +9,14 @@ import scala.quoted._
 @silent
 object Macros {
 
+  def sourceLocation(using ctx: Quotes): Expr[SourceLocation] = {
+    import quotes.reflect._
+    val pos  = Position.ofMacroExpansion
+    val path = pos.sourceFile.path
+    val line = pos.startLine + 1
+    '{SourceLocation(${Expr(path)}, ${Expr(line)})}
+  }
+
   def traceInfo(using ctx: Quotes): String = {
     import quotes.reflect._
 

--- a/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/SourceLocation.scala
+++ b/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/SourceLocation.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal.stacktracer
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+final case class SourceLocation(path: String, line: Int)
+object SourceLocation {
+  inline given SourceLocation = ${Macros.sourceLocation}
+}

--- a/test-tests/shared/src/test/scala/zio/test/ConsoleTestOutputSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ConsoleTestOutputSpec.scala
@@ -1,14 +1,15 @@
 package zio.test
 
 import zio.internal.macros.StringUtils.StringOps
+import zio.internal.stacktracer.SourceLocation
 import zio.test.ReportingTestUtils._
 import zio.test.TestAspect._
 import zio.test.render.ConsoleRenderer
-import zio.{StackTrace, Trace, ZIO}
+import zio.{StackTrace, ZIO}
 
 object ConsoleTestOutputSpec extends ZIOBaseSpec {
 
-  def containsUnstyled(string: String, substring: String)(implicit trace: Trace): TestResult =
+  def containsUnstyled(string: String, substring: String)(implicit sourceLocation: SourceLocation): TestResult =
     assertTrue(string.unstyled.contains(substring.unstyled))
 
   def spec =

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -1,5 +1,6 @@
 package zio.test
 
+import zio.internal.stacktracer.SourceLocation
 import zio.test.Assertion._
 import zio.test.ReporterEventRenderer.ConsoleEventRenderer
 import zio.{Cause, Scope, Trace, ULayer, ZIO, ZIOAppArgs, ZLayer}
@@ -45,14 +46,16 @@ object ReportingTestUtils {
   // TODO de-dup layers?
   def runLog(
     spec: Spec[TestEnvironment, String]
-  )(implicit trace: Trace): ZIO[TestEnvironment with Scope, Nothing, String] =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[TestEnvironment with Scope, Nothing, String] =
     for {
       console <- ZIO.console
       _       <- TestTestRunner(testEnvironment, sinkLayer(console, ConsoleEventRenderer)).run(spec)
       output  <- TestConsole.output
     } yield output.mkString
 
-  def runSummary(spec: Spec[TestEnvironment, String]): ZIO[TestEnvironment, Nothing, String] =
+  def runSummary(
+    spec: Spec[TestEnvironment, String]
+  )(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[TestEnvironment, Nothing, String] =
     for {
       console <- ZIO.console
       summary <- TestTestRunner(testEnvironment, sinkLayer(console, ConsoleEventRenderer)).run(spec)
@@ -62,7 +65,8 @@ object ReportingTestUtils {
     testEnvironment: ZLayer[Scope, Nothing, TestEnvironment],
     sinkLayer: ULayer[ExecutionEventSink]
   )(implicit
-    trace: Trace
+    trace: Trace,
+    sourceLocation: SourceLocation
   ) = TestRunner[TestEnvironment, String](
     executor = TestExecutor.default[TestEnvironment, String](
       Scope.default >>> testEnvironment,
@@ -72,16 +76,17 @@ object ReportingTestUtils {
     )
   )
 
-  def test1(implicit trace: Trace): Spec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(2)))
-  val test1Expected: String                            = expectedSuccess("Addition works fine")
+  def test1(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
+    test("Addition works fine")(assert(1 + 1)(equalTo(2)))
+  val test1Expected: String = expectedSuccess("Addition works fine")
 
-  def test2(implicit trace: Trace): Spec[Any, Nothing] =
+  def test2(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     test("Subtraction works fine")(assert(1 - 1)(equalTo(0)))
   val test2Expected: String = expectedSuccess("Subtraction works fine")
 
-  def test3(implicit trace: Trace): Spec[Any, Nothing] =
+  def test3(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     test("Value falls within range")(assert(52)(equalTo(42) || (isGreaterThan(5) && isLessThan(10))))
-  def test3Expected(implicit trace: Trace): Vector[String] = Vector(
+  def test3Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedFailure("Value falls within range"),
     s"52 did not satisfy equalTo(42)",
     s"52 did not satisfy equalTo(42) || (isGreaterThan(5) && isLessThan(10)",
@@ -91,29 +96,30 @@ object ReportingTestUtils {
     assertSourceLocation()
   )
 
-  def test4(implicit trace: Trace): Spec[Any, String] =
+  def test4(implicit sourceLocation: SourceLocation): Spec[Any, String] =
     Spec.labeled("Failing test", Spec.test(failed(Cause.fail("Test 4 Fail")), TestAnnotationMap.empty))
 
-  def test5(implicit trace: Trace): Spec[Any, Nothing] = test("Addition works fine")(assert(1 + 1)(equalTo(3)))
+  def test5(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
+    test("Addition works fine")(assert(1 + 1)(equalTo(3)))
   // the captured expression for `1+1` is different between dotty and 2.x
   def expressionIfNotRedundant(expr: String, value: Any): String =
     Option(expr).filterNot(_ == value.toString).fold(value.toString)(e => s"`$e` = $value")
-  def test5Expected(implicit trace: Trace): Vector[String] = Vector(
+  def test5Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedFailure("Addition works fine"),
     "2 was not equal to 3",
     assertSourceLocation()
   )
 
-  def test6(implicit trace: Trace): Spec[Any, Nothing] =
+  def test6(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     test("Multiple nested failures")(assert(Right(Some(3)))(isRight(isSome(isGreaterThan(4)))))
-  def test6Expected(implicit trace: Trace): Vector[String] = Vector(
+  def test6Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedFailure("Multiple nested failures"),
     "3 was not greater than 4",
     s"${blue(s"Right(Some(3))")} did not satisfy ${cyan("isRight(") + yellow("isSome(isGreaterThan(4))") + cyan(")")}",
     assertSourceLocation()
   )
 
-  def test7(implicit trace: Trace): Spec[Any, Nothing] = test("labeled failures") {
+  def test7(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] = test("labeled failures") {
     for {
       a <- ZIO.succeed(Some(1))
       b <- ZIO.succeed(Some(1))
@@ -124,59 +130,59 @@ object ReportingTestUtils {
       assert(c)(isSome(equalTo(1)).label("third")) &&
       assert(d)(isSome(equalTo(1)).label("fourth"))
   }
-  def test7Expected(implicit trace: Trace): Vector[String] = Vector(
+  def test7Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedFailure("labeled failures"),
     s"0 was not equal to 1",
     s"""${blue("c")} did not satisfy isSome(equalTo(1)).label("third")""",
     assertSourceLocation()
   )
 
-  def test8(implicit trace: Trace): Spec[Any, Nothing] = test("Not combinator") {
+  def test8(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] = test("Not combinator") {
     assert(100)(not(equalTo(100)))
   }
-  def test8Expected(implicit trace: Trace): Vector[String] = Vector(
+  def test8Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedFailure("Not combinator"),
     "100 was equal to 100",
     s"${blue("100")} did not satisfy ${cyan("not(") + yellow("equalTo(100)") + cyan(")")}",
     assertSourceLocation()
   )
 
-  def test9(implicit trace: Trace): Spec[Any, Nothing] = test("labeled failures") {
+  def test9(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] = test("labeled failures") {
     assertTrue(1 == 1).label("first") &&
     assertTrue(1 == 1).label("second") &&
     assertTrue(1 == 0).label("third") &&
     assertTrue(1 == 0).label("fourth")
   }
 
-  def suite1(implicit trace: Trace): Spec[Any, Nothing] =
+  def suite1(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     suite("Suite1")(test1, test2)
-  def suite1Expected(implicit trace: Trace): Vector[String] = Vector(
+  def suite1Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedSuccess("Suite1"),
     test1Expected,
     test2Expected
   )
 
-  def suite2(implicit trace: Trace): Spec[Any, Nothing] =
+  def suite2(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     suite("Suite2")(test1, test2, test3)
-  def suite2Expected(implicit trace: Trace): Vector[String] = Vector(
+  def suite2Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
     expectedSuccess("Suite2"),
     test1Expected,
     test2Expected
   ) ++ test3Expected
 
-  def suite3(implicit trace: Trace): Spec[Any, Nothing] =
+  def suite3(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     suite("Suite3")(suite1, suite2, test3)
-  def suite3Expected(implicit trace: Trace): Vector[String] = Vector(expectedSuccess("Suite3")) ++
+  def suite3Expected(implicit sourceLocation: SourceLocation): Vector[String] = Vector(expectedSuccess("Suite3")) ++
     suite1Expected ++
     suite2Expected ++
     Vector("\n") ++
     test3Expected
 
-  def suite4(implicit trace: Trace): Spec[Any, Nothing] =
+  def suite4(implicit sourceLocation: SourceLocation): Spec[Any, Nothing] =
     suite("Suite4")(suite1, suite("Empty")(), test3)
-  def suite4Expected(implicit trace: Trace): Vector[String] = {
+  def suite4Expected(implicit sourceLocation: SourceLocation): Vector[String] = {
 
-    def suite1ExpectedLocal(implicit trace: Trace): Vector[String] = Vector(
+    def suite1ExpectedLocal(implicit sourceLocation: SourceLocation): Vector[String] = Vector(
       expectedSuccess("Suite1"),
       test1Expected,
       test2Expected
@@ -188,8 +194,6 @@ object ReportingTestUtils {
       test3Expected
   }
 
-  def assertSourceLocation()(implicit trace: Trace): String =
-    Option(trace).collect { case Trace(_, path, line) =>
-      cyan(s"at $path:$line")
-    }.getOrElse("")
+  def assertSourceLocation()(implicit sourceLocation: SourceLocation): String =
+    cyan(s"at ${sourceLocation.path}:${sourceLocation.line}")
 }

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -17,8 +17,8 @@
 package zio.test
 
 import zio.internal.stacktracer.SourceLocation
-import zio.{Trace, UIO, ZIO}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.{Trace, UIO, ZIO}
 
 trait CompileVariants {
 
@@ -47,8 +47,8 @@ trait CompileVariants {
    * Checks the assertion holds for the given effectfully-computed value.
    */
   def assertZIO[R, E, A](effect: ZIO[R, E, A])(assertion: Assertion[A])(implicit
-    sourceLocation: SourceLocation,
-    trace: Trace
+    trace: Trace,
+    sourceLocation: SourceLocation
   ): ZIO[R, E, TestResult] =
     Assertion.smartAssertZIO(effect)(assertion)
 

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -16,7 +16,8 @@
 
 package zio.test
 
-import zio.{UIO, ZIO, Trace}
+import zio.internal.stacktracer.SourceLocation
+import zio.{Trace, UIO, ZIO}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait CompileVariants {
@@ -46,6 +47,7 @@ trait CompileVariants {
    * Checks the assertion holds for the given effectfully-computed value.
    */
   def assertZIO[R, E, A](effect: ZIO[R, E, A])(assertion: Assertion[A])(implicit
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[R, E, TestResult] =
     Assertion.smartAssertZIO(effect)(assertion)
@@ -60,11 +62,11 @@ object CompileVariants {
 
   def newAssertProxy[A](value: => A, codeString: String, assertionString: String)(
     assertion: Assertion[A]
-  )(implicit trace: Trace): TestResult =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     zio.test.assertImpl(value, Some(codeString), Some(assertionString))(assertion)
 
   def assertZIOProxy[R, E, A](effect: ZIO[R, E, A])(
     assertion: Assertion[A]
-  )(implicit trace: Trace): ZIO[R, E, TestResult] =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[R, E, TestResult] =
     zio.test.assertZIOImpl(effect)(assertion)
 }

--- a/test/shared/src/main/scala-2/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-2/zio/test/Macros.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{UIO, Trace}
+import zio.UIO
 import zio.internal.macros.CleanCodePrinter
 
 import scala.reflect.macros.{TypecheckException, blackbox}

--- a/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
@@ -16,6 +16,7 @@
 
 package zio.test
 
+import zio.internal.stacktracer.{SourceLocation, Tracer}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{UIO, ZIO, Trace}
 
@@ -41,11 +42,11 @@ trait CompileVariants {
   private val errorMessage =
     "Reporting of compilation error messages on Scala 3 is not currently supported due to instability of the underlying APIs."
 
-  inline def assertTrue(inline exprs: => Boolean*)(implicit trace: Trace): TestResult =
-    ${SmartAssertMacros.smartAssert('exprs, 'trace)}
+  inline def assertTrue(inline exprs: => Boolean*)(implicit sourceLocation: SourceLocation): TestResult =
+    ${SmartAssertMacros.smartAssert('exprs, 'sourceLocation)}
 
-  inline def assert[A](inline value: => A)(inline assertion: Assertion[A])(implicit trace: Trace): TestResult =
-    ${Macros.assert_impl('value)('assertion, 'trace)}
+  inline def assert[A](inline value: => A)(inline assertion: Assertion[A])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
+    ${Macros.assert_impl('value)('assertion, 'trace, 'sourceLocation)}
 
   inline def assertZIO[R, E, A](effect: ZIO[R, E, A])(assertion: Assertion[A]): ZIO[R, E, TestResult] =
      ${Macros.assertZIO_impl('effect)('assertion)}
@@ -60,11 +61,11 @@ object CompileVariants {
 
   def assertProxy[A](value: => A, expression: String, assertionCode: String)(
     assertion: Assertion[A]
-  )(implicit trace: Trace): TestResult =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     zio.test.assertImpl(value, Some(expression), Some(assertionCode))(assertion)
 
   def assertZIOProxy[R, E, A](effect: ZIO[R, E, A], expression: String, assertionCode: String)(
     assertion: Assertion[A],
-  )(implicit trace: Trace): ZIO[R, E, TestResult] =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[R, E, TestResult] =
     zio.test.assertZIOImpl(effect, Some(expression), Some(assertionCode))(assertion)
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -1,8 +1,9 @@
 package zio.test
 
 import zio.internal.ansi.AnsiStringOps
+import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Cause, Exit, ZIO, Trace}
+import zio.{Cause, Exit, Trace, ZIO}
 import zio.test.{ErrorMessage => M, _}
 import zio.test.internal.SmartAssertions
 
@@ -25,7 +26,7 @@ final case class Assertion[-A](arrow: TestArrow[A, Boolean]) { self =>
   def negate: Assertion[A] =
     Assertion(!arrow)
 
-  def test(value: A)(implicit trace: Trace): Boolean =
+  def test(value: A)(implicit trace: Trace, sourceLocation: SourceLocation): Boolean =
     TestArrow.run(arrow.withLocation, Right(value)).isSuccess
 
   // TODO: IMPLEMENT LABELING
@@ -51,7 +52,7 @@ object Assertion extends AssertionVariants {
     assertionString: Option[String] = None
   )(
     assertion: Assertion[A]
-  )(implicit trace: Trace): TestResult = {
+  )(implicit trace: Trace, sourceLocation: SourceLocation): TestResult = {
     lazy val value0 = expr
     val completeString =
       codeString.flatMap(code =>

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -3,15 +3,13 @@ package zio.test
 import zio.internal.ansi.AnsiStringOps
 import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Cause, Exit, Trace, ZIO}
-import zio.test.{ErrorMessage => M, _}
 import zio.test.internal.SmartAssertions
+import zio.test.{ErrorMessage => M}
+import zio.{Cause, Exit, Trace, ZIO}
 
 import scala.reflect.ClassTag
 import scala.util.Try
 
-// zio.test.DefaultTestReporterSpec
-// zio.test.TestAspectSpec
 final case class Assertion[-A](arrow: TestArrow[A, Boolean]) { self =>
 
   def &&[A1 <: A](that: Assertion[A1]): Assertion[A1] =
@@ -26,7 +24,7 @@ final case class Assertion[-A](arrow: TestArrow[A, Boolean]) { self =>
   def negate: Assertion[A] =
     Assertion(!arrow)
 
-  def test(value: A)(implicit trace: Trace, sourceLocation: SourceLocation): Boolean =
+  def test(value: A)(implicit sourceLocation: SourceLocation): Boolean =
     TestArrow.run(arrow.withLocation, Right(value)).isSuccess
 
   // TODO: IMPLEMENT LABELING
@@ -36,7 +34,7 @@ final case class Assertion[-A](arrow: TestArrow[A, Boolean]) { self =>
   def ??(message: String): Assertion[A] =
     self.label(message)
 
-  def run(value: => A)(implicit trace: Trace): TestResult =
+  def run(value: => A)(implicit sourceLocation: SourceLocation): TestResult =
     Assertion.smartAssert(value)(self)
 
   private[test] def withCode(code: String): Assertion[A] =
@@ -52,7 +50,7 @@ object Assertion extends AssertionVariants {
     assertionString: Option[String] = None
   )(
     assertion: Assertion[A]
-  )(implicit trace: Trace, sourceLocation: SourceLocation): TestResult = {
+  )(implicit sourceLocation: SourceLocation): TestResult = {
     lazy val value0 = expr
     val completeString =
       codeString.flatMap(code =>
@@ -68,7 +66,7 @@ object Assertion extends AssertionVariants {
 
   private[test] def smartAssertZIO[R, E, A](
     expr: => ZIO[R, E, A]
-  )(assertion: Assertion[A])(implicit trace: Trace): ZIO[R, E, TestResult] = {
+  )(assertion: Assertion[A])(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[R, E, TestResult] = {
     lazy val value0 = expr
     value0.map(smartAssert(_)(assertion))
   }

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio._
+import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicReference
@@ -81,7 +82,7 @@ object TestAnnotation {
    * An annotation for capturing the trace information, including source
    * location (i.e. file name and line number) of the calling test.
    */
-  private[zio] val trace: TestAnnotation[List[Trace]] =
+  private[zio] val trace: TestAnnotation[List[SourceLocation]] =
     TestAnnotation("trace", List.empty, _ ++ _)
 
   val fibers: TestAnnotation[Either[Int, Chunk[AtomicReference[SortedSet[Fiber.Runtime[Any, Any]]]]]] =

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -4,6 +4,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.language.implicitConversions
 import zio.Trace
+import zio.internal.stacktracer.SourceLocation
 
 import scala.util.control.NonFatal
 
@@ -99,12 +100,8 @@ sealed trait TestArrow[-A, +B] { self =>
   def withCompleteCode(completeCode: String): TestArrow[A, B] =
     meta(completeCode = Some(completeCode))
 
-  def withLocation(implicit trace: Trace): TestArrow[A, B] =
-    trace match {
-      case Trace(_, file, line) =>
-        meta(location = Some(s"$file:$line"))
-      case _ => self
-    }
+  def withLocation(implicit sourceLocation: SourceLocation): TestArrow[A, B] =
+    meta(location = Some(s"${sourceLocation.path}:${sourceLocation.line}"))
 
   def withParentSpan(span: (Int, Int)): TestArrow[A, B] =
     meta(parentSpan = Some(Span(span._1, span._2)))

--- a/test/shared/src/main/scala/zio/test/ZIOSpec.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpec.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio._
+import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract with ZIOSpecVersionSpecific[R] { self =>
@@ -31,12 +32,14 @@ abstract class ZIOSpec[R: EnvironmentTag] extends ZIOSpecAbstract with ZIOSpecVe
     assertion: => In
   )(implicit
     testConstructor: TestConstructor[Nothing, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): testConstructor.Out =
     zio.test.test(label)(assertion)
 
   def suite[In](label: String)(specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
     zio.test.suite(label)(specs: _*)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -226,7 +226,7 @@ package object test extends CompileVariants {
     value: => A,
     codeString: Option[String] = None,
     assertionString: Option[String] = None
-  )(assertion: Assertion[A])(implicit trace: Trace): TestResult =
+  )(assertion: Assertion[A])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     Assertion.smartAssert(value, codeString, assertionString)(assertion)
 
   /**
@@ -238,7 +238,7 @@ package object test extends CompileVariants {
     assertionString: Option[String] = None
   )(
     assertion: Assertion[A]
-  )(implicit trace: Trace): ZIO[R, E, TestResult] =
+  )(implicit trace: Trace, sourceLocation: SourceLocation): ZIO[R, E, TestResult] =
     effect.map { value =>
       assertImpl(value, codeString, assertionString)(assertion)
     }
@@ -246,19 +246,19 @@ package object test extends CompileVariants {
   /**
    * Asserts that the given test was completed.
    */
-  def assertCompletes(implicit trace: Trace): TestResult =
+  def assertCompletes(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     assertImpl(true)(Assertion.isTrue)
 
   /**
    * Asserts that the given test was completed.
    */
-  def assertCompletesZIO(implicit trace: Trace): UIO[TestResult] =
+  def assertCompletesZIO(implicit trace: Trace, sourceLocation: SourceLocation): UIO[TestResult] =
     ZIO.succeed(assertCompletes)
 
   /**
    * Asserts that the given test was never completed.
    */
-  def assertNever(message: String)(implicit trace: Trace): TestResult =
+  def assertNever(message: String)(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     assertImpl(true)(Assertion.equalTo(false)) ?? message
 
   /**
@@ -267,6 +267,7 @@ package object test extends CompileVariants {
    */
   def check[R <: TestConfig, A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
@@ -280,6 +281,7 @@ package object test extends CompileVariants {
     test: (A, B) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2)(test.tupled)
@@ -291,6 +293,7 @@ package object test extends CompileVariants {
     test: (A, B, C) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3)(test.tupled)
@@ -302,6 +305,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
@@ -319,6 +323,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
@@ -337,6 +342,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F, G) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     check(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6)(test.tupled)
@@ -348,6 +354,7 @@ package object test extends CompileVariants {
    */
   def checkAll[R <: TestConfig, A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkStream(rv.sample.collectSome)(a => checkConstructor(test(a)))
@@ -359,6 +366,7 @@ package object test extends CompileVariants {
     test: (A, B) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2)(test.tupled)
@@ -370,6 +378,7 @@ package object test extends CompileVariants {
     test: (A, B, C) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3)(test.tupled)
@@ -381,6 +390,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4)(test.tupled)
@@ -398,6 +408,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5)(test.tupled)
@@ -416,6 +427,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F, G) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAll(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6)(test.tupled)
@@ -429,6 +441,7 @@ package object test extends CompileVariants {
     test: A => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkStreamPar(rv.sample.collectSome, parallelism)(a => checkConstructor(test(a)))
@@ -440,6 +453,7 @@ package object test extends CompileVariants {
     test: (A, B) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAllPar(rv1 <*> rv2, parallelism)(test.tupled)
@@ -456,6 +470,7 @@ package object test extends CompileVariants {
     test: (A, B, C) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAllPar(rv1 <*> rv2 <*> rv3, parallelism)(test.tupled)
@@ -473,6 +488,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4, parallelism)(test.tupled)
@@ -491,6 +507,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5, parallelism)(test.tupled)
@@ -510,6 +527,7 @@ package object test extends CompileVariants {
     test: (A, B, C, D, F, G) => In
   )(implicit
     checkConstructor: CheckConstructor[R, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     checkAllPar(rv1 <*> rv2 <*> rv3 <*> rv4 <*> rv5 <*> rv6, parallelism)(test.tupled)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.stacktracer.Tracer
+import zio.internal.stacktracer.{SourceLocation, Tracer}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZChannel.{ChildExecutorDecision, UpstreamPullRequest, UpstreamPullStrategy}
 import zio.stream.{ZChannel, ZSink, ZStream}
@@ -571,6 +571,7 @@ package object test extends CompileVariants {
    */
   def suite[In](label: String)(specs: In*)(implicit
     suiteConstructor: SuiteConstructor[In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): Spec[suiteConstructor.OutEnvironment, suiteConstructor.OutError] =
     Spec.labeled(
@@ -594,6 +595,7 @@ package object test extends CompileVariants {
    */
   def test[In](label: String)(assertion: => In)(implicit
     testConstructor: TestConstructor[Nothing, In],
+    sourceLocation: SourceLocation,
     trace: Trace
   ): testConstructor.Out =
     testConstructor(label)(assertion)

--- a/test/shared/src/main/scala/zio/test/render/IntelliJRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/IntelliJRenderer.scala
@@ -1,6 +1,7 @@
 package zio.test.render
 
 import zio.Trace
+import zio.internal.stacktracer.SourceLocation
 import zio.test.ExecutionEvent.{SectionEnd, SectionStart, Test, TopLevelFlush}
 import zio.test.TestAnnotationRenderer.LeafRenderer
 import zio.test.render.ExecutionResult.{ResultType, Status}
@@ -143,8 +144,8 @@ trait IntelliJRenderer extends TestRenderer {
 object IntelliJRenderer extends IntelliJRenderer {
   val locationRenderer: TestAnnotationRenderer =
     LeafRenderer(TestAnnotation.trace) { case child :: _ =>
-      child.headOption.collect { case Trace(_, file, line) =>
-        s"file://$file:$line"
+      child.headOption.collect { case SourceLocation(path, line) =>
+        s"file://$path:$line"
       }
     }
 }


### PR DESCRIPTION
ZIO's `Trace` currently reports only the filename of the failing test (e.g. `MySpec.scala:34`), stripping the full path (for security reasons), and the filename itself is insufficient for assertions/tooling to be able to navigate to the exact location of the failure.

This PR restores the `SourceLocation` implicit which captures the full path of the executing test.

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/601206/170933785-e6eab694-96af-4b0d-8f16-ba30658f8641.png">