### PR TITLE
ZIO Stream: Don't Interrupt Daemon Fibers in ZStream#mapZIOPar

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1346,6 +1346,11 @@ sealed trait ZIO[-R, +E, +A]
   ): ZIO[R1, E1, A1] =
     (self.exit race that.exit).flatMap(ZIO.done(_))
 
+  final def raceFirstAwait[R1 <: R, E1 >: E, A1 >: A](that: => ZIO[R1, E1, A1])(implicit
+    trace: Trace
+  ): ZIO[R1, E1, A1] =
+    (self.exit raceAwait that.exit).flatMap(ZIO.done(_))
+
   /**
    * Returns an effect that races this effect with the specified effect,
    * yielding the first result to succeed. If neither effect succeeds, then the

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -672,7 +672,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                        _ <- permits.withPermit {
                               latch.succeed(()) *>
                                 ZIO.uninterruptibleMask { restore =>
-                                  restore(errorSignal.await) raceFirst restore(f(outElem))
+                                  restore(errorSignal.await) raceFirstAwait restore(f(outElem))
                                 }
                                   .tapErrorCause(errorSignal.failCause)
                                   .intoPromise(p)

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -676,7 +676,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                                 }
                                   .tapErrorCause(errorSignal.failCause)
                                   .intoPromise(p)
-                            }.fork
+                            }.forkScoped
                        _ <- latch.await
                      } yield ()
                  }


### PR DESCRIPTION
Resolves #7427.

We shouldn't use `withChildren` to interrupt child fibers since it can lead to daemon fibers unexpectedly being interrupted.