### PR TITLE
Publish Sets To SubscriptionRef

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -55,8 +55,8 @@ object SubscriptionRef {
       def modifyZIO[R, E, B](f: A => ZIO[R, E, (B, A)])(implicit trace: Trace): ZIO[R, E, B] =
         ref.modifyZIO(a => f(a).tap { case (_, a) => hub.publish(a) })
       def set(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.modifyZIO(_ => hub.publish(a).as((), a))
+        ref.modifyZIO(_ => hub.publish(a).as(((), a)))
       def setAsync(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.modifyZIO(_ => hub.publish(a).as((), a))
+        ref.modifyZIO(_ => hub.publish(a).as(((), a)))
     }
 }

--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -55,8 +55,8 @@ object SubscriptionRef {
       def modifyZIO[R, E, B](f: A => ZIO[R, E, (B, A)])(implicit trace: Trace): ZIO[R, E, B] =
         ref.modifyZIO(a => f(a).tap { case (_, a) => hub.publish(a) })
       def set(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.set(a)
+        ref.modifyZIO(_ => hub.publish(a).as((), a))
       def setAsync(a: A)(implicit trace: Trace): UIO[Unit] =
-        ref.setAsync(a)
+        ref.modifyZIO(_ => hub.publish(a).as((), a))
     }
 }


### PR DESCRIPTION
We should treat `set` and `setAsync` as any other update and go through `modifyZIO` on the underlying `Ref.Synchronized` to publish the changes and maintain consistency between the order of changes and the order in which they are published.