### PR TITLE
Doc: Fix typo in the ZLayer document

### DIFF
--- a/docs/reference/contextual/zlayer.md
+++ b/docs/reference/contextual/zlayer.md
@@ -100,7 +100,7 @@ object EmailService {
 
 Some components of our applications need to be scoped, meaning they undergo a resource acquisition phase before usage, and a resource release phase after usage (e.g. when the application shuts down). As we stated before, the construction of ZIO layers can be effectful and resourceful, this means they can be acquired and safely released when the services are done being utilized.
 
-The `ZLayer` relies on the powerful `Scope` data type and this makes this process extremely simple. We can lift any scoped `ZIO` to `ZLayer` by providing a scoped resource to the `ZLayer.apply` constructor:
+The `ZLayer` relies on the powerful `Scope` data type and this makes this process extremely simple. We can lift any scoped `ZIO` to `ZLayer` by providing a scoped resource to the `ZLayer.scoped` constructor:
 
 ```scala mdoc:silent:nest
 import zio._
@@ -149,7 +149,7 @@ def scoped: ZIO[Scope, Throwable, UserRepository] =
   } yield new UserRepositoryLive(xa)
 ```
 
-We can convert that to `ZLayer` with `ZLayer.apply`:
+We can convert that to `ZLayer` with `ZLayer.scoped`:
 
 ```scala mdoc:nest
 val usersLayer : ZLayer[Any, Throwable, UserRepository] =


### PR DESCRIPTION
There is a typo in the description of the `scoped` constructor in the `ZLayer` doc page.
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/22493821/182388375-34df6c34-310c-497d-a9f3-51dd10098b25.png">
It should  be "ZLayer.scoped" actually.