### PR TITLE
Documentation: Replace DefaultRunnableSpec with ZIOSpecDefault in zio-test package docs

### DIFF
--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -37,14 +37,13 @@ import scala.language.implicitConversions
  * {{{
  *   import zio.test._
  *   import zio.Clock.nanoTime
- *   import Assertion.isGreaterThan
  *
- *   object MyTest extends DefaultRunnableSpec {
+ *   object MyTest extends ZIOSpecDefault {
  *     def spec = suite("clock")(
  *       test("time is non-zero") {
  *         for {
  *           time <- Live.live(nanoTime)
- *         } yield assertTrue(time >= 0)
+ *         } yield assertTrue(time >= 0L)
  *       }
  *     )
  *   }


### PR DESCRIPTION
[zio-test package docs](https://javadoc.io/doc/dev.zio/zio-test_3/latest/zio/test.html) use the DefaultRunnableSpec which no longer compiles with 2.0.0.

The unused import is also removed and the comparison updated so it compiles (only tested with Scala 3).