### PR TITLE
ZIO Website: Add GTag Support

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -140,6 +140,10 @@ const config = {
           trackingID: 'UA-237088290-2',
           anonymizeIP: true,
         },
+        gtag: {
+          trackingID: 'G-SH0HNKLNRT',
+          anonymizeIP: true,
+        },
       },
     ],
   ],


### PR DESCRIPTION
While UA (google universal analytics) support of Docusaurus doesn't track all events on our SPA site, I'm trying to use gtags. plugin-google-gtag sends new events on [every page click](https://github.com/facebook/docusaurus/pull/3243/files).