### PR TITLE
Remove unidoc Command Temporary

### DIFF
--- a/scripts/checkSite.sh
+++ b/scripts/checkSite.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/unidoc
+#ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/unidoc
 ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/mdoc
 cd website
 

--- a/scripts/createSite.sh
+++ b/scripts/createSite.sh
@@ -10,7 +10,7 @@ rm -Rf website/versioned_docs
 git checkout series/1.x
 git clean -df
 sbt docs/mdoc
-sbt docs/unidoc
+#sbt docs/unidoc
 
 mkdir -p website/versioned_docs/version-1.x
 mv zio-docs/target/mdoc/* website/versioned_docs/version-1.x
@@ -21,7 +21,7 @@ mv website/static/api website/static/api-1.x
 # Now we need to checkout the branch that originally has triggered the site build
 git checkout $1
 git fetch --tags
-ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/unidoc
+#ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/unidoc
 ZIO_LATEST_2=`git describe --tags --abbrev=0 ` sbt docs/mdoc
 
 cd website 


### PR DESCRIPTION
To be able to deploy recent changes on documentation, let's disable the unidoc for a while. Later, we might need to add a custom runner.