### PR TITLE
RFC: Observe set and setAsync in SubscriptionRef

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -55,8 +55,8 @@ object SubscriptionRef {
       def modifyZIO[R, E, B](f: A => ZIO[R, E, (B, A)])(implicit trace: Trace): ZIO[R, E, B] =
         ref.modifyZIO(a => f(a).tap { case (_, a) => hub.publish(a) })
       def set(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.set(a)
+        ref.set(a) <* hub.publish(a)
       def setAsync(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.setAsync(a)
+        ref.setAsync(a) <* hub.publish(a)
     }
 }


### PR DESCRIPTION
Hey so I was surprised that only literal updates (calls to `update*` and `modify*`) actions were observed in `SubscriptionRef`. In my opinion `set` and `setAsync` are also updates.

I guess two questions can come up:

- should these operations be interruptible?
- the behaviour for `setAsync` is that observations via the stream may happen before writes are actually done, and that concurrent writes may not happen in the same order as they are observed by the stream: is that fine?