### PR TITLE
Handle Very Large Collections In ZStream.fromIterable

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4722,9 +4722,19 @@ object ZStreamSpec extends ZIOBaseSpec {
           def lazyL = l
           assertZIO(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))
         }),
+        test("fromIterable is safe with very large collections") {
+          for {
+            _ <- ZStream.fromIterable(1 to 5000000).runDrain
+          } yield assertCompletes
+        },
         test("fromIterableZIO")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           assertZIO(ZStream.fromIterableZIO(ZIO.succeed(l)).runCollect)(equalTo(l))
         }),
+        test("fromIterableZIO is safe with very large collections") {
+          for {
+            _ <- ZStream.fromIterableZIO(ZIO.succeed(1 to 5000000)).runDrain
+          } yield assertCompletes
+        },
         test("fromIterator") {
           check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
             assertZIO(ZStream.fromIterator(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))


### PR DESCRIPTION
`ZStream.fromIterable` is a little tricky because most of the time the collection is a `Chunk` that we can just put into a stream but the collection could potentially be infinite or even if it is finite it could use a "sparse" representation like a `Range` where converting it to a "dense" representation of its values could exceed system resources. We can continue just putting `Chunk` values into the stream to optimize the fast path while otherwise going through `fromIterator` for safety.