### PR TITLE
Align Queue#isEmpty and Queue#isFull with Queue#size

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -767,6 +767,22 @@ object QueueSpec extends ZIOBaseSpec {
           _        <- ZIO.foreach(takers)(_.join)
         } yield assertCompletes
       }
+    },
+    test("isEmpty") {
+      for {
+        queue <- Queue.bounded[Int](2)
+        _     <- queue.take.fork
+        _     <- waitForSize(queue, -1)
+        empty <- queue.isEmpty
+      } yield assertTrue(empty)
+    },
+    test("isFull") {
+      for {
+        queue <- Queue.bounded[Int](2)
+        _     <- queue.offerAll(Chunk(1, 2, 3)).fork
+        _     <- waitForSize(queue, 3)
+        full  <- queue.isFull
+      } yield assertTrue(full)
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Dequeue.scala
+++ b/core/shared/src/main/scala/zio/Dequeue.scala
@@ -45,10 +45,9 @@ trait Dequeue[+A] extends Serializable {
   def shutdown(implicit trace: Trace): UIO[Unit]
 
   /**
-   * Retrieves the size of the queue, which is equal to the number of elements
-   * in the queue. This may be negative if fibers are suspended waiting for
-   * elements to be added to the queue. It may be greater than the capacity if
-   * fibers are suspended waiting for elements to be removed from the queue.
+   * Retrieves the size of the queue. This may be negative if fibers are
+   * suspended waiting for elements to be added to the queue or greater than the
+   * capacity if fibers are suspended waiting to add elements to the queue.
    */
   def size(implicit trace: Trace): UIO[Int]
 

--- a/core/shared/src/main/scala/zio/Enqueue.scala
+++ b/core/shared/src/main/scala/zio/Enqueue.scala
@@ -69,10 +69,9 @@ trait Enqueue[-A] extends Serializable {
   def shutdown(implicit trace: Trace): UIO[Unit]
 
   /**
-   * Retrieves the size of the queue, which is equal to the number of elements
-   * in the queue. This may be negative if fibers are suspended waiting for
-   * elements to be added to the queue. It may be greater than the capacity if
-   * fibers are suspended waiting for elements to be removed from the queue.
+   * Retrieves the size of the queue. This may be negative if fibers are
+   * suspended waiting for elements to be added to the queue or greater than the
+   * capacity if fibers are suspended waiting to add elements to the queue.
    */
   def size(implicit trace: Trace): UIO[Int]
 
@@ -80,11 +79,11 @@ trait Enqueue[-A] extends Serializable {
    * Checks whether the queue is currently empty.
    */
   def isEmpty(implicit trace: Trace): UIO[Boolean] =
-    size.map(_ == 0)
+    size.map(_ <= 0)
 
   /**
    * Checks whether the queue is currently full.
    */
   def isFull(implicit trace: Trace): UIO[Boolean] =
-    size.map(_ == capacity)
+    size.map(_ >= capacity)
 }

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -31,13 +31,13 @@ abstract class Queue[A] extends Dequeue[A] with Enqueue[A] {
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
-    size.map(_ == 0)
+    size.map(_ <= 0)
 
   /**
    * Checks whether the queue is currently full.
    */
   override final def isFull(implicit trace: Trace): UIO[Boolean] =
-    size.map(_ == capacity)
+    size.map(_ >= capacity)
 }
 
 object Queue {


### PR DESCRIPTION
Resolves #7413.

Since some queue implementations allow the size to be less than zero or greater than the capacity we need to handle this possibility in `isEmpty` and `isFull`.