### PR TITLE
Delete Runtime.track

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -472,13 +472,6 @@ object Runtime extends RuntimePlatformSpecific {
     ZLayer.scoped(FiberRef.currentRuntimeFlags.locallyScopedWith(_ + RuntimeFlag.SuperviseOperations))
   }
 
-  /**
-   * A layer that adds a supervisor that tracks all forked fibers in a set. Note
-   * that this may have a negative impact on performance.
-   */
-  def track(weak: Boolean)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
-    addSupervisor(Supervisor.unsafeTrack(weak))
-
   val trackRuntimeMetrics: ZLayer[Any, Nothing, Unit] = {
     implicit val trace = Trace.empty
     ZLayer.scoped(FiberRef.currentRuntimeFlags.locallyScopedWith(_ + RuntimeFlag.TrackRuntimeMetrics))


### PR DESCRIPTION
This is not being used anywhere and it does not seem particularly useful as I think if you wanted to add a supervisor you would both create the supervisor and install it in the same layer so you had access to the supervisor in the implementation of the layer.