### PR TITLE
Delete ZEnvironment#upcast

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -136,9 +136,6 @@ final class ZEnvironment[+R] private (
   private def unsafeUpdate[A >: R](tag: LightTypeTag, f: A => A): ZEnvironment[R] =
     unsafeAdd[A](tag, f(unsafeGet(tag)))
 
-  def upcast[R1](implicit ev: R <:< R1): ZEnvironment[R1] =
-    new ZEnvironment(map, index)
-
   /**
    * Updates a service in the environment.
    */

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -333,7 +333,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
   final def toRuntime(implicit ev: Any <:< RIn, trace: Trace): ZIO[Scope, E, Runtime[ROut]] =
     for {
       scope       <- ZIO.scope
-      layer        = ZLayer.succeedEnvironment(ZEnvironment.empty.upcast(ev))
+      layer        = ZLayer.succeedEnvironment(ZEnvironment.empty.asInstanceOf[ZEnvironment[RIn]])
       environment <- (layer >>> self).build(scope)
       runtime     <- ZIO.runtime[ROut].provideEnvironment(environment)
     } yield runtime


### PR DESCRIPTION
This is a holdover from when `Has` was invariant. It was only used in one specific situation where we wanted to use implicit evidence from another operator to establish a sub-typing relationship but I don't think that is sufficient to keep it in the API.