### PR TITLE
Improve Chunk.empty concatenation 50x for 1.x

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -50,45 +50,51 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] { self =>
    * Returns the concatenation of this chunk with the specified chunk.
    */
   final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] =
-    (self, that) match {
-      case (Chunk.AppendN(start, buffer, bufferUsed, _), that) =>
-        val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
-        start ++ chunk ++ that
-      case (self, Chunk.PrependN(end, buffer, bufferUsed, _)) =>
-        val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).takeRight(bufferUsed)
-        self ++ chunk ++ end
-      case (self, that) =>
-        val diff = that.depth - self.depth
-        if (math.abs(diff) <= 1) Chunk.Concat(self, that)
-        else if (diff < -1) {
-          if (self.left.depth >= self.right.depth) {
-            val nr = self.right ++ that
-            Chunk.Concat(self.left, nr)
-          } else {
-            val nrr = self.right.right ++ that
-            if (nrr.depth == self.depth - 3) {
-              val nr = Chunk.Concat(self.right.left, nrr)
+    if (isEmpty) {
+      that
+    } else if (that.isEmpty) {
+      self
+    } else {
+      (self, that) match {
+        case (Chunk.AppendN(start, buffer, bufferUsed, _), that) =>
+          val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).take(bufferUsed)
+          start ++ chunk ++ that
+        case (self, Chunk.PrependN(end, buffer, bufferUsed, _)) =>
+          val chunk = Chunk.fromArray(buffer.asInstanceOf[Array[A1]]).takeRight(bufferUsed)
+          self ++ chunk ++ end
+        case (self, that) =>
+          val diff = that.depth - self.depth
+          if (math.abs(diff) <= 1) Chunk.Concat(self, that)
+          else if (diff < -1) {
+            if (self.left.depth >= self.right.depth) {
+              val nr = self.right ++ that
               Chunk.Concat(self.left, nr)
             } else {
-              val nl = Chunk.Concat(self.left, self.right.left)
-              Chunk.Concat(nl, nrr)
+              val nrr = self.right.right ++ that
+              if (nrr.depth == self.depth - 3) {
+                val nr = Chunk.Concat(self.right.left, nrr)
+                Chunk.Concat(self.left, nr)
+              } else {
+                val nl = Chunk.Concat(self.left, self.right.left)
+                Chunk.Concat(nl, nrr)
+              }
             }
-          }
-        } else {
-          if (that.right.depth >= that.left.depth) {
-            val nl = self ++ that.left
-            Chunk.Concat(nl, that.right)
           } else {
-            val nll = self ++ that.left.left
-            if (nll.depth == that.depth - 3) {
-              val nl = Chunk.Concat(nll, that.left.right)
+            if (that.right.depth >= that.left.depth) {
+              val nl = self ++ that.left
               Chunk.Concat(nl, that.right)
             } else {
-              val nr = Chunk.Concat(that.left.right, that.right)
-              Chunk.Concat(nll, nr)
+              val nll = self ++ that.left.left
+              if (nll.depth == that.depth - 3) {
+                val nl = Chunk.Concat(nll, that.left.right)
+                Chunk.Concat(nl, that.right)
+              } else {
+                val nr = Chunk.Concat(that.left.right, that.right)
+                Chunk.Concat(nll, nr)
+              }
             }
           }
-        }
+      }
     }
 
   final def ++[A1 >: A](that: NonEmptyChunk[A1]): NonEmptyChunk[A1] =


### PR DESCRIPTION
Inspired by https://github.com/zio/zio/pull/7396 .

The nonempty case is a little slower. The empty case is a lot faster. I'm unsure if the tradeoff is worth it, but I had this idea and wanted to present it.

Before
```
[info] Benchmark                                      (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce        10000  thrpt   10  203992533.765 ± 2075468.906  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive   10000  thrpt   10      18370.965 ±      41.063  ops/s
[info] ChunkConcatBenchmarks.leftConcat0               10000  thrpt   10       1509.055 ±       8.703  ops/s
[info] ChunkConcatBenchmarks.leftConcat1               10000  thrpt   10       1516.642 ±      13.518  ops/s
[info] ChunkConcatBenchmarks.leftConcat10              10000  thrpt   10      21650.274 ±     162.907  ops/s
[info] ChunkConcatBenchmarks.rightConcat0              10000  thrpt   10       1456.520 ±      12.798  ops/s
[info] ChunkConcatBenchmarks.rightConcat1              10000  thrpt   10       1497.503 ±      15.500  ops/s
[info] ChunkConcatBenchmarks.rightConcat10             10000  thrpt   10      20575.558 ±     203.644  ops/s
```
After
```
[info] Benchmark                                      (size)   Mode  Cnt          Score         Error  Units
[info] ChunkConcatBenchmarks.balancedConcatOnce        10000  thrpt   10  206777416.179 ± 1702134.374  ops/s
[info] ChunkConcatBenchmarks.balancedConcatRecursive   10000  thrpt   10      17183.683 ±     203.886  ops/s
[info] ChunkConcatBenchmarks.leftConcat0               10000  thrpt   10      75478.279 ±     542.242  ops/s
[info] ChunkConcatBenchmarks.leftConcat1               10000  thrpt   10       1373.804 ±      96.077  ops/s
[info] ChunkConcatBenchmarks.leftConcat10              10000  thrpt   10      19332.971 ±     149.147  ops/s
[info] ChunkConcatBenchmarks.rightConcat0              10000  thrpt   10      67146.335 ±     509.862  ops/s
[info] ChunkConcatBenchmarks.rightConcat1              10000  thrpt   10       1336.395 ±      10.295  ops/s
[info] ChunkConcatBenchmarks.rightConcat10             10000  thrpt   10      19059.703 ±     131.697  ops/s
```