### PR TITLE
Optimized `slice` for `BitChunk` (#6850)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkByteSpec.scala
@@ -69,6 +69,13 @@ object BitChunkByteSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    test("slice") {
+      check(genByteChunk, genInt, genInt) { (bytes, n, m) =>
+        val actual   = bytes.asBitsByte.slice(n, m).toBinaryString
+        val expected = bytes.map(toBinaryString).mkString.slice(n, m)
+        assert(actual)(equalTo(expected))
+      }
+    },
     test("toBinaryString") {
       check(genByteChunk) { bytes =>
         val actual   = bytes.asBitsByte.toBinaryString

--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -65,6 +65,13 @@ object BitChunkIntSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    test("slice") {
+      check(genIntChunk, genInt, genInt, genEndianness) { (bytes, n, m, endianness) =>
+        val actual   = bytes.asBitsInt(endianness).slice(n, m).toBinaryString
+        val expected = bytes.map(toBinaryString(endianness)).mkString.slice(n, m)
+        assert(actual)(equalTo(expected))
+      }
+    },
     test("toBinaryString") {
       check(genIntChunk, genEndianness) { (ints, endianness) =>
         val actual   = ints.asBitsInt(endianness).toBinaryString

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -65,6 +65,13 @@ object BitChunkLongSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    test("slice") {
+      check(genLongChunk, genInt, genInt, genEndianness) { (bytes, n, m, endianness) =>
+        val actual   = bytes.asBitsLong(endianness).slice(n, m).toBinaryString
+        val expected = bytes.map(toBinaryString(endianness)).mkString.slice(n, m)
+        assert(actual)(equalTo(expected))
+      }
+    },
     test("toBinaryString") {
       check(genLongChunk, genEndianness) { (longs, endianness) =>
         val actual   = longs.asBitsLong(endianness).toBinaryString

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1903,6 +1903,11 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def nextAt(index: Int): Boolean =
       self(index)
 
+    override def slice(from: Int, until: Int): BitChunk[T] =
+      if (from <= 0 && until >= self.length) self
+      else if (from >= self.length || until <= from) newBitChunk(Chunk.empty, 0, 0)
+      else newBitChunk(chunk, self.minBitIndex + from, self.minBitIndex + until min self.maxBitIndex)
+
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Boolean] =
       if (offset <= 0 && length >= self.length) self
       else if (offset >= self.length || length <= 0) ChunkIterator.empty


### PR DESCRIPTION
@adamgfraser As I did already impl. minBit / maxBit for all instances of `BitChunk` in #6849, I think this should conclude #6850