### PR TITLE
Restore test summary failure details

### DIFF
--- a/test-sbt/js/src/main/scala/zio/test/sbt/SummaryProtocol.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/SummaryProtocol.scala
@@ -30,7 +30,7 @@ object SummaryProtocol {
       summary.success.toString,
       summary.fail.toString,
       summary.ignore.toString,
-      summary.summary
+      summary.failureOutput
     ).map(escape).mkString("\t")
 
   def deserialize(s: String): Option[Summary] =

--- a/test-sbt/js/src/main/scala/zio/test/sbt/SummaryProtocol.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/SummaryProtocol.scala
@@ -30,7 +30,7 @@ object SummaryProtocol {
       summary.success.toString,
       summary.fail.toString,
       summary.ignore.toString,
-      summary.failureOutput
+      summary.failureDetails
     ).map(escape).mkString("\t")
 
   def deserialize(s: String): Option[Summary] =

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -39,7 +39,11 @@ sealed abstract class ZTestRunnerJS(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.failureDetails).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries
+        .map(_.failureDetails)
+        .filter(_.nonEmpty)
+        .flatMap(s => colored(s) :: "\n" :: Nil)
+        .mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -39,7 +39,7 @@ sealed abstract class ZTestRunnerJS(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.summary).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries.map(_.failureOutput).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -39,7 +39,7 @@ sealed abstract class ZTestRunnerJS(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.failureOutput).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries.map(_.failureDetails).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-sbt/native/src/main/scala/zio/test/sbt/SummaryProtocol.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/SummaryProtocol.scala
@@ -28,7 +28,7 @@ object SummaryProtocol {
       summary.success.toString,
       summary.fail.toString,
       summary.ignore.toString,
-      summary.failureOutput
+      summary.failureDetails
     ).map(escape).mkString("\t")
 
   def deserialize(s: String): Option[Summary] =

