### PR TITLE
Have IntelliJ renderer test exception cause

### DIFF
--- a/test/shared/src/main/scala/zio/test/ReporterEventRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/ReporterEventRenderer.scala
@@ -20,7 +20,7 @@ object ReporterEventRenderer {
     override def render(executionEvent: ExecutionEvent)(implicit trace: Trace): Chunk[String] =
       Chunk.fromIterable(
         IntelliJRenderer
-          .render(executionEvent, includeCause = false)
+          .render(executionEvent, includeCause = true)
       )
   }
 }


### PR DESCRIPTION
Turns on `renderCause` which was accidentally disabled, preventing showing the exception stack traces on tests that die in IntelliJ.