### PR TITLE
Gen: add utils to get tuple with all differents elements

### DIFF
--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -1014,6 +1014,32 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     }
 
   /**
+   * Generate a tuple of two elements of the same type and guaranties that those
+   * two elements are not the same
+   */
+  def tuple2Diff[R <: Random, A](gen: Gen[R, A]): Gen[R, (A, A)] = Gen.setOfN(2)(gen).map { set =>
+    (set.head, set.tail.head)
+  }
+
+  /**
+   * Generate a tuple of three elements of the same type and guaranties that
+   * those three elements are all different
+   */
+  def tuple3Diff[R <: Random, A](gen: Gen[R, A]): Gen[R, (A, A, A)] = Gen.setOfN(3)(gen).map { set =>
+    val list = set.toList
+    (set.head, list(1), list(2))
+  }
+
+  /**
+   * Generate a tuple of four elements of the same type and guaranties that
+   * those four elements are all different
+   */
+  def tuple4Diff[R <: Random, A](gen: Gen[R, A]): Gen[R, (A, A, A, A)] = Gen.setOfN(4)(gen).map { set =>
+    val list = set.toList
+    (set.head, list(1), list(2), list(3))
+  }
+
+  /**
    * Restricts an integer to the specified range.
    */
   private def clamp(n: Int, min: Int, max: Int): Int =


### PR DESCRIPTION
In our team, when doing property testing it often happens that we want to generate two or three values of the same type but different.
For the moment our technique is to use `Gen.setN` and to deconstruct the result but it's tedious, especially when using `-Werror`.
So we end up coding those `tupleNDiff`.
So here is my PR in case you also think it's a good idea.