### PR TITLE
Optimize chunk.equals(Empty)

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -387,10 +387,10 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
     }
 
   override final def equals(that: Any): Boolean =
-    that match {
+    (self eq that.asInstanceOf[AnyRef]) || (that match {
       case that: Seq[_] => self.corresponds(that)(_ == _)
       case _            => false
-    }
+    })
 
   /**
    * Determines whether a predicate is satisfied for at least one element of


### PR DESCRIPTION
Currently `equals` always allocates new `ChunkIterator`.
chunk.equals(Empty) checked many times in Chunk codebase: 
https://github.com/zio/zio/blob/912c0d61adcf707bc97d904ca79a96479d37a23c/core/shared/src/main/scala/zio/Chunk.scala#L56-L57
https://github.com/zio/zio/blob/912c0d61adcf707bc97d904ca79a96479d37a23c/core/shared/src/main/scala/zio/Chunk.scala#L1746
![Screenshot 2022-10-04 at 12 43 34](https://user-images.githubusercontent.com/423802/193788274-11e64159-496d-491a-af9e-f902e0216ecb.png)
