### PR TITLE
fix interruptAll to interrupt all fibers before waiting

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -802,7 +802,7 @@ object Fiber extends FiberPlatformSpecific {
    *   `UIO[Unit]`
    */
   def interruptAllAs(fiberId: Fiber.Id)(fs: Iterable[Fiber[Any, Any]]): UIO[Unit] =
-    fs.foldLeft(IO.unit)((io, f) => io <* f.interruptAs(fiberId))
+    ZIO.foreach(fs)(_.interruptAs(fiberId).fork).flatMap(fs => ZIO.foreach_(fs)(_.await))
 
   /**
    * A fiber that is already interrupted.


### PR DESCRIPTION
interruptAll can have interdependencies between the fibers, trying to interrupt in order might cause a deadlock.

fixes #https://github.com/zio/zio/issues/7293