### PR TITLE
Fix Flaky Stream Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -443,7 +443,11 @@ object ZChannelSpec extends ZIOBaseSpec {
               )
 
           conduit.runCollect.map { case (chunk, _) =>
-            assert(chunk.toSet)(equalTo(Set(1, 4, 9)))
+            assert(chunk.toSet)(equalTo(Set(1, 4, 9))) ||
+              assert(chunk.toSet)(equalTo(Set(1, 6))) ||
+              assert(chunk.toSet)(equalTo(Set(2, 3, 6))) ||
+              assert(chunk.toSet)(equalTo(Set(2, 9))) ||
+              assert(chunk.toSet)(equalTo(Set(3, 4)))
           }
         }
       ),


### PR DESCRIPTION
The test seems to assume that the streams being merged will read from the upstream sequentially but I do not believe that is guaranteed.