### PR TITLE
Fix Flaky ZStream#bufferSliding Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -787,9 +787,9 @@ object ZStreamSpec extends ZIOBaseSpec {
                      .fromZIO(latch3.await)
                      .flatMap(_ => ZStream.range(17, 26).ensuring(latch4.succeed(())))
               s3 = ZStream
-                      .fromZIO(latch5.await)
-                      .flatMap(_ => ZStream(-1))
-              s  = (s1 ++ s2 ++ s3).bufferSliding(8)
+                     .fromZIO(latch5.await)
+                     .flatMap(_ => ZStream(-1))
+              s = (s1 ++ s2 ++ s3).bufferSliding(8)
               snapshots <- ZIO.scoped {
                              s.toPull.flatMap { as =>
                                for {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -779,13 +779,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch2 <- Promise.make[Nothing, Unit]
               latch3 <- Promise.make[Nothing, Unit]
               latch4 <- Promise.make[Nothing, Unit]
+              latch5 <- Promise.make[Nothing, Unit]
               s1 = ZStream(0) ++ ZStream
                      .fromZIO(latch1.await)
                      .flatMap(_ => ZStream.range(1, 17).ensuring(latch2.succeed(())))
               s2 = ZStream
                      .fromZIO(latch3.await)
-                     .flatMap(_ => ZStream.range(17, 25).ensuring(latch4.succeed(())))
-              s3 = ZStream(-1)
+                     .flatMap(_ => ZStream.range(17, 26).ensuring(latch4.succeed(())))
+              s3 = ZStream
+                      .fromZIO(latch5.await)
+                      .flatMap(_ => ZStream(-1))
               s  = (s1 ++ s2 ++ s3).bufferSliding(8)
               snapshots <- ZIO.scoped {
                              s.toPull.flatMap { as =>
@@ -806,9 +809,9 @@ object ZStreamSpec extends ZIOBaseSpec {
               equalTo(List(16, 15, 14, 13, 12, 11, 10, 9))
             ) &&
               assert(snapshots._3)(
-                equalTo(List(-1, 24, 23, 22, 21, 20, 19, 18, 16, 15, 14, 13, 12, 11, 10, 9))
+                equalTo(List(25, 24, 23, 22, 21, 20, 19, 18, 16, 15, 14, 13, 12, 11, 10, 9))
               )
-          }
+          } @@ nonFlaky
         ),
         suite("bufferUnbounded")(
           test("buffer the Stream")(check(Gen.chunkOf(Gen.int)) { chunk =>


### PR DESCRIPTION
There is a race condition in this test. It is trying to assert that we drop an element from the buffer. However, once we complete the last latch the upstream tries to write an additional value at the same time the downstream tries to read. So if the downstream reads first it will free up space in the buffer and no value will be dropped.