### PR TITLE
Make pure streams interruptible fixes #7240

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -956,7 +956,7 @@ private[zio] object ChannelExecutor {
           case r2 @ ChannelState.Read(upstream2, onEffect2, onEmit2, onDone2) =>
             readStack.push(current.asInstanceOf[ChannelState.Read[Any, Any]])
             readStack.push(r2.asInstanceOf[ChannelState.Read[Any, Any]])
-            read()
+            ZIO.unit *> read()
         }
       }
     }


### PR DESCRIPTION
Pure streams can now be interrupted. I had one test fail intermittently, but this is the case on the current series/2.x branch, so I'm going to say not my problem (raised #7277)