### PR TITLE
Remove More ZIO Internals From Execution Traces

### DIFF
--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -61,7 +61,13 @@ final case class StackTrace(
 object StackTrace {
 
   def fromJava(fiberId: FiberId, stackTrace: Array[StackTraceElement])(implicit trace: Trace): StackTrace =
-    StackTrace(fiberId, Chunk.fromArray(stackTrace).map(Trace.fromJava).takeWhile(!Trace.equalIgnoreLocation(_, trace)))
+    StackTrace(
+      fiberId,
+      Chunk
+        .fromArray(stackTrace.takeWhile(_.getClassName != "zio.internal.FiberRuntime"))
+        .map(Trace.fromJava)
+        .takeWhile(!Trace.equalIgnoreLocation(_, trace))
+    )
 
   lazy val none: StackTrace =
     StackTrace(FiberId.None, Chunk.empty)


### PR DESCRIPTION
We recently updated execution traces from `ZIO.attempt` to include the full `Throwable` stack trace up to the current ZIO trace. This provides significantly more information in cases where the `Throwable` stack trace contains useful information because multiple methods were called within a `ZIO.attempt` constructor.

However, that stack trace can also include ZIO internals which are not useful to the user and we want to avoid. We need to remove the ZIO internals from the `Throwable` stack trace like we already do for the rest of the ZIO execution trace.

Example output before and after:

```
[info] timestamp=2022-10-14T15:54:12.872732Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-4" java.lang.Exception: java.lang.Exception: Boom 6!
[info]  at Example$.$anonfun$methodFour$1(Example.scala:34)
[info]  at zio.ZIOCompanionVersionSpecific.$anonfun$attempt$1(ZIOCompanionVersionSpecific.scala:100)
[info]  at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1095)
[info]  at zio.internal.FiberRuntime.evaluateEffect(FiberRuntime.scala:384)
[info]  at zio.internal.FiberRuntime.evaluateMessageWhileSuspended(FiberRuntime.scala:496)
[info]  at zio.internal.FiberRuntime.drainQueueOnCurrentThread(FiberRuntime.scala:224)
[info]  at zio.internal.FiberRuntime.run(FiberRuntime.scala:137)
[info]  at zio.internal.ZScheduler$$anon$3.run(ZScheduler.scala:457)
[info]  at <empty>.Example.delay(Example.scala:8)
[info]  at <empty>.Example.methodThree(Example.scala:29)
[info]  at <empty>.Example.methodTwo(Example.scala:22)
[info]  at <empty>.Example.methodOne(Example.scala:15)"
```

And after:

```
[info] timestamp=2022-10-14T15:59:21.974262Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-4" java.lang.Exception: java.lang.Exception: Boom 6!
[info]  at Example$.$anonfun$methodFour$1(Example.scala:34)
[info]  at zio.ZIOCompanionVersionSpecific.$anonfun$attempt$1(ZIOCompanionVersionSpecific.scala:100)
[info]  at <empty>.Example.delay(Example.scala:8)
[info]  at <empty>.Example.methodThree(Example.scala:29)
[info]  at <empty>.Example.methodTwo(Example.scala:22)
[info]  at <empty>.Example.methodOne(Example.scala:15)"
```