### PR TITLE
Fix missing trace information when throwing outside of ZIO.attempt

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -864,6 +864,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               } catch {
                 case zioError: ZIOError =>
                   cur = zioError.toEffect(effect.trace)
+                case throwable =>
+                  cur = ZIO.failCause(Cause.die(throwable))(effect.trace)
               }
 
             case effect0: OnFailure[_, _, _, _] =>


### PR DESCRIPTION
Worked on this with @adamgfraser. We found that there was some missing trace information when calling `ZIO.succeed(throw new Error("Oops"))` versus `ZIO.attempt(throw new Error("Oops"))`.

Example:

```scala
def methodOne =
  for {
    _ <- ZIO.debug("START ONE")
    _ <- methodTwo
    _ <- ZIO.debug("END ONE")
  } yield ()

def methodTwo =
  for {
    _ <- ZIO.debug("START TWO")
    _ <- methodThree
    _ <- ZIO.debug("END TWO")
  } yield ()

def methodThree =
  for {
    _ <- ZIO.debug("START THREE")
    // _ <- ZIO.attempt(throw new Error("OOPS")) // Attempt has the right trace
    _ <- ZIO.succeed(throw new Error("OOPS"))    // Succeed is missing methodOne and methodTwo
    _ <- ZIO.debug("END THREE")
  } yield ()
```
