### PR TITLE
Fix SmartAssertionOps match for Scala 3.1.3

### DIFF
--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -131,7 +131,7 @@ object SmartAssertMacros {
       Expr(term.pos.start - summon[PositionContext].start, term.pos.end - summon[PositionContext].start)
 
     expr match {
-      case '{ type t; type v; zio.test.SmartAssertionOps[`t`](${something}: `t`).is[`v`](${Unseal(Lambda(terms, body))}) } =>
+      case '{ type t; type v; SmartAssertionOps[`t`](${something}: `t`).is[`v`](${Unseal(Lambda(terms, body))}) } =>
         val lhs = transform(something).asInstanceOf[Expr[TestArrow[Any, t]]]
         val res = transformAs(body.asExprOf[TestLens[v]])(lhs)
         res.asInstanceOf[Expr[TestArrow[Any, A]]]


### PR DESCRIPTION
Fixes #6937

While debugging this I found bug in Scala 3.1.3 (but not in 3.2.0-RC2 so I guess it was fixed) where matching class with entire path is dependent on caller's package. For now we can just change path to class name and it will work fine.