### PR TITLE
Prevent creating invalid ´BitChunk´ from negative slice parameters

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1959,15 +1959,19 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def nextAt(index: Int): Boolean =
       self(index)
 
-    override def slice(from: Int, until: Int): BitChunk[T] =
-      if (from <= 0 && until >= self.length) self
-      else if (from >= self.length || until <= from) newBitChunk(Chunk.empty, 0, 0)
-      else newBitChunk(chunk, self.minBitIndex + from, self.minBitIndex + until min self.maxBitIndex)
+    override def slice(from: Int, until: Int): BitChunk[T] = {
+      val lo = from max 0
+      if (lo <= 0 && until >= self.length) self
+      else if (lo >= self.length || until <= lo) newBitChunk(Chunk.empty, 0, 0)
+      else newBitChunk(chunk, self.minBitIndex + lo, self.minBitIndex + until min self.maxBitIndex)
+    }
 
-    def sliceIterator(offset: Int, length: Int): ChunkIterator[Boolean] =
-      if (offset <= 0 && length >= self.length) self
-      else if (offset >= self.length || length <= 0) ChunkIterator.empty
-      else newBitChunk(chunk, self.minBitIndex + offset, self.minBitIndex + offset + length min self.maxBitIndex)
+    def sliceIterator(offset: Int, length: Int): ChunkIterator[Boolean] = {
+      val lo = offset max 0
+      if (lo <= 0 && length >= self.length) self
+      else if (lo >= self.length || length <= 0) ChunkIterator.empty
+      else newBitChunk(chunk, self.minBitIndex + lo, self.minBitIndex + lo + length min self.maxBitIndex)
+    }
 
   }
 


### PR DESCRIPTION
If given now a negative from and/or until values we ensure that for
every index < length, the apply of BitChunk will not throw an exception.
The idea is same as in Scala collections lib:
https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/immutable/List.scala#L199