### PR TITLE
Prevent 2nd TestRunnerJVM instantiation causing a shutdown hook error

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -41,25 +41,26 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
     }
   )
 
-  def done(): String = {
-    shutdownHook.foreach(_.apply())
+  def done(): String =
+    shutdownHook.fold("") { hook =>
+      hook.apply()
 
-    val allSummaries = summaries.get
+      val allSummaries = summaries.get
 
-    val total  = allSummaries.map(_.total).sum
-    val ignore = allSummaries.map(_.ignore).sum
+      val total  = allSummaries.map(_.total).sum
+      val ignore = allSummaries.map(_.ignore).sum
 
-    val compositeSummary =
-      allSummaries.foldLeft(Summary.empty)(_.add(_))
+      val compositeSummary =
+        allSummaries.foldLeft(Summary.empty)(_.add(_))
 
-    val renderedSummary = ConsoleRenderer.renderSummary(compositeSummary)
+      val renderedSummary = ConsoleRenderer.renderSummary(compositeSummary)
 
-    if (allSummaries.isEmpty || total == ignore)
-      s"${Console.YELLOW}No tests were executed${Console.RESET}"
-    else {
-      colored(renderedSummary)
+      if (allSummaries.isEmpty || total == ignore)
+        s"${Console.YELLOW}No tests were executed${Console.RESET}"
+      else {
+        colored(renderedSummary)
+      }
     }
-  }
 
   def tasks(defs: Array[TaskDef]): Array[Task] =
     tasksZ(defs, zio.Console.ConsoleLive)(Trace.empty).toArray


### PR DESCRIPTION
Same effect as the PR submitted by @narma here https://github.com/zio/zio/pull/7107
Just without introducing a 2nd var to track the state of the first.