### PR TITLE
Reduce Int boxing using specialization

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5471,7 +5471,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     }
 
     final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: RuntimeFlags => ZIO[R, E, A])
-      extends UpdateRuntimeFlagsWithin[R, E, A] {
+        extends UpdateRuntimeFlagsWithin[R, E, A] {
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = f(oldRuntimeFlags)
     }
 
@@ -5480,8 +5480,11 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = effect
     }
 
-    final case class InterruptibilityRestorer[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: ZIO.InterruptibilityRestorer => ZIO[R, E, A])
-      extends UpdateRuntimeFlagsWithin[R, E, A] {
+    final case class InterruptibilityRestorer[R, E, A](
+      trace: Trace,
+      update: RuntimeFlags.Patch,
+      f: ZIO.InterruptibilityRestorer => ZIO[R, E, A]
+    ) extends UpdateRuntimeFlagsWithin[R, E, A] {
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = {
         val restorer: ZIO.InterruptibilityRestorer =
           if (RuntimeFlags.interruption(oldRuntimeFlags))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5469,6 +5469,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = effect
     }
+
+    final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: RuntimeFlags => ZIO[R, E, A])
+      extends UpdateRuntimeFlagsWithin[R, E, A] {
+      def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = f(oldRuntimeFlags)
+    }
+
     final case class WithRuntimeFlags[R, E, A](trace: Trace, update: RuntimeFlags.Patch, effect: ZIO[R, E, A])
         extends UpdateRuntimeFlagsWithin[R, E, A] {
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = effect


### PR DESCRIPTION
I found these `Integer` allocations while profiling `ZIO.fromCompletableFuture(CompletableFuture.completedFuture(())).forever`. I performed the measurements the same way as https://github.com/zio/zio/pull/7365. Again I show before and after. See that the `java.lang.Integer` allocations disappear.

This implementation removes `ZIO.UpdateRuntimeFlagsWithin.Dynamic` in favor of two classes that are specific to the previous uses of `Dynamic`.

Only accept this PR or https://github.com/zio/zio/pull/7368.

![series-2 x](https://user-images.githubusercontent.com/1625822/192151076-2a9f69ba-508b-4208-964f-3ea9c7ec1c78.png)
![reduce-int-boxing-specialization](https://user-images.githubusercontent.com/1625822/192151083-b8f7edef-f1c1-42eb-a8c9-643caf88450d.png)
