### PR TITLE
ZIO Test: Allow Access To Context In Type Check Function

### DIFF
--- a/test-tests/shared/src/test/scala-2/TestProvideVersionSpecificSpec.scala
+++ b/test-tests/shared/src/test/scala-2/TestProvideVersionSpecificSpec.scala
@@ -1,0 +1,102 @@
+package zio.test
+
+import zio._
+import zio.internal.macros.StringUtils.StringOps
+import zio.test.Assertion._
+
+object TestProvideVersionSpecificSpec extends ZIOBaseSpec {
+  def containsStringWithoutAnsi(element: String): Assertion[String] =
+    Assertion.assertion("containsStringWithoutAnsi")(_.unstyled.contains(element))
+
+  def spec =
+    suite("TestProvideVersionSpecificSpec")(
+      suite(".provide")(
+        test("reports missing top-level dependencies") {
+          val program: URIO[String with Int, String] = ZIO.succeed("test")
+          val _                                      = program
+          val checked =
+            typeCheck("""test("foo")(assertZIO(program)(anything)).provide(ZLayer.succeed(3))""")
+          assertZIO(checked)(isLeft(containsStringWithoutAnsi("String")))
+        },
+        test("reports multiple missing top-level dependencies") {
+          val program: URIO[String with Int, String] = ZIO.succeed("test")
+          val _                                      = program
+
+          val checked = typeCheck("""test("foo")(assertZIO(program)(anything)).provide()""")
+          assertZIO(checked)(
+            isLeft(containsStringWithoutAnsi("String") && containsStringWithoutAnsi("Int"))
+          )
+        },
+        test("reports missing transitive dependencies") {
+          import TestLayer._
+          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
+          val _                               = program
+
+          val checked = typeCheck("""test("foo")(assertZIO(program)(anything)).provide(OldLady.live)""")
+          assertZIO(checked)(
+            isLeft(
+              containsStringWithoutAnsi("zio.test.TestProvideSpec.TestLayer.Fly") &&
+                containsStringWithoutAnsi("Required by TestLayer.OldLady.live")
+            )
+          )
+        },
+        test("reports nested missing transitive dependencies") {
+          import TestLayer._
+          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
+          val _                               = program
+
+          val checked =
+            typeCheck("""test("foo")(assertZIO(program)(anything)).provide(OldLady.live, Fly.live)""")
+          assertZIO(checked)(
+            isLeft(
+              containsStringWithoutAnsi("zio.test.TestProvideSpec.TestLayer.Spider") &&
+                containsStringWithoutAnsi("Required by TestLayer.Fly.live")
+            )
+          )
+        },
+        test("reports circular dependencies") {
+          import TestLayer._
+          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
+          val _                               = program
+
+          val checked =
+            typeCheck(
+              """test("foo")(assertZIO(program)(anything)).provide(OldLady.live, Fly.manEatingFly)"""
+            )
+          assertZIO(checked)(
+            isLeft(
+              containsStringWithoutAnsi("TestLayer.Fly.manEatingFly") &&
+                containsStringWithoutAnsi("OldLady.live") &&
+                containsStringWithoutAnsi(
+                  "A layer simultaneously requires and is required by another"
+                )
+            )
+          )
+        }
+      ),
+    )
+
+  object TestLayer {
+    trait OldLady {
+      def willDie: UIO[Boolean]
+    }
+
+    object OldLady {
+      def live: URLayer[Fly, OldLady] = ZLayer.succeed(new OldLady {
+        override def willDie: UIO[Boolean] = ZIO.succeed(false)
+      })
+    }
+
+    trait Fly {}
+    object Fly {
+      def live: URLayer[Spider, Fly]          = ZLayer.succeed(new Fly {})
+      def manEatingFly: URLayer[OldLady, Fly] = ZLayer.succeed(new Fly {})
+    }
+
+    trait Spider {}
+    object Spider {
+      def live: ULayer[Spider] = ZLayer.succeed(new Spider {})
+    }
+  }
+
+}

--- a/test-tests/shared/src/test/scala-2/TestProvideVersionSpecificSpec.scala
+++ b/test-tests/shared/src/test/scala-2/TestProvideVersionSpecificSpec.scala
@@ -73,7 +73,7 @@ object TestProvideVersionSpecificSpec extends ZIOBaseSpec {
             )
           )
         }
