### PR TITLE
Revert Runtime Flags In ZIO.withRuntimeFlagsScoped

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4718,8 +4718,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   def withRuntimeFlagsScoped(update: RuntimeFlags.Patch)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
     ZIO.uninterruptible {
-      ZIO.updateRuntimeFlags(update) *>
-        ZIO.addFinalizer(ZIO.updateRuntimeFlags(RuntimeFlags.Patch.inverse(update))).unit
+      ZIO.runtimeFlags.flatMap { runtimeFlags =>
+        val updatedRuntimeFlags = RuntimeFlags.Patch.patch(update)(runtimeFlags)
+        val revertRuntimeFlags  = RuntimeFlags.diff(updatedRuntimeFlags, runtimeFlags)
+        ZIO.updateRuntimeFlags(update) *>
+          ZIO.addFinalizer(ZIO.updateRuntimeFlags(revertRuntimeFlags)).unit
+      }
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4717,12 +4717,16 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     DefaultServices.currentServices.locallyScopedWith(_.add(random))
 
   def withRuntimeFlagsScoped(update: RuntimeFlags.Patch)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZIO.uninterruptible {
-      ZIO.runtimeFlags.flatMap { runtimeFlags =>
-        val updatedRuntimeFlags = RuntimeFlags.Patch.patch(update)(runtimeFlags)
-        val revertRuntimeFlags  = RuntimeFlags.diff(updatedRuntimeFlags, runtimeFlags)
-        ZIO.updateRuntimeFlags(update) *>
-          ZIO.addFinalizer(ZIO.updateRuntimeFlags(revertRuntimeFlags)).unit
+    if (update == RuntimeFlags.Patch.empty) {
+      ZIO.unit
+    } else {
+      ZIO.uninterruptible {
+        ZIO.runtimeFlags.flatMap { runtimeFlags =>
+          val updatedRuntimeFlags = RuntimeFlags.Patch.patch(update)(runtimeFlags)
+          val revertRuntimeFlags  = RuntimeFlags.diff(updatedRuntimeFlags, runtimeFlags)
+          ZIO.updateRuntimeFlags(update) *>
+            ZIO.addFinalizer(ZIO.updateRuntimeFlags(revertRuntimeFlags)).unit
+        }
       }
     }
 


### PR DESCRIPTION
We need to only revert the runtime flags we changed rather than all the flags described by the patch.