### PR TITLE
Preserve Additional Stack Trace Information

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -518,7 +518,8 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
         @tailrec
         def loop(die: Cause.Die, result: List[Unified]): List[Unified] = {
           val extra =
-            if (stackless) Chunk.empty else Chunk.fromIterable(die.value.getStackTrace.headOption)
+            if (stackless) Chunk.empty
+            else Chunk.fromArray(die.value.getStackTrace.takeWhile(_.getClassName != "zio.internal.FiberRuntime"))
 
           val unified =
             Unified(die.trace.fiberId, die.value.getClass.getName(), die.value.getMessage(), extra ++ die.trace.toJava)


### PR DESCRIPTION
It appears that just keeping the first line of the underlying `Throwable` stack trace does not provide sufficient information.

For example, consider the following code:

```scala
object Example extends scala.App {

  def createZIOByValue(x: String): UIO[String] = ???

  def run(a: Int): UIO[Unit] =
    for {
      _ <- ZIO.succeed(0)
      _ <- intermediateFunction(a)
    } yield ()

  def intermediateFunction(x: Int): UIO[String] =
    createZIOByValue(functionWithProgrammingError(x))

  def functionWithProgrammingError(index: Int): String =
    List.empty[String](index)

  Unsafe.unsafe { implicit unsafe =>
    Runtime.default.unsafe
      .run(run(5))
      .getOrThrowFiberFailure()
  }
}
```

Currently, the execution trace produced by this program is this:

```
[error] Exception in thread "main" Exception in thread "zio-fiber-0" java.lang.IndexOutOfBoundsException: 5
[error]         at scala.collection.LinearSeqOps.apply(LinearSeq.scala:117)
[error]         at zio.Example.run(Example.scala:9)
[error]         at zio.Example.<local Example>(Example.scala:21)
```

While accurate (the program did fail with an `IndexOutOfBoundsException` and the failure did originate in `run`, it also misses important information, namely that the trace includes `functionWithProgrammingError` and `intermediateFunction`.

We can improve this by retaining all elements of the `Throwable` stack trace up to the ZIO runtime instead of just the first element. With this change the execution trace looks like this:

```
[error] Exception in thread "main" Exception in thread "zio-fiber-0" java.lang.IndexOutOfBoundsException: 5
[error]         at scala.collection.LinearSeqOps.apply(LinearSeq.scala:117)
[error]         at scala.collection.LinearSeqOps.apply$(LinearSeq.scala:114)
[error]         at scala.collection.immutable.List.apply(List.scala:79)
[error]         at zio.Example$.functionWithProgrammingError(Example.scala:17)
[error]         at zio.Example$.intermediateFunction(Example.scala:14)
[error]         at zio.Example$.$anonfun$run$2(Example.scala:10)
[error]         at zio.Example$.$anonfun$run$2$adapted(Example.scala:9)
[error]         at zio.Example.run(Example.scala:9)
[error]         at zio.Example.<local Example>(Example.scala:21)
```