### PR TITLE
Implement ZStream#chunksWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -686,11 +686,13 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     mapChunks(Chunk.single)
 
   /**
-    * Performs the specified stream transformation with the chunk structure of
-    * the stream exposed.
-    */
-   def chunksWith[R1, E1, A1](f: ZStream[R, E, Chunk[A]] => ZStream[R1, E1, Chunk[A1]])(implicit trace: Trace): ZStream[R1, E1, A1] =
-     f(self.chunks).flattenChunks
+   * Performs the specified stream transformation with the chunk structure of
+   * the stream exposed.
+   */
+  def chunksWith[R1, E1, A1](f: ZStream[R, E, Chunk[A]] => ZStream[R1, E1, Chunk[A1]])(implicit
+    trace: Trace
+  ): ZStream[R1, E1, A1] =
+    f(self.chunks).flattenChunks
 
   /**
    * Performs a filter and map in a single step.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -686,6 +686,13 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     mapChunks(Chunk.single)
 
   /**
+    * Performs the specified stream transformation with the chunk structure of
+    * the stream exposed.
+    */
+   def chunksWith[R1, E1, A1](f: ZStream[R, E, Chunk[A]] => ZStream[R1, E1, Chunk[A1]])(implicit trace: Trace): ZStream[R1, E1, A1] =
+     f(self.chunks).flattenChunks
+
+  /**
    * Performs a filter and map in a single step.
    */
   def collect[B](f: PartialFunction[A, B])(implicit trace: Trace): ZStream[R, E, B] =


### PR DESCRIPTION
Allows running a stream transformation function with the chunk structure of the stream exposed, so if you want to tap every chunk in the stream you can do `stream.chunksWith(_.tap(f))`. Hopefully this is a more composable alternative to having more chunk variants of stream operators.