### PR TITLE
Use `AND` PoC.

### DIFF
--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -173,10 +173,10 @@ class SmartAssertMacros(val c: blackbox.Context) {
       case q"!($inner)" =>
         AST.Not(parseExpr(inner), pos.getPos(tree), pos.getPos(inner))
 
-      case q"$lhs && $rhs" =>
+      case q"$lhs && $rhs" if lhs.tpe == typeOf[Boolean] =>
         AST.And(parseExpr(lhs), parseExpr(rhs), pos.getPos(tree), pos.getPos(lhs), pos.getPos(rhs))
 
-      case q"$lhs || $rhs" =>
+      case q"$lhs || $rhs" if lhs.tpe == typeOf[Boolean] =>
         AST.Or(parseExpr(lhs), parseExpr(rhs), pos.getPos(tree), pos.getPos(lhs), pos.getPos(rhs))
 
       case MethodCall(lhs, name, tpes, args) =>

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -161,10 +161,16 @@ object SmartAssertMacros {
       case Unseal(MethodCall(lhs, "==", tpes, Some(List(rhs)))) =>
         val span = getSpan(rhs)
         lhs.tpe.widen.asType match {
-          case '[l] => 
+          case '[l] => ``
             '{${transform(lhs.asExprOf[l])} >>> SmartAssertions.equalTo(${rhs.asExprOf[l]}).span($span)}.asExprOf[TestArrow[Any, A]]
         }
 
+      case Unseal(MethodCall(lhs, "&&", tpes, Some(List(rhs)))) =>
+        val span = getSpan(rhs)
+        lhs.tpe.widen.asType match {
+          case '[l] =>
+        '{${transform(lhs.asExprOf[Boolean])} && {${transform(rhs.asExprOf[Boolean])}}}.asExprOf[TestArrow[Any, A]]
+        }
 
       case Unseal(method @ MethodCall(lhs, name, tpeArgs, args)) =>
         def body(param: Term) =

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -126,6 +126,12 @@ object SmartAssertMacros {
 
   def transform[A: Type](expr: Expr[A])(using PositionContext, Quotes) : Expr[TestArrow[Any, A]] = {
     import quotes.reflect._
+    def isBool(term: quotes.reflect.Term): Boolean = {
+      term.tpe.widen.asType match {
+        case '[Boolean] => true
+        case _ => false
+      }
+    }
 
     def getSpan(term: quotes.reflect.Term): Expr[(Int, Int)] = 
       Expr(term.pos.start - summon[PositionContext].start, term.pos.end - summon[PositionContext].start)
@@ -161,15 +167,22 @@ object SmartAssertMacros {
       case Unseal(MethodCall(lhs, "==", tpes, Some(List(rhs)))) =>
         val span = getSpan(rhs)
         lhs.tpe.widen.asType match {
-          case '[l] => ``
+          case '[l] =>
             '{${transform(lhs.asExprOf[l])} >>> SmartAssertions.equalTo(${rhs.asExprOf[l]}).span($span)}.asExprOf[TestArrow[Any, A]]
         }
 
-      case Unseal(MethodCall(lhs, "&&", tpes, Some(List(rhs)))) =>
+      case Unseal(MethodCall(lhs, "&&", tpes, Some(List(rhs)))) if isBool(lhs) =>
         val span = getSpan(rhs)
         lhs.tpe.widen.asType match {
           case '[l] =>
         '{${transform(lhs.asExprOf[Boolean])} && {${transform(rhs.asExprOf[Boolean])}}}.asExprOf[TestArrow[Any, A]]
+        }
+
+      case Unseal(MethodCall(lhs, "||", tpes, Some(List(rhs)))) if isBool(lhs) =>
+        val span = getSpan(rhs)
+        lhs.tpe.widen.asType match {
+          case '[l] =>
+        '{${transform(lhs.asExprOf[Boolean])} || {${transform(rhs.asExprOf[Boolean])}}}.asExprOf[TestArrow[Any, A]]
         }
 
       case Unseal(method @ MethodCall(lhs, name, tpeArgs, args)) =>


### PR DESCRIPTION
This fixes #7260.
The problem described in the issue is related to the fact that in Scala 3, logicall `&&` and  `||` are both mapped to `AndThen` case class.  This PR fixes it so that we can map logical operations to `And` and `Or` respectively.