### PR TITLE
Reduce Int boxing using IntFunction

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5472,8 +5472,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = effect
     }
-    final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: Int => ZIO[R, E, A])
-      extends UpdateRuntimeFlagsWithin[R, E, A] {
+    final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: RuntimeFlags => ZIO[R, E, A])
+        extends UpdateRuntimeFlagsWithin[R, E, A] {
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = f(oldRuntimeFlags)
     }
     final case class DynamicNoBox[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: IntFunction[ZIO[R, E, A]])

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -20,6 +20,7 @@ import zio.internal.{FiberScope, Platform}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
+import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
 import scala.collection.mutable.Builder
 import scala.concurrent.ExecutionContext
@@ -5471,7 +5472,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = effect
     }
-    final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: RuntimeFlags => ZIO[R, E, A])
+    final case class Dynamic[R, E, A](trace: Trace, update: RuntimeFlags.Patch, f: IntFunction[ZIO[R, E, A]])
         extends UpdateRuntimeFlagsWithin[R, E, A] {
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = f(oldRuntimeFlags)
     }


### PR DESCRIPTION
I found these `Integer` allocations while profiling `ZIO.fromCompletableFuture(CompletableFuture.completedFuture(())).forever`. I performed the measurements the same way as https://github.com/zio/zio/pull/7365. Again I show before and after. See that the `java.lang.Integer` allocations disappear.

This implementation replaces the Scala `Function` in `ZIO.UpdateRuntimeFlagsWithin.Dynamic` with Java's `IntFunction`.

Only accept this PR or https://github.com/zio/zio/pull/7367.

![series-2 x](https://user-images.githubusercontent.com/1625822/192150987-5a924336-8c84-45d0-b77d-e7497724b004.png)
![reduce-int-boxing-IntFunction](https://user-images.githubusercontent.com/1625822/192151029-53d5be63-2314-4e6e-88ad-6fcae2084f46.png)
