### PR TITLE
Preserve Uninterruptibility in ZIO#timeout

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -941,6 +941,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                     else Exit.Success(value)
                   } catch {
                     case zioError: ZIOError =>
+                      runtimeFlags = patchRuntimeFlags(runtimeFlags, revertFlags)
                       Exit.Failure(zioError.cause)
 
                     case reifyStack: ReifyStack =>


### PR DESCRIPTION
Resolves #7170.

If the run loop throws an error, for example due to interruption, we need to revert the runtime flags.