### PR TITLE
Fixing rendering composite test summary

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -50,12 +50,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
     if (allSummaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else {
-      renderedSummary +
-        allSummaries
-          .map(ConsoleRenderer.renderSummary)
-          .filter(_.nonEmpty)
-          .flatMap(summary => colored(summary) :: "\n" :: Nil)
-          .mkString("", "", "Done")
+      colored(renderedSummary)
     }
   }
 


### PR DESCRIPTION
When running with sbt (`sbt test`), this fixes a composite summary rendering from:
![image](https://user-images.githubusercontent.com/601206/170949647-3f8023bf-bc00-48e0-8390-82382f73765b.png)

to

![image](https://user-images.githubusercontent.com/601206/170949672-53e0cba0-aff0-46ae-9b04-6bc0ecfdbf8a.png)
