### PR TITLE
[RFC] Allow ZLayer.fromFunction to have type parameter

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -589,7 +589,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
         .map(environment => ZEnvironment(environment.get.result()))
     }
 
-  class FromFunctionPartiallApplied[+OutParam] {
+  class FromFunctionPartiallApplied[+OutParam](private val self: Unit) extends AnyVal {
     def apply[In[+_], OutParam1 >: OutParam](in: In[OutParam1])(implicit
       constructor: FunctionConstructorX[In],
       trace: Trace,
@@ -602,7 +602,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * Constructs a layer from the specified function.
    */
   def fromFunction[OutParam]: FromFunctionPartiallApplied[OutParam] =
-    new FromFunctionPartiallApplied[OutParam]
+    new FromFunctionPartiallApplied[OutParam](())
 
   /**
    * Constructs a layer from the specified effect.

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -731,7 +731,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   }
 
   object FunctionConstructorX {
-    type WithOut[In[+_], Out0[+_]] = FunctionConstructorX[In] { type Out[x] = Out0[x] }
+    type WithOut[In[+_], Out0[+_]] = FunctionConstructorX[In] { type Out[+x] = Out0[x] }
 
     implicit def function0Constructor
       : WithOut[({ type lambda[+x] = () => x })#lambda, ({ type lambda[+x] = ZLayer[Any, Nothing, x] })#lambda] =

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -599,7 +599,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   }
 
   def fromFunctionX[OutParam]: FromFunctionPartiallApplied[OutParam] =
-    new FromFunctionPartiallApplied[OutParam](())
+    new FromFunctionPartiallApplied[OutParam]
 
   /**
    * Constructs a layer from the specified function.

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -589,7 +589,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
         .map(environment => ZEnvironment(environment.get.result()))
     }
 
-  class FromFunctionPartiallApplied[+OutParam](private val self: Unit) extends AnyVal {
+  class FromFunctionPartiallApplied[+OutParam] {
     def apply[In[+_], OutParam1 >: OutParam](in: In[OutParam1])(implicit
       constructor: FunctionConstructorX[In],
       trace: Trace,

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -598,11 +598,14 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
       constructor(in)
   }
 
+  def fromFunctionX[OutParam]: FromFunctionPartiallApplied[OutParam] =
+    new FromFunctionPartiallApplied[OutParam](())
+
   /**
    * Constructs a layer from the specified function.
    */
-  def fromFunction[OutParam]: FromFunctionPartiallApplied[OutParam] =
-    new FromFunctionPartiallApplied[OutParam](())
+  def fromFunction[In](in: In)(implicit constructor: FunctionConstructor[In], trace: Trace): constructor.Out =
+    constructor(in)
 
   /**
    * Constructs a layer from the specified effect.

--- a/examples/shared/src/main/scala/zio/examples/FromFunctionExample.scala
+++ b/examples/shared/src/main/scala/zio/examples/FromFunctionExample.scala
@@ -14,7 +14,7 @@ object FromFunctionExample extends ZIOAppDefault {
   final case class DatabaseLive(databaseConfig: DatabaseConfig) extends Database
 
   object DatabaseLive {
-    private[examples] val layer = ZLayer.fromFunction[Database](apply _)
+    private[examples] val layer = ZLayer.fromFunctionX[Database](apply _)
   }
 
   trait Analytics
@@ -22,7 +22,7 @@ object FromFunctionExample extends ZIOAppDefault {
   final case class AnalyticsLive() extends Analytics
 
   object AnalyticsLive {
-    private[examples] val layer = ZLayer.fromFunction[Analytics](apply _)
+    private[examples] val layer = ZLayer.fromFunctionX[Analytics](apply _)
   }
 
   trait Users
@@ -30,7 +30,7 @@ object FromFunctionExample extends ZIOAppDefault {
   final case class UsersLive(database: Database, analytics: Analytics) extends Users
 
   object UsersLive {
-    private[examples] val layer = ZLayer.fromFunction[Users](apply _)
+    private[examples] val layer = ZLayer.fromFunctionX[Users](apply _)
   }
 
   final case class App(users: Users, analytics: Analytics) {
@@ -39,7 +39,7 @@ object FromFunctionExample extends ZIOAppDefault {
   }
 
   object App {
-    private[examples] val live = ZLayer.fromFunction(App.apply _)
+    private[examples] val live = ZLayer.fromFunctionX(App.apply _)
   }
 
   def run =


### PR DESCRIPTION
Continuing discussion from https://github.com/zio/zio/pull/6902
This adds the ability to add explicit type parameter to `ZLayer.fromFunction`, typically that would be an interface

The ultimate goal is the same as from the above linked PR:

 * make _hiding the implementation class and exposing only an interface when creating a layer_ as easy and boiler plate free as possible

I'd be excited to hear what you think of this approach @adamgfraser @kitlangton . If you like this, I'll finish the boilerplate and turn this into a mergable PR.

(The changes in `FromFunctionExample.scala` are just to show _you_ that and how it works in practice, we we don't really need to change the file in this PR.)