### PR TITLE
ZIO Stream: Preserve Leftovers in Sink.collectAllWhile

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -348,19 +348,20 @@ object ZSinkSpec extends ZIOBaseSpec {
         )
       },
       test("collectAllWhile") {
-        val sink   = ZSink.collectAllWhile[Int](_ < 5)
+        val sink   = ZSink.collectAllWhile[Int](_ < 5) <* ZSink.collectAllWhile[Int](_ >= 5)
         val input  = List(Chunk(3, 4, 5, 6, 7, 2), Chunk.empty, Chunk(3, 4, 5, 6, 5, 4, 3, 2), Chunk.empty)
         val result = ZStream.fromChunks(input: _*).transduce(sink).runCollect
         assertZIO(result)(
-          equalTo(Chunk(Chunk(3, 4), Chunk(), Chunk(), Chunk(2, 3, 4), Chunk(), Chunk(), Chunk(4, 3, 2)))
+          equalTo(Chunk(Chunk(3, 4), Chunk(2, 3, 4), Chunk(4, 3, 2)))
         )
       },
       test("collectAllWhileZIO") {
-        val sink   = ZSink.collectAllWhileZIO[Any, Nothing, Int]((i: Int) => ZIO.succeed(i < 5))
+        val sink = ZSink.collectAllWhileZIO[Any, Nothing, Int]((i: Int) => ZIO.succeed(i < 5)) <* ZSink
+          .collectAllWhileZIO[Any, Nothing, Int]((i: Int) => ZIO.succeed(i >= 5))
         val input  = List(Chunk(3, 4, 5, 6, 7, 2), Chunk.empty, Chunk(3, 4, 5, 6, 5, 4, 3, 2), Chunk.empty)
         val result = ZStream.fromChunks(input: _*).transduce(sink).runCollect
         assertZIO(result)(
-          equalTo(Chunk(Chunk(3, 4), Chunk(), Chunk(), Chunk(2, 3, 4), Chunk(), Chunk(), Chunk(4, 3, 2)))
+          equalTo(Chunk(Chunk(3, 4), Chunk(2, 3, 4), Chunk(4, 3, 2)))
         )
       },
       test("foldLeft equivalence with Chunk#foldLeft")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -154,7 +154,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           test("simple example") {
             assertZIO(
               ZStream('1', '2', ',', '3', '4')
-                .transduce(ZSink.collectAllWhile((_: Char).isDigit))
+                .transduce(ZSink.collectAllWhile((_: Char).isDigit) <* ZSink.collectAllWhile(!(_: Char).isDigit))
                 .map(_.mkString.toInt)
                 .runCollect
             )(equalTo(Chunk(12, 34)))


### PR DESCRIPTION
Currently in `ZSink.collectAllWhile` when the predicate is no longer satisfied we collect the elements that did satisfy the predicate as our done value and emit the remaining elements as leftovers, but we drop the element that did not satisfy the predicate entirely.

For example, in the code below `Chunk("foo", "foo", "foo")` will be collected as the result of the sink and `"quux"` will be emitted as a leftover but `"buz"` will be dropped completely.

This does have some advantage in ensuring that these sinks remain productive if they are run repeatedly, since they always consume at least one element, but does not seem very principled. Instead, I think we should emit the element that does not satisfy the predicate as a leftover.

```scala
object Example extends ZIOAppDefault {

  val run =
    ZStream
      .fromIterable(List("foo", "foo", "foo", "buz", "quux"))
      .peel(ZSink.collectAllWhile[String](_ == "foo"))
      .tap { case (foos, stream) =>
        for {
          _ <- Console.printLine(s"All foos: $foos")
          _ <- stream.runCollect.tap(s => Console.printLine(s"Rest of the stream: $s"))
        } yield ()
      }
}
```