--- a/test-sbt/native/src/main/scala/zio/test/sbt/SummaryProtocol.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/SummaryProtocol.scala
@@ -28,7 +28,7 @@ object SummaryProtocol {
       summary.success.toString,
       summary.fail.toString,
       summary.ignore.toString,
-      summary.summary
+      summary.failureOutput
     ).map(escape).mkString("\t")
 
   def deserialize(s: String): Option[Summary] =

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -39,7 +39,11 @@ sealed abstract class ZTestRunnerNative(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.failureDetails).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries
+        .map(_.failureDetails)
+        .filter(_.nonEmpty)
+        .flatMap(s => colored(s) :: "\n" :: Nil)
+        .mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -39,7 +39,7 @@ sealed abstract class ZTestRunnerNative(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.summary).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries.map(_.failureOutput).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -39,7 +39,7 @@ sealed abstract class ZTestRunnerNative(
     if (summaries.isEmpty || total == ignore)
       s"${Console.YELLOW}No tests were executed${Console.RESET}"
     else
-      summaries.map(_.failureOutput).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
+      summaries.map(_.failureDetails).filter(_.nonEmpty).flatMap(s => colored(s) :: "\n" :: Nil).mkString("", "", "Done")
   }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -59,7 +59,7 @@ object ReportingTestUtils {
     for {
       console <- ZIO.console
       summary <- TestTestRunner(testEnvironment, sinkLayer(console, ConsoleEventRenderer)).run(spec)
-    } yield summary.failureOutput
+    } yield summary.failureDetails
 
   private[test] def TestTestRunner(
     testEnvironment: ZLayer[Scope, Nothing, TestEnvironment],

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -59,7 +59,7 @@ object ReportingTestUtils {
     for {
       console <- ZIO.console
       summary <- TestTestRunner(testEnvironment, sinkLayer(console, ConsoleEventRenderer)).run(spec)
-    } yield summary.summary
+    } yield summary.failureOutput
 
   private[test] def TestTestRunner(
     testEnvironment: ZLayer[Scope, Nothing, TestEnvironment],

--- a/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
@@ -51,7 +51,7 @@ object ZIOSpecAbstractSpec extends ZIOSpecDefault {
         res <-
           ZIO.consoleWith(console => failingSpec.runSpecInfallible(failingSpec.spec, TestArgs.empty, console))
       } yield assertTrue(res.fail == 1) &&
-        assertTrue(res.summary.contains(s"$suiteName - $testName"))
+        assertTrue(res.failureOutput.contains(s"$suiteName - $testName"))
     }
   ) @@ TestAspect.ignore)
     .provide(
@@ -64,5 +64,5 @@ object ZIOSpecAbstractSpec extends ZIOSpecDefault {
     a.success == b.success &&
       a.fail == b.fail &&
       a.ignore == b.ignore &&
-      a.summary == b.summary
+      a.failureOutput == b.failureOutput
 }

--- a/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
@@ -51,7 +51,7 @@ object ZIOSpecAbstractSpec extends ZIOSpecDefault {
         res <-
           ZIO.consoleWith(console => failingSpec.runSpecInfallible(failingSpec.spec, TestArgs.empty, console))
       } yield assertTrue(res.fail == 1) &&
-        assertTrue(res.failureOutput.contains(s"$suiteName - $testName"))
+        assertTrue(res.failureDetails.contains(s"$suiteName - $testName"))
     }
   ) @@ TestAspect.ignore)
     .provide(
@@ -64,5 +64,5 @@ object ZIOSpecAbstractSpec extends ZIOSpecDefault {
     a.success == b.success &&
       a.fail == b.fail &&
       a.ignore == b.ignore &&
-      a.failureOutput == b.failureOutput
+      a.failureDetails == b.failureDetails
 }

--- a/test/shared/src/main/scala/zio/test/Summary.scala
+++ b/test/shared/src/main/scala/zio/test/Summary.scala
@@ -23,11 +23,11 @@ final case class Summary(
                           success: Int,
                           fail: Int,
                           ignore: Int,
-                          failureOutput: String,
+                          failureDetails: String,
                           duration: Duration = Duration.Zero
 ) {
   val status: Summary.Status =
-    if (failureOutput.trim.isEmpty)
+    if (failureDetails.trim.isEmpty)
       Summary.Success
     else
       Summary.Failure
@@ -41,11 +41,11 @@ final case class Summary(
       success + other.success,
       fail + other.fail,
       ignore + other.ignore,
-      failureOutput +
-        (if (other.failureOutput.trim.isEmpty)
+      failureDetails +
+        (if (other.failureDetails.trim.isEmpty)
            ""
          else
-           "\n" + other.failureOutput),
+           "\n" + other.failureDetails),
       duration.plus(other.duration)
     )
 }

--- a/test/shared/src/main/scala/zio/test/Summary.scala
+++ b/test/shared/src/main/scala/zio/test/Summary.scala
@@ -20,11 +20,11 @@ import zio.{Duration, Trace}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 final case class Summary(
-                          success: Int,
-                          fail: Int,
-                          ignore: Int,
-                          failureDetails: String,
-                          duration: Duration = Duration.Zero
+  success: Int,
+  fail: Int,
+  ignore: Int,
+  failureDetails: String,
+  duration: Duration = Duration.Zero
 ) {
   val status: Summary.Status =
     if (failureDetails.trim.isEmpty)

--- a/test/shared/src/main/scala/zio/test/Summary.scala
+++ b/test/shared/src/main/scala/zio/test/Summary.scala
@@ -20,14 +20,14 @@ import zio.{Duration, Trace}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 final case class Summary(
-  success: Int,
-  fail: Int,
-  ignore: Int,
-  summary: String,
-  duration: Duration = Duration.Zero
+                          success: Int,
+                          fail: Int,
+                          ignore: Int,
+                          failureOutput: String,
+                          duration: Duration = Duration.Zero
 ) {
   val status: Summary.Status =
-    if (summary.trim.isEmpty)
+    if (failureOutput.trim.isEmpty)
       Summary.Success
     else
       Summary.Failure
@@ -41,11 +41,11 @@ final case class Summary(
       success + other.success,
       fail + other.fail,
       ignore + other.ignore,
-      summary +
-        (if (other.summary.trim.isEmpty)
+      failureOutput +
+        (if (other.failureOutput.trim.isEmpty)
            ""
          else
-           "\n" + other.summary),
+           "\n" + other.failureOutput),
       duration.plus(other.duration)
     )
 }

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -176,6 +176,7 @@ trait ConsoleRenderer extends TestRenderer {
   import zio.duration2DurationOps
   def renderSummary(summary: Summary): String =
     s"""${summary.success} tests passed. ${summary.fail} tests failed. ${summary.ignore} tests ignored.
+       |${summary.failureOutput}
        |Executed in ${summary.duration.render}
        |""".stripMargin
 

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -176,7 +176,7 @@ trait ConsoleRenderer extends TestRenderer {
   import zio.duration2DurationOps
   def renderSummary(summary: Summary): String =
     s"""${summary.success} tests passed. ${summary.fail} tests failed. ${summary.ignore} tests ignored.
-       |${summary.failureOutput}
+       |${summary.failureDetails}
        |Executed in ${summary.duration.render}
        |""".stripMargin
 


### PR DESCRIPTION
This restores the details that @adamgfraser noted were absent in this PR: https://github.com/zio/zio/pull/6882

Also renames `summary.summary` to `summary.failureDetails` to hopefully highlight the significance of this field in the future.