### PR TITLE
Categorize console io in tests

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ConsoleSpec.scala
@@ -60,6 +60,18 @@ object ConsoleSpec extends ZIOBaseSpec {
           assert(input2)(equalTo("Input 2"))
         }
       },
+      test("does both") {
+        for {
+          _      <- feedLines("Input 1", "Input 2")
+          input1 <- readLine
+          _ <- printLine("Hi there")
+          input2 <- readLine
+          _ <- printLine("Hey")
+        } yield {
+          assert(input1)(equalTo("Input 1")) &&
+            assert(input2)(equalTo("Input X"))
+        }
+      },
       test("clears lines from input") {
         for {
           _      <- feedLines("Input 1", "Input 2")

--- a/test-tests/shared/src/test/scala/zio/test/ConsoleSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ConsoleSpec.scala
@@ -60,18 +60,6 @@ object ConsoleSpec extends ZIOBaseSpec {
           assert(input2)(equalTo("Input 2"))
         }
       },
-      test("does both") {
-        for {
-          _      <- feedLines("Input 1", "Input 2")
-          input1 <- readLine
-          _ <- printLine("Hi there")
-          input2 <- readLine
-          _ <- printLine("Hey")
-        } yield {
-          assert(input1)(equalTo("Input 1")) &&
-            assert(input2)(equalTo("Input X"))
-        }
-      },
       test("clears lines from input") {
         for {
           _      <- feedLines("Input 1", "Input 2")

--- a/test/shared/src/main/scala/zio/test/ConsoleIO.scala
+++ b/test/shared/src/main/scala/zio/test/ConsoleIO.scala
@@ -1,6 +1,7 @@
 package zio.test
 
-sealed trait ConsoleIO
-
-case class ConsoleInput(line: String) extends ConsoleIO
-case class ConsoleOutput(line: String) extends ConsoleIO
+private[test] sealed trait ConsoleIO
+private[test] object ConsoleIO {
+  case class Input(line: String)  extends ConsoleIO
+  case class Output(line: String) extends ConsoleIO
+}

--- a/test/shared/src/main/scala/zio/test/ConsoleIO.scala
+++ b/test/shared/src/main/scala/zio/test/ConsoleIO.scala
@@ -1,0 +1,6 @@
+package zio.test
+
+sealed trait ConsoleIO
+
+case class ConsoleInput(line: String) extends ConsoleIO
+case class ConsoleOutput(line: String) extends ConsoleIO

--- a/test/shared/src/main/scala/zio/test/TestAnnotation.scala
+++ b/test/shared/src/main/scala/zio/test/TestAnnotation.scala
@@ -57,7 +57,7 @@ object TestAnnotation {
   /**
    * An annotation which tracks output produced by a test.
    */
-  val output: TestAnnotation[Chunk[String]] =
+  val output: TestAnnotation[Chunk[ConsoleIO]] =
     TestAnnotation("output", Chunk.empty, _ ++ _)
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -120,7 +120,7 @@ object TestConsole extends Serializable {
      */
     def readLine(implicit trace: Trace): IO[IOException, String] =
       ZIO.attempt(unsafe.readLine()(Unsafe.unsafe)).refineToOrDie[IOException].tap { line =>
-        annotations.annotate(TestAnnotation.output, Chunk(ConsoleInput(line)))
+        annotations.annotate(TestAnnotation.output, Chunk(ConsoleIO.Input(line)))
       }
 
     /**
@@ -156,7 +156,7 @@ object TestConsole extends Serializable {
      * character.
      */
     override def printLine(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      annotations.annotate(TestAnnotation.output, Chunk(ConsoleOutput(line.toString))) *>
+      annotations.annotate(TestAnnotation.output, Chunk(ConsoleIO.Output(line.toString))) *>
         ZIO.succeed(unsafe.printLine(line)(Unsafe.unsafe)) *>
         live.provide(Console.printLine(line)).whenZIO(debugState.get).unit
 

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -120,7 +120,7 @@ object TestConsole extends Serializable {
      */
     def readLine(implicit trace: Trace): IO[IOException, String] =
       ZIO.attempt(unsafe.readLine()(Unsafe.unsafe)).refineToOrDie[IOException].tap { line =>
-        annotations.annotate(TestAnnotation.output, Chunk(line))
+        annotations.annotate(TestAnnotation.output, Chunk(ConsoleInput(line)))
       }
 
     /**
@@ -156,7 +156,7 @@ object TestConsole extends Serializable {
      * character.
      */
     override def printLine(line: => Any)(implicit trace: Trace): IO[IOException, Unit] =
-      annotations.annotate(TestAnnotation.output, Chunk(line.toString)) *>
+      annotations.annotate(TestAnnotation.output, Chunk(ConsoleOutput(line.toString))) *>
         ZIO.succeed(unsafe.printLine(line)(Unsafe.unsafe)) *>
         live.provide(Console.printLine(line)).whenZIO(debugState.get).unit
 

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -114,19 +114,25 @@ trait ConsoleRenderer extends TestRenderer {
       renderToStringLines(output ++ renderedAnnotations).mkString
     }
 
-  private def renderOutput(output: List[String]): Message =
+  private def renderOutput(output: List[ConsoleIO]): Message =
     if (output.isEmpty)
       Message.empty
     else
       Message(
-        Line.fromString("          Output Produced by Test         ".red.underlined, 2) +:
-          output.map(s => Line.fromString("| ".red + s.yellow, 2)) :+
-          Line.fromString("==========================================\n".red, 2)
+        Line.fromString("          Console IO Produced by Test         ".red.underlined, 2) +:
+          output.map(s => Line.fromString("| ".red + renderConsoleIO(s), 2)) :+
+          Line.fromString("==============================================\n".red, 2)
       )
+
+  private def renderConsoleIO(s: ConsoleIO) =
+    s match {
+      case ConsoleInput(line) => line.cyan
+      case ConsoleOutput(line) => line.yellow
+    }
 
   def renderForSummary(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String] =
     results.map { result =>
-      val testOutput: List[String] = result.annotations.flatMap(_.get(TestAnnotation.output))
+      val testOutput: List[ConsoleIO] = result.annotations.flatMap(_.get(TestAnnotation.output))
       val message                  = (Message(result.summaryLines) ++ renderOutput(testOutput)).intersperse(Line.fromString("\n"))
 
       val output = result.resultType match {

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -126,14 +126,14 @@ trait ConsoleRenderer extends TestRenderer {
 
   private def renderConsoleIO(s: ConsoleIO) =
     s match {
-      case ConsoleInput(line) => line.cyan
-      case ConsoleOutput(line) => line.yellow
+      case ConsoleIO.Input(line)  => line.magenta
+      case ConsoleIO.Output(line) => line.yellow
     }
 
   def renderForSummary(results: Seq[ExecutionResult], testAnnotationRenderer: TestAnnotationRenderer): Seq[String] =
     results.map { result =>
       val testOutput: List[ConsoleIO] = result.annotations.flatMap(_.get(TestAnnotation.output))
-      val message                  = (Message(result.summaryLines) ++ renderOutput(testOutput)).intersperse(Line.fromString("\n"))
+      val message                     = (Message(result.summaryLines) ++ renderOutput(testOutput)).intersperse(Line.fromString("\n"))
 
       val output = result.resultType match {
         case ResultType.Suite =>


### PR DESCRIPTION
Looks like this:

<img width="1328" alt="Screen Shot 2022-09-01 at 7 09 17 AM" src="https://user-images.githubusercontent.com/2054940/187923972-26ee50b6-51be-4628-a435-ebadf1ab03d3.png">


Note - this currently does give colorblind people a way to distinguish Input from Output.

We might want to augment the colors with some symbolic prefix, eg:
```
> Output1
< Input 1
> Output2
```
```
I:  Output1
O: Input 1
I:  Output2
```
but I haven't thought of anything that's very clear & terse.