### PR TITLE
ZLayer: Memoize FiberRef Values

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -524,6 +524,16 @@ object ZLayerSpec extends ZIOBaseSpec {
         for {
           exit <- ZIO.scoped(combined.build).exit
         } yield assert(exit)(failsCause(containsCause(Cause.fail("fail"))))
+      } @@ nonFlaky,
+      test("fiberRef changes are memoized") {
+        for {
+          fiberRef    <- FiberRef.make(false)
+          layer1       = ZLayer.scoped(fiberRef.locallyScoped(true))
+          layer2       = ZLayer.fromZIO(fiberRef.get)
+          layer3       = layer1 ++ (layer1 >>> layer2)
+          environment <- layer3.build
+          value        = environment.get[Boolean]
+        } yield assertTrue(value)
       } @@ nonFlaky
     )
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3556,6 +3556,14 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.sleep(Duration.fromNanos(Long.MaxValue)) *> ZIO.never
 
   /**
+   * Inherits values from all [[FiberRef]] instances into current fiber.
+   */
+  def inheritFiberRefs(childFiberRefs: FiberRefs)(implicit trace: Trace): UIO[Unit] =
+    ZIO.updateFiberRefs { (parentFiberId, parentFiberRefs) =>
+      parentFiberRefs.joinAs(parentFiberId)(childFiberRefs)
+    }
+
+  /**
    * Returns an effect that is interrupted as if by the fiber calling this
    * method.
    */

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -1717,7 +1717,8 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
                 map.get(layer) match {
                   case Some((acquire, release)) =>
                     val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
-                      .asInstanceOf[IO[E, ZEnvironment[B]]]
+                      .asInstanceOf[IO[E, (ZEnvironment[B], FiberRefs)]]
+                      .flatMap { case (b, fiberRefs) => ZIO.inheritFiberRefs(fiberRefs).as(b) }
                       .onExit {
                         case Exit.Success(_) => scope.addFinalizerExit(release)
                         case Exit.Failure(_) => ZIO.unit
@@ -1727,7 +1728,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
                   case None =>
                     for {
                       observers    <- Ref.make(0)
-                      promise      <- Promise.make[E, ZEnvironment[B]]
+                      promise      <- Promise.make[E, (ZEnvironment[B], FiberRefs)]
                       finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
 
                       resource = ZIO.uninterruptibleMask { restore =>
@@ -1739,13 +1740,13 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
                                        restore(
                                          layer
                                            .scope(innerScope)
-                                           .flatMap(_.apply(self))
+                                           .flatMap(_.apply(self) <*> ZIO.getFiberRefs)
                                        ).exit.flatMap {
                                          case e @ Exit.Failure(cause) =>
                                            promise.failCause(cause) *> innerScope.close(e) *> ZIO
                                              .failCause(cause)
 
-                                         case Exit.Success(b) =>
+                                         case Exit.Success((b, fiberRefs)) =>
                                            for {
                                              _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
                                                     ZIO.whenZIO(observers.modify(n => (n == 1, n - 1)))(
@@ -1755,7 +1756,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
                                              _ <- observers.update(_ + 1)
                                              outerFinalizer <-
                                                outerScope.addFinalizerExit(e => finalizerRef.get.flatMap(_.apply(e)))
-                                             _ <- promise.succeed(b)
+                                             _ <- promise.succeed((b, fiberRefs))
                                            } yield b
                                        }
                                    } yield tp


### PR DESCRIPTION
Resolves zio/zio-logging#481.

This raises an interesting issue. Consider a layer construction pattern like the following:

```scala
layer1 ++ (layer1 >>> layer2)
```

Our natural expectation is that `FiberRef` changes made by `layer1` will be visible to `layer2`. However, since layers are constructed in parallel and memoized it is possible that `layer1` will be constructed on the left hand side and the right hand side will get the memoized value. In this case the `FiberRef` changes described by `layer1` will not be visible to `layer2`.

We can fix this by thinking of the output of every layer as being both a bundle of services and a set of updated `FiberRef` values. Then whenever we get a memoized service we also inherit the changes to `FiberRef` values.