### PR TITLE
Fix Flaky Stream Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -582,11 +582,11 @@ object ZStreamSpec extends ZIOBaseSpec {
                     .range(1, 5)
                     .tap(i => ref.update(i :: _) *> latch.succeed(()).when(i == 4))
                     .bufferChunks(2)
-              l1 <- s.take(2).runCollect
+              l1 <- s.take(2).runScoped(ZSink.collectAll)
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          } @@ TestAspect.nonFlaky
         ),
         suite("bufferChunksDropping")(
           test("buffer the Stream with Error") {


### PR DESCRIPTION
There is a race condition in this test. It is supposed to be testing that the upstream can progress independently of the downstream. But when the downstream finishes it will close the scope of the stream which can prevent the upstream from completing. We can fix this by using `runScoped` to extend the scope of the stream so that it does not shut down the upstream before it is done.