### PR TITLE
Start Test Clock Warning When Time Is Accessed

### DIFF
--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -268,19 +268,19 @@ package object environment extends PlatformSpecific {
        * Returns the current clock time as an `OffsetDateTime`.
        */
       def currentDateTime: UIO[OffsetDateTime] =
-        clockState.get.map(data => toDateTime(data.duration, data.timeZone))
+        warningStart *> clockState.get.map(data => toDateTime(data.duration, data.timeZone))
 
       /**
        * Returns the current clock time in the specified time unit.
        */
       def currentTime(unit: TimeUnit): UIO[Long] =
-        clockState.get.map(data => unit.convert(data.duration.toMillis, TimeUnit.MILLISECONDS))
+        warningStart *> clockState.get.map(data => unit.convert(data.duration.toMillis, TimeUnit.MILLISECONDS))
 
       /**
        * Returns the current clock time in nanoseconds.
        */
-      val nanoTime: UIO[Long] =
-        clockState.get.map(_.duration.toNanos)
+      lazy val nanoTime: UIO[Long] =
+        warningStart *> clockState.get.map(_.duration.toNanos)
 
       /**
        * Saves the `TestClock`'s current state in an effect which, when run,


### PR DESCRIPTION
We should start the warning when the time is accessed, even if no one is suspending for the time to be advanced.