### PR TITLE
Reverse arrow direction in Layer Mermaid diagram

### DIFF
--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -287,13 +287,13 @@ final case class LayerBuilder[Type, Expr](
           List(getAlias(key))
         case (key, children) =>
           children.map { child =>
-            s"${getAlias(key)} --> ${getAlias(child)}"
+            s"${getAlias(child)} --> ${getAlias(key)}"
           }
       }
         .mkString("\\n")
 
     val mermaidGraph =
-      s"""{"code":"graph\\n$mermaidCode","mermaid": "{\\"theme\\": \\"default\\"}"}"""
+      s"""{"code":"graph BT\\n$mermaidCode","mermaid": "{\\"theme\\": \\"default\\"}"}"""
 
     val encodedMermaidGraph: String =
       new String(Base64.getEncoder.encode(mermaidGraph.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)


### PR DESCRIPTION
TLDR Change arrow meaning
From: "depends on"
To: "is a dependency of" 

The previous code made a chart like this:
<img width="799" alt="Screen Shot 2022-07-06 at 7 41 13 PM" src="https://user-images.githubusercontent.com/2054940/177672143-3716684b-17d1-4d32-86ad-fdbde17692a8.png">
:

Which struck me as backwards.

Now it looks like this:
<img width="799" alt="Screen Shot 2022-07-06 at 7 38 01 PM" src="https://user-images.githubusercontent.com/2054940/177672315-f1a80e91-b91c-4d48-a232-f214082a2299.png">

Discussed/demo'ed with @kitlangton earlier.