### PR TITLE
Doc: Scala 3.x instead of dotty

### DIFF
--- a/docs/overview/platforms.md
+++ b/docs/overview/platforms.md
@@ -7,7 +7,7 @@ ZIO provides a consistent interface across platforms to the maximum extent possi
 
 ## JVM
 
-ZIO supports Java versions 8 and above and Scala versions 2.11, 2.12, 2.13, and Dotty.
+ZIO supports Java versions 8 and above and Scala versions 2.11, 2.12, 2.13, and 3.x.
 
 On the JVM, effects may be executed on a blocking thread pool using methods like `ZIO.blocking` and `ZIO.attemptBlocking`. See the documentation on [Creating Effects](../overview/creating_effects.md) for further discussion on blocking operations.
 


### PR DESCRIPTION
Typo: Scala 3 instead of dotty.