### PR TITLE
Implement ZStream#zipLatest

### DIFF
--- a/docs/reference/stream/zstream/operations.md
+++ b/docs/reference/stream/zstream/operations.md
@@ -327,7 +327,7 @@ val s2 = ZStream(1, 2, 3).zipAllWith(
 // Output: (1, a), (2, b), (3, c), (0, d), (0, e)
 ```
 
-Sometimes we want to zip streams, but do not want to zip two elements one by one. For example, we may have two streams producing elements at different speeds, and do not want to wait for the slower one when zipping elements. When we need to zip elements with the latest element of the slower stream, `ZStream#zipWithLatest` will do this for us. It zips two streams so that when a value is emitted by either of the two streams, it is combined with the latest value from the other stream to produce a result:
+Sometimes we want to zip streams, but do not want to zip two elements one by one. For example, we may have two streams producing elements at different speeds, and do not want to wait for the slower one when zipping elements. When we need to zip elements with the latest element of the slower stream, `ZStream#zipLatest` or `ZStream#zipLatestWith` will do this for us. It zips two streams so that when a value is emitted by either of the two streams, it is combined with the latest value from the other stream to produce a result:
 
 ```scala mdoc:silent:nest
 val s1 = ZStream(1, 2, 3)
@@ -337,7 +337,7 @@ val s2 = ZStream("a", "b", "c", "d")
   .schedule(Schedule.spaced(500.milliseconds))
   .rechunk(3)
 
-s1.zipWithLatest(s2)((a, b) => (a, b))
+s1.zipLatest(s2)
 
 // Output: (1, a), (1, b), (1, c), (1, d), (2, d), (3, d)
 ```

--- a/docs/reference/test/services/clock.md
+++ b/docs/reference/test/services/clock.md
@@ -162,10 +162,10 @@ import zio.test.{test, _}
 import zio.stream._
 import zio.test.Assertion.equalTo
 
-test("zipWithLatest") {
+test("zipLatest") {
   val s1 = ZStream.iterate(0)(_ + 1).schedule(Schedule.fixed(100.milliseconds))
   val s2 = ZStream.iterate(0)(_ + 1).schedule(Schedule.fixed(70.milliseconds))
-  val s3 = s1.zipWithLatest(s2)((_, _))
+  val s3 = s1.zipLatest(s2)
 
   for {
     q      <- Queue.unbounded[(Int, Int)]

--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -171,10 +171,10 @@ object ClockSpec extends ZIOBaseSpec {
           result  <- (effect <* promise.succeed(())) <&> (promise.await *> effect)
         } yield assert(result)(equalTo((1L, 2L)))
       },
-      test("zipWithLatest example from documentation") {
+      test("zipLatest example from documentation") {
         val s1 = ZStream.iterate(0)(_ + 1).schedule(Schedule.fixed(100.milliseconds))
         val s2 = ZStream.iterate(0)(_ + 1).schedule(Schedule.fixed(70.milliseconds))
-        val s3 = s1.zipWithLatest(s2)((_, _))
+        val s3 = s1.zipLatest(s2)
 
         for {
           q      <- Queue.unbounded[(Int, Int)]


### PR DESCRIPTION
A convenience method for combining the latest value of each stream into a tuple of their results, analogous to the relationship of `zip` to `zipWith`.