### PR TITLE
Notify supervisors before notifying other observers on fiber end

### DIFF
--- a/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
@@ -81,10 +81,8 @@ object SupervisorSpec extends ZIOSpecDefault {
           fiber: Fiber.Runtime[E, A]
         )(implicit unsafe: Unsafe): Unit = ()
 
-        def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
-          Thread.sleep(10)
+        def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
           ref.unsafe.update(_ + 1)
-        }
       }
     }
 

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -64,6 +64,12 @@ abstract class Supervisor[+A] { self =>
   def onSuspend[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
 
   def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
+
+  def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
+
+  def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
+
+  def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
 }
 object Supervisor {
 
@@ -185,6 +191,15 @@ object Supervisor {
 
     override def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
       underlying.onResume(fiber)
+
+    override def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
+      underlying.onAsyncStart(fiber)
+
+    override def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
+      underlying.onAsyncEnd(fiber)
+
+    override def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
+      underlying.onObserverNotify(value, fiber)
   }
 
   sealed trait Patch { self =>
@@ -277,6 +292,23 @@ object Supervisor {
     override def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
       left.onResume(fiber)
       right.onResume(fiber)
+    }
+
+    override def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      left.onAsyncStart(fiber)
+      right.onAsyncStart(fiber)
+    }
+
+    override def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      left.onAsyncEnd(fiber)
+      right.onAsyncEnd(fiber)
+    }
+
+    override def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit
+      unsafe: Unsafe
+    ): Unit = {
+      left.onObserverNotify(value, fiber)
+      right.onObserverNotify(value, fiber)
     }
   }
 

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -64,12 +64,6 @@ abstract class Supervisor[+A] { self =>
   def onSuspend[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
 
   def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
-
-  def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
-
-  def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
-
-  def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
 }
 object Supervisor {
 
@@ -191,15 +185,6 @@ object Supervisor {
 
     override def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
       underlying.onResume(fiber)
-
-    override def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
-      underlying.onAsyncStart(fiber)
-
-    override def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
-      underlying.onAsyncEnd(fiber)
-
-    override def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
-      underlying.onObserverNotify(value, fiber)
   }
 
   sealed trait Patch { self =>
@@ -292,23 +277,6 @@ object Supervisor {
     override def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
       left.onResume(fiber)
       right.onResume(fiber)
-    }
-
-    override def onAsyncStart[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
-      left.onAsyncStart(fiber)
-      right.onAsyncStart(fiber)
-    }
-
-    override def onAsyncEnd[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
-      left.onAsyncEnd(fiber)
-      right.onAsyncEnd(fiber)
-    }
-
-    override def onObserverNotify[E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit
-      unsafe: Unsafe
-    ): Unit = {
-      left.onObserverNotify(value, fiber)
-      right.onObserverNotify(value, fiber)
     }
   }
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -601,6 +601,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val callback = (effect: ZIO[Any, Any, Any]) => {
       if (alreadyCalled.compareAndSet(false, true)) {
         self.asyncEffect = effect
+        getSupervisor().onAsyncEnd(self)
         tell(FiberMessage.Resume)
       } else {
         val msg = s"An async callback was invoked more than once, which could be a sign of a defect: ${effect}"
@@ -610,6 +611,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     }
 
     if (RuntimeFlags.interruptible(runtimeFlags)) self.asyncInterruptor = callback
+
+    getSupervisor().onAsyncStart(self)
 
     try {
       asyncRegister(callback)
@@ -1182,6 +1185,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     }
 
     reportExitValue(e)
+    getSupervisor().onObserverNotify(e, self)
 
     val iterator = observers.iterator
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -601,7 +601,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val callback = (effect: ZIO[Any, Any, Any]) => {
       if (alreadyCalled.compareAndSet(false, true)) {
         self.asyncEffect = effect
-        getSupervisor().onAsyncEnd(self)
         tell(FiberMessage.Resume)
       } else {
         val msg = s"An async callback was invoked more than once, which could be a sign of a defect: ${effect}"
@@ -611,8 +610,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     }
 
     if (RuntimeFlags.interruptible(runtimeFlags)) self.asyncInterruptor = callback
-
-    getSupervisor().onAsyncStart(self)
 
     try {
       asyncRegister(callback)
@@ -1185,7 +1182,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     }
 
     reportExitValue(e)
-    getSupervisor().onObserverNotify(e, self)
 
     val iterator = observers.iterator
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1183,7 +1183,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
     reportExitValue(e)
 
-    val iterator = observers.iterator
+    // ensure we notify observers in the same order they subscribed to us
+    val iterator = observers.reverse.iterator
 
     while (iterator.hasNext) {
       val observer = iterator.next()


### PR DESCRIPTION
Now that we have better traces, I started playing around with profiling again.
In order to support it we would need to expose a few more events to supervisors.

A few notes:

* ~~onAsyncStart: Called on start of an asynchronous wait. This is necessary to track which fibers are semantically 'running' and which are waiting for something.~~
* ~~onAsyncEnd: Called on end of an asynchronous wait. Counterpart to `onAsyncStart`.~~
* ~~In principle both `onAsyncStart` and `onAsyncEnd` could be figured out by supervisors by enabling opSupervision and matching on the Event. Question here is whether we want to support supervisors doing this without opSupervision. (Profilers will have opSupervision enabled anyway, so 🤷 )~~
* ~~onObserverNotify: The usecase here is that we need to know when a fiber might wake up other fibers. `onFiberEnd` is not suitable for this as it is implemented using an observer. Right now observers are maintained as a list and new obsevers are prepended. This leads to the semantics of "whoever observed last will get notified first". As the supervisor will observe the fiber as the very first thing before starting  https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/ZIO.scala#L2487, it will only be notified after all other observers are notified / fibers are woken up. An alternative solution would be to reverse the list of observers before notifying, switching the semantics to "whoever observed first will get notified first"~~

Edit:
Instead of adding a new callback to the supervisor it's enough to enforce that the existing `onEnd` callback is called before any fibers that were forked after supervision are woken up.