### PR TITLE
Make ConcurrentMap.compute consistent with Java implementation

### DIFF
--- a/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -30,11 +30,11 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
     }
 
   /**
-   * Attempts to compute a mapping for the given key and its current mapped
-   * value.
+   * Attempts to compute a mapping for the specified key and its current mapped
+   * value (or None if there is no current mapping).
    */
-  def compute(key: K, remap: (K, V) => V): UIO[Option[V]] =
-    ZIO.succeed(Option(underlying.compute(key, remapWith(remap))))
+  def compute(key: K, remap: (K, Option[V]) => V): UIO[V] =
+    ZIO.succeed(underlying.compute(key, (key, value) => remap(key, Option(value))))
 
   /**
    * Computes a value of a non-existing key.

--- a/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -34,9 +34,7 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
    * value (or None if there is no current mapping).
    */
   def compute(key: K, remap: (K, Option[V]) => Option[V]): UIO[Option[V]] =
-    ZIO.succeed(
-      Option(underlying.compute(key, (key, value) => remap(key, Option(value)).getOrElse(null.asInstanceOf[V])))
-    )
+    ZIO.succeed(Option(underlying.compute(key, remapComputeWith(remap))))
 
   /**
    * Computes a value of a non-existing key.
@@ -49,7 +47,7 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
    */
 
   def computeIfPresent(key: K, remap: (K, V) => V): UIO[Option[V]] =
-    ZIO.succeed(Option(underlying.computeIfPresent(key, remapWith(remap))))
+    ZIO.succeed(Option(underlying.computeIfPresent(key, remapComputeIfPresentWith(remap))))
 
   /**
    * Tests whether a given predicate holds true for at least one element in a
@@ -203,7 +201,12 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
       def apply(k: K): V = map(k)
     }
 
-  private[this] def remapWith(remap: (K, V) => V): java.util.function.BiFunction[K, V, V] =
+  private[this] def remapComputeWith(remap: (K, Option[V]) => Option[V]): java.util.function.BiFunction[K, V, V] =
+    new java.util.function.BiFunction[K, V, V] {
+      def apply(k: K, v: V): V = remap(k, Option(v)).getOrElse(null.asInstanceOf[V])
+    }
+
+  private[this] def remapComputeIfPresentWith(remap: (K, V) => V): java.util.function.BiFunction[K, V, V] =
     new java.util.function.BiFunction[K, V, V] {
       def apply(k: K, v: V): V = if (v == null) v else remap(k, v)
     }

--- a/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -33,8 +33,10 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
    * Attempts to compute a mapping for the specified key and its current mapped
    * value (or None if there is no current mapping).
    */
-  def compute(key: K, remap: (K, Option[V]) => V): UIO[V] =
-    ZIO.succeed(underlying.compute(key, (key, value) => remap(key, Option(value))))
+  def compute(key: K, remap: (K, Option[V]) => Option[V]): UIO[Option[V]] =
+    ZIO.succeed(
+      Option(underlying.compute(key, (key, value) => remap(key, Option(value)).getOrElse(null.asInstanceOf[V])))
+    )
 
   /**
    * Computes a value of a non-existing key.

--- a/concurrent/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/concurrent/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -25,16 +25,16 @@ object ConcurrentMapSpec extends ZIOSpecDefault {
         test("computes a new value") {
           for {
             map      <- ConcurrentMap.make(1 -> 100)
-            computed <- map.compute(1, _ + _)
+            computed <- map.compute(1, _ + _.get)
             stored   <- map.get(1)
-          } yield assert(computed)(isSome(equalTo(101))) && assert(computed)(equalTo(stored))
+          } yield assert(computed)(equalTo(101)) && assert(Some(computed))(equalTo(stored))
         },
-        test("returns None if remap produced null (e.g. missing key)") {
+        test("returns new value for a non-existing key") {
           for {
-            map      <- ConcurrentMap.empty[Int, String]
-            computed <- map.compute(1, (_, v) => v)
+            map      <- ConcurrentMap.empty[Int, Int]
+            computed <- map.compute(1, (_, _) => 100)
             stored   <- map.get(1)
-          } yield assert(computed)(isNone) && assert(computed)(equalTo(stored))
+          } yield assert(computed)(equalTo(100)) && assert(Some(computed))(equalTo(stored))
         }
       ),
       suite("computeIfAbsent")(


### PR DESCRIPTION
Make ConcurrentMap.compute consistent with Java implementation.

Fixes #7105.