### PR TITLE
Preserve Throwable Stack Trace

### DIFF
--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -106,7 +106,8 @@ trait ZIOCompanionVersionSpecific {
 
         ZIO.succeedNow(result)
       } catch {
-        case t: Throwable if !fiberState.isFatal(t)(Unsafe.unsafe) => throw ZIOError.Traced(Cause.fail(t))
+        case t: Throwable if !fiberState.isFatal(t)(Unsafe.unsafe) =>
+          throw ZIOError.Traced(Cause.fail(t, StackTrace.fromJava(fiberState.id, t.getStackTrace())))
       }
     }
 

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -108,7 +108,8 @@ trait ZIOCompanionVersionSpecific {
 
         ZIO.succeedNow(result)
       } catch {
-        case t: Throwable if !fiberState.isFatal(t)(Unsafe.unsafe) => throw ZIOError.Traced(Cause.fail(t))
+        case t: Throwable if !fiberState.isFatal(t)(Unsafe.unsafe) =>
+          throw ZIOError.Traced(Cause.fail(t, StackTrace.fromJava(fiberState.id, t.getStackTrace())))
       }
     }
 

--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -60,6 +60,9 @@ final case class StackTrace(
 
 object StackTrace {
 
+  def fromJava(fiberId: FiberId, stackTrace: Array[StackTraceElement])(implicit trace: Trace): StackTrace =
+    StackTrace(fiberId, Chunk.fromArray(stackTrace).map(Trace.fromJava).takeWhile(!Trace.equalIgnoreLocation(_, trace)))
+
   lazy val none: StackTrace =
     StackTrace(FiberId.None, Chunk.empty)
 }

--- a/core/shared/src/main/scala/zio/Trace.scala
+++ b/core/shared/src/main/scala/zio/Trace.scala
@@ -24,6 +24,12 @@ object Trace {
   def apply(location: String, file: String, line: Int): Trace =
     Tracer.instance(location, file, line)
 
+  def equalIgnoreLocation(left: Trace, right: Trace): Boolean =
+    (left, right) match {
+      case (Trace(_, leftFile, leftLine), Trace(_, rightFile, rightLine)) =>
+        leftFile == rightFile && leftLine == rightLine
+    }
+
   val empty: Trace =
     Tracer.instance.empty
 


### PR DESCRIPTION
Resolves #7003.

When we catch a `Throwable` in `ZIO.attempt` we capture the ZIO trace but don't do anything with the `Throwable` stack trace other than putting the `Throwable` into `Cause.Fail`. Since `Fail` doesn't necessarily contain a `Throwable` polymorphic code then doesn't do anything specific to the error being a `Throwable` and in particular doesn't do anything with the stack trace.

This results in us "losing" the stack trace of the `Throwable`. This means that the execution trace correctly points to the line of the `ZIO.attempt` where the error occurred but doesn't include additional tracing for what happened inside that code block.

We can improve on this by capturing the `Throwable` stack trace inside the `trace` of the `Cause.fail`. We need to be careful when doing this not to capture the trace beyond the ZIO Trace so we don't include ZIO internals in the trace.

With this change we go from a trace that looks like this:

```
[info] timestamp=2022-06-29T12:59:48.841225Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-6" scala.NotImplementedError: scala.NotImplementedError: an implementation is missing
[info]  at <empty>.Example.effect(Example.scala:20)
[info]  at <empty>.Example.run(Example.scala:25)"
```

To one that looks like this:

```
[info] timestamp=2022-06-29T14:49:50.826548Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-6" scala.NotImplementedError: scala.NotImplementedError: an implementation is missing
[info]  at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
[info]  at Example$POJOService.foo(Example.scala:9)
[info]  at Example$POJOService.something(Example.scala:7)
[info]  at <empty>.Example.effect(Example.scala:20)
[info]  at <empty>.Example.run(Example.scala:25)"
```