### PR TITLE
Add tapChunks and tests.

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3410,6 +3410,23 @@ object ZStreamSpec extends ZIOBaseSpec {
             )
           }
         ),
+        suite("tapChunks")(
+          test("tapChunks") {
+            for {
+              ref <- Ref.make(Chunk.empty[Chunk[Int]])
+              res <- ZStream.fromChunks(Chunk(1, 1), Chunk(2, 2)).tapChunks[Any, Nothing](as => ref.update(old => old ++ Chunk(as))).runCollect
+              allValues <- ref.get
+            } yield assert(res)(equalTo(Chunk(1, 1, 2, 2))) && assert(allValues)(equalTo(Chunk(Chunk(1, 1), Chunk(2, 2))))
+          },
+          test("preserves chunks") {
+            assertZIO(
+              ZStream(1, 2, 3)
+                .tapChunks(Function.const(ZIO.unit))
+                .chunks
+                .runCollect
+            )(equalTo(Chunk(Chunk(1, 2, 3))))
+          }
+        ),
         suite("tapError")(
           test("tapError") {
             for {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3185,10 +3185,18 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     self >>> ZPipeline.takeWhile(f)
 
   /**
-   * Adds an effect to consumption of every element of the stream.
+   * Adds an effect to consumption of every element of the stream. This destroys the chunk
+   * structure. For a version that preserves the chunks, see [[tapChunks()]].
    */
   def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Any])(implicit trace: Trace): ZStream[R1, E1, A] =
     mapZIO(a => f(a).as(a))
+
+  /**
+   * Adds an effect to consumption of every element of the stream, preserving
+   * the chunk structure.
+   */
+  def tapChunks[R1 <: R, E1 >: E](f: Chunk[A] => ZIO[R1, E1, Any])(implicit trace: Trace): ZStream[R1, E1, A] =
+    mapChunksZIO(a => f(a).as(a))
 
   /**
    * Returns a stream that effectfully "peeks" at the failure of the stream.


### PR DESCRIPTION
This adds a method that taps a Chunk at a time, and preserves the Chunk structure of the ZStream.