### PR TITLE
Interrupt Fibers In Parallel in Fiber#interruptAll

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -776,7 +776,7 @@ object Fiber extends FiberPlatformSpecific {
    *   `UIO[Unit]`
    */
   def interruptAllAs(fiberId: FiberId)(fs: Iterable[Fiber[Any, Any]])(implicit trace: Trace): UIO[Unit] =
-    fs.foldLeft(ZIO.unit)((io, f) => io <* f.interruptAs(fiberId))
+    ZIO.foreachDiscard(fs)(_.interruptAsFork(fiberId)) *> ZIO.foreachDiscard(fs)(_.await)
 
   /**
    * A fiber that is already interrupted.


### PR DESCRIPTION
This mirrors the behavior of a fiber interrupting its children and handles the case where the completion of finalization by one fiber that is interrupted depends on another fiber that is also being interrupted.