-      ),
+      )
     )
 
   object TestLayer {

--- a/test-tests/shared/src/test/scala/zio/test/CompileSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CompileSpec.scala
@@ -12,6 +12,11 @@ object CompileSpec extends ZIOBaseSpec {
       val expected = "value ++ is not a member of Int"
       if (TestVersion.isScala2) assertZIO(typeCheck("1 ++ 1"))(isLeft(equalTo(expected)))
       else assertZIO(typeCheck("1 ++ 1"))(isLeft(anything))
+    },
+    test("typeCheck must have access to local context") {
+      val x = 3
+      val _ = x
+      assertZIO(typeCheck("x"))(isRight(anything))
     }
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestProvideSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestProvideSpec.scala
@@ -27,69 +27,7 @@ object TestProvideSpec extends ZIOBaseSpec {
             assertZIO(program)(equalTo(128))
           }
             .provide(doubleLayer, stringLayer, intLayer)
-        },
-        test("reports missing top-level dependencies") {
-          val program: URIO[String with Int, String] = ZIO.succeed("test")
-          val _                                      = program
-          val checked =
-            typeCheck("""test("foo")(assertZIO(program)(anything)).provide(ZLayer.succeed(3))""")
-          assertZIO(checked)(isLeft(containsStringWithoutAnsi("String")))
-        } @@ TestAspect.exceptScala3,
-        test("reports multiple missing top-level dependencies") {
-          val program: URIO[String with Int, String] = ZIO.succeed("test")
-          val _                                      = program
-
-          val checked = typeCheck("""test("foo")(assertZIO(program)(anything)).provide()""")
-          assertZIO(checked)(
-            isLeft(containsStringWithoutAnsi("String") && containsStringWithoutAnsi("Int"))
-          )
-        } @@ TestAspect.exceptScala3,
-        test("reports missing transitive dependencies") {
-          import TestLayer._
-          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
-          val _                               = program
-
-          val checked = typeCheck("""test("foo")(assertZIO(program)(anything)).provide(OldLady.live)""")
-          assertZIO(checked)(
-            isLeft(
-              containsStringWithoutAnsi("zio.test.TestProvideSpec.TestLayer.Fly") &&
-                containsStringWithoutAnsi("Required by TestLayer.OldLady.live")
-            )
-          )
-        } @@ TestAspect.exceptScala3,
-        test("reports nested missing transitive dependencies") {
-          import TestLayer._
-          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
-          val _                               = program
-
-          val checked =
-            typeCheck("""test("foo")(assertZIO(program)(anything)).provide(OldLady.live, Fly.live)""")
-          assertZIO(checked)(
-            isLeft(
-              containsStringWithoutAnsi("zio.test.TestProvideSpec.TestLayer.Spider") &&
-                containsStringWithoutAnsi("Required by TestLayer.Fly.live")
-            )
-          )
-        } @@ TestAspect.exceptScala3,
-        test("reports circular dependencies") {
-          import TestLayer._
-          val program: URIO[OldLady, Boolean] = ZIO.service[OldLady].flatMap(_.willDie)
-          val _                               = program
-
-          val checked =
-            typeCheck(
-              """test("foo")(assertZIO(program)(anything)).provide(OldLady.live, Fly.manEatingFly)"""
-            )
-          assertZIO(checked)(
-            isLeft(
-              containsStringWithoutAnsi("TestLayer.Fly.manEatingFly") &&
-                containsStringWithoutAnsi("OldLady.live") &&
-                containsStringWithoutAnsi(
-                  "A layer simultaneously requires and is required by another"
-                )
-            )
-          )
-        } @@ TestAspect.exceptScala3
+        }
       ),
       suite(".provideSome") {
         val stringLayer = ZLayer.succeed("10")

--- a/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
@@ -31,7 +31,7 @@ trait CompileVariants {
    * exception if specified string cannot be parsed or is not a known value at
    * compile time.
    */
-  inline def typeCheck(inline code: String): UIO[Either[String, Unit]] =
+  transparent inline def typeCheck(inline code: String): UIO[Either[String, Unit]] =
     try {
       if (typeChecks(code)) ZIO.succeedNow(Right(()))
       else ZIO.succeedNow(Left(errorMessage))


### PR DESCRIPTION
Allows `typeCheck` macro to access local context in ZIO Test.