### PR TITLE
Implement Unsafe.unsafely

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
+++ b/core-tests/shared/src/test/scala-3/zio/UnsafeSpecVersionSpecific.scala
@@ -5,15 +5,21 @@ import zio.test._
 object UnsafeSpecVersionSpecific extends ZIOSpecDefault {
 
   def spec = suite("UnsafeSpecVersionSpecific") {
-    suite("unsafe")(
+    suite("unsafely")(
       test("provides capability to method with implicit parameter") {
-        Unsafe.unsafe(doSomethingUnsafe())
+        Unsafe.unsafely(doSomethingUnsafe())
         assertCompletes
       },
       test("provides capability to implicit function") {
         def succeed[A](block: Unsafe ?=> A): ZIO[Any, Nothing, A] =
-          ZIO.succeed(Unsafe.unsafe(block))
+          ZIO.succeed(Unsafe.unsafely(block))
         assertCompletes
+      },
+      test("provides capability to implicit function with multiple parameters") {
+        val result = Unsafe.unsafely {
+          Runtime.default.unsafe.run(ZIO.succeed(42)).getOrThrowFiberFailure()
+        }
+        assertTrue(result == 42)
       }
     )
   }

--- a/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/UnsafeVersionSpecific.scala
@@ -16,6 +16,10 @@
 package zio 
 
 private[zio] trait UnsafeVersionSpecific { self =>
+
+  def unsafely[A](f: Unsafe ?=> A): A =
+    f(using Unsafe.unsafe)
+
   implicit def implicitFunctionIsFunction[A](f: Unsafe ?=> A): Unsafe => A =
     unsafe => {
       given Unsafe = unsafe

--- a/docs/guides/migrate/migration-guide.md
+++ b/docs/guides/migrate/migration-guide.md
@@ -821,15 +821,15 @@ object MainApp {
 
 This way it is easy to distinguish between _safe_ and _unsafe_ variants of the same operator. 
 
-To run an unsafe operator, we need implicit value of `Unsafe` in scope. This works particularly well in Scala 3 due to its support for implicit function types championed by Martin Odersky. In Scala 3 we can use the `Unsafe.unsafe` operator to create a block of code in which we can freely call unsafe operators:
+To run an unsafe operator, we need implicit value of `Unsafe` in scope. This works particularly well in Scala 3 due to its support for implicit function types championed by Martin Odersky. In Scala 3 we can use the `Unsafe.unsafely` operator to create a block of code in which we can freely call unsafe operators:
 
 ```scala
-Unsafe.unsafe {
+Unsafe.unsafely {
   Runtime.default.unsafe.run(Console.printLine("Hello, World!"))
 }
 ```
 
-If we want to support Scala 2 we need to use a slightly more verbose syntax:
+If we want to support Scala 2 we need to use a slightly more verbose syntax with `unsafe` and a lambda that takes an implicit value of `Unsafe`:
 
 ```scala mdoc:compile-only
 import zio._
@@ -844,7 +844,7 @@ In summary, here are the rules for migrating from ZIO 1.x to ZIO 2.x correspondi
 |         | ZIO 1.0                | ZIO 2.x                                                                               |
 |---------|------------------------|---------------------------------------------------------------------------------------|
 | Scala 2 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { implicit unsafe => runtime.unsafe.run(x).getOrThrowFiberFailure() }` |
-| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafe { runtime.unsafe.run(x).getOrThrowFiberFailure() }`                    |
+| Scala 3 | `runtime.unsafeRun(x)` | `Unsafe.unsafely { runtime.unsafe.run(x).getOrThrowFiberFailure() }`                    |
 
 ### Unsafe Variants
 


### PR DESCRIPTION
Resolves #7237.

While the implicit conversion from a function to a context function works with `Unsafe.unsafe` in simple cases, it can break down in more complex cases.

By adding an `unsafely` operator that accepts a context function directly we can let early adopters of Scala 3 take advantage of all the context function goodness without requiring changes to code from existing users.