### PR TITLE
Update 'Running Effects' documentation

### DIFF
--- a/docs/overview/running_effects.md
+++ b/docs/overview/running_effects.md
@@ -49,7 +49,7 @@ val runtime = Runtime.default
 Once you have a runtime, you can use it to execute effects:
 
 ```scala mdoc:silent
-Unsafe.unsafe { implicit unsafe =>
+Unsafe.unsafeCompat { implicit unsafe =>
     runtime.unsafe.run(ZIO.attempt(println("Hello World!"))).getOrThrowFiberFailure()
 }
 ```


### PR DESCRIPTION
Calling `Unsafe.unsafe` gives a 'Missing parameter type' compile error. Calling `Unsafe.unsafeCompat` works as intended.