### PR TITLE
Increase Blocking Pool Size

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/Blocking.scala
+++ b/core/jvm/src/main/scala/zio/internal/Blocking.scala
@@ -9,7 +9,7 @@ object Blocking {
   val blockingExecutor: zio.Executor =
     zio.Executor.fromThreadPoolExecutor {
       val corePoolSize  = 0
-      val maxPoolSize   = 1000
+      val maxPoolSize   = Int.MaxValue
       val keepAliveTime = 60000L
       val timeUnit      = TimeUnit.MILLISECONDS
       val workQueue     = new SynchronousQueue[Runnable]()


### PR DESCRIPTION
Resolves #7318.

We previously changed the blocking pool size to 1,000. This had some value in failing loudly if you were doing something that didn't really make sense like forking a million tasks on the blocking pool and pushing you to use higher level operators like `foreachParN` to control the level of parallelism. However, it also makes it relatively easy to blow yourself up if you do that. I tend to think it is better to have a default that just accepts submitted tasks and let performance be an optimization after that.