### PR TITLE
Use Parent Value On Join In Fork Scope Override

### DIFF
--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -481,7 +481,7 @@ object FiberRef {
   }
 
   private[zio] val forkScopeOverride: FiberRef[Option[FiberScope]] =
-    FiberRef.unsafe.make[Option[FiberScope]](None, _ => None)(Unsafe.unsafe) // Do not inherit on `fork`
+    FiberRef.unsafe.make[Option[FiberScope]](None, _ => None, (parent, _) => parent)(Unsafe.unsafe)
 
   private[zio] val overrideExecutor: FiberRef[Option[Executor]] =
     FiberRef.unsafe.make[Option[Executor]](None)(Unsafe.unsafe)


### PR DESCRIPTION
Resolves #7288.

I think when we join a child fiber we should use the parent value here rather than the child value. An easy way to think about this is that using the child value violates fork join identity because when we fork the child we fork it without a fork scope override so if we join it back and use the child's value we lose the override.