### PR TITLE
ZIOApp: Run Finalizers In Scope Of Bootstrap Layer

### DIFF
--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -13,14 +13,14 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
     implicit val unsafe = Unsafe.unsafe
 
     val newLayer =
-      Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
-        bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
+      ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
+        bootstrap +!+ ZLayer.environment[ZIOAppArgs]
 
     runtime.unsafe.fork {
       (for {
-        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs]
         _       <- installSignalHandlers(runtime)
-        _       <- runtime.run(run).tapErrorCause(ZIO.logErrorCause(_))
+        _       <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
       } yield ()).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_))).exitCode.tap(exit)
     }
   }

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -13,14 +13,14 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
     implicit val unsafe: Unsafe = Unsafe.unsafe
 
     val newLayer =
-      Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
-        bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
+      ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
+        bootstrap +!+ ZLayer.environment[ZIOAppArgs]
 
     runtime.unsafe.run {
       (for {
-        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs]
         _       <- installSignalHandlers(runtime)
-        fiber   <- runtime.run(run).fork
+        fiber   <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).fork
         _ <-
           ZIO.succeed(Platform.addShutdownHook { () =>
             if (!shuttingDown.getAndSet(true)) {

--- a/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -13,14 +13,14 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
     implicit val unsafe = Unsafe.unsafe
 
     val newLayer =
-      Scope.default +!+ ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
-        bootstrap +!+ ZLayer.environment[ZIOAppArgs with Scope]
+      ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
+        bootstrap +!+ ZLayer.environment[ZIOAppArgs]
 
     runtime.unsafe.fork {
       (for {
-        runtime <- ZIO.runtime[Environment with ZIOAppArgs with Scope]
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs]
         _       <- installSignalHandlers(runtime)
-        _       <- runtime.run(run).tapErrorCause(ZIO.logErrorCause(_))
+        _       <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
       } yield ()).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_))).exitCode.tap(exit)
     }
   }

--- a/core/shared/src/main/scala/zio/ZIOAppDefault.scala
+++ b/core/shared/src/main/scala/zio/ZIOAppDefault.scala
@@ -40,7 +40,7 @@ trait ZIOAppDefault extends ZIOApp {
 
   type Environment = Any
 
-  val bootstrap: ZLayer[ZIOAppArgs with Scope, Any, Any] = ZLayer.empty
+  val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = ZLayer.empty
 
   val environmentTag: EnvironmentTag[Any] = EnvironmentTag[Any]
 


### PR DESCRIPTION
In `ZIOApp` we should close the application scope inside the scope of the bootstrap layer so that any configuration set by the bootstrap layer, such as adding loggers, is applied when the finalizers are run.