### PR TITLE
ZIO Test: Implement Annotations In Terms Of Ref

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AnnotationsSpec.scala
@@ -6,16 +6,6 @@ import zio.test.Assertion._
 object AnnotationsSpec extends ZIOBaseSpec {
 
   def spec = suite("annotationsSpec")(
-    test("withAnnotation executes specified effect with an empty annotation map") {
-      for {
-        _ <- Annotations.annotate(count, 1)
-        a <- Annotations.get(count)
-        map <- Annotations
-                 .withAnnotation(Annotations.annotate(count, 2) *> ZIO.succeed(TestSuccess.Ignored()))
-                 .map(_.annotations)
-        b = map.get(count)
-      } yield assert(a)(equalTo(1)) && assert(b)(equalTo(2))
-    },
     test("withAnnotation returns annotation map with result") {
       for {
         map <- Annotations

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -21,23 +21,26 @@ trait Annotations extends Serializable {
     trace: Trace
   ): ZIO[R, TestFailure[E], TestSuccess]
   def supervisedFibers(implicit trace: Trace): UIO[SortedSet[Fiber.Runtime[Any, Any]]]
+  private[zio] def unsafe: UnsafeAPI
+  private[zio] trait UnsafeAPI {
+    def annotate[V](key: TestAnnotation[V], value: V)(implicit unsafe: Unsafe): Unit
+  }
 }
 
 object Annotations {
 
   val tag: Tag[Annotations] = Tag[Annotations]
 
-  final case class Test(fiberRef: FiberRef[TestAnnotationMap]) extends Annotations {
+  final case class Test(ref: Ref.Atomic[TestAnnotationMap]) extends Annotations {
     def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: Trace): UIO[Unit] =
-      fiberRef.update(_.annotate(key, value))
+      ref.update(_.annotate(key, value))
     def get[V](key: TestAnnotation[V])(implicit trace: Trace): UIO[V] =
-      fiberRef.get.map(_.get(key))
+      ref.get.map(_.get(key))
     def withAnnotation[R, E](zio: ZIO[R, TestFailure[E], TestSuccess])(implicit
       trace: Trace
     ): ZIO[R, TestFailure[E], TestSuccess] =
-      fiberRef.locally(TestAnnotationMap.empty) {
-        zio.foldZIO(e => fiberRef.get.map(e.annotated).flip, a => fiberRef.get.map(a.annotated))
-      }
+      ref.get.tap(map => if (map != TestAnnotationMap.empty) ZIO.dieMessage("die") else ZIO.unit) *>
+        zio.foldZIO(e => ref.get.map(e.annotated).flip, a => ref.get.map(a.annotated))
     def supervisedFibers(implicit trace: Trace): UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
       ZIO.descriptorWith { descriptor =>
         get(TestAnnotation.fibers).flatMap {
@@ -48,6 +51,11 @@ object Annotations {
               .map(_.foldLeft(SortedSet.empty[Fiber.Runtime[Any, Any]])(_ ++ _))
               .map(_.filter(_.id != descriptor.id))
         }
+      }
+    private[zio] def unsafe: UnsafeAPI =
+      new UnsafeAPI {
+        def annotate[V](key: TestAnnotation[V], value: V)(implicit unsafe: Unsafe): Unit =
+          ref.unsafe.update(_.annotate(key, value))
       }
   }
 
@@ -78,8 +86,8 @@ object Annotations {
     implicit val trace = Tracer.newTrace
     ZLayer.scoped {
       for {
-        fiberRef   <- FiberRef.make(TestAnnotationMap.empty)
-        annotations = Test(fiberRef)
+        ref        <- ZIO.succeed(Unsafe.unsafe(Ref.unsafe.make(TestAnnotationMap.empty)(_)))
+        annotations = Test(ref)
         _          <- withAnnotationsScoped(annotations)
       } yield annotations
     }

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -39,8 +39,7 @@ object Annotations {
     def withAnnotation[R, E](zio: ZIO[R, TestFailure[E], TestSuccess])(implicit
       trace: Trace
     ): ZIO[R, TestFailure[E], TestSuccess] =
-      ref.get.tap(map => if (map != TestAnnotationMap.empty) ZIO.dieMessage("die") else ZIO.unit) *>
-        zio.foldZIO(e => ref.get.map(e.annotated).flip, a => ref.get.map(a.annotated))
+      zio.foldZIO(e => ref.get.map(e.annotated).flip, a => ref.get.map(a.annotated))
     def supervisedFibers(implicit trace: Trace): UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
       ZIO.descriptorWith { descriptor =>
         get(TestAnnotation.fibers).flatMap {

--- a/test/shared/src/main/scala/zio/test/TestServices.scala
+++ b/test/shared/src/main/scala/zio/test/TestServices.scala
@@ -27,7 +27,7 @@ object TestServices {
    */
   val test: ZEnvironment[Annotations with Live with Sized with TestConfig] =
     ZEnvironment[Annotations, Live, Sized, TestConfig](
-      Annotations.Test(FiberRef.unsafe.make(TestAnnotationMap.empty)(Unsafe.unsafe)),
+      Annotations.Test(Ref.unsafe.make(TestAnnotationMap.empty)(Unsafe.unsafe)),
       Live.Test(DefaultServices.live),
       Sized.Test(FiberRef.unsafe.make(100)(Unsafe.unsafe)),
       TestConfig.Test(100, 100, 200, 1000)


### PR DESCRIPTION
We provide a separate copy of the `Annotations` service to each test so we don't actually need it to be a `FiberRef`. This will allow us to support updating test annotations outside of `ZIO` workflows, for example in logging implementations.