### PR TITLE
Improve ZEnvironment Rendering

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -86,7 +86,7 @@ final class ZEnvironment[+R] private (
     map.size
 
   override def toString: String =
-    s"ZEnvironment($map)"
+    s"ZEnvironment(${map.toList.sortBy(_._2._2).map { case (tag, (service, _)) => s"$tag -> $service" }.mkString(", ")})"
 
   /**
    * Combines this environment with the specified environment.


### PR DESCRIPTION
The indices associated with different services are an internal implementation detail. We can capture that information simply by sorting the services by index as part of rendering. Sample output:

```scala
ZEnvironment(Int -> 1, String -> Adam, Double -> 2.0)
```