### PR TITLE
Running unsafe as context function

### DIFF
--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -49,7 +49,7 @@ val runtime = Runtime.default
 Once you have a runtime, you can use it to execute effects:
 
 ```scala mdoc:silent
-Unsafe.unsafe { implicit unsafe =>
+Unsafe.unsafe {  unsafe ?=>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
 }
 ```


### PR DESCRIPTION
The current version on scala 3  for unsafe 
```
def unsafe[A](f: Unsafe ?=> A): A = {
    given Unsafe = self.unsafe
    
    f
  }
```
which makes the previous snippet not working.