### PR TITLE
Implement Schedule#passthrough

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -622,6 +622,12 @@ object ScheduleSpec extends ZIOBaseSpec {
         actual   <- alsoWednesday.delays.run(now, in)
         expected <- wednesday.delays.run(now, in)
       } yield assert(actual)(equalTo(expected))
+    },
+    test("passthrough") {
+      for {
+        ref   <- Ref.make(0)
+        value <- ref.getAndUpdate(_ + 1).repeat(Schedule.recurs(10).passthrough)
+      } yield assertTrue(value == 10)
     }
   )
 

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -700,6 +700,21 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
     }
 
   /**
+   * Returns a new schedule that passes through the inputs of this schedule.
+   */
+  def passthrough[In1 <: In](implicit trace: Trace): Schedule.WithState[self.State, Env, In1, In1] =
+    new Schedule[Env, In1, In1] {
+      type State = self.State
+      val initial = self.initial
+      def step(now: OffsetDateTime, in: In1, state: State)(implicit
+        trace: Trace
+      ): ZIO[Env, Nothing, (State, In1, Decision)] =
+        self.step(now, in, state).map {
+          case (state, _, decision) => (state, in, decision)
+        }
+    }
+
+  /**
    * Returns a new schedule with its environment provided to it, so the
    * resulting schedule does not require any environment.
    */

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -709,8 +709,8 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
       def step(now: OffsetDateTime, in: In1, state: State)(implicit
         trace: Trace
       ): ZIO[Env, Nothing, (State, In1, Decision)] =
-        self.step(now, in, state).map {
-          case (state, _, decision) => (state, in, decision)
+        self.step(now, in, state).map { case (state, _, decision) =>
+          (state, in, decision)
         }
     }
 


### PR DESCRIPTION
A convenience method to create a version of a schedule that passes through its inputs unchanged.