### PR TITLE
Timing information for executing tests

### DIFF
--- a/test/shared/src/main/scala/zio/test/ExecutionEvent.scala
+++ b/test/shared/src/main/scala/zio/test/ExecutionEvent.scala
@@ -7,7 +7,7 @@ object ExecutionEvent {
     test: Either[TestFailure[E], TestSuccess],
     annotations: TestAnnotationMap,
     ancestors: List[SuiteId],
-    duration: Long = 0L,
+    duration: Long,
     id: SuiteId
   ) extends ExecutionEvent {
     val labels: List[String] = labelsReversed.reverse

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -101,7 +101,7 @@ object TestExecutor {
                     ) =>
                   (for {
                     result  <- ZIO.withClock(ClockLive)(test.timed.either)
-                    duration = result.map(_._1.toMillis).getOrElse(1L)
+                    duration = result.map(_._1.toMillis).fold(_ => 1L, identity)
                     event =
                       ExecutionEvent
                         .Test(

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -44,7 +44,8 @@ trait ConsoleRenderer extends TestRenderer {
                 Status.Passed,
                 offset = depth,
                 List(TestAnnotationMap.empty), // TODO Examine all results to get this
-                lines = List(fr(nonEmptyList.last).toLine)
+                lines = List(fr(nonEmptyList.last).toLine),
+                duration = None
               )
             )
         }
@@ -70,7 +71,8 @@ trait ConsoleRenderer extends TestRenderer {
             initialDepth,
             List(annotations),
             streamingOutput,
-            summaryOutput
+            summaryOutput,
+            duration = None
           )
         )
       case runtimeFailure @ ExecutionEvent.RuntimeFailure(_, _, failure, _) =>
@@ -174,7 +176,8 @@ trait ConsoleRenderer extends TestRenderer {
   import zio.duration2DurationOps
   def renderSummary(summary: Summary): String =
     s"""${summary.success} tests passed. ${summary.fail} tests failed. ${summary.ignore} tests ignored.
-       |Executed in ${summary.duration.render}""".stripMargin
+       |Executed in ${summary.duration.render}
+       |""".stripMargin
 
   def render(cause: Cause[_], labels: List[String]): Option[String] =
     cause match {

--- a/test/shared/src/main/scala/zio/test/render/ExecutionResult.scala
+++ b/test/shared/src/main/scala/zio/test/render/ExecutionResult.scala
@@ -29,7 +29,8 @@ case class ExecutionResult(
   offset: Int,
   annotations: List[TestAnnotationMap],
   streamingLines: List[Line],
-  summaryLines: List[Line]
+  summaryLines: List[Line],
+  duration: Option[Long]
 ) {
   self =>
 
@@ -71,7 +72,8 @@ object ExecutionResult {
     status: Status,
     offset: Int,
     annotations: List[TestAnnotationMap],
-    lines: List[Line]
+    lines: List[Line],
+    duration: Option[Long]
   ): ExecutionResult =
     ExecutionResult(
       resultType,
@@ -80,7 +82,8 @@ object ExecutionResult {
       offset,
       annotations,
       lines,
-      lines // Re-uses lines when we don't have summary-specific output
+      lines, // Re-uses lines when we don't have summary-specific output,
+      duration
     )
 
   sealed abstract class Status

--- a/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
@@ -227,7 +227,7 @@ trait TestRenderer {
     offset: Int,
     lines: Line*
   ): ExecutionResult =
-    ExecutionResult(caseType, label, result, offset, Nil, lines.toList, lines.toList)
+    ExecutionResult(caseType, label, result, offset, Nil, lines.toList, lines.toList, None)
 
   def renderedWithSummary(
     caseType: ResultType,
@@ -237,5 +237,5 @@ trait TestRenderer {
     lines: List[Line],
     summaryLines: List[Line]
   ): ExecutionResult =
-    ExecutionResult(caseType, label, result, offset, Nil, lines, summaryLines)
+    ExecutionResult(caseType, label, result, offset, Nil, lines, summaryLines, None)
 }


### PR DESCRIPTION
This PR times the test execution inside the `TestExecutor` and reports the duration. This is useful for tooling such as the IntelliJ test runner, which uses this to display the test duration, but also fixes a long-standing issue of test durations not being reported inside JUnit's Test XML produced by sbt.

Fixes #6752
Fixes #6101