### PR TITLE
Fix typo in scaladoc for ZIO.scoped

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4205,7 +4205,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.service[Scope]
 
   /**
-   * Scopes all resources uses in this effect to the lifetime of the effect,
+   * Scopes all resources used in this effect to the lifetime of the effect,
    * ensuring that their finalizers are run as soon as this effect completes
    * execution, whether by success, failure, or interruption.
    *


### PR DESCRIPTION
"uses" --> "used"