### PR TITLE
Add possibility to ignore tags

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -57,6 +57,8 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
         colored(renderedSummary)
       else if (ignore > 0)
         s"${Console.YELLOW}All eligible tests are currently ignored ${Console.RESET}"
+      else if (total == 0)
+        s"${Console.YELLOW}No tests were executed${Console.RESET}"
 
     // We eagerly print out the info here, rather than returning it
     // from this function as a workaround for this bug when running

--- a/test/shared/src/main/scala/zio/test/FilteredSpec.scala
+++ b/test/shared/src/main/scala/zio/test/FilteredSpec.scala
@@ -27,21 +27,23 @@ private[zio] object FilteredSpec {
 
   def apply[R, E](spec: Spec[R, E], args: TestArgs)(implicit trace: Trace): Spec[R, E] = {
     val testSearchedSpec = args.testSearchTerms match {
-      case Nil             => spec
-      case testSearchTerms => spec.filterTags(testSearchTerms.contains(_)).getOrElse(Spec.empty)
+      case Nil => spec
+      case testSearchTerms =>
+        spec.filterLabels(label => testSearchTerms.exists(term => label.contains(term))).getOrElse(Spec.empty)
     }
-    val tagSearchedSpec = args.tagSearchTerms match {
+    val tagIgnoredSpec = args.tagIgnoreTerms match {
       case Nil => testSearchedSpec
-      case tagSearchTerms =>
+      case tagIgnoreTerms =>
         testSearchedSpec
-          .filterLabels(label => tagSearchTerms.exists(term => label.contains(term)))
+          .filterNotTags(tag => tagIgnoreTerms.contains(tag))
           .getOrElse(Spec.empty)
     }
-    args.tagIgnoreTerms match {
-      case Nil => tagSearchedSpec
-      case tagIgnoreTerms =>
-        tagSearchedSpec
-          .filterLabels(label => !tagIgnoreTerms.exists(term => label.contains(term)))
+
+    args.tagSearchTerms match {
+      case Nil => tagIgnoredSpec
+      case tagSearchTerms =>
+        tagIgnoredSpec
+          .filterTags(tag => tagSearchTerms.contains(tag))
           .getOrElse(Spec.empty)
     }
   }

--- a/test/shared/src/main/scala/zio/test/FilteredSpec.scala
+++ b/test/shared/src/main/scala/zio/test/FilteredSpec.scala
@@ -37,14 +37,12 @@ private[zio] object FilteredSpec {
           .filterLabels(label => tagSearchTerms.exists(term => label.contains(term)))
           .getOrElse(Spec.empty)
     }
-    val tagIgnoredSpec = args.tagIgnoreTerms match {
+    args.tagIgnoreTerms match {
       case Nil => tagSearchedSpec
       case tagIgnoreTerms =>
         tagSearchedSpec
           .filterLabels(label => !tagIgnoreTerms.exists(term => label.contains(term)))
           .getOrElse(Spec.empty)
     }
-
-    tagIgnoredSpec
   }
 }

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -138,6 +138,15 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
     filterAnnotations(TestAnnotation.tagged)(_.exists(f))
 
   /**
+   * Returns a new spec with only those suites and tests except for the ones
+   * with tags satisfying the predicate. If all tests or suites have tags that
+   * satisfy the specified predicate then returns `Some` with an empty suite
+   * with the root label if this is a suite or `None` otherwise.
+   */
+  final def filterNotTags(f: String => Boolean)(implicit trace: Trace): Option[Spec[R, E]] =
+    filterAnnotations(TestAnnotation.tagged)(!_.exists(f))
+
+  /**
    * Effectfully folds over all nodes according to the execution strategy of
    * suites, utilizing the specified default for other cases.
    */

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -28,7 +28,8 @@ final case class TestArgs(
 )
 
 object TestArgs {
-  def empty: TestArgs = TestArgs(List.empty[String], List.empty[String], None, None, printSummary = true)
+  def empty: TestArgs =
+    TestArgs(List.empty[String], List.empty[String], List.empty[String], None, None, printSummary = true)
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -21,6 +21,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 final case class TestArgs(
   testSearchTerms: List[String],
   tagSearchTerms: List[String],
+  tagIgnoreTerms: List[String],
   testTaskPolicy: Option[String],
   testRenderer: Option[String],
   printSummary: Boolean
@@ -34,11 +35,12 @@ object TestArgs {
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term)        => ("testSearchTerm", term)
-        case Array("-tags", term)     => ("tagSearchTerm", term)
-        case Array("-policy", name)   => ("policy", name)
-        case Array("-renderer", name) => ("renderer", name)
-        case Array("-summary", flag)  => ("summary", flag)
+        case Array("-t", term)           => ("testSearchTerm", term)
+        case Array("-tags", term)        => ("tagSearchTerm", term)
+        case Array("-ignore-tags", term) => ("tagIgnoreTerm", term)
+        case Array("-policy", name)      => ("policy", name)
+        case Array("-renderer", name)    => ("renderer", name)
+        case Array("-summary", flag)     => ("summary", flag)
       }
       .toList
       .groupBy(_._1)
@@ -48,9 +50,10 @@ object TestArgs {
 
     val terms          = parsedArgs.getOrElse("testSearchTerm", Nil)
     val tags           = parsedArgs.getOrElse("tagSearchTerm", Nil)
+    val ignoreTags     = parsedArgs.getOrElse("tagIgnoreTerm", Nil)
     val testTaskPolicy = parsedArgs.getOrElse("policy", Nil).headOption
     val testRenderer   = parsedArgs.getOrElse("renderer", Nil).headOption.map(_.toLowerCase)
     val printSummary   = parsedArgs.getOrElse("summary", Nil).headOption.forall(_.toBoolean)
-    TestArgs(terms, tags, testTaskPolicy, testRenderer, printSummary)
+    TestArgs(terms, tags, ignoreTags, testTaskPolicy, testRenderer, printSummary)
   }
 }


### PR DESCRIPTION
This should add a possibility to ignore specified tags as proposed in https://github.com/zio/zio/issues/7232.

I've modified slightly code to avoid having 9 different cases. Will test tomorrow morning and mark ready for review if works correctly.

I've also modified slightly a reporting code since currently if none of the test fulfill the requirements passed by `-t`, `-tags` or `-ignore-tags` we will just print `()`, which isn't too informative.