### PR TITLE
Remove Spurious Warning

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -602,10 +602,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val callback = (effect: ZIO[Any, Any, Any]) => {
       if (alreadyCalled.compareAndSet(false, true)) {
         tell(FiberMessage.Resume(effect))
-      } else {
-        val msg = s"An async callback was invoked more than once, which could be a sign of a defect: ${effect}"
-
-        log(() => msg, Cause.empty, ZIO.someDebug, self.asyncTrace)
       }
     }
 


### PR DESCRIPTION
Resolves #7082.

The assumption that the asynchronous callback will be called at most once is not accurate in the presence of asynchronous interruption since the callback could be called by third party code concurrently with being called by the ZIO runtime if the fiber is interrupted.