### PR TITLE
Add methods to get at least a certain number of Semaphore permits.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -94,7 +94,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
       test("acquireRange doesn't necessarily give the max requested number of permits") {
         for {
           semaphore <- TSemaphore.make(2L)
-          actual    <- semaphore.acquireRange(0L, 5L)
+          actual    <- semaphore.acquireBetween(0L, 5L)
           remaining <- semaphore.available
         } yield {
           assertTrue(actual == 2L)
@@ -106,7 +106,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
         for {
           semaphore <- TSemaphore.make(maxPermits).commit
           actualAndRemainingInEffect <-
-            semaphore.withPermitsRange(0L, 5L) { (actual: Long) =>
+            semaphore.withPermitsBetween(0L, 5L) { (actual: Long) =>
               for (remainingInEffect <- semaphore.available.commit) yield {
                 (actual, remainingInEffect)
               }
@@ -119,11 +119,11 @@ object TSemaphoreSpec extends ZIOBaseSpec {
           assertTrue(remainingWhenComplete == maxPermits)
         }
       },
-      test("withPermitsRange fails if the minimum number of permits is unavailable.") {
+      test("withPermitsBetween fails if the minimum number of permits is unavailable.") {
         val transaction =
           for {
             semaphore <- TSemaphore.make(2L)
-            actual <- semaphore.acquireRange(3L, 5L)
+            actual <- semaphore.acquireBetween(3L, 5L)
           } yield actual
         transaction.commitEither *> assertTrue(false)
       } @@ timeout(1.second) @@ failing

--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -123,7 +123,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
         val transaction =
           for {
             semaphore <- TSemaphore.make(2L)
-            actual <- semaphore.acquireBetween(3L, 5L)
+            actual    <- semaphore.acquireBetween(3L, 5L)
           } yield actual
         transaction.commitEither *> assertTrue(false)
       } @@ timeout(1.second) @@ failing,

--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -101,7 +101,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
           assertTrue(remaining == 0L)
         }
       },
-      test("withPermitsBetween passes the number of permits actually allotted") {
+      test("withPermitsBetween returns the number of permits allotted") {
         val maxPermits = 2L
         for {
           semaphore <- TSemaphore.make(maxPermits).commit
@@ -127,24 +127,14 @@ object TSemaphoreSpec extends ZIOBaseSpec {
           } yield actual
         transaction.commitEither *> assertTrue(false)
       } @@ timeout(1.second) @@ failing,
-      test("acquireAtMost") {
+      test("acquireUpTo") {
         for {
           semaphore <- TSemaphore.make(5L)
-          actual    <- semaphore.acquireAtMost(2L)
+          actual    <- semaphore.acquireUpTo(2L)
           remaining <- semaphore.available
         } yield {
           assertTrue(actual == 2L)
           assertTrue(remaining == 3L)
-        }
-      },
-      test("acquireAtLeast") {
-        for {
-          semaphore <- TSemaphore.make(5L)
-          actual <- semaphore.acquireAtLeast(2L)
-          remaining <- semaphore.available
-        } yield {
-          assertTrue(actual == 5L)
-          assertTrue(remaining == 0L)
         }
       }
     )

--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -91,7 +91,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
           permits   <- semaphore.available.commit
         } yield assertTrue(permits == 2L)
       },
-      test("acquireRange doesn't necessarily give the max requested number of permits") {
+      test("acquireBetween doesn't necessarily give the max requested number of permits") {
         for {
           semaphore <- TSemaphore.make(2L)
           actual    <- semaphore.acquireBetween(0L, 5L)
@@ -101,7 +101,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
           assertTrue(remaining == 0L)
         }
       },
-      test("withPermitsRange passes the number of permits actually allotted") {
+      test("withPermitsBetween passes the number of permits actually allotted") {
         val maxPermits = 2L
         for {
           semaphore <- TSemaphore.make(maxPermits).commit
@@ -126,7 +126,27 @@ object TSemaphoreSpec extends ZIOBaseSpec {
             actual <- semaphore.acquireBetween(3L, 5L)
           } yield actual
         transaction.commitEither *> assertTrue(false)
-      } @@ timeout(1.second) @@ failing
+      } @@ timeout(1.second) @@ failing,
+      test("acquireAtMost") {
+        for {
+          semaphore <- TSemaphore.make(5L)
+          actual    <- semaphore.acquireAtMost(2L)
+          remaining <- semaphore.available
+        } yield {
+          assertTrue(actual == 2L)
+          assertTrue(remaining == 3L)
+        }
+      },
+      test("acquireAtLeast") {
+        for {
+          semaphore <- TSemaphore.make(5L)
+          actual <- semaphore.acquireAtLeast(2L)
+          remaining <- semaphore.available
+        } yield {
+          assertTrue(actual == 5L)
+          assertTrue(remaining == 0L)
+        }
+      }
     )
   )
 

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -60,7 +60,7 @@ sealed trait Semaphore extends Serializable {
    * immediately after the workflow completes execution, whether by success,
    * failure, or interruption.
    */
-  def withPermitsRange[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+  def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
    * Returns a scoped workflow that describes acquiring the specified number of
@@ -72,7 +72,7 @@ sealed trait Semaphore extends Serializable {
    * Returns a scoped workflow that describes acquiring at least `min` and at most `max`
    * permits and releasing them when the scope is closed.
    */
-  def withPermitsRangeScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
+  def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
 }
 
 object Semaphore {
@@ -92,11 +92,11 @@ object Semaphore {
         semaphore.withPermitScoped
       def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermits(n)(zio)
-      override def withPermitsRange[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        semaphore.withPermitsRange(min, max)(zio)
+      override def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        semaphore.withPermitsBetween(min, max)(zio)
       def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
         semaphore.withPermitsScoped(n)
-      override def withPermitsRangeScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
-        semaphore.withPermitsRangeScoped(min, max)
+      override def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
+        semaphore.withPermitsBetweenScoped(min, max)
     }
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -69,15 +69,7 @@ sealed trait Semaphore extends Serializable {
    * immediately after the effect completes execution, whether by success,
    * failure, or interruption.
    */
-  def withPermitsAtMost[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
-
-  /**
-   * Executes the specified effect, acquiring at least the specified number of permits
-   * immediately before the effect begins execution and releasing them
-   * immediately after the effect completes execution, whether by success,
-   * failure, or interruption.
-   */
-  def withPermitsAtLeast[R, E, A](min: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+  def withPermitsUpTo[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
    * Returns a scoped workflow that describes acquiring the specified number of
@@ -95,13 +87,7 @@ sealed trait Semaphore extends Serializable {
    * Returns a scoped effect that describes acquiring at most `max`
    * permits and releasing them when the scope is closed.
    */
-  def withPermitsAtMostScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
-
-  /**
-   * Returns a scoped effect that describes acquiring at least `min`
-   * permits and releasing them when the scope is closed.
-   */
-  def withPermitsAtLeastScoped(min: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
+  def withPermitsUpToScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
 }
 
 object Semaphore {
@@ -123,17 +109,13 @@ object Semaphore {
         semaphore.withPermits(n)(zio)
       override def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermitsBetween(min, max)(zio)
-      override def withPermitsAtMost[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        semaphore.withPermitsAtMost(max)(zio)
-      override def withPermitsAtLeast[R, E, A](min: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        semaphore.withPermitsAtLeast(min)(zio)
+      override def withPermitsUpTo[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        semaphore.withPermitsUpTo(max)(zio)
       override def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
         semaphore.withPermitsScoped(n)
       override def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
         semaphore.withPermitsBetweenScoped(min, max)
-      override def withPermitsAtMostScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
-        semaphore.withPermitsAtMostScoped(max)
-      override def withPermitsAtLeastScoped(min: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
-        semaphore.withPermitsAtLeastScoped(min)
+      override def withPermitsUpToScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
+        semaphore.withPermitsUpToScoped(max)
     }
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -55,7 +55,7 @@ sealed trait Semaphore extends Serializable {
   def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
-   * Executes the specified workflow, acquiring at least `min` and up to `max` permits
+   * Executes the specified workflow, acquiring at least `min` and at most `max` permits
    * immediately before the workflow begins execution and releasing them
    * immediately after the workflow completes execution, whether by success,
    * failure, or interruption.

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -55,17 +55,16 @@ sealed trait Semaphore extends Serializable {
   def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
-   * Executes the specified workflow, acquiring at least `min` and at most `max` permits
-   * immediately before the workflow begins execution and releasing them
+   * Executes the specified workflow, acquiring at least `min` and at most `max`
+   * permits immediately before the workflow begins execution and releasing them
    * immediately after the workflow completes execution, whether by success,
    * failure, or interruption.
    */
   def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
-
   /**
-   * Executes the specified effect, acquiring at most the specified number of permits
-   * immediately before the effect begins execution and releasing them
+   * Executes the specified effect, acquiring at most the specified number of
+   * permits immediately before the effect begins execution and releasing them
    * immediately after the effect completes execution, whether by success,
    * failure, or interruption.
    */
@@ -78,14 +77,14 @@ sealed trait Semaphore extends Serializable {
   def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit]
 
   /**
-   * Returns a scoped workflow that describes acquiring at least `min` and at most `max`
-   * permits and releasing them when the scope is closed.
+   * Returns a scoped workflow that describes acquiring at least `min` and at
+   * most `max` permits and releasing them when the scope is closed.
    */
   def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
 
   /**
-   * Returns a scoped effect that describes acquiring at most `max`
-   * permits and releasing them when the scope is closed.
+   * Returns a scoped effect that describes acquiring at most `max` permits and
+   * releasing them when the scope is closed.
    */
   def withPermitsUpToScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
 }
@@ -107,7 +106,9 @@ object Semaphore {
         semaphore.withPermitScoped
       override def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermits(n)(zio)
-      override def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      override def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit
+        trace: Trace
+      ): ZIO[R, E, A] =
         semaphore.withPermitsBetween(min, max)(zio)
       override def withPermitsUpTo[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermitsUpTo(max)(zio)

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -25,6 +25,9 @@ import zio.stm.TSemaphore
  * by different parties. Attempts to acquire more permits than available result
  * in the acquiring fiber being suspended until the specified number of permits
  * become available.
+ *
+ * If you need functionality that `Semaphore` doesnt' provide, use a
+ * [[TSemaphore]] and define it in a [[zio.stm.ZSTM]] transaction.
  */
 sealed trait Semaphore extends Serializable {
 

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -55,38 +55,10 @@ sealed trait Semaphore extends Serializable {
   def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
-   * Executes the specified workflow, acquiring at least `min` and at most `max`
-   * permits immediately before the workflow begins execution and releasing them
-   * immediately after the workflow completes execution, whether by success,
-   * failure, or interruption.
-   */
-  def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
-
-  /**
-   * Executes the specified effect, acquiring at most the specified number of
-   * permits immediately before the effect begins execution and releasing them
-   * immediately after the effect completes execution, whether by success,
-   * failure, or interruption.
-   */
-  def withPermitsUpTo[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
-
-  /**
    * Returns a scoped workflow that describes acquiring the specified number of
    * permits and releasing them when the scope is closed.
    */
   def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit]
-
-  /**
-   * Returns a scoped workflow that describes acquiring at least `min` and at
-   * most `max` permits and releasing them when the scope is closed.
-   */
-  def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
-
-  /**
-   * Returns a scoped effect that describes acquiring at most `max` permits and
-   * releasing them when the scope is closed.
-   */
-  def withPermitsUpToScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long]
 }
 
 object Semaphore {
@@ -98,25 +70,15 @@ object Semaphore {
     for {
       semaphore <- TSemaphore.makeCommit(permits)
     } yield new Semaphore {
-      override def available(implicit trace: Trace): UIO[Long] =
+      def available(implicit trace: Trace): UIO[Long] =
         semaphore.available.commit
-      override def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermit(zio)
-      override def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
         semaphore.withPermitScoped
-      override def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         semaphore.withPermits(n)(zio)
-      override def withPermitsBetween[R, E, A](min: Long, max: Long)(zio: Long => ZIO[R, E, A])(implicit
-        trace: Trace
-      ): ZIO[R, E, A] =
-        semaphore.withPermitsBetween(min, max)(zio)
-      override def withPermitsUpTo[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        semaphore.withPermitsUpTo(max)(zio)
-      override def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
         semaphore.withPermitsScoped(n)
-      override def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
-        semaphore.withPermitsBetweenScoped(min, max)
-      override def withPermitsUpToScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
-        semaphore.withPermitsUpToScoped(max)
     }
 }

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -108,8 +108,25 @@ final class TSemaphore private (val permits: TRef[Long]) extends Serializable {
     acquireN(Const(n)).unit
   }
 
+  /**
+   * Acquire at least `min` permits and at most `max` permits in a transactional context.
+   */
   def acquireBetween(min: Long, max: Long): USTM[Long] = {
     acquireN(Request(min, max))
+  }
+
+  /**
+   * Acquire at most `max` permits in a transactional context.
+   */
+  def acquireAtMost(max: Long): USTM[Long] = {
+    acquireBetween(0, max)
+  }
+
+  /**
+   * Acquire at least `min` permits in a transactional context.
+   */
+  def acquireAtLeast(min: Long): USTM[Long] = {
+    acquireBetween(min, Long.MaxValue)
   }
 
   /**
@@ -169,6 +186,24 @@ final class TSemaphore private (val permits: TRef[Long]) extends Serializable {
     ZSTM.acquireReleaseWith(acquireBetween(min, max))((actualN: Long) => releaseN(actualN).commit)(zio)
 
   /**
+   * Executes the specified effect, acquiring at most the specified number of permits
+   * immediately before the effect begins execution and releasing them
+   * immediately after the effect completes execution, whether by success,
+   * failure, or interruption.
+   */
+  def withPermitsAtMost[R, E, A](max: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    ZSTM.acquireReleaseWith(acquireAtMost(max))((actualN: Long) => releaseN(actualN).commit)(zio)
+
+  /**
+   * Executes the specified effect, acquiring at least the specified number of permits
+   * immediately before the effect begins execution and releasing them
+   * immediately after the effect completes execution, whether by success,
+   * failure, or interruption.
+   */
+  def withPermitsAtLeast[R, E, A](min: Long)(zio: Long => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    ZSTM.acquireReleaseWith(acquireAtLeast(min))((actualN: Long) => releaseN(actualN).commit)(zio)
+
+  /**
    * Returns a scoped effect that describes acquiring the specified number of
    * permits and releasing them when the scope is closed.
    */
@@ -181,6 +216,20 @@ final class TSemaphore private (val permits: TRef[Long]) extends Serializable {
    */
   def withPermitsBetweenScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
     ZSTM.acquireReleaseWith(acquireBetween(min, max))((actualN: Long) => Scope.addFinalizer(releaseN(actualN).commit))(ZIO.succeedNow)
+
+  /**
+   * Returns a scoped effect that describes acquiring at most `max`
+   * permits and releasing them when the scope is closed.
+   */
+  def withPermitsAtMostScoped(max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
+    ZSTM.acquireReleaseWith(acquireAtMost(max))((actualN: Long) => Scope.addFinalizer(releaseN(actualN).commit))(ZIO.succeedNow)
+
+  /**
+   * Returns a scoped effect that describes acquiring at least `min`
+   * permits and releasing them when the scope is closed.
+   */
+  def withPermitsAtLeastScoped(min: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =
+    ZSTM.acquireReleaseWith(acquireAtLeast(min))((actualN: Long) => Scope.addFinalizer(releaseN(actualN).commit))(ZIO.succeedNow)
 
   private def assertNonNegative(n: Long): Unit =
     require(n >= 0, s"Unexpected negative value `$n` passed to acquireN or releaseN.")

--- a/core/shared/src/main/scala/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/zio/stm/TSemaphore.scala
@@ -160,7 +160,7 @@ final class TSemaphore private (val permits: TRef[Long]) extends Serializable {
     ZSTM.acquireReleaseWith(acquireN(n))(_ => releaseN(n).commit)(_ => zio)
 
   /**
-   * Executes the specified effect, acquiring up to the specified number of permits
+   * Executes the specified effect, acquiring at least `min` and at most `max` permits
    * immediately before the effect begins execution and releasing them
    * immediately after the effect completes execution, whether by success,
    * failure, or interruption.
@@ -176,7 +176,7 @@ final class TSemaphore private (val permits: TRef[Long]) extends Serializable {
     ZSTM.acquireReleaseWith(acquireN(n))(_ => Scope.addFinalizer(releaseN(n).commit))(_ => ZIO.unit)
 
   /**
-   * Returns a scoped effect that describes acquiring up to the specified number of
+   * Returns a scoped effect that describes acquiring at least `min` and at most `max`
    * permits and releasing them when the scope is closed.
    */
   def withPermitsRangeScoped(min: Long, max: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Long] =


### PR DESCRIPTION
This allows clients to not block forever if they might never get the full number of permits they'd ideally like.