### PR TITLE
Apply Fork Patch When A Fiber Is Unsafely Forked

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -111,7 +111,7 @@ trait Runtime[+R] { self =>
 
       val fiberId   = FiberId.make(trace)
       val fiberRefs = self.fiberRefs.updatedAs(fiberId)(FiberRef.currentEnvironment, environment)
-      val fiber     = FiberRuntime[E, A](fiberId, fiberRefs, runtimeFlags)
+      val fiber     = FiberRuntime[E, A](fiberId, fiberRefs.forkAs(fiberId), runtimeFlags)
 
       val supervisor = fiber.getSupervisor()
 
@@ -140,7 +140,7 @@ trait Runtime[+R] { self =>
 
       val fiberId   = FiberId.make(trace)
       val fiberRefs = self.fiberRefs.updatedAs(fiberId)(FiberRef.currentEnvironment, environment)
-      val fiber     = FiberRuntime[E, A](fiberId, fiberRefs, runtimeFlags)
+      val fiber     = FiberRuntime[E, A](fiberId, fiberRefs.forkAs(fiberId), runtimeFlags)
 
       FiberScope.global.add(runtimeFlags, fiber)
 


### PR DESCRIPTION
Currently when we fork a new fiber using `Runtime.unsafe.run` or `Runtime.unsafe.fork` we give that fiber the `FiberRefs` in the `Runtime`. However, we should actually apply the fork patch to the fibers in the `Runtime` since we are forking a new fiber.

This can be an issue if for example we create a `Runtime` in a `ZIO` workflow where the `forkScopeOverride` is set. In this case the fibers forked by the `Runtime` would inherit the `forkScopeOverride` of the region they are created in instead of having it set to `None` per the `fork` logic of the `FiberRef`. This can result in unexpected behavior if the children of the fibers forked in the new runtime are then terminated prematurely when the fiber that created the runtime ends life.