### PR TITLE
Make concatenation of empty chunks 600 times faster

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -10,43 +10,109 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ChunkConcatBenchmarks {
 
-  val chunk: Chunk[Int] = Chunk.empty
-
   @Param(Array("10000"))
   var size: Int = _
 
-  def concatBalanced(n: Int): Chunk[Int] =
+  var chunk0: Chunk[Int]        = _
+  var chunk1: Chunk[Int]        = _
+  var chunk10: Chunk[Int]       = _
+  var chunkHalfSize: Chunk[Int] = _
+
+  @Setup
+  def setUp(): Unit = {
+    chunk0 = Chunk.empty
+    chunk1 = Chunk.single(1)
+    chunk10 = Chunk.fill(10)(1)
+    chunkHalfSize = Chunk.fill(size / 2)(1)
+  }
+
+  @Benchmark
+  def leftConcat0(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk0
+
+    while (i < size) {
+      current = chunk0 ++ current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def leftConcat1(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk1
+
+    while (i < size) {
+      current = chunk1 ++ current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def leftConcat10(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk10
+
+    while (i < size) {
+      current = chunk10 ++ current
+      i += 10
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat0(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk0
+
+    while (i < size) {
+      current = current ++ chunk0
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat1(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk1
+
+    while (i < size) {
+      current = current ++ chunk1
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat10(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk10
+
+    while (i < size) {
+      current = current ++ chunk10
+      i += 10
+    }
+
+    current
+  }
+  @Benchmark
+  def balancedConcatOnce(): Chunk[Int] =
+    chunkHalfSize ++ chunkHalfSize
+
+  @Benchmark
+  def balancedConcatRecursive(): Chunk[Int] =
+    concatBalancedRec(size)
+
+  def concatBalancedRec(n: Int): Chunk[Int] =
     if (n == 0) Chunk.empty
-    else if (n == 1) Chunk(1)
-    else concatBalanced(n / 2) ++ concatBalanced(n / 2)
-
-  @Benchmark
-  def leftConcat(): Chunk[Int] = {
-    var i       = 1
-    var current = chunk
-
-    while (i < size) {
-      current = Chunk(i) ++ current
-      i += 1
-    }
-
-    current
-  }
-
-  @Benchmark
-  def rightConcat(): Chunk[Int] = {
-    var i       = 1
-    var current = chunk
-
-    while (i < size) {
-      current = current ++ Chunk(i)
-      i += 1
-    }
-
-    current
-  }
-
-  @Benchmark
-  def balancedConcat(): Chunk[Int] =
-    concatBalanced(size)
+    else if (n == 1) chunk1
+    else concatBalancedRec(n / 2) ++ concatBalancedRec(n / 2)
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1340,7 +1340,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       case x: AppendN[A]     => x.classTag
       case x: Arr[A]         => x.classTag
       case x: Concat[A]      => x.classTag
-      case x: Empty.type     => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
+      case _: Empty.type     => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
       case x: PrependN[A]    => x.classTag
       case x: Singleton[A]   => x.classTag
       case x: Slice[A]       => x.classTag

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1340,7 +1340,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       case x: AppendN[A]     => x.classTag
       case x: Arr[A]         => x.classTag
       case x: Concat[A]      => x.classTag
-      case Empty             => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
+      case x: Empty.type     => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
       case x: PrependN[A]    => x.classTag
       case x: Singleton[A]   => x.classTag
       case x: Slice[A]       => x.classTag
@@ -1621,8 +1621,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
     implicit val classTag: ClassTag[A] =
       left match {
-        case Empty => classTagOf(right)
-        case _     => classTagOf(left)
+        case _: Empty.type => classTagOf(right)
+        case _             => classTagOf(left)
       }
 
     override val depth: Int =


### PR DESCRIPTION
Concatenation of empty Chunks is very slow. This is caused by `Empty match {case Empty => ???}` being an expensive operation. Usually pattern machine on case object is very cheap, because their default `equals` is cheap. Not in this case. `Empty` inherits  `equals` from Chunk. 

The focus of this PR is to improve the performance of concatenation of empty chunks. In addition to that I've extended the benchmarks. There's more that can be done, but ensuring that there are no performance regressions takes a lot of time designing benchmarks and running them for hours, so I scaled the scope of the PR down to this very simple change which ensures that concatenation of empty chunks is as fast as concatenation of non-empty chunks.

This PR extends benchmark coverage of Chunk concatenation. 

### Benchmarks
Pay attention to the improvement in the leftConcat0 and rightConcat0 benchmarks. No regressions in other benchmarks.

#### Before
```
[info] Benchmark                                       (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce         10000  thrpt   10  194930350.454 ± 2798462.583  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive    10000  thrpt   10      16074.025 ±      69.190  ops/s
[info] ChunkConcatBenchmarks.leftConcat0                10000  thrpt   10          1.768 ±       0.004  ops/s
[info] ChunkConcatBenchmarks.leftConcat1                10000  thrpt   10       1173.516 ±       2.286  ops/s
[info] ChunkConcatBenchmarks.leftConcat10               10000  thrpt   10      16301.090 ±      39.158  ops/s
[info] ChunkConcatBenchmarks.rightConcat0               10000  thrpt   10          1.858 ±       0.004  ops/s
[info] ChunkConcatBenchmarks.rightConcat1               10000  thrpt   10       1142.122 ±       2.001  ops/s
[info] ChunkConcatBenchmarks.rightConcat10              10000  thrpt   10      15818.502 ±     568.069  ops/s
```

#### After
```
After
[info] Benchmark                                      (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce        10000  thrpt   10  196492469.987 ± 3233479.713  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive   10000  thrpt   10      16834.564 ±     256.764  ops/s
[info] ChunkConcatBenchmarks.leftConcat0               10000  thrpt   10       1144.024 ±       3.648  ops/s
[info] ChunkConcatBenchmarks.leftConcat1               10000  thrpt   10       1181.615 ±       5.951  ops/s
[info] ChunkConcatBenchmarks.leftConcat10              10000  thrpt   10      16262.446 ±      72.468  ops/s
[info] ChunkConcatBenchmarks.rightConcat0              10000  thrpt   10       1143.104 ±       1.150  ops/s
[info] ChunkConcatBenchmarks.rightConcat1              10000  thrpt   10       1149.469 ±       1.610  ops/s
[info] ChunkConcatBenchmarks.rightConcat10             10000  thrpt   10      15900.734 ±     167.511  ops/s
```

Side note: This should significantly improve performance of `ZValidated.validateAll` (`zio-prelude`) and other operations on `ZValidated`, because concatenation of often empty Chunks of logs is involved in these operations. 