### PR TITLE
Align Traces

### DIFF
--- a/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Macros.scala
+++ b/stacktracer/shared/src/main/scala-3/zio/internal/stacktracer/Macros.scala
@@ -22,9 +22,9 @@ object Macros {
 
     val location = {
       def loop(current: Symbol, acc: List[String] = Nil): List[String] = {
-        val currentName = current.name.toString.trim
+        val currentName = current.name.trim.stripSuffix("$")
         if (currentName != "<root>")
-          loop(current.owner, if (currentName == "$anonfun") acc else currentName :: acc)
+          loop(current.owner, if (currentName == "$anonfun" || currentName == "macro") acc else currentName :: acc)
         else acc
       }
 


### PR DESCRIPTION
Removes a `macro` and `$` that could appear in traces on Scala 3 so that traces look the same on both Scala versions.