### PR TITLE
Add fail-fast assertion to ZIO test

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -2,6 +2,7 @@ package zio.test
 
 import zio._
 import zio.Clock._
+import zio.internal.macros.StringUtils.StringOps
 import zio.stm.STM
 import zio.test.Assertion._
 import zio.test.TestAspect.{failing, timeout}
@@ -74,9 +75,8 @@ object TestSpec extends ZIOBaseSpec {
         count   <- ref.get
       } yield assert(count)(equalTo(1)) &&
         assert(summary.fail)(equalTo(1)) &&
-        assert(summary.failureDetails)(
-          containsString("Result was false") &&
-            containsString("1 == 2") &&
+        assert(summary.failureDetails.unstyled)(
+          containsString("1 == 2") &&
             not(containsString("3 == 4"))
         )
     },
@@ -94,9 +94,8 @@ object TestSpec extends ZIOBaseSpec {
         count   <- ref.get
       } yield assert(count)(equalTo(1)) &&
         assert(summary.fail)(equalTo(1)) &&
-        assert(summary.failureDetails)(
-          containsString("Result was false") &&
-            containsString("1 == 2") &&
+        assert(summary.failureDetails.unstyled)(
+          containsString("1 == 2") &&
             containsString("3 == 4")
         )
     },

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -60,15 +60,15 @@ object TestSpec extends ZIOBaseSpec {
         message <- STM.succeed("Hello from an STM transaction!")
       } yield assert(message)(anything)
     },
-    test("TestResult#orDie enables fail-fast assertion") {
+    test("fail-fast assertion by automatic lifting to ZIO") {
       for {
         ref <- Ref.make(0)
         spec = test("test") {
                  for {
                    _ <- ref.update(_ + 1)
-                   _ <- assertTrue(false).orDie
+                   _ <- assertTrue(false)
                    _ <- ref.update(_ + 1)
-                   _ <- assertTrue(false).orDie
+                   _ <- assertTrue(false)
                    _ <- ref.update(_ + 1)
                  } yield assertCompletes
                }

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -66,15 +66,19 @@ object TestSpec extends ZIOBaseSpec {
         spec = test("test") {
                  for {
                    _ <- ref.update(_ + 1)
-                   _ <- assertTrue(false)
+                   _ <- assertTrue(1 == 2)
                    _ <- ref.update(_ + 1)
-                 } yield assertCompletes
+                 } yield assertTrue(3 == 4)
                }
         summary <- execute(spec)
         count   <- ref.get
       } yield assert(count)(equalTo(1)) &&
         assert(summary.fail)(equalTo(1)) &&
-        assert(summary.failureDetails)(containsString("Result was false"))
+        assert(summary.failureDetails)(
+          containsString("Result was false") &&
+            containsString("1 == 2") &&
+            not(containsString("3 == 4"))
+        )
     },
     test("composed assertions are lifted to ZIO and fully evaluated") {
       for {

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -47,11 +47,11 @@ object TestResult {
 
   def any(asserts: TestResult*): TestResult = asserts.reduce(_ || _)
 
-  implicit def liftTestResultToZIO[R, E](testResult: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
-    if (testResult.isSuccess)
-      ZIO.succeed(testResult)
+  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    if (result.isSuccess)
+      ZIO.succeed(result)
     else
-      ZIO.die(TestResult.Exit(testResult))
+      ZIO.die(TestResult.Exit(result))
 
   private[zio] case class Exit(result: TestResult) extends Throwable
 }

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -49,7 +49,7 @@ object TestResult {
 
   implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
     if (result.isSuccess)
-      ZIO.succeed(result)
+      ZIO.succeedNow(result)
     else
       ZIO.die(TestResult.Exit(result))
 

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -40,18 +40,18 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
   def setGenFailureDetails(details: GenFailureDetails): TestResult =
     TestResult(arrow.setGenFailureDetails(details))
-
-  def orDie[R, E](implicit trace: Trace): ZIO[R, E, TestResult] =
-    if (isSuccess)
-      ZIO.succeed(this)
-    else
-      ZIO.die(TestResult.Exit(this))
 }
 
 object TestResult {
   def all(asserts: TestResult*): TestResult = asserts.reduce(_ && _)
 
   def any(asserts: TestResult*): TestResult = asserts.reduce(_ || _)
+
+  implicit def liftTestResultToZIO[R, E](testResult: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    if (testResult.isSuccess)
+      ZIO.succeed(testResult)
+    else
+      ZIO.die(TestResult.Exit(testResult))
 
   private[zio] case class Exit(result: TestResult) extends Throwable
 }

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -51,9 +51,9 @@ object TestResult {
     if (result.isSuccess)
       ZIO.succeedNow(result)
     else
-      ZIO.die(TestResult.Exit(result))
+      ZIO.die(Exit(result))
 
-  private[zio] case class Exit(result: TestResult) extends Throwable
+  private[zio] final case class Exit(result: TestResult) extends Throwable
 }
 
 sealed trait TestArrow[-A, +B] { self =>

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -214,7 +214,11 @@ package object test extends CompileVariants {
           }
         }
         .foldCauseZIO(
-          cause => ZIO.fail(TestFailure.Runtime(cause)),
+          cause =>
+            cause.dieOption match {
+              case Some(TestResult.Exit(assert)) => ZIO.fail(TestFailure.Assertion(assert))
+              case _                             => ZIO.fail(TestFailure.Runtime(cause))
+            },
           assert =>
             if (assert.isFailure)
               ZIO.fail(TestFailure.Assertion(assert))


### PR DESCRIPTION
It enables fail-fast assertion with helpful error reports in large test scenarios such as integration tests.

 Closes #5181