### PR TITLE
Fix `ZIOApp#<>` producing an invalid tag 

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -51,8 +51,12 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    * Composes this [[ZIOApp]] with another [[ZIOApp]], to yield an application
    * that executes the logic of both applications.
    */
-  final def <>(that: ZIOApp)(implicit trace: Trace): ZIOApp =
-    ZIOApp(self.run.zipPar(that.run), self.bootstrap +!+ that.bootstrap)
+  final def <>(that: ZIOApp)(implicit trace: Trace): ZIOApp = {
+    def combine[A: EnvironmentTag, B: EnvironmentTag]: EnvironmentTag[A with B] = EnvironmentTag[A with B]
+    ZIOApp(self.run.zipPar(that.run), self.bootstrap +!+ that.bootstrap)(
+      combine[this.Environment, that.Environment](this.environmentTag, that.environmentTag)
+    )
+  }
 
   /**
    * A helper function to obtain access to the command-line arguments of the


### PR DESCRIPTION
(using path dependent tags like this doesn't work properly right now https://github.com/zio/izumi-reflect/pull/296/files#diff-7f44db757a318e96b6a901e02afb93cd004e09344ced86aa40fef3a2260ca326R9)