### PR TITLE
Spec layer initialization defects

### DIFF
--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
@@ -1,8 +1,8 @@
 package zio.test.sbt
 
-import sbt.testing.{EventHandler, TaskDef}
+import sbt.testing.{EventHandler, Status, TaskDef}
 import zio.{UIO, ZIO}
-import zio.test.{ExecutionEvent, ZTestEventHandler}
+import zio.test.{ExecutionEvent, TestAnnotation, TestFailure, ZTestEventHandler}
 
 class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends ZTestEventHandler {
   def handle(event: ExecutionEvent): UIO[Unit] =
@@ -12,6 +12,21 @@ class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends
       case ExecutionEvent.SectionStart(_, _, _)      => ZIO.unit
       case ExecutionEvent.SectionEnd(_, _, _)        => ZIO.unit
       case ExecutionEvent.TopLevelFlush(_)           => ZIO.unit
-      case ExecutionEvent.RuntimeFailure(_, _, _, _) => ZIO.unit
+      case ExecutionEvent.RuntimeFailure(id, labelsReversed, failure, ancestors) =>
+        val (e, annotations) = failure match {
+          case TestFailure.Assertion(result, annotations) => ???
+          case TestFailure.Runtime(cause, annotations) => (cause.dieOption, annotations)
+        }
+
+
+        val zTestEvent = ZTestEvent(
+          fullyQualifiedName = taskDef.fullyQualifiedName(),
+          selector = taskDef.selectors().head,
+          status = Status.Failure,
+          maybeThrowable = e,
+          duration = annotations.get(TestAnnotation.timing).toMillis,
+          fingerprint = ZioSpecFingerprint
+        )
+        ZIO.succeed(eventHandler.handle(zTestEvent))
     }
 }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
@@ -26,12 +26,12 @@ class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends
           case TestFailure.Assertion(_, _) => ZIO.unit // Assertion failures all come through Execution.Test path above
           case TestFailure.Runtime(cause, annotations) =>
             val zTestEvent = ZTestEvent(
-              fullyQualifiedName = taskDef.fullyQualifiedName(),
-              selector = taskDef.selectors().head,
-              status = Status.Failure,
-              maybeThrowable = cause.dieOption,
-              duration = annotations.get(TestAnnotation.timing).toMillis,
-              fingerprint = ZioSpecFingerprint
+              taskDef.fullyQualifiedName(),
+              taskDef.selectors().head,
+              Status.Failure,
+              cause.dieOption,
+              annotations.get(TestAnnotation.timing).toMillis,
+              ZioSpecFingerprint
             )
             ZIO.succeed(eventHandler.handle(zTestEvent))
         }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/ZTestEventHandlerSbt.scala
@@ -9,15 +9,14 @@ class ZTestEventHandlerSbt(eventHandler: EventHandler, taskDef: TaskDef) extends
     event match {
       case evt @ ExecutionEvent.Test(_, _, _, _, _, _) =>
         ZIO.succeed(eventHandler.handle(ZTestEvent.convertEvent(evt, taskDef)))
-      case ExecutionEvent.SectionStart(_, _, _)      => ZIO.unit
-      case ExecutionEvent.SectionEnd(_, _, _)        => ZIO.unit
-      case ExecutionEvent.TopLevelFlush(_)           => ZIO.unit
+      case ExecutionEvent.SectionStart(_, _, _) => ZIO.unit
+      case ExecutionEvent.SectionEnd(_, _, _)   => ZIO.unit
+      case ExecutionEvent.TopLevelFlush(_)      => ZIO.unit
       case ExecutionEvent.RuntimeFailure(id, labelsReversed, failure, ancestors) =>
         val (e, annotations) = failure match {
           case TestFailure.Assertion(result, annotations) => ???
-          case TestFailure.Runtime(cause, annotations) => (cause.dieOption, annotations)
+          case TestFailure.Runtime(cause, annotations)    => (cause.dieOption, annotations)
         }
-
 
         val zTestEvent = ZTestEvent(
           fullyQualifiedName = taskDef.fullyQualifiedName(),

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -47,7 +47,7 @@ object TestExecutor {
           _ <- {
             def processEvent(
               event: ExecutionEvent
-                           ) =
+            ) =
               summary.update(
                 _.add(event)
               ) *>
@@ -56,8 +56,8 @@ object TestExecutor {
                 ) *> eventHandlerZ.handle(event)
 
             def loop(
-                      labels: List[String],
-                      spec: Spec[Scope, E],
+              labels: List[String],
+              spec: Spec[Scope, E],
               exec: ExecutionStrategy,
               ancestors: List[SuiteId],
               sectionId: SuiteId
@@ -105,8 +105,8 @@ object TestExecutor {
                       test,
                       staticAnnotations: TestAnnotationMap
                     ) => {
-                  val testResultZ  = (for {
-                    result <- ZIO.withClock(ClockLive)(test.timed.either)
+                  val testResultZ = (for {
+                    result  <- ZIO.withClock(ClockLive)(test.timed.either)
                     duration = result.map(_._1.toMillis).fold(_ => 1L, identity)
                     event =
                       ExecutionEvent
@@ -118,15 +118,14 @@ object TestExecutor {
                           duration,
                           sectionId
                         )
-                  } yield event)
-                    .catchAllCause { e =>
+                  } yield event).catchAllCause { e =>
                     val event = ExecutionEvent.RuntimeFailure(sectionId, labels, TestFailure.Runtime(e), ancestors)
                     ConsoleRenderer.render(e, labels).foreach(cr => println("CR: " + cr))
                     ZIO.succeed(event)
                   }
                   for {
                     testResult <- testResultZ
-                    _ <- processEvent(testResult)
+                    _          <- processEvent(testResult)
                   } yield ()
                 }
               }

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -153,7 +153,7 @@ object TestExecutor {
               loop(List.empty, scopedSpec, defExec, List.empty, topParent)
             } *> processEvent(topLevelFlush)
           }
-          summary <- summary.get // .debug("Summary at end of Test execution")
+          summary <- summary.get
         } yield summary).provideLayer(sinkLayer)
 
       private def extractAnnotations(result: Either[TestFailure[E], TestSuccess]) =


### PR DESCRIPTION
Fixes #7141 

Also de-dup some of the `ExecutionEvent` processing by adding a small helper in `TestExecutor`

Before, falsely reporting success to SBT:
<img width="1390" alt="Screen Shot 2022-07-28 at 4 11 31 PM" src="https://user-images.githubusercontent.com/2054940/181647031-56c986bd-4eef-4c9f-92b0-3147fb6adee0.png">


After, correctly reporting failure to SBT:
<img width="1390" alt="Screen Shot 2022-07-28 at 4 12 07 PM" src="https://user-images.githubusercontent.com/2054940/181647080-5f9c3129-4b66-41ab-865e-9cea69a6d175.png">

