### PR TITLE
Improve Chunk.empty concatenation 50x for 1.x

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkConcatBenchmarks.scala
@@ -10,43 +10,109 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ChunkConcatBenchmarks {
 
-  val chunk: Chunk[Int] = Chunk.empty
-
   @Param(Array("10000"))
   var size: Int = _
 
-  def concatBalanced(n: Int): Chunk[Int] =
+  var chunk0: Chunk[Int]        = _
+  var chunk1: Chunk[Int]        = _
+  var chunk10: Chunk[Int]       = _
+  var chunkHalfSize: Chunk[Int] = _
+
+  @Setup
+  def setUp(): Unit = {
+    chunk0 = Chunk.empty
+    chunk1 = Chunk.single(1)
+    chunk10 = Chunk.fill(10)(1)
+    chunkHalfSize = Chunk.fill(size / 2)(1)
+  }
+
+  @Benchmark
+  def leftConcat0(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk0
+
+    while (i < size) {
+      current = chunk0 ++ current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def leftConcat1(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk1
+
+    while (i < size) {
+      current = chunk1 ++ current
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def leftConcat10(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk10
+
+    while (i < size) {
+      current = chunk10 ++ current
+      i += 10
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat0(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk0
+
+    while (i < size) {
+      current = current ++ chunk0
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat1(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk1
+
+    while (i < size) {
+      current = current ++ chunk1
+      i += 1
+    }
+
+    current
+  }
+
+  @Benchmark
+  def rightConcat10(): Chunk[Int] = {
+    var i       = 1
+    var current = chunk10
+
+    while (i < size) {
+      current = current ++ chunk10
+      i += 10
+    }
+
+    current
+  }
+  @Benchmark
+  def balancedConcatOnce(): Chunk[Int] =
+    chunkHalfSize ++ chunkHalfSize
+
+  @Benchmark
+  def balancedConcatRecursive(): Chunk[Int] =
+    concatBalancedRec(size)
+
+  def concatBalancedRec(n: Int): Chunk[Int] =
     if (n == 0) Chunk.empty
-    else if (n == 1) Chunk(1)
-    else concatBalanced(n / 2) ++ concatBalanced(n / 2)
-
-  @Benchmark
-  def leftConcat(): Chunk[Int] = {
-    var i       = 1
-    var current = chunk
-
-    while (i < size) {
-      current = Chunk(i) ++ current
-      i += 1
-    }
-
-    current
-  }
-
-  @Benchmark
-  def rightConcat(): Chunk[Int] = {
-    var i       = 1
-    var current = chunk
-
-    while (i < size) {
-      current = current ++ Chunk(i)
-      i += 1
-    }
-
-    current
-  }
-
-  @Benchmark
-  def balancedConcat(): Chunk[Int] =
-    concatBalanced(size)
+    else if (n == 1) chunk1
+    else concatBalancedRec(n / 2) ++ concatBalancedRec(n / 2)
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -50,45 +50,51 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * Returns the concatenation of this chunk with the specified chunk.
    */
   final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] =
-    (self, that) match {
-      case (Chunk.AppendN(start, buffer, bufferUsed, _), that) =>
-        val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
-        start ++ chunk ++ that
-      case (self, Chunk.PrependN(end, buffer, bufferUsed, _)) =>
-        val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).takeRight(bufferUsed)
-        self ++ chunk ++ end
-      case (self, that) =>
-        val diff = that.depth - self.depth
-        if (math.abs(diff) <= 1) Chunk.Concat(self, that)
-        else if (diff < -1) {
-          if (self.left.depth >= self.right.depth) {
-            val nr = self.right ++ that
-            Chunk.Concat(self.left, nr)
-          } else {
-            val nrr = self.right.right ++ that
-            if (nrr.depth == self.depth - 3) {
-              val nr = Chunk.Concat(self.right.left, nrr)
+    if (isEmpty) {
+      that
+    } else if (that.isEmpty) {
+      self
+    } else {
+      (self, that) match {
+        case (Chunk.AppendN(start, buffer, bufferUsed, _), that) =>
+          val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
+          start ++ chunk ++ that
+        case (self, Chunk.PrependN(end, buffer, bufferUsed, _)) =>
+          val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).takeRight(bufferUsed)
+          self ++ chunk ++ end
+        case (self, that) =>
+          val diff = that.depth - self.depth
+          if (math.abs(diff) <= 1) Chunk.Concat(self, that)
+          else if (diff < -1) {
+            if (self.left.depth >= self.right.depth) {
+              val nr = self.right ++ that
               Chunk.Concat(self.left, nr)
             } else {
-              val nl = Chunk.Concat(self.left, self.right.left)
-              Chunk.Concat(nl, nrr)
+              val nrr = self.right.right ++ that
+              if (nrr.depth == self.depth - 3) {
+                val nr = Chunk.Concat(self.right.left, nrr)
+                Chunk.Concat(self.left, nr)
+              } else {
+                val nl = Chunk.Concat(self.left, self.right.left)
+                Chunk.Concat(nl, nrr)
+              }
             }
-          }
-        } else {
-          if (that.right.depth >= that.left.depth) {
-            val nl = self ++ that.left
-            Chunk.Concat(nl, that.right)
           } else {
-            val nll = self ++ that.left.left
-            if (nll.depth == that.depth - 3) {
-              val nl = Chunk.Concat(nll, that.left.right)
+            if (that.right.depth >= that.left.depth) {
+              val nl = self ++ that.left
               Chunk.Concat(nl, that.right)
             } else {
-              val nr = Chunk.Concat(that.left.right, that.right)
-              Chunk.Concat(nll, nr)
+              val nll = self ++ that.left.left
+              if (nll.depth == that.depth - 3) {
+                val nl = Chunk.Concat(nll, that.left.right)
+                Chunk.Concat(nl, that.right)
+              } else {
+                val nr = Chunk.Concat(that.left.right, that.right)
+                Chunk.Concat(nll, nr)
+              }
             }
           }
-        }
+      }
     }
 
   final def ++[A1 >: A](that: NonEmptyChunk[A1]): NonEmptyChunk[A1] =

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1340,7 +1340,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       case x: AppendN[A]     => x.classTag
       case x: Arr[A]         => x.classTag
       case x: Concat[A]      => x.classTag
-      case Empty             => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
+      case _: Empty.type     => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
       case x: PrependN[A]    => x.classTag
       case x: Singleton[A]   => x.classTag
       case x: Slice[A]       => x.classTag
@@ -1621,8 +1621,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
     implicit val classTag: ClassTag[A] =
       left match {
-        case Empty => classTagOf(right)
-        case _     => classTagOf(left)
+        case _: Empty.type => classTagOf(right)
+        case _             => classTagOf(left)
       }
 
     override val depth: Int =

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -44,6 +44,7 @@ object GenSpec extends ZIOBaseSpec {
             val p = (as ++ bs).reverse == (as.reverse ++ bs.reverse)
             if (p) assert(())(Assertion.anything) else assert((as, bs))(Assertion.nothing)
         }
+
         assertM(CheckN(100)(gen)(test).map { result =>
           result.failures.fold(false) {
             case BoolAlgebra.Value(FailureDetailsResult(failureDetails, _)) =>
@@ -254,6 +255,22 @@ object GenSpec extends ZIOBaseSpec {
         val min = Instant.ofEpochSecond(-38457693893669L, 435345)
         val max = Instant.ofEpochSecond(74576982873324L, 345345345)
         checkSample(Gen.instant(min, max))(forall(isGreaterThanEqualTo(min) && isLessThanEqualTo(max)))
+      },
+      testM("instant generates values in range when upper and lower bound share same second ") {
+        val min = Instant.ofEpochSecond(1, 2)
+        val max = Instant.ofEpochSecond(1, 3)
+        checkSample(Gen.instant(min, max))(forall(isGreaterThanEqualTo(min) && isLessThanEqualTo(max)))
+      },
+      testM("instant generates values in range when upper bound nano part is smaller than lower bound one") {
+        val min = Instant.ofEpochSecond(2, 1)
+        val max = Instant.ofEpochSecond(3, 9)
+        checkSample(Gen.instant(min, max))(forall(isGreaterThanEqualTo(min) && isLessThanEqualTo(max)))
+      },
+      testM("instant generates one value when upper and lower bound are equals") {
+        val anInstant = Instant.ofEpochSecond(1, 1)
+        checkSample(Gen.instant(anInstant, anInstant))(
+          forall(equalTo(anInstant))
+        )
       },
       testM("int generates values in range") {
         checkSample(smallInt)(forall(isGreaterThanEqualTo(-10) && isLessThanEqualTo(10)))
@@ -750,7 +767,8 @@ object GenSpec extends ZIOBaseSpec {
       case object Pop                   extends Command
       final case class Push(value: Int) extends Command
 
-      val genPop: Gen[Any, Command]     = Gen.const(Pop)
+      val genPop: Gen[Any, Command] = Gen.const(Pop)
+
       def genPush: Gen[Random, Command] = Gen.anyInt.map(value => Push(value))
 
       val genCommands: Gen[Random with Sized, List[Command]] =

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -192,7 +192,7 @@ trait TimeVariants {
    */
   final def instant(min: Instant, max: Instant): Gen[Random, Instant] = {
 
-    def genSecond(min: Instant, max: Instant): Gen[Random, Long] = Gen.long(min.getEpochSecond, max.getEpochSecond - 1)
+    def genSecond(min: Instant, max: Instant): Gen[Random, Long] = Gen.long(min.getEpochSecond, max.getEpochSecond)
 
     def genNano(min: Instant, max: Instant, second: Long): Gen[Random, Long] = {
       val minNano = if (min.getEpochSecond == second) min.getNano.toLong else 0L


### PR DESCRIPTION
Inspired by #7396 . 

The nonempty case is a little slower. The empty case is a lot faster. I'm unsure if the tradeoff is worth it, but I had this idea and wanted to present it.

Before

```
[info] Benchmark                                      (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce        10000  thrpt   10  203992533.765 ± 2075468.906  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive   10000  thrpt   10      18370.965 ±      41.063  ops/s
[info] ChunkConcatBenchmarks.leftConcat0               10000  thrpt   10       1509.055 ±       8.703  ops/s
[info] ChunkConcatBenchmarks.leftConcat1               10000  thrpt   10       1516.642 ±      13.518  ops/s
[info] ChunkConcatBenchmarks.leftConcat10              10000  thrpt   10      21650.274 ±     162.907  ops/s
[info] ChunkConcatBenchmarks.rightConcat0              10000  thrpt   10       1456.520 ±      12.798  ops/s
[info] ChunkConcatBenchmarks.rightConcat1              10000  thrpt   10       1497.503 ±      15.500  ops/s
[info] ChunkConcatBenchmarks.rightConcat10             10000  thrpt   10      20575.558 ±     203.644  ops/s
```

After

```
[info] Benchmark                                      (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce        10000  thrpt   10  206777416.179 ± 1702134.374  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive   10000  thrpt   10      17183.683 ±     203.886  ops/s
[info] ChunkConcatBenchmarks.leftConcat0               10000  thrpt   10      75478.279 ±     542.242  ops/s
[info] ChunkConcatBenchmarks.leftConcat1               10000  thrpt   10       1373.804 ±      96.077  ops/s
[info] ChunkConcatBenchmarks.leftConcat10              10000  thrpt   10      19332.971 ±     149.147  ops/s
[info] ChunkConcatBenchmarks.rightConcat0              10000  thrpt   10      67146.335 ±     509.862  ops/s
[info] ChunkConcatBenchmarks.rightConcat1              10000  thrpt   10       1336.395 ±      10.295  ops/s
[info] ChunkConcatBenchmarks.rightConcat10             10000  thrpt   10      19059.703 ±     131.697  ops/s
```