### PR TITLE
Reduce allocations

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -774,7 +774,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     type ErasedSuccessK = Any => ZIO[Any, Any, Any]
     type ErasedFailureK = Cause[Any] => ZIO[Any, Any, Any]
 
-    // Note that assigning `cur` as the result of `try` can cause scalac to box `runtimeFlags` or `lastTrace`.
+    // Note that assigning `cur` as the result of `try` or `if` can cause scalac to box `runtimeFlags` or `lastTrace`.
     var cur          = effect
     var done         = null.asInstanceOf[AnyRef]
     var stackIndex   = 0

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -774,8 +774,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     type ErasedSuccessK = Any => ZIO[Any, Any, Any]
     type ErasedFailureK = Cause[Any] => ZIO[Any, Any, Any]
 
-    // Note that assigning `cur` as the result of `try` causes scalac to box `runtimeFlags`.
-    // Note that assigning `cur` as the result of the `try` causes scalac to box `lastTrace`.
+    // Note that assigning `cur` as the result of `try` can cause scalac to box `runtimeFlags` or `lastTrace`.
     var cur          = effect
     var done         = null.asInstanceOf[AnyRef]
     var stackIndex   = 0


### PR DESCRIPTION
This branch significantly reduces allocations in the runtime. The following shows allocations for `ZIO.unit.forever` before the commits and then after. Note that after the changes, `scala.runtime.ObjectRef` and `scala.runtime.IntRef` no longer appear on the list of top allocations.

I got the measurement by doing memory profiling with VisualVM, setting the profiled classes to `*`, and disabling `Track only  live objects`.

![series-2 x](https://user-images.githubusercontent.com/1625822/192106240-0f60f4df-fef6-41f8-b84e-dc543c0c0095.png)
![reduce-allocations](https://user-images.githubusercontent.com/1625822/192106246-491903ec-0792-4a25-9794-60a9b5af1d01.png)
