### PR TITLE
Fix: `equalTo` compare CharSequence type

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -93,6 +93,19 @@ object AssertionSpec extends ZIOBaseSpec {
           )
         )
       } @@ TestAspect.scala2Only,
+      test("equalTo should succeed for same CharSequence value") {
+        val probe: CharSequence = "test"
+        assert(probe)(equalTo(probe))
+      },
+      test("equalTo should succeed for CharSequence value compared with String value") {
+        val probe: CharSequence = "test"
+        assert(probe)(equalTo("test"))
+      },
+      test("equalTo should fail for difference CharSequence values") {
+        val probe: CharSequence    = "test"
+        val expected: CharSequence = "test123"
+        assert(probe)(equalTo(expected))
+      } @@ failing,
       test("exists must succeed when at least one element of iterable satisfy specified assertion") {
         assert(Seq(1, 42, 5))(exists(equalTo(42)))
       },

--- a/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
@@ -27,7 +27,7 @@ trait AssertionVariants {
         .make[B, Boolean] { actual =>
           val result = (actual, expected) match {
             case (left: Array[_], right: Array[_])         => left.sameElements[Any](right)
-            case (left: CharSequence, right: CharSequence) => left.toString.contentEquals(right)
+            case (left: CharSequence, right: CharSequence) => left.toString == right.toString
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {

--- a/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
@@ -26,8 +26,9 @@ trait AssertionVariants {
       TestArrow
         .make[B, Boolean] { actual =>
           val result = (actual, expected) match {
-            case (left: Array[_], right: Array[_]) => left.sameElements[Any](right)
-            case (left, right)                     => left == right
+            case (left: Array[_], right: Array[_])         => left.sameElements[Any](right)
+            case (left: CharSequence, right: CharSequence) => left.toString.contentEquals(right)
+            case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
             M.pretty(actual) + M.equals + M.pretty(expected)

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -30,6 +30,7 @@ trait AssertionVariants {
         .make[A, Boolean] { actual =>
           val result = (actual, expected) match {
             case (left: Array[_], right: Array[_]) => left.sameElements[Any](right)
+            case (left: CharSequence, right: CharSequence) => left.toString.contentEquals(right)
             case (left, right)                     => left == right
           }
           TestTrace.boolean(result) {

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -30,7 +30,7 @@ trait AssertionVariants {
         .make[A, Boolean] { actual =>
           val result = (actual, expected) match {
             case (left: Array[_], right: Array[_]) => left.sameElements[Any](right)
-            case (left: CharSequence, right: CharSequence) => left.toString.contentEquals(right)
+            case (left: CharSequence, right: CharSequence) => left.toString == right.toString
             case (left, right)                     => left == right
           }
           TestTrace.boolean(result) {


### PR DESCRIPTION
updated `equalTo` implementation to be able to properly compare for equality `java.lang.CharSequence` type

Fixes #7103 