### PR TITLE
Improve Stack Traces Of Die Failures

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -92,6 +92,20 @@ object StackTracesSpec extends ZIOBaseSpec {
           assert(trace)(containsString("Suppressed: java.lang.RuntimeException: other failure")) &&
           assertTrue(numberOfOccurrences("Suppressed")(trace) == 1)
         }
+      },
+      test("captures a die failure") {
+        val underlyingFailure =
+          ZIO
+            .succeed("ITEM")
+            .map(_ => List.empty.head)
+
+        for {
+          trace <- matchPrettyPrintCause(underlyingFailure)
+        } yield {
+          assertHasExceptionInThreadZioFiber(trace)("java.util.NoSuchElementException: head of empty list") &&
+          assertHasStacktraceFor(trace)("spec.underlyingFailure") &&
+          assertHasStacktraceFor(trace)("matchPrettyPrintCause")
+        }
       }
     )
   ) @@ sequential

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1102,7 +1102,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
           case throwable: Throwable =>
             cur = if (isFatal(throwable)) {
               handleFatalError(throwable)
-            } else Exit.Failure(Cause.die(throwable))
+            } else ZIO.failCause(Cause.die(throwable))(lastTrace)
         }
       }
     }


### PR DESCRIPTION
Resolves #7111.

With this change we go from a stack trace that looks like this:

```
timestamp=2022-07-21T12:50:21.656468272Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-" java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:662)"
```

To one that looks like this:

```
[info] timestamp=2022-07-21T19:44:50.441297Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-6" java.util.NoSuchElementException: head of empty list
[info]  at scala.collection.immutable.Nil$.head(List.scala:662)
[info]  at zio.Example.run(Example.scala:8)"
```