### PR TITLE
Fix - polling metric collectAll generates a metric based only on the …

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/PollingMetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/PollingMetricSpec.scala
@@ -12,7 +12,7 @@ object PollingMetricSpec extends ZIOSpecDefault {
 
       for {
         name           <- Clock.currentTime(TimeUnit.NANOSECONDS).map(ns => s"gauge-$ns")
-        (gauge, metric) = makePollingGauge(name)
+        (gauge, metric) = makePollingGauge(name, 1.0)
         f0             <- metric.launch(Schedule.forever.delayed(_ => 250.millis))
         _              <- f0.interrupt
         state          <- gauge.value
@@ -23,25 +23,41 @@ object PollingMetricSpec extends ZIOSpecDefault {
 
       for {
         name           <- Clock.currentTime(TimeUnit.NANOSECONDS).map(ns => s"gauge-$ns")
-        (gauge, metric) = makePollingGauge(name)
+        (gauge, metric) = makePollingGauge(name, 1.0)
         f0             <- metric.launch(Schedule.once)
         _              <- f0.join
         state          <- gauge.value
       } yield assertTrue(state.value == 1.0)
 
+    },
+    test("collectAll should generate a metric that polls all the provided metrics") {
+      val gaugeIncrement1 = 1.0
+      val gaugeIncrement2 = 2.0
+      val pollingCount    = 2
+      for {
+        name1            <- Clock.currentTime(TimeUnit.NANOSECONDS).map(ns => s"gauge1-$ns")
+        name2            <- Clock.currentTime(TimeUnit.NANOSECONDS).map(ns => s"gauge2-$ns")
+        (gauge1, metric1) = makePollingGauge(name1, gaugeIncrement1)
+        (gauge2, metric2) = makePollingGauge(name2, gaugeIncrement2)
+        metric            = PollingMetric.collectAll(Seq(metric1, metric2))
+        f0               <- metric.launch(Schedule.recurs(pollingCount))
+        _                <- f0.join
+        state1           <- gauge1.value
+        state2           <- gauge2.value
+      } yield assertTrue(
+        state1.value == gaugeIncrement1 * pollingCount && state2.value == gaugeIncrement2 * pollingCount
+      )
     }
   ) @@ withLiveClock
 
-  private def makePollingGauge(name: String) = {
+  private def makePollingGauge(name: String, increment: Double) = {
     val gauge = Metric.gauge(name)
 
     def metric = PollingMetric(
       gauge,
-      gauge.value.map(_.value + 1.0)
+      gauge.value.map(_.value + increment)
     )
 
     (gauge, metric)
-
   }
-
 }


### PR DESCRIPTION
**Issue description:**
when trying to collect jvm heap metrics only the "nonheap" metric is exported and the "heap" metric is absent!

**Bug description:**
the reason is that PollingMetric's collectAll function which should generate a new metric that collects all the provided metrics actually collects only the last provided one. 

the issue lies in the fact that the implementation runs a foldLeft on the sequence of the provided metrics but never uses the accumulator and always returns only the last metric in the collection.

**Proposed fix:**
the proposed fix replaces the foldLeft implementation by simply creating a new metric that overrides the required functions of Metric and collect all the provided metrics.

**How was it tested:**

- added test to check all the provided metrics are collected
- published zio locally and provided the jar to a project that exposes a prometheus metric endpoint and checked that the missing metrics are exported 