### PR TITLE
Make Unsafe Operators Package Private

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2446,7 +2446,7 @@ sealed trait ZIO[-R, +E, +A]
 }
 
 object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific {
-  private object unsafe {
+  private[zio] object unsafe {
     def fork[R, E1, E2, A, B](
       trace: Trace,
       effect: ZIO[R, E1, A],


### PR DESCRIPTION
The `forkUnstarted` operator can be necessary for implementing some low level logic in other ZIO ecosystem libraries.