### PR TITLE
ZIO Test: make existsIterable assertion more strict

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -115,6 +115,12 @@ object AssertionSpec extends ZIOBaseSpec {
       test("exists must fail when iterable is empty") {
         assert(Seq[String]())(exists(hasField("length", _.length, isWithin(0, 3))))
       } @@ failing,
+      test("exists must fail when inner assertion throws an exception") {
+        assert(Seq(1, 2, 3))(exists(assertion("bad_assertion")(i => if (i == 1) ??? else i == 2)))
+      } @@ failing,
+      test("exists must not fail when inner assertion throws an exception after predicate is satisfied") {
+        assert(Seq(1, 2, 3))(exists(assertion("bad_assertion")(i => if (i == 3) ??? else i == 2)))
+      },
       test("fails must succeed when error value satisfy specified assertion") {
         assert(Exit.fail("Some Error"))(fails(equalTo("Some Error")))
       },

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -205,6 +205,12 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       val value = Seq(1, 42, 5)
       assertTrue(value.exists(_ == 423))
     } @@ failing,
+    test("exists must fail when predicate throws an exception") {
+      assertTrue(Seq(1, 2, 3).exists(i => if (i == 1) ??? else i == 2))
+    } @@ failing,
+    test("exists must not fail when predicate throws an exception after predicate is satisfied") {
+      assertTrue(Seq(1, 2, 3).exists(i => if (i == 3) ??? else i == 2))
+    },
     test("forall must succeed when all elements of iterable satisfy specified assertion") {
       assertTrue(Seq("a", "bb", "ccc").forall(l => l.nonEmpty && l.length <= 3))
     },


### PR DESCRIPTION
Let's say we've got the following test

```scala
import zio.test._

object MySpec extends ZIOSpecDefault {
  override def spec: Spec[Any, Any] =
    suite("sweet") {
      test("test") {
        val exists = Seq(1, 2, 3).exists(i => if (i == 1) ??? else i == 2)
        assertTrue(exists)
      }
    }
}
```
If we run it, it fails as expected
```
+ sweet
  - test
    Exception in thread "zio-fiber-25" scala.NotImplementedError: an implementation is missing
        at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
        at zio.MySpec.spec(MySpec.scala:8)
0 tests passed. 1 tests failed. 0 tests ignored.
```
However, if we just inline `exists` variable, the test unexpectedly passes 
```scala
import zio.test._

object MySpec extends ZIOSpecDefault {
  override def spec: Spec[Any, Any] =
    suite("sweet") {
      test("test") {
        assertTrue(Seq(1, 2, 3).exists(i => if (i == 1) ??? else i == 2))
      }
    }
}
```
```
+ sweet
  + test
1 tests passed. 0 tests failed. 0 tests ignored.
```
I actually faced this corner case and was surprised that my tests pass when they shouldn't.
Proposed solution to this issue is somewhat arbitrary, I don't know if it's better to fail the test with `Result.die(???)` using the first found exception or to use `Result.succeed(false)` and combine errors, but the latter looks more informative to me.
So if you apply suggested changes and run the test again, you'll see something like this
```
+ sweet
  - test
    ? 1 element satisfied the predicate but it's discarded since the predicate threw an exception on 1 element
    Seq(1, 2, 3).exists(i => if (i == 1) ??? else i == 2)
          ? ERROR: scala.NotImplementedError: an implementation is missing
            scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
            zio.MySpec$.$anonfun$spec$5(MySpec.scala:9)
            scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.scala:17)
          Seq(1, 2, 3).exists(i => if (i == 1) ??? else i == 2)
          at foo/bar/buzz/zio/MySpec.scala:9
    (1, 2, 3) = List(1, 2, 3)
    Seq = scala.collection.immutable.Seq$@1855a2b8
    at foo/bar/buzz/zio/MySpec.scala:9

0 tests passed. 1 tests failed. 0 tests ignored.

```
Note that this solution still a little bit inconsistent with Scala's `exists`, because it will fail event if the exception was thrown after the predicate had been satisfied at least once. It could be fixed, but maybe it's a feature?
Also, I believe this PR might break some test somewhere. Don't think it's a big issue, but still needs to be highlighted.