### PR TITLE
Unify Unsafe Operators

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -5,7 +5,7 @@ import cats.effect.{Fiber => CFiber, IO => CIO}
 
 import scala.concurrent.ExecutionContext
 
-object BenchmarkUtil extends Runtime[Any] {
+object BenchmarkUtil extends Runtime[Any] { self =>
   val environment = Runtime.default.environment
 
   val fiberRefs = Runtime.default.fiberRefs
@@ -32,5 +32,5 @@ object BenchmarkUtil extends Runtime[Any] {
     else io.flatMap(_ => catsRepeat(n - 1)(io))
 
   def unsafeRun[E, A](zio: ZIO[Any, E, A]): A =
-    Unsafe.unsafe(implicit u => unsafe.run(zio).getOrThrowFiberFailure())
+    Unsafe.unsafe(implicit unsafe => self.unsafe.run(zio).getOrThrowFiberFailure())
 }

--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -32,5 +32,5 @@ object BenchmarkUtil extends Runtime[Any] {
     else io.flatMap(_ => catsRepeat(n - 1)(io))
 
   def unsafeRun[E, A](zio: ZIO[Any, E, A]): A =
-    Unsafe.unsafeCompat(implicit u => unsafe.run(zio).getOrThrowFiberFailure())
+    Unsafe.unsafely(implicit u => unsafe.run(zio).getOrThrowFiberFailure())
 }

--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -32,5 +32,5 @@ object BenchmarkUtil extends Runtime[Any] {
     else io.flatMap(_ => catsRepeat(n - 1)(io))
 
   def unsafeRun[E, A](zio: ZIO[Any, E, A]): A =
-    Unsafe.unsafely(implicit u => unsafe.run(zio).getOrThrowFiberFailure())
+    Unsafe.unsafe(implicit u => unsafe.run(zio).getOrThrowFiberFailure())
 }

--- a/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
@@ -90,7 +90,7 @@ class BroadFlatMapBenchmark {
       else
         fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.succeed(a + b)))
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(fib(depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
@@ -90,7 +90,7 @@ class BroadFlatMapBenchmark {
       else
         fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.succeed(a + b)))
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(fib(depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
@@ -90,7 +90,7 @@ class BroadFlatMapBenchmark {
       else
         fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.succeed(a + b)))
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(fib(depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
@@ -23,7 +23,7 @@ class DeepLeftBindBenchmark {
       i += 1
     }
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(io).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
@@ -23,7 +23,7 @@ class DeepLeftBindBenchmark {
       i += 1
     }
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(io).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/DeepLeftBindBenchmark.scala
@@ -23,7 +23,7 @@ class DeepLeftBindBenchmark {
       i += 1
     }
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(io).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -35,7 +35,7 @@ class EmptyRaceBenchmark {
       if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeedNow(i)
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -35,7 +35,7 @@ class EmptyRaceBenchmark {
       if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeedNow(i)
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -35,7 +35,7 @@ class EmptyRaceBenchmark {
       if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeedNow(i)
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -63,7 +63,7 @@ class FiberRefBenchmarks {
   def createAndJoinUpdatesDeep(): Unit =
     createAndJoinUpdatesDeep(BenchmarkUtil)
 
-  private def justYield(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def justYield(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       for {
         _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
@@ -71,7 +71,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createFiberRefsAndYield(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createFiberRefsAndYield(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -84,7 +84,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createUpdateAndRead(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createUpdateAndRead(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -99,7 +99,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoin(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createAndJoin(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -111,7 +111,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinExpensive(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createAndJoinExpensive(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -123,7 +123,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinInitialValue(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createAndJoinInitialValue(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -134,7 +134,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -146,7 +146,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
+  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0)).flatMap { fiberRefs =>

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -63,107 +63,115 @@ class FiberRefBenchmarks {
   def createAndJoinUpdatesDeep(): Unit =
     createAndJoinUpdatesDeep(BenchmarkUtil)
 
-  private def justYield(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      for {
-        _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
-      } yield ()
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createFiberRefsAndYield(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
+  private def justYield(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
         for {
-          fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.make(i))
-          _         <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
-          values    <- ZIO.foreachPar(fiberRefs)(_.get)
-          _         <- verify(values == 1.to(n))(s"Got $values")
+          _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
         } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
+      }.getOrThrowFiberFailure()
+    }
 
-  private def createUpdateAndRead(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        for {
-          fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.make(i))
-          values1   <- ZIO.foreachPar(fiberRefs)(ref => ref.update(-_) *> ref.get)
-          values2   <- ZIO.foreachPar(fiberRefs)(_.get)
-          _ <- verify(values1.forall(_ < 0) && values1.size == values2.size)(
-                 s"Got \nvalues1: $values1, \nvalues2: $values2"
-               )
-        } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createAndJoin(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        for {
-          fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
-          _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
-          _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
-        } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createAndJoinExpensive(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        for {
-          fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makeSet(1.to(i).toSet))
-          _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_.map(_ + 1)))
-          _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
-        } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createAndJoinInitialValue(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        for {
-          _ <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
-          _ <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
-        } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        for {
-          fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
-          _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
-          _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))))
-        } yield ()
-      }
-    }.getOrThrowFiberFailure()
-  }
-
-  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      ZIO.scoped {
-        ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0)).flatMap { fiberRefs =>
-          def go(depth: Int): UIO[Unit] =
-            if (depth <= 0) ZIO.unit
-            else
-              for {
-                _  <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
-                f1 <- go(depth - 1).fork
-                _  <- f1.join
-              } yield ()
-
-          go(m)
+  private def createFiberRefsAndYield(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.make(i))
+            _         <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
+            values    <- ZIO.foreachPar(fiberRefs)(_.get)
+            _         <- verify(values == 1.to(n))(s"Got $values")
+          } yield ()
         }
-      }
-    }.getOrThrowFiberFailure()
-  }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createUpdateAndRead(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.make(i))
+            values1   <- ZIO.foreachPar(fiberRefs)(ref => ref.update(-_) *> ref.get)
+            values2   <- ZIO.foreachPar(fiberRefs)(_.get)
+            _ <- verify(values1.forall(_ < 0) && values1.size == values2.size)(
+                   s"Got \nvalues1: $values1, \nvalues2: $values2"
+                 )
+          } yield ()
+        }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createAndJoin(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
+            _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
+            _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
+          } yield ()
+        }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createAndJoinExpensive(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makeSet(1.to(i).toSet))
+            _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_.map(_ + 1)))
+            _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
+          } yield ()
+        }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createAndJoinInitialValue(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            _ <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
+            _ <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.unit))
+          } yield ()
+        }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          for {
+            fiberRefs <- ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0))
+            _         <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
+            _         <- ZIO.collectAllParDiscard(List.fill(m)(ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))))
+          } yield ()
+        }
+      }.getOrThrowFiberFailure()
+    }
+
+  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        ZIO.scoped {
+          ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0)).flatMap { fiberRefs =>
+            def go(depth: Int): UIO[Unit] =
+              if (depth <= 0) ZIO.unit
+              else
+                for {
+                  _  <- ZIO.foreachDiscard(fiberRefs)(_.update(_ + 1))
+                  f1 <- go(depth - 1).fork
+                  _  <- f1.join
+                } yield ()
+
+            go(m)
+          }
+        }
+      }.getOrThrowFiberFailure()
+    }
 
   private val addDiffer = new Differ[Int, Int] {
     def combine(first: Int, second: Int): Int   = first + second

--- a/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/FiberRefBenchmarks.scala
@@ -63,7 +63,7 @@ class FiberRefBenchmarks {
   def createAndJoinUpdatesDeep(): Unit =
     createAndJoinUpdatesDeep(BenchmarkUtil)
 
-  private def justYield(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def justYield(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       for {
         _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow)
@@ -71,7 +71,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createFiberRefsAndYield(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createFiberRefsAndYield(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -84,7 +84,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createUpdateAndRead(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createUpdateAndRead(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -99,7 +99,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoin(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createAndJoin(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -111,7 +111,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinExpensive(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createAndJoinExpensive(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -123,7 +123,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinInitialValue(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createAndJoinInitialValue(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -134,7 +134,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createAndJoinUpdatesWide(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         for {
@@ -146,7 +146,7 @@ class FiberRefBenchmarks {
     }.getOrThrowFiberFailure()
   }
 
-  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) = Unsafe.unsafeCompat { implicit u =>
+  private def createAndJoinUpdatesDeep(runtime: Runtime[Any]) = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       ZIO.scoped {
         ZIO.foreach(1.to(n))(i => FiberRef.makePatch(i, addDiffer, 0)).flatMap { fiberRefs =>

--- a/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
@@ -35,7 +35,7 @@ class ForkInterruptBenchmark {
       if (i < size) ZIO.never.fork.flatMap(_.interrupt *> loop(i + 1))
       else ZIO.unit
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
@@ -35,7 +35,7 @@ class ForkInterruptBenchmark {
       if (i < size) ZIO.never.fork.flatMap(_.interrupt *> loop(i + 1))
       else ZIO.unit
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkInterruptBenchmark.scala
@@ -35,7 +35,7 @@ class ForkInterruptBenchmark {
       if (i < size) ZIO.never.fork.flatMap(_.interrupt *> loop(i + 1))
       else ZIO.unit
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
@@ -99,7 +99,7 @@ class LeftBindBenchmark {
       else if (i < size) loop(i + 1).flatMap(i => ZIO.succeed(i))
       else ZIO.succeed(i)
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
@@ -99,7 +99,7 @@ class LeftBindBenchmark {
       else if (i < size) loop(i + 1).flatMap(i => ZIO.succeed(i))
       else ZIO.succeed(i)
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/LeftBindBenchmark.scala
@@ -99,7 +99,7 @@ class LeftBindBenchmark {
       else if (i < size) loop(i + 1).flatMap(i => ZIO.succeed(i))
       else ZIO.succeed(i)
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/MapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/MapBenchmark.scala
@@ -88,7 +88,7 @@ class MapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(sumTo(ZIO.succeed(0), depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/MapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/MapBenchmark.scala
@@ -88,7 +88,7 @@ class MapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(sumTo(ZIO.succeed(0), depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/MapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/MapBenchmark.scala
@@ -88,7 +88,7 @@ class MapBenchmark {
       if (n <= 1) t
       else sumTo(t.map(_ + n), n - 1)
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(sumTo(ZIO.succeed(0), depth)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
@@ -92,7 +92,7 @@ class NarrowFlatMapBenchmark {
       if (i < size) ZIO.succeed[Int](i + 1).flatMap(loop)
       else ZIO.succeed(i)
 
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
@@ -92,7 +92,7 @@ class NarrowFlatMapBenchmark {
       if (i < size) ZIO.succeed[Int](i + 1).flatMap(loop)
       else ZIO.succeed(i)
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
@@ -92,7 +92,7 @@ class NarrowFlatMapBenchmark {
       if (i < size) ZIO.succeed[Int](i + 1).flatMap(loop)
       else ZIO.succeed(i)
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(ZIO.succeed(0).flatMap[Any, Nothing, Int](loop)).getOrThrowFiberFailure()
     }
   }

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -54,7 +54,7 @@ class ParallelMergeSortBenchmark {
     sortInput.zip(sortOutput).foreach(verifySorted)
   }
 
-  private def benchMergeSort(runtime: Runtime[Any]): Unit = Unsafe.unsafely { implicit u =>
+  private def benchMergeSort(runtime: Runtime[Any]): Unit = Unsafe.unsafe { implicit u =>
     runtime.unsafe.run {
       for {
         sortOutput <- ZIO.foreach(sortInput)(mergeSort)

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -54,7 +54,7 @@ class ParallelMergeSortBenchmark {
     sortInput.zip(sortOutput).foreach(verifySorted)
   }
 
-  private def benchMergeSort(runtime: Runtime[Any]): Unit = Unsafe.unsafeCompat { implicit u =>
+  private def benchMergeSort(runtime: Runtime[Any]): Unit = Unsafe.unsafely { implicit u =>
     runtime.unsafe.run {
       for {
         sortOutput <- ZIO.foreach(sortInput)(mergeSort)

--- a/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ParallelMergeSortBenchmark.scala
@@ -54,14 +54,15 @@ class ParallelMergeSortBenchmark {
     sortInput.zip(sortOutput).foreach(verifySorted)
   }
 
-  private def benchMergeSort(runtime: Runtime[Any]): Unit = Unsafe.unsafe { implicit u =>
-    runtime.unsafe.run {
-      for {
-        sortOutput <- ZIO.foreach(sortInput)(mergeSort)
-        _          <- ZIO.foreach(sortInput.zip(sortOutput))(verifySorted)
-      } yield ()
-    }.getOrThrowFiberFailure()
-  }
+  private def benchMergeSort(runtime: Runtime[Any]): Unit =
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run {
+        for {
+          sortOutput <- ZIO.foreach(sortInput)(mergeSort)
+          _          <- ZIO.foreach(sortInput.zip(sortOutput))(verifySorted)
+        } yield ()
+      }.getOrThrowFiberFailure()
+    }
 
   private def verifySorted(inOut: (Iterable[Int], Iterable[Int])): IO[AssertionError, Unit] = {
     val sorted = inOut._2.toArray.sliding(2).forall {

--- a/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
@@ -1,5 +1,7 @@
 package zio.chunks
 
+package zio.chunks
+
 import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 
@@ -37,7 +39,7 @@ class ChunkFoldBenchmarks {
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
@@ -37,7 +37,5 @@ class ChunkFoldBenchmarks {
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
-    }
+    BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
@@ -1,7 +1,5 @@
 package zio.chunks
 
-package zio.chunks
-
 import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 
@@ -39,7 +37,7 @@ class ChunkFoldBenchmarks {
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
@@ -37,7 +37,7 @@ class ChunkFoldBenchmarks {
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
@@ -37,8 +37,6 @@ class ChunkMapBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
-    }
+    BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
 
 }

--- a/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
@@ -37,7 +37,7 @@ class ChunkMapBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
     }
 

--- a/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
@@ -37,7 +37,7 @@ class ChunkMapBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
     }
 

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -58,15 +58,11 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def filterZIO(): Chunk[Int] =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunk.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
-    }
+    BenchmarkUtil.unsafeRun(chunk.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
 
   @Benchmark
   def filterMaterializedZIO(): Chunk[Int] =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunkMaterialized.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
-    }
+    BenchmarkUtil.unsafeRun(chunkMaterialized.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
 
   @Benchmark
   def map(): Chunk[Int] = chunk.map(_ * 2)
@@ -88,26 +84,18 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
-    }
+    BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
 
   @Benchmark
   def mapZIOMaterialized(): Unit =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIODiscard(_ => ZIO.unit))
-    }
+    BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIODiscard(_ => ZIO.unit))
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
-    }
+    BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
 
   @Benchmark
   def foldZIOMaterialized(): Int =
-    Unsafe.unsafe { implicit u =>
-      BenchmarkUtil.unsafeRun(chunkMaterialized.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
-    }
+    BenchmarkUtil.unsafeRun(chunkMaterialized.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
 
 }

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -58,13 +58,13 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def filterZIO(): Chunk[Int] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
     }
 
   @Benchmark
   def filterMaterializedZIO(): Chunk[Int] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
     }
 
@@ -88,25 +88,25 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
     }
 
   @Benchmark
   def mapZIOMaterialized(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIODiscard(_ => ZIO.unit))
     }
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 
   @Benchmark
   def foldZIOMaterialized(): Int =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -58,13 +58,13 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def filterZIO(): Chunk[Int] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
     }
 
   @Benchmark
   def filterMaterializedZIO(): Chunk[Int] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
     }
 
@@ -88,25 +88,25 @@ class MixedChunkBenchmarks {
 
   @Benchmark
   def mapZIO(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
     }
 
   @Benchmark
   def mapZIOMaterialized(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIODiscard(_ => ZIO.unit))
     }
 
   @Benchmark
   def foldZIO(): Int =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunk.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 
   @Benchmark
   def foldZIOMaterialized(): Int =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       BenchmarkUtil.unsafeRun(chunkMaterialized.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
     }
 

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -29,7 +29,7 @@ class SingleRefBenchmark {
 
   @Benchmark
   def trefContention(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafeRun(for {
         tref  <- TRef.make(0).commit
         fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -29,7 +29,7 @@ class SingleRefBenchmark {
 
   @Benchmark
   def trefContention(): Unit =
-    Unsafe.unsafe { implicit u =>
+    Unsafe.unsafe { implicit unsafe =>
       unsafeRun(for {
         tref  <- TRef.make(0).commit
         fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))

--- a/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SingleRefBenchmark.scala
@@ -29,7 +29,7 @@ class SingleRefBenchmark {
 
   @Benchmark
   def trefContention(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafeRun(for {
         tref  <- TRef.make(0).commit
         fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -28,7 +28,7 @@ class TArrayOpsBenchmarks {
   def setup(): Unit = {
     val data = (1 to size).toList
     idx = size / 2
-    array = Unsafe.unsafe(implicit u => unsafeRun(TArray.fromIterable(data).commit))
+    array = Unsafe.unsafe(implicit unsafe => unsafeRun(TArray.fromIterable(data).commit))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -1,5 +1,7 @@
 package zio.stm
 
+package zio.stm
+
 import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 
@@ -28,7 +30,7 @@ class TArrayOpsBenchmarks {
   def setup(): Unit = {
     val data = (1 to size).toList
     idx = size / 2
-    array = Unsafe.unsafeCompat(implicit u => unsafeRun(TArray.fromIterable(data).commit))
+    array = Unsafe.unsafe(implicit u => unsafeRun(TArray.fromIterable(data).commit))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -1,7 +1,5 @@
 package zio.stm
 
-package zio.stm
-
 import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 
@@ -30,7 +28,7 @@ class TArrayOpsBenchmarks {
   def setup(): Unit = {
     val data = (1 to size).toList
     idx = size / 2
-    array = Unsafe.unsafe(implicit u => unsafeRun(TArray.fromIterable(data).commit))
+    array = Unsafe.unsafely(implicit u => unsafeRun(TArray.fromIterable(data).commit))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/stm/TArrayOpsBenchmarks.scala
@@ -28,7 +28,7 @@ class TArrayOpsBenchmarks {
   def setup(): Unit = {
     val data = (1 to size).toList
     idx = size / 2
-    array = Unsafe.unsafely(implicit u => unsafeRun(TArray.fromIterable(data).commit))
+    array = Unsafe.unsafe(implicit u => unsafeRun(TArray.fromIterable(data).commit))
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import org.openjdk.jmh.annotations._
 import zio.BenchmarkUtil._
-import zio.{Trace, Unsafe, ZIO}
+import zio.{Trace, ZIO}
 
 import java.util.concurrent.TimeUnit
 
@@ -36,13 +36,9 @@ class GenBenchmark {
 
   @Benchmark
   def listOfN(): Unit =
-    Unsafe.unsafe { implicit u =>
-      unsafeRun(listOfNEffect)
-    }
+    unsafeRun(listOfNEffect)
 
   @Benchmark
   def causes(): Unit =
-    Unsafe.unsafe { implicit u =>
-      unsafeRun(causesEffect)
-    }
+    unsafeRun(causesEffect)
 }

--- a/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
@@ -36,13 +36,13 @@ class GenBenchmark {
 
   @Benchmark
   def listOfN(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafeRun(listOfNEffect)
     }
 
   @Benchmark
   def causes(): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafeRun(causesEffect)
     }
 }

--- a/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/GenBenchmark.scala
@@ -36,13 +36,13 @@ class GenBenchmark {
 
   @Benchmark
   def listOfN(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafeRun(listOfNEffect)
     }
 
   @Benchmark
   def causes(): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafeRun(causesEffect)
     }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 
 lazy val coreJVM = core.jvm
   .settings(replSettings)
-  .settings(mimaSettings(failOnProblem = false))
+  .settings(mimaSettings(failOnProblem = true))
 
 lazy val coreJS = core.js
   .settings(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0")
@@ -328,7 +328,7 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 
 lazy val streamsJVM = streams.jvm
   // No bincompat on streams yet
-  .settings(mimaSettings(failOnProblem = false))
+  .settings(mimaSettings(failOnProblem = true))
 
 lazy val streamsJS = streams.js
 

--- a/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
@@ -19,7 +19,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
           for {
             runtime <- ZIO.runtime[Any]
             r <- ZIO.fromFuture { _ =>
-                   Unsafe.unsafe { implicit u =>
+                   Unsafe.unsafe { implicit unsafe =>
                      runtime.unsafe.runToFuture(ZIO.succeedNow(0))
                    }
                  }
@@ -32,7 +32,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
         ZIO
           .runtime[Any]
           .map(runtime =>
-            Unsafe.unsafe(implicit u => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
+            Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
           )
       } @@ nonFlaky
     ) @@ zioTag(future)

--- a/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
@@ -19,7 +19,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
           for {
             runtime <- ZIO.runtime[Any]
             r <- ZIO.fromFuture { _ =>
-                   Unsafe.unsafeCompat { implicit u =>
+                   Unsafe.unsafely { implicit u =>
                      runtime.unsafe.runToFuture(ZIO.succeedNow(0))
                    }
                  }
@@ -32,7 +32,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
         ZIO
           .runtime[Any]
           .map(runtime =>
-            Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
+            Unsafe.unsafely(implicit u => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
           )
       } @@ nonFlaky
     ) @@ zioTag(future)

--- a/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/CancelableFutureSpecJVM.scala
@@ -19,7 +19,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
           for {
             runtime <- ZIO.runtime[Any]
             r <- ZIO.fromFuture { _ =>
-                   Unsafe.unsafely { implicit u =>
+                   Unsafe.unsafe { implicit u =>
                      runtime.unsafe.runToFuture(ZIO.succeedNow(0))
                    }
                  }
@@ -32,7 +32,7 @@ object CancelableFutureSpecJVM extends ZIOBaseSpec {
         ZIO
           .runtime[Any]
           .map(runtime =>
-            Unsafe.unsafely(implicit u => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
+            Unsafe.unsafe(implicit u => runtime.unsafe.run(tst.onExecutor(executor)).getOrThrowFiberFailure())
           )
       } @@ nonFlaky
     ) @@ zioTag(future)

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -12,7 +12,7 @@ object FiberRefSpecJvm extends ZIOBaseSpec {
     test("unsafe handles behave properly if fiber specific data cannot be accessed") {
       for {
         fiberRef <- FiberRef.make(initial)
-        handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+        handle   <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
         resRef   <- ZIO.succeed(new AtomicReference(("", "", "")))
 
         unsafelyGetSetGet = new Runnable {

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -12,7 +12,7 @@ object FiberRefSpecJvm extends ZIOBaseSpec {
     test("unsafe handles behave properly if fiber specific data cannot be accessed") {
       for {
         fiberRef <- FiberRef.make(initial)
-        handle   <- Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+        handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
         resRef   <- ZIO.succeed(new AtomicReference(("", "", "")))
 
         unsafelyGetSetGet = new Runnable {

--- a/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
+++ b/core-tests/jvm/src/test/scala/zio/FiberRefSpecJvm.scala
@@ -12,7 +12,7 @@ object FiberRefSpecJvm extends ZIOBaseSpec {
     test("unsafe handles behave properly if fiber specific data cannot be accessed") {
       for {
         fiberRef <- FiberRef.make(initial)
-        handle   <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
+        handle   <- Unsafe.unsafe(implicit unsafe => fiberRef.asThreadLocal)
         resRef   <- ZIO.succeed(new AtomicReference(("", "", "")))
 
         unsafelyGetSetGet = new Runnable {

--- a/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
@@ -19,11 +19,11 @@ object HubConcurrencyTests {
   @State
   class ManyToManyTest {
     val hub: Hub[Int] =
-      Unsafe.unsafe(implicit u => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
-    val left: Dequeue[Int] = Unsafe.unsafe { implicit u =>
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
+    val left: Dequeue[Int] = Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
-    val right: Dequeue[Int] = Unsafe.unsafe { implicit u =>
+    val right: Dequeue[Int] = Unsafe.unsafe { implicit unsafe =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
     var p1 = 0
@@ -32,20 +32,22 @@ object HubConcurrencyTests {
     var p4 = 0
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafe { implicit u =>
-      runtime.unsafe.run(hub.publish(1)).getOrThrowFiberFailure()
-      ()
-    }
+    def actor1(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(hub.publish(1)).getOrThrowFiberFailure()
+        ()
+      }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafe { implicit u =>
-      runtime.unsafe.run(hub.publish(2)).getOrThrowFiberFailure()
-      ()
-    }
+    def actor2(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(hub.publish(2)).getOrThrowFiberFailure()
+        ()
+      }
 
     @Actor
     def actor3(): Unit =
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafe { implicit unsafe =>
         runtime.unsafe.run {
           left.take.zipWith(left.take) { (first, last) =>
             p1 = first
@@ -56,7 +58,7 @@ object HubConcurrencyTests {
 
     @Actor
     def actor4(): Unit =
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafe { implicit unsafe =>
         runtime.unsafe.run {
           right.take.zipWith(right.take) { (first, last) =>
             p3 = first

--- a/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
@@ -19,11 +19,11 @@ object HubConcurrencyTests {
   @State
   class ManyToManyTest {
     val hub: Hub[Int] =
-      Unsafe.unsafely(implicit u => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
-    val left: Dequeue[Int] = Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
+    val left: Dequeue[Int] = Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
-    val right: Dequeue[Int] = Unsafe.unsafely { implicit u =>
+    val right: Dequeue[Int] = Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
     var p1 = 0
@@ -32,20 +32,20 @@ object HubConcurrencyTests {
     var p4 = 0
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafely { implicit u =>
+    def actor1(): Unit = Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(hub.publish(1)).getOrThrowFiberFailure()
       ()
     }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafely { implicit u =>
+    def actor2(): Unit = Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(hub.publish(2)).getOrThrowFiberFailure()
       ()
     }
 
     @Actor
     def actor3(): Unit =
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         runtime.unsafe.run {
           left.take.zipWith(left.take) { (first, last) =>
             p1 = first
@@ -56,7 +56,7 @@ object HubConcurrencyTests {
 
     @Actor
     def actor4(): Unit =
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         runtime.unsafe.run {
           right.take.zipWith(right.take) { (first, last) =>
             p3 = first

--- a/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/HubConcurrencyTests.scala
@@ -19,11 +19,11 @@ object HubConcurrencyTests {
   @State
   class ManyToManyTest {
     val hub: Hub[Int] =
-      Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
-    val left: Dequeue[Int] = Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely(implicit u => runtime.unsafe.run(Hub.bounded[Int](2)).getOrThrowFiberFailure())
+    val left: Dequeue[Int] = Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
-    val right: Dequeue[Int] = Unsafe.unsafeCompat { implicit u =>
+    val right: Dequeue[Int] = Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(Scope.global.extend[Any](hub.subscribe)).getOrThrowFiberFailure()
     }
     var p1 = 0
@@ -32,20 +32,20 @@ object HubConcurrencyTests {
     var p4 = 0
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor1(): Unit = Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(hub.publish(1)).getOrThrowFiberFailure()
       ()
     }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor2(): Unit = Unsafe.unsafely { implicit u =>
       runtime.unsafe.run(hub.publish(2)).getOrThrowFiberFailure()
       ()
     }
 
     @Actor
     def actor3(): Unit =
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         runtime.unsafe.run {
           left.take.zipWith(left.take) { (first, last) =>
             p1 = first
@@ -56,7 +56,7 @@ object HubConcurrencyTests {
 
     @Actor
     def actor4(): Unit =
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         runtime.unsafe.run {
           right.take.zipWith(right.take) { (first, last) =>
             p3 = first

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -34,7 +34,7 @@ object RTSSpec extends ZIOBaseSpec {
         done  <- Ref.make(false)
         start <- Promise.make[Nothing, Unit]
         fiber <- ZIO.attemptBlockingInterrupt {
-                   Unsafe.unsafe { implicit u => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
+                   Unsafe.unsafe { implicit unsafe => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
                  }
                    .ensuring(done.set(true))
                    .fork
@@ -48,7 +48,7 @@ object RTSSpec extends ZIOBaseSpec {
         for {
           release <- Promise.make[Nothing, Int]
           latch   <- Promise.make[Nothing, Unit]
-          async = ZIO.asyncInterruptUnsafe[Any, Nothing, Unit] { implicit u => _ =>
+          async = ZIO.asyncInterruptUnsafe[Any, Nothing, Unit] { implicit unsafe => _ =>
                     latch.unsafe.done(ZIO.unit); Left(release.succeed(42).unit)
                   }
           fiber  <- async.fork
@@ -100,7 +100,7 @@ object RTSSpec extends ZIOBaseSpec {
       val e   = Executors.newSingleThreadExecutor()
 
       (0 until 1000).foreach { _ =>
-        Unsafe.unsafe { implicit u =>
+        Unsafe.unsafe { implicit unsafe =>
           rts.unsafe.run {
             ZIO.async[Any, Nothing, Int] { k =>
               val c: Callable[Unit] = () => k(ZIO.succeed(1))

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -34,7 +34,7 @@ object RTSSpec extends ZIOBaseSpec {
         done  <- Ref.make(false)
         start <- Promise.make[Nothing, Unit]
         fiber <- ZIO.attemptBlockingInterrupt {
-                   Unsafe.unsafeCompat { implicit u => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
+                   Unsafe.unsafely { implicit u => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
                  }
                    .ensuring(done.set(true))
                    .fork
@@ -100,7 +100,7 @@ object RTSSpec extends ZIOBaseSpec {
       val e   = Executors.newSingleThreadExecutor()
 
       (0 until 1000).foreach { _ =>
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafely { implicit u =>
           rts.unsafe.run {
             ZIO.async[Any, Nothing, Int] { k =>
               val c: Callable[Unit] = () => k(ZIO.succeed(1))

--- a/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/RTSSpec.scala
@@ -34,7 +34,7 @@ object RTSSpec extends ZIOBaseSpec {
         done  <- Ref.make(false)
         start <- Promise.make[Nothing, Unit]
         fiber <- ZIO.attemptBlockingInterrupt {
-                   Unsafe.unsafely { implicit u => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
+                   Unsafe.unsafe { implicit u => start.unsafe.done(ZIO.unit); Thread.sleep(60L * 60L * 1000L) }
                  }
                    .ensuring(done.set(true))
                    .fork
@@ -100,7 +100,7 @@ object RTSSpec extends ZIOBaseSpec {
       val e   = Executors.newSingleThreadExecutor()
 
       (0 until 1000).foreach { _ =>
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           rts.unsafe.run {
             ZIO.async[Any, Nothing, Int] { k =>
               val c: Callable[Unit] = () => k(ZIO.succeed(1))

--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -20,15 +20,15 @@ object ZSTMConcurrencyTests {
   )
   @State
   class ConcurrentWithPermit {
-    val promise: Promise[Nothing, Unit] = Unsafe.unsafeCompat { implicit u =>
+    val promise: Promise[Nothing, Unit] = Unsafe.unsafely { implicit u =>
       Promise.unsafe.make[Nothing, Unit](FiberId.None)
     }
     val semaphore: TSemaphore =
-      Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
+      Unsafe.unsafely(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
     var fiber: Fiber[Nothing, Unit] = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor1(): Unit = Unsafe.unsafely { implicit u =>
       val zio = semaphore.withPermit(ZIO.unit)
       fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
       runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
@@ -37,14 +37,14 @@ object ZSTMConcurrencyTests {
     }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor2(): Unit = Unsafe.unsafely { implicit u =>
       val zio = promise.await *> fiber.interrupt
       runtime.unsafe.run(zio).getOrThrowFiberFailure()
       ()
     }
 
     @Arbiter
-    def arbiter(r: I_Result): Unit = Unsafe.unsafeCompat { implicit u =>
+    def arbiter(r: I_Result): Unit = Unsafe.unsafely { implicit u =>
       val zio     = semaphore.permits.get.commit
       val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
       r.r1 = permits.toInt
@@ -63,15 +63,15 @@ object ZSTMConcurrencyTests {
   )
   @State
   class ConcurrentWithPermitScoped {
-    val promise: Promise[Nothing, Unit] = Unsafe.unsafeCompat { implicit u =>
+    val promise: Promise[Nothing, Unit] = Unsafe.unsafely { implicit u =>
       Promise.unsafe.make[Nothing, Unit](FiberId.None)
     }
     val semaphore: TSemaphore =
-      Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
+      Unsafe.unsafely(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
     var fiber: Fiber[Nothing, Unit] = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor1(): Unit = Unsafe.unsafely { implicit u =>
       val zio = ZIO.scoped(semaphore.withPermitScoped)
       fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
       runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
@@ -80,14 +80,14 @@ object ZSTMConcurrencyTests {
     }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafeCompat { implicit u =>
+    def actor2(): Unit = Unsafe.unsafely { implicit u =>
       val zio = promise.await *> fiber.interrupt
       runtime.unsafe.run(zio).getOrThrowFiberFailure()
       ()
     }
 
     @Arbiter
-    def arbiter(r: I_Result): Unit = Unsafe.unsafeCompat { implicit u =>
+    def arbiter(r: I_Result): Unit = Unsafe.unsafely { implicit u =>
       val zio     = semaphore.permits.get.commit
       val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
       r.r1 = permits.toInt
@@ -108,9 +108,9 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentGetAndSet {
     val inner: TRef[Boolean] =
-      Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(TRef.makeCommit(false)).getOrThrowFiberFailure())
+      Unsafe.unsafely(implicit u => runtime.unsafe.run(TRef.makeCommit(false)).getOrThrowFiberFailure())
     val outer: TRef[TRef[Boolean]] =
-      Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(TRef.makeCommit(inner)).getOrThrowFiberFailure())
+      Unsafe.unsafely(implicit u => runtime.unsafe.run(TRef.makeCommit(inner)).getOrThrowFiberFailure())
 
     @Actor
     def actor1(): Unit = {
@@ -122,7 +122,7 @@ object ZSTMConcurrencyTests {
              else inner.set(true) *> outer.set(fresh)
       } yield value
       val zio = ZIO.foreachParDiscard(1 to 1000)(_ => stm.commit)
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         runtime.unsafe.run(zio).getOrThrowFiberFailure()
         ()
       }

--- a/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/stm/ZSTMConcurrencyTests.scala
@@ -20,35 +20,38 @@ object ZSTMConcurrencyTests {
   )
   @State
   class ConcurrentWithPermit {
-    val promise: Promise[Nothing, Unit] = Unsafe.unsafe { implicit u =>
+    val promise: Promise[Nothing, Unit] = Unsafe.unsafe { implicit unsafe =>
       Promise.unsafe.make[Nothing, Unit](FiberId.None)
     }
     val semaphore: TSemaphore =
-      Unsafe.unsafe(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
     var fiber: Fiber[Nothing, Unit] = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafe { implicit u =>
-      val zio = semaphore.withPermit(ZIO.unit)
-      fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
-      runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
-      runtime.unsafe.run(fiber.await).getOrThrowFiberFailure()
-      ()
-    }
+    def actor1(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio = semaphore.withPermit(ZIO.unit)
+        fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
+        runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
+        runtime.unsafe.run(fiber.await).getOrThrowFiberFailure()
+        ()
+      }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafe { implicit u =>
-      val zio = promise.await *> fiber.interrupt
-      runtime.unsafe.run(zio).getOrThrowFiberFailure()
-      ()
-    }
+    def actor2(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio = promise.await *> fiber.interrupt
+        runtime.unsafe.run(zio).getOrThrowFiberFailure()
+        ()
+      }
 
     @Arbiter
-    def arbiter(r: I_Result): Unit = Unsafe.unsafe { implicit u =>
-      val zio     = semaphore.permits.get.commit
-      val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
-      r.r1 = permits.toInt
-    }
+    def arbiter(r: I_Result): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio     = semaphore.permits.get.commit
+        val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
+        r.r1 = permits.toInt
+      }
   }
 
   /**
@@ -63,35 +66,38 @@ object ZSTMConcurrencyTests {
   )
   @State
   class ConcurrentWithPermitScoped {
-    val promise: Promise[Nothing, Unit] = Unsafe.unsafe { implicit u =>
+    val promise: Promise[Nothing, Unit] = Unsafe.unsafe { implicit unsafe =>
       Promise.unsafe.make[Nothing, Unit](FiberId.None)
     }
     val semaphore: TSemaphore =
-      Unsafe.unsafe(implicit u => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(TSemaphore.makeCommit(1L)).getOrThrowFiberFailure())
     var fiber: Fiber[Nothing, Unit] = null.asInstanceOf[Fiber[Nothing, Unit]]
 
     @Actor
-    def actor1(): Unit = Unsafe.unsafe { implicit u =>
-      val zio = ZIO.scoped(semaphore.withPermitScoped)
-      fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
-      runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
-      runtime.unsafe.run(fiber.await).getOrThrowFiberFailure()
-      ()
-    }
+    def actor1(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio = ZIO.scoped(semaphore.withPermitScoped)
+        fiber = runtime.unsafe.run(zio.fork).getOrThrowFiberFailure()
+        runtime.unsafe.run(promise.succeed(())).getOrThrowFiberFailure()
+        runtime.unsafe.run(fiber.await).getOrThrowFiberFailure()
+        ()
+      }
 
     @Actor
-    def actor2(): Unit = Unsafe.unsafe { implicit u =>
-      val zio = promise.await *> fiber.interrupt
-      runtime.unsafe.run(zio).getOrThrowFiberFailure()
-      ()
-    }
+    def actor2(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio = promise.await *> fiber.interrupt
+        runtime.unsafe.run(zio).getOrThrowFiberFailure()
+        ()
+      }
 
     @Arbiter
-    def arbiter(r: I_Result): Unit = Unsafe.unsafe { implicit u =>
-      val zio     = semaphore.permits.get.commit
-      val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
-      r.r1 = permits.toInt
-    }
+    def arbiter(r: I_Result): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        val zio     = semaphore.permits.get.commit
+        val permits = runtime.unsafe.run(zio).getOrThrowFiberFailure()
+        r.r1 = permits.toInt
+      }
   }
 
   /*
@@ -108,9 +114,9 @@ object ZSTMConcurrencyTests {
   @State
   class ConcurrentGetAndSet {
     val inner: TRef[Boolean] =
-      Unsafe.unsafe(implicit u => runtime.unsafe.run(TRef.makeCommit(false)).getOrThrowFiberFailure())
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(TRef.makeCommit(false)).getOrThrowFiberFailure())
     val outer: TRef[TRef[Boolean]] =
-      Unsafe.unsafe(implicit u => runtime.unsafe.run(TRef.makeCommit(inner)).getOrThrowFiberFailure())
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(TRef.makeCommit(inner)).getOrThrowFiberFailure())
 
     @Actor
     def actor1(): Unit = {
@@ -122,7 +128,7 @@ object ZSTMConcurrencyTests {
              else inner.set(true) *> outer.set(fresh)
       } yield value
       val zio = ZIO.foreachParDiscard(1 to 1000)(_ => stm.commit)
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafe { implicit unsafe =>
         runtime.unsafe.run(zio).getOrThrowFiberFailure()
         ()
       }

--- a/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
+++ b/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
@@ -5,14 +5,14 @@ import zio.test._
 object UnsafeSpecVersionSpecific extends ZIOSpecDefault {
 
   def spec = suite("UnsafeSpecVersionSpecific") {
-    suite("unsafely")(
+    suite("unsafe")(
       test("provides capability to method with implicit parameter") {
-        Unsafe.unsafely(doSomethingUnsafe())
+        Unsafe.unsafe(doSomethingUnsafe())
         assertCompletes
       },
       test("provides capability to implicit function") {
         def succeed[A](block: Unsafe ?=> A): ZIO[Any, Nothing, A] =
-          ZIO.succeed(Unsafe.unsafely(block))
+          ZIO.succeed(Unsafe.unsafe(block))
         assertCompletes
       }
     )

--- a/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
+++ b/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
@@ -1,0 +1,23 @@
+package zio
+
+import zio.test._
+
+object UnsafeSpecVersionSpecific extends ZIOSpecDefault {
+
+  def spec = suite("UnsafeSpecVersionSpecific") {
+    suite("unsafely")(
+      test("provides capability to method with implicit parameter") {
+        Unsafe.unsafely(doSomethingUnsafe())
+        assertCompletes
+      },
+      test("provides capability to implicit function") {
+        def succeed[A](block: Unsafe ?=> A): ZIO[Any, Nothing, A] =
+          ZIO.succeed(Unsafe.unsafely(block))
+        assertCompletes
+      }
+    )
+  }
+
+  def doSomethingUnsafe()(implicit unsafe: Unsafe): Unit =
+    ()
+}

--- a/core-tests/shared/src/test/scala/REPLSpec.scala
+++ b/core-tests/shared/src/test/scala/REPLSpec.scala
@@ -12,7 +12,7 @@ object REPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafely { implicit u =>
+          Unsafe.unsafe { implicit u =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/core-tests/shared/src/test/scala/REPLSpec.scala
+++ b/core-tests/shared/src/test/scala/REPLSpec.scala
@@ -12,7 +12,7 @@ object REPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafe { implicit u =>
+          Unsafe.unsafe { implicit unsafe =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/core-tests/shared/src/test/scala/REPLSpec.scala
+++ b/core-tests/shared/src/test/scala/REPLSpec.scala
@@ -12,7 +12,7 @@ object REPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafeCompat { implicit u =>
+          Unsafe.unsafely { implicit u =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -21,7 +21,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit unsafe => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.as(0)
@@ -33,7 +33,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit unsafe => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.forever
@@ -43,7 +43,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
       test("unsafeRunToFuture interruptibility") {
         for {
           runtime <- ZIO.runtime[Any]
-          f        = Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(ZIO.never))
+          f        = Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(ZIO.never))
           _       <- ZIO.succeed(f.cancel())
           r       <- ZIO.fromFuture(_ => f).exit
         } yield assert(r.isSuccess)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -21,7 +21,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafely(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit u => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.as(0)
@@ -33,7 +33,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafely(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafe(implicit u => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.forever
@@ -43,7 +43,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
       test("unsafeRunToFuture interruptibility") {
         for {
           runtime <- ZIO.runtime[Any]
-          f        = Unsafe.unsafely(implicit u => runtime.unsafe.runToFuture(ZIO.never))
+          f        = Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(ZIO.never))
           _       <- ZIO.succeed(f.cancel())
           r       <- ZIO.fromFuture(_ => f).exit
         } yield assert(r.isSuccess)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.

--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -21,7 +21,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafeCompat(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafely(implicit u => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.as(0)
@@ -33,7 +33,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
 
         val roundtrip = for {
           rt <- ZIO.runtime[Any]
-          _  <- ZIO.fromFuture(_ => Unsafe.unsafeCompat(implicit u => rt.unsafe.runToFuture(effect)))
+          _  <- ZIO.fromFuture(_ => Unsafe.unsafely(implicit u => rt.unsafe.runToFuture(effect)))
         } yield ()
 
         val result = roundtrip.orDie.forever
@@ -43,7 +43,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
       test("unsafeRunToFuture interruptibility") {
         for {
           runtime <- ZIO.runtime[Any]
-          f        = Unsafe.unsafeCompat(implicit u => runtime.unsafe.runToFuture(ZIO.never))
+          f        = Unsafe.unsafely(implicit u => runtime.unsafe.runToFuture(ZIO.never))
           _       <- ZIO.succeed(f.cancel())
           r       <- ZIO.fromFuture(_ => f).exit
         } yield assert(r.isSuccess)(isFalse) // not interrupted, as the Future fails when the effect in interrupted.

--- a/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
@@ -53,7 +53,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an executor that cannot have tasks submitted to and check that:")(
       test("It throws an exception upon submission") {
-        assert(Unsafe.unsafe(implicit u => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit unsafe => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
           throwsA[RejectedExecutionException]
         )
       },
@@ -63,7 +63,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create a yielding executor and check that:")(
       test("Runnables can be submitted ") {
-        assert(Unsafe.unsafe(implicit u => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit unsafe => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },
@@ -73,7 +73,7 @@ object ExecutorSpec extends ZIOBaseSpec {
         )
       },
       test("When created from an EC, must not throw when fed an effect ") {
-        assert(Unsafe.unsafe { implicit u =>
+        assert(Unsafe.unsafe { implicit unsafe =>
           Executor.fromExecutionContext(TestExecutor.ec).submit(TestExecutor.runnable)
         })(
           not(throwsA[RejectedExecutionException])
@@ -85,7 +85,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an unyielding executor and check that:")(
       test("Runnables can be submitted") {
-        assert(Unsafe.unsafe(implicit u => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit unsafe => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },

--- a/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
@@ -53,7 +53,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an executor that cannot have tasks submitted to and check that:")(
       test("It throws an exception upon submission") {
-        assert(Unsafe.unsafeCompat(implicit u => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafely(implicit u => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
           throwsA[RejectedExecutionException]
         )
       },
@@ -63,7 +63,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create a yielding executor and check that:")(
       test("Runnables can be submitted ") {
-        assert(Unsafe.unsafeCompat(implicit u => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafely(implicit u => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },
@@ -73,7 +73,7 @@ object ExecutorSpec extends ZIOBaseSpec {
         )
       },
       test("When created from an EC, must not throw when fed an effect ") {
-        assert(Unsafe.unsafeCompat { implicit u =>
+        assert(Unsafe.unsafely { implicit u =>
           Executor.fromExecutionContext(TestExecutor.ec).submit(TestExecutor.runnable)
         })(
           not(throwsA[RejectedExecutionException])
@@ -85,7 +85,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an unyielding executor and check that:")(
       test("Runnables can be submitted") {
-        assert(Unsafe.unsafeCompat(implicit u => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafely(implicit u => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },

--- a/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ExecutorSpec.scala
@@ -53,7 +53,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an executor that cannot have tasks submitted to and check that:")(
       test("It throws an exception upon submission") {
-        assert(Unsafe.unsafely(implicit u => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit u => TestExecutor.failing.submitOrThrow(TestExecutor.runnable)))(
           throwsA[RejectedExecutionException]
         )
       },
@@ -63,7 +63,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create a yielding executor and check that:")(
       test("Runnables can be submitted ") {
-        assert(Unsafe.unsafely(implicit u => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit u => TestExecutor.y.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },
@@ -73,7 +73,7 @@ object ExecutorSpec extends ZIOBaseSpec {
         )
       },
       test("When created from an EC, must not throw when fed an effect ") {
-        assert(Unsafe.unsafely { implicit u =>
+        assert(Unsafe.unsafe { implicit u =>
           Executor.fromExecutionContext(TestExecutor.ec).submit(TestExecutor.runnable)
         })(
           not(throwsA[RejectedExecutionException])
@@ -85,7 +85,7 @@ object ExecutorSpec extends ZIOBaseSpec {
     ),
     suite("Create an unyielding executor and check that:")(
       test("Runnables can be submitted") {
-        assert(Unsafe.unsafely(implicit u => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
+        assert(Unsafe.unsafe(implicit u => TestExecutor.u.submitOrThrow(TestExecutor.runnable)))(
           not(throwsA[RejectedExecutionException])
         )
       },

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -313,7 +313,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("an unsafe handle is initialized and updated properly") {
         for {
           fiberRef <- FiberRef.make(initial)
-          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
           value1   <- ZIO.succeed(handle.get())
           _        <- fiberRef.set(update1)
           value2   <- ZIO.succeed(handle.get())
@@ -324,7 +324,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("unsafe handles work properly when initialized in a race") {
         for {
           fiberRef  <- FiberRef.make(initial)
-          initHandle = Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+          initHandle = Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
           handle    <- ZIO.raceAll(initHandle, Iterable.fill(64)(initHandle))
           value1    <- ZIO.succeed(handle.get())
           doUpdate   = fiberRef.set(update)
@@ -337,7 +337,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           fiberRef <- FiberRef.make(0)
           setAndGet =
             (value: Int) =>
-              setRefOrHandle(fiberRef, value) *> Unsafe.unsafely { implicit u =>
+              setRefOrHandle(fiberRef, value) *> Unsafe.unsafe { implicit u =>
                 fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.get()))
               }
           n       = 64
@@ -348,7 +348,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("unsafe handles don't see updates from other fibers") {
         for {
           fiberRef <- FiberRef.make(initial)
-          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
           value1   <- ZIO.succeed(handle.get())
           n         = 64
           fiber    <- ZIO.forkAll(Iterable.fill(n)(fiberRef.set(update).race(ZIO.succeed(handle.set(update)))))
@@ -362,7 +362,7 @@ object FiberRefSpec extends ZIOBaseSpec {
 
           test = (i: Int) =>
                    for {
-                     handle <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+                     handle <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
                      _      <- setRefOrHandle(fiberRef, handle, i)
                      _      <- ZIO.yieldNow
                      value  <- ZIO.succeed(handle.get())
@@ -376,7 +376,7 @@ object FiberRefSpec extends ZIOBaseSpec {
         for {
           fiberRef <- FiberRef.make(initial)
           _        <- fiberRef.set(update)
-          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafe(implicit u => fiberRef.asThreadLocal)
           _        <- ZIO.succeed(handle.remove())
           value1   <- fiberRef.get
           value2   <- ZIO.succeed(handle.get())
@@ -423,7 +423,7 @@ object FiberRefSpecUtil {
 
   def setRefOrHandle(fiberRef: FiberRef[Int], value: Int): UIO[Unit] =
     if (value % 2 == 0) fiberRef.set(value)
-    else Unsafe.unsafely(implicit u => fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.set(value))))
+    else Unsafe.unsafe(implicit u => fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.set(value))))
 
   def setRefOrHandle(fiberRef: FiberRef[Int], handle: ThreadLocal[Int], value: Int): UIO[Unit] =
     if (value % 2 == 0) fiberRef.set(value)

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -313,7 +313,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("an unsafe handle is initialized and updated properly") {
         for {
           fiberRef <- FiberRef.make(initial)
-          handle   <- Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
           value1   <- ZIO.succeed(handle.get())
           _        <- fiberRef.set(update1)
           value2   <- ZIO.succeed(handle.get())
@@ -324,7 +324,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("unsafe handles work properly when initialized in a race") {
         for {
           fiberRef  <- FiberRef.make(initial)
-          initHandle = Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+          initHandle = Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
           handle    <- ZIO.raceAll(initHandle, Iterable.fill(64)(initHandle))
           value1    <- ZIO.succeed(handle.get())
           doUpdate   = fiberRef.set(update)
@@ -337,7 +337,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           fiberRef <- FiberRef.make(0)
           setAndGet =
             (value: Int) =>
-              setRefOrHandle(fiberRef, value) *> Unsafe.unsafeCompat { implicit u =>
+              setRefOrHandle(fiberRef, value) *> Unsafe.unsafely { implicit u =>
                 fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.get()))
               }
           n       = 64
@@ -348,7 +348,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("unsafe handles don't see updates from other fibers") {
         for {
           fiberRef <- FiberRef.make(initial)
-          handle   <- Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
           value1   <- ZIO.succeed(handle.get())
           n         = 64
           fiber    <- ZIO.forkAll(Iterable.fill(n)(fiberRef.set(update).race(ZIO.succeed(handle.set(update)))))
@@ -362,7 +362,7 @@ object FiberRefSpec extends ZIOBaseSpec {
 
           test = (i: Int) =>
                    for {
-                     handle <- Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+                     handle <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
                      _      <- setRefOrHandle(fiberRef, handle, i)
                      _      <- ZIO.yieldNow
                      value  <- ZIO.succeed(handle.get())
@@ -376,7 +376,7 @@ object FiberRefSpec extends ZIOBaseSpec {
         for {
           fiberRef <- FiberRef.make(initial)
           _        <- fiberRef.set(update)
-          handle   <- Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal)
+          handle   <- Unsafe.unsafely(implicit u => fiberRef.asThreadLocal)
           _        <- ZIO.succeed(handle.remove())
           value1   <- fiberRef.get
           value2   <- ZIO.succeed(handle.get())
@@ -423,7 +423,7 @@ object FiberRefSpecUtil {
 
   def setRefOrHandle(fiberRef: FiberRef[Int], value: Int): UIO[Unit] =
     if (value % 2 == 0) fiberRef.set(value)
-    else Unsafe.unsafeCompat(implicit u => fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.set(value))))
+    else Unsafe.unsafely(implicit u => fiberRef.asThreadLocal.flatMap(h => ZIO.succeed(h.set(value))))
 
   def setRefOrHandle(fiberRef: FiberRef[Int], handle: ThreadLocal[Int], value: Int): UIO[Unit] =
     if (value % 2 == 0) fiberRef.set(value)

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -16,8 +16,8 @@ object FiberRefsSpec extends ZIOBaseSpec {
       } yield assertTrue(value)
     } +
       test("interruptedCause") {
-        val parent = Unsafe.unsafely(implicit u => FiberId.make(Trace.empty))
-        val child  = Unsafe.unsafely(implicit u => FiberId.make(Trace.empty))
+        val parent = Unsafe.unsafe(implicit u => FiberId.make(Trace.empty))
+        val child  = Unsafe.unsafe(implicit u => FiberId.make(Trace.empty))
 
         val parentFiberRefs = FiberRefs.empty
         val childFiberRefs  = parentFiberRefs.updatedAs(child)(FiberRef.interruptedCause, Cause.interrupt(parent))

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -16,8 +16,8 @@ object FiberRefsSpec extends ZIOBaseSpec {
       } yield assertTrue(value)
     } +
       test("interruptedCause") {
-        val parent = Unsafe.unsafe(implicit u => FiberId.make(Trace.empty))
-        val child  = Unsafe.unsafe(implicit u => FiberId.make(Trace.empty))
+        val parent = Unsafe.unsafe(implicit unsafe => FiberId.make(Trace.empty))
+        val child  = Unsafe.unsafe(implicit unsafe => FiberId.make(Trace.empty))
 
         val parentFiberRefs = FiberRefs.empty
         val childFiberRefs  = parentFiberRefs.updatedAs(child)(FiberRef.interruptedCause, Cause.interrupt(parent))

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -16,8 +16,8 @@ object FiberRefsSpec extends ZIOBaseSpec {
       } yield assertTrue(value)
     } +
       test("interruptedCause") {
-        val parent = Unsafe.unsafeCompat(implicit u => FiberId.make(Trace.empty))
-        val child  = Unsafe.unsafeCompat(implicit u => FiberId.make(Trace.empty))
+        val parent = Unsafe.unsafely(implicit u => FiberId.make(Trace.empty))
+        val child  = Unsafe.unsafely(implicit u => FiberId.make(Trace.empty))
 
         val parentFiberRefs = FiberRefs.empty
         val childFiberRefs  = parentFiberRefs.updatedAs(child)(FiberRef.interruptedCause, Cause.interrupt(parent))

--- a/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
@@ -9,7 +9,7 @@ object RuntimeBootstrapTests {
   implicit class RunSyntax[A](
     task: Task[A]
   ) {
-    def run(): A = Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
+    def run(): A = Unsafe.unsafely(implicit u => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
   }
 
   def test(name: String)(task: => Task[Any]): Unit = {

--- a/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
@@ -9,7 +9,7 @@ object RuntimeBootstrapTests {
   implicit class RunSyntax[A](
     task: Task[A]
   ) {
-    def run(): A = Unsafe.unsafely(implicit u => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
+    def run(): A = Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
   }
 
   def test(name: String)(task: => Task[Any]): Unit = {

--- a/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
@@ -9,7 +9,7 @@ object RuntimeBootstrapTests {
   implicit class RunSyntax[A](
     task: Task[A]
   ) {
-    def run(): A = Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
+    def run(): A = Unsafe.unsafe(implicit unsafe => Runtime.default.unsafe.run(task).getOrThrowFiberFailure())
   }
 
   def test(name: String)(task: => Task[Any]): Unit = {

--- a/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
@@ -7,7 +7,7 @@ object SupervisorSpec extends ZIOSpecDefault {
   def spec = suite("SupervisorSpec")(
     test("++") {
       for {
-        ref       <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(0))
+        ref       <- ZIO.succeedUnsafe(implicit unsafe => Ref.unsafe.make(0))
         left      <- makeSupervisor(ref)
         right     <- makeSupervisor(ref)
         supervisor = left ++ right

--- a/core-tests/shared/src/test/scala/zio/UnsafeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/UnsafeSpec.scala
@@ -5,9 +5,9 @@ import zio.test._
 object UnsafeSpec extends ZIOSpecDefault {
 
   def spec = suite("UnsafeSpec") {
-    suite("unsafely")(
+    suite("unsafe")(
       test("provides capability to function") {
-        Unsafe.unsafely { implicit unsafe =>
+        Unsafe.unsafe { implicit unsafe =>
           doSomethingUnsafe()
         }
         assertCompletes

--- a/core-tests/shared/src/test/scala/zio/UnsafeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/UnsafeSpec.scala
@@ -1,0 +1,20 @@
+package zio
+
+import zio.test._
+
+object UnsafeSpec extends ZIOSpecDefault {
+
+  def spec = suite("UnsafeSpec") {
+    suite("unsafely")(
+      test("provides capability to function") {
+        Unsafe.unsafely { implicit unsafe =>
+          doSomethingUnsafe()
+        }
+        assertCompletes
+      }
+    )
+  }
+
+  def doSomethingUnsafe()(implicit unsafe: Unsafe): Unit =
+    ()
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2570,14 +2570,14 @@ object ZIOSpec extends ZIOBaseSpec {
           runtime         <- ZIO.runtime[Live]
           fork <- ZIO
                     .async[Any, Nothing, Unit] { k =>
-                      Unsafe.unsafeCompat { implicit u =>
+                      Unsafe.unsafely { implicit u =>
                         runtime.unsafe.fork {
                           step.await *> ZIO.succeed(k(unexpectedPlace.update(1 :: _)))
                         }
                       }
                     }
                     .ensuring(ZIO.async[Any, Nothing, Unit] { _ =>
-                      Unsafe.unsafeCompat { implicit u =>
+                      Unsafe.unsafely { implicit u =>
                         runtime.unsafe.fork {
                           step.succeed(())
                         }
@@ -3494,7 +3494,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val executor = Executor.fromExecutionContext {
           scala.concurrent.ExecutionContext.Implicits.global
         }
-        val pool = ZIO.succeed(Unsafe.unsafeCompat(implicit u => Platform.getCurrentThreadGroup()))
+        val pool = ZIO.succeed(Unsafe.unsafely(implicit u => Platform.getCurrentThreadGroup()))
         val io = for {
           parentPool <- pool
           childPool  <- pool.fork.flatMap(_.join)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2570,14 +2570,14 @@ object ZIOSpec extends ZIOBaseSpec {
           runtime         <- ZIO.runtime[Live]
           fork <- ZIO
                     .async[Any, Nothing, Unit] { k =>
-                      Unsafe.unsafely { implicit u =>
+                      Unsafe.unsafe { implicit u =>
                         runtime.unsafe.fork {
                           step.await *> ZIO.succeed(k(unexpectedPlace.update(1 :: _)))
                         }
                       }
                     }
                     .ensuring(ZIO.async[Any, Nothing, Unit] { _ =>
-                      Unsafe.unsafely { implicit u =>
+                      Unsafe.unsafe { implicit u =>
                         runtime.unsafe.fork {
                           step.succeed(())
                         }
@@ -3494,7 +3494,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val executor = Executor.fromExecutionContext {
           scala.concurrent.ExecutionContext.Implicits.global
         }
-        val pool = ZIO.succeed(Unsafe.unsafely(implicit u => Platform.getCurrentThreadGroup()))
+        val pool = ZIO.succeed(Unsafe.unsafe(implicit u => Platform.getCurrentThreadGroup()))
         val io = for {
           parentPool <- pool
           childPool  <- pool.fork.flatMap(_.join)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2570,14 +2570,14 @@ object ZIOSpec extends ZIOBaseSpec {
           runtime         <- ZIO.runtime[Live]
           fork <- ZIO
                     .async[Any, Nothing, Unit] { k =>
-                      Unsafe.unsafe { implicit u =>
+                      Unsafe.unsafe { implicit unsafe =>
                         runtime.unsafe.fork {
                           step.await *> ZIO.succeed(k(unexpectedPlace.update(1 :: _)))
                         }
                       }
                     }
                     .ensuring(ZIO.async[Any, Nothing, Unit] { _ =>
-                      Unsafe.unsafe { implicit u =>
+                      Unsafe.unsafe { implicit unsafe =>
                         runtime.unsafe.fork {
                           step.succeed(())
                         }
@@ -3494,7 +3494,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val executor = Executor.fromExecutionContext {
           scala.concurrent.ExecutionContext.Implicits.global
         }
-        val pool = ZIO.succeed(Unsafe.unsafe(implicit u => Platform.getCurrentThreadGroup()))
+        val pool = ZIO.succeed(Unsafe.unsafe(implicit unsafe => Platform.getCurrentThreadGroup()))
         val io = for {
           parentPool <- pool
           childPool  <- pool.fork.flatMap(_.join)

--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -9,20 +9,19 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
    * The Scala main function, intended to be called only by the Scala runtime.
    */
   final def main(args0: Array[String]): Unit = {
-    implicit val trace = Tracer.newTrace
+    implicit val trace  = Tracer.newTrace
+    implicit val unsafe = Unsafe.unsafe
 
     val newLayer =
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafe { implicit u =>
-      runtime.unsafe.fork {
-        (for {
-          runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
-          _       <- installSignalHandlers(runtime)
-          _       <- runtime.run(run)
-        } yield ()).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
-      }
+    runtime.unsafe.fork {
+      (for {
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        _       <- installSignalHandlers(runtime)
+        _       <- runtime.run(run)
+      } yield ()).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
     }
   }
 }

--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.fork {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.fork {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.run {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -9,44 +9,43 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
    * The Scala main function, intended to be called only by the Scala runtime.
    */
   final def main(args0: Array[String]): Unit = {
-    implicit val trace: Trace = Trace.empty
+    implicit val trace: Trace   = Trace.empty
+    implicit val unsafe: Unsafe = Unsafe.unsafe
 
     val newLayer =
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafe { implicit u =>
-      runtime.unsafe.run {
-        (for {
-          runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
-          _       <- installSignalHandlers(runtime)
-          fiber   <- runtime.run(run).fork
-          _ <-
-            ZIO.succeed(Platform.addShutdownHook { () =>
-              if (!shuttingDown.getAndSet(true)) {
+    runtime.unsafe.run {
+      (for {
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        _       <- installSignalHandlers(runtime)
+        fiber   <- runtime.run(run).fork
+        _ <-
+          ZIO.succeed(Platform.addShutdownHook { () =>
+            if (!shuttingDown.getAndSet(true)) {
 
-                if (FiberRuntime.catastrophicFailure.get) {
-                  println(
-                    "**** WARNING ****\n" +
-                      "Catastrophic error encountered. " +
-                      "Application not safely interrupted. " +
-                      "Resources may be leaked. " +
-                      "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
-                  )
-                } else {
-                  try runtime.unsafe.run(fiber.interrupt)
-                  catch {
-                    case _: Throwable =>
-                  }
+              if (FiberRuntime.catastrophicFailure.get) {
+                println(
+                  "**** WARNING ****\n" +
+                    "Catastrophic error encountered. " +
+                    "Application not safely interrupted. " +
+                    "Resources may be leaked. " +
+                    "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
+                )
+              } else {
+                try runtime.unsafe.run(fiber.interrupt)
+                catch {
+                  case _: Throwable =>
                 }
-
-                ()
               }
-            })
-          result <- fiber.join
-        } yield result).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
-      }.getOrThrowFiberFailure()
-    }
+
+              ()
+            }
+          })
+        result <- fiber.join
+      } yield result).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
+    }.getOrThrowFiberFailure()
   }
 
 }

--- a/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
@@ -67,7 +67,7 @@ object MemoryAllocation {
       if (diff2 < 0) diff2 = 0
       val increase = diff1 + diff2
       if (increase > 0) {
-        Unsafe.unsafely(implicit u => runtime.run(countAllocations(memoryPool).incrementBy(increase)))
+        Unsafe.unsafe(implicit u => runtime.run(countAllocations(memoryPool).incrementBy(increase)))
       }
     }
   }

--- a/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
@@ -67,7 +67,7 @@ object MemoryAllocation {
       if (diff2 < 0) diff2 = 0
       val increase = diff1 + diff2
       if (increase > 0) {
-        Unsafe.unsafe(implicit u => runtime.run(countAllocations(memoryPool).incrementBy(increase)))
+        runtime.unsafe.run(countAllocations(memoryPool).incrementBy(increase))(Trace.empty, Unsafe.unsafe)
       }
     }
   }

--- a/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/MemoryAllocation.scala
@@ -67,7 +67,7 @@ object MemoryAllocation {
       if (diff2 < 0) diff2 = 0
       val increase = diff1 + diff2
       if (increase > 0) {
-        Unsafe.unsafeCompat(implicit u => runtime.run(countAllocations(memoryPool).incrementBy(increase)))
+        Unsafe.unsafely(implicit u => runtime.run(countAllocations(memoryPool).incrementBy(increase)))
       }
     }
   }

--- a/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
@@ -87,7 +87,7 @@ object Standard {
 
   val live: ZLayer[JvmMetricsSchedule, Throwable, Standard] =
     ZLayer.scoped {
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         for {
           runtimeMXBean         <- ZIO.attempt(ManagementFactory.getRuntimeMXBean)
           operatingSystemMXBean <- ZIO.attempt(ManagementFactory.getOperatingSystemMXBean)

--- a/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
@@ -87,7 +87,7 @@ object Standard {
 
   val live: ZLayer[JvmMetricsSchedule, Throwable, Standard] =
     ZLayer.scoped {
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         for {
           runtimeMXBean         <- ZIO.attempt(ManagementFactory.getRuntimeMXBean)
           operatingSystemMXBean <- ZIO.attempt(ManagementFactory.getOperatingSystemMXBean)

--- a/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/Standard.scala
@@ -87,63 +87,61 @@ object Standard {
 
   val live: ZLayer[JvmMetricsSchedule, Throwable, Standard] =
     ZLayer.scoped {
-      Unsafe.unsafe { implicit u =>
-        for {
-          runtimeMXBean         <- ZIO.attempt(ManagementFactory.getRuntimeMXBean)
-          operatingSystemMXBean <- ZIO.attempt(ManagementFactory.getOperatingSystemMXBean)
-          getProcessCpuTime      = new MXReflection("getProcessCpuTime", operatingSystemMXBean)
-          getOpenFileDescriptorCount =
-            new MXReflection("getOpenFileDescriptorCount", operatingSystemMXBean)
-          getMaxFileDescriptorCount =
-            new MXReflection("getMaxFileDescriptorCount", operatingSystemMXBean)
-          isLinux <- ZIO.attempt(operatingSystemMXBean.getName.indexOf("Linux") == 0)
-          cpuSecondsTotal =
-            PollingMetric(
-              Metric.gauge("process_cpu_seconds_total").contramap[Long](_.toDouble / 1.0e09),
-              getProcessCpuTime.get
-            )
-          processStartTime =
-            PollingMetric(
-              Metric
-                .gauge("process_start_time_seconds")
-                .contramap[Long](_.toDouble / 1000.0),
-              ZIO.attempt(runtimeMXBean.getStartTime)
-            )
-          openFdCount =
-            PollingMetric(
-              Metric
-                .gauge("process_open_fds")
-                .contramap[Long](_.toDouble),
-              getOpenFileDescriptorCount.get
-            )
-          maxFdCount =
-            PollingMetric(
-              Metric
-                .gauge("process_max_fds")
-                .contramap[Long](_.toDouble),
-              getMaxFileDescriptorCount.get
-            )
-          virtualMemorySize  = Metric.gauge("process_virtual_memory_bytes")
-          residentMemorySize = Metric.gauge("process_resident_memory_bytes")
+      for {
+        runtimeMXBean         <- ZIO.attempt(ManagementFactory.getRuntimeMXBean)
+        operatingSystemMXBean <- ZIO.attempt(ManagementFactory.getOperatingSystemMXBean)
+        getProcessCpuTime      = new MXReflection("getProcessCpuTime", operatingSystemMXBean)
+        getOpenFileDescriptorCount =
+          new MXReflection("getOpenFileDescriptorCount", operatingSystemMXBean)
+        getMaxFileDescriptorCount =
+          new MXReflection("getMaxFileDescriptorCount", operatingSystemMXBean)
+        isLinux <- ZIO.attempt(operatingSystemMXBean.getName.indexOf("Linux") == 0)
+        cpuSecondsTotal =
+          PollingMetric(
+            Metric.gauge("process_cpu_seconds_total").contramap[Long](_.toDouble / 1.0e09),
+            getProcessCpuTime.get(Trace.empty, Unsafe.unsafe)
+          )
+        processStartTime =
+          PollingMetric(
+            Metric
+              .gauge("process_start_time_seconds")
+              .contramap[Long](_.toDouble / 1000.0),
+            ZIO.attempt(runtimeMXBean.getStartTime)
+          )
+        openFdCount =
+          PollingMetric(
+            Metric
+              .gauge("process_open_fds")
+              .contramap[Long](_.toDouble),
+            getOpenFileDescriptorCount.get(Trace.empty, Unsafe.unsafe)
+          )
+        maxFdCount =
+          PollingMetric(
+            Metric
+              .gauge("process_max_fds")
+              .contramap[Long](_.toDouble),
+            getMaxFileDescriptorCount.get(Trace.empty, Unsafe.unsafe)
+          )
+        virtualMemorySize  = Metric.gauge("process_virtual_memory_bytes")
+        residentMemorySize = Metric.gauge("process_resident_memory_bytes")
 
-          schedule <- ZIO.service[JvmMetricsSchedule]
-          _        <- cpuSecondsTotal.launch(schedule.updateMetrics)
-          _        <- processStartTime.launch(schedule.updateMetrics)
-          _        <- openFdCount.launch(schedule.updateMetrics).when(getOpenFileDescriptorCount.isAvailable)
-          _        <- maxFdCount.launch(schedule.updateMetrics).when(getMaxFileDescriptorCount.isAvailable)
-          _ <-
-            collectMemoryMetricsLinux(virtualMemorySize, residentMemorySize)
-              .scheduleFork(schedule.updateMetrics)
-              .when(isLinux)
+        schedule <- ZIO.service[JvmMetricsSchedule]
+        _        <- cpuSecondsTotal.launch(schedule.updateMetrics)
+        _        <- processStartTime.launch(schedule.updateMetrics)
+        _        <- openFdCount.launch(schedule.updateMetrics).when(getOpenFileDescriptorCount.isAvailable)
+        _        <- maxFdCount.launch(schedule.updateMetrics).when(getMaxFileDescriptorCount.isAvailable)
+        _ <-
+          collectMemoryMetricsLinux(virtualMemorySize, residentMemorySize)
+            .scheduleFork(schedule.updateMetrics)
+            .when(isLinux)
 
-        } yield Standard(
-          cpuSecondsTotal,
-          processStartTime,
-          openFdCount,
-          maxFdCount,
-          virtualMemorySize,
-          residentMemorySize
-        )
-      }
+      } yield Standard(
+        cpuSecondsTotal,
+        processStartTime,
+        openFdCount,
+        maxFdCount,
+        virtualMemorySize,
+        residentMemorySize
+      )
     }
 }

--- a/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -9,20 +9,19 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
    * The Scala main function, intended to be called only by the Scala runtime.
    */
   final def main(args0: Array[String]): Unit = {
-    implicit val trace = Tracer.newTrace
+    implicit val trace  = Tracer.newTrace
+    implicit val unsafe = Unsafe.unsafe
 
     val newLayer =
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafe { implicit u =>
-      runtime.unsafe.fork {
-        (for {
-          runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
-          _       <- installSignalHandlers(runtime)
-          _       <- runtime.run(run)
-        } yield ()).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
-      }
+    runtime.unsafe.fork {
+      (for {
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        _       <- installSignalHandlers(runtime)
+        _       <- runtime.run(run)
+      } yield ()).provideLayer(newLayer).tapErrorCause(ZIO.logErrorCause(_)).exitCode.tap(exit)
     }
   }
 }

--- a/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.fork {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -15,7 +15,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
         bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       runtime.unsafe.fork {
         (for {
           runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]

--- a/core/shared/src/main/scala-2/zio/UnsafeVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/UnsafeVersionSpecific.scala
@@ -18,5 +18,6 @@ package zio
 private[zio] trait UnsafeVersionSpecific {
   private[zio] def unsafe: Unsafe
 
+  @deprecated("use unsafely", "3.0.0")
   def unsafe[A](f: Unsafe => A): A = f(unsafe)
 }

--- a/core/shared/src/main/scala-2/zio/UnsafeVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/UnsafeVersionSpecific.scala
@@ -15,9 +15,4 @@
  */
 package zio
 
-private[zio] trait UnsafeVersionSpecific {
-  private[zio] def unsafe: Unsafe
-
-  @deprecated("use unsafely", "3.0.0")
-  def unsafe[A](f: Unsafe => A): A = f(unsafe)
-}
+private[zio] trait UnsafeVersionSpecific

--- a/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
@@ -18,9 +18,17 @@ package zio
 private[zio] trait UnsafeVersionSpecific { self =>
   private[zio] def unsafe: Unsafe
 
+  @deprecated("use unsafely", "3.0.0")
   def unsafe[A](f: Unsafe ?=> A): A = {
     given Unsafe = self.unsafe
     
     f
   }
+
+  implicit def implicitFunctionIsFunction[A](f: Unsafe ?=> A): Unsafe => A =
+    unsafe => {
+      given Unsafe = unsafe
+      
+      f
+    }
 }

--- a/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
@@ -16,15 +16,6 @@
 package zio 
 
 private[zio] trait UnsafeVersionSpecific { self =>
-  private[zio] def unsafe: Unsafe
-
-  @deprecated("use unsafely", "3.0.0")
-  def unsafe[A](f: Unsafe ?=> A): A = {
-    given Unsafe = self.unsafe
-    
-    f
-  }
-
   implicit def implicitFunctionIsFunction[A](f: Unsafe ?=> A): Unsafe => A =
     unsafe => {
       given Unsafe = unsafe

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -21,7 +21,7 @@ trait ZIOCompanionVersionSpecific {
     register: Unsafe ?=> (ZIO[R, E, A] => Unit) => Any,
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    Async(trace, Unsafe.unsafe(register), () => blockingOn)
+    Async(trace, Unsafe.unsafely(register), () => blockingOn)
 
   /**
    * Converts an asynchronous, callback-style API into a ZIO effect, which will
@@ -158,7 +158,7 @@ trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: Unsafe ?=> A)(implicit trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => Unsafe.unsafe(a))
+    ZIO.Sync(trace, () => Unsafe.unsafely(a))
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -42,8 +42,8 @@ trait ZIOCompanionVersionSpecific {
     register: Unsafe ?=> (ZIO[R, E, A] => Unit) => Either[URIO[R, Any], ZIO[R, E, A]],
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    ZIO.suspendSucceedUnsafe { implicit u =>
-      val cancelerRef = Ref.unsafe.make[URIO[R, Any]](ZIO.unit)
+    ZIO.suspendSucceed {
+      val cancelerRef = Ref.unsafe.make[URIO[R, Any]](ZIO.unit)(Unsafe.unsafe)
 
       ZIO
         .async[R, E, A](
@@ -57,7 +57,7 @@ trait ZIOCompanionVersionSpecific {
           },
           blockingOn
         )
-        .onInterrupt(cancelerRef.unsafe.get)
+        .onInterrupt(cancelerRef.unsafe.get(Unsafe.unsafe))
     }
 
   /**

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -21,7 +21,7 @@ trait ZIOCompanionVersionSpecific {
     register: Unsafe ?=> (ZIO[R, E, A] => Unit) => Any,
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    Async(trace, Unsafe.unsafely(register), () => blockingOn)
+    Async(trace, Unsafe.unsafe(register), () => blockingOn)
 
   /**
    * Converts an asynchronous, callback-style API into a ZIO effect, which will
@@ -157,7 +157,7 @@ trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: Unsafe ?=> A)(implicit trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => Unsafe.unsafely(a))
+    ZIO.Sync(trace, () => Unsafe.unsafe(a))
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -153,7 +153,6 @@ trait ZIOCompanionVersionSpecific {
   def attemptBlockingIO[A](effect: Unsafe ?=> A)(implicit trace: Trace): IO[IOException, A] =
     attemptBlocking(effect).refineToOrDie[IOException]
 
-
   /**
    * Returns an effect that models success with the specified value.
    */

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -83,7 +83,7 @@ object Console extends Serializable {
       ZIO.attemptBlockingIOUnsafe(implicit u => unsafe.printLineError(line))
 
     def readLine(implicit trace: Trace): IO[IOException, String] =
-      ZIO.attemptBlockingInterrupt(Unsafe.unsafeCompat(implicit u => unsafe.readLine())).refineToOrDie[IOException]
+      ZIO.attemptBlockingInterrupt(Unsafe.unsafely(implicit u => unsafe.readLine())).refineToOrDie[IOException]
 
     @transient override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
       override def print(line: Any)(implicit unsafe: Unsafe): Unit =

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -83,7 +83,7 @@ object Console extends Serializable {
       ZIO.attemptBlockingIOUnsafe(implicit u => unsafe.printLineError(line))
 
     def readLine(implicit trace: Trace): IO[IOException, String] =
-      ZIO.attemptBlockingInterrupt(Unsafe.unsafely(implicit u => unsafe.readLine())).refineToOrDie[IOException]
+      ZIO.attemptBlockingInterrupt(Unsafe.unsafe(implicit u => unsafe.readLine())).refineToOrDie[IOException]
 
     @transient override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
       override def print(line: Any)(implicit unsafe: Unsafe): Unit =

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -35,5 +35,5 @@ object DefaultServices {
   private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[
     Clock with Console with System with Random
   ], ZEnvironment.Patch[Clock with Console with System with Random, Clock with Console with System with Random]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeEnvironment(live))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeEnvironment(live))
 }

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -35,5 +35,5 @@ object DefaultServices {
   private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[
     Clock with Console with System with Random
   ], ZEnvironment.Patch[Clock with Console with System with Random, Clock with Console with System with Random]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.makeEnvironment(live))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeEnvironment(live))
 }

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -35,5 +35,5 @@ object DefaultServices {
   private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[
     Clock with Console with System with Random
   ], ZEnvironment.Patch[Clock with Console with System with Random, Clock with Console with System with Random]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeEnvironment(live))
+    FiberRef.unsafe.makeEnvironment(live)(Unsafe.unsafe)
 }

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -44,9 +44,7 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   lazy val asExecutionContext: ExecutionContext =
     new ExecutionContext {
       override def execute(r: Runnable): Unit =
-        Unsafe.unsafe { implicit u =>
-          if (!submit(r)) throw new RejectedExecutionException("Rejected: " + r.toString)
-        }
+        if (!submit(r)(Unsafe.unsafe)) throw new RejectedExecutionException("Rejected: " + r.toString)
 
       override def reportFailure(cause: Throwable): Unit =
         cause.printStackTrace
@@ -57,10 +55,8 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
    */
   lazy val asJava: java.util.concurrent.Executor =
     command =>
-      Unsafe.unsafe { implicit u =>
-        if (submit(command)) ()
-        else throw new java.util.concurrent.RejectedExecutionException
-      }
+      if (submit(command)(Unsafe.unsafe)) ()
+      else throw new java.util.concurrent.RejectedExecutionException
 
   /**
    * Submits an effect for execution and signals that the current fiber is ready

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -44,7 +44,7 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   lazy val asExecutionContext: ExecutionContext =
     new ExecutionContext {
       override def execute(r: Runnable): Unit =
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           if (!submit(r)) throw new RejectedExecutionException("Rejected: " + r.toString)
         }
 
@@ -57,7 +57,7 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
    */
   lazy val asJava: java.util.concurrent.Executor =
     command =>
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         if (submit(command)) ()
         else throw new java.util.concurrent.RejectedExecutionException
       }

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -44,7 +44,7 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   lazy val asExecutionContext: ExecutionContext =
     new ExecutionContext {
       override def execute(r: Runnable): Unit =
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafely { implicit u =>
           if (!submit(r)) throw new RejectedExecutionException("Rejected: " + r.toString)
         }
 
@@ -57,7 +57,7 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
    */
   lazy val asJava: java.util.concurrent.Executor =
     command =>
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         if (submit(command)) ()
         else throw new java.util.concurrent.RejectedExecutionException
       }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -367,7 +367,7 @@ sealed abstract class Fiber[+E, +A] { self =>
         _ <- completeFuture.forkDaemon // Cannot afford to NOT complete the promise, no matter what, so we fork daemon
       } yield new CancelableFuture[A](p.future) {
         def cancel(): Future[Exit[Throwable, A]] =
-          Unsafe.unsafeCompat { implicit u =>
+          Unsafe.unsafely { implicit u =>
             runtime.unsafe.runToFuture[Nothing, Exit[Throwable, A]](self.interrupt.map(_.mapErrorExit(f)))
           }
       }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -367,9 +367,10 @@ sealed abstract class Fiber[+E, +A] { self =>
         _ <- completeFuture.forkDaemon // Cannot afford to NOT complete the promise, no matter what, so we fork daemon
       } yield new CancelableFuture[A](p.future) {
         def cancel(): Future[Exit[Throwable, A]] =
-          Unsafe.unsafe { implicit u =>
-            runtime.unsafe.runToFuture[Nothing, Exit[Throwable, A]](self.interrupt.map(_.mapErrorExit(f)))
-          }
+          runtime.unsafe.runToFuture[Nothing, Exit[Throwable, A]](self.interrupt.map(_.mapErrorExit(f)))(
+            trace,
+            Unsafe.unsafe
+          )
       }
     }.uninterruptible
 

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -367,7 +367,7 @@ sealed abstract class Fiber[+E, +A] { self =>
         _ <- completeFuture.forkDaemon // Cannot afford to NOT complete the promise, no matter what, so we fork daemon
       } yield new CancelableFuture[A](p.future) {
         def cancel(): Future[Exit[Throwable, A]] =
-          Unsafe.unsafely { implicit u =>
+          Unsafe.unsafe { implicit u =>
             runtime.unsafe.runToFuture[Nothing, Exit[Throwable, A]](self.interrupt.map(_.mapErrorExit(f)))
           }
       }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -330,13 +330,13 @@ object FiberRef {
   type WithPatch[Value0, Patch0] = FiberRef[Value0] { type Patch = Patch0 }
 
   lazy val currentLogLevel: FiberRef[LogLevel] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(LogLevel.Info))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(LogLevel.Info))
 
   lazy val currentLogSpan: FiberRef[List[LogSpan]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Nil))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Nil))
 
   lazy val currentLogAnnotations: FiberRef[Map[String, String]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Map.empty))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Map.empty))
 
   /**
    * Creates a new `FiberRef` with given initial value.
@@ -346,7 +346,7 @@ object FiberRef {
     fork: A => A = (a: A) => a,
     join: (A, A) => A = ((_: A, a: A) => a)
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef[A]] =
-    makeWith(Unsafe.unsafely { implicit u =>
+    makeWith(Unsafe.unsafe { implicit u =>
       unsafe.make(initial, fork, join)
     })
 
@@ -358,7 +358,7 @@ object FiberRef {
   def makeEnvironment[A](initial: => ZEnvironment[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[ZEnvironment[A], ZEnvironment.Patch[A, A]]] =
-    makeWith(Unsafe.unsafely { implicit u =>
+    makeWith(Unsafe.unsafe { implicit u =>
       unsafe.makeEnvironment(initial)
     })
 
@@ -372,12 +372,12 @@ object FiberRef {
     differ: Differ[Value, Patch],
     fork: Patch
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef.WithPatch[Value, Patch]] =
-    makeWith(Unsafe.unsafely(implicit u => unsafe.makePatch(initial, differ, fork)))
+    makeWith(Unsafe.unsafe(implicit u => unsafe.makePatch(initial, differ, fork)))
 
   def makeSet[A](initial: => Set[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[Set[A], SetPatch[A]]] =
-    makeWith(Unsafe.unsafely(implicit u => unsafe.makeSet(initial)))
+    makeWith(Unsafe.unsafe(implicit u => unsafe.makeSet(initial)))
 
   private[zio] object unsafe {
     def make[A](
@@ -485,34 +485,34 @@ object FiberRef {
   }
 
   private[zio] val forkScopeOverride: FiberRef[Option[FiberScope]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None, _ => None)) // Do not inherit on `fork`
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None, _ => None)) // Do not inherit on `fork`
 
   private[zio] val overrideExecutor: FiberRef[Option[Executor]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None))
 
   private[zio] val currentEnvironment: FiberRef.WithPatch[ZEnvironment[Any], ZEnvironment.Patch[Any, Any]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeEnvironment(ZEnvironment.empty))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeEnvironment(ZEnvironment.empty))
 
   private[zio] val interruptedCause: FiberRef[Cause[Nothing]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Cause.empty, identity(_), (parent, _) => parent))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Cause.empty, identity(_), (parent, _) => parent))
 
   private[zio] val currentBlockingExecutor: FiberRef[Executor] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Runtime.defaultBlockingExecutor))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Runtime.defaultBlockingExecutor))
 
   private[zio] val currentFatal: FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal))
 
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeSet(Runtime.defaultLoggers))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeSet(Runtime.defaultLoggers))
 
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Runtime.defaultReportFatal))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Runtime.defaultReportFatal))
 
   private[zio] val currentSupervisor: FiberRef.WithPatch[Supervisor[Any], Supervisor.Patch] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor))
 
   private[zio] val unhandledErrorLogLevel: FiberRef[Option[LogLevel]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Some(LogLevel.Debug), identity(_), (_, child) => child))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Some(LogLevel.Debug), identity(_), (_, child) => child))
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -330,13 +330,13 @@ object FiberRef {
   type WithPatch[Value0, Patch0] = FiberRef[Value0] { type Patch = Patch0 }
 
   lazy val currentLogLevel: FiberRef[LogLevel] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(LogLevel.Info))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(LogLevel.Info))
 
   lazy val currentLogSpan: FiberRef[List[LogSpan]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Nil))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Nil))
 
   lazy val currentLogAnnotations: FiberRef[Map[String, String]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Map.empty))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Map.empty))
 
   /**
    * Creates a new `FiberRef` with given initial value.
@@ -346,7 +346,7 @@ object FiberRef {
     fork: A => A = (a: A) => a,
     join: (A, A) => A = ((_: A, a: A) => a)
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef[A]] =
-    makeWith(Unsafe.unsafeCompat { implicit u =>
+    makeWith(Unsafe.unsafely { implicit u =>
       unsafe.make(initial, fork, join)
     })
 
@@ -358,7 +358,7 @@ object FiberRef {
   def makeEnvironment[A](initial: => ZEnvironment[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[ZEnvironment[A], ZEnvironment.Patch[A, A]]] =
-    makeWith(Unsafe.unsafeCompat { implicit u =>
+    makeWith(Unsafe.unsafely { implicit u =>
       unsafe.makeEnvironment(initial)
     })
 
@@ -372,12 +372,12 @@ object FiberRef {
     differ: Differ[Value, Patch],
     fork: Patch
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef.WithPatch[Value, Patch]] =
-    makeWith(Unsafe.unsafeCompat(implicit u => unsafe.makePatch(initial, differ, fork)))
+    makeWith(Unsafe.unsafely(implicit u => unsafe.makePatch(initial, differ, fork)))
 
   def makeSet[A](initial: => Set[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[Set[A], SetPatch[A]]] =
-    makeWith(Unsafe.unsafeCompat(implicit u => unsafe.makeSet(initial)))
+    makeWith(Unsafe.unsafely(implicit u => unsafe.makeSet(initial)))
 
   private[zio] object unsafe {
     def make[A](
@@ -485,34 +485,34 @@ object FiberRef {
   }
 
   private[zio] val forkScopeOverride: FiberRef[Option[FiberScope]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(None, _ => None)) // Do not inherit on `fork`
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None, _ => None)) // Do not inherit on `fork`
 
   private[zio] val overrideExecutor: FiberRef[Option[Executor]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(None))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None))
 
   private[zio] val currentEnvironment: FiberRef.WithPatch[ZEnvironment[Any], ZEnvironment.Patch[Any, Any]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.makeEnvironment(ZEnvironment.empty))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeEnvironment(ZEnvironment.empty))
 
   private[zio] val interruptedCause: FiberRef[Cause[Nothing]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Cause.empty, identity(_), (parent, _) => parent))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Cause.empty, identity(_), (parent, _) => parent))
 
   private[zio] val currentBlockingExecutor: FiberRef[Executor] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Runtime.defaultBlockingExecutor))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Runtime.defaultBlockingExecutor))
 
   private[zio] val currentFatal: FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal))
 
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.makeSet(Runtime.defaultLoggers))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeSet(Runtime.defaultLoggers))
 
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Runtime.defaultReportFatal))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Runtime.defaultReportFatal))
 
   private[zio] val currentSupervisor: FiberRef.WithPatch[Supervisor[Any], Supervisor.Patch] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor))
 
   private[zio] val unhandledErrorLogLevel: FiberRef[Option[LogLevel]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(Some(LogLevel.Debug), identity(_), (_, child) => child))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(Some(LogLevel.Debug), identity(_), (_, child) => child))
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -330,13 +330,13 @@ object FiberRef {
   type WithPatch[Value0, Patch0] = FiberRef[Value0] { type Patch = Patch0 }
 
   lazy val currentLogLevel: FiberRef[LogLevel] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(LogLevel.Info))
+    FiberRef.unsafe.make(LogLevel.Info)(Unsafe.unsafe)
 
   lazy val currentLogSpan: FiberRef[List[LogSpan]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Nil))
+    FiberRef.unsafe.make[List[LogSpan]](Nil)(Unsafe.unsafe)
 
   lazy val currentLogAnnotations: FiberRef[Map[String, String]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Map.empty))
+    FiberRef.unsafe.make[Map[String, String]](Map.empty)(Unsafe.unsafe)
 
   /**
    * Creates a new `FiberRef` with given initial value.
@@ -346,9 +346,7 @@ object FiberRef {
     fork: A => A = (a: A) => a,
     join: (A, A) => A = ((_: A, a: A) => a)
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef[A]] =
-    makeWith(Unsafe.unsafe { implicit u =>
-      unsafe.make(initial, fork, join)
-    })
+    makeWith(unsafe.make(initial, fork, join)(Unsafe.unsafe))
 
   /**
    * Creates a new `FiberRef` with specified initial value of the
@@ -358,9 +356,7 @@ object FiberRef {
   def makeEnvironment[A](initial: => ZEnvironment[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[ZEnvironment[A], ZEnvironment.Patch[A, A]]] =
-    makeWith(Unsafe.unsafe { implicit u =>
-      unsafe.makeEnvironment(initial)
-    })
+    makeWith(unsafe.makeEnvironment(initial)(Unsafe.unsafe))
 
   /**
    * Creates a new `FiberRef` with the specified initial value, using the
@@ -372,12 +368,12 @@ object FiberRef {
     differ: Differ[Value, Patch],
     fork: Patch
   )(implicit trace: Trace): ZIO[Scope, Nothing, FiberRef.WithPatch[Value, Patch]] =
-    makeWith(Unsafe.unsafe(implicit u => unsafe.makePatch(initial, differ, fork)))
+    makeWith(unsafe.makePatch(initial, differ, fork)(Unsafe.unsafe))
 
   def makeSet[A](initial: => Set[A])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[Set[A], SetPatch[A]]] =
-    makeWith(Unsafe.unsafe(implicit u => unsafe.makeSet(initial)))
+    makeWith(unsafe.makeSet(initial)(Unsafe.unsafe))
 
   private[zio] object unsafe {
     def make[A](
@@ -485,34 +481,34 @@ object FiberRef {
   }
 
   private[zio] val forkScopeOverride: FiberRef[Option[FiberScope]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None, _ => None)) // Do not inherit on `fork`
+    FiberRef.unsafe.make[Option[FiberScope]](None, _ => None)(Unsafe.unsafe) // Do not inherit on `fork`
 
   private[zio] val overrideExecutor: FiberRef[Option[Executor]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None))
+    FiberRef.unsafe.make[Option[Executor]](None)(Unsafe.unsafe)
 
   private[zio] val currentEnvironment: FiberRef.WithPatch[ZEnvironment[Any], ZEnvironment.Patch[Any, Any]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeEnvironment(ZEnvironment.empty))
+    FiberRef.unsafe.makeEnvironment(ZEnvironment.empty)(Unsafe.unsafe)
 
   private[zio] val interruptedCause: FiberRef[Cause[Nothing]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Cause.empty, identity(_), (parent, _) => parent))
+    FiberRef.unsafe.make[Cause[Nothing]](Cause.empty, identity(_), (parent, _) => parent)(Unsafe.unsafe)
 
   private[zio] val currentBlockingExecutor: FiberRef[Executor] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Runtime.defaultBlockingExecutor))
+    FiberRef.unsafe.make(Runtime.defaultBlockingExecutor)(Unsafe.unsafe)
 
   private[zio] val currentFatal: FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal))
+    FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal)(Unsafe.unsafe)
 
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeSet(Runtime.defaultLoggers))
+    FiberRef.unsafe.makeSet(Runtime.defaultLoggers)(Unsafe.unsafe)
 
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Runtime.defaultReportFatal))
+    FiberRef.unsafe.make(Runtime.defaultReportFatal)(Unsafe.unsafe)
 
   private[zio] val currentSupervisor: FiberRef.WithPatch[Supervisor[Any], Supervisor.Patch] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor))
+    FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor)(Unsafe.unsafe)
 
   private[zio] val unhandledErrorLogLevel: FiberRef[Option[LogLevel]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(Some(LogLevel.Debug), identity(_), (_, child) => child))
+    FiberRef.unsafe.make[Option[LogLevel]](Some(LogLevel.Debug), identity(_), (_, child) => child)(Unsafe.unsafe)
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]

--- a/core/shared/src/main/scala/zio/Random.scala
+++ b/core/shared/src/main/scala/zio/Random.scala
@@ -68,78 +68,79 @@ trait Random extends Serializable { self =>
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A]
   }
 
-  private[zio] def unsafe: UnsafeAPI = new UnsafeAPI {
-    def nextBoolean()(implicit unsafe: Unsafe): Boolean =
-      Runtime.default.unsafe.run(self.nextBoolean(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+  private[zio] def unsafe: UnsafeAPI =
+    new UnsafeAPI {
+      def nextBoolean()(implicit unsafe: Unsafe): Boolean =
+        Runtime.default.unsafe.run(self.nextBoolean(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextBytes(length: Int)(implicit unsafe: Unsafe): Chunk[Byte] =
-      Runtime.default.unsafe.run(self.nextBytes(length)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextBytes(length: Int)(implicit unsafe: Unsafe): Chunk[Byte] =
+        Runtime.default.unsafe.run(self.nextBytes(length)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextDouble()(implicit unsafe: Unsafe): Double =
-      Runtime.default.unsafe.run(self.nextDouble(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextDouble()(implicit unsafe: Unsafe): Double =
+        Runtime.default.unsafe.run(self.nextDouble(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit
-      unsafe: Unsafe
-    ): Double =
-      Runtime.default.unsafe
-        .run(self.nextDoubleBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit
+        unsafe: Unsafe
+      ): Double =
+        Runtime.default.unsafe
+          .run(self.nextDoubleBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def nextFloat()(implicit unsafe: Unsafe): Float =
-      Runtime.default.unsafe.run(self.nextFloat(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextFloat()(implicit unsafe: Unsafe): Float =
+        Runtime.default.unsafe.run(self.nextFloat(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit
-      unsafe: Unsafe
-    ): Float =
-      Runtime.default.unsafe
-        .run(self.nextFloatBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit
+        unsafe: Unsafe
+      ): Float =
+        Runtime.default.unsafe
+          .run(self.nextFloatBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def nextGaussian()(implicit unsafe: Unsafe): Double =
-      Runtime.default.unsafe.run(self.nextGaussian(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextGaussian()(implicit unsafe: Unsafe): Double =
+        Runtime.default.unsafe.run(self.nextGaussian(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextInt()(implicit unsafe: Unsafe): Int =
-      Runtime.default.unsafe.run(self.nextInt(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextInt()(implicit unsafe: Unsafe): Int =
+        Runtime.default.unsafe.run(self.nextInt(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextIntBetween(minInclusive: Int, maxExclusive: Int)(implicit unsafe: Unsafe): Int =
-      Runtime.default.unsafe
-        .run(self.nextIntBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def nextIntBetween(minInclusive: Int, maxExclusive: Int)(implicit unsafe: Unsafe): Int =
+        Runtime.default.unsafe
+          .run(self.nextIntBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def nextIntBounded(n: Int)(implicit unsafe: Unsafe): Int =
-      Runtime.default.unsafe.run(self.nextIntBounded(n)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextIntBounded(n: Int)(implicit unsafe: Unsafe): Int =
+        Runtime.default.unsafe.run(self.nextIntBounded(n)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextLong()(implicit unsafe: Unsafe): Long =
-      Runtime.default.unsafe.run(self.nextLong(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextLong()(implicit unsafe: Unsafe): Long =
+        Runtime.default.unsafe.run(self.nextLong(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
-      Runtime.default.unsafe
-        .run(self.nextLongBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
+        Runtime.default.unsafe
+          .run(self.nextLongBetween(minInclusive, maxExclusive)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
-      Runtime.default.unsafe.run(self.nextLongBounded(n)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
+        Runtime.default.unsafe.run(self.nextLongBounded(n)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextPrintableChar()(implicit unsafe: Unsafe): Char =
-      Runtime.default.unsafe.run(self.nextPrintableChar(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextPrintableChar()(implicit unsafe: Unsafe): Char =
+        Runtime.default.unsafe.run(self.nextPrintableChar(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextString(length: Int)(implicit unsafe: Unsafe): String =
-      Runtime.default.unsafe.run(self.nextString(length)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextString(length: Int)(implicit unsafe: Unsafe): String =
+        Runtime.default.unsafe.run(self.nextString(length)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def nextUUID()(implicit unsafe: Unsafe): UUID =
-      Runtime.default.unsafe.run(self.nextUUID(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def nextUUID()(implicit unsafe: Unsafe): UUID =
+        Runtime.default.unsafe.run(self.nextUUID(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
-      Runtime.default.unsafe.run(self.setSeed(seed)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
+        Runtime.default.unsafe.run(self.setSeed(seed)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def shuffle[A, Collection[+Element] <: Iterable[Element]](collection: Collection[A])(implicit
-      bf: BuildFrom[Collection[A], A, Collection[A]],
-      unsafe: Unsafe
-    ): Collection[A] =
-      Runtime.default.unsafe
-        .run(self.shuffle(collection)(bf, Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
-  }
+      def shuffle[A, Collection[+Element] <: Iterable[Element]](collection: Collection[A])(implicit
+        bf: BuildFrom[Collection[A], A, Collection[A]],
+        unsafe: Unsafe
+      ): Collection[A] =
+        Runtime.default.unsafe
+          .run(self.shuffle(collection)(bf, Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
+    }
 }
 
 object Random extends Serializable {
@@ -149,125 +150,126 @@ object Random extends Serializable {
   object RandomLive extends Random {
 
     def nextBoolean(implicit trace: Trace): UIO[Boolean] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBoolean())
+      ZIO.succeed(unsafe.nextBoolean()(Unsafe.unsafe))
 
     def nextBytes(length: => Int)(implicit trace: Trace): UIO[Chunk[Byte]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBytes(length))
+      ZIO.succeed(unsafe.nextBytes(length)(Unsafe.unsafe))
 
     def nextDouble(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDouble())
+      ZIO.succeed(unsafe.nextDouble()(Unsafe.unsafe))
 
     def nextDoubleBetween(minInclusive: => Double, maxExclusive: => Double)(implicit
       trace: Trace
     ): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDoubleBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextDoubleBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextFloat(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloat())
+      ZIO.succeed(unsafe.nextFloat()(Unsafe.unsafe))
 
     def nextFloatBetween(minInclusive: => Float, maxExclusive: => Float)(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloatBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextFloatBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextGaussian(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextGaussian())
+      ZIO.succeed(unsafe.nextGaussian()(Unsafe.unsafe))
 
     def nextInt(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextInt())
+      ZIO.succeed(unsafe.nextInt()(Unsafe.unsafe))
 
     def nextIntBetween(minInclusive: => Int, maxExclusive: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextIntBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextIntBounded(n: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBounded(n))
+      ZIO.succeed(unsafe.nextIntBounded(n)(Unsafe.unsafe))
 
     def nextLong(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLong())
+      ZIO.succeed(unsafe.nextLong()(Unsafe.unsafe))
 
     def nextLongBetween(minInclusive: => Long, maxExclusive: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextLongBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextLongBounded(n: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBounded(n))
+      ZIO.succeed(unsafe.nextLongBounded(n)(Unsafe.unsafe))
 
     def nextPrintableChar(implicit trace: Trace): UIO[Char] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextPrintableChar())
+      ZIO.succeed(unsafe.nextPrintableChar()(Unsafe.unsafe))
 
     def nextString(length: => Int)(implicit trace: Trace): UIO[String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextString(length))
+      ZIO.succeed(unsafe.nextString(length)(Unsafe.unsafe))
 
     def nextUUID(implicit trace: Trace): UIO[UUID] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextUUID())
+      ZIO.succeed(unsafe.nextUUID()(Unsafe.unsafe))
 
     def setSeed(seed: => Long)(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.setSeed(seed))
+      ZIO.succeed(unsafe.setSeed(seed)(Unsafe.unsafe))
 
     def shuffle[A, Collection[+Element] <: Iterable[Element]](
       collection: => Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.shuffle(collection))
+      ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient private[zio] override val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
-        scala.util.Random.nextBoolean()
+    @transient private[zio] override val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
+          scala.util.Random.nextBoolean()
 
-      override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] = {
-        val array = Array.ofDim[Byte](length)
-        scala.util.Random.nextBytes(array)
-        Chunk.fromArray(array)
+        override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] = {
+          val array = Array.ofDim[Byte](length)
+          scala.util.Random.nextBytes(array)
+          Chunk.fromArray(array)
+        }
+
+        override def nextDouble()(implicit unsafe: Unsafe): Double =
+          scala.util.Random.nextDouble()
+
+        override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
+          nextDoubleBetweenWith(minInclusive, maxExclusive)(() => nextDouble())
+
+        override def nextFloat()(implicit unsafe: Unsafe): Float =
+          scala.util.Random.nextFloat()
+
+        override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
+          nextFloatBetweenWith(minInclusive, maxExclusive)(() => nextFloat())
+
+        override def nextGaussian()(implicit unsafe: Unsafe): Double =
+          scala.util.Random.nextGaussian()
+
+        override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
+          scala.util.Random.nextInt()
+
+        override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
+          unsafe: Unsafe
+        ): RuntimeFlags =
+          nextIntBetweenWith(minInclusive, maxExclusive)(() => nextInt(), nextIntBounded(_))
+
+        override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
+          scala.util.Random.nextInt(n)
+
+        override def nextLong()(implicit unsafe: Unsafe): Long =
+          scala.util.Random.nextLong()
+
+        override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
+          nextLongBetweenWith(minInclusive, maxExclusive)(() => nextLong(), nextLongBounded(_))
+
+        override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
+          Random.nextLongBoundedWith(n)(() => nextLong())
+
+        override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
+          scala.util.Random.nextPrintableChar()
+
+        override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
+          scala.util.Random.nextString(length)
+
+        override def nextUUID()(implicit unsafe: Unsafe): UUID =
+          Random.nextUUIDWith(() => nextLong())
+
+        override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
+          scala.util.Random.setSeed(seed)
+
+        override def shuffle[A, Collection[+Element] <: Iterable[Element]](
+          collection: Collection[A]
+        )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
+          Random.shuffleWith(nextIntBounded(_), collection)
       }
-
-      override def nextDouble()(implicit unsafe: Unsafe): Double =
-        scala.util.Random.nextDouble()
-
-      override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
-        nextDoubleBetweenWith(minInclusive, maxExclusive)(() => nextDouble())
-
-      override def nextFloat()(implicit unsafe: Unsafe): Float =
-        scala.util.Random.nextFloat()
-
-      override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
-        nextFloatBetweenWith(minInclusive, maxExclusive)(() => nextFloat())
-
-      override def nextGaussian()(implicit unsafe: Unsafe): Double =
-        scala.util.Random.nextGaussian()
-
-      override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
-        scala.util.Random.nextInt()
-
-      override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
-        unsafe: Unsafe
-      ): RuntimeFlags =
-        nextIntBetweenWith(minInclusive, maxExclusive)(() => nextInt(), nextIntBounded(_))
-
-      override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
-        scala.util.Random.nextInt(n)
-
-      override def nextLong()(implicit unsafe: Unsafe): Long =
-        scala.util.Random.nextLong()
-
-      override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
-        nextLongBetweenWith(minInclusive, maxExclusive)(() => nextLong(), nextLongBounded(_))
-
-      override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
-        Random.nextLongBoundedWith(n)(() => nextLong())
-
-      override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
-        scala.util.Random.nextPrintableChar()
-
-      override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
-        scala.util.Random.nextString(length)
-
-      override def nextUUID()(implicit unsafe: Unsafe): UUID =
-        Random.nextUUIDWith(() => nextLong())
-
-      override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
-        scala.util.Random.setSeed(seed)
-
-      override def shuffle[A, Collection[+Element] <: Iterable[Element]](
-        collection: Collection[A]
-      )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
-        Random.shuffleWith(nextIntBounded(_), collection)
-    }
   }
 
   /**
@@ -276,125 +278,126 @@ object Random extends Serializable {
   final case class RandomScala(random: scala.util.Random) extends Random {
 
     def nextBoolean(implicit trace: Trace): UIO[Boolean] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBoolean())
+      ZIO.succeed(unsafe.nextBoolean()(Unsafe.unsafe))
 
     def nextBytes(length: => Int)(implicit trace: Trace): UIO[Chunk[Byte]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBytes(length))
+      ZIO.succeed(unsafe.nextBytes(length)(Unsafe.unsafe))
 
     def nextDouble(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDouble())
+      ZIO.succeed(unsafe.nextDouble()(Unsafe.unsafe))
 
     def nextDoubleBetween(minInclusive: => Double, maxExclusive: => Double)(implicit
       trace: Trace
     ): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDoubleBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextDoubleBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextFloat(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloat())
+      ZIO.succeed(unsafe.nextFloat()(Unsafe.unsafe))
 
     def nextFloatBetween(minInclusive: => Float, maxExclusive: => Float)(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloatBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextFloatBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextGaussian(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextGaussian())
+      ZIO.succeed(unsafe.nextGaussian()(Unsafe.unsafe))
 
     def nextInt(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextInt())
+      ZIO.succeed(unsafe.nextInt()(Unsafe.unsafe))
 
     def nextIntBetween(minInclusive: => Int, maxExclusive: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextIntBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextIntBounded(n: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBounded(n))
+      ZIO.succeed(unsafe.nextIntBounded(n)(Unsafe.unsafe))
 
     def nextLong(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLong())
+      ZIO.succeed(unsafe.nextLong()(Unsafe.unsafe))
 
     def nextLongBetween(minInclusive: => Long, maxExclusive: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextLongBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     def nextLongBounded(n: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBounded(n))
+      ZIO.succeed(unsafe.nextLongBounded(n)(Unsafe.unsafe))
 
     def nextPrintableChar(implicit trace: Trace): UIO[Char] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextPrintableChar())
+      ZIO.succeed(unsafe.nextPrintableChar()(Unsafe.unsafe))
 
     def nextString(length: => Int)(implicit trace: Trace): UIO[String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextString(length))
+      ZIO.succeed(unsafe.nextString(length)(Unsafe.unsafe))
 
     def nextUUID(implicit trace: Trace): UIO[UUID] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextUUID())
+      ZIO.succeed(unsafe.nextUUID()(Unsafe.unsafe))
 
     def setSeed(seed: => Long)(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.setSeed(seed))
+      ZIO.succeed(unsafe.setSeed(seed)(Unsafe.unsafe))
 
     def shuffle[A, Collection[+Element] <: Iterable[Element]](
       collection: => Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.shuffle(collection))
+      ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient private[zio] override val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
-        random.nextBoolean()
+    @transient private[zio] override val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
+          random.nextBoolean()
 
-      override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] = {
-        val array = Array.ofDim[Byte](length)
-        random.nextBytes(array)
-        Chunk.fromArray(array)
+        override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] = {
+          val array = Array.ofDim[Byte](length)
+          random.nextBytes(array)
+          Chunk.fromArray(array)
+        }
+
+        override def nextDouble()(implicit unsafe: Unsafe): Double =
+          random.nextDouble()
+
+        override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
+          nextDoubleBetweenWith(minInclusive, maxExclusive)(() => nextDouble())
+
+        override def nextFloat()(implicit unsafe: Unsafe): Float =
+          random.nextFloat()
+
+        override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
+          nextFloatBetweenWith(minInclusive, maxExclusive)(() => nextFloat())
+
+        override def nextGaussian()(implicit unsafe: Unsafe): Double =
+          random.nextGaussian()
+
+        override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
+          random.nextInt()
+
+        override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
+          unsafe: Unsafe
+        ): RuntimeFlags =
+          nextIntBetweenWith(minInclusive, maxExclusive)(() => nextInt(), nextIntBounded(_))
+
+        override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
+          random.nextInt(n)
+
+        override def nextLong()(implicit unsafe: Unsafe): Long =
+          random.nextLong()
+
+        override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
+          nextLongBetweenWith(minInclusive, maxExclusive)(() => nextLong(), nextLongBounded(_))
+
+        override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
+          Random.nextLongBoundedWith(n)(() => nextLong())
+
+        override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
+          random.nextPrintableChar()
+
+        override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
+          random.nextString(length)
+
+        override def nextUUID()(implicit unsafe: Unsafe): UUID =
+          Random.nextUUIDWith(() => nextLong())
+
+        override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
+          random.setSeed(seed)
+
+        override def shuffle[A, Collection[+Element] <: Iterable[Element]](
+          collection: Collection[A]
+        )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
+          Random.shuffleWith(nextIntBounded(_), collection)
       }
-
-      override def nextDouble()(implicit unsafe: Unsafe): Double =
-        random.nextDouble()
-
-      override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
-        nextDoubleBetweenWith(minInclusive, maxExclusive)(() => nextDouble())
-
-      override def nextFloat()(implicit unsafe: Unsafe): Float =
-        random.nextFloat()
-
-      override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
-        nextFloatBetweenWith(minInclusive, maxExclusive)(() => nextFloat())
-
-      override def nextGaussian()(implicit unsafe: Unsafe): Double =
-        random.nextGaussian()
-
-      override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
-        random.nextInt()
-
-      override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
-        unsafe: Unsafe
-      ): RuntimeFlags =
-        nextIntBetweenWith(minInclusive, maxExclusive)(() => nextInt(), nextIntBounded(_))
-
-      override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
-        random.nextInt(n)
-
-      override def nextLong()(implicit unsafe: Unsafe): Long =
-        random.nextLong()
-
-      override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
-        nextLongBetweenWith(minInclusive, maxExclusive)(() => nextLong(), nextLongBounded(_))
-
-      override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
-        Random.nextLongBoundedWith(n)(() => nextLong())
-
-      override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
-        random.nextPrintableChar()
-
-      override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
-        random.nextString(length)
-
-      override def nextUUID()(implicit unsafe: Unsafe): UUID =
-        Random.nextUUIDWith(() => nextLong())
-
-      override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
-        random.setSeed(seed)
-
-      override def shuffle[A, Collection[+Element] <: Iterable[Element]](
-        collection: Collection[A]
-      )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
-        Random.shuffleWith(nextIntBounded(_), collection)
-    }
   }
 
   private[zio] def nextDoubleBetweenWith(minInclusive: Double, maxExclusive: Double)(nextDouble: () => Double): Double =

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -261,7 +261,7 @@ object Scope {
      * Creates a new ReleaseMap.
      */
     def make(implicit trace: Trace): UIO[ReleaseMap] =
-      ZIO.succeedUnsafe(implicit u => unsafe.make())
+      ZIO.succeed(unsafe.make()(Unsafe.unsafe))
 
     private object unsafe {
 

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -77,7 +77,7 @@ object Supervisor {
    *   (platform-dependent).
    */
   def track(weak: Boolean)(implicit trace: Trace): UIO[Supervisor[Chunk[Fiber.Runtime[Any, Any]]]] =
-    ZIO.succeedUnsafe(implicit u => unsafe.track(weak))
+    ZIO.succeed(unsafe.track(weak)(Unsafe.unsafe))
 
   def fromZIO[A](value: UIO[A]): Supervisor[A] = new ConstSupervisor(_ => value)
 

--- a/core/shared/src/main/scala/zio/System.scala
+++ b/core/shared/src/main/scala/zio/System.scala
@@ -59,46 +59,47 @@ trait System extends Serializable { self =>
     def propertyOrOption(prop: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String]
   }
 
-  private[zio] def unsafe: UnsafeAPI = new UnsafeAPI {
-    def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
-      Runtime.default.unsafe.run(self.env(variable)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+  private[zio] def unsafe: UnsafeAPI =
+    new UnsafeAPI {
+      def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
+        Runtime.default.unsafe.run(self.env(variable)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
-      Runtime.default.unsafe
-        .run(self.envOrElse(variable, alt)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
+        Runtime.default.unsafe
+          .run(self.envOrElse(variable, alt)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def envOrOption(variable: String, alt: => Option[String])(implicit
-      unsafe: Unsafe
-    ): Option[String] =
-      Runtime.default.unsafe
-        .run(self.envOrOption(variable, alt)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def envOrOption(variable: String, alt: => Option[String])(implicit
+        unsafe: Unsafe
+      ): Option[String] =
+        Runtime.default.unsafe
+          .run(self.envOrOption(variable, alt)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def envs()(implicit unsafe: Unsafe): Map[String, String] =
-      Runtime.default.unsafe.run(self.envs(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def envs()(implicit unsafe: Unsafe): Map[String, String] =
+        Runtime.default.unsafe.run(self.envs(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def lineSeparator()(implicit unsafe: Unsafe): String =
-      Runtime.default.unsafe.run(self.lineSeparator(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def lineSeparator()(implicit unsafe: Unsafe): String =
+        Runtime.default.unsafe.run(self.lineSeparator(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def properties()(implicit unsafe: Unsafe): Map[String, String] =
-      Runtime.default.unsafe.run(self.properties(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def properties()(implicit unsafe: Unsafe): Map[String, String] =
+        Runtime.default.unsafe.run(self.properties(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
-      Runtime.default.unsafe.run(self.property(prop)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+      def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
+        Runtime.default.unsafe.run(self.property(prop)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-    def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
-      Runtime.default.unsafe
-        .run(self.propertyOrElse(prop, alt)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
+      def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
+        Runtime.default.unsafe
+          .run(self.propertyOrElse(prop, alt)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
 
-    def propertyOrOption(prop: String, alt: => Option[String])(implicit
-      unsafe: Unsafe
-    ): Option[String] =
-      Runtime.default.unsafe
-        .run(self.propertyOrOption(prop, alt)(Trace.empty))(Trace.empty, unsafe)
-        .getOrThrowFiberFailure()
-  }
+      def propertyOrOption(prop: String, alt: => Option[String])(implicit
+        unsafe: Unsafe
+      ): Option[String] =
+        Runtime.default.unsafe
+          .run(self.propertyOrOption(prop, alt)(Trace.empty))(Trace.empty, unsafe)
+          .getOrThrowFiberFailure()
+    }
 }
 
 object System extends Serializable {
@@ -107,68 +108,69 @@ object System extends Serializable {
 
   object SystemLive extends System {
     def env(variable: => String)(implicit trace: Trace): IO[SecurityException, Option[String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.env(variable)).refineToOrDie[SecurityException]
+      ZIO.attempt(unsafe.env(variable)(Unsafe.unsafe)).refineToOrDie[SecurityException]
 
     def envOrElse(variable: => String, alt: => String)(implicit trace: Trace): IO[SecurityException, String] =
-      ZIO.attemptUnsafe(implicit u => unsafe.envOrElse(variable, alt)).refineToOrDie[SecurityException]
+      ZIO.attempt(unsafe.envOrElse(variable, alt)(Unsafe.unsafe)).refineToOrDie[SecurityException]
 
     def envOrOption(variable: => String, alt: => Option[String])(implicit
       trace: Trace
     ): IO[SecurityException, Option[String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.envOrOption(variable, alt)).refineToOrDie[SecurityException]
+      ZIO.attempt(unsafe.envOrOption(variable, alt)(Unsafe.unsafe)).refineToOrDie[SecurityException]
 
     def envs(implicit trace: Trace): IO[SecurityException, Map[String, String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.envs()).refineToOrDie[SecurityException]
+      ZIO.attempt(unsafe.envs()(Unsafe.unsafe)).refineToOrDie[SecurityException]
 
     def lineSeparator(implicit trace: Trace): UIO[String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.lineSeparator())
+      ZIO.succeed(unsafe.lineSeparator()(Unsafe.unsafe))
 
     def properties(implicit trace: Trace): IO[Throwable, Map[String, String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.properties())
+      ZIO.attempt(unsafe.properties()(Unsafe.unsafe))
 
     def property(prop: => String)(implicit trace: Trace): IO[Throwable, Option[String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.property(prop))
+      ZIO.attempt(unsafe.property(prop)(Unsafe.unsafe))
 
     def propertyOrElse(prop: => String, alt: => String)(implicit trace: Trace): IO[Throwable, String] =
-      ZIO.attemptUnsafe(implicit u => unsafe.propertyOrElse(prop, alt))
+      ZIO.attempt(unsafe.propertyOrElse(prop, alt)(Unsafe.unsafe))
 
     def propertyOrOption(prop: => String, alt: => Option[String])(implicit
       trace: Trace
     ): IO[Throwable, Option[String]] =
-      ZIO.attemptUnsafe(implicit u => unsafe.propertyOrOption(prop, alt))
+      ZIO.attempt(unsafe.propertyOrOption(prop, alt)(Unsafe.unsafe))
 
-    @transient override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
-        Option(JSystem.getenv(variable))
+    @transient override private[zio] val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
+          Option(JSystem.getenv(variable))
 
-      override def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
-        envOrElseWith(variable, alt)(env)
+        override def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
+          envOrElseWith(variable, alt)(env)
 
-      override def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String] =
-        envOrOptionWith(variable, alt)(env)
+        override def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String] =
+          envOrOptionWith(variable, alt)(env)
 
-      @silent("JavaConverters")
-      override def envs()(implicit unsafe: Unsafe): Map[String, String] =
-        JSystem.getenv.asScala.toMap
+        @silent("JavaConverters")
+        override def envs()(implicit unsafe: Unsafe): Map[String, String] =
+          JSystem.getenv.asScala.toMap
 
-      override def lineSeparator()(implicit unsafe: Unsafe): String =
-        JSystem.lineSeparator
+        override def lineSeparator()(implicit unsafe: Unsafe): String =
+          JSystem.lineSeparator
 
-      @silent("JavaConverters")
-      override def properties()(implicit unsafe: Unsafe): Map[String, String] =
-        JSystem.getProperties.asScala.toMap
+        @silent("JavaConverters")
+        override def properties()(implicit unsafe: Unsafe): Map[String, String] =
+          JSystem.getProperties.asScala.toMap
 
-      override def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
-        Option(JSystem.getProperty(prop))
+        override def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
+          Option(JSystem.getProperty(prop))
 
-      override def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
-        propertyOrElseWith(prop, alt)(property)
+        override def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
+          propertyOrElseWith(prop, alt)(property)
 
-      override def propertyOrOption(prop: String, alt: => Option[String])(implicit
-        unsafe: Unsafe
-      ): Option[String] =
-        propertyOrOptionWith(prop, alt)(property)
-    }
+        override def propertyOrOption(prop: String, alt: => Option[String])(implicit
+          unsafe: Unsafe
+        ): Option[String] =
+          propertyOrOptionWith(prop, alt)(property)
+      }
   }
 
   private[zio] def envOrElseWith(variable: String, alt: => String)(env: String => Option[String]): String =

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -24,11 +24,11 @@ object ThreadLocalBridge {
           for {
             fiberRef <- FiberRef.make(initialValue)
             _         = link(initialValue)
-            _         = Unsafe.unsafe(implicit u => supervisor.trackFiberRef(fiberRef, link))
+            _         = supervisor.trackFiberRef(fiberRef, link)(Unsafe.unsafe)
             _ <- Scope.addFinalizer(
-                   ZIO.succeedUnsafe { implicit u =>
+                   ZIO.succeed {
                      link(initialValue)
-                     supervisor.forgetFiberRef(fiberRef, link)
+                     supervisor.forgetFiberRef(fiberRef, link)(Unsafe.unsafe)
                    }
                  )
           } yield {

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -24,7 +24,7 @@ object ThreadLocalBridge {
           for {
             fiberRef <- FiberRef.make(initialValue)
             _         = link(initialValue)
-            _         = Unsafe.unsafeCompat(implicit u => supervisor.trackFiberRef(fiberRef, link))
+            _         = Unsafe.unsafely(implicit u => supervisor.trackFiberRef(fiberRef, link))
             _ <- Scope.addFinalizer(
                    ZIO.succeedUnsafe { implicit u =>
                      link(initialValue)

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -24,7 +24,7 @@ object ThreadLocalBridge {
           for {
             fiberRef <- FiberRef.make(initialValue)
             _         = link(initialValue)
-            _         = Unsafe.unsafely(implicit u => supervisor.trackFiberRef(fiberRef, link))
+            _         = Unsafe.unsafe(implicit u => supervisor.trackFiberRef(fiberRef, link))
             _ <- Scope.addFinalizer(
                    ZIO.succeedUnsafe { implicit u =>
                      link(initialValue)

--- a/core/shared/src/main/scala/zio/Unsafe.scala
+++ b/core/shared/src/main/scala/zio/Unsafe.scala
@@ -23,7 +23,7 @@ package zio
  * always pure, total, and type-safe.
  *
  * {{{
- * import Unsafe.unsafely
+ * import Unsafe.unsafe
  *
  * unsafely { ... }
  * }}}
@@ -33,9 +33,10 @@ sealed trait Unsafe extends Serializable
 object Unsafe extends UnsafeVersionSpecific {
   private[zio] val unsafe: Unsafe = new Unsafe {}
 
-  def unsafely[A](f: Unsafe => A): A =
+  def unsafe[A](f: Unsafe => A): A =
     f(unsafe)
 
-  @deprecated("use unsafely", "3.0.0")
-  def unsafeCompat[A](f: Unsafe => A): A = f(unsafe)
+  @deprecated("use unsafe", "3.0.0")
+  def unsafeCompat[A](f: Unsafe => A): A =
+    f(unsafe)
 }

--- a/core/shared/src/main/scala/zio/Unsafe.scala
+++ b/core/shared/src/main/scala/zio/Unsafe.scala
@@ -25,7 +25,7 @@ package zio
  * {{{
  * import Unsafe.unsafe
  *
- * unsafely { ... }
+ * unsafe { ... }
  * }}}
  */
 sealed trait Unsafe extends Serializable

--- a/core/shared/src/main/scala/zio/Unsafe.scala
+++ b/core/shared/src/main/scala/zio/Unsafe.scala
@@ -23,9 +23,9 @@ package zio
  * always pure, total, and type-safe.
  *
  * {{{
- * import Unsafe.unsafe
+ * import Unsafe.unsafely
  *
- * unsafe { ... }
+ * unsafely { ... }
  * }}}
  */
 sealed trait Unsafe extends Serializable
@@ -33,5 +33,9 @@ sealed trait Unsafe extends Serializable
 object Unsafe extends UnsafeVersionSpecific {
   private[zio] val unsafe: Unsafe = new Unsafe {}
 
+  def unsafely[A](f: Unsafe => A): A =
+    f(unsafe)
+
+  @deprecated("use unsafely", "3.0.0")
   def unsafeCompat[A](f: Unsafe => A): A = f(unsafe)
 }

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -33,7 +33,7 @@ final class ZEnvironment[+R] private (
    * Adds a service to the environment.
    */
   def add[A](a: A)(implicit tag: Tag[A]): ZEnvironment[R with A] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafe.add[A](tag.tag, a)
     }
 
@@ -46,7 +46,7 @@ final class ZEnvironment[+R] private (
    * Retrieves a service from the environment.
    */
   def get[A >: R](implicit tag: Tag[A]): A =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafe.get[A](tag.tag)
     }
 
@@ -55,7 +55,7 @@ final class ZEnvironment[+R] private (
    * key.
    */
   def getAt[K, V](k: K)(implicit ev: R <:< Map[K, V], tagged: EnvironmentTag[Map[K, V]]): Option[V] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       unsafe.get[Map[K, V]](taggedTagType(tagged)).get(k)
     }
 
@@ -123,7 +123,7 @@ final class ZEnvironment[+R] private (
    * Updates a service in the environment corresponding to the specified key.
    */
   def updateAt[K, V](k: K)(f: V => V)(implicit ev: R <:< Map[K, V], tag: Tag[Map[K, V]]): ZEnvironment[R] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       self.add[Map[K, V]](unsafe.get[Map[K, V]](taggedTagType(tag)).updated(k, f(getAt(k).get)))
     }
 
@@ -260,7 +260,7 @@ object ZEnvironment {
      * Applies an update to the environment to produce a new environment.
      */
     def apply(environment: ZEnvironment[In]): ZEnvironment[Out] =
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         @tailrec
         def loop(environment: ZEnvironment[Any], patches: List[Patch[Any, Any]]): ZEnvironment[Any] =
           patches match {

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -33,7 +33,7 @@ final class ZEnvironment[+R] private (
    * Adds a service to the environment.
    */
   def add[A](a: A)(implicit tag: Tag[A]): ZEnvironment[R with A] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafe.add[A](tag.tag, a)
     }
 
@@ -46,7 +46,7 @@ final class ZEnvironment[+R] private (
    * Retrieves a service from the environment.
    */
   def get[A >: R](implicit tag: Tag[A]): A =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafe.get[A](tag.tag)
     }
 
@@ -55,7 +55,7 @@ final class ZEnvironment[+R] private (
    * key.
    */
   def getAt[K, V](k: K)(implicit ev: R <:< Map[K, V], tagged: EnvironmentTag[Map[K, V]]): Option[V] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       unsafe.get[Map[K, V]](taggedTagType(tagged)).get(k)
     }
 
@@ -123,7 +123,7 @@ final class ZEnvironment[+R] private (
    * Updates a service in the environment corresponding to the specified key.
    */
   def updateAt[K, V](k: K)(f: V => V)(implicit ev: R <:< Map[K, V], tag: Tag[Map[K, V]]): ZEnvironment[R] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       self.add[Map[K, V]](unsafe.get[Map[K, V]](taggedTagType(tag)).updated(k, f(getAt(k).get)))
     }
 
@@ -260,7 +260,7 @@ object ZEnvironment {
      * Applies an update to the environment to produce a new environment.
      */
     def apply(environment: ZEnvironment[In]): ZEnvironment[Out] =
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         @tailrec
         def loop(environment: ZEnvironment[Any], patches: List[Patch[Any, Any]]): ZEnvironment[Any] =
           patches match {

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -33,9 +33,7 @@ final class ZEnvironment[+R] private (
    * Adds a service to the environment.
    */
   def add[A](a: A)(implicit tag: Tag[A]): ZEnvironment[R with A] =
-    Unsafe.unsafe { implicit u =>
-      unsafe.add[A](tag.tag, a)
-    }
+    unsafe.add[A](tag.tag, a)(Unsafe.unsafe)
 
   override def equals(that: Any): Boolean = that match {
     case that: ZEnvironment[_] => self.map == that.map
@@ -46,18 +44,14 @@ final class ZEnvironment[+R] private (
    * Retrieves a service from the environment.
    */
   def get[A >: R](implicit tag: Tag[A]): A =
-    Unsafe.unsafe { implicit u =>
-      unsafe.get[A](tag.tag)
-    }
+    unsafe.get[A](tag.tag)(Unsafe.unsafe)
 
   /**
    * Retrieves a service from the environment corresponding to the specified
    * key.
    */
   def getAt[K, V](k: K)(implicit ev: R <:< Map[K, V], tagged: EnvironmentTag[Map[K, V]]): Option[V] =
-    Unsafe.unsafe { implicit u =>
-      unsafe.get[Map[K, V]](taggedTagType(tagged)).get(k)
-    }
+    unsafe.get[Map[K, V]](taggedTagType(tagged))(Unsafe.unsafe).get(k)
 
   override def hashCode: Int =
     map.hashCode
@@ -123,9 +117,7 @@ final class ZEnvironment[+R] private (
    * Updates a service in the environment corresponding to the specified key.
    */
   def updateAt[K, V](k: K)(f: V => V)(implicit ev: R <:< Map[K, V], tag: Tag[Map[K, V]]): ZEnvironment[R] =
-    Unsafe.unsafe { implicit u =>
-      self.add[Map[K, V]](unsafe.get[Map[K, V]](taggedTagType(tag)).updated(k, f(getAt(k).get)))
-    }
+    self.add[Map[K, V]](unsafe.get[Map[K, V]](taggedTagType(tag))(Unsafe.unsafe).updated(k, f(getAt(k).get)))
 
   /**
    * Filters a map by retaining only keys satisfying a predicate.
@@ -151,38 +143,39 @@ final class ZEnvironment[+R] private (
     ): ZEnvironment[R]
   }
 
-  val unsafe: UnsafeAPI = new UnsafeAPI {
-    private[ZEnvironment] def add[A](tag: LightTypeTag, a: A)(implicit unsafe: Unsafe): ZEnvironment[R with A] = {
-      val self0 = if (index == Int.MaxValue) self.clean else self
-      new ZEnvironment(self0.map + (tag -> (a -> self0.index)), self0.index + 1)
-    }
-
-    def get[A](tag: LightTypeTag)(implicit unsafe: Unsafe): A =
-      self.cache.get(tag) match {
-        case Some(a) => a.asInstanceOf[A]
-        case None =>
-          var index      = -1
-          val iterator   = self.map.iterator
-          var service: A = null.asInstanceOf[A]
-          while (iterator.hasNext) {
-            val (curTag, (curService, curIndex)) = iterator.next()
-            if (taggedIsSubtype(curTag, tag) && curIndex > index) {
-              index = curIndex
-              service = curService.asInstanceOf[A]
-            }
-          }
-          if (service == null) throw new Error(s"Defect in zio.ZEnvironment: Could not find ${tag} inside ${self}")
-          else {
-            self.cache = self.cache + (tag -> service)
-            service
-          }
+  val unsafe: UnsafeAPI =
+    new UnsafeAPI {
+      private[ZEnvironment] def add[A](tag: LightTypeTag, a: A)(implicit unsafe: Unsafe): ZEnvironment[R with A] = {
+        val self0 = if (index == Int.MaxValue) self.clean else self
+        new ZEnvironment(self0.map + (tag -> (a -> self0.index)), self0.index + 1)
       }
 
-    private[ZEnvironment] def update[A >: R](tag: LightTypeTag, f: A => A)(implicit
-      unsafe: Unsafe
-    ): ZEnvironment[R] =
-      add[A](tag, f(get(tag)))
-  }
+      def get[A](tag: LightTypeTag)(implicit unsafe: Unsafe): A =
+        self.cache.get(tag) match {
+          case Some(a) => a.asInstanceOf[A]
+          case None =>
+            var index      = -1
+            val iterator   = self.map.iterator
+            var service: A = null.asInstanceOf[A]
+            while (iterator.hasNext) {
+              val (curTag, (curService, curIndex)) = iterator.next()
+              if (taggedIsSubtype(curTag, tag) && curIndex > index) {
+                index = curIndex
+                service = curService.asInstanceOf[A]
+              }
+            }
+            if (service == null) throw new Error(s"Defect in zio.ZEnvironment: Could not find ${tag} inside ${self}")
+            else {
+              self.cache = self.cache + (tag -> service)
+              service
+            }
+        }
+
+      private[ZEnvironment] def update[A >: R](tag: LightTypeTag, f: A => A)(implicit
+        unsafe: Unsafe
+      ): ZEnvironment[R] =
+        add[A](tag, f(get(tag)))
+    }
 }
 
 object ZEnvironment {
@@ -259,21 +252,22 @@ object ZEnvironment {
     /**
      * Applies an update to the environment to produce a new environment.
      */
-    def apply(environment: ZEnvironment[In]): ZEnvironment[Out] =
-      Unsafe.unsafe { implicit u =>
-        @tailrec
-        def loop(environment: ZEnvironment[Any], patches: List[Patch[Any, Any]]): ZEnvironment[Any] =
-          patches match {
-            case AddService(service, tag) :: patches   => loop(environment.unsafe.add(tag, service), patches)
-            case AndThen(first, second) :: patches     => loop(environment, erase(first) :: erase(second) :: patches)
-            case Empty() :: patches                    => loop(environment, patches)
-            case RemoveService(tag) :: patches         => loop(environment, patches)
-            case UpdateService(update, tag) :: patches => loop(environment.unsafe.update(tag, update), patches)
-            case Nil                                   => environment
-          }
+    def apply(environment: ZEnvironment[In]): ZEnvironment[Out] = {
 
-        loop(environment, List(self.asInstanceOf[Patch[Any, Any]])).asInstanceOf[ZEnvironment[Out]]
-      }
+      @tailrec
+      def loop(environment: ZEnvironment[Any], patches: List[Patch[Any, Any]]): ZEnvironment[Any] =
+        patches match {
+          case AddService(service, tag) :: patches => loop(environment.unsafe.add(tag, service)(Unsafe.unsafe), patches)
+          case AndThen(first, second) :: patches   => loop(environment, erase(first) :: erase(second) :: patches)
+          case Empty() :: patches                  => loop(environment, patches)
+          case RemoveService(tag) :: patches       => loop(environment, patches)
+          case UpdateService(update, tag) :: patches =>
+            loop(environment.unsafe.update(tag, update)(Unsafe.unsafe), patches)
+          case Nil => environment
+        }
+
+      loop(environment, List(self.asInstanceOf[Patch[Any, Any]])).asInstanceOf[ZEnvironment[Out]]
+    }
 
     /**
      * Combines two patches to produce a new patch that describes applying the

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2498,7 +2498,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * The level of parallelism for parallel operators.
    */
   final lazy val Parallelism: FiberRef[Option[Int]] =
-    Unsafe.unsafeCompat(implicit u => FiberRef.unsafe.make(None))
+    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None))
 
   /**
    * Submerges the error case of an `Either` into the `ZIO`. The inverse
@@ -2628,7 +2628,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     register: Unsafe => (ZIO[R, E, A] => Unit) => Either[URIO[R, Any], ZIO[R, E, A]],
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    asyncInterrupt(cb => Unsafe.unsafeCompat(implicit u => register(u)(cb)), blockingOn)
+    asyncInterrupt(cb => Unsafe.unsafely(implicit u => register(u)(cb)), blockingOn)
 
   /**
    * Converts an asynchronous, callback-style API into a ZIO effect, which will
@@ -2644,7 +2644,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       r <- ZIO.runtime[R]
       a <- ZIO.uninterruptibleMask { restore =>
              val f = register(k =>
-               Unsafe.unsafeCompat { implicit u =>
+               Unsafe.unsafely { implicit u =>
                  r.unsafe.fork(k.intoPromise(p))
                }
              )
@@ -2654,10 +2654,10 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     } yield a
 
   def attemptUnsafe[A](a: Unsafe => A)(implicit trace: Trace): Task[A] =
-    ZIO.attempt(Unsafe.unsafeCompat(a))
+    ZIO.attempt(Unsafe.unsafely(a))
 
   def attemptBlockingIOUnsafe[A](effect: Unsafe => A)(implicit trace: Trace): IO[IOException, A] =
-    attemptBlockingIO(Unsafe.unsafeCompat(implicit u => effect(u)))
+    attemptBlockingIO(Unsafe.unsafely(implicit u => effect(u)))
 
   /**
    * Returns a new effect that, when executed, will execute the original effect
@@ -4307,7 +4307,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.blocking(ZIO.succeedUnsafe(a))
 
   def succeedUnsafe[A](a: Unsafe => A)(implicit trace: Trace): UIO[A] =
-    ZIO.succeed(Unsafe.unsafeCompat(a))
+    ZIO.succeed(Unsafe.unsafely(a))
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2498,7 +2498,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * The level of parallelism for parallel operators.
    */
   final lazy val Parallelism: FiberRef[Option[Int]] =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None))
+    FiberRef.unsafe.make[Option[Int]](None)(Unsafe.unsafe)
 
   /**
    * Submerges the error case of an `Either` into the `ZIO`. The inverse
@@ -2628,7 +2628,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     register: Unsafe => (ZIO[R, E, A] => Unit) => Either[URIO[R, Any], ZIO[R, E, A]],
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    asyncInterrupt(cb => Unsafe.unsafe(implicit u => register(u)(cb)), blockingOn)
+    asyncInterrupt(cb => register(Unsafe.unsafe)(cb), blockingOn)
 
   /**
    * Converts an asynchronous, callback-style API into a ZIO effect, which will
@@ -2643,21 +2643,17 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       p <- Promise.make[E, A]
       r <- ZIO.runtime[R]
       a <- ZIO.uninterruptibleMask { restore =>
-             val f = register(k =>
-               Unsafe.unsafe { implicit u =>
-                 r.unsafe.fork(k.intoPromise(p))
-               }
-             )
+             val f = register(k => r.unsafe.fork(k.intoPromise(p))(trace, Unsafe.unsafe))
 
              restore(f.catchAllCause(p.refailCause)).fork *> restore(p.await)
            }
     } yield a
 
   def attemptUnsafe[A](a: Unsafe => A)(implicit trace: Trace): Task[A] =
-    ZIO.attempt(Unsafe.unsafe(a))
+    ZIO.attempt(a(Unsafe.unsafe))
 
   def attemptBlockingIOUnsafe[A](effect: Unsafe => A)(implicit trace: Trace): IO[IOException, A] =
-    attemptBlockingIO(Unsafe.unsafe(implicit u => effect(u)))
+    attemptBlockingIO(effect(Unsafe.unsafe))
 
   /**
    * Returns a new effect that, when executed, will execute the original effect
@@ -4946,8 +4942,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       trace: Trace
     ): ZIO[R with Service, E, A] = {
       implicit val tag = tagged.tag
-      ZIO.suspendSucceedUnsafe { implicit u =>
-        FiberRef.currentEnvironment.get.flatMap(environment => f(environment.unsafe.get(tag)))
+      ZIO.suspendSucceed {
+        FiberRef.currentEnvironment.get.flatMap(environment => f(environment.unsafe.get(tag)(Unsafe.unsafe)))
       }
     }
   }
@@ -5574,13 +5570,13 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   private def foreachParUnboundedDiscard[R, E, A](
     as0: => Iterable[A]
   )(f: A => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
-    ZIO.suspendSucceedUnsafe { implicit u =>
+    ZIO.suspendSucceed {
       val as = as0
       if (as.isEmpty) ZIO.unit
       else {
         val size = as.size
         ZIO.uninterruptibleMask { restore =>
-          val promise = Promise.unsafe.make[Unit, Unit](FiberId.None)
+          val promise = Promise.unsafe.make[Unit, Unit](FiberId.None)(Unsafe.unsafe)
           val ref     = new java.util.concurrent.atomic.AtomicInteger(0)
           ZIO.transplant { graft =>
             ZIO.foreach(as) { a =>
@@ -5589,7 +5585,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                   cause => promise.fail(()) *> ZIO.refailCause(cause),
                   _ =>
                     if (ref.incrementAndGet == size) {
-                      promise.unsafe.done(ZIO.unit)
+                      promise.unsafe.done(ZIO.unit)(Unsafe.unsafe)
                       ZIO.unit
                     } else {
                       ZIO.unit

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2498,7 +2498,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * The level of parallelism for parallel operators.
    */
   final lazy val Parallelism: FiberRef[Option[Int]] =
-    Unsafe.unsafely(implicit u => FiberRef.unsafe.make(None))
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make(None))
 
   /**
    * Submerges the error case of an `Either` into the `ZIO`. The inverse
@@ -2628,7 +2628,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     register: Unsafe => (ZIO[R, E, A] => Unit) => Either[URIO[R, Any], ZIO[R, E, A]],
     blockingOn: => FiberId = FiberId.None
   )(implicit trace: Trace): ZIO[R, E, A] =
-    asyncInterrupt(cb => Unsafe.unsafely(implicit u => register(u)(cb)), blockingOn)
+    asyncInterrupt(cb => Unsafe.unsafe(implicit u => register(u)(cb)), blockingOn)
 
   /**
    * Converts an asynchronous, callback-style API into a ZIO effect, which will
@@ -2644,7 +2644,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       r <- ZIO.runtime[R]
       a <- ZIO.uninterruptibleMask { restore =>
              val f = register(k =>
-               Unsafe.unsafely { implicit u =>
+               Unsafe.unsafe { implicit u =>
                  r.unsafe.fork(k.intoPromise(p))
                }
              )
@@ -2654,10 +2654,10 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     } yield a
 
   def attemptUnsafe[A](a: Unsafe => A)(implicit trace: Trace): Task[A] =
-    ZIO.attempt(Unsafe.unsafely(a))
+    ZIO.attempt(Unsafe.unsafe(a))
 
   def attemptBlockingIOUnsafe[A](effect: Unsafe => A)(implicit trace: Trace): IO[IOException, A] =
-    attemptBlockingIO(Unsafe.unsafely(implicit u => effect(u)))
+    attemptBlockingIO(Unsafe.unsafe(implicit u => effect(u)))
 
   /**
    * Returns a new effect that, when executed, will execute the original effect
@@ -4307,7 +4307,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.blocking(ZIO.succeedUnsafe(a))
 
   def succeedUnsafe[A](a: Unsafe => A)(implicit trace: Trace): UIO[A] =
-    ZIO.succeed(Unsafe.unsafely(a))
+    ZIO.succeed(Unsafe.unsafe(a))
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -66,7 +66,7 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    */
   final def exit(code: ExitCode)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         if (!shuttingDown.getAndSet(true)) {
           try Platform.exit(code.code)
           catch { case _: SecurityException => }
@@ -94,10 +94,10 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
 
   protected def installSignalHandlers(runtime: Runtime[Any])(implicit trace: Trace): UIO[Any] =
     ZIO.attempt {
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         if (!ZIOApp.installedSignals.getAndSet(true)) {
           val dumpFibers =
-            () => Unsafe.unsafely(implicit u => runtime.unsafe.run(Fiber.dumpAll).getOrThrowFiberFailure())
+            () => Unsafe.unsafe(implicit u => runtime.unsafe.run(Fiber.dumpAll).getOrThrowFiberFailure())
 
           if (System.os.isWindows) {
             Platform.addSignalHandler("INT", dumpFibers)

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -66,7 +66,7 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    */
   final def exit(code: ExitCode)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         if (!shuttingDown.getAndSet(true)) {
           try Platform.exit(code.code)
           catch { case _: SecurityException => }
@@ -94,10 +94,10 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
 
   protected def installSignalHandlers(runtime: Runtime[Any])(implicit trace: Trace): UIO[Any] =
     ZIO.attempt {
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafely { implicit u =>
         if (!ZIOApp.installedSignals.getAndSet(true)) {
           val dumpFibers =
-            () => Unsafe.unsafeCompat(implicit u => runtime.unsafe.run(Fiber.dumpAll).getOrThrowFiberFailure())
+            () => Unsafe.unsafely(implicit u => runtime.unsafe.run(Fiber.dumpAll).getOrThrowFiberFailure())
 
           if (System.os.isWindows) {
             Platform.addSignalHandler("INT", dumpFibers)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -63,12 +63,14 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * without locks or immutable data.
    */
   def ask[A](f: Unsafe => (FiberRuntime[_, _], Fiber.Status) => A)(implicit trace: Trace): UIO[A] =
-    ZIO.suspendSucceedUnsafe { implicit u =>
-      val promise = zio.Promise.unsafe.make[Nothing, A](fiberId)
+    ZIO.suspendSucceed {
+      val promise = zio.Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
 
       tell(
-        FiberMessage.Stateful((fiber, status) => promise.unsafe.done(ZIO.succeedNow(f(u)(fiber, status))))
-      )
+        FiberMessage.Stateful((fiber, status) =>
+          promise.unsafe.done(ZIO.succeedNow(f(Unsafe.unsafe)(fiber, status)))(Unsafe.unsafe)
+        )
+      )(Unsafe.unsafe)
 
       promise.await
     }
@@ -84,10 +86,10 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     )
 
   def children(implicit trace: Trace): UIO[Chunk[FiberRuntime[_, _]]] =
-    ask(implicit u => (fiber, _) => Chunk.fromJavaIterable(fiber.getChildren()))
+    ask(unsafe => (fiber, _) => Chunk.fromJavaIterable(fiber.getChildren()(unsafe)))
 
   def fiberRefs(implicit trace: Trace): UIO[FiberRefs] =
-    ask(implicit u => (fiber, _) => fiber.getFiberRefs())
+    ask(unsafe => (fiber, _) => fiber.getFiberRefs()(unsafe))
 
   def id: FiberId.Runtime = fiberId
 
@@ -134,7 +136,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     drainQueueOnCurrentThread()(Unsafe.unsafe)
 
   def runtimeFlags(implicit trace: Trace): UIO[RuntimeFlags] =
-    ask[RuntimeFlags] { implicit u => (state, status) =>
+    ask[RuntimeFlags] { _ => (state, status) =>
       status match {
         case Fiber.Status.Done               => state._runtimeFlags
         case active: Fiber.Status.Unfinished => active.runtimeFlags
@@ -144,7 +146,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   def scope: FiberScope = FiberScope.make(this)
 
   def status(implicit trace: Trace): UIO[zio.Fiber.Status] =
-    ask[zio.Fiber.Status](implicit u => (_, currentStatus) => currentStatus)
+    ask[zio.Fiber.Status](_ => (_, currentStatus) => currentStatus)
 
   def trace(implicit trace: Trace): UIO[StackTrace] =
     ZIO.suspendSucceed {

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -176,7 +176,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         zio.map { a =>
-          Unsafe.unsafely { implicit u =>
+          Unsafe.unsafe { implicit u =>
             unsafe.update(in)
             a
           }
@@ -199,7 +199,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
   final def trackDefectWith(f: Throwable => In): ZIOAspect[Nothing, Any, Nothing, Throwable, Nothing, Any] =
     new ZIOAspect[Nothing, Any, Nothing, Throwable, Nothing, Any] {
       val updater: Throwable => Unit = defect =>
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           unsafe.update(f(defect))
         }
 
@@ -227,7 +227,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
           val startTime = java.lang.System.nanoTime()
 
           zio.map { a =>
-            Unsafe.unsafely { implicit u =>
+            Unsafe.unsafe { implicit u =>
               val endTime  = java.lang.System.nanoTime()
               val duration = Duration.fromNanos(endTime - startTime)
 
@@ -400,7 +400,7 @@ object Metric {
       def hook(extraTags: Set[MetricLabel]): MetricHook[key.keyType.In, key.keyType.Out] = {
         val fullKey = key.tagged(extraTags).asInstanceOf[MetricKey[key.keyType.type]]
 
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           metricRegistry.get(fullKey)
         }
       }

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -176,7 +176,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         zio.map { a =>
-          Unsafe.unsafeCompat { implicit u =>
+          Unsafe.unsafely { implicit u =>
             unsafe.update(in)
             a
           }
@@ -199,7 +199,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
   final def trackDefectWith(f: Throwable => In): ZIOAspect[Nothing, Any, Nothing, Throwable, Nothing, Any] =
     new ZIOAspect[Nothing, Any, Nothing, Throwable, Nothing, Any] {
       val updater: Throwable => Unit = defect =>
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafely { implicit u =>
           unsafe.update(f(defect))
         }
 
@@ -227,7 +227,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
           val startTime = java.lang.System.nanoTime()
 
           zio.map { a =>
-            Unsafe.unsafeCompat { implicit u =>
+            Unsafe.unsafely { implicit u =>
               val endTime  = java.lang.System.nanoTime()
               val duration = Duration.fromNanos(endTime - startTime)
 
@@ -400,7 +400,7 @@ object Metric {
       def hook(extraTags: Set[MetricLabel]): MetricHook[key.keyType.In, key.keyType.Out] = {
         val fullKey = key.tagged(extraTags).asInstanceOf[MetricKey[key.keyType.type]]
 
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafely { implicit u =>
           metricRegistry.get(fullKey)
         }
       }

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -133,15 +133,16 @@ object PollingMetric {
         new Metric[Type, In, Chunk[Out]] {
           override val keyType: Type = Chunk[Any](())
 
-          override private[zio] val unsafe = new UnsafeAPI {
-            override def update(in: In, extraTags: Set[MetricLabel])(implicit unsafe: Unsafe): Unit =
-              ins.zip(in).foreach { case (pollingmetric, input) =>
-                pollingmetric.metric.unsafe.update(input.asInstanceOf[pollingmetric.In])
-              }
+          override private[zio] val unsafe =
+            new UnsafeAPI {
+              override def update(in: In, extraTags: Set[MetricLabel])(implicit unsafe: Unsafe): Unit =
+                ins.zip(in).foreach { case (pollingmetric, input) =>
+                  pollingmetric.metric.unsafe.update(input.asInstanceOf[pollingmetric.In])
+                }
 
-            override def value(extraTags: Set[MetricLabel])(implicit unsafe: Unsafe): Chunk[Out] =
-              ins.map(_.metric.unsafe.value(extraTags))
-          }
+              override def value(extraTags: Set[MetricLabel])(implicit unsafe: Unsafe): Chunk[Out] =
+                ins.map(_.metric.unsafe.value(extraTags))
+            }
         }
 
       def poll(implicit trace: Trace): ZIO[R, E, In] = ZIO.foreach(ins)(_.poll)

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -55,7 +55,7 @@ object RunZIOEffectUsingUnsafeRun extends scala.App {
     _ <- Console.printLine("Hello, " + n + ", good to meet you!")
   } yield ()
 
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafely { implicit u =>
       zio.Runtime.default.unsafe.run(
         myAppLogic
       ).getOrThrowFiberFailure()
@@ -83,7 +83,7 @@ We can easily access the default `Runtime` to run an effect:
 object MainApp extends scala.App {
   val myAppLogic = ZIO.succeed(???)
   val runtime = Runtime.default
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafely { implicit u =>
     runtime.unsafe.run(myAppLogic).getOrThrowFiberFailure()
   }
 }
@@ -159,7 +159,7 @@ val testableRuntime: Runtime[Logging with Email] =
 Now we can run our effects using this custom `Runtime`:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafely { implicit u =>
     testableRuntime.unsafe.run(
       for {
         _ <- Logging.log("sending newsletter")

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -55,7 +55,7 @@ object RunZIOEffectUsingUnsafeRun extends scala.App {
     _ <- Console.printLine("Hello, " + n + ", good to meet you!")
   } yield ()
 
-  Unsafe.unsafely { implicit u =>
+  Unsafe.unsafe { implicit u =>
       zio.Runtime.default.unsafe.run(
         myAppLogic
       ).getOrThrowFiberFailure()
@@ -83,7 +83,7 @@ We can easily access the default `Runtime` to run an effect:
 object MainApp extends scala.App {
   val myAppLogic = ZIO.succeed(???)
   val runtime = Runtime.default
-  Unsafe.unsafely { implicit u =>
+  Unsafe.unsafe { implicit u =>
     runtime.unsafe.run(myAppLogic).getOrThrowFiberFailure()
   }
 }
@@ -159,7 +159,7 @@ val testableRuntime: Runtime[Logging with Email] =
 Now we can run our effects using this custom `Runtime`:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafely { implicit u =>
+Unsafe.unsafe { implicit u =>
     testableRuntime.unsafe.run(
       for {
         _ <- Logging.log("sending newsletter")

--- a/docs/datatypes/core/runtime.md
+++ b/docs/datatypes/core/runtime.md
@@ -55,7 +55,7 @@ object RunZIOEffectUsingUnsafeRun extends scala.App {
     _ <- Console.printLine("Hello, " + n + ", good to meet you!")
   } yield ()
 
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(
         myAppLogic
       ).getOrThrowFiberFailure()
@@ -83,7 +83,7 @@ We can easily access the default `Runtime` to run an effect:
 object MainApp extends scala.App {
   val myAppLogic = ZIO.succeed(???)
   val runtime = Runtime.default
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafe { implicit unsafe =>
     runtime.unsafe.run(myAppLogic).getOrThrowFiberFailure()
   }
 }
@@ -159,7 +159,7 @@ val testableRuntime: Runtime[Logging with Email] =
 Now we can run our effects using this custom `Runtime`:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafe { implicit unsafe =>
     testableRuntime.unsafe.run(
       for {
         _ <- Logging.log("sending newsletter")

--- a/docs/datatypes/test/environment/sized.md
+++ b/docs/datatypes/test/environment/sized.md
@@ -66,7 +66,7 @@ val samples: URIO[Sized, List[Int]] =
 The return type require the _Sized_ service. Therefore, to run this effect, we need to provide this service:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafe { implicit unsafe =>
     zio.Runtime.default.unsafe.run(
       samples.provide(Sized.live(100)) 
     ).getOrThrowFiberFailure()

--- a/docs/datatypes/test/environment/sized.md
+++ b/docs/datatypes/test/environment/sized.md
@@ -66,7 +66,7 @@ val samples: URIO[Sized, List[Int]] =
 The return type require the _Sized_ service. Therefore, to run this effect, we need to provide this service:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafely { implicit u =>
     zio.Runtime.default.unsafe.run(
       samples.provide(Sized.live(100)) 
     ).getOrThrowFiberFailure()

--- a/docs/datatypes/test/environment/sized.md
+++ b/docs/datatypes/test/environment/sized.md
@@ -66,7 +66,7 @@ val samples: URIO[Sized, List[Int]] =
 The return type require the _Sized_ service. Therefore, to run this effect, we need to provide this service:
 
 ```scala mdoc:silent:nest
-Unsafe.unsafely { implicit u =>
+Unsafe.unsafe { implicit u =>
     zio.Runtime.default.unsafe.run(
       samples.provide(Sized.live(100)) 
     ).getOrThrowFiberFailure()

--- a/docs/datatypes/test/index.md
+++ b/docs/datatypes/test/index.md
@@ -30,7 +30,7 @@ import zio._
 ```scala mdoc:compile-only
 import scala.Predef.assert
 
-val random = Unsafe.unsafe { implicit u =>
+val random = Unsafe.unsafely { implicit u =>
   Runtime.default.unsafe.run(
     Random.nextIntBounded(10)
   ).getOrThrowFiberFailure()

--- a/docs/datatypes/test/index.md
+++ b/docs/datatypes/test/index.md
@@ -30,7 +30,7 @@ import zio._
 ```scala mdoc:compile-only
 import scala.Predef.assert
 
-val random = Unsafe.unsafely { implicit u =>
+val random = Unsafe.unsafe { implicit u =>
   Runtime.default.unsafe.run(
     Random.nextIntBounded(10)
   ).getOrThrowFiberFailure()

--- a/docs/datatypes/test/index.md
+++ b/docs/datatypes/test/index.md
@@ -30,7 +30,7 @@ import zio._
 ```scala mdoc:compile-only
 import scala.Predef.assert
 
-val random = Unsafe.unsafe { implicit u =>
+val random = Unsafe.unsafe { implicit unsafe =>
   Runtime.default.unsafe.run(
     Random.nextIntBounded(10)
   ).getOrThrowFiberFailure()

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,7 +61,7 @@ import zio._
 object IntegrationExample {
   val runtime = Runtime.default
 
-  Unsafe.unsafely { implicit u =>
+  Unsafe.unsafe { implicit u =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
   }
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,7 +61,7 @@ import zio._
 object IntegrationExample {
   val runtime = Runtime.default
 
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafe { implicit unsafe =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
   }
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,7 +61,7 @@ import zio._
 object IntegrationExample {
   val runtime = Runtime.default
 
-  Unsafe.unsafe { implicit u =>
+  Unsafe.unsafely { implicit u =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
   }
 }

--- a/docs/guides/migrate/migration-guide.md
+++ b/docs/guides/migrate/migration-guide.md
@@ -791,7 +791,7 @@ object MainApp {
 
   def zioApplication: Int =
 -    Runtime.default.unsafeRun(zioWorkflow)
-+    Unsafe.unsafe { implicit u =>
++    Unsafe.unsafe { implicit unsafe =>
 +      Runtime.default.unsafe.run(zioWorkflow).getOrThrowFiberFailure()
 +    }
 
@@ -824,10 +824,10 @@ Unsafe.unsafe { implicit unsafe =>
 
 In summary, here are the rules for migrating from ZIO 1.x to ZIO 2.x corresponding to the unsafe operators:
 
-|         | ZIO 1.0                | ZIO 2.x                                                                          |
-|---------|------------------------|----------------------------------------------------------------------------------|
-| Scala 2 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x).getOrThrowFiberFailure() }` |
-| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { runtime.unsafe.run(x).getOrThrowFiberFailure() }`               |
+|         | ZIO 1.0                | ZIO 2.x                                                                               |
+|---------|------------------------|---------------------------------------------------------------------------------------|
+| Scala 2 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.run(x).getOrThrowFiberFailure() }` |
+| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { runtime.unsafe.run(x).getOrThrowFiberFailure() }`                    |
 
 ### Unsafe Variants
 
@@ -900,7 +900,7 @@ We can rewrite it in ZIO 2.x as follows:
 // ZIO 2.x
 import zio._
 
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafe { implicit unsafe =>
   Runtime.default.unsafe
     .fork(
       Console
@@ -920,12 +920,12 @@ Unsafe.unsafe { implicit u =>
 
 Similarly, we can do the same for other unsafe operators. Here are some of them:
 
-| ZIO 1.0                        | ZIO 2.x                                                              |
-|--------------------------------|----------------------------------------------------------------------|
-| `runtime.unsafeRunSync(x)`     | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x) }`              |
-| `runtime.unsafeRunTask(x)`     | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x).getOrThrow() }` |
-| `runtime.unsafeRunAsync_(x)`   | `Unsafe.unsafe { implicit u => runtime.unsafe.fork(x) }`             |
-| `runtime.unsafeRunToFuture(x)` | `Unsafe.unsafe { implicit u => runtime.unsafe.runToFuture(x) }`      |
+| ZIO 1.0                        | ZIO 2.x                                                                   |
+|--------------------------------|---------------------------------------------------------------------------|
+| `runtime.unsafeRunSync(x)`     | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.run(x) }`              |
+| `runtime.unsafeRunTask(x)`     | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.run(x).getOrThrow() }` |
+| `runtime.unsafeRunAsync_(x)`   | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.fork(x) }`             |
+| `runtime.unsafeRunToFuture(x)` | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture(x) }`      |
 
 ### Runtime Customization using Layers
 
@@ -954,7 +954,7 @@ object MainApp extends zio.App {
     ZIO
       .runtime[ZEnv]
       .map { runtime =>
-        Unsafe.unsafe { implicit u =>
+        Unsafe.unsafe { implicit unsafe =>
           runtime
             .mapPlatform(_.withExecutor(customExecutor))
             .unsafe
@@ -1037,7 +1037,7 @@ object MainApp {
   val zioWorkflow: ZIO[Any, Nothing, Int] = ???
 
   def zioApplication(): Int =
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafe { implicit unsafe =>
         Runtime
           .unsafe
           .fromLayer(

--- a/docs/guides/migrate/migration-guide.md
+++ b/docs/guides/migrate/migration-guide.md
@@ -767,7 +767,7 @@ In ZIO 2.x, we added the `Unsafe` data type to help developers to differentiate 
 
 ```scala
 object Unsafe {
-  def unsafely[A](f: Unsafe => A): A = ???
+  def unsafe[A](f: Unsafe => A): A = ???
 }
 
 trait Runtime[+R] { self =>

--- a/docs/guides/migrate/migration-guide.md
+++ b/docs/guides/migrate/migration-guide.md
@@ -791,7 +791,7 @@ object MainApp {
 
   def zioApplication: Int =
 -    Runtime.default.unsafeRun(zioWorkflow)
-+    Unsafe.unsafely { implicit u =>
++    Unsafe.unsafe { implicit u =>
 +      Runtime.default.unsafe.run(zioWorkflow).getOrThrowFiberFailure()
 +    }
 
@@ -807,7 +807,7 @@ This way it is easy to distinguish between _safe_ and _unsafe_ variants of the s
 To run an unsafe operator, we need implicit value of `Unsafe` in scope. This works particularly well in Scala 3 due to its support for implicit function types championed by Martin Odersky. In Scala 3 we can use the `Unsafe.unsafe` operator to create a block of code in which we can freely call unsafe operators:
 
 ```scala
-Unsafe.unsafely {
+Unsafe.unsafe {
   Runtime.default.unsafe.run(Console.printLine("Hello, World!"))
 }
 ```
@@ -817,7 +817,7 @@ If we want to support Scala 2 we need to use a slightly more verbose syntax:
 ```scala mdoc:compile-only
 import zio._
 
-Unsafe.unsafely { implicit unsafe =>
+Unsafe.unsafe { implicit unsafe =>
   Runtime.default.unsafe.run(Console.printLine("Hello, World!"))
 }
 ```
@@ -826,8 +826,8 @@ In summary, here are the rules for migrating from ZIO 1.x to ZIO 2.x correspondi
 
 |         | ZIO 1.0                | ZIO 2.x                                                                          |
 |---------|------------------------|----------------------------------------------------------------------------------|
-| Scala 2 | `runtime.unsafeRun(x)` | `Unsafe.unsafely { implicit u => runtime.unsafe.run(x).getOrThrowFiberFailure() }` |
-| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafely { runtime.unsafe.run(x).getOrThrowFiberFailure() }`               |
+| Scala 2 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x).getOrThrowFiberFailure() }` |
+| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { runtime.unsafe.run(x).getOrThrowFiberFailure() }`               |
 
 ### Unsafe Variants
 
@@ -900,7 +900,7 @@ We can rewrite it in ZIO 2.x as follows:
 // ZIO 2.x
 import zio._
 
-Unsafe.unsafely { implicit u =>
+Unsafe.unsafe { implicit u =>
   Runtime.default.unsafe
     .fork(
       Console
@@ -922,10 +922,10 @@ Similarly, we can do the same for other unsafe operators. Here are some of them:
 
 | ZIO 1.0                        | ZIO 2.x                                                              |
 |--------------------------------|----------------------------------------------------------------------|
-| `runtime.unsafeRunSync(x)`     | `Unsafe.unsafely { implicit u => runtime.unsafe.run(x) }`              |
-| `runtime.unsafeRunTask(x)`     | `Unsafe.unsafely { implicit u => runtime.unsafe.run(x).getOrThrow() }` |
-| `runtime.unsafeRunAsync_(x)`   | `Unsafe.unsafely { implicit u => runtime.unsafe.fork(x) }`             |
-| `runtime.unsafeRunToFuture(x)` | `Unsafe.unsafely { implicit u => runtime.unsafe.runToFuture(x) }`      |
+| `runtime.unsafeRunSync(x)`     | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x) }`              |
+| `runtime.unsafeRunTask(x)`     | `Unsafe.unsafe { implicit u => runtime.unsafe.run(x).getOrThrow() }` |
+| `runtime.unsafeRunAsync_(x)`   | `Unsafe.unsafe { implicit u => runtime.unsafe.fork(x) }`             |
+| `runtime.unsafeRunToFuture(x)` | `Unsafe.unsafe { implicit u => runtime.unsafe.runToFuture(x) }`      |
 
 ### Runtime Customization using Layers
 
@@ -954,7 +954,7 @@ object MainApp extends zio.App {
     ZIO
       .runtime[ZEnv]
       .map { runtime =>
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           runtime
             .mapPlatform(_.withExecutor(customExecutor))
             .unsafe
@@ -1037,7 +1037,7 @@ object MainApp {
   val zioWorkflow: ZIO[Any, Nothing, Int] = ???
 
   def zioApplication(): Int =
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         Runtime
           .unsafe
           .fromLayer(

--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -45,7 +45,7 @@ val runtime = Runtime.default
 Once you have a runtime, you can use it to execute effects:
 
 ```scala mdoc:silent
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafe { implicit unsafe =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
 }
 ```

--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -45,7 +45,7 @@ val runtime = Runtime.default
 Once you have a runtime, you can use it to execute effects:
 
 ```scala mdoc:silent
-Unsafe.unsafe { implicit u =>
+Unsafe.unsafely { implicit u =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
 }
 ```

--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -45,7 +45,7 @@ val runtime = Runtime.default
 Once you have a runtime, you can use it to execute effects:
 
 ```scala mdoc:silent
-Unsafe.unsafely { implicit u =>
+Unsafe.unsafe { implicit u =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
 }
 ```

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -454,7 +454,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           runtime <- ZIO.runtime[Any]
           effects <- Ref.make(List[String]())
           closeable = ZIO.succeed(new AutoCloseable {
-                        def close(): Unit = Unsafe.unsafeCompat { implicit u =>
+                        def close(): Unit = Unsafe.unsafely { implicit u =>
                           runtime.unsafe.run(effects.update("Closed" :: _)).getOrThrowFiberFailure()
                         }
                       })

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -454,7 +454,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           runtime <- ZIO.runtime[Any]
           effects <- Ref.make(List[String]())
           closeable = ZIO.succeed(new AutoCloseable {
-                        def close(): Unit = Unsafe.unsafely { implicit u =>
+                        def close(): Unit = Unsafe.unsafe { implicit u =>
                           runtime.unsafe.run(effects.update("Closed" :: _)).getOrThrowFiberFailure()
                         }
                       })

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -454,7 +454,7 @@ object ZManagedSpec extends ZIOBaseSpec {
           runtime <- ZIO.runtime[Any]
           effects <- Ref.make(List[String]())
           closeable = ZIO.succeed(new AutoCloseable {
-                        def close(): Unit = Unsafe.unsafe { implicit u =>
+                        def close(): Unit = Unsafe.unsafe { implicit unsafe =>
                           runtime.unsafe.run(effects.update("Closed" :: _)).getOrThrowFiberFailure()
                         }
                       })

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1213,7 +1213,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
 object ZManaged extends ZManagedPlatformSpecific {
 
   lazy val currentReleaseMap: FiberRef[ReleaseMap] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       FiberRef.unsafe.make(ReleaseMap.unsafe.make())
     }
 
@@ -2343,7 +2343,7 @@ object ZManaged extends ZManagedPlatformSpecific {
         map.get(a) match {
           case Some(promise) => (promise.await, map)
           case None =>
-            Unsafe.unsafeCompat { implicit u =>
+            Unsafe.unsafely { implicit u =>
               val promise = Promise.unsafe.make[E, B](fiberId)
               (scope(f(a)).map(_._2).intoPromise(promise) *> promise.await, map + (a -> promise))
             }

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1213,7 +1213,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
 object ZManaged extends ZManagedPlatformSpecific {
 
   lazy val currentReleaseMap: FiberRef[ReleaseMap] =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       FiberRef.unsafe.make(ReleaseMap.unsafe.make())
     }
 
@@ -2343,7 +2343,7 @@ object ZManaged extends ZManagedPlatformSpecific {
         map.get(a) match {
           case Some(promise) => (promise.await, map)
           case None =>
-            Unsafe.unsafely { implicit u =>
+            Unsafe.unsafe { implicit u =>
               val promise = Promise.unsafe.make[E, B](fiberId)
               (scope(f(a)).map(_._2).intoPromise(promise) *> promise.await, map + (a -> promise))
             }

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1213,9 +1213,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
 object ZManaged extends ZManagedPlatformSpecific {
 
   lazy val currentReleaseMap: FiberRef[ReleaseMap] =
-    Unsafe.unsafe { implicit u =>
-      FiberRef.unsafe.make(ReleaseMap.unsafe.make())
-    }
+    FiberRef.unsafe.make[ReleaseMap](ReleaseMap.unsafe.make()(Unsafe.unsafe))(Unsafe.unsafe)
 
   private sealed abstract class State
   private final case class Exited(nextKey: Long, exit: Exit[Any, Any], update: Finalizer => Finalizer) extends State
@@ -1437,7 +1435,7 @@ object ZManaged extends ZManagedPlatformSpecific {
      * Creates a new ReleaseMap.
      */
     def make(implicit trace: Trace): UIO[ReleaseMap] =
-      ZIO.succeedUnsafe(implicit u => unsafe.make())
+      ZIO.succeed(unsafe.make()(Unsafe.unsafe))
 
     private[zio] object unsafe {
 
@@ -2343,10 +2341,8 @@ object ZManaged extends ZManagedPlatformSpecific {
         map.get(a) match {
           case Some(promise) => (promise.await, map)
           case None =>
-            Unsafe.unsafe { implicit u =>
-              val promise = Promise.unsafe.make[E, B](fiberId)
-              (scope(f(a)).map(_._2).intoPromise(promise) *> promise.await, map + (a -> promise))
-            }
+            val promise = Promise.unsafe.make[E, B](fiberId)(Unsafe.unsafe)
+            (scope(f(a)).map(_._2).intoPromise(promise) *> promise.await, map + (a -> promise))
         }
       }.flatten
 

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -6,15 +6,13 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
 object MimaSettings {
-  lazy val bincompatVersionToCompare = "1.0.11"
+  lazy val bincompatVersionToCompare = "2.0.0"
 
   def mimaSettings(failOnProblem: Boolean) =
     Seq(
       mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
       mimaBinaryIssueFilters ++= Seq(
-        exclude[Problem]("zio.internal.*"),
-        exclude[Problem]("zio.Queue#internal#*"),
-        exclude[ReversedMissingMethodProblem]("zio.ZIO.catchNonFatalOrDie")
+        exclude[Problem]("zio.internal.*")
       ),
       mimaFailOnProblem := failOnProblem
     )

--- a/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
+++ b/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
@@ -13,7 +13,7 @@ object StreamREPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafe { implicit u =>
+          Unsafe.unsafe { implicit unsafe =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
+++ b/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
@@ -13,7 +13,7 @@ object StreamREPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafeCompat { implicit u =>
+          Unsafe.unsafely { implicit u =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
+++ b/streams-tests/shared/src/test/scala/StreamREPLSpec.scala
@@ -13,7 +13,7 @@ object StreamREPLSpec extends ZIOSpecDefault {
       @silent("never used")
       implicit class RunSyntax[A](io: ZIO[Any, Any, A]) {
         def unsafeRun: A =
-          Unsafe.unsafely { implicit u =>
+          Unsafe.unsafe { implicit u =>
             Runtime.default.unsafe.run(io).getOrThrowFiberFailure()
           }
       }

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -57,7 +57,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafeCompat { implicit u =>
+                            Unsafe.unsafely { implicit u =>
                               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             }
                           } catch {
@@ -103,7 +103,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafeCompat { implicit u =>
+                 Unsafe.unsafely { implicit u =>
                    runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                  }
                } catch {
@@ -136,7 +136,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafeCompat { implicit u =>
+               Unsafe.unsafely { implicit u =>
                  runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                }
              } catch {

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -54,18 +54,17 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
     ZStream.unwrapScoped[R](for {
       output  <- ZIO.acquireRelease(Queue.bounded[stream.Take[E, A]](outputBuffer))(_.shutdown)
       runtime <- ZIO.runtime[R]
-      eitherStream <- ZIO.succeed {
-                        register { k =>
-                          try {
-                            Unsafe.unsafe { implicit u =>
-                              runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-                            }
-                          } catch {
-                            case FiberFailure(c) if c.isInterrupted =>
-                              Future.successful(false)
-                          }
-                        }
-                      }
+      eitherStream <-
+        ZIO.succeed {
+          register { k =>
+            try {
+              runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
+            } catch {
+              case FiberFailure(c) if c.isInterrupted =>
+                Future.successful(false)
+            }
+          }
+        }
     } yield {
       eitherStream match {
         case Right(value) => ZStream.unwrap(output.shutdown as value)
@@ -103,9 +102,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafe { implicit u =>
-                   runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-                 }
+                 runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
                } catch {
                  case FiberFailure(c) if c.isInterrupted =>
                    Future.successful(false)
@@ -136,9 +133,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafe { implicit u =>
-                 runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-               }
+               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
              } catch {
                case FiberFailure(c) if c.isInterrupted =>
                  Future.successful(false)

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -57,7 +57,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafely { implicit u =>
+                            Unsafe.unsafe { implicit u =>
                               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             }
                           } catch {
@@ -103,7 +103,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafely { implicit u =>
+                 Unsafe.unsafe { implicit u =>
                    runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                  }
                } catch {
@@ -136,7 +136,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafely { implicit u =>
+               Unsafe.unsafe { implicit u =>
                  runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                }
              } catch {

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -66,7 +66,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafely { implicit u =>
+                            Unsafe.unsafe { implicit u =>
                               runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                               ()
                             }
@@ -112,7 +112,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafely { implicit u =>
+                 Unsafe.unsafe { implicit u =>
                    runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                    ()
                  }
@@ -145,7 +145,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafely { implicit u =>
+               Unsafe.unsafe { implicit u =>
                  runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                  ()
                }

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -66,10 +66,9 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafe { implicit u =>
-                              runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
-                              ()
-                            }
+                            runtime.unsafe
+                              .run(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
+                              .getOrThrowFiberFailure()(Unsafe.unsafe)
                           } catch {
                             case FiberFailure(c) if c.isInterrupted =>
                           }
@@ -112,10 +111,9 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafe { implicit u =>
-                   runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
-                   ()
-                 }
+                 runtime.unsafe
+                   .run(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
+                   .getOrThrowFiberFailure()(Unsafe.unsafe)
                } catch {
                  case FiberFailure(c) if c.isInterrupted =>
                }
@@ -145,10 +143,9 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafe { implicit u =>
-                 runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
-                 ()
-               }
+               runtime.unsafe
+                 .run(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
+                 .getOrThrowFiberFailure()(Unsafe.unsafe)
              } catch {
                case FiberFailure(c) if c.isInterrupted =>
              }

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -66,7 +66,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafeCompat { implicit u =>
+                            Unsafe.unsafely { implicit u =>
                               runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                               ()
                             }
@@ -112,7 +112,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafeCompat { implicit u =>
+                 Unsafe.unsafely { implicit u =>
                    runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                    ()
                  }
@@ -145,7 +145,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafeCompat { implicit u =>
+               Unsafe.unsafely { implicit u =>
                  runtime.unsafe.run(stream.Take.fromPull(k).flatMap(output.offer)).getOrThrowFiberFailure()
                  ()
                }

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -57,7 +57,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafeCompat { implicit u =>
+                            Unsafe.unsafely { implicit u =>
                               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             }
                           } catch {
@@ -103,7 +103,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafeCompat { implicit u =>
+                 Unsafe.unsafely { implicit u =>
                    runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                  }
                } catch {
@@ -136,7 +136,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafeCompat { implicit u =>
+               Unsafe.unsafely { implicit u =>
                  runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                }
              } catch {

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -54,18 +54,17 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
     ZStream.unwrapScoped[R](for {
       output  <- ZIO.acquireRelease(Queue.bounded[stream.Take[E, A]](outputBuffer))(_.shutdown)
       runtime <- ZIO.runtime[R]
-      eitherStream <- ZIO.succeed {
-                        register { k =>
-                          try {
-                            Unsafe.unsafe { implicit u =>
-                              runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-                            }
-                          } catch {
-                            case FiberFailure(c) if c.isInterrupted =>
-                              Future.successful(false)
-                          }
-                        }
-                      }
+      eitherStream <-
+        ZIO.succeed {
+          register { k =>
+            try {
+              runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
+            } catch {
+              case FiberFailure(c) if c.isInterrupted =>
+                Future.successful(false)
+            }
+          }
+        }
     } yield {
       eitherStream match {
         case Right(value) => ZStream.unwrap(output.shutdown as value)
@@ -103,9 +102,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafe { implicit u =>
-                   runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-                 }
+                 runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
                } catch {
                  case FiberFailure(c) if c.isInterrupted =>
                    Future.successful(false)
@@ -136,9 +133,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafe { implicit u =>
-                 runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
-               }
+               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))(trace, Unsafe.unsafe)
              } catch {
                case FiberFailure(c) if c.isInterrupted =>
                  Future.successful(false)

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -57,7 +57,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       eitherStream <- ZIO.succeed {
                         register { k =>
                           try {
-                            Unsafe.unsafely { implicit u =>
+                            Unsafe.unsafe { implicit u =>
                               runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                             }
                           } catch {
@@ -103,7 +103,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
         runtime <- ZIO.runtime[R]
         _ <- register { k =>
                try {
-                 Unsafe.unsafely { implicit u =>
+                 Unsafe.unsafe { implicit u =>
                    runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                  }
                } catch {
@@ -136,7 +136,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
       runtime <- ZIO.runtime[R]
       _ <- register { k =>
              try {
-               Unsafe.unsafely { implicit u =>
+               Unsafe.unsafe { implicit u =>
                  runtime.unsafe.runToFuture(stream.Take.fromPull(k).flatMap(output.offer))
                }
              } catch {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3425,7 +3425,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             }
         }
 
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         unfoldPull
       }
     }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3414,8 +3414,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       runtime <- ZIO.runtime[R]
       pull    <- toPull
     } yield {
-      def unfoldPull(implicit unsafe: Unsafe): Iterator[Either[E, A]] =
-        runtime.unsafe.run(pull) match {
+      def unfoldPull: Iterator[Either[E, A]] =
+        runtime.unsafe.run(pull)(trace, Unsafe.unsafe) match {
           case Exit.Success(chunk) => chunk.iterator.map(Right(_)) ++ unfoldPull
           case Exit.Failure(cause) =>
             cause.failureOrCause match {
@@ -3425,9 +3425,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             }
         }
 
-      Unsafe.unsafe { implicit u =>
-        unfoldPull
-      }
+      unfoldPull
     }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3425,7 +3425,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             }
         }
 
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafely { implicit u =>
         unfoldPull
       }
     }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3425,7 +3425,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             }
         }
 
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         unfoldPull
       }
     }

--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -122,7 +122,7 @@ private[zio] object ZInputStream {
           }
       }
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       new ZInputStream(Iterator.empty ++ unfoldPull)
     }
   }

--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -122,7 +122,7 @@ private[zio] object ZInputStream {
           }
       }
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       new ZInputStream(Iterator.empty ++ unfoldPull)
     }
   }

--- a/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZInputStream.scala
@@ -111,8 +111,8 @@ private[zio] object ZInputStream {
   def fromPull[R](runtime: Runtime[R], pull: ZIO[R, Option[Throwable], Chunk[Byte]])(implicit
     trace: Trace
   ): ZInputStream = {
-    def unfoldPull(implicit unsafe: Unsafe): Iterator[Chunk[Byte]] =
-      runtime.unsafe.run(pull) match {
+    def unfoldPull: Iterator[Chunk[Byte]] =
+      runtime.unsafe.run(pull)(trace, Unsafe.unsafe) match {
         case Exit.Success(chunk) => Iterator.single(chunk) ++ unfoldPull
         case Exit.Failure(cause) =>
           cause.failureOrCause match {
@@ -122,8 +122,6 @@ private[zio] object ZInputStream {
           }
       }
 
-    Unsafe.unsafe { implicit u =>
-      new ZInputStream(Iterator.empty ++ unfoldPull)
-    }
+    new ZInputStream(Iterator.empty ++ unfoldPull)
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
@@ -119,7 +119,7 @@ private[zio] object ZReader {
           }
       }
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       new ZReader(Iterator.empty ++ unfoldPull)
     }
   }

--- a/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ZReader.scala
@@ -119,7 +119,7 @@ private[zio] object ZReader {
           }
       }
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       new ZReader(Iterator.empty ++ unfoldPull)
     }
   }

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -78,7 +78,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
         traverse(filteredSpec, description)
       )
 
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       zio.Runtime.default.unsafe
         .run(
           scoped
@@ -93,7 +93,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   }
 
   override def run(notifier: RunNotifier): Unit = {
-    val _ = Unsafe.unsafely { implicit u =>
+    val _ = Unsafe.unsafe { implicit u =>
       zio.Runtime.default.unsafe.run {
 
         val instrumented: Spec[spec.Environment with TestEnvironment with Scope, Any] =

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -78,7 +78,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
         traverse(filteredSpec, description)
       )
 
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       zio.Runtime.default.unsafe
         .run(
           scoped
@@ -93,7 +93,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   }
 
   override def run(notifier: RunNotifier): Unit = {
-    val _ = Unsafe.unsafeCompat { implicit u =>
+    val _ = Unsafe.unsafely { implicit u =>
       zio.Runtime.default.unsafe.run {
 
         val instrumented: Spec[spec.Environment with TestEnvironment with Scope, Any] =

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -78,33 +78,29 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
         traverse(filteredSpec, description)
       )
 
-    Unsafe.unsafe { implicit u =>
-      zio.Runtime.default.unsafe
-        .run(
-          scoped
-            .provide(
-              Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
-              spec.bootstrap
-            )
-        )
-        .getOrThrowFiberFailure()
-      description
-    }
+    zio.Runtime.default.unsafe
+      .run(
+        scoped
+          .provide(
+            Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+            spec.bootstrap
+          )
+      )(Trace.empty, Unsafe.unsafe)
+      .getOrThrowFiberFailure()(Unsafe.unsafe)
+    description
   }
 
   override def run(notifier: RunNotifier): Unit = {
-    val _ = Unsafe.unsafe { implicit u =>
-      zio.Runtime.default.unsafe.run {
+    val _ = zio.Runtime.default.unsafe.run {
 
-        val instrumented: Spec[spec.Environment with TestEnvironment with Scope, Any] =
-          instrumentSpec(filteredSpec, new JUnitNotifier(notifier))
-        spec
-          .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive)
-          .provide(
-            Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope])
-          )
-      }.getOrThrowFiberFailure()
-    }
+      val instrumented: Spec[spec.Environment with TestEnvironment with Scope, Any] =
+        instrumentSpec(filteredSpec, new JUnitNotifier(notifier))
+      spec
+        .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive)
+        .provide(
+          Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope])
+        )
+    }(Trace.empty, Unsafe.unsafe).getOrThrowFiberFailure()(Unsafe.unsafe)
   }
 
   private def reportRuntimeFailure[E](

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -93,7 +93,7 @@ sealed class ZTestTask(
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs, spec, Runtime.default) {
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       val fiber = Runtime.default.unsafe.fork {
         val logic =
           ZIO.consoleWith { console =>

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -18,7 +18,7 @@ package zio.test.sbt
 
 import sbt.testing._
 import zio.test.{FilteredSpec, Summary, TestArgs, TestEnvironment, TestLogger, ZIOSpecAbstract}
-import zio.{Exit, Layer, Runtime, Scope, Unsafe, ZEnvironment, ZIO, ZIOAppArgs, ZLayer}
+import zio.{Exit, Layer, Runtime, Scope, Trace, Unsafe, ZEnvironment, ZIO, ZIOAppArgs, ZLayer}
 
 import scala.collection.mutable
 
@@ -92,47 +92,46 @@ sealed class ZTestTask(
   spec: ZIOSpecAbstract
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs, spec, Runtime.default) {
 
-  def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
-    Unsafe.unsafe { implicit u =>
-      val fiber = Runtime.default.unsafe.fork {
-        val logic =
-          ZIO.consoleWith { console =>
-            (for {
-              summary <- spec
-                           .runSpecAsApp(FilteredSpec(spec.spec, args), args, console)
-              _ <- sendSummary.provide(ZLayer.succeed(summary))
-              // TODO Confirm if/how these events needs to be handled in #6481
-              //    Check XML behavior
-              _ <- ZIO.when(summary.status == Summary.Failure) {
-                     ZIO.attempt(
-                       eventHandler.handle(
-                         ZTestEvent(
-                           fullyQualifiedName = taskDef.fullyQualifiedName(),
-                           // taskDef.selectors() is "one to many" so we can expect nonEmpty here
-                           selector = taskDef.selectors().head,
-                           status = Status.Failure,
-                           maybeThrowable = None,
-                           duration = 0L,
-                           fingerprint = ZioSpecFingerprint
-                         )
+  def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit = {
+    val fiber = Runtime.default.unsafe.fork {
+      val logic =
+        ZIO.consoleWith { console =>
+          (for {
+            summary <- spec
+                         .runSpecAsApp(FilteredSpec(spec.spec, args), args, console)
+            _ <- sendSummary.provide(ZLayer.succeed(summary))
+            // TODO Confirm if/how these events needs to be handled in #6481
+            //    Check XML behavior
+            _ <- ZIO.when(summary.status == Summary.Failure) {
+                   ZIO.attempt(
+                     eventHandler.handle(
+                       ZTestEvent(
+                         fullyQualifiedName = taskDef.fullyQualifiedName(),
+                         // taskDef.selectors() is "one to many" so we can expect nonEmpty here
+                         selector = taskDef.selectors().head,
+                         status = Status.Failure,
+                         maybeThrowable = None,
+                         duration = 0L,
+                         fingerprint = ZioSpecFingerprint
                        )
                      )
-                   }
-            } yield ())
-              .provideLayer(
-                sharedFilledTestLayer
-              )
-          }
-        logic
-      }
-      fiber.unsafe.addObserver { exit =>
-        exit match {
-          case Exit.Failure(cause) => Console.err.println(s"$runnerType failed.")
-          case _                   =>
+                   )
+                 }
+          } yield ())
+            .provideLayer(
+              sharedFilledTestLayer
+            )
         }
-        continuation(Array())
+      logic
+    }(Trace.empty, Unsafe.unsafe)
+    fiber.unsafe.addObserver { exit =>
+      exit match {
+        case Exit.Failure(cause) => Console.err.println(s"$runnerType failed.")
+        case _                   =>
       }
-    }
+      continuation(Array())
+    }(Unsafe.unsafe)
+  }
 }
 object ZTestTask {
   def apply(

--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -93,7 +93,7 @@ sealed class ZTestTask(
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs, spec, Runtime.default) {
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger], continuation: Array[Task] => Unit): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       val fiber = Runtime.default.unsafe.fork {
         val logic =
           ZIO.consoleWith { console =>

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -74,9 +74,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
       sharedLayerFromSpecs +!+ sharedSinkLayer
 
     val runtime: zio.Runtime[ExecutionEventSink] =
-      Unsafe.unsafe { implicit u =>
-        zio.Runtime.unsafe.fromLayer(sharedLayer)
-      }
+      zio.Runtime.unsafe.fromLayer(sharedLayer)(Trace.empty, Unsafe.unsafe)
 
     defs.map(ZTestTask(_, testClassLoader, sendSummary, testArgs, runtime))
   }

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -74,7 +74,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
       sharedLayerFromSpecs +!+ sharedSinkLayer
 
     val runtime: zio.Runtime[ExecutionEventSink] =
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         zio.Runtime.unsafe.fromLayer(sharedLayer)
       }
 

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -74,7 +74,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
       sharedLayerFromSpecs +!+ sharedSinkLayer
 
     val runtime: zio.Runtime[ExecutionEventSink] =
-      Unsafe.unsafe { implicit u =>
+      Unsafe.unsafely { implicit u =>
         zio.Runtime.unsafe.fromLayer(sharedLayer)
       }
 

--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -74,7 +74,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
       sharedLayerFromSpecs +!+ sharedSinkLayer
 
     val runtime: zio.Runtime[ExecutionEventSink] =
-      Unsafe.unsafely { implicit u =>
+      Unsafe.unsafe { implicit u =>
         zio.Runtime.unsafe.fromLayer(sharedLayer)
       }
 

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -90,7 +90,7 @@ sealed class ZTestTask(
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs, spec, zio.Runtime.default) {
 
   def execute(continuation: Array[Task] => Unit): Unit =
-    Unsafe.unsafely { implicit u =>
+    Unsafe.unsafe { implicit u =>
       val fiber = Runtime.default.unsafe.fork {
         for {
           summary <- ZIO.scoped {

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -90,7 +90,7 @@ sealed class ZTestTask(
 ) extends BaseTestTask(taskDef, testClassLoader, sendSummary, testArgs, spec, zio.Runtime.default) {
 
   def execute(continuation: Array[Task] => Unit): Unit =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafely { implicit u =>
       val fiber = Runtime.default.unsafe.fork {
         for {
           summary <- ZIO.scoped {

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -42,11 +42,7 @@ abstract class BaseTestTask[T](
     var resOutter: CancelableFuture[Unit] = null
     try {
       val res: CancelableFuture[Unit] =
-        Unsafe.unsafe { implicit u =>
-          runtime.unsafe.runToFuture {
-            run(zTestHandler)
-          }
-        }
+        runtime.unsafe.runToFuture(run(zTestHandler))(trace, Unsafe.unsafe)
 
       resOutter = res
       Await.result(res, Duration.Inf)

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -42,7 +42,7 @@ abstract class BaseTestTask[T](
     var resOutter: CancelableFuture[Unit] = null
     try {
       val res: CancelableFuture[Unit] =
-        Unsafe.unsafely { implicit u =>
+        Unsafe.unsafe { implicit u =>
           runtime.unsafe.runToFuture {
             run(zTestHandler)
           }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/BaseTestTask.scala
@@ -42,7 +42,7 @@ abstract class BaseTestTask[T](
     var resOutter: CancelableFuture[Unit] = null
     try {
       val res: CancelableFuture[Unit] =
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafely { implicit u =>
           runtime.unsafe.runToFuture {
             run(zTestHandler)
           }

--- a/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -21,7 +21,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafely { implicit u =>
+                         Unsafe.unsafe { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -48,7 +48,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafely { implicit u =>
+                         Unsafe.unsafe { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(5.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -75,7 +75,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleWithFixedDelay(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafely { implicit u =>
+                         Unsafe.unsafe { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -102,7 +102,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                         scheduledExecutorService.scheduleAtFixedRate(
                           new Runnable {
                             def run(): Unit =
-                              Unsafe.unsafely { implicit u =>
+                              Unsafe.unsafe { implicit u =>
                                 runtime.unsafe.run {
                                   clock.sleep(2.seconds) *>
                                     clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))

--- a/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -21,7 +21,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafeCompat { implicit u =>
+                         Unsafe.unsafely { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -48,7 +48,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafeCompat { implicit u =>
+                         Unsafe.unsafely { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(5.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -75,7 +75,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleWithFixedDelay(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafeCompat { implicit u =>
+                         Unsafe.unsafely { implicit u =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -102,7 +102,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                         scheduledExecutorService.scheduleAtFixedRate(
                           new Runnable {
                             def run(): Unit =
-                              Unsafe.unsafeCompat { implicit u =>
+                              Unsafe.unsafely { implicit u =>
                                 runtime.unsafe.run {
                                   clock.sleep(2.seconds) *>
                                     clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))

--- a/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -21,7 +21,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafe { implicit u =>
+                         Unsafe.unsafe { implicit unsafe =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -48,7 +48,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleAtFixedRate(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafe { implicit u =>
+                         Unsafe.unsafe { implicit unsafe =>
                            runtime.unsafe.run {
                              clock.sleep(5.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -75,7 +75,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    scheduledExecutorService.scheduleWithFixedDelay(
                      new Runnable {
                        def run(): Unit =
-                         Unsafe.unsafe { implicit u =>
+                         Unsafe.unsafe { implicit unsafe =>
                            runtime.unsafe.run {
                              clock.sleep(2.seconds) *>
                                clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))
@@ -102,7 +102,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                         scheduledExecutorService.scheduleAtFixedRate(
                           new Runnable {
                             def run(): Unit =
-                              Unsafe.unsafe { implicit u =>
+                              Unsafe.unsafe { implicit unsafe =>
                                 runtime.unsafe.run {
                                   clock.sleep(2.seconds) *>
                                     clock.currentTime(TimeUnit.SECONDS).flatMap(now => ref.update(now :: _))

--- a/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
@@ -59,9 +59,13 @@ object RandomSpec extends ZIOBaseSpec {
         .runtime[Any]
         .map { rt =>
           val x = Unsafe
-            .unsafe(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
+            .unsafe(implicit unsafe =>
+              rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure()
+            )
           val y = Unsafe
-            .unsafe(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
+            .unsafe(implicit unsafe =>
+              rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure()
+            )
           assert(x)(equalTo(y))
         }
     },

--- a/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
@@ -58,12 +58,10 @@ object RandomSpec extends ZIOBaseSpec {
       ZIO
         .runtime[Any]
         .map { rt =>
-          val x = Unsafe.unsafeCompat(implicit u =>
-            rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure()
-          )
-          val y = Unsafe.unsafeCompat(implicit u =>
-            rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure()
-          )
+          val x = Unsafe
+            .unsafely(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
+          val y = Unsafe
+            .unsafely(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
           assert(x)(equalTo(y))
         }
     },

--- a/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/RandomSpec.scala
@@ -59,9 +59,9 @@ object RandomSpec extends ZIOBaseSpec {
         .runtime[Any]
         .map { rt =>
           val x = Unsafe
-            .unsafely(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
+            .unsafe(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
           val y = Unsafe
-            .unsafely(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
+            .unsafe(implicit u => rt.unsafe.run(test.flatMap[Any, Nothing, Int](_.nextInt)).getOrThrowFiberFailure())
           assert(x)(equalTo(y))
         }
     },

--- a/test/jvm/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -48,7 +48,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
             }
 
           def now(): Instant =
-            Unsafe.unsafeCompat { implicit u =>
+            Unsafe.unsafely { implicit u =>
               clockState.unsafe.get.instant
             }
 
@@ -73,7 +73,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
               if (updatedState == Scheduling(end)) {
                 val start    = now()
                 val interval = Duration.fromInterval(start, end)
-                val cancelToken = Unsafe.unsafeCompat { implicit u =>
+                val cancelToken = Unsafe.unsafely { implicit u =>
                   schedule(
                     () =>
                       executor.submitOrThrow { () =>
@@ -160,7 +160,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
             def awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
               false
             def execute(command: Runnable): Unit =
-              Unsafe.unsafeCompat { implicit u =>
+              Unsafe.unsafely { implicit u =>
                 executor.submit(command)
                 ()
               }

--- a/test/jvm/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -48,7 +48,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
             }
 
           def now(): Instant =
-            Unsafe.unsafely { implicit u =>
+            Unsafe.unsafe { implicit u =>
               clockState.unsafe.get.instant
             }
 
@@ -73,7 +73,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
               if (updatedState == Scheduling(end)) {
                 val start    = now()
                 val interval = Duration.fromInterval(start, end)
-                val cancelToken = Unsafe.unsafely { implicit u =>
+                val cancelToken = Unsafe.unsafe { implicit u =>
                   schedule(
                     () =>
                       executor.submitOrThrow { () =>
@@ -160,7 +160,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
             def awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
               false
             def execute(command: Runnable): Unit =
-              Unsafe.unsafely { implicit u =>
+              Unsafe.unsafe { implicit u =>
                 executor.submit(command)
                 ()
               }

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -64,10 +64,7 @@ private[test] object Fun {
       } { _ =>
         funRuntime[R].map { runtime =>
           Fun(
-            a =>
-              Unsafe.unsafe { implicit u =>
-                runtime.unsafe.run(f(a)).getOrThrowFiberFailure()
-              },
+            a => runtime.unsafe.run(f(a))(trace, Unsafe.unsafe).getOrThrowFiberFailure()(Unsafe.unsafe),
             hash
           )
         }

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -65,7 +65,7 @@ private[test] object Fun {
         funRuntime[R].map { runtime =>
           Fun(
             a =>
-              Unsafe.unsafeCompat { implicit u =>
+              Unsafe.unsafely { implicit u =>
                 runtime.unsafe.run(f(a)).getOrThrowFiberFailure()
               },
             hash

--- a/test/shared/src/main/scala/zio/test/Fun.scala
+++ b/test/shared/src/main/scala/zio/test/Fun.scala
@@ -65,7 +65,7 @@ private[test] object Fun {
         funRuntime[R].map { runtime =>
           Fun(
             a =>
-              Unsafe.unsafely { implicit u =>
+              Unsafe.unsafe { implicit u =>
                 runtime.unsafe.run(f(a)).getOrThrowFiberFailure()
               },
             hash

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -157,7 +157,7 @@ object TestClock extends Serializable {
         def getZone(): ZoneId =
           zoneId
         def instant(): Instant =
-          Unsafe.unsafeCompat { implicit u =>
+          Unsafe.unsafely { implicit u =>
             clockState.unsafe.get.instant
           }
         override def withZone(zoneId: ZoneId): JavaClock =
@@ -393,7 +393,7 @@ object TestClock extends Serializable {
       for {
         live                  <- ZIO.service[Live]
         annotations           <- ZIO.service[Annotations]
-        clockState            <- ZIO.succeedNow(Unsafe.unsafeCompat(implicit u => Ref.unsafe.make(data)))
+        clockState            <- ZIO.succeedNow(Unsafe.unsafely(implicit u => Ref.unsafe.make(data)))
         warningState          <- Ref.Synchronized.make(WarningData.start)
         suspendedWarningState <- Ref.Synchronized.make(SuspendedWarningData.start)
         test                   = Test(clockState, live, annotations, warningState, suspendedWarningState)

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -125,28 +125,28 @@ object TestClock extends Serializable {
      * Returns the current clock time as an `OffsetDateTime`.
      */
     def currentDateTime(implicit trace: Trace): UIO[OffsetDateTime] =
-      ZIO.succeedUnsafe(implicit u => unsafe.currentDateTime())
+      ZIO.succeed(unsafe.currentDateTime()(Unsafe.unsafe))
 
     /**
      * Returns the current clock time in the specified time unit.
      */
     def currentTime(unit: => TimeUnit)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.currentTime(unit))
+      ZIO.succeed(unsafe.currentTime(unit)(Unsafe.unsafe))
 
     def currentTime(unit: => ChronoUnit)(implicit trace: Trace, d: DummyImplicit): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.currentTime(unit))
+      ZIO.succeed(unsafe.currentTime(unit)(Unsafe.unsafe))
 
     /**
      * Returns the current clock time in nanoseconds.
      */
     def nanoTime(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nanoTime())
+      ZIO.succeed(unsafe.nanoTime()(Unsafe.unsafe))
 
     /**
      * Returns the current clock time as an `Instant`.
      */
     def instant(implicit trace: Trace): UIO[Instant] =
-      ZIO.succeedUnsafe(implicit u => unsafe.instant())
+      ZIO.succeed(unsafe.instant()(Unsafe.unsafe))
 
     /**
      * Constructs a `java.time.Clock` backed by the `Clock` service.
@@ -157,9 +157,7 @@ object TestClock extends Serializable {
         def getZone(): ZoneId =
           zoneId
         def instant(): Instant =
-          Unsafe.unsafe { implicit u =>
-            clockState.unsafe.get.instant
-          }
+          clockState.unsafe.get(Unsafe.unsafe).instant
         override def withZone(zoneId: ZoneId): JavaClock =
           copy(zoneId = zoneId)
       }
@@ -171,7 +169,7 @@ object TestClock extends Serializable {
      * Returns the current clock time as a `LocalDateTime`.
      */
     def localDateTime(implicit trace: Trace): UIO[LocalDateTime] =
-      ZIO.succeedUnsafe(implicit u => unsafe.localDateTime())
+      ZIO.succeed(unsafe.localDateTime()(Unsafe.unsafe))
 
     /**
      * Saves the `TestClock`'s current state in an effect which, when run, will
@@ -228,29 +226,30 @@ object TestClock extends Serializable {
     def timeZone(implicit trace: Trace): UIO[ZoneId] =
       clockState.get.map(_.timeZone)
 
-    override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
-        unit.convert(clockState.unsafe.get.instant.toEpochMilli, TimeUnit.MILLISECONDS)
+    override private[zio] val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
+          unit.convert(clockState.unsafe.get.instant.toEpochMilli, TimeUnit.MILLISECONDS)
 
-      override def currentTime(unit: ChronoUnit)(implicit unsafe: Unsafe): Long =
-        unit.between(Instant.EPOCH, clockState.unsafe.get.instant)
+        override def currentTime(unit: ChronoUnit)(implicit unsafe: Unsafe): Long =
+          unit.between(Instant.EPOCH, clockState.unsafe.get.instant)
 
-      override def currentDateTime()(implicit unsafe: Unsafe): OffsetDateTime = {
-        val data = clockState.unsafe.get
-        OffsetDateTime.ofInstant(data.instant, data.timeZone)
+        override def currentDateTime()(implicit unsafe: Unsafe): OffsetDateTime = {
+          val data = clockState.unsafe.get
+          OffsetDateTime.ofInstant(data.instant, data.timeZone)
+        }
+
+        override def instant()(implicit unsafe: Unsafe): Instant =
+          clockState.unsafe.get.instant
+
+        override def localDateTime()(implicit unsafe: Unsafe): LocalDateTime = {
+          val data = clockState.unsafe.get
+          LocalDateTime.ofInstant(data.instant, data.timeZone)
+        }
+
+        override def nanoTime()(implicit unsafe: Unsafe): Long =
+          currentTime(ChronoUnit.NANOS)
       }
-
-      override def instant()(implicit unsafe: Unsafe): Instant =
-        clockState.unsafe.get.instant
-
-      override def localDateTime()(implicit unsafe: Unsafe): LocalDateTime = {
-        val data = clockState.unsafe.get
-        LocalDateTime.ofInstant(data.instant, data.timeZone)
-      }
-
-      override def nanoTime()(implicit unsafe: Unsafe): Long =
-        currentTime(ChronoUnit.NANOS)
-    }
 
     /**
      * Cancels the warning message that is displayed if a test is advancing the
@@ -393,7 +392,7 @@ object TestClock extends Serializable {
       for {
         live                  <- ZIO.service[Live]
         annotations           <- ZIO.service[Annotations]
-        clockState            <- ZIO.succeedNow(Unsafe.unsafe(implicit u => Ref.unsafe.make(data)))
+        clockState            <- ZIO.succeedNow(Ref.unsafe.make(data)(Unsafe.unsafe))
         warningState          <- Ref.Synchronized.make(WarningData.start)
         suspendedWarningState <- Ref.Synchronized.make(SuspendedWarningData.start)
         test                   = Test(clockState, live, annotations, warningState, suspendedWarningState)

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -157,7 +157,7 @@ object TestClock extends Serializable {
         def getZone(): ZoneId =
           zoneId
         def instant(): Instant =
-          Unsafe.unsafely { implicit u =>
+          Unsafe.unsafe { implicit u =>
             clockState.unsafe.get.instant
           }
         override def withZone(zoneId: ZoneId): JavaClock =
@@ -393,7 +393,7 @@ object TestClock extends Serializable {
       for {
         live                  <- ZIO.service[Live]
         annotations           <- ZIO.service[Annotations]
-        clockState            <- ZIO.succeedNow(Unsafe.unsafely(implicit u => Ref.unsafe.make(data)))
+        clockState            <- ZIO.succeedNow(Unsafe.unsafe(implicit u => Ref.unsafe.make(data)))
         warningState          <- Ref.Synchronized.make(WarningData.start)
         suspendedWarningState <- Ref.Synchronized.make(SuspendedWarningData.start)
         test                   = Test(clockState, live, annotations, warningState, suspendedWarningState)

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -118,7 +118,7 @@ object TestConsole extends Serializable {
      * with an `EOFException`.
      */
     def readLine(implicit trace: Trace): IO[IOException, String] =
-      ZIO.attemptUnsafe(implicit u => unsafe.readLine()).refineToOrDie[IOException]
+      ZIO.attempt(unsafe.readLine()(Unsafe.unsafe)).refineToOrDie[IOException]
 
     /**
      * Returns the contents of the output buffer. The first value written to the
@@ -138,14 +138,14 @@ object TestConsole extends Serializable {
      * Writes the specified string to the output buffer.
      */
     override def print(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.print(line)) *>
+      ZIO.succeed(unsafe.print(line)(Unsafe.unsafe)) *>
         live.provide(Console.print(line)).whenZIO(debugState.get).unit
 
     /**
      * Writes the specified string to the error buffer.
      */
     override def printError(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.printError(line)) *>
+      ZIO.succeed(unsafe.printError(line)(Unsafe.unsafe)) *>
         live.provide(Console.printError(line)).whenZIO(debugState.get).unit
 
     /**
@@ -153,7 +153,7 @@ object TestConsole extends Serializable {
      * character.
      */
     override def printLine(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.printLine(line)) *>
+      ZIO.succeed(unsafe.printLine(line)(Unsafe.unsafe)) *>
         live.provide(Console.printLine(line)).whenZIO(debugState.get).unit
 
     /**
@@ -161,7 +161,7 @@ object TestConsole extends Serializable {
      * character.
      */
     override def printLineError(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.printLineError(line)) *>
+      ZIO.succeed(unsafe.printLineError(line)(Unsafe.unsafe)) *>
         live.provide(Console.printLineError(line)).whenZIO(debugState.get).unit
 
     /**
@@ -181,38 +181,39 @@ object TestConsole extends Serializable {
     def silent[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
       debugState.locally(false)(zio)
 
-    override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def print(line: Any)(implicit unsafe: Unsafe): Unit =
-        consoleState.unsafe.update { data =>
-          Data(data.input, data.output :+ line.toString, data.errOutput)
-        }
-
-      override def printError(line: Any)(implicit unsafe: Unsafe): Unit =
-        consoleState.unsafe.update { data =>
-          Data(data.input, data.output, data.errOutput :+ line.toString)
-        }
-
-      override def printLine(line: Any)(implicit unsafe: Unsafe): Unit =
-        consoleState.unsafe.update { data =>
-          Data(data.input, data.output :+ s"$line\n", data.errOutput)
-        }
-
-      override def printLineError(line: Any)(implicit unsafe: Unsafe): Unit =
-        consoleState.unsafe.update { data =>
-          Data(data.input, data.output, data.errOutput :+ s"$line\n")
-        }
-
-      override def readLine()(implicit unsafe: Unsafe): String =
-        consoleState.unsafe.modify { data =>
-          data.input match {
-            case head :: tail =>
-              head -> Data(tail, data.output, data.errOutput)
-            case Nil =>
-              throw new EOFException("There is no more input left to read")
-
+    override private[zio] val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def print(line: Any)(implicit unsafe: Unsafe): Unit =
+          consoleState.unsafe.update { data =>
+            Data(data.input, data.output :+ line.toString, data.errOutput)
           }
-        }
-    }
+
+        override def printError(line: Any)(implicit unsafe: Unsafe): Unit =
+          consoleState.unsafe.update { data =>
+            Data(data.input, data.output, data.errOutput :+ line.toString)
+          }
+
+        override def printLine(line: Any)(implicit unsafe: Unsafe): Unit =
+          consoleState.unsafe.update { data =>
+            Data(data.input, data.output :+ s"$line\n", data.errOutput)
+          }
+
+        override def printLineError(line: Any)(implicit unsafe: Unsafe): Unit =
+          consoleState.unsafe.update { data =>
+            Data(data.input, data.output, data.errOutput :+ s"$line\n")
+          }
+
+        override def readLine()(implicit unsafe: Unsafe): String =
+          consoleState.unsafe.modify { data =>
+            data.input match {
+              case head :: tail =>
+                head -> Data(tail, data.output, data.errOutput)
+              case Nil =>
+                throw new EOFException("There is no more input left to read")
+
+            }
+          }
+      }
   }
 
   /**
@@ -225,7 +226,7 @@ object TestConsole extends Serializable {
     ZLayer.scoped {
       for {
         live     <- ZIO.service[Live]
-        ref      <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(data))
+        ref      <- ZIO.succeed(Ref.unsafe.make(data)(Unsafe.unsafe))
         debugRef <- FiberRef.make(debug)
         test      = Test(ref, live, debugRef)
         _        <- ZIO.withConsoleScoped(test)

--- a/test/shared/src/main/scala/zio/test/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/TestRandom.scala
@@ -237,21 +237,21 @@ object TestRandom extends Serializable {
      * pseudo-random boolean.
      */
     def nextBoolean(implicit trace: Trace): UIO[Boolean] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBoolean())
+      ZIO.succeed(unsafe.nextBoolean()(Unsafe.unsafe))
 
     /**
      * Takes a chunk of bytes from the buffer if one exists or else generates a
      * pseudo-random chunk of bytes of the specified length.
      */
     def nextBytes(length: => Int)(implicit trace: Trace): UIO[Chunk[Byte]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextBytes(length))
+      ZIO.succeed(unsafe.nextBytes(length)(Unsafe.unsafe))
 
     /**
      * Takes a double from the buffer if one exists or else generates a
      * pseudo-random, uniformly distributed double between 0.0 and 1.0.
      */
     def nextDouble(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDouble())
+      ZIO.succeed(unsafe.nextDouble()(Unsafe.unsafe))
 
     /**
      * Takes a double from the buffer if one exists or else generates a
@@ -260,21 +260,21 @@ object TestRandom extends Serializable {
     def nextDoubleBetween(minInclusive: => Double, maxExclusive: => Double)(implicit
       trace: Trace
     ): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextDoubleBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextDoubleBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     /**
      * Takes a float from the buffer if one exists or else generates a
      * pseudo-random, uniformly distributed float between 0.0 and 1.0.
      */
     def nextFloat(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloat())
+      ZIO.succeed(unsafe.nextFloat()(Unsafe.unsafe))
 
     /**
      * Takes a float from the buffer if one exists or else generates a
      * pseudo-random float in the specified range.
      */
     def nextFloatBetween(minInclusive: => Float, maxExclusive: => Float)(implicit trace: Trace): UIO[Float] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextFloatBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextFloatBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     /**
      * Takes a double from the buffer if one exists or else generates a
@@ -282,21 +282,21 @@ object TestRandom extends Serializable {
      * standard deviation 1.0.
      */
     def nextGaussian(implicit trace: Trace): UIO[Double] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextGaussian())
+      ZIO.succeed(unsafe.nextGaussian()(Unsafe.unsafe))
 
     /**
      * Takes an integer from the buffer if one exists or else generates a
      * pseudo-random integer.
      */
     def nextInt(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextInt())
+      ZIO.succeed(unsafe.nextInt()(Unsafe.unsafe))
 
     /**
      * Takes an integer from the buffer if one exists or else generates a
      * pseudo-random integer in the specified range.
      */
     def nextIntBetween(minInclusive: => Int, maxExclusive: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextIntBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     /**
      * Takes an integer from the buffer if one exists or else generates a
@@ -304,21 +304,21 @@ object TestRandom extends Serializable {
      * (exclusive).
      */
     def nextIntBounded(n: => Int)(implicit trace: Trace): UIO[Int] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextIntBounded(n))
+      ZIO.succeed(unsafe.nextIntBounded(n)(Unsafe.unsafe))
 
     /**
      * Takes a long from the buffer if one exists or else generates a
      * pseudo-random long.
      */
     def nextLong(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLong())
+      ZIO.succeed(unsafe.nextLong()(Unsafe.unsafe))
 
     /**
      * Takes a long from the buffer if one exists or else generates a
      * pseudo-random long in the specified range.
      */
     def nextLongBetween(minInclusive: => Long, maxExclusive: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBetween(minInclusive, maxExclusive))
+      ZIO.succeed(unsafe.nextLongBetween(minInclusive, maxExclusive)(Unsafe.unsafe))
 
     /**
      * Takes a long from the buffer if one exists or else generates a
@@ -326,28 +326,28 @@ object TestRandom extends Serializable {
      * (exclusive).
      */
     def nextLongBounded(n: => Long)(implicit trace: Trace): UIO[Long] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextLongBounded(n))
+      ZIO.succeed(unsafe.nextLongBounded(n)(Unsafe.unsafe))
 
     /**
      * Takes a character from the buffer if one exists or else generates a
      * pseudo-random character from the ASCII range 33-126.
      */
     def nextPrintableChar(implicit trace: Trace): UIO[Char] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextPrintableChar())
+      ZIO.succeed(unsafe.nextPrintableChar()(Unsafe.unsafe))
 
     /**
      * Takes a string from the buffer if one exists or else generates a
      * pseudo-random string of the specified length.
      */
     def nextString(length: => Int)(implicit trace: Trace): UIO[String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextString(length))
+      ZIO.succeed(unsafe.nextString(length)(Unsafe.unsafe))
 
     /**
      * Takes a UUID from the buffer if one exists or else generates a
      * pseudo-random UUID.
      */
     def nextUUID(implicit trace: Trace): UIO[UUID] =
-      ZIO.succeedUnsafe(implicit u => unsafe.nextUUID())
+      ZIO.succeed(unsafe.nextUUID()(Unsafe.unsafe))
 
     /**
      * Saves the `TestRandom`'s current state in an effect which, when run, will
@@ -363,7 +363,7 @@ object TestRandom extends Serializable {
      * Sets the seed of this `TestRandom` to the specified value.
      */
     def setSeed(seed: => Long)(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeedUnsafe(implicit u => unsafe.setSeed(seed))
+      ZIO.succeed(unsafe.setSeed(seed)(Unsafe.unsafe))
 
     /**
      * Randomly shuffles the specified list.
@@ -371,194 +371,195 @@ object TestRandom extends Serializable {
     def shuffle[A, Collection[+Element] <: Iterable[Element]](
       list: => Collection[A]
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.shuffle(list))
+      ZIO.succeed(unsafe.shuffle(list)(bf, Unsafe.unsafe))
 
-    override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
-        getOrElse(bufferedBoolean)(randomBoolean)
+    override private[zio] val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
+          getOrElse(bufferedBoolean)(randomBoolean)
 
-      override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] =
-        getOrElse(bufferedBytes)(randomBytes(length))
+        override def nextBytes(length: RuntimeFlags)(implicit unsafe: Unsafe): Chunk[Byte] =
+          getOrElse(bufferedBytes)(randomBytes(length))
 
-      override def nextDouble()(implicit unsafe: Unsafe): Double =
-        getOrElse(bufferedDouble)(randomDouble)
+        override def nextDouble()(implicit unsafe: Unsafe): Double =
+          getOrElse(bufferedDouble)(randomDouble)
 
-      override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
-        getOrElse(bufferedDouble)(randomDoubleBetween(minInclusive, maxExclusive))
+        override def nextDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit unsafe: Unsafe): Double =
+          getOrElse(bufferedDouble)(randomDoubleBetween(minInclusive, maxExclusive))
 
-      override def nextFloat()(implicit unsafe: Unsafe): Float =
-        getOrElse(bufferedFloat)(randomFloat)
+        override def nextFloat()(implicit unsafe: Unsafe): Float =
+          getOrElse(bufferedFloat)(randomFloat)
 
-      override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
-        getOrElse(bufferedFloat)(randomFloatBetween(minInclusive, maxExclusive))
+        override def nextFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
+          getOrElse(bufferedFloat)(randomFloatBetween(minInclusive, maxExclusive))
 
-      override def nextGaussian()(implicit unsafe: Unsafe): Double =
-        getOrElse(bufferedDouble)(randomGaussian)
+        override def nextGaussian()(implicit unsafe: Unsafe): Double =
+          getOrElse(bufferedDouble)(randomGaussian)
 
-      override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
-        getOrElse(bufferedInt)(randomInt)
+        override def nextInt()(implicit unsafe: Unsafe): RuntimeFlags =
+          getOrElse(bufferedInt)(randomInt)
 
-      override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
-        unsafe: Unsafe
-      ): RuntimeFlags =
-        getOrElse(bufferedInt)(randomIntBetween(minInclusive, maxExclusive))
+        override def nextIntBetween(minInclusive: RuntimeFlags, maxExclusive: RuntimeFlags)(implicit
+          unsafe: Unsafe
+        ): RuntimeFlags =
+          getOrElse(bufferedInt)(randomIntBetween(minInclusive, maxExclusive))
 
-      override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
-        getOrElse(bufferedInt)(randomIntBounded(n))
+        override def nextIntBounded(n: RuntimeFlags)(implicit unsafe: Unsafe): RuntimeFlags =
+          getOrElse(bufferedInt)(randomIntBounded(n))
 
-      override def nextLong()(implicit unsafe: Unsafe): Long =
-        getOrElse(bufferedLong)(randomLong)
+        override def nextLong()(implicit unsafe: Unsafe): Long =
+          getOrElse(bufferedLong)(randomLong)
 
-      override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
-        getOrElse(bufferedLong)(randomLongBetween(minInclusive, maxExclusive))
+        override def nextLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
+          getOrElse(bufferedLong)(randomLongBetween(minInclusive, maxExclusive))
 
-      override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
-        getOrElse(bufferedLong)(randomLongBounded(n))
+        override def nextLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
+          getOrElse(bufferedLong)(randomLongBounded(n))
 
-      override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
-        getOrElse(bufferedChar)(randomPrintableChar)
+        override def nextPrintableChar()(implicit unsafe: Unsafe): Char =
+          getOrElse(bufferedChar)(randomPrintableChar)
 
-      override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
-        getOrElse(bufferedString)(randomString(length))
+        override def nextString(length: RuntimeFlags)(implicit unsafe: Unsafe): String =
+          getOrElse(bufferedString)(randomString(length))
 
-      override def nextUUID()(implicit unsafe: Unsafe): UUID =
-        getOrElse(bufferedUUID)(Random.nextUUIDWith(() => nextLong()))
+        override def nextUUID()(implicit unsafe: Unsafe): UUID =
+          getOrElse(bufferedUUID)(Random.nextUUIDWith(() => nextLong()))
 
-      override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
-        randomState.unsafe.set {
-          val newSeed = (seed ^ 0x5deece66dL) & ((1L << 48) - 1)
-          val seed1   = (newSeed >>> 24).toInt
-          val seed2   = newSeed.toInt & ((1 << 24) - 1)
-          Data(seed1, seed2, Queue.empty)
-        }
-
-      override def shuffle[A, Collection[+Element] <: Iterable[Element]](
-        collection: Collection[A]
-      )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
-        Random.shuffleWith(randomIntBounded, collection)
-
-      private def getOrElse[A](buffer: Buffer => (Option[A], Buffer))(random: => A)(implicit unsafe: Unsafe): A =
-        bufferState.unsafe.modify(buffer).getOrElse(random)
-
-      private def randomBits(bits: Int)(implicit unsafe: Unsafe): Int =
-        randomState.unsafe.modify { data =>
-          val multiplier  = 0x5deece66dL
-          val multiplier1 = (multiplier >>> 24).toInt
-          val multiplier2 = multiplier.toInt & ((1 << 24) - 1)
-          val product1    = data.seed2.toDouble * multiplier1.toDouble + data.seed1.toDouble * multiplier2.toDouble
-          val product2    = data.seed2.toDouble * multiplier2.toDouble + 0xb
-          val newSeed1    = (mostSignificantBits(product2) + leastSignificantBits(product1)) & ((1 << 24) - 1)
-          val newSeed2    = leastSignificantBits(product2)
-          val result      = (newSeed1 << 8) | (newSeed2 >> 16)
-          (result >>> (32 - bits), Data(newSeed1, newSeed2, data.nextNextGaussians))
-        }
-
-      private def randomBoolean(implicit unsafe: Unsafe): Boolean =
-        randomBits(1) != 0
-
-      private def randomBytes(length: Int)(implicit unsafe: Unsafe): Chunk[Byte] = {
-        //  Our RNG generates 32 bit integers so to maximize efficiency we want to
-        //  pull 8 bit bytes from the current integer until it is exhausted
-        //  before generating another random integer
-        @tailrec
-        def loop(i: Int, rnd: () => Int, n: Int, acc: List[Byte]): List[Byte] =
-          if (i == length)
-            acc.reverse
-          else if (n > 0) {
-            val r = rnd()
-            loop(i + 1, () => r >> 8, n - 1, r.toByte :: acc)
-          } else
-            loop(i, () => randomInt, (length - i) min 4, acc)
-
-        Chunk.fromIterable(loop(0, () => randomInt, length min 4, List.empty))
-      }
-
-      private def randomDouble(implicit unsafe: Unsafe): Double = {
-        val i1 = randomBits(26)
-        val i2 = randomBits(27)
-        ((i1.toDouble * (1L << 27).toDouble) + i2.toDouble) / (1L << 53).toDouble
-      }
-
-      private def randomDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit
-        unsafe: Unsafe
-      ): Double =
-        Random.nextDoubleBetweenWith(minInclusive, maxExclusive)(() => randomDouble)
-
-      private def randomFloat(implicit unsafe: Unsafe): Float =
-        (randomBits(24).toDouble / (1 << 24).toDouble).toFloat
-
-      private def randomFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
-        Random.nextFloatBetweenWith(minInclusive, maxExclusive)(() => randomFloat)
-
-      private def randomGaussian(implicit unsafe: Unsafe): Double =
-        //  The Box-Muller transform generates two normally distributed random
-        //  doubles, so we store the second double in a queue and check the
-        //  queue before computing a new pair of values to avoid wasted work.
-        randomState.unsafe.modify { case Data(seed1, seed2, queue) =>
-          queue.dequeueOption.fold((Option.empty[Double], Data(seed1, seed2, queue))) { case (d, queue) =>
-            (Some(d), Data(seed1, seed2, queue))
+        override def setSeed(seed: Long)(implicit unsafe: Unsafe): Unit =
+          randomState.unsafe.set {
+            val newSeed = (seed ^ 0x5deece66dL) & ((1L << 48) - 1)
+            val seed1   = (newSeed >>> 24).toInt
+            val seed2   = newSeed.toInt & ((1 << 24) - 1)
+            Data(seed1, seed2, Queue.empty)
           }
-        } match {
-          case Some(nextNextGaussian) => nextNextGaussian
-          case None =>
-            @tailrec
-            def loop: (Double, Double, Double) = {
-              val d1     = randomDouble
-              val d2     = randomDouble
-              val x      = 2 * d1 - 1
-              val y      = 2 * d2 - 1
-              val radius = x * x + y * y
-              if (radius >= 1 || radius == 0) loop else (x, y, radius)
-            }
-            loop match {
-              case (x, y, radius) =>
-                val c = sqrt(-2 * log(radius) / radius)
-                randomState.unsafe.modify { case Data(seed1, seed2, queue) =>
-                  (x * c, Data(seed1, seed2, queue.enqueue(y * c)))
-                }
-            }
-        }
 
-      private def randomInt(implicit unsafe: Unsafe): Int =
-        randomBits(32)
+        override def shuffle[A, Collection[+Element] <: Iterable[Element]](
+          collection: Collection[A]
+        )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A] =
+          Random.shuffleWith(randomIntBounded, collection)
 
-      private def randomIntBounded(n: Int)(implicit unsafe: Unsafe): Int =
-        if (n <= 0)
-          throw new IllegalArgumentException("n must be positive")
-        else if ((n & -n) == n)
-          randomBits(31) >> Integer.numberOfLeadingZeros(n)
-        else {
+        private def getOrElse[A](buffer: Buffer => (Option[A], Buffer))(random: => A)(implicit unsafe: Unsafe): A =
+          bufferState.unsafe.modify(buffer).getOrElse(random)
+
+        private def randomBits(bits: Int)(implicit unsafe: Unsafe): Int =
+          randomState.unsafe.modify { data =>
+            val multiplier  = 0x5deece66dL
+            val multiplier1 = (multiplier >>> 24).toInt
+            val multiplier2 = multiplier.toInt & ((1 << 24) - 1)
+            val product1    = data.seed2.toDouble * multiplier1.toDouble + data.seed1.toDouble * multiplier2.toDouble
+            val product2    = data.seed2.toDouble * multiplier2.toDouble + 0xb
+            val newSeed1    = (mostSignificantBits(product2) + leastSignificantBits(product1)) & ((1 << 24) - 1)
+            val newSeed2    = leastSignificantBits(product2)
+            val result      = (newSeed1 << 8) | (newSeed2 >> 16)
+            (result >>> (32 - bits), Data(newSeed1, newSeed2, data.nextNextGaussians))
+          }
+
+        private def randomBoolean(implicit unsafe: Unsafe): Boolean =
+          randomBits(1) != 0
+
+        private def randomBytes(length: Int)(implicit unsafe: Unsafe): Chunk[Byte] = {
+          //  Our RNG generates 32 bit integers so to maximize efficiency we want to
+          //  pull 8 bit bytes from the current integer until it is exhausted
+          //  before generating another random integer
           @tailrec
-          def loop: Int = {
-            val i     = randomBits(31)
-            val value = i % n
-            if (i - value + (n - 1) < 0) loop
-            else value
-          }
-          loop
+          def loop(i: Int, rnd: () => Int, n: Int, acc: List[Byte]): List[Byte] =
+            if (i == length)
+              acc.reverse
+            else if (n > 0) {
+              val r = rnd()
+              loop(i + 1, () => r >> 8, n - 1, r.toByte :: acc)
+            } else
+              loop(i, () => randomInt, (length - i) min 4, acc)
+
+          Chunk.fromIterable(loop(0, () => randomInt, length min 4, List.empty))
         }
 
-      private def randomIntBetween(minInclusive: Int, maxExclusive: Int)(implicit unsafe: Unsafe): Int =
-        Random.nextIntBetweenWith(minInclusive, maxExclusive)(() => randomInt, randomIntBounded)
+        private def randomDouble(implicit unsafe: Unsafe): Double = {
+          val i1 = randomBits(26)
+          val i2 = randomBits(27)
+          ((i1.toDouble * (1L << 27).toDouble) + i2.toDouble) / (1L << 53).toDouble
+        }
 
-      private def randomLong(implicit unsafe: Unsafe): Long = {
-        val i1 = randomBits(32)
-        val i2 = randomBits(32)
-        (i1.toLong << 32) + i2
+        private def randomDoubleBetween(minInclusive: Double, maxExclusive: Double)(implicit
+          unsafe: Unsafe
+        ): Double =
+          Random.nextDoubleBetweenWith(minInclusive, maxExclusive)(() => randomDouble)
+
+        private def randomFloat(implicit unsafe: Unsafe): Float =
+          (randomBits(24).toDouble / (1 << 24).toDouble).toFloat
+
+        private def randomFloatBetween(minInclusive: Float, maxExclusive: Float)(implicit unsafe: Unsafe): Float =
+          Random.nextFloatBetweenWith(minInclusive, maxExclusive)(() => randomFloat)
+
+        private def randomGaussian(implicit unsafe: Unsafe): Double =
+          //  The Box-Muller transform generates two normally distributed random
+          //  doubles, so we store the second double in a queue and check the
+          //  queue before computing a new pair of values to avoid wasted work.
+          randomState.unsafe.modify { case Data(seed1, seed2, queue) =>
+            queue.dequeueOption.fold((Option.empty[Double], Data(seed1, seed2, queue))) { case (d, queue) =>
+              (Some(d), Data(seed1, seed2, queue))
+            }
+          } match {
+            case Some(nextNextGaussian) => nextNextGaussian
+            case None =>
+              @tailrec
+              def loop: (Double, Double, Double) = {
+                val d1     = randomDouble
+                val d2     = randomDouble
+                val x      = 2 * d1 - 1
+                val y      = 2 * d2 - 1
+                val radius = x * x + y * y
+                if (radius >= 1 || radius == 0) loop else (x, y, radius)
+              }
+              loop match {
+                case (x, y, radius) =>
+                  val c = sqrt(-2 * log(radius) / radius)
+                  randomState.unsafe.modify { case Data(seed1, seed2, queue) =>
+                    (x * c, Data(seed1, seed2, queue.enqueue(y * c)))
+                  }
+              }
+          }
+
+        private def randomInt(implicit unsafe: Unsafe): Int =
+          randomBits(32)
+
+        private def randomIntBounded(n: Int)(implicit unsafe: Unsafe): Int =
+          if (n <= 0)
+            throw new IllegalArgumentException("n must be positive")
+          else if ((n & -n) == n)
+            randomBits(31) >> Integer.numberOfLeadingZeros(n)
+          else {
+            @tailrec
+            def loop: Int = {
+              val i     = randomBits(31)
+              val value = i % n
+              if (i - value + (n - 1) < 0) loop
+              else value
+            }
+            loop
+          }
+
+        private def randomIntBetween(minInclusive: Int, maxExclusive: Int)(implicit unsafe: Unsafe): Int =
+          Random.nextIntBetweenWith(minInclusive, maxExclusive)(() => randomInt, randomIntBounded)
+
+        private def randomLong(implicit unsafe: Unsafe): Long = {
+          val i1 = randomBits(32)
+          val i2 = randomBits(32)
+          (i1.toLong << 32) + i2
+        }
+
+        private def randomLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
+          Random.nextLongBoundedWith(n)(() => randomLong)
+
+        private def randomLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
+          Random.nextLongBetweenWith(minInclusive, maxExclusive)(() => randomLong, randomLongBounded)
+
+        private def randomPrintableChar(implicit unsafe: Unsafe): Char =
+          (randomIntBounded(127 - 33) + 33).toChar
+
+        private def randomString(length: Int)(implicit unsafe: Unsafe): String =
+          List.fill(length)((randomIntBounded(0xd800 - 1) + 1).toChar).mkString
       }
-
-      private def randomLongBounded(n: Long)(implicit unsafe: Unsafe): Long =
-        Random.nextLongBoundedWith(n)(() => randomLong)
-
-      private def randomLongBetween(minInclusive: Long, maxExclusive: Long)(implicit unsafe: Unsafe): Long =
-        Random.nextLongBetweenWith(minInclusive, maxExclusive)(() => randomLong, randomLongBounded)
-
-      private def randomPrintableChar(implicit unsafe: Unsafe): Char =
-        (randomIntBounded(127 - 33) + 33).toChar
-
-      private def randomString(length: Int)(implicit unsafe: Unsafe): String =
-        List.fill(length)((randomIntBounded(0xd800 - 1) + 1).toChar).mkString
-    }
 
     private def bufferedBoolean(buffer: Buffer): (Option[Boolean], Buffer) =
       (
@@ -782,8 +783,8 @@ object TestRandom extends Serializable {
     implicit val trace = Tracer.newTrace
     ZLayer.scoped {
       for {
-        data   <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(data))
-        buffer <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(Buffer()))
+        data   <- ZIO.succeed(Ref.unsafe.make(data)(Unsafe.unsafe))
+        buffer <- ZIO.succeed(Ref.unsafe.make(Buffer())(Unsafe.unsafe))
         test    = Test(data, buffer)
         _      <- ZIO.withRandomScoped(test)
       } yield test
@@ -814,8 +815,8 @@ object TestRandom extends Serializable {
    */
   def makeTest(data: Data)(implicit trace: Trace): UIO[Test] =
     for {
-      data   <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(data))
-      buffer <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(Buffer()))
+      data   <- ZIO.succeed(Ref.unsafe.make(data)(Unsafe.unsafe))
+      buffer <- ZIO.succeed(Ref.unsafe.make(Buffer())(Unsafe.unsafe))
     } yield Test(data, buffer)
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -53,31 +53,32 @@ final case class TestRunner[R, E](
     def runSync(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Exit[Nothing, Unit]
   }
 
-  val unsafe: UnsafeAPI = new UnsafeAPI {
+  val unsafe: UnsafeAPI =
+    new UnsafeAPI {
 
-    /**
-     * An unsafe, synchronous run of the specified spec.
-     */
-    def run(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Unit =
-      runtime.unsafe.run(self.run(spec).provideLayer(bootstrap)).getOrThrowFiberFailure()
+      /**
+       * An unsafe, synchronous run of the specified spec.
+       */
+      def run(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Unit =
+        runtime.unsafe.run(self.run(spec).provideLayer(bootstrap)).getOrThrowFiberFailure()
 
-    /**
-     * An unsafe, asynchronous run of the specified spec.
-     */
-    def runAsync(spec: Spec[R, E])(k: => Unit)(implicit trace: Trace, unsafe: Unsafe): Unit = {
-      val fiber = runtime.unsafe.fork(self.run(spec).provideLayer(bootstrap))
-      fiber.unsafe.addObserver {
-        case Exit.Success(_) => k
-        case Exit.Failure(c) => throw FiberFailure(c)
+      /**
+       * An unsafe, asynchronous run of the specified spec.
+       */
+      def runAsync(spec: Spec[R, E])(k: => Unit)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+        val fiber = runtime.unsafe.fork(self.run(spec).provideLayer(bootstrap))
+        fiber.unsafe.addObserver {
+          case Exit.Success(_) => k
+          case Exit.Failure(c) => throw FiberFailure(c)
+        }
       }
-    }
 
-    /**
-     * An unsafe, synchronous run of the specified spec.
-     */
-    def runSync(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Exit[Nothing, Unit] =
-      runtime.unsafe.run(self.run(spec).unit.provideLayer(bootstrap))
-  }
+      /**
+       * An unsafe, synchronous run of the specified spec.
+       */
+      def runSync(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Exit[Nothing, Unit] =
+        runtime.unsafe.run(self.run(spec).unit.provideLayer(bootstrap))
+    }
 
   private[test] def buildRuntime(implicit
     trace: Trace

--- a/test/shared/src/main/scala/zio/test/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/TestSystem.scala
@@ -53,14 +53,14 @@ object TestSystem extends Serializable {
      * Returns the specified environment variable if it exists.
      */
     def env(variable: => String)(implicit trace: Trace): IO[SecurityException, Option[String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.env(variable))
+      ZIO.succeed(unsafe.env(variable)(Unsafe.unsafe))
 
     /**
      * Returns the specified environment variable if it exists or else the
      * specified fallback value.
      */
     def envOrElse(variable: => String, alt: => String)(implicit trace: Trace): IO[SecurityException, String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.envOrElse(variable, alt))
+      ZIO.succeed(unsafe.envOrElse(variable, alt)(Unsafe.unsafe))
 
     /**
      * Returns the specified environment variable if it exists or else the
@@ -69,32 +69,32 @@ object TestSystem extends Serializable {
     def envOrOption(variable: => String, alt: => Option[String])(implicit
       trace: Trace
     ): IO[SecurityException, Option[String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.envOrOption(variable, alt))
+      ZIO.succeed(unsafe.envOrOption(variable, alt)(Unsafe.unsafe))
 
     def envs(implicit trace: Trace): ZIO[Any, SecurityException, Map[String, String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.envs())
+      ZIO.succeed(unsafe.envs()(Unsafe.unsafe))
 
     /**
      * Returns the system line separator.
      */
     def lineSeparator(implicit trace: Trace): UIO[String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.lineSeparator())
+      ZIO.succeed(unsafe.lineSeparator()(Unsafe.unsafe))
 
     def properties(implicit trace: Trace): ZIO[Any, Throwable, Map[String, String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.properties())
+      ZIO.succeed(unsafe.properties()(Unsafe.unsafe))
 
     /**
      * Returns the specified system property if it exists.
      */
     def property(prop: => String)(implicit trace: Trace): IO[Throwable, Option[String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.property(prop))
+      ZIO.succeed(unsafe.property(prop)(Unsafe.unsafe))
 
     /**
      * Returns the specified system property if it exists or else the specified
      * fallback value.
      */
     def propertyOrElse(prop: => String, alt: => String)(implicit trace: Trace): IO[Throwable, String] =
-      ZIO.succeedUnsafe(implicit u => unsafe.propertyOrElse(prop, alt))
+      ZIO.succeed(unsafe.propertyOrElse(prop, alt)(Unsafe.unsafe))
 
     /**
      * Returns the specified system property if it exists or else the specified
@@ -103,7 +103,7 @@ object TestSystem extends Serializable {
     def propertyOrOption(prop: => String, alt: => Option[String])(implicit
       trace: Trace
     ): IO[Throwable, Option[String]] =
-      ZIO.succeedUnsafe(implicit u => unsafe.propertyOrOption(prop, alt))
+      ZIO.succeed(unsafe.propertyOrOption(prop, alt)(Unsafe.unsafe))
 
     /**
      * Adds the specified name and value to the mapping of environment variables
@@ -147,36 +147,37 @@ object TestSystem extends Serializable {
         systemData <- systemState.get
       } yield systemState.set(systemData)
 
-    override private[zio] val unsafe: UnsafeAPI = new UnsafeAPI {
-      override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
-        systemState.unsafe.get.envs.get(variable)
+    override private[zio] val unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
+          systemState.unsafe.get.envs.get(variable)
 
-      override def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
-        System.envOrElseWith(variable, alt)(env)
+        override def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String =
+          System.envOrElseWith(variable, alt)(env)
 
-      override def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String] =
-        System.envOrOptionWith(variable, alt)(env)
+        override def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String] =
+          System.envOrOptionWith(variable, alt)(env)
 
-      override def envs()(implicit unsafe: Unsafe): Map[String, String] =
-        systemState.unsafe.get.envs
+        override def envs()(implicit unsafe: Unsafe): Map[String, String] =
+          systemState.unsafe.get.envs
 
-      override def lineSeparator()(implicit unsafe: Unsafe): String =
-        systemState.unsafe.get.lineSeparator
+        override def lineSeparator()(implicit unsafe: Unsafe): String =
+          systemState.unsafe.get.lineSeparator
 
-      override def properties()(implicit unsafe: Unsafe): Map[String, String] =
-        systemState.unsafe.get.properties
+        override def properties()(implicit unsafe: Unsafe): Map[String, String] =
+          systemState.unsafe.get.properties
 
-      override def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
-        systemState.unsafe.get.properties.get(prop)
+        override def property(prop: String)(implicit unsafe: Unsafe): Option[String] =
+          systemState.unsafe.get.properties.get(prop)
 
-      override def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
-        System.propertyOrElseWith(prop, alt)(property)
+        override def propertyOrElse(prop: String, alt: => String)(implicit unsafe: Unsafe): String =
+          System.propertyOrElseWith(prop, alt)(property)
 
-      override def propertyOrOption(prop: String, alt: => Option[String])(implicit
-        unsafe: Unsafe
-      ): Option[String] =
-        System.propertyOrOptionWith(prop, alt)(property)
-    }
+        override def propertyOrOption(prop: String, alt: => Option[String])(implicit
+          unsafe: Unsafe
+        ): Option[String] =
+          System.propertyOrOptionWith(prop, alt)(property)
+      }
   }
 
   /**
@@ -195,7 +196,7 @@ object TestSystem extends Serializable {
     implicit val trace: Trace = Tracer.newTrace
     ZLayer.scoped {
       for {
-        ref <- ZIO.succeedUnsafe(implicit u => Ref.unsafe.make(data))
+        ref <- ZIO.succeed(Ref.unsafe.make(data)(Unsafe.unsafe))
         test = Test(ref)
         _   <- ZIO.withSystemScoped(test)
       } yield test


### PR DESCRIPTION
The existence of both `unsafe` and `unsafeCompat` is a bit of a wart and creates one more thing to learn. We can unify them by providing proof to the Scala compiler that an implicit function is a function.