### PR TITLE
Fix unsafeCompat deprecated since version

### DIFF
--- a/core/shared/src/main/scala/zio/Unsafe.scala
+++ b/core/shared/src/main/scala/zio/Unsafe.scala
@@ -36,7 +36,7 @@ object Unsafe extends UnsafeVersionSpecific {
   def unsafe[A](f: Unsafe => A): A =
     f(unsafe)
 
-  @deprecated("use unsafe", "2.0.0")
+  @deprecated("use unsafe", "2.0.1")
   def unsafeCompat[A](f: Unsafe => A): A =
     f(unsafe)
 }

--- a/core/shared/src/main/scala/zio/Unsafe.scala
+++ b/core/shared/src/main/scala/zio/Unsafe.scala
@@ -36,7 +36,7 @@ object Unsafe extends UnsafeVersionSpecific {
   def unsafe[A](f: Unsafe => A): A =
     f(unsafe)
 
-  @deprecated("use unsafe", "3.0.0")
+  @deprecated("use unsafe", "2.0.0")
   def unsafeCompat[A](f: Unsafe => A): A =
     f(unsafe)
 }


### PR DESCRIPTION
Unless I'm _completely_ out of the loop, I don't think we've dropped ZIO 3 yet 🙂 