### PR TITLE
Set `Test / fork := true` to improve log readability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     mimaSettings(failOnProblem = true)
   )
   .jsSettings(
+    jsSettings,
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0",
     scalacOptions ++= {
       if (scalaVersion.value == Scala3) {
@@ -270,6 +271,7 @@ lazy val coreTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmConfigure(_.enablePlugins(JCStressPlugin))
   .jvmSettings(replSettings)
   .jsSettings(
+    jsSettings,
     scalacOptions ++= {
       if (scalaVersion.value == Scala3) {
         List()
@@ -287,6 +289,7 @@ lazy val macros = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(crossProjectSettings)
   .settings(macroDefinitionSettings)
   .settings(macroExpansionSettings)
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
 
 lazy val macrosTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -301,6 +304,7 @@ lazy val macrosTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(buildInfoSettings("zio"))
   .settings(publish / skip := true)
   .enablePlugins(BuildInfoPlugin)
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -312,6 +316,7 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(streamReplSettings)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
 
 lazy val streamsTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -330,6 +335,7 @@ lazy val streamsTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmConfigure(_.dependsOn(coreTests.jvm % "test->compile"))
   .jsSettings(
+    jsSettings,
     scalacOptions ++= {
       if (scalaVersion.value == Scala3) {
         List()
@@ -355,6 +361,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(
+    jsSettings,
     libraryDependencies ++= List(
       "io.github.cquiroz" %%% "scala-java-time"      % "2.4.0-M3",
       "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.4.0-M3"
@@ -380,6 +387,7 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(macroExpansionSettings)
   .enablePlugins(BuildInfoPlugin)
   .jsSettings(
+    jsSettings,
     libraryDependencies ++= List(
       ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
     )
@@ -412,6 +420,7 @@ lazy val testMagnolia = crossProject(JVMPlatform, JSPlatform)
       }
     }
   )
+  .jsSettings(jsSettings)
 
 lazy val testMagnoliaTests = crossProject(JVMPlatform, JSPlatform)
   .in(file("test-magnolia-tests"))
@@ -426,6 +435,7 @@ lazy val testMagnoliaTests = crossProject(JVMPlatform, JSPlatform)
     publish / skip := true,
     crossScalaVersions --= Seq(Scala211)
   )
+  .jsSettings(jsSettings)
   .enablePlugins(BuildInfoPlugin)
 
 lazy val testRefined = crossProject(JVMPlatform, JSPlatform)
@@ -441,6 +451,7 @@ lazy val testRefined = crossProject(JVMPlatform, JSPlatform)
         ("eu.timepit" %% "refined" % "0.9.27").cross(CrossVersion.for3Use2_13)
       )
   )
+  .jsSettings(jsSettings)
 
 lazy val testScalaCheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("test-scalacheck"))
@@ -453,6 +464,7 @@ lazy val testScalaCheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ("org.scalacheck" %%% "scalacheck" % "1.16.0")
     )
   )
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
 
 lazy val stacktracer = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -462,6 +474,7 @@ lazy val stacktracer = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(buildInfoSettings("zio.internal.stacktracer"))
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(replSettings)
+  .jsSettings(jsSettings)
   .nativeSettings(
     nativeSettings,
     scalacOptions -= "-Xfatal-warnings" // Issue 3112
@@ -476,6 +489,7 @@ lazy val testRunner = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(tests)
   .jvmSettings(libraryDependencies ++= Seq("org.scala-sbt" % "test-interface" % "1.0"))
   .jsSettings(
+    jsSettings,
     libraryDependencies ++= Seq(
       ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
     )
@@ -549,6 +563,7 @@ lazy val concurrent = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(testRunner % Test)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
 
 /**
@@ -568,6 +583,7 @@ lazy val examples = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(macros, testRunner)
   .jvmConfigure(_.dependsOn(testJunitRunner))
   .jsSettings(
+    jsSettings,
     libraryDependencies ++= List(
       ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
     )

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -220,7 +220,7 @@ object BuildHelper {
     autoAPIMappings := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
     Compile / fork := true,
-    Test / fork    := false,
+    Test / fork    := true,
     // For compatibility with Java 9+ module system;
     // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
     Compile / packageBin / packageOptions +=

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -4,6 +4,7 @@ import sbt._
 import sbtbuildinfo.BuildInfoKeys._
 import sbtbuildinfo._
 import sbtcrossproject.CrossPlugin.autoImport._
+import scalajscrossproject._
 
 object BuildHelper {
   private val versions: Map[String, String] = {
@@ -220,7 +221,7 @@ object BuildHelper {
     autoAPIMappings := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
     Compile / fork := true,
-    Test / fork    := true,
+    Test / fork    := true, // set fork to `true` to improve log readability
     // For compatibility with Java 9+ module system;
     // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
     Compile / packageBin / packageOptions +=
@@ -259,6 +260,10 @@ object BuildHelper {
 
   def nativeSettings = Seq(
     Test / test := (Test / compile).value
+  )
+
+  def jsSettings: List[Def.Setting[_]] = List(
+    Test / fork := crossProjectPlatform.value != JSPlatform // set fork to `true` for non-JS platforms to improve log readability, JS needs `false`
   )
 
   def welcomeMessage = onLoadMessage := {


### PR DESCRIPTION
@adpi2
> @swoogles @sideeffffect I looked into your problem and this is what I found:
> - It is not specific to zio-test framework. I can reproduce it with any other test framework.
> - The problem disappears with `Test / fork := true` but that's a weird side effect of the `concurrentRestrictions` on `forked-test-group`

https://discord.com/channels/632150470000902164/922600050989875282/1016386123322364074
