### PR TITLE
Add a Scala 3 macro to derive simple layers based on case classes

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ZLayerDerivationSpec.scala
@@ -1,0 +1,28 @@
+package zio
+
+import zio.test._
+
+object ZLayerDerivationSpec extends ZIOSpecDefault {
+  case class OneDependency(d1: String)
+  case class TwoDependencies(d1: String, d2: Int)
+
+  val derivedOne = ZLayer.derive[OneDependency]
+  val derivedTwo = ZLayer.derive[TwoDependencies]
+  override def spec = suite("ZLayerDerivationSpec")(
+    test("ZLayer.derive[OneDependency]") {
+      for {
+        d1 <- ZIO.service[OneDependency]
+      } yield assertTrue(d1 == OneDependency("one"))
+    },
+    test("ZLayer.derive[TwoDependencies]") {
+      for {
+        d1 <- ZIO.service[TwoDependencies]
+      } yield assertTrue(d1 == TwoDependencies("one", 2))
+    }
+  ).provide(
+    derivedOne,
+    derivedTwo,
+    ZLayer.succeed("one"),
+    ZLayer.succeed(2)
+  )
+}

--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -47,7 +47,7 @@ trait ZLayerCompanionVersionSpecific {
    * case class Car(engine: Engine, wheels: Wheels)
    * val derivedLayer: ZLayer[Engine & Wheels, Nothing, Car] = ZLayer.deriveLayer[Car]
    * // equivalent to:
-   * val manualLayer: ZLayer[Engine with Wheels, Nothing, Car] =
+   * val manualLayer: ZLayer[Engine & Wheels, Nothing, Car] =
    *   ZLayer.fromFunction(Car(_, _))
    * }}}
    *

--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -1,7 +1,9 @@
 package zio
 
 import zio.internal.macros.LayerMacros
+import zio.internal.macros.LayerMacroUtils
 import zio.internal.macros.ProvideMethod
+import scala.deriving._
 
 final class WirePartiallyApplied[R](val dummy: Boolean = true) extends AnyVal {
   inline def apply[E](inline layer: ZLayer[_, E, _]*): ZLayer[Any, E, R] =
@@ -38,4 +40,20 @@ trait ZLayerCompanionVersionSpecific {
    */
   def makeSome[R0, R] =
     new WireSomePartiallyApplied[R0, R]
+
+  /**
+   * Derives a simple layer for a case class given as a type parameter.
+   * {{{
+   * case class Car(engine: Engine, wheels: Wheels)
+   * val derivedLayer: ZLayer[Engine & Wheels, Nothing, Car] = ZLayer.deriveLayer[Car]
+   * // equivalent to:
+   * val manualLayer: ZLayer[Engine with Wheels, Nothing, Car] =
+   *   ZLayer.fromFunction(Car(_, _))
+   * }}}
+   *
+   */
+   inline def derive[A](
+    using inline m: Mirror.ProductOf[A]
+  ): URLayer[LayerMacroUtils.Env[m.MirroredElemTypes], A] =
+    LayerMacroUtils.genLayer[m.MirroredElemTypes, A]
 }

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -122,4 +122,69 @@ private [zio] object LayerMacroUtils {
 
     loop(TypeRepr.of[T])
   }
+
+  type Env[Elems] =
+    Elems match {
+    case t *: EmptyTuple => t
+    case t *: rest => t & Env[rest]
+  }
+
+  inline def genLayer[T <: Tuple, A]: URLayer[Env[T], A] =
+    ${ genLayerImpl[T, A] }
+
+  def genLayerImpl[T <: Tuple: Type, A: Type](using ctx: Quotes): Expr[URLayer[Env[T], A]] = {
+    import ctx.reflect.*
+    val clsSymbol = TypeRepr.of[A].classSymbol.get
+
+    if clsSymbol.flags.is(Flags.Case) then deriveLayer[T, A]
+    else report.errorAndAbort("Only case classes are supported")
+  }
+
+  private def deriveLayer[T <: Tuple: Type, A: Type](using ctx: Quotes): Expr[URLayer[Env[T], A]] = {
+    import ctx.reflect._
+    val caseFields = TypeTree.of[A].symbol.caseFields
+    val fieldTypes = caseFields.map(_.tree).map { case ValDef(_, tpe, _) => tpe.tpe.asType }
+    val clsSymbol = TypeRepr.of[A].classSymbol.get
+
+    def caseClassApply(input: List[Term]) =
+      Apply(Select.unique(Ref(clsSymbol.companionModule), "apply"), input)
+
+    def genDeps(caseClassFields: List[Tree]): Expr[URIO[Env[T], Tuple]] =
+      caseClassFields.foldLeft[Expr[URIO[Env[T], Tuple]]]('{ZIO.succeed(EmptyTuple)}) {
+        case (acc, ValDef(_, tp, _)) =>
+          tp.tpe.asType match {
+            case'[t] =>
+          '{
+          ${
+          acc
+          }.zipWith (ZIO.serviceWith[t] (dep => Tuple1 (dep) ) ) (_ ++ _)
+          }
+          .asInstanceOf[Expr[URIO[Env[T], Tuple]]]
+          }
+      }
+
+    def genLayer(fields: List[Tree]): Expr[URIO[Env[T], A]] =
+      if fields.size == 1
+
+    then'{ZIO.serviceWith(dep => ${caseClassApply('{dep}.asTerm :: Nil).asExprOf[A]})}
+    else
+    '{${genDeps(fields)}.map(deps => ${depsDefs('{deps.asInstanceOf[T]}).asExprOf[A]})}
+
+    def depsDefs(deps: Expr[T]) = {
+      ValDef.let(
+        Symbol.spliceOwner,
+        fieldTypes.zipWithIndex.map { case ('[t
+          ], i
+          ) =>
+          Apply(
+            TypeApply(Select.unique(deps.asTerm, "apply"), List(TypeTree.of[T])),
+            List(Literal(IntConstant(i))),
+            )
+        },
+        )(caseClassApply(_)).asExprOf[A]
+
+    }
+
+    '{ZLayer(${genLayer(caseFields.map(_.tree))})}
+  }
 }


### PR DESCRIPTION
I had the idea of generating simple layers based on the signature of a case class.
So for a given `case class Car(engine: Engine, wheels: Wheels)` instead of
```scala
val layer = ZLayer {
  for {
    engine <- ZIO.service[Engine]
    wheels <- ZIO.service[Wheels]
  } yield Car(engine, wheels)
```
one could write `val layer = ZLayer.deriveLayer[Car]`.
After a session with @jdegoes I got it woking (thanks) and I guess it is a good addition to ZIO.
Maybe you @kitlangton like to take a look too 🙂 